### PR TITLE
Filter videos by audio stream language

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4518,6 +4518,17 @@ namespace Emby.Server.Implementations.Data
                 }
             }
 
+            if (query.AudioLanguages.Any())
+            {
+                var index = 0;
+                foreach (string audioLanguage in query.AudioLanguages)
+                {
+                    whereClauses.Add($"(@audioLanguage{index} IN (SELECT Language FROM MediaStreams WHERE MediaStreams.ItemId = Guid AND MediaStreams.StreamType = 'Audio'))");
+                    statement?.TryBind($"@audioLanguage{index}", audioLanguage);
+                    index++;
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(query.HasNoAudioTrackWithLanguage))
             {
                 whereClauses.Add("((select language from MediaStreams where MediaStreams.ItemId=A.Guid and MediaStreams.StreamType='Audio' and MediaStreams.Language=@HasNoAudioTrackWithLanguage limit 1) is null)");
@@ -5672,7 +5683,8 @@ where AncestorIdText not null and ItemValues.Value not null and ItemValues.Type 
                 NameContains = query.NameContains,
                 SearchTerm = query.SearchTerm,
                 SimilarTo = query.SimilarTo,
-                ExcludeItemIds = query.ExcludeItemIds
+                ExcludeItemIds = query.ExcludeItemIds,
+                AudioLanguages = query.AudioLanguages
             };
 
             var outerWhereClauses = GetWhereClauses(outerQuery, null);

--- a/MediaBrowser.Api/FilterService.cs
+++ b/MediaBrowser.Api/FilterService.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Querying;
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Services;
 
 namespace MediaBrowser.Api
@@ -218,6 +219,16 @@ namespace MediaBrowser.Api
                 .Where(i => !string.IsNullOrWhiteSpace(i))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(i => i)
+                .ToArray();
+
+            result.AudioLanguages = items
+                .Select(item => item.GetMediaStreams()
+                    .Where(stream => stream.Type == MediaStreamType.Audio)
+                    .Select(stream => stream.Language))
+                .SelectMany(names => names)
+                .Where(name => !string.IsNullOrEmpty(name))
+                .DistinctNames()
+                .OrderBy(name => name)
                 .ToArray();
 
             return result;

--- a/MediaBrowser.Api/UserLibrary/BaseItemsByNameService.cs
+++ b/MediaBrowser.Api/UserLibrary/BaseItemsByNameService.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
@@ -126,7 +126,8 @@ namespace MediaBrowser.Api.UserLibrary
                 MinCommunityRating = request.MinCommunityRating,
                 DtoOptions = dtoOptions,
                 SearchTerm = request.SearchTerm,
-                EnableTotalRecordCount = request.EnableTotalRecordCount
+                EnableTotalRecordCount = request.EnableTotalRecordCount,
+                AudioLanguages = request.GetAudioLanguages()
             };
 
             if (!string.IsNullOrWhiteSpace(request.ParentId))

--- a/MediaBrowser.Api/UserLibrary/BaseItemsRequest.cs
+++ b/MediaBrowser.Api/UserLibrary/BaseItemsRequest.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using System;
 using System.Collections.Generic;
@@ -356,6 +356,9 @@ namespace MediaBrowser.Api.UserLibrary
         [ApiMember(Name = "NameLessThan", Description = "Optional filter by items whose name is equally or lesser than a given input string.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
         public string NameLessThan { get; set; }
 
+        [ApiMember(Name = "AudioLanguages", Description = "Optional. If specified, results will be filtered based on available audio language streams. This allows multiple, pipe delimeted.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
+        public string AudioLanguages { get; set; }
+
         public string[] GetGenres()
         {
             return (Genres ?? string.Empty).Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
@@ -399,6 +402,11 @@ namespace MediaBrowser.Api.UserLibrary
         public string[] GetPersonTypes()
         {
             return (PersonTypes ?? string.Empty).Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public string[] GetAudioLanguages()
+        {
+            return (AudioLanguages ?? string.Empty).Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public VideoType[] GetVideoTypes()

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
@@ -315,7 +315,8 @@ namespace MediaBrowser.Api.UserLibrary
                 EnableTotalRecordCount = request.EnableTotalRecordCount,
                 ExcludeItemIds = GetGuids(request.ExcludeItemIds),
                 DtoOptions = dtoOptions,
-                SearchTerm = request.SearchTerm
+                SearchTerm = request.SearchTerm,
+                AudioLanguages = request.GetAudioLanguages()
             };
 
             if (!string.IsNullOrWhiteSpace(request.Ids) || !string.IsNullOrWhiteSpace(request.SearchTerm))

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Entities;
 using System;
 using System.Collections.Generic;
 using MediaBrowser.Model.Configuration;
@@ -167,6 +167,7 @@ namespace MediaBrowser.Controller.Entities
         public DtoOptions DtoOptions { get; set; }
         public int MinSimilarityScore { get; set; }
         public string HasNoAudioTrackWithLanguage { get; set; }
+        public string[] AudioLanguages { get; set; }
         public string HasNoInternalSubtitleTrackWithLanguage { get; set; }
         public string HasNoExternalSubtitleTrackWithLanguage { get; set; }
         public string HasNoSubtitleTrackWithLanguage { get; set; }
@@ -214,6 +215,7 @@ namespace MediaBrowser.Controller.Entities
             TrailerTypes = Array.Empty<TrailerType>();
             VideoTypes = Array.Empty<VideoType>();
             Years = Array.Empty<int>();
+            AudioLanguages= Array.Empty<string>();
         }
 
         public InternalItemsQuery(User user)

--- a/MediaBrowser.Model/Querying/QueryFilters.cs
+++ b/MediaBrowser.Model/Querying/QueryFilters.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Dto;
 using System;
 
 namespace MediaBrowser.Model.Querying
@@ -9,6 +9,7 @@ namespace MediaBrowser.Model.Querying
         public string[] Tags { get; set; }
         public string[] OfficialRatings { get; set; }
         public int[] Years { get; set; }
+        public string[] AudioLanguages { get; set; }
 
         public QueryFiltersLegacy()
         {
@@ -16,6 +17,7 @@ namespace MediaBrowser.Model.Querying
             Tags = Array.Empty<string>();
             OfficialRatings = Array.Empty<string>();
             Years = Array.Empty<int>();
+            AudioLanguages = Array.Empty<string>();
         }
     }
     public class QueryFilters


### PR DESCRIPTION
Adds backend functionality to allow filtering videos by audio stream languages.
A PR will be done for jellyfin-web to expose the functionality.

This PR will require some more work, please check my comments.

Limitations:
- The filtering does not work for e.g. series, as `BaseItem.GetMediaStreams()` is being used; this only returns streams if the `BaseItem` is a Video.