### PR TITLE
Lower the ffmpeg stop timeout duration

### DIFF
--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -421,12 +421,15 @@ namespace MediaBrowser.Api
                 return;
             }
 
+            /*
             var timerDuration = 10000;
 
             if (job.Type != TranscodingJobType.Progressive)
             {
                 timerDuration = 60000;
             }
+            */
+            var timerDuration = 2000;
 
             job.PingTimeout = timerDuration;
             job.LastPingDate = DateTime.UtcNow;


### PR DESCRIPTION
As this was, ffmpeg would continue to transcode video for timerDuration
seconds after stopping playback (i.e. returning to the menu). However,
this 60s timeout was a little obnoxious. Tested a 100ms timeout but
this ended up causing playback to constantly terminate. 2s seems like
the sweet spot where playback works normally, but terminating quickly
on stop.

Hotfixing to `master` for quick release as this was a blocking release bug
for 3.5.2-2.