### PR TITLE
Return Audio objects from MusicAlbum.Tracks

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4712,9 +4712,21 @@ namespace Emby.Server.Implementations.Data
                         continue;
                     }
 
-                    var paramName = "@HasAnyProviderId" + index;
+                    // TODO this seems to be an idea for a better schema where ProviderIds are their own table
+                    //      buut this is not implemented
                     //hasProviderIds.Add("(COALESCE((select value from ProviderIds where ItemId=Guid and Name = '" + pair.Key + "'), '') <> " + paramName + ")");
+
+                    // TODO this is a really BAD way to do it since the pair:
+                    //      Tmdb, 1234 matches Tmdb=1234 but also Tmdb=1234567
+                    //      and maybe even NotTmdb=1234.
+
+                    // this is a placeholder for this specific pair to correlate it in the bigger query
+                    var paramName = "@HasAnyProviderId" + index;
+
+                    // this is a search for the placeholder
                     hasProviderIds.Add("ProviderIds like " + paramName + "");
+
+                    // this replaces the placeholder with a value, here: %key=val%
                     if (statement != null)
                     {
                         statement.TryBind(paramName, "%" + pair.Key + "=" + pair.Value + "%");

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -96,7 +96,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         /// </summary>
         /// <value>The tracks.</value>
         [IgnoreDataMember]
-        public IEnumerable<BaseItem> Tracks => GetRecursiveChildren(i => i is Audio);
+        public IEnumerable<Audio> Tracks => GetRecursiveChildren(i => i is Audio).Cast<Audio>();
 
         protected override IEnumerable<BaseItem> GetEligibleChildrenForRecursiveChildren(User user)
         {


### PR DESCRIPTION
Prerequisite of https://github.com/jellyfin/jellyfin-plugin-reports/pull/1

This adds a cast that should have been there before imho. Compiled fine for me but I'd like someone else to test it as well to feel safe about it.

I opted to fix it here instead of casting it in the plugin because the plugin is the wrong place to do that.

There's also some comments added in the SqliteItemRepository.cs file to help people understand what the particular function actually accomplishes.

Lastly, this probably requires an ABI version bump.