### PR TITLE
Fix CONTRIBUTORS.md formatting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@
  - [Bond_009](https://github.com/Bond-009)
  - [AnthonyLavado](https://github.com/anthonylavado)
  - [sparky8251](https://github.com/sparky8251)
- - [LeoVerto](https://github.com/LeoVerto]
+ - [LeoVerto](https://github.com/LeoVerto)
 
 # Emby Contributors
 


### PR DESCRIPTION
Looks like *someone* managed to mess up formatting the link to their profile in CONTRIBUTORS.md.