### PR TITLE
Revert "Fix segment_time_delta for ffmpeg 4.1"

### DIFF
--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -936,10 +936,10 @@ namespace MediaBrowser.Api.Playback.Hls
 
             var timeDeltaParam = string.Empty;
 
-            if (isEncoding && state.TargetFramerate > 0)
+            if (isEncoding && startNumber > 0)
             {
-                float startTime = 1 / (state.TargetFramerate.Value * 2);
-                timeDeltaParam = string.Format("-segment_time_delta {0}", Math.Round(startTime, 3));
+                var startTime = state.SegmentLength * startNumber;
+                timeDeltaParam = string.Format("-segment_time_delta -{0}", startTime);
             }
 
             var segmentFormat = GetSegmentFileExtension(state.Request).TrimStart('.');


### PR DESCRIPTION
Reverts jellyfin/jellyfin#639

CC @Bond-009 

After more extensive testing, it looks like this change resulted in both the "End of Episode Skip" bug, which only seems present with this PR in and ffmpeg 4.1, as well as breaking support for skipping around videos with ffmpeg <4.1. #659 does not appear to make a difference to ffmpeg skip support, and hence makes testing the EoES bug very difficult. I'm able to confirm from testing that the EoES bug was eliminated once this PR was reverted (using ffmpeg 3.2 and 4.0), and this also ensures that we continue to support older ffmpeg versions which are in Debian Stable and similar distros for now. We should revisit supporting 4.1 in more detail after release as it appears more work is required.

Closes #659 