### PR TITLE
Fixed encoding to make it compatible with Weblate

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "LabelPrevious": "Previous",
   "LabelFinish": "Finish",
   "LabelNext": "Next",


### PR DESCRIPTION
This is required as preparation for weblate as the language file started with an UTF-8 BOM header, which broke python json