### PR TITLE
Fix error with uppercase photo extension and fix typo in a log line

### DIFF
--- a/Emby.Drawing/Common/ImageHeader.cs
+++ b/Emby.Drawing/Common/ImageHeader.cs
@@ -50,12 +50,13 @@ namespace Emby.Drawing.Common
         /// <exception cref="ArgumentException">The image was of an unrecognised format.</exception>
         public static ImageSize GetDimensions(string path, ILogger logger, IFileSystem fileSystem)
         {
-            var extension = Path.GetExtension(path);
-
-            if (string.IsNullOrEmpty(extension))
+            if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentException("ImageHeader doesn't support image file");
+                throw new ArgumentNullException(nameof(path));
             }
+
+            string extension = Path.GetExtension(path).ToLower();
+
             if (!SupportedExtensions.Contains(extension))
             {
                 throw new ArgumentException("ImageHeader doesn't support " + extension);

--- a/Emby.Server.Implementations/IO/FileRefresher.cs
+++ b/Emby.Server.Implementations/IO/FileRefresher.cs
@@ -156,7 +156,7 @@ namespace Emby.Server.Implementations.IO
                     continue;
                 }
 
-                Logger.LogInformation("{name} ({path}}) will be refreshed.", item.Name, item.Path);
+                Logger.LogInformation("{name} ({path}) will be refreshed.", item.Name, item.Path);
 
                 try
                 {


### PR DESCRIPTION
Some small bugs I found while trying to index some pictures. I have tested both fixes successfully.

The file extension bug has the consequence that jellyfin fails to display photos with non-lowercase extensions (Unsupported image type). With this, uppercase extensions will work too :)