### PR TITLE
Add Master codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Jellyfin CODEOWNERS file (`master` branch)
+
+# Require org owner approvals for all files, when merging to master
+*   @joshuaboniface @nvllsvm


### PR DESCRIPTION
In conjunction with branch protection rules, this will require
approval from the Org owners (myself or @nvllsvm) before a merge
can be accepted.