### PR TITLE
Fix transcoding of AAC from 5.1 to stereo to support Chromecast

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -589,6 +589,22 @@ namespace MediaBrowser.Api.Playback
         }
 
         /// <summary>
+        /// Parses query parameters as StreamOptions
+        /// <summary>
+        /// <param name="request">The stream request.</param>
+        private void ParseStreamOptions(StreamRequest request)
+        {
+            foreach (var param in Request.QueryString) {
+                if (Char.IsLower(param.Name[0])) {
+                    // This was probably not parsed initially and should be a StreamOptions
+                    // TODO: This should be incorporated either in the lower framework for parsing requests
+                    // or the generated URL should correctly serialize it
+                    request.StreamOptions[param.Name] = param.Value;
+                }
+            }
+        }
+
+        /// <summary>
         /// Parses the dlna headers.
         /// </summary>
         /// <param name="request">The request.</param>
@@ -665,6 +681,8 @@ namespace MediaBrowser.Api.Playback
             {
                 ParseParams(request);
             }
+
+            ParseStreamOptions(request);
 
             var url = Request.PathInfo;
 


### PR DESCRIPTION
The chromecast Emby app will request streams with only 2 audio channel. Jellyfin will correctly respond with the following media URL:

```
http://server-ip:8096/emby/videos/<item-id>/stream.mkv?DeviceId=<chromecast-id>&MediaSourceId=<item-id>&VideoCodec=h264,vp8&AudioCodec=aac,mp3,opus,flac,vorbis&AudioStreamIndex=1&VideoBitrate=30000000&AudioBitrate=437308&PlaySessionId=55c6303fb0444e958c05265e6eec08d5&api_key=<auth-token>&TranscodingMaxAudioChannels=6&CopyTimestamps=true&RequireAvc=false&Tag=f5be0495a3fe3ea4947070698c1a5889&h264-profile=high,main,baseline,constrainedbaseline&h264-level=42&aac-audiochannels=2&TranscodeReasons=AudioChannelsNotSupported
```
However, in the `StreamRequest` object, the `aac-audiochannels` will not be added to the `StreamOptions` property, which is later consulted to determine the number of audio channels to be used and configure `ffmpeg` arguments respectively.

Wrong `ffmpeg`:
```
ffmpeg -f mov,mp4,m4a,3gp,3g2,mj2 -i file:"/media/video.mp4" -map 0:0 -map 0:1 -map -0:s -codec:v:0 copy -copyts -avo
id_negative_ts disabled -start_at_zero -vsync -1 -map_metadata -1 -map_chapters -1 -threads 0 -codec:a:0 copy -y "c
ontainer-config/transcoding-temp/44ca2013cd7c8cc13a992f09e0e06da5.mkv"
```

Correct `ffmpeg`:
```
ffmpeg -f mov,mp4,m4a,3gp,3g2,mj2 -i file:"/media/video.mp4" -map 0:0 -map 0:1 -map -0:s -codec:v:0 copy -copyts -avoid_negative_ts disabled -start_at_zero -vsync -1 -map_metadata -1 -map_chapters -1 -threads 0 -codec:a:0 aac -strict experimental -ac 2 -ab 384000 -af "volume=2" -y "container-config/transcoding-temp/0fb069abfe3790e8fcd0d49dc5454556.mkv"
```

This problem arises only for video files with 5.1 channel audio. Video files with stereo sound plays without problems.

I'd like this fix to be elsewhere, but I'm not familiar with .NET enough to be find it a better place for it (or a better fix then checking for lower case chars :) ).