### PR TITLE
Refactor and remove dead code around system startup

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
  - [AnthonyLavado](https://github.com/anthonylavado)
  - [sparky8251](https://github.com/sparky8251)
  - [LeoVerto](https://github.com/LeoVerto)
+ - [wtayl0r](https://github.com/wtayl0r)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -114,31 +114,14 @@ using MediaBrowser.Controller.Authentication;
 using System.Diagnostics;
 using ServiceStack.Text.Jsv;
 using Microsoft.Extensions.Logging;
+using OperatingSystem = MediaBrowser.Model.System.OperatingSystem;
 
 namespace Emby.Server.Implementations
 {
-    /// <summary>
-    /// Class CompositionRoot
-    /// </summary>
     public abstract class ApplicationHost : IServerApplicationHost, IDisposable
     {
-        /// <summary>
-        /// Gets a value indicating whether this instance can self restart.
-        /// </summary>
-        /// <value><c>true</c> if this instance can self restart; otherwise, <c>false</c>.</value>
         public abstract bool CanSelfRestart { get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance can self update.
-        /// </summary>
-        /// <value><c>true</c> if this instance can self update; otherwise, <c>false</c>.</value>
-        public virtual bool CanSelfUpdate
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public virtual bool CanSelfUpdate => false;
 
         public virtual bool CanLaunchWebBrowser
         {
@@ -186,45 +169,17 @@ namespace Emby.Server.Implementations
 
         public bool IsShuttingDown { get; private set; }
 
-        /// <summary>
-        /// Gets or sets the logger.
-        /// </summary>
-        /// <value>The logger.</value>
         protected ILogger Logger { get; set; }
 
-        /// <summary>
-        /// Gets or sets the plugins.
-        /// </summary>
-        /// <value>The plugins.</value>
         public IPlugin[] Plugins { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the logger factory.
-        /// </summary>
-        /// <value>The logger factory.</value>
         public ILoggerFactory LoggerFactory { get; protected set; }
 
-        /// <summary>
-        /// Gets the application paths.
-        /// </summary>
-        /// <value>The application paths.</value>
         protected ServerApplicationPaths ApplicationPaths { get; set; }
 
-        /// <summary>
-        /// Gets all concrete types.
-        /// </summary>
-        /// <value>All concrete types.</value>
         public Tuple<Type, string>[] AllConcreteTypes { get; protected set; }
 
-        /// <summary>
-        /// The disposable parts
-        /// </summary>
         protected readonly List<IDisposable> DisposableParts = new List<IDisposable>();
 
-        /// <summary>
-        /// Gets the configuration manager.
-        /// </summary>
-        /// <value>The configuration manager.</value>
         protected IConfigurationManager ConfigurationManager { get; set; }
 
         public IFileSystem FileSystemManager { get; set; }
@@ -237,7 +192,6 @@ namespace Emby.Server.Implementations
         {
             get
             {
-
 #if BETA
                 return PackageVersionClass.Beta;
 #endif
@@ -250,26 +204,14 @@ namespace Emby.Server.Implementations
             get { return EnvironmentInfo.OperatingSystemName; }
         }
 
-        /// <summary>
-        /// The container
-        /// </summary>
+
         protected readonly SimpleInjector.Container Container = new SimpleInjector.Container();
 
         protected ISystemEvents SystemEvents { get; set; }
 
-        /// <summary>
-        /// Gets the server configuration manager.
-        /// </summary>
-        /// <value>The server configuration manager.</value>
-        public IServerConfigurationManager ServerConfigurationManager
-        {
-            get { return (IServerConfigurationManager)ConfigurationManager; }
-        }
+        public IServerConfigurationManager ServerConfigurationManager =>
+            (IServerConfigurationManager)ConfigurationManager;
 
-        /// <summary>
-        /// Gets the configuration manager.
-        /// </summary>
-        /// <returns>IConfigurationManager.</returns>
         protected IConfigurationManager GetConfigurationManager()
         {
             return new ServerConfigurationManager(ApplicationPaths, LoggerFactory, XmlSerializer, FileSystemManager);
@@ -280,38 +222,14 @@ namespace Emby.Server.Implementations
             return new ResourceFileManager(HttpResultFactory, LoggerFactory.CreateLogger("ResourceManager"), FileSystemManager);
         }
 
-        /// <summary>
-        /// Gets or sets the user manager.
-        /// </summary>
-        /// <value>The user manager.</value>
         public IUserManager UserManager { get; set; }
-        /// <summary>
-        /// Gets or sets the library manager.
-        /// </summary>
-        /// <value>The library manager.</value>
         internal ILibraryManager LibraryManager { get; set; }
-        /// <summary>
-        /// Gets or sets the directory watchers.
-        /// </summary>
-        /// <value>The directory watchers.</value>
         private ILibraryMonitor LibraryMonitor { get; set; }
-        /// <summary>
-        /// Gets or sets the provider manager.
-        /// </summary>
-        /// <value>The provider manager.</value>
         private IProviderManager ProviderManager { get; set; }
-        /// <summary>
-        /// Gets or sets the HTTP server.
-        /// </summary>
-        /// <value>The HTTP server.</value>
         private IHttpServer HttpServer { get; set; }
         private IDtoService DtoService { get; set; }
         public IImageProcessor ImageProcessor { get; set; }
 
-        /// <summary>
-        /// Gets or sets the media encoder.
-        /// </summary>
-        /// <value>The media encoder.</value>
         private IMediaEncoder MediaEncoder { get; set; }
         private ISubtitleEncoder SubtitleEncoder { get; set; }
 
@@ -325,10 +243,6 @@ namespace Emby.Server.Implementations
         private IChannelManager ChannelManager { get; set; }
         protected ITextEncoding TextEncoding { get; private set; }
 
-        /// <summary>
-        /// Gets or sets the user data repository.
-        /// </summary>
-        /// <value>The user data repository.</value>
         private IUserDataManager UserDataManager { get; set; }
         private IUserRepository UserRepository { get; set; }
         internal IDisplayPreferencesRepository DisplayPreferencesRepository { get; set; }
@@ -347,21 +261,10 @@ namespace Emby.Server.Implementations
         private IMediaSourceManager MediaSourceManager { get; set; }
         private IPlaylistManager PlaylistManager { get; set; }
 
-        /// <summary>
-        /// Gets or sets the installation manager.
-        /// </summary>
-        /// <value>The installation manager.</value>
         protected IInstallationManager InstallationManager { get; private set; }
-        /// <summary>
-        /// Gets the security manager.
-        /// </summary>
-        /// <value>The security manager.</value>
+
         protected ISecurityManager SecurityManager { get; private set; }
 
-        /// <summary>
-        /// Gets or sets the zip client.
-        /// </summary>
-        /// <value>The zip client.</value>
         protected IZipClient ZipClient { get; private set; }
         protected IHttpResultFactory HttpResultFactory { get; private set; }
         protected IAuthService AuthService { get; private set; }
@@ -382,9 +285,6 @@ namespace Emby.Server.Implementations
         public IJsonSerializer JsonSerializer { get; private set; }
         protected IIsoManager IsoManager { get; private set; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApplicationHost" /> class.
-        /// </summary>
         public ApplicationHost(ServerApplicationPaths applicationPaths,
             ILoggerFactory loggerFactory,
             StartupOptions options,
@@ -438,28 +338,13 @@ namespace Emby.Server.Implementations
                 .Replace(appPaths.InternalMetadataPath, appPaths.VirtualInternalMetadataPath, StringComparison.OrdinalIgnoreCase);
         }
 
-        private string[] GetConfiguredLocalSubnets()
-        {
-            return ServerConfigurationManager.Configuration.LocalNetworkSubnets;
-        }
+        private string[] GetConfiguredLocalSubnets() => ServerConfigurationManager.Configuration.LocalNetworkSubnets;
 
-        private void NetworkManager_NetworkChanged(object sender, EventArgs e)
-        {
-            _validAddressResults.Clear();
-        }
+        private void NetworkManager_NetworkChanged(object sender, EventArgs e) => _validAddressResults.Clear();
 
         private Version _version;
-        /// <summary>
-        /// Gets the current application version
-        /// </summary>
-        /// <value>The application version.</value>
-        public Version ApplicationVersion
-        {
-            get
-            {
-                return _version ?? (_version = typeof(ApplicationHost).Assembly.GetName().Version);
-            }
-        }
+        public Version ApplicationVersion =>
+            _version ?? (_version = typeof(ApplicationHost).Assembly.GetName().Version);
 
         private DeviceId _deviceId;
         public string SystemId
@@ -475,17 +360,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        /// <summary>
-        /// Gets the name.
-        /// </summary>
-        /// <value>The name.</value>
-        public string Name
-        {
-            get
-            {
-                return "Emby Server";
-            }
-        }
+        public string Name => "Jellyfin Server";
 
         private Tuple<Assembly, string> GetAssembly(Type type)
         {
@@ -495,10 +370,7 @@ namespace Emby.Server.Implementations
             return new Tuple<Assembly, string>(assembly, path);
         }
 
-        public virtual IStreamHelper CreateStreamHelper()
-        {
-            return new StreamHelper();
-        }
+        public virtual IStreamHelper CreateStreamHelper() => new StreamHelper();
 
         /// <summary>
         /// Creates an instance of type and resolves all constructor dependancies
@@ -553,32 +425,17 @@ namespace Emby.Server.Implementations
             }
         }
 
-        /// <summary>
-        /// Registers the single instance.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="func">The func.</param>
         protected void RegisterSingleInstance<T>(Func<T> func)
             where T : class
         {
             Container.RegisterSingleton(func);
         }
 
-        /// <summary>
-        /// Resolves this instance.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>``0.</returns>
         public T Resolve<T>()
         {
             return (T)Container.GetRegistration(typeof(T), true).GetInstance();
         }
 
-        /// <summary>
-        /// Resolves this instance.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>``0.</returns>
         public T TryResolve<T>()
         {
             var result = Container.GetRegistration(typeof(T), false);
@@ -590,11 +447,6 @@ namespace Emby.Server.Implementations
             return (T)result.GetInstance();
         }
 
-        /// <summary>
-        /// Loads the assembly.
-        /// </summary>
-        /// <param name="file">The file.</param>
-        /// <returns>Assembly.</returns>
         protected Tuple<Assembly, string> LoadAssembly(string file)
         {
             try
@@ -610,11 +462,6 @@ namespace Emby.Server.Implementations
             }
         }
 
-        /// <summary>
-        /// Gets the export types.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>IEnumerable{Type}.</returns>
         public IEnumerable<Tuple<Type, string>> GetExportTypes<T>()
         {
             var currentType = typeof(T);
@@ -622,12 +469,6 @@ namespace Emby.Server.Implementations
             return AllConcreteTypes.Where(i => currentType.IsAssignableFrom(i.Item1));
         }
 
-        /// <summary>
-        /// Gets the exports.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="manageLifetime">if set to <c>true</c> [manage lifetime].</param>
-        /// <returns>IEnumerable{``0}.</returns>
         public IEnumerable<T> GetExports<T>(bool manageLifetime = true)
         {
             var parts = GetExportTypes<T>()
@@ -673,9 +514,6 @@ namespace Emby.Server.Implementations
             return parts;
         }
 
-        /// <summary>
-        /// Runs the startup tasks.
-        /// </summary>
         public Task RunStartupTasks()
         {
             Resolve<ITaskManager>().AddTasks(GetExports<IScheduledTask>(false));
@@ -683,15 +521,6 @@ namespace Emby.Server.Implementations
             ConfigurationManager.ConfigurationUpdated += OnConfigurationUpdated;
 
             MediaEncoder.Init();
-
-            //if (string.IsNullOrWhiteSpace(MediaEncoder.EncoderPath))
-            //{
-            //    if (ServerConfigurationManager.Configuration.IsStartupWizardCompleted)
-            //    {
-            //        ServerConfigurationManager.Configuration.IsStartupWizardCompleted = false;
-            //        ServerConfigurationManager.SaveConfiguration();
-            //    }
-            //}
 
             Logger.LogInformation("ServerId: {0}", SystemId);
 
@@ -891,9 +720,6 @@ namespace Emby.Server.Implementations
 
             RegisterSingleInstance<ISearchEngine>(() => new SearchEngine(LoggerFactory, LibraryManager, UserManager));
 
-            CertificateInfo = GetCertificateInfo(true);
-            Certificate = GetCertificate(CertificateInfo);
-
             HttpServer = new HttpListenerHost(this,
                 LoggerFactory.CreateLogger("HttpServer"),
                 ServerConfigurationManager,
@@ -994,23 +820,14 @@ namespace Emby.Server.Implementations
             ((LibraryManager)LibraryManager).ItemRepository = ItemRepository;
         }
 
-        protected virtual IBrotliCompressor CreateBrotliCompressor()
-        {
-            return null;
-        }
+        protected virtual IBrotliCompressor CreateBrotliCompressor() => null;
 
         private static Func<string, object> GetParseFn(Type propertyType)
         {
             return s => JsvReader.GetParseFn(propertyType)(s);
         }
 
-        public virtual string PackageRuntime
-        {
-            get
-            {
-                return "netcore";
-            }
-        }
+        public virtual string PackageRuntime => "netcore";
 
         public static void LogEnvironmentInfo(ILogger logger, IApplicationPaths appPaths, EnvironmentInfo.EnvironmentInfo environmentInfo)
         {
@@ -1042,12 +859,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        protected string GetDefaultUserAgent()
-        {
-            var name = FormatAttribute(Name);
-
-            return name + "/" + ApplicationVersion;
-        }
+        protected string GetDefaultUserAgent() => $"{FormatAttribute(Name)}/{ApplicationVersion}";
 
         private string FormatAttribute(string str)
         {
@@ -1060,105 +872,40 @@ namespace Emby.Server.Implementations
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                result = "Emby";
+                result = "Jellyfin";
             }
 
             return result;
         }
 
-        protected virtual bool SupportsDualModeSockets
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        private X509Certificate GetCertificate(CertificateInfo info)
-        {
-            var certificateLocation = info == null ? null : info.Path;
-
-            if (string.IsNullOrWhiteSpace(certificateLocation))
-            {
-                return null;
-            }
-
-            try
-            {
-                if (!FileSystemManager.FileExists(certificateLocation))
-                {
-                    return null;
-                }
-
-                // Don't use an empty string password
-                var password = string.IsNullOrWhiteSpace(info.Password) ? null : info.Password;
-
-                X509Certificate2 localCert = new X509Certificate2(certificateLocation, password);
-                //localCert.PrivateKey = PrivateKey.CreateFromFile(pvk_file).RSA;
-                if (!localCert.HasPrivateKey)
-                {
-                    Logger.LogError("No private key included in SSL cert {CertificateLocation}.", certificateLocation);
-                    return null;
-                }
-
-                return localCert;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error loading cert from {CertificateLocation}", certificateLocation);
-                return null;
-            }
-        }
+        protected virtual bool SupportsDualModeSockets => true;
 
         private IImageProcessor GetImageProcessor()
         {
             return new ImageProcessor(LoggerFactory.CreateLogger("ImageProcessor"), ServerConfigurationManager.ApplicationPaths, FileSystemManager, JsonSerializer, ImageEncoder, () => LibraryManager, TimerFactory, () => MediaEncoder);
         }
 
-        protected virtual FFMpegInstallInfo GetFfmpegInstallInfo()
+        private FFMpegInstallInfo GetFfmpegInstallInfo()
         {
-            var info = new FFMpegInstallInfo();
-
-            // Windows builds: http://ffmpeg.zeranoe.com/builds/
-            // Linux builds: http://johnvansickle.com/ffmpeg/
-            // OS X builds: http://ffmpegmac.net/
-            // OS X x64: http://www.evermeet.cx/ffmpeg/
-
-            if (EnvironmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.Linux)
+            switch (EnvironmentInfo.OperatingSystem)
             {
-                info.FFMpegFilename = "ffmpeg";
-                info.FFProbeFilename = "ffprobe";
-                info.ArchiveType = "7z";
-                info.Version = "20170308";
+                case OperatingSystem.Linux:
+                    return FFMpegInstallInfo.Linux;
+                case OperatingSystem.Windows:
+                    return FFMpegInstallInfo.Windows;
+                case OperatingSystem.OSX:
+                    return FFMpegInstallInfo.OSX;
+                default:
+                    return FFMpegInstallInfo.Default;
             }
-            else if (EnvironmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.Windows)
-            {
-                info.FFMpegFilename = "ffmpeg.exe";
-                info.FFProbeFilename = "ffprobe.exe";
-                info.Version = "20170308";
-                info.ArchiveType = "7z";
-            }
-            else if (EnvironmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.OSX)
-            {
-                info.FFMpegFilename = "ffmpeg";
-                info.FFProbeFilename = "ffprobe";
-                info.ArchiveType = "7z";
-                info.Version = "20170308";
-            }
-
-            return info;
         }
 
-        protected virtual FFMpegInfo GetFFMpegInfo()
+        protected FFMpegInfo GetFFMpegInfo()
         {
             return new FFMpegLoader(Logger, ApplicationPaths, HttpClient, ZipClient, FileSystemManager, GetFfmpegInstallInfo())
                 .GetFFMpegInfo(StartupOptions);
         }
 
-        /// <summary>
-        /// Registers the media encoder.
-        /// </summary>
-        /// <returns>Task.</returns>
         private void RegisterMediaEncoder(IAssemblyInfo assemblyInfo)
         {
             string encoderPath = null;
@@ -1194,10 +941,6 @@ namespace Emby.Server.Implementations
             RegisterSingleInstance(MediaEncoder);
         }
 
-        /// <summary>
-        /// Gets the user repository.
-        /// </summary>
-        /// <returns>Task{IUserRepository}.</returns>
         private IUserRepository GetUserRepository()
         {
             var repo = new SqliteUserRepository(LoggerFactory.CreateLogger("SqliteUserRepository"), ApplicationPaths, JsonSerializer);
@@ -1255,9 +998,6 @@ namespace Emby.Server.Implementations
             AuthenticatedAttribute.AuthService = AuthService;
         }
 
-        /// <summary>
-        /// Finds the parts.
-        /// </summary>
         protected void FindParts()
         {
             if (!ServerConfigurationManager.Configuration.IsPortAuthorized)
@@ -1350,9 +1090,6 @@ namespace Emby.Server.Implementations
             return plugin;
         }
 
-        /// <summary>
-        /// Discovers the types.
-        /// </summary>
         protected void DiscoverTypes()
         {
             Logger.LogInformation("Loading assemblies");
@@ -1429,9 +1166,6 @@ namespace Emby.Server.Implementations
             }
         }
 
-        private CertificateInfo CertificateInfo { get; set; }
-        protected X509Certificate Certificate { get; private set; }
-
         private IEnumerable<string> GetUrlPrefixes()
         {
             var hosts = new[] { "+" };
@@ -1443,20 +1177,12 @@ namespace Emby.Server.Implementations
                     "http://"+i+":" + HttpPort + "/"
                 };
 
-                if (CertificateInfo != null)
-                {
-                    prefixes.Add("https://" + i + ":" + HttpsPort + "/");
-                }
-
                 return prefixes;
             });
         }
 
         protected abstract IHttpListener CreateHttpListener();
 
-        /// <summary>
-        /// Starts the server.
-        /// </summary>
         private void StartServer()
         {
             try
@@ -1492,54 +1218,12 @@ namespace Emby.Server.Implementations
             }
         }
 
-        private CertificateInfo GetCertificateInfo(bool generateCertificate)
-        {
-            if (!string.IsNullOrWhiteSpace(ServerConfigurationManager.Configuration.CertificatePath))
-            {
-                // Custom cert
-                return new CertificateInfo
-                {
-                    Path = ServerConfigurationManager.Configuration.CertificatePath,
-                    Password = ServerConfigurationManager.Configuration.CertificatePassword
-                };
-            }
-
-            // Generate self-signed cert
-            var certHost = GetHostnameFromExternalDns(ServerConfigurationManager.Configuration.WanDdns);
-            var certPath = Path.Combine(ServerConfigurationManager.ApplicationPaths.ProgramDataPath, "ssl", "cert_" + (certHost + "2").GetMD5().ToString("N") + ".pfx");
-            var password = "embycert";
-
-            //if (generateCertificate)
-            //{
-            //    if (!FileSystemManager.FileExists(certPath))
-            //    {
-            //        FileSystemManager.CreateDirectory(FileSystemManager.GetDirectoryName(certPath));
-
-            //        try
-            //        {
-            //            CertificateGenerator.CreateSelfSignCertificatePfx(certPath, certHost, password, Logger);
-            //        }
-            //        catch (Exception ex)
-            //        {
-            //            Logger.LogError(ex, "Error creating ssl cert");
-            //            return null;
-            //        }
-            //    }
-            //}
-
-            return new CertificateInfo
-            {
-                Path = certPath,
-                Password = password
-            };
-        }
-
         /// <summary>
         /// Called when [configuration updated].
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        protected void OnConfigurationUpdated(object sender, EventArgs e)
+        private void OnConfigurationUpdated(object sender, EventArgs e)
         {
             var requiresRestart = false;
 
@@ -1561,15 +1245,6 @@ namespace Emby.Server.Implementations
             }
 
             if (!HttpServer.UrlPrefixes.SequenceEqual(GetUrlPrefixes(), StringComparer.OrdinalIgnoreCase))
-            {
-                requiresRestart = true;
-            }
-
-            var currentCertPath = CertificateInfo == null ? null : CertificateInfo.Path;
-            var newCertInfo = GetCertificateInfo(false);
-            var newCertPath = newCertInfo == null ? null : newCertInfo.Path;
-
-            if (!string.Equals(currentCertPath, newCertPath, StringComparison.OrdinalIgnoreCase))
             {
                 requiresRestart = true;
             }
@@ -1599,9 +1274,6 @@ namespace Emby.Server.Implementations
             }
         }
 
-        /// <summary>
-        /// Restarts this instance.
-        /// </summary>
         public void Restart()
         {
             if (!CanSelfRestart)
@@ -1782,7 +1454,6 @@ namespace Emby.Server.Implementations
 
         private IEnumerable<string> FilterAssembliesToLoad(IEnumerable<string> paths)
         {
-
             var exclude = new[]
             {
                 "mbplus.dll",
@@ -1835,8 +1506,7 @@ namespace Emby.Server.Implementations
                     return false;
                 }
 
-                Version minRequiredVersion;
-                if (minRequiredVersions.TryGetValue(filename, out minRequiredVersion))
+                if (minRequiredVersions.TryGetValue(filename, out var minRequiredVersion))
                 {
                     try
                     {
@@ -1859,10 +1529,6 @@ namespace Emby.Server.Implementations
             });
         }
 
-        /// <summary>
-        /// Gets the system status.
-        /// </summary>
-        /// <returns>SystemInfo.</returns>
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
@@ -1927,25 +1593,17 @@ namespace Emby.Server.Implementations
             };
         }
 
-        public bool EnableHttps
-        {
-            get
-            {
-                return SupportsHttps && ServerConfigurationManager.Configuration.EnableHttps;
-            }
-        }
+        public bool EnableHttps => SupportsHttps && ServerConfigurationManager.Configuration.EnableHttps;
 
-        public bool SupportsHttps
-        {
-            get { return Certificate != null || ServerConfigurationManager.Configuration.IsBehindProxy; }
-        }
+        private bool SupportsHttps => false;
 
         public async Task<string> GetLocalApiUrl(CancellationToken cancellationToken)
         {
             try
             {
                 // Return the first matched address, if found, or the first known local address
-                var addresses = await GetLocalIpAddressesInternal(false, 1, cancellationToken).ConfigureAwait(false);
+                var addresses = await GetLocalIpAddressesInternal(false, 1, cancellationToken)
+                    .ConfigureAwait(false);
 
                 foreach (var address in addresses)
                 {
@@ -1962,7 +1620,7 @@ namespace Emby.Server.Implementations
             return null;
         }
 
-        public async Task<string> GetWanApiUrl(CancellationToken cancellationToken)
+        private async Task<string> GetWanApiUrl(CancellationToken cancellationToken)
         {
             var url = "http://ipv4.icanhazip.com";
             try
@@ -2000,17 +1658,15 @@ namespace Emby.Server.Implementations
 
         public string GetLocalApiUrl(string host)
         {
-            return string.Format("http://{0}:{1}",
-                host,
-                HttpPort.ToString(CultureInfo.InvariantCulture));
+            return $"http://{host}:{HttpPort.ToString(CultureInfo.InvariantCulture)}";
         }
 
-        public Task<List<IpAddressInfo>> GetLocalIpAddresses(CancellationToken cancellationToken)
-        {
-            return GetLocalIpAddressesInternal(true, 0, cancellationToken);
-        }
+        public Task<List<IpAddressInfo>> GetLocalIpAddresses(CancellationToken cancellationToken) =>
+            GetLocalIpAddressesInternal(true, 0, cancellationToken);
 
-        private async Task<List<IpAddressInfo>> GetLocalIpAddressesInternal(bool allowLoopback, int limit, CancellationToken cancellationToken)
+        private async Task<List<IpAddressInfo>> GetLocalIpAddressesInternal(bool allowLoopback,
+            int limit,
+            CancellationToken cancellationToken)
         {
             var addresses = ServerConfigurationManager
                 .Configuration
@@ -2060,8 +1716,7 @@ namespace Emby.Server.Implementations
                 address = address.Substring(index + 1);
             }
 
-            IpAddressInfo result;
-            if (NetworkManager.TryParseIpAddress(address.Trim('/'), out result))
+            if (NetworkManager.TryParseIpAddress(address.Trim('/'), out var result))
             {
                 return result;
             }
@@ -2080,8 +1735,7 @@ namespace Emby.Server.Implementations
             var apiUrl = GetLocalApiUrl(address);
             apiUrl += "/system/ping";
 
-            bool cachedResult;
-            if (_validAddressResults.TryGetValue(apiUrl, out cachedResult))
+            if (_validAddressResults.TryGetValue(apiUrl, out var cachedResult))
             {
                 return cachedResult;
             }
@@ -2132,23 +1786,14 @@ namespace Emby.Server.Implementations
             }
         }
 
-        public string FriendlyName
-        {
-            get
-            {
-                return string.IsNullOrEmpty(ServerConfigurationManager.Configuration.ServerName)
-                    ? Environment.MachineName
-                    : ServerConfigurationManager.Configuration.ServerName;
-            }
-        }
+        public string FriendlyName =>
+            string.IsNullOrEmpty(ServerConfigurationManager.Configuration.ServerName)
+                ? Environment.MachineName
+                : ServerConfigurationManager.Configuration.ServerName;
 
         public int HttpPort { get; private set; }
-
         public int HttpsPort { get; private set; }
 
-        /// <summary>
-        /// Shuts down.
-        /// </summary>
         public async Task Shutdown()
         {
             if (IsShuttingDown)
@@ -2191,10 +1836,6 @@ namespace Emby.Server.Implementations
             }
         }
 
-        /// <summary>
-        /// Removes the plugin.
-        /// </summary>
-        /// <param name="plugin">The plugin.</param>
         public void RemovePlugin(IPlugin plugin)
         {
             var list = Plugins.ToList();
@@ -2268,19 +1909,10 @@ namespace Emby.Server.Implementations
             }
         }
 
