### PR TITLE
Changed the App.Config to longer break both nix (in debug mode) and w…

### DIFF
--- a/MediaBrowser.Server.Mono/ApplicationPathHelper.cs
+++ b/MediaBrowser.Server.Mono/ApplicationPathHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Configuration;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace MediaBrowser.Server.Mono
 {
@@ -22,7 +23,15 @@ namespace MediaBrowser.Server.Mono
                 ConfigurationManager.AppSettings["DebugProgramDataPath"] : 
                 ConfigurationManager.AppSettings["ReleaseProgramDataPath"];
 
-            programDataPath = programDataPath.Replace("%ApplicationData%", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                programDataPath = programDataPath.Replace("%ApplicationData%", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            }
+            else
+            {
+                programDataPath = programDataPath.Replace("%ApplicationData%", "/var/lib");
+            }
+            
 
             programDataPath = programDataPath
                 .Replace('/', Path.DirectorySeparatorChar)

--- a/MediaBrowser.Server.Mono/app.config
+++ b/MediaBrowser.Server.Mono/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="DebugProgramDataPath" value="E:\Temp" />
-    <add key="ReleaseProgramDataPath" value="/var/lib/emby/" />
+    <add key="DebugProgramDataPath" value="%ApplicationData%/jellyfin-debug/" />
+    <add key="ReleaseProgramDataPath" value="%ApplicationData%/jellyfin/" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
…indows (in release mode) profiles. Changed the Path helper library to replace %ApplicationData% in Windows land with the Userdata\roaming folder, and with /var/lib in nix land