### PR TITLE
Revert "Update MediaEncoding"

### DIFF
--- a/MediaBrowser.Api/Playback/StreamRequest.cs
+++ b/MediaBrowser.Api/Playback/StreamRequest.cs
@@ -9,6 +9,29 @@ namespace MediaBrowser.Api.Playback
     /// </summary>
     public class StreamRequest : BaseEncodingJobOptions
     {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        /// <value>The id.</value>
+        [ApiMember(Name = "Id", Description = "Item Id", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "GET")]
+        public Guid Id { get; set; }
+
+        [ApiMember(Name = "MediaSourceId", Description = "The media version id, if playing an alternate version", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "GET")]
+        public string MediaSourceId { get; set; }
+
+        [ApiMember(Name = "DeviceId", Description = "The device id of the client requesting. Used to stop encoding processes when needed.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
+        public string DeviceId { get; set; }
+
+        [ApiMember(Name = "Container", Description = "Container", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "GET")]
+        public string Container { get; set; }
+
+        /// <summary>
+        /// Gets or sets the audio codec.
+        /// </summary>
+        /// <value>The audio codec.</value>
+        [ApiMember(Name = "AudioCodec", Description = "Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
+        public string AudioCodec { get; set; }
+
         [ApiMember(Name = "DeviceProfileId", Description = "Optional. The dlna device profile id to utilize.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
         public string DeviceProfileId { get; set; }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
@@ -22,8 +21,6 @@ namespace MediaBrowser.Controller.MediaEncoding
         private readonly IMediaEncoder _mediaEncoder;
         private readonly IFileSystem _fileSystem;
         private readonly ISubtitleEncoder _subtitleEncoder;
-        // private readonly IApplicationPaths _appPaths;
-        // private readonly IAssemblyInfo _assemblyInfo;
 
         public EncodingHelper(IMediaEncoder mediaEncoder, IFileSystem fileSystem, ISubtitleEncoder subtitleEncoder)
         {
@@ -43,55 +40,56 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 var hwType = encodingOptions.HardwareAccelerationType;
 
-                var codecMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                if (!encodingOptions.EnableHardwareEncoding)
                 {
-                    {"qsv",          "h264_qsv"},
-                    {"h264_qsv",     "h264_qsv"},
-                    {"nvenc",        "h264_nvenc"},
-                    {"amf",          "h264_amf"},
-                    {"omx",          "h264_omx"},
-                    {"h264_v4l2m2m", "h264_v4l2m2m"},
-                    {"mediacodec",   "h264_mediacodec"},
-                    {"vaapi",        "h264_vaapi"}
-                };
-
-                if (!string.IsNullOrEmpty(hwType)
-                    && encodingOptions.EnableHardwareEncoding && codecMap.ContainsKey(hwType))
-                {
-                    if (CheckVaapi(state, hwType, encodingOptions))
-                    {
-                        var preferredEncoder = codecMap[hwType];
-
-                        if (_mediaEncoder.SupportsEncoder(preferredEncoder))
-                        {
-                            return preferredEncoder;
-                        }
-                    }
+                    hwType = null;
                 }
 
+                if (string.Equals(hwType, "qsv", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(hwType, "h264_qsv", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_qsv", defaultEncoder);
+                }
+
+                if (string.Equals(hwType, "nvenc", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_nvenc", defaultEncoder);
+                }
+                if (string.Equals(hwType, "amf", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_amf", defaultEncoder);
+                }
+                if (string.Equals(hwType, "omx", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_omx", defaultEncoder);
+                }
+                if (string.Equals(hwType, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_v4l2m2m", defaultEncoder);
+                }
+                if (string.Equals(hwType, "mediacodec", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_mediacodec", defaultEncoder);
+                }
+                if (string.Equals(hwType, "vaapi", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(encodingOptions.VaapiDevice))
+                {
+                    if (IsVaapiSupported(state))
+                    {
+                        return GetAvailableEncoder("h264_vaapi", defaultEncoder);
+                    }
+                }
             }
 
-            // Avoid performing a second attempt when the first one
-            // hasn't tried hardware encoding anyway.
-            encodingOptions.EnableHardwareEncoding = false;
             return defaultEncoder;
         }
 
-        private bool CheckVaapi(EncodingJobInfo state, string hwType, EncodingOptions encodingOptions)
+        private string GetAvailableEncoder(string preferredEncoder, string defaultEncoder)
         {
-            if (!string.Equals(hwType, "vaapi", StringComparison.OrdinalIgnoreCase))
+            if (_mediaEncoder.SupportsEncoder(preferredEncoder))
             {
-                // No vaapi requested, return OK.
-                return true;
+                return preferredEncoder;
             }
-
-            if (string.IsNullOrEmpty(encodingOptions.VaapiDevice))
-            {
-                // No device specified, return OK.
-                return true;
-            }
-
-            return IsVaapiSupported(state);
+            return defaultEncoder;
         }
 
         private bool IsVaapiSupported(EncodingJobInfo state)
@@ -342,7 +340,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public int GetVideoProfileScore(string profile)
         {
-            var list = new[]
+            string[] list =
             {
                 "ConstrainedBaseline",
                 "Baseline",
@@ -540,54 +538,14 @@ namespace MediaBrowser.Controller.MediaEncoding
                 ? string.Empty
                 : string.Format(",setpts=PTS -{0}/TB", seconds.ToString(_usCulture));
 
-            // TODO
-            // var fallbackFontPath = Path.Combine(_appPaths.ProgramDataPath, "fonts", "DroidSansFallback.ttf");
-            // string fallbackFontParam = string.Empty;
-
-            // if (!_fileSystem.FileExists(fallbackFontPath))
-            // {
-            //     _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(fallbackFontPath));
-            //     using (var stream = _assemblyInfo.GetManifestResourceStream(GetType(), GetType().Namespace + ".DroidSansFallback.ttf"))
-            //     {
-            //         using (var fileStream = _fileSystem.GetFileStream(fallbackFontPath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
-            //         {
-            //             stream.CopyTo(fileStream);
-            //         }
-            //     }
-            // }
-
-            // fallbackFontParam = string.Format(":force_style='FontName=Droid Sans Fallback':fontsdir='{0}'", _mediaEncoder.EscapeSubtitleFilterPath(_fileSystem.GetDirectoryName(fallbackFontPath)));
-
-            if (state.SubtitleStream.IsExternal)
-            {
-                var subtitlePath = state.SubtitleStream.Path;
-
-                var charsetParam = string.Empty;
-
-                if (!string.IsNullOrEmpty(state.SubtitleStream.Language))
-                {
-                    var charenc = _subtitleEncoder.GetSubtitleFileCharacterSet(subtitlePath, state.SubtitleStream.Language, state.MediaSource.Protocol, CancellationToken.None).Result;
-
-                    if (!string.IsNullOrEmpty(charenc))
-                    {
-                        charsetParam = ":charenc=" + charenc;
-                    }
-                }
-
-                // TODO: Perhaps also use original_size=1920x800 ??
-                return string.Format("subtitles=filename='{0}'{1}{2}{3}",
-                    _mediaEncoder.EscapeSubtitleFilterPath(subtitlePath),
-                    charsetParam,
-                    // fallbackFontParam,
-                    setPtsParam);
-            }
+            string fallbackFontParam = string.Empty;
 
             var mediaPath = state.MediaPath ?? string.Empty;
 
-            return string.Format("subtitles='{0}:si={1}'{2}",
+            return string.Format("subtitles='{0}:si={1}'{2}{3}",
                 _mediaEncoder.EscapeSubtitleFilterPath(mediaPath),
                 state.InternalSubtitleStreamOffset.ToString(_usCulture),
-                // fallbackFontParam,
+                fallbackFontParam,
                 setPtsParam);
         }
 
@@ -760,18 +718,14 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var request = state.BaseRequest;
             var profile = state.GetRequestedProfiles(targetVideoCodec).FirstOrDefault();
-
-            // vaapi does not support Baseline profile, force Constrained Baseline in this case,
-            // which is compatible (and ugly)
-            if (string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase) &&
-                profile != null && profile.ToLower().Contains("baseline"))
+            if (string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
-                    profile = "constrained_baseline";
+                param += " -profile:v 578";
             }
-
-            if (!string.IsNullOrEmpty(profile))
+            else if (!string.IsNullOrEmpty(profile))
             {
                 if (!string.Equals(videoEncoder, "h264_omx", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(videoEncoder, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
                 {
                     // not supported by h264_omx
@@ -1085,67 +1039,51 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             var bitrate = request.VideoBitRate;
 
-            // If specific values were requested, then force the caller to supply a bitrate as well
-            if (request.Height.HasValue && request.Width.HasValue)
-            {
-                return bitrate;
-            }
-
             if (videoStream != null)
             {
-                if (bitrate.HasValue)
-                {
-                    var inputVideoCodec = videoStream.Codec;
-                    bitrate = ScaleBitrate(bitrate.Value, inputVideoCodec, outputVideoCodec);
+                var isUpscaling = request.Height.HasValue && videoStream.Height.HasValue &&
+                                   request.Height.Value > videoStream.Height.Value && request.Width.HasValue && videoStream.Width.HasValue &&
+                    request.Width.Value > videoStream.Width.Value;
 
-                    // If a max bitrate was requested, don't let the scaled bitrate exceed it
-                    if (request.VideoBitRate.HasValue)
+                // Don't allow bitrate increases unless upscaling
+                if (!isUpscaling)
+                {
+                    if (bitrate.HasValue && videoStream.BitRate.HasValue)
                     {
-                        bitrate = Math.Min(bitrate.Value, request.VideoBitRate.Value);
+                        bitrate = GetMinBitrate(videoStream.BitRate.Value, bitrate.Value);
                     }
+                }
+            }
+
+            if (bitrate.HasValue)
+            {
+                var inputVideoCodec = videoStream == null ? null : videoStream.Codec;
+                bitrate = ResolutionNormalizer.ScaleBitrate(bitrate.Value, inputVideoCodec, outputVideoCodec);
+
+                // If a max bitrate was requested, don't let the scaled bitrate exceed it
+                if (request.VideoBitRate.HasValue)
+                {
+                    bitrate = Math.Min(bitrate.Value, request.VideoBitRate.Value);
                 }
             }
 
             return bitrate;
         }
 
-        private static double GetVideoBitrateScaleFactor(string codec)
+        private int GetMinBitrate(int sourceBitrate, int requestedBitrate)
         {
-            if (StringHelper.EqualsIgnoreCase(codec, "h265") ||
-                StringHelper.EqualsIgnoreCase(codec, "hevc") ||
-                StringHelper.EqualsIgnoreCase(codec, "vp9"))
+            if (sourceBitrate <= 2000000)
             {
-                return .5;
+                sourceBitrate = Convert.ToInt32(sourceBitrate * 2.5);
             }
-            return 1;
-        }
-
-        private static int ScaleBitrate(int bitrate, string inputVideoCodec, string outputVideoCodec)
-        {
-            var inputScaleFactor = GetVideoBitrateScaleFactor(inputVideoCodec);
-            var outputScaleFactor = GetVideoBitrateScaleFactor(outputVideoCodec);
-            var scaleFactor = outputScaleFactor / inputScaleFactor;
-
-            if (bitrate <= 500000)
+            else if (sourceBitrate <= 3000000)
             {
-                scaleFactor = Math.Max(scaleFactor, 4);
-            }
-            else if (bitrate <= 1000000)
-            {
-                scaleFactor = Math.Max(scaleFactor, 3);
-            }
-            else if (bitrate <= 2000000)
-            {
-                scaleFactor = Math.Max(scaleFactor, 2.5);
-            }
-            else if (bitrate <= 3000000)
-            {
-                scaleFactor = Math.Max(scaleFactor, 2);
+                sourceBitrate = Convert.ToInt32(sourceBitrate * 2);
             }
 
-            var newBitrate = scaleFactor * bitrate;
+            var bitrate = Math.Min(sourceBitrate, requestedBitrate);
 
-            return Convert.ToInt32(newBitrate);
+            return bitrate;
         }
 
         public int? GetAudioBitrateParam(BaseEncodingJobOptions request, MediaStream audioStream)
@@ -1467,7 +1405,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 videoSizeParam);
         }
 
-        private ValueTuple<int?, int?> GetFixedOutputSize(int? videoWidth,
+        private Tuple<int?, int?> GetFixedOutputSize(int? videoWidth,
             int? videoHeight,
             int? requestedWidth,
             int? requestedHeight,
@@ -1476,11 +1414,11 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (!videoWidth.HasValue && !requestedWidth.HasValue)
             {
-                return new ValueTuple<int?, int?>(null, null);
+                return new Tuple<int?, int?>(null, null);
             }
             if (!videoHeight.HasValue && !requestedHeight.HasValue)
             {
-                return new ValueTuple<int?, int?>(null, null);
+                return new Tuple<int?, int?>(null, null);
             }
 
             decimal inputWidth = Convert.ToDecimal(videoWidth ?? requestedWidth);
@@ -1500,7 +1438,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             outputWidth = 2 * Math.Truncate(outputWidth / 2);
             outputHeight = 2 * Math.Truncate(outputHeight / 2);
 
-            return new ValueTuple<int?, int?>(Convert.ToInt32(outputWidth), Convert.ToInt32(outputHeight));
+            return new Tuple<int?, int?>(Convert.ToInt32(outputWidth), Convert.ToInt32(outputHeight));
         }
 
         public List<string> GetScalingFilters(int? videoWidth,
@@ -1731,7 +1669,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var inputHeight = videoStream == null ? null : videoStream.Height;
             var threeDFormat = state.MediaSource.Video3DFormat;
 
-            var videoDecoder = this.GetHardwareAcceleratedVideoDecoder(state, options);
+            var videoDecoder = GetVideoDecoder(state, options);
 
             filters.AddRange(GetScalingFilters(inputWidth, inputHeight, threeDFormat, videoDecoder, outputVideoCodec, request.Width, request.Height, request.MaxWidth, request.MaxHeight));
 
@@ -1913,7 +1851,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 inputModifier += " -fflags " + string.Join("", flags.ToArray());
             }
 
-            var videoDecoder = this.GetHardwareAcceleratedVideoDecoder(state, encodingOptions);
+            var videoDecoder = GetVideoDecoder(state, encodingOptions);
             if (!string.IsNullOrEmpty(videoDecoder))
             {
                 inputModifier += " " + videoDecoder;
@@ -1955,7 +1893,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.MediaSource.RequiresLooping)
             {
-                inputModifier += " -stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
+                inputModifier += " -stream_loop -1";
             }
 
             return inputModifier;
@@ -2051,7 +1989,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     if (string.IsNullOrEmpty(requestedUrl))
                     {
-                        requestedUrl = "test." + videoRequest.Container;
+                        requestedUrl = "test." + videoRequest.OutputContainer;
                     }
 
                     videoRequest.VideoCodec = InferVideoCodec(requestedUrl);
@@ -2077,49 +2015,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             state.MediaSource = mediaSource;
-
-            var request = state.BaseRequest;
-            if (!string.IsNullOrWhiteSpace(request.AudioCodec))
-            {
-                var supportedAudioCodecsList = request.AudioCodec.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
-
-                ShiftAudioCodecsIfNeeded(supportedAudioCodecsList, state.AudioStream);
-
-                state.SupportedAudioCodecs = supportedAudioCodecsList.ToArray();
-
-                request.AudioCodec = state.SupportedAudioCodecs.FirstOrDefault(i => _mediaEncoder.CanEncodeToAudioCodec(i))
-                    ?? state.SupportedAudioCodecs.FirstOrDefault();
-            }
-        }
-
-        private void ShiftAudioCodecsIfNeeded(List<string> audioCodecs, MediaStream audioStream)
-        {
-            // Nothing to do here
-            if (audioCodecs.Count < 2)
-            {
-                return;
-            }
-
-            var inputChannels = audioStream == null ? 6 : audioStream.Channels ?? 6;
-            if (inputChannels >= 6)
-            {
-                return;
-            }
-
-            // Transcoding to 2ch ac3 almost always causes a playback failure
-            // Keep it in the supported codecs list, but shift it to the end of the list so that if transcoding happens, another codec is used
-            var shiftAudioCodecs = new[] { "ac3", "eac3" };
-            if (audioCodecs.All(i => shiftAudioCodecs.Contains(i, StringComparer.OrdinalIgnoreCase)))
-            {
-                return;
-            }
-
-            while (shiftAudioCodecs.Contains(audioCodecs[0], StringComparer.OrdinalIgnoreCase))
-            {
-                var removed = shiftAudioCodecs[0];
-                audioCodecs.RemoveAt(0);
-                audioCodecs.Add(removed);
-            }
         }
 
         private void NormalizeSubtitleEmbed(EncodingJobInfo state)
@@ -2140,17 +2035,17 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Gets the name of the output video codec
         /// </summary>
-        protected string GetHardwareAcceleratedVideoDecoder(EncodingJobInfo state, EncodingOptions encodingOptions)
+        protected string GetVideoDecoder(EncodingJobInfo state, EncodingOptions encodingOptions)
         {
             if (string.Equals(state.OutputVideoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
-            return this.GetHardwareAcceleratedVideoDecoder(state.MediaSource.VideoType ?? VideoType.VideoFile, state.VideoStream, encodingOptions);
+            return GetVideoDecoder(state.MediaSource.VideoType ?? VideoType.VideoFile, state.VideoStream, encodingOptions);
         }
 
-        public string GetHardwareAcceleratedVideoDecoder(VideoType videoType, MediaStream videoStream, EncodingOptions encodingOptions)
+        public string GetVideoDecoder(VideoType videoType, MediaStream videoStream, EncodingOptions encodingOptions)
         {
             // Only use alternative encoders for video files.
             // When using concat with folder rips, if the mfx session fails to initialize, ffmpeg will be stuck retrying and will not exit gracefully
@@ -2175,7 +2070,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                                 // qsv decoder does not support 10-bit input
                                 if ((videoStream.BitDepth ?? 8) > 8)
                                 {
-                                    encodingOptions.HardwareDecodingCodecs = Array.Empty<string>();
                                     return null;
                                 }
                                 return "-c:v h264_qsv ";
@@ -2310,11 +2204,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 else if (string.Equals(encodingOptions.HardwareAccelerationType, "amf", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                    {
-                        return "-hwaccel dxva2";
-                    }
-
                     switch (videoStream.Codec.ToLower())
                     {
                         case "avc":
@@ -2333,9 +2222,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
                 }
             }
-
-            // Avoid a second attempt if no hardware acceleration is being used
-            encodingOptions.HardwareDecodingCodecs = Array.Empty<string>();
 
             // leave blank so ffmpeg will decide
             return null;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobOptions.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobOptions.cs
@@ -11,8 +11,9 @@ namespace MediaBrowser.Controller.MediaEncoding
     {
         public string OutputDirectory { get; set; }
         public string ItemId { get; set; }
+        public string MediaSourceId { get; set; }
+        public string AudioCodec { get; set; }
 
-        public string TempDirectory { get; set; }
         public bool ReadInputAtNativeFramerate { get; set; }
 
         /// <summary>
@@ -21,16 +22,15 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <value><c>true</c> if this instance has fixed resolution; otherwise, <c>false</c>.</value>
         public bool HasFixedResolution => Width.HasValue || Height.HasValue;
 
-        public DeviceProfile DeviceProfile { get; set; }
-
+        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         public EncodingJobOptions(StreamInfo info, DeviceProfile deviceProfile)
         {
-            Container = info.Container;
+            OutputContainer = info.Container;
             StartTimeTicks = info.StartPositionTicks;
             MaxWidth = info.MaxWidth;
             MaxHeight = info.MaxHeight;
             MaxFramerate = info.MaxFramerate;
-            Id = info.ItemId;
+            ItemId = info.ItemId.ToString("");
             MediaSourceId = info.MediaSourceId;
             AudioCodec = info.TargetAudioCodec.FirstOrDefault();
             MaxAudioChannels = info.GlobalMaxAudioChannels;
@@ -55,29 +55,6 @@ namespace MediaBrowser.Controller.MediaEncoding
     // For now until api and media encoding layers are unified
     public class BaseEncodingJobOptions
     {
-        /// <summary>
-        /// Gets or sets the id.
-        /// </summary>
-        /// <value>The id.</value>
-        [ApiMember(Name = "Id", Description = "Item Id", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "GET")]
-        public Guid Id { get; set; }
-
-        [ApiMember(Name = "MediaSourceId", Description = "The media version id, if playing an alternate version", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "GET")]
-        public string MediaSourceId { get; set; }
-
-        [ApiMember(Name = "DeviceId", Description = "The device id of the client requesting. Used to stop encoding processes when needed.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
-        public string DeviceId { get; set; }
-
-        [ApiMember(Name = "Container", Description = "Container", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "GET")]
-        public string Container { get; set; }
-
-        /// <summary>
-        /// Gets or sets the audio codec.
-        /// </summary>
-        /// <value>The audio codec.</value>
-        [ApiMember(Name = "AudioCodec", Description = "Optional. Specify a audio codec to encode to, e.g. mp3. If omitted the server will auto-select using the url's extension. Options: aac, mp3, vorbis, wma.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
-        public string AudioCodec { get; set; }
-
         [ApiMember(Name = "EnableAutoStreamCopy", Description = "Whether or not to allow automatic stream copy if requested values match the original source. Defaults to true.", IsRequired = false, DataType = "bool", ParameterType = "query", Verb = "GET")]
         public bool EnableAutoStreamCopy { get; set; }
 
@@ -203,7 +180,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         public bool RequireNonAnamorphic { get; set; }
         public int? TranscodingMaxAudioChannels { get; set; }
         public int? CpuCoreLimit { get; set; }
-
+        public string OutputContainer { get; set; }
         public string LiveStreamId { get; set; }
 
         public bool EnableMpegtsM2TsMode { get; set; }
@@ -267,5 +244,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             Context = EncodingContext.Streaming;
             StreamOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
+
+        public string TempDirectory { get; set; }
+        public string DeviceId { get; set; }
+        public Guid Id { get; set; }
+        public string Container { get; set; }
+        public DeviceProfile DeviceProfile { get; set; }
     }
 }


### PR DESCRIPTION
CC @MatMaul 

PR #613 seems to be causing a release-critical bug with `ffmpeg` logging. Specifically, with any version of `ffmpeg` (tested `3.2`, `4.0`, and `4.1`), the `ffmpeg` logs do not update with live transcode information. From our understanding of the code, these frame updates are required by Jellyfin for the WebUI to keep track of where the transcode is, and also to assist in troubleshooting any `ffmpeg` problems.

For example, an `ffmpeg` log without #613:

```
    Side data:
      cpb: bitrate max/min/avg: 7360000/0/0 buffer size: 14720000 vbv_delay: -1
    Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, 384 kb/s (default)
    Metadata:
      encoder         : Lavc58.35.100 aac
frame=   39 fps=0.0 q=28.0 size=N/A time=00:00:02.00 bitrate=N/A speed=4.01x
frame=   64 fps= 63 q=28.0 size=N/A time=00:00:02.96 bitrate=N/A speed=2.92x
frame=   94 fps= 61 q=28.0 size=N/A time=00:00:04.30 bitrate=N/A speed=2.78x
```

And an ffmpeg log with #613:

```
    Side data:
      cpb: bitrate max/min/avg: 7360000/0/0 buffer size: 14720000 vbv_delay: -1
    Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, 384 kb/s (default)
    Metadata:
      encoder         : Lavc58.35.100 aac [end with no newline]
```

The admin team has tried several quick fixes, including:

1. Swapping around these two statement to restore the pre-#613 order:
```
--- a/MediaBrowser.Api/Playback/StreamState.cs
+++ b/MediaBrowser.Api/Playback/StreamState.cs
@@ -109,8 +109,8 @@ namespace MediaBrowser.Api.Playback
         public override void Dispose()
         {
             DisposeTranscodingThrottler();
-            DisposeLogStream();
             DisposeLiveStream();
+            DisposeLogStream();

             TranscodingJob = null;
         }
```
2. Removing the `try` block around `new StreamReader(source)`:
```
--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -20,8 +20,6 @@ namespace MediaBrowser.Controller.MediaEncoding

         public async void StartStreamingLog(EncodingJobInfo state, Stream source, Stream target)
         {
-            try
-            {
                 using (var reader = new StreamReader(source))
                 {
                     while (!reader.EndOfStream)
@@ -36,16 +34,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                         await target.FlushAsync().ConfigureAwait(false);
                     }
                 }
-            }
-            catch (ObjectDisposedException)
-            {
-                //TODO Investigate and properly fix.
-                // Don't spam the log. This doesn't seem to throw in windows, but sometimes under linux
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error reading ffmpeg log");
-            }
         }

         private void ParseLogLine(string line, EncodingJobInfo state)
```

Which results in this unhandled exception:
```
[2019-01-21 16:51:27.474 -05:00] [FTL] Unhandled Exception
System.NullReferenceException: Object reference not set to an instance of an object.
   at MediaBrowser.Controller.MediaEncoding.EncodingJobInfo.ReportTranscodingProgress(Nullable`1 transcodingPosition, Single framerate, Nullable`1 percentComplete, Int64 bytesTranscoded, Nullable`1 bitRate) in /jellyfin-10.1/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs:line 722
   at MediaBrowser.Controller.MediaEncoding.JobLogger.ParseLogLine(String line, EncodingJobInfo state) in /jellyfin-10.1/MediaBrowser.Controller/MediaEncoding/JobLogger.cs:line 128
   at MediaBrowser.Controller.MediaEncoding.JobLogger.StartStreamingLog(EncodingJobInfo state, Stream source, Stream target) in /jellyfin-10.1/MediaBrowser.Controller/MediaEncoding/JobLogger.cs:line 29
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

But neither have succeeded and we do not know exactly why this is happening.

We will need to revert this PR for the 10.1.0 release and revisit this in `dev` afterwards unless someone knows a quick fix.