-        private static void ProcessExited(object sender, EventArgs e)
-        {
-            ((IProcess)sender).Dispose();
-        }
+        private static void ProcessExited(object sender, EventArgs e) => ((IProcess)sender).Dispose();
 
-        public virtual void EnableLoopback(string appName)
-        {
-        }
+        public virtual void EnableLoopback(string appName) { }
 
-        /// <summary>
-        /// Called when [application updated].
-        /// </summary>
-        /// <param name="package">The package.</param>
         protected void OnApplicationUpdated(PackageVersionInfo package)
         {
             Logger.LogInformation("Application has been updated to version {0}", package.versionStr);
@@ -2337,11 +1969,5 @@ namespace Emby.Server.Implementations
                 }
             }
         }
-    }
-
-    internal class CertificateInfo
-    {
-        public string Path { get; set; }
-        public string Password { get; set; }
     }
 }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -172,17 +172,17 @@ namespace Emby.Server.Implementations
         protected ILogger Logger { get; set; }
 
         public IPlugin[] Plugins { get; protected set; }
-        public ILoggerFactory LoggerFactory { get; protected set; }
+        private ILoggerFactory LoggerFactory { get; set; }
 
-        protected ServerApplicationPaths ApplicationPaths { get; set; }
+        private ServerApplicationPaths ApplicationPaths { get; set; }
 
