### PR TITLE
Fix startup of Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN apt update \
 
 ENTRYPOINT if [ -n "$PUID$PGUID" ]; \
     then echo "PUID/PGID are deprecated. Use Docker user param." >&2; exit 1; \
-    else dotnet /jellyfin/jellyfin.dll -programdata /config; fi
+    else dotnet /jellyfin/jellyfin.dll -programdata /config -configdir /config/config; fi

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,4 +14,4 @@ EXPOSE 8096
 RUN apt update \
  && apt install -y ffmpeg
 VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config -configdir /config/config


### PR DESCRIPTION
Latest Docker container fails with:
```
Unhandled Exception: System.UnauthorizedAccessException: Access to the path '/.local/share/jellyfin' is denied. ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath)
   at System.IO.Directory.CreateDirectory(String path)
   at Jellyfin.Server.Program.createApplicationPaths(StartupOptions options) in /repo/Jellyfin.Server/Program.cs:line 152
   at Jellyfin.Server.Program.Main(String[] args) in /repo/Jellyfin.Server/Program.cs:line 49
   at Jellyfin.Server.Program.<Main>(String[] args)
Aborted (core dumped)
```

This seems to be because of PR #428, which no longer puts `${-configdir}` under `${-programdata}/config` by default if not specified. This causes the Docker container to fail booting, because it tries to create `/.local/share/jellyfin`, which may fail if the container is not run with less privileged user.

A simple fix is to just add `-configdir /config/config` to the `Dockerfile` to keep it compatible with the previous format for the container.

I was thinking of creating another volume for the `/programdata` (along the `/config` and `/media`), but I couldn't convince myself it will bring any benefit. If there are use cases you know about, I have no objections of changing it :)