### PR TITLE
Change "who is EmbyServer?" and other udp responders to jellyfin alternatives.

### DIFF
--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -41,6 +41,8 @@ namespace Emby.Server.Implementations.Udp
             _socketFactory = socketFactory;
 
             AddMessageResponder("who is JellyfinServer?", true, RespondToV2Message);
+            AddMessageResponder("who is EmbyServer?", true, RespondToV2Message);
+            AddMessageResponder("who is MediaBrowserServer_v2?", true, RespondToV2Message);
         }
 
         private void AddMessageResponder(string message, bool isSubstring, Func<string, IpEndPointInfo, Encoding, CancellationToken, Task> responder)

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -42,7 +42,7 @@ namespace Emby.Server.Implementations.Udp
 
             AddMessageResponder("who is JellyfinServer?", true, RespondToV2Message);
             AddMessageResponder("who is EmbyServer?", true, RespondToV2Message);
-            AddMessageResponder("who is MediaBrowserServer_v2?", true, RespondToV2Message);
+            AddMessageResponder("who is MediaBrowserServer_v2?", false, RespondToV2Message);
         }
 
         private void AddMessageResponder(string message, bool isSubstring, Func<string, IpEndPointInfo, Encoding, CancellationToken, Task> responder)

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -41,7 +41,6 @@ namespace Emby.Server.Implementations.Udp
             _socketFactory = socketFactory;
 
             AddMessageResponder("who is JellyfinServer?", true, RespondToV2Message);
-            AddMessageResponder("who is Jellyfin?", true, RespondToV2Message);
         }
 
         private void AddMessageResponder(string message, bool isSubstring, Func<string, IpEndPointInfo, Encoding, CancellationToken, Task> responder)

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -40,8 +40,8 @@ namespace Emby.Server.Implementations.Udp
             _json = json;
             _socketFactory = socketFactory;
 
-            AddMessageResponder("who is EmbyServer?", true, RespondToV2Message);
-            AddMessageResponder("who is MediaBrowserServer_v2?", false, RespondToV2Message);
+            AddMessageResponder("who is JellyfinServer?", true, RespondToV2Message);
+            AddMessageResponder("who is Jellyfin?", true, RespondToV2Message);
         }
 
         private void AddMessageResponder(string message, bool isSubstring, Func<string, IpEndPointInfo, Encoding, CancellationToken, Task> responder)


### PR DESCRIPTION
use "who is JellyfinServer?" and "who is Jellyfin?" instead of emby specific ones.

Resolves #395 