### PR TITLE
Support `*.log` files in browser log viewer

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -183,6 +183,10 @@ namespace MediaBrowser.Model.Net
             {
                 return "text/plain";
             }
+            if (StringHelper.EqualsIgnoreCase(ext, ".log"))
+            {
+                return "text/plain";
+            }
             if (StringHelper.EqualsIgnoreCase(ext, ".xml"))
             {
                 return "application/xml";


### PR DESCRIPTION
Fixes #485

Looks like we regressed and now only the .txt logs would open in the browser when clicked. 

Added in MimeType handler for .log files. Problem solved.