### PR TITLE
Add Markdown and Docker files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 .git
+.dockerignore
+Dockerfile
+CONTRIBUTORS.md
+README.md

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
  - [Bond_009](https://github.com/Bond-009)
  - [AnthonyLavado](https://github.com/anthonylavado)
  - [sparky8251](https://github.com/sparky8251)
+ - [LeoVerto](https://github.com/LeoVerto]
 
 # Emby Contributors
 


### PR DESCRIPTION
Right now making any changes to the Dockerfile or any of the Markdown files causes subsequent Docker builds to repeat step 5 (`COPY . .`) and all the following ones, including rebuilding jellyfin even when this may not be required.

By adding a .dockerignore file, the `COPY`-step ignores all matching files and thus does not trigger rebuilds on changes to those.