-        public Tuple<Type, string>[] AllConcreteTypes { get; protected set; }
+        private Tuple<Type, string>[] AllConcreteTypes { get; set; }
 
-        protected readonly List<IDisposable> DisposableParts = new List<IDisposable>();
+        private readonly List<IDisposable> DisposableParts = new List<IDisposable>();
 
-        protected IConfigurationManager ConfigurationManager { get; set; }
+        private IConfigurationManager ConfigurationManager { get; set; }
 
-        public IFileSystem FileSystemManager { get; set; }
+        protected IFileSystem FileSystemManager { get; set; }
 
         protected IEnvironmentInfo EnvironmentInfo { get; set; }
 
@@ -199,20 +199,17 @@ namespace Emby.Server.Implementations
             }
         }
 
-        public virtual string OperatingSystemDisplayName
-        {
-            get { return EnvironmentInfo.OperatingSystemName; }
-        }
+        public virtual string OperatingSystemDisplayName => EnvironmentInfo.OperatingSystemName;
 
 
-        protected readonly SimpleInjector.Container Container = new SimpleInjector.Container();
+        private readonly SimpleInjector.Container Container = new SimpleInjector.Container();
 
-        protected ISystemEvents SystemEvents { get; set; }
+        private ISystemEvents SystemEvents { get; set; }
 
