### PR TITLE
Clean up EnvironmentInfo

### DIFF
--- a/Emby.Server.Implementations/EnvironmentInfo/EnvironmentInfo.cs
+++ b/Emby.Server.Implementations/EnvironmentInfo/EnvironmentInfo.cs
@@ -8,34 +8,12 @@ namespace Emby.Server.Implementations.EnvironmentInfo
     // TODO: Rework @bond
     public class EnvironmentInfo : IEnvironmentInfo
     {
-        private MediaBrowser.Model.System.OperatingSystem? _customOperatingSystem;
-
-        public virtual MediaBrowser.Model.System.OperatingSystem OperatingSystem
+        public EnvironmentInfo(MediaBrowser.Model.System.OperatingSystem operatingSystem)
         {
-            get
-            {
-                if (_customOperatingSystem.HasValue)
-                {
-                    return _customOperatingSystem.Value;
-                }
-
-                switch (Environment.OSVersion.Platform)
-                {
-                    case PlatformID.MacOSX:
-                        return MediaBrowser.Model.System.OperatingSystem.OSX;
-                    case PlatformID.Win32NT:
-                        return MediaBrowser.Model.System.OperatingSystem.Windows;
-                    case PlatformID.Unix:
-                        return MediaBrowser.Model.System.OperatingSystem.Linux;
-                }
-
-                return MediaBrowser.Model.System.OperatingSystem.Windows;
-            }
-            set
-            {
-                _customOperatingSystem = value;
-            }
+            OperatingSystem = operatingSystem;
         }
+
+        public MediaBrowser.Model.System.OperatingSystem OperatingSystem { get; private set; }
 
         public string OperatingSystemName
         {
@@ -69,7 +47,7 @@ namespace Emby.Server.Implementations.EnvironmentInfo
             }
         }
 
-        public Architecture SystemArchitecture { get; set; }
+        public Architecture SystemArchitecture { get { return RuntimeInformation.OSArchitecture; } }
 
         public string GetEnvironmentVariable(string name)
         {

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -57,7 +57,7 @@ namespace Jellyfin.Server
 
             _logger.LogInformation("Jellyfin version: {Version}", version);
 
-            EnvironmentInfo environmentInfo = getEnvironmentInfo();
+            EnvironmentInfo environmentInfo = new EnvironmentInfo(getOperatingSystem());
             ApplicationHost.LogEnvironmentInfo(_logger, appPaths, environmentInfo);
 
             SQLitePCL.Batteries_V2.Init();
@@ -219,13 +219,6 @@ namespace Jellyfin.Server
 
             return new NullImageEncoder();
         }
-
-        private static EnvironmentInfo getEnvironmentInfo()
-            => new EnvironmentInfo()
-            {
-                SystemArchitecture = RuntimeInformation.OSArchitecture,
-                OperatingSystem = getOperatingSystem()
-            };
 
         private static MediaBrowser.Model.System.OperatingSystem getOperatingSystem() {
             switch (Environment.OSVersion.Platform)


### PR DESCRIPTION
Small change, but ensures `EnvironmentInfo` doesn't get created without an OS