### PR TITLE
Do some logging in MediaInfoService

### DIFF
--- a/MediaBrowser.Api/Playback/MediaInfoService.cs
+++ b/MediaBrowser.Api/Playback/MediaInfoService.cs
@@ -74,8 +74,19 @@ namespace MediaBrowser.Api.Playback
         private readonly IUserManager _userManager;
         private readonly IJsonSerializer _json;
         private readonly IAuthorizationContext _authContext;
+        private readonly ILogger _logger;
 
-        public MediaInfoService(IMediaSourceManager mediaSourceManager, IDeviceManager deviceManager, ILibraryManager libraryManager, IServerConfigurationManager config, INetworkManager networkManager, IMediaEncoder mediaEncoder, IUserManager userManager, IJsonSerializer json, IAuthorizationContext authContext)
+        public MediaInfoService(
+            IMediaSourceManager mediaSourceManager,
+            IDeviceManager deviceManager,
+            ILibraryManager libraryManager,
+            IServerConfigurationManager config,
+            INetworkManager networkManager,
+            IMediaEncoder mediaEncoder,
+            IUserManager userManager,
+            IJsonSerializer json,
+            IAuthorizationContext authContext,
+            ILoggerFactory loggerFactory)
         {
             _mediaSourceManager = mediaSourceManager;
             _deviceManager = deviceManager;
@@ -86,6 +97,7 @@ namespace MediaBrowser.Api.Playback
             _userManager = userManager;
             _json = json;
             _authContext = authContext;
+            _logger = loggerFactory.CreateLogger(nameof(MediaInfoService));
         }
 
         public object Get(GetBitrateTestBytes request)
@@ -165,7 +177,7 @@ namespace MediaBrowser.Api.Playback
 
             var profile = request.DeviceProfile;
 
-            //Logger.Info("GetPostedPlaybackInfo profile: {0}", _json.SerializeToString(profile));
+            //Logger.LogInformation("GetPostedPlaybackInfo profile: {profile}", _json.SerializeToString(profile));
 
             if (profile == null)
             {
@@ -262,7 +274,7 @@ namespace MediaBrowser.Api.Playback
                 catch (Exception ex)
                 {
                     mediaSources = new List<MediaSourceInfo>();
-                    // TODO Log exception
+                    _logger.LogError(ex, "Could not find media sources for item id {id}", id);
                     // TODO PlaybackException ??
                     //result.ErrorCode = ex.ErrorCode;
                 }

--- a/MediaBrowser.Api/Playback/UniversalAudioService.cs
+++ b/MediaBrowser.Api/Playback/UniversalAudioService.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Services;
 using MediaBrowser.Model.System;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Api.Playback
 {
@@ -75,7 +76,24 @@ namespace MediaBrowser.Api.Playback
     [Authenticated]
     public class UniversalAudioService : BaseApiService
     {
-        public UniversalAudioService(IServerConfigurationManager serverConfigurationManager, IUserManager userManager, ILibraryManager libraryManager, IIsoManager isoManager, IMediaEncoder mediaEncoder, IFileSystem fileSystem, IDlnaManager dlnaManager, IDeviceManager deviceManager, ISubtitleEncoder subtitleEncoder, IMediaSourceManager mediaSourceManager, IZipClient zipClient, IJsonSerializer jsonSerializer, IAuthorizationContext authorizationContext, IImageProcessor imageProcessor, INetworkManager networkManager, IEnvironmentInfo environmentInfo)
+        public UniversalAudioService(
+            IServerConfigurationManager serverConfigurationManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IIsoManager isoManager,
+            IMediaEncoder mediaEncoder,
+            IFileSystem fileSystem,
+            IDlnaManager dlnaManager,
+            IDeviceManager deviceManager,
+            ISubtitleEncoder subtitleEncoder,
+            IMediaSourceManager mediaSourceManager,
+            IZipClient zipClient,
+            IJsonSerializer jsonSerializer,
+            IAuthorizationContext authorizationContext,
+            IImageProcessor imageProcessor,
+            INetworkManager networkManager,
+            IEnvironmentInfo environmentInfo,
+            ILoggerFactory loggerFactory)
         {
             ServerConfigurationManager = serverConfigurationManager;
             UserManager = userManager;
@@ -93,6 +111,8 @@ namespace MediaBrowser.Api.Playback
             ImageProcessor = imageProcessor;
             NetworkManager = networkManager;
             EnvironmentInfo = environmentInfo;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger(nameof(UniversalAudioService));
         }
 
         protected IServerConfigurationManager ServerConfigurationManager { get; private set; }
@@ -111,6 +131,8 @@ namespace MediaBrowser.Api.Playback
         protected IImageProcessor ImageProcessor { get; private set; }
         protected INetworkManager NetworkManager { get; private set; }
         protected IEnvironmentInfo EnvironmentInfo { get; private set; }
+        private ILoggerFactory _loggerFactory;
+        private ILogger _logger;
 
         public Task<object> Get(GetUniversalAudioStream request)
         {
@@ -221,7 +243,7 @@ namespace MediaBrowser.Api.Playback
 
             AuthorizationContext.GetAuthorizationInfo(Request).DeviceId = request.DeviceId;
 
-            var mediaInfoService = new MediaInfoService(MediaSourceManager, DeviceManager, LibraryManager, ServerConfigurationManager, NetworkManager, MediaEncoder, UserManager, JsonSerializer, AuthorizationContext)
+            var mediaInfoService = new MediaInfoService(MediaSourceManager, DeviceManager, LibraryManager, ServerConfigurationManager, NetworkManager, MediaEncoder, UserManager, JsonSerializer, AuthorizationContext, _loggerFactory)
             {
                 Request = Request
             };


### PR DESCRIPTION
Pull #600 got the feedback that it would be better to implement logging than to nuke it. I saw that it would be more than a line or two of change, so that's the background for this PR.

I feel like this could be done better with some DI stuff, but I have no idea how it works, so I hope you'll help me out here and I'll fix this PR to be awesome :p

**Changes**
* remove a TODO in MediaInfoService by implementing logging there
* Add logging capability to MediaInfoService
* Add logging capability to UniversalAudioService since it has to pass it down


ALSO, and this is kinda important.
I didn't test how often it will throw, so if it throws a ton of stack traces then we might want to tone it down to debug and see what we can do to fix it properly.