### PR TITLE
Fix potential bug where aspect ratio would be incorrectly calculated

### DIFF
--- a/MediaBrowser.Controller/Entities/Photo.cs
+++ b/MediaBrowser.Controller/Entities/Photo.cs
@@ -79,8 +79,7 @@ namespace MediaBrowser.Controller.Entities
                     }
                 }
 
-                width /= Height.Value;
-                return width;
+                return width / height;
             }
 
             return base.GetDefaultPrimaryImageAspectRatio();


### PR DESCRIPTION
Just came across this function. If the image is flipped it would swap the width and height variables but still divide by the original height. For a flipped image this would lead to `return height / height` so this fixes that. I think it will save us some hunting in the future. But to be honest, I would like to evaluate if we need this aspect ratio magic. I would assume that the frontend would handle aspect ratios