### PR TITLE
Add license from upstream RSSDP project

### DIFF
--- a/RSSDP/LICENSE
+++ b/RSSDP/LICENSE
@@ -1,0 +1,4 @@
+RSSDP
+
+Copyright (c) 2015 Troy Willmot
+Copyright (c) 2015-2018 Luke Pulverenti


### PR DESCRIPTION
Technically, we can import this as GPL'd into the project directly, but the changes might be useful to upstream, so preserving the sublicense is preferable and compatible. Eventual goal is to try to send the changes upstream and remove from the repo to a submodule.

Addresses #350 