### PR TITLE
Fix encoding profile handling for vaapi

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -771,14 +771,18 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var request = state.BaseRequest;
             var profile = state.GetRequestedProfiles(targetVideoCodec).FirstOrDefault();
-            if (string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+
+            // vaapi does not support Baseline profile, force Constrained Baseline in this case,
+            // which is compatible (and ugly)
+            if (string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase) &&
+                profile != null && profile.ToLower().Contains("baseline"))
             {
-                param += " -profile:v 578";
+                    profile = "constrained_baseline";
             }
-            else if (!string.IsNullOrEmpty(profile))
+
+            if (!string.IsNullOrEmpty(profile))
             {
                 if (!string.Equals(videoEncoder, "h264_omx", StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(videoEncoder, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
                 {
                     // not supported by h264_omx


### PR DESCRIPTION
Profile was forced to constrained baseline which is really bad quality, especially with 3s keyframes interval.
Use the specified profile as with other encoders, but force constrained baseline if baseline is specified, since baseline is not supported by vaapi.