### PR TITLE
Remove useless properties from IEnvironmentInfo

### DIFF
--- a/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
+++ b/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
@@ -44,13 +44,13 @@ namespace IsoMounter
             _logger.LogDebug(
                 "[{0}] System PATH is currently set to [{1}].",
                 Name,
-                EnvironmentInfo.GetEnvironmentVariable("PATH") ?? ""
+                Environment.GetEnvironmentVariable("PATH") ?? ""
             );
 
             _logger.LogDebug(
                 "[{0}] System path separator is [{1}].",
                 Name,
-                EnvironmentInfo.PathSeparator
+                Path.PathSeparator
             );
 
             _logger.LogDebug(
@@ -118,25 +118,27 @@ namespace IsoMounter
         public bool CanMount(string path)
         {
 
-            if (EnvironmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.Linux) {
-                _logger.LogInformation(
-                    "[{0}] Checking we can attempt to mount [{1}], Extension = [{2}], Operating System = [{3}], Executables Available = [{4}].",
-                    Name,
-                    path,
-                    Path.GetExtension(path),
-                    EnvironmentInfo.OperatingSystem,
-                    ExecutablesAvailable.ToString()
-                );
-
-                if (ExecutablesAvailable) {
-                    return string.Equals(Path.GetExtension(path), ".iso", StringComparison.OrdinalIgnoreCase);
-                } else {
-                    return false;
-                }
-            } else {
+            if (EnvironmentInfo.OperatingSystem != MediaBrowser.Model.System.OperatingSystem.Linux)
+            {
                 return false;
             }
+            _logger.LogInformation(
+                "[{0}] Checking we can attempt to mount [{1}], Extension = [{2}], Operating System = [{3}], Executables Available = [{4}].",
+                Name,
+                path,
+                Path.GetExtension(path),
+                EnvironmentInfo.OperatingSystem,
+                ExecutablesAvailable.ToString()
+            );
 
+            if (ExecutablesAvailable)
+            {
+                return string.Equals(Path.GetExtension(path), ".iso", StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public Task Install(CancellationToken cancellationToken)
@@ -211,18 +213,16 @@ namespace IsoMounter
         private string GetFullPathForExecutable(string name)
         {
 
-            foreach (string test in (EnvironmentInfo.GetEnvironmentVariable("PATH") ?? "").Split(EnvironmentInfo.PathSeparator)) {
-
+            foreach (string test in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+            {
                 string path = test.Trim();
 
                 if (!String.IsNullOrEmpty(path) && FileSystem.FileExists(path = Path.Combine(path, name))) {
                     return FileSystem.GetFullPath(path);
                 }
-
             }
 
-            return String.Empty;
-
+            return string.Empty;
         }
 
         private uint GetUID()
@@ -315,9 +315,9 @@ namespace IsoMounter
                 );
 
             } else {
-                
+
                 throw new ArgumentNullException(nameof(isoPath));
-            
+
             }
 
             try
@@ -397,9 +397,9 @@ namespace IsoMounter
                 );
 
             } else {
-                
+
                 throw new ArgumentNullException(nameof(mount));
-            
+
             }
 
             if (GetUID() == 0) {
@@ -444,7 +444,7 @@ namespace IsoMounter
         }
 
         #endregion
-  
+
         #region Internal Methods
 
         internal void OnUnmount(LinuxMount mount)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1188,8 +1188,7 @@ namespace Emby.Server.Implementations
                 HttpClient,
                 ZipClient,
                 ProcessFactory,
-                5000,
-                EnvironmentInfo);
+                5000);
 
             MediaEncoder = mediaEncoder;
             RegisterSingleInstance(MediaEncoder);
@@ -1647,25 +1646,25 @@ namespace Emby.Server.Implementations
             // Gets all plugin assemblies by first reading all bytes of the .dll and calling Assembly.Load against that
             // This will prevent the .dll file from getting locked, and allow us to replace it when needed
 
-            // Include composable parts in the Api assembly 
+            // Include composable parts in the Api assembly
             list.Add(GetAssembly(typeof(ApiEntryPoint)));
 
-            // Include composable parts in the Dashboard assembly 
+            // Include composable parts in the Dashboard assembly
             list.Add(GetAssembly(typeof(DashboardService)));
 
-            // Include composable parts in the Model assembly 
+            // Include composable parts in the Model assembly
             list.Add(GetAssembly(typeof(SystemInfo)));
 
-            // Include composable parts in the Common assembly 
+            // Include composable parts in the Common assembly
             list.Add(GetAssembly(typeof(IApplicationHost)));
 
-            // Include composable parts in the Controller assembly 
+            // Include composable parts in the Controller assembly
             list.Add(GetAssembly(typeof(IServerApplicationHost)));
 
-            // Include composable parts in the Providers assembly 
+            // Include composable parts in the Providers assembly
             list.Add(GetAssembly(typeof(ProviderUtils)));
 
-            // Include composable parts in the Photos assembly 
+            // Include composable parts in the Photos assembly
             list.Add(GetAssembly(typeof(PhotoProvider)));
 
             // Emby.Server implementations
@@ -1674,16 +1673,16 @@ namespace Emby.Server.Implementations
             // MediaEncoding
             list.Add(GetAssembly(typeof(MediaBrowser.MediaEncoding.Encoder.MediaEncoder)));
 
-            // Dlna 
+            // Dlna
             list.Add(GetAssembly(typeof(DlnaEntryPoint)));
 
-            // Local metadata 
+            // Local metadata
             list.Add(GetAssembly(typeof(BoxSetXmlSaver)));
 
             // Notifications
             list.Add(GetAssembly(typeof(NotificationManager)));
 
-            // Xbmc 
+            // Xbmc
             list.Add(GetAssembly(typeof(ArtistNfoProvider)));
 
             list.AddRange(GetAssembliesWithPartsInternal().Select(i => new Tuple<Assembly, string>(i, null)));
@@ -2219,7 +2218,7 @@ namespace Emby.Server.Implementations
         }
 
         /// <summary>
