### PR TITLE
Master 10.0.1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@
  - [Bond_009](https://github.com/Bond-009)
  - [AnthonyLavado](https://github.com/anthonylavado)
  - [sparky8251](https://github.com/sparky8251)
- - [LeoVerto](https://github.com/LeoVerto]
+ - [LeoVerto](https://github.com/LeoVerto)
 
 # Emby Contributors
 

--- a/Emby.Drawing/Common/ImageHeader.cs
+++ b/Emby.Drawing/Common/ImageHeader.cs
@@ -121,7 +121,7 @@ namespace Emby.Drawing.Common
         /// </summary>
         /// <param name="binaryReader">The binary reader.</param>
         /// <returns>System.Int16.</returns>
-        private static short ReadLittleEndianInt16(BinaryReader binaryReader)
+        private static short ReadLittleEndianInt16(this BinaryReader binaryReader)
         {
             var bytes = new byte[sizeof(short)];
 
@@ -137,7 +137,7 @@ namespace Emby.Drawing.Common
         /// </summary>
         /// <param name="binaryReader">The binary reader.</param>
         /// <returns>System.Int32.</returns>
-        private static int ReadLittleEndianInt32(BinaryReader binaryReader)
+        private static int ReadLittleEndianInt32(this BinaryReader binaryReader)
         {
             var bytes = new byte[sizeof(int)];
             for (int i = 0; i < sizeof(int); i += 1)
@@ -205,25 +205,30 @@ namespace Emby.Drawing.Common
         /// <exception cref="System.ArgumentException"></exception>
         private static ImageSize DecodeJfif(BinaryReader binaryReader)
         {
+            // A JPEG image consists of a sequence of segments,
+            // each beginning with a marker, each of which begins with a 0xFF byte
+            // followed by a byte indicating what kind of marker it is.
+            // Source: https://en.wikipedia.org/wiki/JPEG#Syntax_and_structure
             while (binaryReader.ReadByte() == 0xff)
             {
                 byte marker = binaryReader.ReadByte();
-                short chunkLength = ReadLittleEndianInt16(binaryReader);
-                if (marker == 0xc0)
+                short chunkLength = binaryReader.ReadLittleEndianInt16();
+                // SOF0: Indicates that this is a baseline DCT-based JPEG,
+                // and specifies the width, height, number of components, and component subsampling
+                // SOF2: Indicates that this is a progressive DCT-based JPEG,
+                // and specifies the width, height, number of components, and component subsampling
+                if (marker == 0xc0 || marker == 0xc2)
                 {
-                    binaryReader.ReadByte();
-                    int height = ReadLittleEndianInt16(binaryReader);
-                    int width = ReadLittleEndianInt16(binaryReader);
-                    return new ImageSize
-                    {
-                        Width = width,
-                        Height = height
-                    };
+                    // https://help.accusoft.com/ImageGear/v18.2/Windows/ActiveX/IGAX-10-12.html
+                    binaryReader.ReadByte(); // We don't care about the first byte
+                    int height = binaryReader.ReadLittleEndianInt16();
+                    int width = binaryReader.ReadLittleEndianInt16();
+                    return new ImageSize(width, height);
                 }
 
                 if (chunkLength < 0)
                 {
-                    var uchunkLength = (ushort)chunkLength;
+                    ushort uchunkLength = (ushort)chunkLength;
                     binaryReader.ReadBytes(uchunkLength - 2);
                 }
                 else

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -45,7 +45,6 @@
     <EmbeddedResource Include="TextEncoding\NLangDetect\Profiles\*" />
     <EmbeddedResource Include="TextEncoding\NLangDetect\Utils\messages.properties" />
     <EmbeddedResource Include="Localization\Ratings\*.txt" />
-    <EmbeddedResource Include="values.txt" />
   </ItemGroup>
 
 </Project>

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -1056,7 +1056,7 @@ namespace Emby.Server.Implementations.LiveTv
             var numComplete = 0;
             double progressPerService = _services.Length == 0
                 ? 0
-                : 1 / _services.Length;
+                : 1.0 / _services.Length;
 
             var newChannelIdList = new List<Guid>();
             var newProgramIdList = new List<Guid>();
@@ -1262,7 +1262,7 @@ namespace Emby.Server.Implementations.LiveTv
                 }
 
                 numComplete++;
-                double percent = numComplete / allChannelsList.Count;
+                double percent = numComplete / (double) allChannelsList.Count;
 
                 progress.Report(85 * percent + 15);
             }
@@ -1307,7 +1307,7 @@ namespace Emby.Server.Implementations.LiveTv
                 }
 
                 numComplete++;
-                double percent = numComplete / list.Count;
+                double percent = numComplete / (double) list.Count;
 
                 progress.Report(100 * percent);
             }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
@@ -65,7 +65,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 
             foreach (var file in filesToDelete)
             {
-                double percent = index / filesToDelete.Count;
+                double percent = index / (double) filesToDelete.Count;
 
                 progress.Report(100 * percent);
 

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Authors>Jellyfin Contributors</Authors>
+    <PackageId>Jellyfin.Common</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />
   </ItemGroup>

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -64,7 +64,7 @@ namespace MediaBrowser.Controller.Entities.Movies
         }
 
         public override double GetDefaultPrimaryImageAspectRatio()
-            => 2 / 3;
+            => 2.0 / 3;
 
         public override UnratedItem GetBlockUnratedType()
         {

--- a/MediaBrowser.Controller/Entities/Movies/Movie.cs
+++ b/MediaBrowser.Controller/Entities/Movies/Movie.cs
@@ -51,7 +51,7 @@ namespace MediaBrowser.Controller.Entities.Movies
                 return 0;
             }
 
-            return 2 / 3;
+            return 2.0 / 3;
         }
 
         protected override async Task<bool> RefreshedOwnedItems(MetadataRefreshOptions options, List<FileSystemMetadata> fileSystemChildren, CancellationToken cancellationToken)

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -111,7 +111,7 @@ namespace MediaBrowser.Controller.Entities.TV
                 return 0;
             }
 
-            return 16 / 9;
+            return 16.0 / 9;
         }
 
         public override List<string> GetUserDataKeys()

--- a/MediaBrowser.Controller/Entities/Trailer.cs
+++ b/MediaBrowser.Controller/Entities/Trailer.cs
@@ -21,7 +21,7 @@ namespace MediaBrowser.Controller.Entities
         public TrailerType[] TrailerTypes { get; set; }
 
         public override double GetDefaultPrimaryImageAspectRatio()
-            => 2 / 3;
+            => 2.0 / 3;
 
         public override UnratedItem GetBlockUnratedType()
         {

--- a/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
@@ -54,11 +54,11 @@ namespace MediaBrowser.Controller.LiveTv
 
             if (string.Equals(serviceName, EmbyServiceName, StringComparison.OrdinalIgnoreCase) || string.Equals(serviceName, "Next Pvr", StringComparison.OrdinalIgnoreCase))
             {
-                return 2 / 3;
+                return 2.0 / 3;
             }
             else
             {
-                return 16 / 9;
+                return 16.0 / 9;
             }
         }
 

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Authors>Jellyfin Contributors</Authors>
+    <PackageId>Jellyfin.Controller</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />
     <ProjectReference Include="..\MediaBrowser.Common\MediaBrowser.Common.csproj" />

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Authors>Jellyfin Contributors</Authors>
+    <PackageId>Jellyfin.Model</PackageId>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -183,6 +183,10 @@ namespace MediaBrowser.Model.Net
             {
                 return "text/plain";
             }
+            if (StringHelper.EqualsIgnoreCase(ext, ".log"))
+            {
+                return "text/plain";
+            }
             if (StringHelper.EqualsIgnoreCase(ext, ".xml"))
             {
                 return "application/xml";

--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -232,10 +232,10 @@ namespace MediaBrowser.Model.Net
             if (StringHelper.EqualsIgnoreCase(ext, ".oga"))
             {
                 return "audio/ogg";
-			}
-			if (StringHelper.EqualsIgnoreCase(ext, ".opus"))
-			{
-				return "audio/ogg";
+            }
+            if (StringHelper.EqualsIgnoreCase(ext, ".opus"))
+            {
+                return "audio/ogg";
             }
             if (StringHelper.EqualsIgnoreCase(ext, ".ac3"))
             {

--- a/MediaBrowser.WebDashboard/dashboard-ui/dashboardgeneral.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/dashboardgeneral.html
@@ -18,7 +18,7 @@
                         <div class="fieldDescription">
                             <div>${LabelPreferredDisplayLanguageHelp}</div>
                             <div style="margin-top: .25em;">
-                                <a is="emby-linkbutton" class="button-link" href="https://github.com/jellyfin/jellyfin" target="_blank">${LabelReadHowYouCanContribute}</a>
+                                <a is="emby-linkbutton" class="button-link" href="https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/" target="_blank">${LabelReadHowYouCanContribute}</a>
                             </div>
                         </div>
                     </div>

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/myprofile.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/myprofile.js
@@ -14,7 +14,7 @@ define(["scripts/userpasswordpage", "loading", "libraryMenu", "apphost", "emby-l
                 type: "Primary"
             }) : "css/images/logindefault.png", fldImage.classList.remove("hide"), fldImage.innerHTML = "<img width='140px' src='" + imageUrl + "' />";
             var showImageEditing = !1;
-            "Guest" == user.ConnectLinkType ? page.querySelector(".connectMessage").classList.remove("hide") : (user.PrimaryImageTag, showImageEditing = !0, page.querySelector(".connectMessage").classList.add("hide")), Dashboard.getCurrentUser().then(function(loggedInUser) {
+            Dashboard.getCurrentUser().then(function(loggedInUser) {
                 showImageEditing && appHost.supports("fileinput") && (loggedInUser.Policy.IsAdministrator || user.Policy.EnableUserPreferenceAccess) ? (page.querySelector(".newImageForm").classList.remove("hide"), user.PrimaryImageTag ? page.querySelector("#btnDeleteImage").classList.remove("hide") : page.querySelector("#btnDeleteImage").classList.add("hide")) : (page.querySelector(".newImageForm").classList.add("hide"), page.querySelector("#btnDeleteImage").classList.add("hide"))
             }), loading.hide()
         })

--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -1,3 +1,3 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.0.0")]
+[assembly: AssemblyVersion("10.0.1")]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+jellyfin (10.0.1-1) unstable; urgency=medium
+
+  * Hotfix release, corrects several small bugs from 10.0.0
+  * #512: Fix CONTRIBUTORS.md formatting
+  * #501: Fix regression in integer divisions in latest movies category
+  * #498: Change contributing link in settings to readthedocs.io
+  * #493: Remove unused values.txt resource
+  * #491: Fix userprofile.js crash
+  * #519: Fix the DecodeJfif function to get proper image sizes
+  * #486: Add NuGet package info to plugin projects
+
+ -- Joshua Boniface <joshua@boniface.me>  Tue, 08 Jan 2019 20:06:01 -0500
+
 jellyfin (10.0.0-1) unstable; urgency=medium
 
   * The first Jellyfin release under our new versioning scheme


### PR DESCRIPTION
Hotfix release correcting regressions and obvious bugs from `10.0.0`.

Release tagged `10.0.1`. Debian build `10.0.1-1`.

## Changelog

#487: Support `*.log` files in browser log viewer
#488: Fix odd formatting in MimeType.cs
#512: Fix CONTRIBUTORS.md formatting    
#501: Fix regression in integer divisions in latest movies category
#498: Change contributing link in settings to readthedocs.io        
#493: Remove unused values.txt resource                           
#491: Fix userprofile.js crash
#519: Fix the DecodeJfif function to get proper image sizes
#486: Add NuGet package info to plugin projects
#523: Bump version for 10.0.1