### PR TITLE
Fix subtitle converter misinterpreting 0 valued endTimeTicks

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -66,7 +66,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             string inputFormat,
             string outputFormat,
             long startTimeTicks,
-            long? endTimeTicks,
+            long endTimeTicks,
             bool preserveOriginalTimestamps,
             CancellationToken cancellationToken)
         {
@@ -94,16 +94,16 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             return ms;
         }
 
-        private void FilterEvents(SubtitleTrackInfo track, long startPositionTicks, long? endTimeTicks, bool preserveTimestamps)
+        private void FilterEvents(SubtitleTrackInfo track, long startPositionTicks, long endTimeTicks, bool preserveTimestamps)
         {
             // Drop subs that are earlier than what we're looking for
             track.TrackEvents = track.TrackEvents
                 .SkipWhile(i => (i.StartPositionTicks - startPositionTicks) < 0 || (i.EndPositionTicks - startPositionTicks) < 0)
                 .ToArray();
 
-            if (endTimeTicks.HasValue)
+            if (endTimeTicks > 0)
             {
-                long endTime = endTimeTicks.Value;
+                long endTime = endTimeTicks;
 
                 track.TrackEvents = track.TrackEvents
                     .TakeWhile(i => i.StartPositionTicks <= endTime)

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -103,10 +103,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             if (endTimeTicks > 0)
             {
-                long endTime = endTimeTicks;
-
                 track.TrackEvents = track.TrackEvents
-                    .TakeWhile(i => i.StartPositionTicks <= endTime)
+                    .TakeWhile(i => i.StartPositionTicks <= endTimeTicks)
                     .ToArray();
             }
 


### PR DESCRIPTION
**Changes**
Changed a nullable long to a non-nullable.

Problem was that endTimeTicks was always 0 for (at least) direct streams and then it filtered out any timestamps that were not before the endtime...
**Issues**
Fixes #254
