### PR TITLE
Remove PUID and PGUID env vars, stop chowning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
 COPY --from=builder /jellyfin /jellyfin
-RUN apt update \
- && apt install -y ffmpeg gosu
 EXPOSE 8096
+RUN apt update \
+ && apt install -y ffmpeg
 VOLUME /config /media
-ENV PUID=1000 PGID=1000
-ENTRYPOINT chown $PUID:$PGID /config /media \
- && gosu $PUID:$PGID dotnet /jellyfin/jellyfin.dll -programdata /config
+ENTRYPOINT if [ -n "$PUID$PGUID" ]; \
+    then echo "PUID/PGID are deprecated. Use Docker user param." >&2; exit 1; \
+    else dotnet /jellyfin/jellyfin.dll -programdata /config; fi


### PR DESCRIPTION
**This is a breaking change for those currently using the `PUID` and `PGID` environment variables.**

The new method is to use Docker's built-in `user` option instead. This will *not* change the permissions of anything.
Ex. `docker run --user 1000:1000 -v /your/dir:/config jellyfin/jellyfin`. 



Resolves https://github.com/jellyfin/jellyfin/issues/220