### PR TITLE
DeviceQuery: change UserId to GUID

### DIFF
--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -145,7 +145,8 @@ namespace Emby.Server.Implementations.Devices
                 HasUser = true
 
             }).Items;
-
+            
+            // TODO: DeviceQuery doesn't seem to be used from client. Not even Swagger.
             if (query.SupportsSync.HasValue)
             {
                 var val = query.SupportsSync.Value;

--- a/MediaBrowser.Model/Devices/DeviceQuery.cs
+++ b/MediaBrowser.Model/Devices/DeviceQuery.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace MediaBrowser.Model.Devices
 {
     public class DeviceQuery
@@ -17,6 +19,6 @@ namespace MediaBrowser.Model.Devices
         /// Gets or sets the user identifier.
         /// </summary>
         /// <value>The user identifier.</value>
-        public string UserId { get; set; }
+        public Guid UserId { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #352

Crash caused by uninstantiated UserId, which for a string defaults to the value `null`. Default value for Guid is Guid.Empty, which is a bunch of zeros but it still has a `.Equals` method.