### PR TITLE
Change Dockerfile to use ffmpeg 4.0.3 rather than a distro one.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@ FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 
-#RUN apt update \
-# && apt install -y ffmpeg
-#Use a ffmpeg 4.0.3 build for now, until we have our own (fixes chromecasts and androidtv app)
-
 VOLUME /config /media
 
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG DOTNET_VERSION=2
+ARG FFMPEG_URL=https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
 
 FROM microsoft/dotnet:${DOTNET_VERSION}-sdk as builder
 WORKDIR /repo
@@ -13,15 +14,10 @@ EXPOSE 8096
 
 VOLUME /config /media
 
-RUN apt update
-RUN apt install -y wget xz-utils
-RUN mkdir /ffmpeg
-WORKDIR /ffmpeg
-RUN wget https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
-RUN tar xf /ffmpeg/ffmpeg-4.0.3-64bit-static.tar.xz
-RUN ln -s /ffmpeg/ffmpeg-4.0.3-64bit-static/ffmpeg /usr/local/sbin/ffmpeg
-RUN ln -s /ffmpeg/ffmpeg-4.0.3-64bit-static/ffprobe /usr/local/sbin/ffprobe
-
+RUN apt update \
+ && apt install -y xz-utils \
+ && curl ${FFMPEG_URL} | tar Jxf - -C /usr/bin --wildcards --strip-components=1 ffmpeg*/ffmpeg ffmpeg*/ffprobe \
+ && apt remove -y xz-utils
 
 ENTRYPOINT if [ -n "$PUID$PGUID" ]; \
     then echo "PUID/PGID are deprecated. Use Docker user param." >&2; exit 1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG DOTNET_VERSION=2
-ARG FFMPEG_URL=https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
 
 FROM microsoft/dotnet:${DOTNET_VERSION}-sdk as builder
 WORKDIR /repo
@@ -14,6 +13,7 @@ EXPOSE 8096
 
 VOLUME /config /media
 
+ARG FFMPEG_URL=https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
 RUN apt update \
  && apt install -y xz-utils \
  && curl ${FFMPEG_URL} | tar Jxf - -C /usr/bin --wildcards --strip-components=1 ffmpeg*/ffmpeg ffmpeg*/ffprobe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,23 @@ RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
-RUN apt update \
- && apt install -y ffmpeg
+
+#RUN apt update \
+# && apt install -y ffmpeg
+#Use a ffmpeg 4.0.3 build for now, until we have our own (fixes chromecasts and androidtv app)
+
 VOLUME /config /media
+
+RUN apt update
+RUN apt install -y wget xz-utils
+RUN mkdir /ffmpeg
+WORKDIR /ffmpeg
+RUN wget https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
+RUN tar xf /ffmpeg/ffmpeg-4.0.3-64bit-static.tar.xz
+RUN ln -s /ffmpeg/ffmpeg-4.0.3-64bit-static/ffmpeg /usr/local/sbin/ffmpeg
+RUN ln -s /ffmpeg/ffmpeg-4.0.3-64bit-static/ffprobe /usr/local/sbin/ffprobe
+
+
 ENTRYPOINT if [ -n "$PUID$PGUID" ]; \
     then echo "PUID/PGID are deprecated. Use Docker user param." >&2; exit 1; \
     else dotnet /jellyfin/jellyfin.dll -programdata /config; fi


### PR DESCRIPTION
This fixes the issue with chromecasts (#307 ) in docker scenarios also allows the androidtv app to work.

This is a stop-gap solution until we have our own ffmpeg builds.