### PR TITLE
fix incorrect comma passed to ffmpeg when creating segments

### DIFF
--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -94,7 +94,7 @@ namespace MediaBrowser.Api.Playback.Hls
     [Authenticated]
     public class DynamicHlsService : BaseHlsService
     {
-
+        
         public DynamicHlsService(IServerConfigurationManager serverConfig, IUserManager userManager, ILibraryManager libraryManager, IIsoManager isoManager, IMediaEncoder mediaEncoder, IFileSystem fileSystem, IDlnaManager dlnaManager, ISubtitleEncoder subtitleEncoder, IDeviceManager deviceManager, IMediaSourceManager mediaSourceManager, IZipClient zipClient, IJsonSerializer jsonSerializer, IAuthorizationContext authorizationContext, INetworkManager networkManager) : base(serverConfig, userManager, libraryManager, isoManager, mediaEncoder, fileSystem, dlnaManager, subtitleEncoder, deviceManager, mediaSourceManager, zipClient, jsonSerializer, authorizationContext)
         {
             NetworkManager = networkManager;
@@ -918,6 +918,30 @@ namespace MediaBrowser.Api.Playback.Hls
             return args;
         }
 
+        private NumberFormatInfo _ffmpegSegmentTimeDeltaNumberFormat = null;
+        protected NumberFormatInfo ffmpegSegmentTimeDeltaNumberFormat
+        {
+            get
+            {
+                if (_ffmpegSegmentTimeDeltaNumberFormat == null)
+                {
+                    NumberFormatInfo nfi = new NumberFormatInfo();
+                    nfi.CurrencySymbol = "";
+                    nfi.NaNSymbol = "0";
+                    nfi.NegativeInfinitySymbol = "0";
+                    nfi.NegativeSign = "";
+                    nfi.NumberDecimalDigits = 3;
+                    nfi.NumberDecimalSeparator = ".";
+                    nfi.NumberGroupSeparator = "";
+                    nfi.PositiveInfinitySymbol = "0";
+                    nfi.PositiveSign = "";
+                    nfi.PercentSymbol = "0";
+                    _ffmpegSegmentTimeDeltaNumberFormat = nfi;
+                }
+                return _ffmpegSegmentTimeDeltaNumberFormat;
+            }
+        }
+
         protected override string GetCommandLineArguments(string outputPath, EncodingOptions encodingOptions, StreamState state, bool isEncoding)
         {
             var videoCodec = EncodingHelper.GetVideoEncoder(state, encodingOptions);
@@ -939,7 +963,8 @@ namespace MediaBrowser.Api.Playback.Hls
             if (isEncoding && startNumber > 0)
             {
                 var startTime = state.SegmentLength * startNumber;
-                timeDeltaParam = string.Format("-segment_time_delta -{0}", startTime);
+                string startTimeString = startTime.ToString(ffmpegSegmentTimeDeltaNumberFormat);
+                timeDeltaParam = string.Format("-segment_time_delta -{0}", startTimeString);
             }
 
             var segmentFormat = GetSegmentFileExtension(state.Request).TrimStart('.');


### PR DESCRIPTION
This is @Tthecreator s work and I think he/her must have quit github in frustration. I'm creating this PR so that the work will not be wasted.

I'd like to ask their permission before this is merged. The commits were technically released under the GPL, but I want to be respectful

**Changes**
In some locales, Jellyfin passes a comma ',' instead of a dot '.' to ffmpeg which causes it to fail parsing the time. This implements a fixed locale.

There are things I'd like to fix here, such as moving the definition and removing the trailing whitespace. As well as using it whenever string formatting for ffmpeg happens.