### PR TITLE
Change contributing link in settings to readthedocs.io

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/dashboardgeneral.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/dashboardgeneral.html
@@ -18,7 +18,7 @@
                         <div class="fieldDescription">
                             <div>${LabelPreferredDisplayLanguageHelp}</div>
                             <div style="margin-top: .25em;">
-                                <a is="emby-linkbutton" class="button-link" href="https://github.com/jellyfin/jellyfin" target="_blank">${LabelReadHowYouCanContribute}</a>
+                                <a is="emby-linkbutton" class="button-link" href="https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/" target="_blank">${LabelReadHowYouCanContribute}</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Change link text in settings for "Learn how you can contribute" to readthedocs.io contributing entry rather than GitHub repo.