### PR TITLE
Update Emby API keys to our own

### DIFF
--- a/MediaBrowser.Controller/Library/TVUtils.cs
+++ b/MediaBrowser.Controller/Library/TVUtils.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Controller.Library
         /// <summary>
         /// The TVDB API key
         /// </summary>
-        public static readonly string TvdbApiKey = "B89CE93890E9419B";
+        public static readonly string TvdbApiKey = "OG4V3YJ3FAP7FP2K";
         public static readonly string TvdbBaseUrl = "https://www.thetvdb.com/";
         /// <summary>
         /// The banner URL

--- a/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
@@ -46,7 +46,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             _config.NamedConfigurationUpdating += _config_NamedConfigurationUpdating;
 
             Utilities.HttpClient = httpClient;
-            OpenSubtitles.SetUserAgent("mediabrowser.tv");
+            OpenSubtitles.SetUserAgent("jellyfin");
         }
 
         private const string PasswordHashPrefix = "h:";

--- a/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
@@ -37,7 +37,6 @@ namespace MediaBrowser.Providers.Movies
         private readonly IJsonSerializer _json;
 
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3/movies/{1}?api_key={0}";
-        // &client_key=52c813aa7b8c8b3bb87f4797532a2f8c
 
         internal static FanartMovieImageProvider Current;
 

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -168,7 +168,7 @@ namespace MediaBrowser.Providers.Movies
         private const string TmdbConfigUrl = BaseMovieDbUrl + "3/configuration?api_key={0}";
         private const string GetMovieInfo3 = BaseMovieDbUrl + @"3/movie/{0}?api_key={1}&append_to_response=casts,releases,images,keywords,trailers";
 
-        internal static string ApiKey = "f6bd687ffa63cd282b6ff2c6877f2669";
+        internal static string ApiKey = "4219e299c89411838049ab0dab19ebd5";
         internal static string AcceptHeader = "application/json,image/*";
 
         /// <summary>

--- a/MediaBrowser.Providers/Movies/MovieDbSearch.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbSearch.cs
@@ -20,7 +20,7 @@ namespace MediaBrowser.Providers.Movies
         private static readonly CultureInfo EnUs = new CultureInfo("en-US");
         private const string Search3 = MovieDbProvider.BaseMovieDbUrl + @"3/search/{3}?api_key={1}&query={0}&language={2}";
 
-        internal static string ApiKey = "f6bd687ffa63cd282b6ff2c6877f2669";
+        internal static string ApiKey = "4219e299c89411838049ab0dab19ebd5";
         internal static string AcceptHeader = "application/json,image/*";
 
         private readonly ILogger _logger;

--- a/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
@@ -27,7 +27,7 @@ namespace MediaBrowser.Providers.Music
 
         public static AudioDbArtistProvider Current;
 
-        private const string ApiKey = "49jhsf8248yfahka89724011";
+        private const string ApiKey = "195003";
         public const string BaseUrl = "https://www.theaudiodb.com/api/v1/json/" + ApiKey;
 
         public AudioDbArtistProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json)

--- a/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
@@ -28,7 +28,7 @@ namespace MediaBrowser.Providers.Music
 {
     public class FanartArtistProvider : IRemoteImageProvider, IHasOrder
     {
-        internal const string ApiKey = "5c6b04c68e904cfed1e6cbc9a9e683d4";
+        internal const string ApiKey = "184e1a2b1fe3b94935365411f919f638";
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3.1/music/{1}?api_key={0}";
 
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");

--- a/MediaBrowser.Providers/Omdb/OmdbImageProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbImageProvider.cs
@@ -69,7 +69,7 @@ namespace MediaBrowser.Providers.Omdb
                         list.Add(new RemoteImageInfo
                         {
                             ProviderName = Name,
-                            Url = string.Format("https://img.omdbapi.com/?i={0}&apikey=fe53f97e", imdbId)
+                            Url = string.Format("https://img.omdbapi.com/?i={0}&apikey=2c9d9507", imdbId)
                         });
                     }
                 }

--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -270,7 +270,7 @@ namespace MediaBrowser.Providers.Omdb
 
         public static string GetOmdbUrl(string query, IApplicationHost appHost, CancellationToken cancellationToken)
         {
-            const string url = "https://www.omdbapi.com?apikey=fe53f97e";
+            const string url = "https://www.omdbapi.com?apikey=2c9d9507";
 
             if (string.IsNullOrWhiteSpace(query))
             {

--- a/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
@@ -36,7 +36,6 @@ namespace MediaBrowser.Providers.TV
         private readonly IJsonSerializer _json;
 
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3/tv/{1}?api_key={0}";
-        // &client_key=52c813aa7b8c8b3bb87f4797532a2f8c
 
         internal static FanartSeriesProvider Current { get; private set; }
 


### PR DESCRIPTION
Updates the 5 API keys that I've been able to find, to our own API keys. All of these, where applicable, have been registered using a new account with the name "jellyfin" and the email address "team@jellyfin.org". This removes our dependency on the Emby API keys.

We should probably move these out of the deep-in-code, hardcoded locations they're currently in, but that can be a future project as we make them configurable from the UI.

Fixes #36 