### PR TITLE
Hotfix to postinst to correct permissions

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,21 +25,22 @@ case "$1" in
       adduser --system --ingroup jellyfin --shell /bin/false jellyfin --no-create-home --home ${PROGRAMDATA} \
         --gecos "Jellyfin default user" > /dev/null 2>&1
     fi
-    # ensure $PROGRAMDATA has appropriate permissions
+    # ensure $PROGRAMDATA exists
     if [[ ! -d $PROGRAMDATA ]]; then
       mkdir $PROGRAMDATA
-      chown -R jellyfin:jellyfin $PROGRAMDATA
     fi
-    # ensure $JELLYFIN_CONFIG_DIRECTORY has appropriate permissions
-    if [[ -n $JELLYFIN_CONFIG_DIRECTORY && ! -d $JELLYFIN_CONFIG_DIRECTORY ]]; then
-      mkdir $JELLYFIN_CONFIG_DIRECTORY
-      chown -R jellyfin:jellyfin $JELLYFIN_CONFIG_DIRECTORY
+    # ensure $CONFIGDATA exists
+    if [[ ! -d $CONFIGDATA ]]; then
+      mkdir $CONFIGDATA
     fi
-    # ensure $JELLYFIN_LOG_DIRECTORY has appropriate permissions
-    if [[ -n $JELLYFIN_LOG_DIRECTORY && ! -d $JELLYFIN_LOG_DIRECTORY ]]; then
-      mkdir $JELLYFIN_LOG_DIRECTORY
-      chown -R jellyfin:jellyfin $JELLYFIN_LOG_DIRECTORY
+    # ensure $LOGDATA exists
+    if [[ ! -d $LOGDATA ]]; then
+      mkdir $LOGDATA
     fi
+    # Ensure permissions are correct on all config directories
+    chown -R jellyfin:jellyfin $PROGRAMDATA
+    chown -R jellyfin:jellyfin $CONFIGDATA
+    chown -R jellyfin:jellyfin $LOGDATA
 
     chmod +x /usr/lib/jellyfin/restart.sh > /dev/null 2>&1 || true
 


### PR DESCRIPTION
Without this, if not importing a previous config, the perms are broken on the config directories. Fixes this.