### PR TITLE
Really slim down Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ COPY --from=builder /jellyfin /jellyfin
 COPY --from=ffmpeg /ffmpeg-bin/* /usr/bin/
 EXPOSE 8096
 VOLUME /config /media
+
+# libfontconfig1 is required for Skia
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y \
-   libfontconfig1 # Required for Skia \
+   libfontconfig1 \
  && apt-get clean autoclean \
  && apt-get autoremove \
  && rm -rf /var/lib/{apt,dpkg,cache,log}


### PR DESCRIPTION
#606 didn't actually run the new commands due to the comments position.

This fixes the comment location.
