### PR TITLE
Readd System import to correct Array failure

### DIFF
--- a/MediaBrowser.Model/Session/ClientCapabilities.cs
+++ b/MediaBrowser.Model/Session/ClientCapabilities.cs
@@ -1,4 +1,5 @@
 ﻿using MediaBrowser.Model.Dlna;
+using System;
 
 namespace MediaBrowser.Model.Session
 {


### PR DESCRIPTION
Fixes a build bug introduced in #383 .

```
Session/ClientCapabilities.cs(25,34): error CS0103: The name 'Array' does not exist in the current context [/var/home/joshua/Projects/Emby/jellyfin/MediaBrowser.Model/MediaBrowser.Model.csproj]
```