### PR TITLE
Set Parent to current query Item if ParentId is empty

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -646,7 +646,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (!(this is UserRootFolder) && !(this is AggregateFolder))
             {
-                if (!query.ParentId.Equals(Guid.Empty))
+                if (query.ParentId.Equals(Guid.Empty))
                 {
                     query.Parent = this;
                 }

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -644,7 +644,7 @@ namespace MediaBrowser.Controller.Entities
                 return PostFilterAndSort(items, query, true);
             }
 
-            if (!(this is UserRootFolder) && !(this is AggregateFolder) && query.ParentId.Equals(Guid.Empty))
+            if (!(this is UserRootFolder) && !(this is AggregateFolder) && query.ParentId == Guid.Empty)
             {
                 query.Parent = this;
             }

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -644,12 +644,9 @@ namespace MediaBrowser.Controller.Entities
                 return PostFilterAndSort(items, query, true);
             }
 
-            if (!(this is UserRootFolder) && !(this is AggregateFolder))
+            if (!(this is UserRootFolder) && !(this is AggregateFolder) && query.ParentId.Equals(Guid.Empty))
             {
-                if (query.ParentId.Equals(Guid.Empty))
-                {
-                    query.Parent = this;
-                }
+                query.Parent = this;
             }
 
             if (RequiresPostFiltering2(query))


### PR DESCRIPTION
**Changes**
Fixed a faulty change in logic that occurred during the Christmas GPL nightmare.

I stepped through Emby 3.5.2 and stumbled over a difference in the query between Jellyfin and Emby, where in Emby, query.ParentId was set to the item itself. So I did a little digging in the old GPLv2 source and found this https://github.com/MediaBrowser/Emby/blob/3.4.1.8/MediaBrowser.Controller/Entities/Folder.cs#L720

**Issues**
Fixes #673