-        public IServerConfigurationManager ServerConfigurationManager =>
+        private IServerConfigurationManager ServerConfigurationManager =>
             (IServerConfigurationManager)ConfigurationManager;
 
-        protected IConfigurationManager GetConfigurationManager()
+        private IConfigurationManager GetConfigurationManager()
         {
             return new ServerConfigurationManager(ApplicationPaths, LoggerFactory, XmlSerializer, FileSystemManager);
         }
@@ -222,8 +219,8 @@ namespace Emby.Server.Implementations
             return new ResourceFileManager(HttpResultFactory, LoggerFactory.CreateLogger("ResourceManager"), FileSystemManager);
         }
 
-        public IUserManager UserManager { get; set; }
-        internal ILibraryManager LibraryManager { get; set; }
+        private IUserManager UserManager { get; set; }
+        private ILibraryManager LibraryManager { get; set; }
         private ILibraryMonitor LibraryMonitor { get; set; }
         private IProviderManager ProviderManager { get; set; }
         private IHttpServer HttpServer { get; set; }
@@ -245,15 +242,15 @@ namespace Emby.Server.Implementations
 
         private IUserDataManager UserDataManager { get; set; }
         private IUserRepository UserRepository { get; set; }
-        internal IDisplayPreferencesRepository DisplayPreferencesRepository { get; set; }
-        internal IItemRepository ItemRepository { get; set; }
+        private IDisplayPreferencesRepository DisplayPreferencesRepository { get; set; }
+        private IItemRepository ItemRepository { get; set; }
 
         private INotificationManager NotificationManager { get; set; }
         private ISubtitleManager SubtitleManager { get; set; }
         private IChapterManager ChapterManager { get; set; }
         private IDeviceManager DeviceManager { get; set; }
 
