### PR TITLE
Add aarch64 image

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+ARG DOTNET_VERSION=3.0
+
+FROM microsoft/dotnet:${DOTNET_VERSION}-sdk as builder
+WORKDIR /repo
+COPY . .
+RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+ && find . -type f -exec sed -i 's/netcoreapp2.1/netcoreapp3.0/g' {} \; \
+ && dotnet clean \
+ && dotnet publish --configuration release --output /jellyfin
+
+FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
+COPY --from=builder /jellyfin /jellyfin
+EXPOSE 8096
+RUN apt update \
+ && apt install -y ffmpeg
+VOLUME /config /media
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config


### PR DESCRIPTION
There is no 2 version of the dotnet image for aarch64. Need to use a 3 image for now.