### PR TITLE
fixed linux temp directory so you can build windows on linux

### DIFF
--- a/Build-JellyFin.ps1
+++ b/Build-JellyFin.ps1
@@ -8,6 +8,13 @@ param(
     [ValidateSet('win','win7', 'win8','win81','win10')][string]$WindowsVersion = 'win',
     [ValidateSet('x64','x86', 'arm', 'arm64')][string]$Architecture = 'x64'
 )
+
+if($IsWindows){
+    $TempDir = $env:Temp
+}else{
+    $TempDir = mktemp -d 
+}
+
 function Build-JellyFin {
     if($Architecture -eq 'arm64'){
         if($WindowsVersion -ne 'win10'){
@@ -35,26 +42,26 @@ function Install-FFMPEG {
         Write-Warning "FFMPEG will not be installed" 
     }elseif($Architecture -eq 'x64'){
          Write-Verbose "Downloading 64 bit FFMPEG"
-         Invoke-WebRequest -Uri https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.1-win64-static.zip -UseBasicParsing -OutFile "$env:TEMP/fmmpeg.zip" | Write-Verbose
+         Invoke-WebRequest -Uri https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.1-win64-static.zip -UseBasicParsing -OutFile "$tempdir/fmmpeg.zip" | Write-Verbose
     }else{
          Write-Verbose "Downloading 32 bit FFMPEG"
-         Invoke-WebRequest -Uri https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.1-win32-static.zip -UseBasicParsing -OutFile "$env:TEMP/fmmpeg.zip" | Write-Verbose
+         Invoke-WebRequest -Uri https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.1-win32-static.zip -UseBasicParsing -OutFile "$tempdir/fmmpeg.zip" | Write-Verbose
     }
    
-    Expand-Archive "$env:TEMP/fmmpeg.zip" -DestinationPath "$env:TEMP/ffmpeg/" | Write-Verbose
+    Expand-Archive "$tempdir/fmmpeg.zip" -DestinationPath "$tempdir/ffmpeg/" | Write-Verbose
     if($Architecture -eq 'x64'){
         Write-Verbose "Copying Binaries to Jellyfin location"
-        Get-ChildItem "$env:temp/ffmpeg/ffmpeg-4.1-win64-static/bin" | ForEach-Object {
+        Get-ChildItem "$tempdir/ffmpeg/ffmpeg-4.1-win64-static/bin" | ForEach-Object {
             Copy-Item $_.FullName -Destination $installLocation | Write-Verbose
         }
     }else{
         Write-Verbose "Copying Binaries to Jellyfin location"
-        Get-ChildItem "$env:temp/ffmpeg/ffmpeg-4.1-win32-static/bin" | ForEach-Object {
+        Get-ChildItem "$tempdir/ffmpeg/ffmpeg-4.1-win32-static/bin" | ForEach-Object {
             Copy-Item $_.FullName -Destination $installLocation | Write-Verbose
         }
     }
-    Remove-Item "$env:TEMP/ffmpeg/" -Recurse -Force -ErrorAction Continue | Write-Verbose
-    Remove-Item "$env:TEMP/fmmpeg.zip" -Force -ErrorAction Continue | Write-Verbose
+    Remove-Item "$tempdir/ffmpeg/" -Recurse -Force -ErrorAction Continue | Write-Verbose
+    Remove-Item "$tempdir/fmmpeg.zip" -Force -ErrorAction Continue | Write-Verbose
 }
 Write-Verbose "Starting Build Process: Selected Environment is $WindowsVersion-$Architecture"
 Build-JellyFin


### PR DESCRIPTION
this makes it possible for any CICD we run to be able to generate packaged windows builds with the following line: ./Build-JellyFin.ps1 -InstallLocation /path/to/targetfolder -InstallFFMPEG -GenerateZip
