### PR TITLE
Ensure config and log folders exist

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -45,7 +45,8 @@ namespace Jellyfin.Server
                 Console.WriteLine(version.ToString());
             }
 
-            ServerApplicationPaths appPaths = createApplicationPaths(options);
+            ServerApplicationPaths appPaths = CreateApplicationPaths(options);
+
             // $JELLYFIN_LOG_DIR needs to be set for the logger configuration manager
             Environment.SetEnvironmentVariable("JELLYFIN_LOG_DIR", appPaths.LogDirectoryPath);
             await createLogger(appPaths);
@@ -130,7 +131,7 @@ namespace Jellyfin.Server
             }
         }
 
-        private static ServerApplicationPaths createApplicationPaths(StartupOptions options)
+        private static ServerApplicationPaths CreateApplicationPaths(StartupOptions options)
         {
             string programDataPath = Environment.GetEnvironmentVariable("JELLYFIN_DATA_PATH");
             if (string.IsNullOrEmpty(programDataPath))
@@ -155,10 +156,19 @@ namespace Jellyfin.Server
                             programDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
                         }
                     }
+
                     programDataPath = Path.Combine(programDataPath, "jellyfin");
-                    // Ensure the dir exists
-                    Directory.CreateDirectory(programDataPath);
                 }
+            }
+
+            if (string.IsNullOrEmpty(programDataPath))
+            {
+                Console.WriteLine("Cannot continue without path to program data folder (try -programdata)");
+                Environment.Exit(1);
+            }
+            else
+            {
+                Directory.CreateDirectory(programDataPath);
             }
 
             string configDir = Environment.GetEnvironmentVariable("JELLYFIN_CONFIG_DIR");
@@ -175,6 +185,11 @@ namespace Jellyfin.Server
                 }
             }
 
+            if (string.IsNullOrEmpty(configDir))
+            {
+                Directory.CreateDirectory(configDir);
+            }
+
             string logDir = Environment.GetEnvironmentVariable("JELLYFIN_LOG_DIR");
             if (string.IsNullOrEmpty(logDir))
             {
@@ -187,6 +202,11 @@ namespace Jellyfin.Server
                     // Let BaseApplicationPaths set up the default value
                     logDir = null;
                 }
+            }
+
+            if (string.IsNullOrEmpty(logDir))
+            {
+                Directory.CreateDirectory(logDir);
             }
 
             string appPath = AppContext.BaseDirectory;

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -185,7 +185,7 @@ namespace Jellyfin.Server
                 }
             }
 
-            if (string.IsNullOrEmpty(configDir))
+            if (!string.IsNullOrEmpty(configDir))
             {
                 Directory.CreateDirectory(configDir);
             }
@@ -204,7 +204,7 @@ namespace Jellyfin.Server
                 }
             }
 
-            if (string.IsNullOrEmpty(logDir))
+            if (!string.IsNullOrEmpty(logDir))
             {
                 Directory.CreateDirectory(logDir);
             }

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -185,7 +185,7 @@ namespace Jellyfin.Server
                 }
             }
 
-            if (!string.IsNullOrEmpty(configDir))
+            if (configDir != null)
             {
                 Directory.CreateDirectory(configDir);
             }
@@ -204,7 +204,7 @@ namespace Jellyfin.Server
                 }
             }
 
-            if (!string.IsNullOrEmpty(logDir))
+            if (logDir != null)
             {
                 Directory.CreateDirectory(logDir);
             }


### PR DESCRIPTION
Whilst testing virgin starts, cleared away log and config folders prior to launch, noticed exception being trapped becuase logging.json file could not be created:

```
ploughpuff@vb-deb-jelly:~/jellyfin$ ~/tmp/bin/jellyfin -configdir ~/tmp/config/ -logdir ~/tmp/log/
[13:31:57] [FTL] Failed to create/read logger configuration
System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/ploughpuff/tmp/config/logging.json'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at Jellyfin.Server.Program.createLogger(IApplicationPaths appPaths) in /home/ploughpuff/jellyfin/Jellyfin.Server/Program.cs:line 178
```

Granted this shouldn't be an issue for releases, but during testing it's a nice to have (for me).