-        /// This returns localhost in the case of no external dns, and the hostname if the 
+        /// This returns localhost in the case of no external dns, and the hostname if the
         /// dns is prefixed with a valid Uri prefix.
         /// </summary>
         /// <param name="externalDns">The external dns prefix to get the hostname of.</param>

--- a/Emby.Server.Implementations/EnvironmentInfo/EnvironmentInfo.cs
+++ b/Emby.Server.Implementations/EnvironmentInfo/EnvironmentInfo.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.IO;
 using MediaBrowser.Model.System;
 using System.Runtime.InteropServices;
 
 namespace Emby.Server.Implementations.EnvironmentInfo
 {
-    // TODO: Rework @bond
     public class EnvironmentInfo : IEnvironmentInfo
     {
         public EnvironmentInfo(MediaBrowser.Model.System.OperatingSystem operatingSystem)
@@ -39,29 +37,6 @@ namespace Emby.Server.Implementations.EnvironmentInfo
             }
         }
 
-        public char PathSeparator
-        {
-            get
-            {
-                return Path.PathSeparator;
-            }
-        }
-
         public Architecture SystemArchitecture { get { return RuntimeInformation.OSArchitecture; } }
-
-        public string GetEnvironmentVariable(string name)
-        {
-            return Environment.GetEnvironmentVariable(name);
-        }
-
-        public string StackTrace
-        {
-            get { return Environment.StackTrace; }
-        }
-
-        public void SetProcessEnvironmentVariable(string name, string value)
-        {
-            Environment.SetEnvironmentVariable(name, value);
-        }
     }
 }

--- a/MediaBrowser.Model/System/IEnvironmentInfo.cs
+++ b/MediaBrowser.Model/System/IEnvironmentInfo.cs
@@ -8,10 +8,6 @@ namespace MediaBrowser.Model.System
         string OperatingSystemName { get; }
         string OperatingSystemVersion { get; }
         Architecture SystemArchitecture { get; }
-        string GetEnvironmentVariable(string name);
-        void SetProcessEnvironmentVariable(string name, string value);
-        string StackTrace { get; }
-        char PathSeparator { get; }
     }
 
     public enum OperatingSystem


### PR DESCRIPTION
These are easily accessible from the standard lib.