### PR TITLE
Replaced injections of ILogger with ILoggerFactory

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
  - [LeoVerto](https://github.com/LeoVerto)
  - [grafixeyehero](https://github.com/grafixeyehero)
  - [cvium](https://github.com/cvium)
+ - [wtayl0r](https://github.com/wtayl0r)
  
 # Emby Contributors
 

--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -32,16 +32,17 @@ namespace Emby.Dlna
 
         private readonly Dictionary<string, Tuple<InternalProfileInfo, DeviceProfile>> _profiles = new Dictionary<string, Tuple<InternalProfileInfo, DeviceProfile>>(StringComparer.Ordinal);
 
-        public DlnaManager(IXmlSerializer xmlSerializer,
+        public DlnaManager(
+            IXmlSerializer xmlSerializer,
             IFileSystem fileSystem,
             IApplicationPaths appPaths,
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IJsonSerializer jsonSerializer, IServerApplicationHost appHost, IAssemblyInfo assemblyInfo)
         {
             _xmlSerializer = xmlSerializer;
             _fileSystem = fileSystem;
             _appPaths = appPaths;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("Dlna");
             _jsonSerializer = jsonSerializer;
             _appHost = appHost;
             _assemblyInfo = assemblyInfo;

--- a/Emby.Dlna/Ssdp/DeviceDiscovery.cs
+++ b/Emby.Dlna/Ssdp/DeviceDiscovery.cs
@@ -52,9 +52,13 @@ namespace Emby.Dlna.Ssdp
         private readonly ISocketFactory _socketFactory;
         private ISsdpCommunicationsServer _commsServer;
 
-        public DeviceDiscovery(ILogger logger, IServerConfigurationManager config, ISocketFactory socketFactory, ITimerFactory timerFactory)
+        public DeviceDiscovery(
+            ILoggerFactory loggerFactory,
+            IServerConfigurationManager config,
+            ISocketFactory socketFactory,
+            ITimerFactory timerFactory)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(DeviceDiscovery));
             _config = config;
             _socketFactory = socketFactory;
             _timerFactory = timerFactory;

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -53,14 +53,15 @@ namespace Emby.Drawing
         private readonly Func<ILibraryManager> _libraryManager;
         private readonly Func<IMediaEncoder> _mediaEncoder;
 
-        public ImageProcessor(ILogger logger,
+        public ImageProcessor(
+            ILoggerFactory loggerFactory,
             IServerApplicationPaths appPaths,
             IFileSystem fileSystem,
             IJsonSerializer jsonSerializer,
             IImageEncoder imageEncoder,
             Func<ILibraryManager> libraryManager, ITimerFactory timerFactory, Func<IMediaEncoder> mediaEncoder)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(ImageProcessor));
             _fileSystem = fileSystem;
             _jsonSerializer = jsonSerializer;
             _imageEncoder = imageEncoder;

--- a/Emby.Drawing/SkiaEncoder.cs
+++ b/Emby.Drawing/SkiaEncoder.cs
@@ -23,9 +23,14 @@ namespace Emby.Drawing
         private readonly IFileSystem _fileSystem;
         private static ILocalizationManager _localizationManager;
 
-        public SkiaEncoder(ILogger logger, IApplicationPaths appPaths, Func<IHttpClient> httpClientFactory, IFileSystem fileSystem, ILocalizationManager localizationManager)
+        public SkiaEncoder(
+            ILoggerFactory loggerFactory,
+            IApplicationPaths appPaths,
+            Func<IHttpClient> httpClientFactory,
+            IFileSystem fileSystem,
+            ILocalizationManager localizationManager)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("ImageEncoder");
             _appPaths = appPaths;
             _httpClientFactory = httpClientFactory;
             _fileSystem = fileSystem;

--- a/Emby.Server.Implementations/Activity/ActivityManager.cs
+++ b/Emby.Server.Implementations/Activity/ActivityManager.cs
@@ -16,9 +16,12 @@ namespace Emby.Server.Implementations.Activity
         private readonly ILogger _logger;
         private readonly IUserManager _userManager;
 
-        public ActivityManager(ILogger logger, IActivityRepository repo, IUserManager userManager)
+        public ActivityManager(
+            ILoggerFactory loggerFactory,
+            IActivityRepository repo,
+            IUserManager userManager)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(ActivityManager));
             _repo = repo;
             _userManager = userManager;
         }

--- a/Emby.Server.Implementations/Activity/ActivityRepository.cs
+++ b/Emby.Server.Implementations/Activity/ActivityRepository.cs
@@ -18,8 +18,8 @@ namespace Emby.Server.Implementations.Activity
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         protected IFileSystem FileSystem { get; private set; }
 
-        public ActivityRepository(ILogger logger, IServerApplicationPaths appPaths, IFileSystem fileSystem)
-            : base(logger)
+        public ActivityRepository(ILoggerFactory loggerFactory, IServerApplicationPaths appPaths, IFileSystem fileSystem)
+            : base(loggerFactory.CreateLogger(nameof(ActivityRepository)))
         {
             DbFilePath = Path.Combine(appPaths.DataPath, "activitylog.db");
             FileSystem = fileSystem;

--- a/Emby.Server.Implementations/Channels/ChannelManager.cs
+++ b/Emby.Server.Implementations/Channels/ChannelManager.cs
@@ -45,12 +45,23 @@ namespace Emby.Server.Implementations.Channels
 
         private readonly ILocalizationManager _localization;
 
-        public ChannelManager(IUserManager userManager, IDtoService dtoService, ILibraryManager libraryManager, ILogger logger, IServerConfigurationManager config, IFileSystem fileSystem, IUserDataManager userDataManager, IJsonSerializer jsonSerializer, ILocalizationManager localization, IHttpClient httpClient, IProviderManager providerManager)
+        public ChannelManager(
+            IUserManager userManager,
+            IDtoService dtoService,
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
+            IServerConfigurationManager config,
+            IFileSystem fileSystem,
+            IUserDataManager userDataManager,
+            IJsonSerializer jsonSerializer,
+            ILocalizationManager localization,
+            IHttpClient httpClient,
+            IProviderManager providerManager)
         {
             _userManager = userManager;
             _dtoService = dtoService;
             _libraryManager = libraryManager;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(ChannelManager));
             _config = config;
             _fileSystem = fileSystem;
             _userDataManager = userDataManager;

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -34,12 +34,19 @@ namespace Emby.Server.Implementations.Collections
         public event EventHandler<CollectionModifiedEventArgs> ItemsAddedToCollection;
         public event EventHandler<CollectionModifiedEventArgs> ItemsRemovedFromCollection;
 
-        public CollectionManager(ILibraryManager libraryManager, IApplicationPaths appPaths, ILocalizationManager localizationManager, IFileSystem fileSystem, ILibraryMonitor iLibraryMonitor, ILogger logger, IProviderManager providerManager)
+        public CollectionManager(
+            ILibraryManager libraryManager,
+            IApplicationPaths appPaths,
+            ILocalizationManager localizationManager,
+            IFileSystem fileSystem,
+            ILibraryMonitor iLibraryMonitor,
+            ILoggerFactory loggerFactory,
+            IProviderManager providerManager)
         {
             _libraryManager = libraryManager;
             _fileSystem = fileSystem;
             _iLibraryMonitor = iLibraryMonitor;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(CollectionManager));
             _providerManager = providerManager;
             _localizationManager = localizationManager;
             _appPaths = appPaths;

--- a/Emby.Server.Implementations/Data/SqliteDisplayPreferencesRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteDisplayPreferencesRepository.cs
@@ -20,8 +20,8 @@ namespace Emby.Server.Implementations.Data
     {
         protected IFileSystem FileSystem { get; private set; }
 
-        public SqliteDisplayPreferencesRepository(ILogger logger, IJsonSerializer jsonSerializer, IApplicationPaths appPaths, IFileSystem fileSystem)
-            : base(logger)
+        public SqliteDisplayPreferencesRepository(ILoggerFactory loggerFactory, IJsonSerializer jsonSerializer, IApplicationPaths appPaths, IFileSystem fileSystem)
+            : base(loggerFactory.CreateLogger(nameof(SqliteDisplayPreferencesRepository)))
         {
             _jsonSerializer = jsonSerializer;
             FileSystem = fileSystem;

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -67,8 +67,16 @@ namespace Emby.Server.Implementations.Data
         /// <summary>
         /// Initializes a new instance of the <see cref="SqliteItemRepository"/> class.
         /// </summary>
-        public SqliteItemRepository(IServerConfigurationManager config, IServerApplicationHost appHost, IJsonSerializer jsonSerializer, ILogger logger, IAssemblyInfo assemblyInfo, IFileSystem fileSystem, IEnvironmentInfo environmentInfo, ITimerFactory timerFactory)
-            : base(logger)
+        public SqliteItemRepository(
+            IServerConfigurationManager config,
+            IServerApplicationHost appHost,
+            IJsonSerializer jsonSerializer,
+            ILoggerFactory loggerFactory,
+            IAssemblyInfo assemblyInfo,
+            IFileSystem fileSystem,
+            IEnvironmentInfo environmentInfo,
+            ITimerFactory timerFactory)
+            : base(loggerFactory.CreateLogger(nameof(SqliteItemRepository)))
         {
             if (config == null)
             {

--- a/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
@@ -15,12 +15,11 @@ namespace Emby.Server.Implementations.Data
 {
     public class SqliteUserDataRepository : BaseSqliteRepository, IUserDataRepository
     {
-        private readonly IFileSystem _fileSystem;
-
-        public SqliteUserDataRepository(ILogger logger, IApplicationPaths appPaths, IFileSystem fileSystem)
-            : base(logger)
+        public SqliteUserDataRepository(
+            ILoggerFactory loggerFactory,
+            IApplicationPaths appPaths)
+            : base(loggerFactory.CreateLogger(nameof(SqliteUserDataRepository)))
         {
-            _fileSystem = fileSystem;
             DbFilePath = Path.Combine(appPaths.DataPath, "library.db");
         }
 

--- a/Emby.Server.Implementations/Data/SqliteUserRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserRepository.cs
@@ -17,8 +17,11 @@ namespace Emby.Server.Implementations.Data
     {
         private readonly IJsonSerializer _jsonSerializer;
 
-        public SqliteUserRepository(ILogger logger, IServerApplicationPaths appPaths, IJsonSerializer jsonSerializer)
-            : base(logger)
+        public SqliteUserRepository(
+            ILoggerFactory loggerFactory,
+            IServerApplicationPaths appPaths,
+            IJsonSerializer jsonSerializer)
+            : base(loggerFactory.CreateLogger(nameof(SqliteUserRepository)))
         {
             _jsonSerializer = jsonSerializer;
 

--- a/Emby.Server.Implementations/Devices/DeviceId.cs
+++ b/Emby.Server.Implementations/Devices/DeviceId.cs
@@ -86,7 +86,10 @@ namespace Emby.Server.Implementations.Devices
 
         private string _id;
 
-        public DeviceId(IApplicationPaths appPaths, ILogger logger, IFileSystem fileSystem)
+        public DeviceId(
+            IApplicationPaths appPaths,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem)
         {
             if (fileSystem == null)
             {
@@ -94,7 +97,7 @@ namespace Emby.Server.Implementations.Devices
             }
 
             _appPaths = appPaths;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("SystemId");
             _fileSystem = fileSystem;
         }
 

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -47,14 +47,24 @@ namespace Emby.Server.Implementations.Devices
         private readonly object _cameraUploadSyncLock = new object();
         private readonly object _capabilitiesSyncLock = new object();
 
-        public DeviceManager(IAuthenticationRepository authRepo, IJsonSerializer json, ILibraryManager libraryManager, ILocalizationManager localizationManager, IUserManager userManager, IFileSystem fileSystem, ILibraryMonitor libraryMonitor, IServerConfigurationManager config, ILogger logger, INetworkManager network)
+        public DeviceManager(
+            IAuthenticationRepository authRepo,
+            IJsonSerializer json,
+            ILibraryManager libraryManager,
+            ILocalizationManager localizationManager,
+            IUserManager userManager,
+            IFileSystem fileSystem,
+            ILibraryMonitor libraryMonitor,
+            IServerConfigurationManager config,
+            ILoggerFactory loggerFactory,
+            INetworkManager network)
         {
             _json = json;
             _userManager = userManager;
             _fileSystem = fileSystem;
             _libraryMonitor = libraryMonitor;
             _config = config;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(DeviceManager));
             _network = network;
             _libraryManager = libraryManager;
             _localizationManager = localizationManager;

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -46,9 +46,22 @@ namespace Emby.Server.Implementations.Dto
         private readonly Func<IMediaSourceManager> _mediaSourceManager;
         private readonly Func<ILiveTvManager> _livetvManager;
 
-        public DtoService(ILogger logger, ILibraryManager libraryManager, IUserDataManager userDataRepository, IItemRepository itemRepo, IImageProcessor imageProcessor, IServerConfigurationManager config, IFileSystem fileSystem, IProviderManager providerManager, Func<IChannelManager> channelManagerFactory, IApplicationHost appHost, Func<IDeviceManager> deviceManager, Func<IMediaSourceManager> mediaSourceManager, Func<ILiveTvManager> livetvManager)
+        public DtoService(
+            ILoggerFactory loggerFactory,
+            ILibraryManager libraryManager,
+            IUserDataManager userDataRepository,
+            IItemRepository itemRepo,
+            IImageProcessor imageProcessor,
+            IServerConfigurationManager config,
+            IFileSystem fileSystem,
+            IProviderManager providerManager,
+            Func<IChannelManager> channelManagerFactory,
+            IApplicationHost appHost,
+            Func<IDeviceManager> deviceManager,
+            Func<IMediaSourceManager> mediaSourceManager,
+            Func<ILiveTvManager> livetvManager)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(DtoService));
             _libraryManager = libraryManager;
             _userDataRepository = userDataRepository;
             _itemRepo = itemRepo;

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -44,18 +44,22 @@ namespace Emby.Server.Implementations.HttpClientManager
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpClientManager" /> class.
         /// </summary>
-        public HttpClientManager(IApplicationPaths appPaths, ILogger logger, IFileSystem fileSystem, Func<string> defaultUserAgentFn)
+        public HttpClientManager(
+            IApplicationPaths appPaths,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem,
+            Func<string> defaultUserAgentFn)
         {
             if (appPaths == null)
             {
                 throw new ArgumentNullException(nameof(appPaths));
             }
-            if (logger == null)
+            if (loggerFactory == null)
             {
-                throw new ArgumentNullException(nameof(logger));
+                throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("HttpClient");
             _fileSystem = fileSystem;
             _appPaths = appPaths;
             _defaultUserAgentFn = defaultUserAgentFn;

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -51,7 +51,7 @@ namespace Emby.Server.Implementations.HttpServer
 
         public HttpListenerHost(
             IServerApplicationHost applicationHost,
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IServerConfigurationManager config,
             string defaultRedirectPath,
             INetworkManager networkManager,
@@ -60,7 +60,7 @@ namespace Emby.Server.Implementations.HttpServer
             Func<Type, Func<string, object>> funcParseFn)
         {
             _appHost = applicationHost;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("HttpServer");
             _config = config;
             DefaultRedirectPath = defaultRedirectPath;
             _networkManager = networkManager;

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -29,9 +29,14 @@ namespace Emby.Server.Implementations.IO
 
         private string _defaultDirectory;
 
-        public ManagedFileSystem(ILogger logger, IEnvironmentInfo environmentInfo, string defaultDirectory, string tempPath, bool enableSeparateFileAndDirectoryQueries)
+        public ManagedFileSystem(
+            ILoggerFactory loggerFactory,
+            IEnvironmentInfo environmentInfo,
+            string defaultDirectory,
+            string tempPath,
+            bool enableSeparateFileAndDirectoryQueries)
         {
-            Logger = logger;
+            Logger = loggerFactory.CreateLogger("FileSystem");
             _supportsAsyncFileStreams = true;
             _tempPath = tempPath;
             _environmentInfo = environmentInfo;

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -155,9 +155,19 @@ namespace Emby.Server.Implementations.Library
         /// <param name="userManager">The user manager.</param>
         /// <param name="configurationManager">The configuration manager.</param>
         /// <param name="userDataRepository">The user data repository.</param>
-        public LibraryManager(IServerApplicationHost appHost, ILogger logger, ITaskManager taskManager, IUserManager userManager, IServerConfigurationManager configurationManager, IUserDataManager userDataRepository, Func<ILibraryMonitor> libraryMonitorFactory, IFileSystem fileSystem, Func<IProviderManager> providerManagerFactory, Func<IUserViewManager> userviewManager)
+        public LibraryManager(
+            IServerApplicationHost appHost,
+            ILoggerFactory loggerFactory,
+            ITaskManager taskManager,
+            IUserManager userManager,
+            IServerConfigurationManager configurationManager,
+            IUserDataManager userDataRepository,
+            Func<ILibraryMonitor> libraryMonitorFactory,
+            IFileSystem fileSystem,
+            Func<IProviderManager> providerManagerFactory,
+            Func<IUserViewManager> userviewManager)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(LibraryManager));
             _taskManager = taskManager;
             _userManager = userManager;
             ConfigurationManager = configurationManager;

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -41,12 +41,23 @@ namespace Emby.Server.Implementations.Library
         private ILocalizationManager _localizationManager;
         private IApplicationPaths _appPaths;
 
-        public MediaSourceManager(IItemRepository itemRepo, IApplicationPaths applicationPaths, ILocalizationManager localizationManager, IUserManager userManager, ILibraryManager libraryManager, ILogger logger, IJsonSerializer jsonSerializer, IFileSystem fileSystem, IUserDataManager userDataManager, ITimerFactory timerFactory, Func<IMediaEncoder> mediaEncoder)
+        public MediaSourceManager(
+            IItemRepository itemRepo,
+            IApplicationPaths applicationPaths,
+            ILocalizationManager localizationManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
+            IJsonSerializer jsonSerializer,
+            IFileSystem fileSystem,
+            IUserDataManager userDataManager,
+            ITimerFactory timerFactory,
+            Func<IMediaEncoder> mediaEncoder)
         {
             _itemRepo = itemRepo;
             _userManager = userManager;
             _libraryManager = libraryManager;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(MediaSourceManager));
             _jsonSerializer = jsonSerializer;
             _fileSystem = fileSystem;
             _userDataManager = userDataManager;

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -80,9 +80,20 @@ namespace Emby.Server.Implementations.Library
         private IAuthenticationProvider[] _authenticationProviders;
         private DefaultAuthenticationProvider _defaultAuthenticationProvider;
 
-        public UserManager(ILogger logger, IServerConfigurationManager configurationManager, IUserRepository userRepository, IXmlSerializer xmlSerializer, INetworkManager networkManager, Func<IImageProcessor> imageProcessorFactory, Func<IDtoService> dtoServiceFactory, IServerApplicationHost appHost, IJsonSerializer jsonSerializer, IFileSystem fileSystem, ICryptoProvider cryptographyProvider)
+        public UserManager(
+            ILoggerFactory loggerFactory,
+            IServerConfigurationManager configurationManager,
+            IUserRepository userRepository,
+            IXmlSerializer xmlSerializer,
+            INetworkManager networkManager,
+            Func<IImageProcessor> imageProcessorFactory,
+            Func<IDtoService> dtoServiceFactory,
+            IServerApplicationHost appHost,
+            IJsonSerializer jsonSerializer,
+            IFileSystem fileSystem,
+            ICryptoProvider cryptographyProvider)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(UserManager));
             UserRepository = userRepository;
             _xmlSerializer = xmlSerializer;
             _networkManager = networkManager;

--- a/Emby.Server.Implementations/LiveTv/LiveTvDtoService.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvDtoService.cs
@@ -26,11 +26,16 @@ namespace Emby.Server.Implementations.LiveTv
         private readonly IApplicationHost _appHost;
         private readonly ILibraryManager _libraryManager;
 
-        public LiveTvDtoService(IDtoService dtoService, IImageProcessor imageProcessor, ILogger logger, IApplicationHost appHost, ILibraryManager libraryManager)
+        public LiveTvDtoService(
+            IDtoService dtoService,
+            IImageProcessor imageProcessor,
+            ILoggerFactory loggerFactory,
+            IApplicationHost appHost,
+            ILibraryManager libraryManager)
         {
             _dtoService = dtoService;
             _imageProcessor = imageProcessor;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(LiveTvDtoService));
             _appHost = appHost;
             _libraryManager = libraryManager;
         }

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -72,14 +72,10 @@ namespace Emby.Server.Implementations.LiveTv
             return EmbyTV.EmbyTV.Current.GetActiveRecordingPath(id);
         }
 
-        private IServerApplicationHost _appHost;
-        private IHttpClient _httpClient;
-
         public LiveTvManager(
             IServerApplicationHost appHost,
-            IHttpClient httpClient,
             IServerConfigurationManager config,
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IItemRepository itemRepo,
             IImageProcessor imageProcessor,
             IUserDataManager userDataManager,
@@ -93,9 +89,8 @@ namespace Emby.Server.Implementations.LiveTv
             IFileSystem fileSystem,
             Func<IChannelManager> channelManager)
         {
-            _appHost = appHost;
             _config = config;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(LiveTvManager));
             _itemRepo = itemRepo;
             _userManager = userManager;
             _libraryManager = libraryManager;
@@ -107,9 +102,8 @@ namespace Emby.Server.Implementations.LiveTv
             _dtoService = dtoService;
             _userDataManager = userDataManager;
             _channelManager = channelManager;
-            _httpClient = httpClient;
 
-            _tvDtoService = new LiveTvDtoService(dtoService, imageProcessor, logger, appHost, _libraryManager);
+            _tvDtoService = new LiveTvDtoService(dtoService, imageProcessor, loggerFactory, appHost, _libraryManager);
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -45,12 +45,18 @@ namespace Emby.Server.Implementations.Localization
         /// <param name="configurationManager">The configuration manager.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="jsonSerializer">The json serializer.</param>
-        public LocalizationManager(IServerConfigurationManager configurationManager, IFileSystem fileSystem, IJsonSerializer jsonSerializer, ILogger logger, IAssemblyInfo assemblyInfo, ITextLocalizer textLocalizer)
+        public LocalizationManager(
+            IServerConfigurationManager configurationManager,
+            IFileSystem fileSystem,
+            IJsonSerializer jsonSerializer,
+            ILoggerFactory loggerFactory,
+            IAssemblyInfo assemblyInfo,
+            ITextLocalizer textLocalizer)
         {
             _configurationManager = configurationManager;
             _fileSystem = fileSystem;
             _jsonSerializer = jsonSerializer;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(LocalizationManager));
             _assemblyInfo = assemblyInfo;
             _textLocalizer = textLocalizer;
 

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -26,13 +26,14 @@ namespace Emby.Server.Implementations.MediaEncoder
         private readonly IChapterManager _chapterManager;
         private readonly ILibraryManager _libraryManager;
 
-        public EncodingManager(IFileSystem fileSystem,
-            ILogger logger,
+        public EncodingManager(
+            IFileSystem fileSystem,
+            ILoggerFactory loggerFactory,
             IMediaEncoder encoder,
             IChapterManager chapterManager, ILibraryManager libraryManager)
         {
             _fileSystem = fileSystem;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(EncodingManager));
             _encoder = encoder;
             _chapterManager = chapterManager;
             _libraryManager = libraryManager;

--- a/Emby.Server.Implementations/Net/SocketFactory.cs
+++ b/Emby.Server.Implementations/Net/SocketFactory.cs
@@ -17,18 +17,6 @@ namespace Emby.Server.Implementations.Net
         // but that wasn't really the point so kept to YAGNI principal for now, even if the
         // interfaces are a bit ugly, specific and make assumptions.
 
-        private readonly ILogger _logger;
-
-        public SocketFactory(ILogger logger)
-        {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            _logger = logger;
-        }
-
         public ISocket CreateTcpSocket(IpAddressInfo remoteAddress, int remotePort)
         {
             if (remotePort < 0) throw new ArgumentException("remotePort cannot be less than zero.", nameof(remotePort));

--- a/Emby.Server.Implementations/Networking/NetworkManager.cs
+++ b/Emby.Server.Implementations/Networking/NetworkManager.cs
@@ -22,9 +22,11 @@ namespace Emby.Server.Implementations.Networking
         public event EventHandler NetworkChanged;
         public Func<string[]> LocalSubnetsFn { get; set; }
 
-        public NetworkManager(ILogger logger, IEnvironmentInfo environment)
+        public NetworkManager(
+            ILoggerFactory loggerFactory,
+            IEnvironmentInfo environment)
         {
-            Logger = logger;
+            Logger = loggerFactory.CreateLogger(nameof(NetworkManager));
 
             // In FreeBSD these events cause a crash
             if (environment.OperatingSystem != MediaBrowser.Model.System.OperatingSystem.BSD)

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -28,12 +28,18 @@ namespace Emby.Server.Implementations.Playlists
         private readonly IUserManager _userManager;
         private readonly IProviderManager _providerManager;
 
-        public PlaylistManager(ILibraryManager libraryManager, IFileSystem fileSystem, ILibraryMonitor iLibraryMonitor, ILogger logger, IUserManager userManager, IProviderManager providerManager)
+        public PlaylistManager(
+            ILibraryManager libraryManager,
+            IFileSystem fileSystem,
+            ILibraryMonitor iLibraryMonitor,
+            ILoggerFactory loggerFactory,
+            IUserManager userManager,
+            IProviderManager providerManager)
         {
             _libraryManager = libraryManager;
             _fileSystem = fileSystem;
             _iLibraryMonitor = iLibraryMonitor;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(PlaylistManager));
             _userManager = userManager;
             _providerManager = providerManager;
         }

--- a/Emby.Server.Implementations/ResourceFileManager.cs
+++ b/Emby.Server.Implementations/ResourceFileManager.cs
@@ -15,10 +15,13 @@ namespace Emby.Server.Implementations
         private readonly ILogger _logger;
         private readonly IHttpResultFactory _resultFactory;
 
-        public ResourceFileManager(IHttpResultFactory resultFactory, ILogger logger, IFileSystem fileSystem)
+        public ResourceFileManager(
+            IHttpResultFactory resultFactory,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem)
         {
             _resultFactory = resultFactory;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("ResourceManager");
             _fileSystem = fileSystem;
         }
 

--- a/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
@@ -60,7 +60,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         /// </summary>
         /// <param name="applicationPaths">The application paths.</param>
         /// <param name="jsonSerializer">The json serializer.</param>
-        /// <param name="logger">The logger.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
         /// <exception cref="System.ArgumentException">kernel</exception>
         public TaskManager(
             IApplicationPaths applicationPaths,

--- a/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
@@ -61,12 +61,17 @@ namespace Emby.Server.Implementations.ScheduledTasks
         /// <param name="applicationPaths">The application paths.</param>
         /// <param name="jsonSerializer">The json serializer.</param>
         /// <param name="logger">The logger.</param>
-        /// <exception cref="ArgumentException">kernel</exception>
-        public TaskManager(IApplicationPaths applicationPaths, IJsonSerializer jsonSerializer, ILogger logger, IFileSystem fileSystem, ISystemEvents systemEvents)
+        /// <exception cref="System.ArgumentException">kernel</exception>
+        public TaskManager(
+            IApplicationPaths applicationPaths,
+            IJsonSerializer jsonSerializer,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem,
+            ISystemEvents systemEvents)
         {
             ApplicationPaths = applicationPaths;
             JsonSerializer = jsonSerializer;
-            Logger = logger;
+            Logger = loggerFactory.CreateLogger(nameof(TaskManager));
             _fileSystem = fileSystem;
             _systemEvents = systemEvents;
 

--- a/Emby.Server.Implementations/Security/AuthenticationRepository.cs
+++ b/Emby.Server.Implementations/Security/AuthenticationRepository.cs
@@ -18,8 +18,8 @@ namespace Emby.Server.Implementations.Security
         private readonly IServerConfigurationManager _config;
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
 
-        public AuthenticationRepository(ILogger logger, IServerConfigurationManager config)
-            : base(logger)
+        public AuthenticationRepository(ILoggerFactory loggerFactory, IServerConfigurationManager config)
+            : base(loggerFactory.CreateLogger(nameof(AuthenticationRepository)))
         {
             _config = config;
             DbFilePath = Path.Combine(config.ApplicationPaths.DataPath, "authentication.db");

--- a/Emby.Server.Implementations/Serialization/JsonSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/JsonSerializer.cs
@@ -13,12 +13,11 @@ namespace Emby.Common.Implementations.Serialization
     public class JsonSerializer : IJsonSerializer
     {
         private readonly IFileSystem _fileSystem;
-        private readonly ILogger _logger;
 
-        public JsonSerializer(IFileSystem fileSystem, ILogger logger)
+        public JsonSerializer(
+            IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
-            _logger = logger;
             Configure();
         }
 
@@ -69,7 +68,6 @@ namespace Emby.Common.Implementations.Serialization
 
         private static Stream OpenFile(string path)
         {
-            //_logger.LogDebug("Deserializing file {0}", path);
             return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 131072);
         }
 

--- a/Emby.Server.Implementations/Serialization/XmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/XmlSerializer.cs
@@ -17,10 +17,12 @@ namespace Emby.Server.Implementations.Serialization
         private readonly IFileSystem _fileSystem;
         private readonly ILogger _logger;
 
-        public MyXmlSerializer(IFileSystem fileSystem, ILogger logger)
+        public MyXmlSerializer(
+            IFileSystem fileSystem,
+            ILoggerFactory loggerFactory)
         {
             _fileSystem = fileSystem;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger("XmlSerializer");
         }
 
         // Need to cache these

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -90,10 +90,24 @@ namespace Emby.Server.Implementations.Session
         public event EventHandler<SessionEventArgs> SessionEnded;
         public event EventHandler<SessionEventArgs> SessionActivity;
 
-        public SessionManager(IUserDataManager userDataManager, ILogger logger, ILibraryManager libraryManager, IUserManager userManager, IMusicManager musicManager, IDtoService dtoService, IImageProcessor imageProcessor, IJsonSerializer jsonSerializer, IServerApplicationHost appHost, IHttpClient httpClient, IAuthenticationRepository authRepo, IDeviceManager deviceManager, IMediaSourceManager mediaSourceManager, ITimerFactory timerFactory)
+        public SessionManager(
+            IUserDataManager userDataManager,
+            ILoggerFactory loggerFactory,
+            ILibraryManager libraryManager,
+            IUserManager userManager,
+            IMusicManager musicManager,
+            IDtoService dtoService,
+            IImageProcessor imageProcessor,
+            IJsonSerializer jsonSerializer,
+            IServerApplicationHost appHost,
+            IHttpClient httpClient,
+            IAuthenticationRepository authRepo,
+            IDeviceManager deviceManager,
+            IMediaSourceManager mediaSourceManager,
+            ITimerFactory timerFactory)
         {
             _userDataManager = userDataManager;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(SessionManager));
             _libraryManager = libraryManager;
             _userManager = userManager;
             _musicManager = musicManager;

--- a/Emby.Server.Implementations/SystemEvents.cs
+++ b/Emby.Server.Implementations/SystemEvents.cs
@@ -1,6 +1,5 @@
 using System;
 using MediaBrowser.Model.System;
-using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations
 {
@@ -10,12 +9,5 @@ namespace Emby.Server.Implementations
         public event EventHandler Suspend;
         public event EventHandler SessionLogoff;
         public event EventHandler SystemShutdown;
-
-        private readonly ILogger _logger;
-
-        public SystemEvents(ILogger logger)
-        {
-            _logger = logger;
-        }
     }
 }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -121,7 +121,7 @@ namespace Emby.Server.Implementations.Updates
         private readonly string _packageRuntime;
 
         public InstallationManager(
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IApplicationHost appHost,
             IApplicationPaths appPaths,
             IHttpClient httpClient,
@@ -131,9 +131,9 @@ namespace Emby.Server.Implementations.Updates
             ICryptoProvider cryptographyProvider,
             string packageRuntime)
         {
-            if (logger == null)
+            if (loggerFactory == null)
             {
-                throw new ArgumentNullException(nameof(logger));
+                throw new ArgumentNullException(nameof(loggerFactory));
             }
 
             CurrentInstallations = new List<Tuple<InstallationInfo, CancellationTokenSource>>();
@@ -147,7 +147,7 @@ namespace Emby.Server.Implementations.Updates
             _fileSystem = fileSystem;
             _cryptographyProvider = cryptographyProvider;
             _packageRuntime = packageRuntime;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(InstallationManager));
         }
 
         private static Version GetPackageVersion(PackageVersionInfo version)

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -103,7 +103,7 @@ namespace Jellyfin.Server
             {
                 appHost.Init();
 
-                appHost.ImageProcessor.ImageEncoder = getImageEncoder(_loggerFactory, fileSystem, options, () => appHost.HttpClient, appPaths, environmentInfo, appHost.LocalizationManager);
+                appHost.ImageProcessor.ImageEncoder = getImageEncoder(fileSystem, () => appHost.HttpClient, appPaths, appHost.LocalizationManager);
 
                 _logger.LogInformation("Running startup tasks");
 
@@ -257,17 +257,14 @@ namespace Jellyfin.Server
         }
 
         public static IImageEncoder getImageEncoder(
-            ILoggerFactory loggerFactory,
             IFileSystem fileSystem,
-            StartupOptions startupOptions,
             Func<IHttpClient> httpClient,
             IApplicationPaths appPaths,
-            IEnvironmentInfo environment,
             ILocalizationManager localizationManager)
         {
             try
             {
-                return new SkiaEncoder(loggerFactory, appPaths, httpClient, fileSystem, localizationManager);
+                return new SkiaEncoder(_loggerFactory, appPaths, httpClient, fileSystem, localizationManager);
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -89,7 +89,7 @@ namespace Jellyfin.Server
             // Allow all https requests
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(delegate { return true; });
 
-            var fileSystem = new ManagedFileSystem(_loggerFactory.CreateLogger("FileSystem"), environmentInfo, null, appPaths.TempDirectory, true);
+            var fileSystem = new ManagedFileSystem(_loggerFactory, environmentInfo, null, appPaths.TempDirectory, true);
 
             using (var appHost = new CoreAppHost(
                 appPaths,
@@ -98,12 +98,12 @@ namespace Jellyfin.Server
                 fileSystem,
                 environmentInfo,
                 new NullImageEncoder(),
-                new SystemEvents(_loggerFactory.CreateLogger("SystemEvents")),
-                new NetworkManager(_loggerFactory.CreateLogger("NetworkManager"), environmentInfo)))
+                new SystemEvents(),
+                new NetworkManager(_loggerFactory, environmentInfo)))
             {
                 appHost.Init();
 
-                appHost.ImageProcessor.ImageEncoder = getImageEncoder(_logger, fileSystem, options, () => appHost.HttpClient, appPaths, environmentInfo, appHost.LocalizationManager);
+                appHost.ImageProcessor.ImageEncoder = getImageEncoder(_loggerFactory, fileSystem, options, () => appHost.HttpClient, appPaths, environmentInfo, appHost.LocalizationManager);
 
                 _logger.LogInformation("Running startup tasks");
 
@@ -257,7 +257,7 @@ namespace Jellyfin.Server
         }
 
         public static IImageEncoder getImageEncoder(
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IFileSystem fileSystem,
             StartupOptions startupOptions,
             Func<IHttpClient> httpClient,
@@ -267,11 +267,11 @@ namespace Jellyfin.Server
         {
             try
             {
-                return new SkiaEncoder(logger, appPaths, httpClient, fileSystem, localizationManager);
+                return new SkiaEncoder(loggerFactory, appPaths, httpClient, fileSystem, localizationManager);
             }
             catch (Exception ex)
             {
-                logger.LogInformation(ex, "Skia not available. Will fallback to NullIMageEncoder. {0}");
+                _logger.LogInformation(ex, "Skia not available. Will fallback to NullIMageEncoder. {0}");
             }
 
             return new NullImageEncoder();

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -70,7 +70,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private readonly string _originalFFProbePath;
         private readonly int DefaultImageExtractionTimeoutMs;
 
-        public MediaEncoder(ILogger logger,
+        public MediaEncoder(
+            ILoggerFactory loggerFactory,
             IJsonSerializer jsonSerializer,
             string ffMpegPath,
             string ffProbePath,
@@ -89,7 +90,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             IProcessFactory processFactory,
             int defaultImageExtractionTimeoutMs)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(MediaEncoder));
             _jsonSerializer = jsonSerializer;
             ConfigurationManager = configurationManager;
             FileSystem = fileSystem;

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -35,8 +35,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly IProcessFactory _processFactory;
 
-        public SubtitleEncoder(ILibraryManager libraryManager,
-            ILogger logger,
+        public SubtitleEncoder(
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
             IApplicationPaths appPaths,
             IFileSystem fileSystem,
             IMediaEncoder mediaEncoder,
@@ -46,7 +47,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             IProcessFactory processFactory)
         {
             _libraryManager = libraryManager;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(SubtitleEncoder));
             _appPaths = appPaths;
             _fileSystem = fileSystem;
             _mediaEncoder = mediaEncoder;

--- a/MediaBrowser.Providers/Chapters/ChapterManager.cs
+++ b/MediaBrowser.Providers/Chapters/ChapterManager.cs
@@ -16,10 +16,14 @@ namespace MediaBrowser.Providers.Chapters
         private readonly IServerConfigurationManager _config;
         private readonly IItemRepository _itemRepo;
 
-        public ChapterManager(ILibraryManager libraryManager, ILogger logger, IServerConfigurationManager config, IItemRepository itemRepo)
+        public ChapterManager(
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
+            IServerConfigurationManager config,
+            IItemRepository itemRepo)
         {
             _libraryManager = libraryManager;
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(ChapterManager));
             _config = config;
             _itemRepo = itemRepo;
         }

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -37,9 +37,15 @@ namespace MediaBrowser.Providers.Subtitles
 
         private ILocalizationManager _localization;
 
-        public SubtitleManager(ILogger logger, IFileSystem fileSystem, ILibraryMonitor monitor, IMediaSourceManager mediaSourceManager, IServerConfigurationManager config, ILocalizationManager localizationManager)
+        public SubtitleManager(
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem,
+            ILibraryMonitor monitor,
+            IMediaSourceManager mediaSourceManager,
+            IServerConfigurationManager config,
+            ILocalizationManager localizationManager)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger(nameof(SubtitleManager));
             _fileSystem = fileSystem;
             _monitor = monitor;
             _mediaSourceManager = mediaSourceManager;


### PR DESCRIPTION
This makes resolving dependencies from the container much easier as
you cannot resolve with primitives parameters in a way that is any
more readable.

The aim of this commit is to change as little as possible with the end
result, loggers that were newed up for the parent object were given the same
name. Objects that used the base or app loggers, were given a new logger with
an appropriate name.

Also removed some unused dependencies.

Fixes no issues but is step one in sorting out the poor dependency registration that is occurring
in ApplicationHost.cs
