### PR TITLE
Fix default language

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -246,7 +246,7 @@ namespace MediaBrowser.Model.Configuration
             SortRemoveCharacters = new[] { ",", "&", "-", "{", "}", "'" };
             SortRemoveWords = new[] { "the", "a", "an" };
 
-            UICulture = "en-us";
+            UICulture = "en-US";
 
             MetadataOptions = new[]
             {


### PR DESCRIPTION
The default preferred language in the startup wizard now defaults to English (United States).