### PR TITLE
Try to eliminate compile warnings

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -357,7 +357,7 @@ namespace MediaBrowser.Controller.Entities
         {
             var list = new List<Tuple<StringBuilder, bool>>();
 
-            int thisMarker = 0, thisNumericChunk = 0;
+            int thisMarker = 0;
 
             while (thisMarker < s1.Length)
             {

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -47,7 +47,6 @@ namespace Mono.Nat
     {
         public event EventHandler<DeviceEventArgs> DeviceFound;
 
-        private DateTime nextSearch;
         private readonly ILogger _logger;
         private readonly IHttpClient _httpClient;
 
@@ -96,11 +95,6 @@ namespace Mono.Nat
 
         public void Handle(IPAddress localAddress, byte[] response, IPEndPoint endpoint)
         {
-        }
-
-        public DateTime NextSearch
-        {
-            get { return nextSearch; }
         }
 
         private void OnDeviceFound(DeviceEventArgs args)

--- a/SocketHttpListener/HttpBase.cs
+++ b/SocketHttpListener/HttpBase.cs
@@ -13,12 +13,6 @@ namespace SocketHttpListener
 
         #endregion
 
-        #region Internal Fields
-
-        internal byte[] EntityBodyData;
-
-        #endregion
-
         #region Protected Fields
 
         protected const string CrLf = "\r\n";
@@ -36,18 +30,6 @@ namespace SocketHttpListener
         #endregion
 
         #region Public Properties
-
-        public string EntityBody
-        {
-            get
-            {
-                var data = EntityBodyData;
-
-                return data != null && data.Length > 0
-                       ? getEncoding(_headers["Content-Type"]).GetString(data, 0, data.Length)
-                       : string.Empty;
-            }
-        }
 
         public QueryParamCollection Headers => _headers;
 

--- a/SocketHttpListener/HttpResponse.cs
+++ b/SocketHttpListener/HttpResponse.cs
@@ -115,10 +115,6 @@ namespace SocketHttpListener
 
             output.Append(CrLf);
 
-            var entity = EntityBody;
-            if (entity.Length > 0)
-                output.Append(entity);
-
             return output.ToString();
         }
 

--- a/SocketHttpListener/Net/HttpConnection.cs
+++ b/SocketHttpListener/Net/HttpConnection.cs
@@ -32,8 +32,6 @@ namespace SocketHttpListener.Net
         int _reuses;
         bool _contextBound;
         bool secure;
-        int _timeout = 90000; // 90k ms for first request, 15k ms from then on
-        private Timer _timer;
         IPEndPoint local_ep;
         HttpListener _lastListener;
         X509Certificate cert;
@@ -91,8 +89,6 @@ namespace SocketHttpListener.Net
 
         public async Task Init()
         {
-            _timer = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
-
             if (ssl_stream != null)
             {
                 var enableAsync = true;
@@ -162,14 +158,10 @@ namespace SocketHttpListener.Net
                 _buffer = new byte[BufferSize];
             try
             {
-                if (_reuses == 1)
-                    _timeout = 15000;
-                //_timer.Change(_timeout, Timeout.Infinite);
                 _stream.BeginRead(_buffer, 0, BufferSize, s_onreadCallback, this);
             }
             catch
             {
-                //_timer.Change(Timeout.Infinite, Timeout.Infinite);
                 CloseSocket();
                 Unbind();
             }
@@ -216,7 +208,6 @@ namespace SocketHttpListener.Net
 
         private void OnReadInternal(IAsyncResult ares)
         {
-            //_timer.Change(Timeout.Infinite, Timeout.Infinite);
             int nread = -1;
             try
             {

--- a/SocketHttpListener/WebSocket.cs
+++ b/SocketHttpListener/WebSocket.cs
@@ -24,7 +24,6 @@ namespace SocketHttpListener
     {
         #region Private Fields
 
-        private string _base64Key;
         private Action _closeContext;
         private CompressionMethod _compression;
         private WebSocketContext _context;
@@ -35,20 +34,12 @@ namespace SocketHttpListener
         private object _forMessageEventQueue;
         private object _forSend;
         private const string _guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-        private Func<WebSocketContext, string>
-                                        _handshakeRequestChecker;
         private Queue<MessageEventArgs> _messageEventQueue;
-        private uint _nonceCount;
-        private string _origin;
-        private bool _preAuth;
         private string _protocol;
-        private string[] _protocols;
-        private Uri _proxyUri;
         private volatile WebSocketState _readyState;
         private AutoResetEvent _receivePong;
         private bool _secure;
         private Stream _stream;
-        private Uri _uri;
         private const string _version = "13";
 
         #endregion


### PR DESCRIPTION
Trying to remove compilation warnings.

Here are some I'm not experienced enough to fix:
* Some of them are classes with public events that are there because they are required by an interface. They may be used from another class somehow, but the compiler still calls them unused.
* async methods running synchronously, probably because they are stubs. Some of the stubs have TODOs on them, so refactoring them away will just create more work. Other stubs may be worth taking a look at.
* Warning about a call that is not awaited (what does this even mean? Wait for it to complete?), recommends adding await but that might break the whole point of launching a process to the background
* exception ex that is only read in debug compiles

If you can help me remove more of the warnings, I will probably learn more about C#.

**Changes**
* Remove some unused variables
* remove duplicate "using .." by sorting and deduping the list
* Remove things that already exist in the parent class (in one case I moved some documentation to the parent)
* EntityBodyData and and NextSearch were never set (only read), removed
* _timeout was never read, subsequently _timer became unused. part of a TODO timeout functionality that was not implemented yet

**Issues**
None, but it may create some :-p Alternately, the issues we don't know about yet.

By moving some stuff to the parent class, the logic seems more correct so I assume this will fix some issues that can stem from the parent class not having correct data. I checked that removed functions were implemented exactly the same and depended on common factors only.