### PR TITLE
Add build script for Debian packages via Docker

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Build a Jellyfin .deb file with Docker on Linux
+# Places the output .deb file in the parent directory
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+date="$( date +%s )"
+curdir="$( pwd )"
+tmpdir="$( mktemp -d )"
+curuser="$( whoami )"
+
+docker build ${curdir} --tag jellyfin-debuild-${date} --file ${curdir}/Dockerfile.debian_package
+docker run --volume ${tmpdir}:/temp --interactive --tty jellyfin-debuild-${date} cp --recursive /dist /temp/
+docker image rm jellyfin-debuild-${date} --force
+sudo chown --recursive ${curuser} ${tmpdir}
+mv ${tmpdir}/dist/*.deb ${curdir}/../
+rm --recursive --force ${tmpdir}

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -4,7 +4,6 @@
 # Places the output .deb file in the parent directory
 
 set -o xtrace
-set -o errexit
 set -o nounset
 
 package_temporary_dir="`mktemp -d`"
@@ -16,6 +15,7 @@ cleanup() {
     test -d "$package_temporary_dir" && rm -r "$package_temporary_dir"
 }
 trap cleanup EXIT
+trap cleanup INT
 
 docker build . -t "$image_name" -f ./Dockerfile.debian_package
 docker run --rm -v "$package_temporary_dir:/temp" "$image_name" cp -r /dist /temp/

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -14,10 +14,9 @@ cleanup() {
     docker image rm $image_name --force
     test -d "$package_temporary_dir" && rm -r "$package_temporary_dir"
 }
-trap cleanup EXIT
-trap cleanup INT
+trap cleanup EXIT INT
 
-docker build . -t "$image_name" -f ./Dockerfile.debian_package
-docker run --rm -v "$package_temporary_dir:/temp" "$image_name" cp -r /dist /temp/
-sudo chown -R "$current_user" "$package_temporary_dir"
-mv "$package_temporary_dir"/dist/*.deb ../
+docker build . -t "$image_name" -f ./Dockerfile.debian_package || exit 1
+docker run --rm -v "$package_temporary_dir:/temp" "$image_name" cp -r /dist /temp/ || exit 1
+sudo chown -R "$current_user" "$package_temporary_dir" || exit 1
+mv "$package_temporary_dir"/dist/*.deb ../ || exit 1

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -13,11 +13,11 @@ image_name="jellyfin-debuild"
 
 cleanup() {
     docker image rm $image_name --force
-    test -d ${package_temporary_dir} && rm -r ${package_temporary_dir}
+    test -d "$package_temporary_dir" && rm -r "$package_temporary_dir"
 }
 trap cleanup EXIT
 
-docker build . -t $image_name -f ./Dockerfile.debian_package
-docker run --rm -v $package_temporary_dir:/temp $image_name cp -r /dist /temp/
-sudo chown -R $current_user $package_temporary_dir
-mv $package_temporary_dir/dist/*.deb ../
+docker build . -t "$image_name" -f ./Dockerfile.debian_package
+docker run --rm -v "$package_temporary_dir:/temp" "$image_name" cp -r /dist /temp/
+sudo chown -R "$current_user" "$package_temporary_dir"
+mv "$package_temporary_dir"/dist/*.deb ../


### PR DESCRIPTION
Adds a build script to automate the building of Debian packages using Docker. It fully cleans up after itself and puts the resulting `.deb` in the same place that a normal `dpkg-buildpackage` would (the directory directly above the repository).