### PR TITLE
Reorganize README and add section on upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,22 @@ The Jellyfin Docker image is available on Docker Hub at https://hub.docker.com/r
 
 The Jellyfin package is in the AUR at https://aur.archlinux.org/packages/jellyfin-git/
 
+### Unraid
+
+An Unraid Docker template is available. See [this documentation page](https://github.com/jellyfin/jellyfin/blob/master/unRaid/docker-templates/README.md) for details on installing it.
+
 ### Debian/Ubuntu
 
-A package repository is available at https://repo.jellyfin.org. To use it:
+A package repository is available at https://repo.jellyfin.org.
+
+#### Clean install
 
 0. Install the `dotnet-runtime-2.1` package via [Microsoft's repositories](https://dotnet.microsoft.com/download/dotnet-core/2.1).
 0. Import the GPG signing key (signed by Joshua):
     ```
     wget -O - https://repo.jellyfin.org/debian/jellyfin-signing-key-joshua.gpg.key | sudo apt-key add -
     ```
-0. Add an entry to `/etc/apt/sources.list.d/jellyfin.list` (note that Ubuntu will get `buster` but this should work fine):
+0. Add an entry to `/etc/apt/sources.list.d/jellyfin.list` (note that Ubuntu will get `buster` in the list file, but this should still work fine):
     ```
     echo "deb https://repo.jellyfin.org/debian $( grep -Ewo -m1 --color=none 'jessie|stretch|buster' /etc/os-release || echo buster ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
     ```
@@ -51,9 +57,42 @@ A package repository is available at https://repo.jellyfin.org. To use it:
     sudo apt install jellyfin
     ```
 
-### Unraid
+#### Upgrade from Emby
 
-An Unraid Docker template is available. See [this documentation page](https://github.com/jellyfin/jellyfin/blob/master/unRaid/docker-templates/README.md) for details on installing it.
+The following procedure should work to upgrade from Emby to Jellyfin on an existing installation:
+
+0. Upgrade to Emby 3.5.X, preferably 3.5.2, so the database schema is fully up-to-date and consistent. This is somewhat optional but can reduce the risk of obscure bugs later on.
+0. Stop the `emby-server` daemon:
+    ```
+    sudo service emby-server stop
+    ```
+0. Move your existing Emby data directory out of the way:
+    ```
+    sudo mv /var/lib/emby /var/lib/emby.backup
+    ```
+0. Remove the `emby-server` package:
+    ```
+    sudo apt remove emby-server
+    ```
+0. Install the `jellyfin` package using the instructions above, verifying that `/var/lib/emby` is a symlink to `/var/lib/jellyfin`.
+0. Stop the `jellyfin` daemon:
+    ```
+    sudo service jellyfin stop
+    ```
+0. Copy over all the data files from the old backup data directory:
+    ```
+    sudo cp -a /var/lib/emby.backup/* /var/lib/jellyfin/
+    ```
+0. Correct ownership on the new data directory:
+    ```
+    sudo chown -R jellyfin /var/lib/jellyfin
+    ```
+0. Start the `jellyfin` daemon:
+    ```
+    sudo service jellyfin start
+    ```
+
+This same general procedure should apply for upgrades on any other platform as well though the specific commands and/or paths may be different.
 
 ## Building Jellyfin packages from source
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A package repository is available at https://repo.jellyfin.org.
 
 #### Clean install
 
-0. Install the `dotnet-runtime-2.1` package via [Microsoft's repositories](https://dotnet.microsoft.com/download/dotnet-core/2.1).
+0. Install the `dotnet-runtime-2.2` package via [Microsoft's repositories](https://dotnet.microsoft.com/download/dotnet-core/2.2).
 0. Import the GPG signing key (signed by Joshua):
     ```
     wget -O - https://repo.jellyfin.org/debian/jellyfin-signing-key-joshua.gpg.key | sudo apt-key add -
@@ -85,7 +85,7 @@ The following procedure should work to upgrade from Emby to Jellyfin on an exist
     ```
 0. Correct ownership on the new data directory:
     ```
-    sudo chown -R jellyfin /var/lib/jellyfin
+    sudo chown -R jellyfin:jellyfin /var/lib/jellyfin
     ```
 0. Start the `jellyfin` daemon:
     ```
@@ -104,7 +104,7 @@ NOTE: When building from source, only cloning the full Git repository is support
 
 Debian build facilities are integrated into the repo at `debian/`.
 
-0. Install the `dotnet-sdk-2.1` package via [Microsoft's repositories](https://dotnet.microsoft.com/download/dotnet-core/2.1).
+0. Install the `dotnet-sdk-2.2` package via [Microsoft's repositories](https://dotnet.microsoft.com/download/dotnet-core/2.2).
 0. Run `dpkg-buildpackage -us -uc`.
 0. Install the resulting `jellyfin_*.deb` file on your system.
 
@@ -114,7 +114,7 @@ A huge thanks to Carlos Hernandez who created the original Debian build configur
 
 A pre-built windows installer will be available soon. Until then it isn't too hard to install Jellyfin from Source.
 
-0. Install the dotnet core SDK 2.1 from [Microsoft's Webpage](https://dotnet.microsoft.com/download/dotnet-core/2.1) and [install Git for Windows](https://gitforwindows.org/)
+0. Install the dotnet core SDK 2.2 from [Microsoft's Webpage](https://dotnet.microsoft.com/download/dotnet-core/2.2) and [install Git for Windows](https://gitforwindows.org/)
 0. Clone Jellyfin into a directory of your choice.
     ```
     git clone https://github.com/jellyfin/jellyfin.git C:\Jellyfin


### PR DESCRIPTION
Add a section on upgrading Debian installs from Emby to Jellyfin,
and reformat some other elements to make the list clearer.

Fixes remaining item in #77