### PR TITLE
Update readme to use readthedocs and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,36 @@
 <h1 align="center">Jellyfin</h1>
 <h3 align="center">The Free Software Media System</h3>
 
-<p align="center">
-Jellyfin is a free software media system that puts you in control of managing and streaming your media.
-</p>
-
------
+---
 
 <p align="center">
-<strong>Want to get started?</strong> Choose from <a href="https://github.com/jellyfin/jellyfin/wiki/Prebuilt-Packages">Prebuilt Packages</a>, or <a href="https://github.com/jellyfin/jellyfin/wiki/Building-from-Source">Build from Source</a>.
-</p>
-<p align="center">
-<strong>Want to contribute?</strong> Check out <a href="https://github.com/jellyfin/jellyfin/wiki/Contributing-to-Jellyfin">our wiki for guidelines</a>.
+<img alt="Logo banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<br/></br>
+<a href="https://github.com/jellyfin/jellyfin"><img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin.svg"></a>
+<a href="https://cloud.drone.io/jellyfin/jellyfin"><img alt="Build Status" src="https://cloud.drone.io/api/badges/jellyfin/jellyfin/status.svg"></a>
+<a href="https://hub.docker.com/r/jellyfin/jellyfin"><img alt="Docker Pull Count" src="https://img.shields.io/docker/pulls/jellyfin/jellyfin.svg"></a>
+<a href="https://jellyfin.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/readthedocs/jellyfin.svg"></a>
+<a href="https://matrix.to/#/+jellyfin:matrix.org"><img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"></a>
+<a href="https://www.reddit.com/r/jellyfin/"><img alt="Join our Subreddit" src="https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg"></a>
 </p>
 
 ---
 
-<p align="center">
-<a href="https://github.com/jellyfin/jellyfin"><img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin.svg"></a>
-<a href="https://cloud.drone.io/jellyfin/jellyfin"><img alt="Build Status" src="https://cloud.drone.io/api/badges/jellyfin/jellyfin/status.svg"></a>
-<a href="https://hub.docker.com/r/jellyfin/jellyfin"><img alt="Docker Pull Count" src="https://img.shields.io/docker/pulls/jellyfin/jellyfin.svg"></a>
-<a href="https://matrix.to/#/#jellyfin:matrix.org"><img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"></a>
-<a href="https://www.reddit.com/r/jellyfin/"><img alt="Join our Subreddit" src="https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg"></a>
-</p>
+Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!
 
-For further details, please see [our wiki](https://github.com/jellyfin/jellyfin/wiki).
+For further details, please see [our documentation page](https://jellyfin.readthedocs.io). To receive the latest updates, get help with Jellyfin, and join the community, please visit [one of our communication channels on Matrix/Riot or social media](https://jellyfin.readthedocs.io/en/latest/user-docs/getting-help).
 
-To receive the latest updates, please visit [our public chat on Matrix/Riot](https://matrix.to/#/#jellyfin:matrix.org), our [announce chat](https://matrix.to/#/#jellyfin-announce:matrix.org) for release info, and follow us on [Social Media](https://github.com/jellyfin/jellyfin/wiki/Social-Media).
-
-## About
-
-The Jellyfin project was started as a result of Emby's decision to take their code closed-source, as well as various philosophical differences with the core developers. Jellyfin seeks to be the free software alternative to Emby and Plex to provide media management and streaming from a dedicated server to end-user devices.
-
-Jellyfin is descended from Emby 3.5.2, ported to the .NET Core framework, and aims to contain build facilities for every platform.
-
-## Issues and Feature Requests
-
-
+For more information about the project, please see our [about page](https://jellyfin.readthedocs.io/en/latest/about/).
 
 <p align="center">
-  <strong>New idea or improvement?</strong>
-<em>Open a <a href="https://github.com/jellyfin/jellyfin/wiki/Feature-Requests">Feature Request</a>.</em>
+<strong>Want to get started?</strong>
+<em>Choose from <a href="https://jellyfin.readthedocs.io/en/latest/user-docs/installing/">Prebuilt Packages</a> or <a href="https://jellyfin.readthedocs.io/en/latest/user-docs/building/">Build from Source</a>, then see our <a href="https://jellyfin.readthedocs.io/en/latest/user-docs/quick-start/">Quickstart guide</a>.</em>
 </p>
 <p align="center">
-  <Strong>Something not working right?</strong>
-<em>Open an <a href="https://github.com/jellyfin/jellyfin/wiki/Issue-Guidelines">Issue</a>.</em>
+<strong>Want to contribute?</strong>
+<em>Check out <a href="https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/">our documentation for guidelines</a>.</em>
 </p>
-
-
-## Contributing to Jellyfin
-
-If you're interested in contributing, please see [our wiki for guidelines](https://github.com/jellyfin/jellyfin/wiki/Contributing-to-Jellyfin).
+<p align="center">
+<strong>New idea or improvement? Something not working right?</strong>
+<em>Open an <a href="https://jellyfin.readthedocs.io/en/latest/developer-docs/issues/">Issue</a>.</em>
+</p>


### PR DESCRIPTION
1. Replace all Wiki references to Readthedocs.io references
2. Clean up the layout a bit, remove some redundant bits and make
"about" bits consistent between Docs and README