### PR TITLE
Restore the name Emby in manifest.json

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
@@ -3,7 +3,7 @@
   "name": "Emby",
   "short_name": "Emby",
   "start_url": "/web/index.html",
-  "description": "The open media solution.",
+  "description": "Jellyfin: the Free Software media system.",
   "lang": "en-US",
   "related_applications": [
     {

--- a/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
@@ -1,6 +1,7 @@
 ﻿{
-  "name": "Jellyfin",
-  "short_name": "Jellyfin",
+  "_comment": "This should be Jellyfin, but that breaks apps...",
+  "name": "Emby",
+  "short_name": "Emby",
   "start_url": "/web/index.html",
   "description": "The open media solution.",
   "lang": "en-US",


### PR DESCRIPTION
Reenables support for most client apps that were broken by this rename change.