### PR TITLE
Allow subtitle extraction and conversion in direct streaming

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1018,7 +1018,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         public bool CanExtractSubtitles(string codec)
         {
-            return false;
+            // TODO is there ever a case when a subtitle can't be extracted??
+            return true;
         }
 
         private class ProcessWrapper : IDisposable


### PR DESCRIPTION
**Changes**
Changed CanExtractSubtitles to return true.

I don't really understand why it's even there. Is there ever a case when it can't be extracted? Maybe live streams?

This PR is really just to create some discussion
**Issues**
Related to #254 
Related to #172