### PR TITLE
Fix userprofile.js crash

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/myprofile.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/myprofile.js
@@ -14,7 +14,7 @@ define(["scripts/userpasswordpage", "loading", "libraryMenu", "apphost", "emby-l
                 type: "Primary"
             }) : "css/images/logindefault.png", fldImage.classList.remove("hide"), fldImage.innerHTML = "<img width='140px' src='" + imageUrl + "' />";
             var showImageEditing = !1;
-            "Guest" == user.ConnectLinkType ? page.querySelector(".connectMessage").classList.remove("hide") : (user.PrimaryImageTag, showImageEditing = !0, page.querySelector(".connectMessage").classList.add("hide")), Dashboard.getCurrentUser().then(function(loggedInUser) {
+            Dashboard.getCurrentUser().then(function(loggedInUser) {
                 showImageEditing && appHost.supports("fileinput") && (loggedInUser.Policy.IsAdministrator || user.Policy.EnableUserPreferenceAccess) ? (page.querySelector(".newImageForm").classList.remove("hide"), user.PrimaryImageTag ? page.querySelector("#btnDeleteImage").classList.remove("hide") : page.querySelector("#btnDeleteImage").classList.add("hide")) : (page.querySelector(".newImageForm").classList.add("hide"), page.querySelector("#btnDeleteImage").classList.add("hide"))
             }), loading.hide()
         })


### PR DESCRIPTION
Fixes #483

Crash caused the endless loading circle.

Crash prevented password changes, icon updates, and easy pin code changes.

This pulls the fix from #412. Can Either merge this or reject it and merge the whole of #412.