### PR TITLE
Fix regression in integer divisions in latest movies category

### DIFF
--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -1056,7 +1056,7 @@ namespace Emby.Server.Implementations.LiveTv
             var numComplete = 0;
             double progressPerService = _services.Length == 0
                 ? 0
-                : 1 / _services.Length;
+                : 1.0 / _services.Length;
 
             var newChannelIdList = new List<Guid>();
             var newProgramIdList = new List<Guid>();
@@ -1262,7 +1262,7 @@ namespace Emby.Server.Implementations.LiveTv
                 }
 
                 numComplete++;
-                double percent = numComplete / allChannelsList.Count;
+                double percent = numComplete / (double) allChannelsList.Count;
 
                 progress.Report(85 * percent + 15);
             }
@@ -1307,7 +1307,7 @@ namespace Emby.Server.Implementations.LiveTv
                 }
 
                 numComplete++;
-                double percent = numComplete / list.Count;
+                double percent = numComplete / (double) list.Count;
 
                 progress.Report(100 * percent);
             }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
@@ -65,7 +65,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 
             foreach (var file in filesToDelete)
             {
-                double percent = index / filesToDelete.Count;
+                double percent = index / (double) filesToDelete.Count;
 
                 progress.Report(100 * percent);
 

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -64,7 +64,7 @@ namespace MediaBrowser.Controller.Entities.Movies
         }
 
         public override double GetDefaultPrimaryImageAspectRatio()
-            => 2 / 3;
+            => 2.0 / 3;
 
         public override UnratedItem GetBlockUnratedType()
         {

--- a/MediaBrowser.Controller/Entities/Movies/Movie.cs
+++ b/MediaBrowser.Controller/Entities/Movies/Movie.cs
@@ -51,7 +51,7 @@ namespace MediaBrowser.Controller.Entities.Movies
                 return 0;
             }
 
-            return 2 / 3;
+            return 2.0 / 3;
         }
 
         protected override async Task<bool> RefreshedOwnedItems(MetadataRefreshOptions options, List<FileSystemMetadata> fileSystemChildren, CancellationToken cancellationToken)

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -111,7 +111,7 @@ namespace MediaBrowser.Controller.Entities.TV
                 return 0;
             }
 
-            return 16 / 9;
+            return 16.0 / 9;
         }
 
         public override List<string> GetUserDataKeys()

--- a/MediaBrowser.Controller/Entities/Trailer.cs
+++ b/MediaBrowser.Controller/Entities/Trailer.cs
@@ -21,7 +21,7 @@ namespace MediaBrowser.Controller.Entities
         public TrailerType[] TrailerTypes { get; set; }
 
         public override double GetDefaultPrimaryImageAspectRatio()
-            => 2 / 3;
+            => 2.0 / 3;
 
         public override UnratedItem GetBlockUnratedType()
         {

--- a/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
@@ -54,11 +54,11 @@ namespace MediaBrowser.Controller.LiveTv
 
             if (string.Equals(serviceName, EmbyServiceName, StringComparison.OrdinalIgnoreCase) || string.Equals(serviceName, "Next Pvr", StringComparison.OrdinalIgnoreCase))
             {
-                return 2 / 3;
+                return 2.0 / 3;
             }
             else
             {
-                return 16 / 9;
+                return 16.0 / 9;
             }
         }
 


### PR DESCRIPTION
As discussed right now in the #jellyfin-dev chat, the GPL cleanup made a regression where double division turned into integer division

Fixes #489