### PR TITLE
Revert "Add Master codeowners"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Jellyfin CODEOWNERS file (`master` branch)
-
-# Require org owner approvals for all files, when merging to master
-*   @joshuaboniface @nvllsvm


### PR DESCRIPTION
Reverts jellyfin/jellyfin#559
So there will be no force push to master.
Should ideally be replaced with a branch restriction on master.
Ref: https://help.github.com/articles/enabling-branch-restrictions/