### PR TITLE
Download ffmpeg in a separate layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 ARG DOTNET_VERSION=2
 
+
+# Download ffmpeg first to allow quicker rebuild of other layers
+FROM alpine as ffmpeg
+ARG FFMPEG_URL=https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
+RUN wget ${FFMPEG_URL} -O - | tar Jxf - \
+ && mkdir ffmpeg-bin \
+ && mv ffmpeg*/ffmpeg ffmpeg-bin \
+ && mv ffmpeg*/ffprobe ffmpeg-bin
+
+
 FROM microsoft/dotnet:${DOTNET_VERSION}-sdk as builder
 WORKDIR /repo
 COPY . .
@@ -7,17 +17,12 @@ RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
  && dotnet clean \
  && dotnet publish --configuration release --output /jellyfin
 
+
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
 COPY --from=builder /jellyfin /jellyfin
+COPY --from=ffmpeg /ffmpeg-bin/* /usr/bin/
 EXPOSE 8096
-
 VOLUME /config /media
-
-ARG FFMPEG_URL=https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz
 RUN apt update \
- && apt install -y xz-utils \
- && curl ${FFMPEG_URL} | tar Jxf - -C /usr/bin --wildcards --strip-components=1 ffmpeg*/ffmpeg ffmpeg*/ffprobe \
- && apt remove -y xz-utils \
  && apt install -y libfontconfig1  # needed for Skia
-
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config


### PR DESCRIPTION
This slightly speeds up rebuilding since the ffmpeg layer cache is used
even when Jellyfin source is changed.