### PR TITLE
Add maxcpucount to dotnet clean

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,5 +18,5 @@ override_dh_auto_build:
 	dotnet publish --configuration $(CONFIG) $(CURDIR)/MediaBrowser.sln --output='$(CURDIR)/usr/lib/jellyfin/bin'
 
 override_dh_auto_clean:
-	dotnet clean --configuration $(CONFIG) $(CURDIR)/MediaBrowser.sln || true
+	dotnet clean -maxcpucount:1 --configuration $(CONFIG) $(CURDIR)/MediaBrowser.sln || true
 	rm -rf '$(CURDIR)/usr/lib/jellyfin'


### PR DESCRIPTION
Fixes #120 as per https://github.com/dotnet/sdk/issues/2526

Confirmed that this allows the `dotnet clean`