### PR TITLE
Dashboard cleanup

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
@@ -13,9 +13,6 @@
                             <i class="md-icon">mode_edit</i>
                         </button>
 
-                        <div class="supporterIconContainer flex align-items-center" style="margin: 0 0 0 .5em;">
-                        </div>
-
                     </div>
                     <div class="paperList" style="padding: 1em;">
                         <p id="appVersionNumber">

--- a/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
@@ -42,7 +42,6 @@
                         <div id="pPluginUpdates"></div>
 
                         <p class="localUrl"></p>
-                        <p class="externalUrl"></p>
                         <p class="hide">
                             <a class="btnConnectionHelp" href="#" is="emby-linkbutton">${HowToConnectFromEmbyApps}</a>
                         </p>

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ar.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ar.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "\u0627\u0644\u062a\u0634\u063a\u064a\u0644 \u0627\u0644\u0645\u0628\u0627\u0634\u0631",
     "LabelAudioCodec": "\u0645\u0642\u0637\u0639 \u0627\u0644\u0635\u0648\u062a: {0}",
     "LabelVideoCodec": "\u0645\u0642\u0637\u0639 \u0627\u0644\u0641\u064a\u062f\u064a\u0648: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "\u0645\u062a\u0635\u0644 \u0639\u0628\u0631 \u0645\u0646\u0641\u0630 http\u0640 {0}",
     "LabelRunningOnPorts": "\u0645\u062a\u0635\u0644 \u0639\u0628\u0631 \u0645\u0646\u0641\u0630 http\u0640 {0}\u060c \u0648\u0645\u0646\u0641\u0630 https\u0640 {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ar.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ar.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\u0645\u0642\u0637\u0639 \u0627\u0644\u0635\u0648\u062a: {0}",
     "LabelVideoCodec": "\u0645\u0642\u0637\u0639 \u0627\u0644\u0641\u064a\u062f\u064a\u0648: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "\u0645\u062a\u0635\u0644 \u0639\u0628\u0631 \u0645\u0646\u0641\u0630 http\u0640 {0}",
     "LabelRunningOnPorts": "\u0645\u062a\u0635\u0644 \u0639\u0628\u0631 \u0645\u0646\u0641\u0630 http\u0640 {0}\u060c \u0648\u0645\u0646\u0641\u0630 https\u0640 {1}.",
     "HeaderLatestFromChannel": "\u0627\u0644\u0623\u062d\u062f\u062b \u0645\u0646 {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/be-BY.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/be-BY.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/be-BY.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/be-BY.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/bg-BG.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/bg-BG.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\u0417\u0432\u0443\u043a: {0}",
     "LabelVideoCodec": "\u0412\u0438\u0434\u0435\u043e: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "\u0412\u044a\u0440\u0432\u0438 \u043d\u0430 \u043f\u043e\u0440\u0442 {0} (http).",
     "LabelRunningOnPorts": "\u0412\u044a\u0440\u0432\u0438 \u043d\u0430 \u043f\u043e\u0440\u0442 {0} (http) \u0438 \u043f\u043e\u0440\u0442 {1} (https).",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/bg-BG.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/bg-BG.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "\u0417\u0432\u0443\u043a: {0}",
     "LabelVideoCodec": "\u0412\u0438\u0434\u0435\u043e: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "\u0412\u044a\u0440\u0432\u0438 \u043d\u0430 \u043f\u043e\u0440\u0442 {0} (http).",
     "LabelRunningOnPorts": "\u0412\u044a\u0440\u0432\u0438 \u043d\u0430 \u043f\u043e\u0440\u0442 {0} (http) \u0438 \u043f\u043e\u0440\u0442 {1} (https).",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/el.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/el.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "\u0393\u03af\u03bd\u03b5\u03c4\u03b1\u03b9 \u0386\u03bc\u03b5\u03c3\u03b7 \u0391\u03bd\u03b1\u03c0\u03b1\u03c1\u03b1\u03b3\u03c9\u03b3\u03ae",
     "LabelAudioCodec": "\u0389\u03c7\u03bf\u03c2: {0}",
     "LabelVideoCodec": "\u0392\u03af\u03bd\u03c4\u03b5\u03bf: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/el.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/el.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\u0389\u03c7\u03bf\u03c2: {0}",
     "LabelVideoCodec": "\u0392\u03af\u03bd\u03c4\u03b5\u03bf: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "\u03a4\u03b5\u03bb\u03b5\u03c5\u03c4\u03b1\u03af\u03b1 \u03b1\u03c0\u03cc {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-GB.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-GB.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on HTTP port {0}.",
     "LabelRunningOnPorts": "Running on HTTP port {0}, and HTTPS port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-GB.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-GB.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on HTTP port {0}.",
     "LabelRunningOnPorts": "Running on HTTP port {0}, and HTTPS port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
@@ -1262,7 +1262,7 @@
   "LabelAudioCodec": "Audio: {0}",
   "LabelVideoCodec": "Video: {0}",
   "LabelLocalAccessUrl": "LAN address: {0}",
-  "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+  "LabelRemoteAccessUrl": "WAN address: {0}",
   "LabelRunningOnPort": "Running on http port {0}.",
   "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
   "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
@@ -1261,7 +1261,7 @@
   "LabelPlayMethodDirectPlay": "Direct Playing",
   "LabelAudioCodec": "Audio: {0}",
   "LabelVideoCodec": "Video: {0}",
-  "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+  "LabelLocalAccessUrl": "LAN address: {0}",
   "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
   "LabelRunningOnPort": "Running on http port {0}.",
   "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/es-AR.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/es-AR.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/es-AR.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/es-AR.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fa.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fa.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fa.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fa.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fi.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fi.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fi.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fi.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fr-CA.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fr-CA.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/fr-CA.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/fr-CA.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/gsw.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/gsw.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/gsw.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/gsw.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/he.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/he.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/he.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/he.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/hi-IN.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/hi-IN.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/hi-IN.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/hi-IN.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/hr.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/hr.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Izvodi se na http port-u {0}.",
     "LabelRunningOnPorts": "Izvodi se na http port-u {0} i na https port-u {1}.",
     "HeaderLatestFromChannel": "Zadnje od {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/hr.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/hr.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direktno izvo\u0111enje",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Izvodi se na http port-u {0}.",
     "LabelRunningOnPorts": "Izvodi se na http port-u {0} i na https port-u {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/id.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/id.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/id.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/id.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/is-IS.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/is-IS.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/is-IS.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/is-IS.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ko.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ko.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\uc624\ub514\uc624: {0}",
     "LabelVideoCodec": "\ube44\ub514\uc624: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ko.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ko.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "\ub2e4\uc774\ub809\ud2b8 \uc7ac\uc0dd",
     "LabelAudioCodec": "\uc624\ub514\uc624: {0}",
     "LabelVideoCodec": "\ube44\ub514\uc624: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/lt-LT.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/lt-LT.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/lt-LT.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/lt-LT.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ms.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ms.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ms.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ms.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/nb.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/nb.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direkte Avspilling",
     "LabelAudioCodec": "Lyd: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Kj\u00f8rer p\u00e5 http port {0}.",
     "LabelRunningOnPorts": "Kj\u00f8rer p\u00e5 http port {0} og https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/nb.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/nb.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Lyd: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Kj\u00f8rer p\u00e5 http port {0}.",
     "LabelRunningOnPorts": "Kj\u00f8rer p\u00e5 http port {0} og https port {1}.",
     "HeaderLatestFromChannel": "Siste fra {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/no.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/no.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/no.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/no.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/pt-PT.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/pt-PT.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\u00c1udio: {0}",
     "LabelVideoCodec": "V\u00eddeo: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "A executar na porta http {0}.",
     "LabelRunningOnPorts": "A executar na porta http {0} e na porta https {1}.",
     "HeaderLatestFromChannel": "Mais recentes de {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/pt-PT.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/pt-PT.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Reprodu\u00e7\u00e3o Direta",
     "LabelAudioCodec": "\u00c1udio: {0}",
     "LabelVideoCodec": "V\u00eddeo: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "A executar na porta http {0}.",
     "LabelRunningOnPorts": "A executar na porta http {0} e na porta https {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ro.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ro.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/ro.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/ro.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/sl-SI.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/sl-SI.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/sl-SI.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/sl-SI.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/tr.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/tr.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/tr.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/tr.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/uk.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/uk.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/uk.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/uk.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/vi.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/vi.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/vi.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/vi.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-HK.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-HK.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "\u97f3\u8a0a\uff1a{0}",
     "LabelVideoCodec": "\u5f71\u7247\uff1a{0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "\u904b\u884c\u65bc http \u9023\u63a5\u57e0 {0}.",
     "LabelRunningOnPorts": "\u904b\u884c\u65bc http \u9023\u63a5\u57e0 {0}, \u548c https \u9023\u63a5\u57e0 {1}.",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-HK.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-HK.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "\u97f3\u8a0a\uff1a{0}",
     "LabelVideoCodec": "\u5f71\u7247\uff1a{0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "\u904b\u884c\u65bc http \u9023\u63a5\u57e0 {0}.",
     "LabelRunningOnPorts": "\u904b\u884c\u65bc http \u9023\u63a5\u57e0 {0}, \u548c https \u9023\u63a5\u57e0 {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-TW.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-TW.json
@@ -1262,7 +1262,7 @@
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
     "LabelLocalAccessUrl": "LAN address: {0}",
-    "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
+    "LabelRemoteAccessUrl": "WAN address: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",
     "HeaderLatestFromChannel": "Latest from {0}",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-TW.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/zh-TW.json
@@ -1261,7 +1261,7 @@
     "LabelPlayMethodDirectPlay": "Direct Playing",
     "LabelAudioCodec": "Audio: {0}",
     "LabelVideoCodec": "Video: {0}",
-    "LabelLocalAccessUrl": "In-Home (LAN) access: {0}",
+    "LabelLocalAccessUrl": "LAN address: {0}",
     "LabelRemoteAccessUrl": "Remote (WAN) access: {0}",
     "LabelRunningOnPort": "Running on http port {0}.",
     "LabelRunningOnPorts": "Running on http port {0}, and https port {1}.",


### PR DESCRIPTION
Remove the WAN URL that was removed in #22 and rename the "In-Home" part, and remove the "thanks for supporting" button.