-        internal IUserViewManager UserViewManager { get; set; }
+        private IUserViewManager UserViewManager { get; set; }
 
         private IAuthenticationRepository AuthenticationRepository { get; set; }
         private ITVSeriesManager TVSeriesManager { get; set; }
@@ -261,29 +258,29 @@ namespace Emby.Server.Implementations
         private IMediaSourceManager MediaSourceManager { get; set; }
         private IPlaylistManager PlaylistManager { get; set; }
 
-        protected IInstallationManager InstallationManager { get; private set; }
+        private IInstallationManager InstallationManager { get; set; }
 
-        protected ISecurityManager SecurityManager { get; private set; }
+        private ISecurityManager SecurityManager { get; set; }
 
-        protected IZipClient ZipClient { get; private set; }
-        protected IHttpResultFactory HttpResultFactory { get; private set; }
-        protected IAuthService AuthService { get; private set; }
+        private IZipClient ZipClient { get; set; }
+        private IHttpResultFactory HttpResultFactory { get; set; }
+        private IAuthService AuthService { get; set; }
 
         public StartupOptions StartupOptions { get; private set; }
 
-        internal IImageEncoder ImageEncoder { get; private set; }
+        private IImageEncoder ImageEncoder { get; set; }
 
-        protected IProcessFactory ProcessFactory { get; private set; }
-        protected ITimerFactory TimerFactory { get; private set; }
+        private IProcessFactory ProcessFactory { get; set; }
+        private ITimerFactory TimerFactory { get; set; }
         protected ICryptoProvider CryptographyProvider = new CryptographyProvider();
