### PR TITLE
Move all built files out of docker image

### DIFF
--- a/Dockerfile.debian_package
+++ b/Dockerfile.debian_package
@@ -17,6 +17,6 @@ COPY . .
 RUN yes|mk-build-deps -i \
  && dpkg-buildpackage -us -uc \
  && mkdir /dist \
- && mv /jellyfin*deb /dist
+ && mv /jellyfin* /dist
 
 WORKDIR /dist

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -21,4 +21,4 @@ trap cleanup EXIT INT
 docker build . -t "$image_name" -f ./Dockerfile.debian_package
 docker run --rm -v "$package_temporary_dir:/temp" "$image_name" cp -r /dist /temp/
 sudo chown -R "$current_user" "$package_temporary_dir"
-mv "$package_temporary_dir"/dist/*.deb ../
+mv "$package_temporary_dir"/dist/* ../


### PR DESCRIPTION
Allows the extraction of the `.dsc` and source packages.