### PR TITLE
Debian packaging improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin (3.5.2-3) unstable; urgency=medium
+
+  * Correct several bugs in 3.5.2-2 packaging
+
+ -- Joshua Boniface <joshua@boniface.me>  Sat, 15 Dec 2018 18:17:32 -0500
+
 jellyfin (3.5.2-2) unstable; urgency=medium
 
   * Major code updates related to rebranding and cleanup

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: jellyfin
 Section: misc
 Priority: optional
-Maintainer: Vasily <just.one.man@yandex.ru>
+Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
                 dotnet-sdk-2.2,
                 libc6-dev,
@@ -13,6 +13,6 @@ Replaces: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Breaks: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, at, libsqlite3-0, ffmpeg
+Depends: at, libsqlite3-0, ffmpeg, libssl1.0.0 | libssl1.0.2
 Description: Jellyfin is a home media server.
  It is built on top of other popular open source technologies such as Service Stack, jQuery, jQuery mobile, and Mono. It features a REST-based api with built-in documentation to facilitate client development. We also have client libraries for our api to enable rapid development.

--- a/debian/preinst
+++ b/debian/preinst
@@ -53,6 +53,10 @@ case "$1" in
         [[ -f $PIDFILE ]] && rm $PIDFILE
       fi
     fi
+
+    # Clean up old Emby cruft that can break the user's system
+    test -f /etc/sudoers.d/emby && rm -f /etc/sudoers.d/emby
+
     ;;
   abort-upgrade)
     ;;

--- a/debian/preinst
+++ b/debian/preinst
@@ -55,7 +55,7 @@ case "$1" in
     fi
 
     # Clean up old Emby cruft that can break the user's system
-    test -f /etc/sudoers.d/emby && rm -f /etc/sudoers.d/emby
+    [[ -f /etc/sudoers.d/emby ]] && rm -f /etc/sudoers.d/emby
 
     ;;
   abort-upgrade)


### PR DESCRIPTION
Fixes #176 and issues reported in Riot with the latest Debian build.

1. Remove the old Emby `/etc/sudoers.d/emby` cruft which can cause major system breakage on an update from `emby-server` if it is not `purge`'d first.
2. Remove the automated shlib deps and misc deps, as these were creating bad values.
3. Add the explicit libssl1.0.X dependency which is all that seems to really be required.
4. Make the maintainer the team rather than just one of us.
5. Bump up the Debian build version.