### PR TITLE
Fixed odd formatting in MimeType.CS

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -228,10 +228,10 @@ namespace MediaBrowser.Model.Net
             if (StringHelper.EqualsIgnoreCase(ext, ".oga"))
             {
                 return "audio/ogg";
-			}
-			if (StringHelper.EqualsIgnoreCase(ext, ".opus"))
-			{
-				return "audio/ogg";
+            }
+            if (StringHelper.EqualsIgnoreCase(ext, ".opus"))
+            {
+                return "audio/ogg";
             }
             if (StringHelper.EqualsIgnoreCase(ext, ".ac3"))
             {


### PR DESCRIPTION
Think there might have been a mismatch between tabs and spaces. All spaces now.