-        protected readonly IXmlSerializer XmlSerializer;
+        private readonly IXmlSerializer XmlSerializer;
 
         protected ISocketFactory SocketFactory { get; private set; }
-        protected ITaskManager TaskManager { get; private set; }
+        private ITaskManager TaskManager { get; set; }
         public IHttpClient HttpClient { get; private set; }
         protected INetworkManager NetworkManager { get; set; }
-        public IJsonSerializer JsonSerializer { get; private set; }
-        protected IIsoManager IsoManager { get; private set; }
+        private IJsonSerializer JsonSerializer { get; set; }
+        private IIsoManager IsoManager { get; set; }
 
         public ApplicationHost(ServerApplicationPaths applicationPaths,
             ILoggerFactory loggerFactory,
@@ -370,7 +367,7 @@ namespace Emby.Server.Implementations
             return new Tuple<Assembly, string>(assembly, path);
         }
 
-        public virtual IStreamHelper CreateStreamHelper() => new StreamHelper();
+        private IStreamHelper CreateStreamHelper() => new StreamHelper();
 
         /// <summary>
         /// Creates an instance of type and resolves all constructor dependancies
@@ -387,7 +384,7 @@ namespace Emby.Server.Implementations
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>System.Object.</returns>
-        protected object CreateInstanceSafe(Tuple<Type, string> typeInfo)
+        private object CreateInstanceSafe(Tuple<Type, string> typeInfo)
         {
             var type = typeInfo.Item1;
 
@@ -409,7 +406,7 @@ namespace Emby.Server.Implementations
         /// <typeparam name="T"></typeparam>
         /// <param name="obj">The obj.</param>
         /// <param name="manageLifetime">if set to <c>true</c> [manage lifetime].</param>
-        protected void RegisterSingleInstance<T>(T obj, bool manageLifetime = true)
+        private void RegisterSingleInstance<T>(T obj, bool manageLifetime = true)
             where T : class
         {
             Container.RegisterSingleton(obj);
@@ -425,7 +422,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        protected void RegisterSingleInstance<T>(Func<T> func)
+        private void RegisterSingleInstance<T>(Func<T> func)
             where T : class
         {
             Container.RegisterSingleton(func);
@@ -447,7 +444,7 @@ namespace Emby.Server.Implementations
             return (T)result.GetInstance();
         }
 
-        protected Tuple<Assembly, string> LoadAssembly(string file)
+        private Tuple<Assembly, string> LoadAssembly(string file)
         {
             try
             {
@@ -462,7 +459,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        public IEnumerable<Tuple<Type, string>> GetExportTypes<T>()
+        private IEnumerable<Tuple<Type, string>> GetExportTypes<T>()
         {
             var currentType = typeof(T);
 
@@ -487,7 +484,7 @@ namespace Emby.Server.Implementations
             return parts;
         }
 
-        public List<Tuple<T, string>> GetExportsWithInfo<T>(bool manageLifetime = true)
+        private List<Tuple<T, string>> GetExportsWithInfo<T>(bool manageLifetime = true)
         {
             var parts = GetExportTypes<T>()
                 .Select(i =>
@@ -612,7 +609,7 @@ namespace Emby.Server.Implementations
         /// <summary>
         /// Registers resources that classes will depend on
         /// </summary>
-        protected void RegisterResources()
+        private void RegisterResources()
         {
             RegisterSingleInstance(ConfigurationManager);
             RegisterSingleInstance<IApplicationHost>(this);
@@ -859,7 +856,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        protected string GetDefaultUserAgent() => $"{FormatAttribute(Name)}/{ApplicationVersion}";
+        private string GetDefaultUserAgent() => $"{FormatAttribute(Name)}/{ApplicationVersion}";
 
         private string FormatAttribute(string str)
         {
@@ -900,7 +897,7 @@ namespace Emby.Server.Implementations
             }
         }
 
-        protected FFMpegInfo GetFFMpegInfo()
+        private FFMpegInfo GetFFMpegInfo()
         {
             return new FFMpegLoader(Logger, ApplicationPaths, HttpClient, ZipClient, FileSystemManager, GetFfmpegInstallInfo())
                 .GetFFMpegInfo(StartupOptions);
@@ -998,7 +995,7 @@ namespace Emby.Server.Implementations
             AuthenticatedAttribute.AuthService = AuthService;
         }
 
-        protected void FindParts()
+        private void FindParts()
         {
             if (!ServerConfigurationManager.Configuration.IsPortAuthorized)
             {
@@ -1090,7 +1087,7 @@ namespace Emby.Server.Implementations
             return plugin;
         }
 
-        protected void DiscoverTypes()
+        private void DiscoverTypes()
         {
             Logger.LogInformation("Loading assemblies");
 
@@ -1125,7 +1122,7 @@ namespace Emby.Server.Implementations
         /// Gets a list of types within an assembly
         /// This will handle situations that would normally throw an exception - such as a type within the assembly that depends on some other non-existant reference
         /// </summary>
-        protected List<Tuple<Type, string>> GetTypes(Tuple<Assembly, string> assemblyInfo)
+        private List<Tuple<Type, string>> GetTypes(Tuple<Assembly, string> assemblyInfo)
         {
             if (assemblyInfo == null)
             {
@@ -1311,7 +1308,7 @@ namespace Emby.Server.Implementations
         /// Gets the composable part assemblies.
         /// </summary>
         /// <returns>IEnumerable{Assembly}.</returns>
-        protected List<Tuple<Assembly, string>> GetComposablePartAssemblies()
+        private List<Tuple<Assembly, string>> GetComposablePartAssemblies()
         {
             var list = GetPluginAssemblies();
 
@@ -1913,7 +1910,7 @@ namespace Emby.Server.Implementations
 
         public virtual void EnableLoopback(string appName) { }
 
-        protected void OnApplicationUpdated(PackageVersionInfo package)
+        private void OnApplicationUpdated(PackageVersionInfo package)
         {
             Logger.LogInformation("Application has been updated to version {0}", package.versionStr);
 

--- a/Emby.Server.Implementations/FFMpeg/FFMpegInstallInfo.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegInstallInfo.cs
@@ -20,23 +20,27 @@
         }
 
         public static FFMpegInstallInfo Linux = new FFMpegInstallInfo(
-            "20170308",
-            "ffmpeg",
-            "ffprobe",
-            "7z");
+            version: "20170308",
+            ffMpegFilename: "ffmpeg",
+            ffProbeFilename: "ffprobe",
+            archiveType: "7z");
 
         public static FFMpegInstallInfo Windows = new FFMpegInstallInfo(
-            "20170308",
-            "ffmpeg.exe",
-            "ffprobe.exe",
-            "7z");
+            version: "20170308",
+            ffMpegFilename:"ffmpeg.exe",
+            ffProbeFilename:"ffprobe.exe",
+            archiveType: "7z");
 
         public static FFMpegInstallInfo OSX = new FFMpegInstallInfo(
-            version:"20170308",
-            ffMpegFilename:"ffmpeg",
-            ffProbeFilename:"ffprobe",
-            archiveType:"7z");
+            version: "20170308",
+            ffMpegFilename: "ffmpeg",
+            ffProbeFilename: "ffprobe",
+            archiveType: "7z");
 
-        public static FFMpegInstallInfo Default = new FFMpegInstallInfo("Path", "ffmpeg", "ffprobe", null);
+        public static FFMpegInstallInfo Default = new FFMpegInstallInfo(
+            version: "Path",
+            ffMpegFilename: "ffmpeg",
+            ffProbeFilename: "ffprobe",
+            archiveType: null);
     }
 }

--- a/Emby.Server.Implementations/FFMpeg/FFMpegInstallInfo.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegInstallInfo.cs
@@ -1,18 +1,42 @@
-﻿
-namespace Emby.Server.Implementations.FFMpeg
+﻿namespace Emby.Server.Implementations.FFMpeg
 {
     public class FFMpegInstallInfo
     {
-        public string Version { get; set; }
-        public string FFMpegFilename { get; set; }
-        public string FFProbeFilename { get; set; }
-        public string ArchiveType { get; set; }
+        public string Version { get; }
+        public string FFMpegFilename { get; }
+        public string FFProbeFilename { get; }
+        public string ArchiveType { get; }
 
-        public FFMpegInstallInfo()
+        private FFMpegInstallInfo(
+            string version,
+            string ffMpegFilename,
+            string ffProbeFilename,
+            string archiveType)
         {
-            Version = "Path";
-            FFMpegFilename = "ffmpeg";
-            FFProbeFilename = "ffprobe";
+            Version = version;
+            FFMpegFilename = ffMpegFilename;
+            FFProbeFilename = ffProbeFilename;
+            ArchiveType = archiveType;
         }
+
+        public static FFMpegInstallInfo Linux = new FFMpegInstallInfo(
+            "20170308",
+            "ffmpeg",
+            "ffprobe",
+            "7z");
+
+        public static FFMpegInstallInfo Windows = new FFMpegInstallInfo(
+            "20170308",
+            "ffmpeg.exe",
+            "ffprobe.exe",
+            "7z");
+
+        public static FFMpegInstallInfo OSX = new FFMpegInstallInfo(
+            version:"20170308",
+            ffMpegFilename:"ffmpeg",
+            ffProbeFilename:"ffprobe",
+            archiveType:"7z");
+
+        public static FFMpegInstallInfo Default = new FFMpegInstallInfo("Path", "ffmpeg", "ffprobe", null);
     }
 }

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -16,14 +16,7 @@ namespace Jellyfin.Server
         {
         }
 
-        public override bool CanSelfRestart
-        {
-            get
-            {
-                // A restart script must be provided
-                return StartupOptions.ContainsOption("-restartpath");
-            }
-        }
+        public override bool CanSelfRestart => StartupOptions.ContainsOption("-restartpath");
 
         protected override void RestartInternal() => Program.Restart();
 
@@ -32,18 +25,12 @@ namespace Jellyfin.Server
 
         protected override void ShutdownInternal() => Program.Shutdown();
 
-        protected override bool SupportsDualModeSockets
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool SupportsDualModeSockets => true;
 
         protected override IHttpListener CreateHttpListener()
             => new WebSocketSharpListener(
                 Logger,
-                Certificate,
+                null,
                 StreamHelper,
                 TextEncoding,
                 NetworkManager,


### PR DESCRIPTION
Removed the certificate storage of the currently broken implementation of HTTPS and forced the web server to be started without HTTPS.
Moved FFMpeg OS logic into FFMpegInstallInfo class and made it an immutable
static enum.
Stripped out commented code.
Updated lines to some newer C# features (string interpolation, expression
bodied getters, inline out vars).
reduces accessor levels on most methods within ApplicationHost 
Added myself to Contributors.md