### PR TITLE
Reduce log spam and clean up EncoderValidator

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -139,15 +139,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             var required = codec == Codec.Encoder ? requiredEncoders : requiredDecoders;
 
-            Regex regex = new Regex(@"\s\S{6}\s(?<codec>(\w|-)+)\s{3}");
+            Regex regex = new Regex(@"\s\S{6}\s(?<codec>[\w|-]+)\s{3}");
 
             MatchCollection matches = regex.Matches(output);
 
             var found = matches.Cast<Match>()
                 .Select(x => x.Groups["codec"].Value)
                 .Where(x => required.Contains(x));
-
-            //var found = required.Where(x => output.IndexOf(x, StringComparison.OrdinalIgnoreCase) != -1);
 
             _logger.LogInformation("Available {Codec}: {Codecs}", codecstr, found);
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -139,10 +139,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             var required = codec == Codec.Encoder ? requiredEncoders : requiredDecoders;
 
-            Regex regex = new Regex(@"\s\S{6}\s(?<codec>[\w|-]+)\s{3}");
-
+            Regex regex = new Regex(@"^\s\S{6}\s(?<codec>[\w|-]+)\s+.+$", RegexOptions.Multiline);
             MatchCollection matches = regex.Matches(output);
-
             var found = matches.Cast<Match>()
                 .Select(x => x.Groups["codec"].Value)
                 .Where(x => required.Contains(x));

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -139,9 +139,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             var required = codec == Codec.Encoder ? requiredEncoders : requiredDecoders;
 
-            Regex regex = new Regex(@"^\s\S{6}\s(?<codec>[\w|-]+)\s+.+$", RegexOptions.Multiline);
-            MatchCollection matches = regex.Matches(output);
-            var found = matches.Cast<Match>()
+            var found = Regex
+                .Matches(output, @"^\s\S{6}\s(?<codec>[\w|-]+)\s+.+$", RegexOptions.Multiline)
+                .Cast<Match>()
                 .Select(x => x.Groups["codec"].Value)
                 .Where(x => required.Contains(x));
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -175,8 +175,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 var result = new EncoderValidator(_logger, _processFactory).Validate(FFMpegPath);
 
-                SetAvailableDecoders(result.Item1);
-                SetAvailableEncoders(result.Item2);
+                SetAvailableDecoders(result.decoders);
+                SetAvailableEncoders(result.encoders);
 
                 if (EnableEncoderFontFile)
                 {
@@ -401,14 +401,14 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         private List<string> _encoders = new List<string>();
-        public void SetAvailableEncoders(List<string> list)
+        public void SetAvailableEncoders(IEnumerable<string> list)
         {
             _encoders = list.ToList();
             //_logger.Info("Supported encoders: {0}", string.Join(",", list.ToArray()));
         }
 
         private List<string> _decoders = new List<string>();
-        public void SetAvailableDecoders(List<string> list)
+        public void SetAvailableDecoders(IEnumerable<string> list)
         {
             _decoders = list.ToList();
             //_logger.Info("Supported decoders: {0}", string.Join(",", list.ToArray()));


### PR DESCRIPTION
Don't write each codec on a new line.
Use a regex to match codecs in the ffmpeg output.
ex: https://regex101.com/r/bn9IOy/12/