### PR TITLE
Dev ffmpeg bugs delta time

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -76,7 +76,17 @@ namespace MediaBrowser.Api.Playback
         protected IAuthorizationContext AuthorizationContext { get; private set; }
 
         protected EncodingHelper EncodingHelper { get; set; }
-        protected NumberFormatInfo _ffmpegTimeDeltaFormat { get; private set; }
+        protected static NumberFormatInfo _ffmpegTimeDeltaFormat { get; private set; }
+
+        static BaseStreamingService()
+        {
+            _ffmpegTimeDeltaFormat = new NumberFormatInfo()
+            {
+                NumberDecimalDigits = 3,
+                NumberDecimalSeparator = ".",
+                NumberGroupSeparator = ""
+            };
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseStreamingService" /> class.
@@ -97,12 +107,6 @@ namespace MediaBrowser.Api.Playback
             IsoManager = isoManager;
             MediaEncoder = mediaEncoder;
             EncodingHelper = new EncodingHelper(MediaEncoder, FileSystem, SubtitleEncoder);
-
-            _ffmpegTimeDeltaFormat = new NumberFormatInfo() {
-                NumberDecimalDigits = 3,
-                NumberDecimalSeparator = ".",
-                NumberGroupSeparator = ""
-            };
         }
 
         /// <summary>

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -76,6 +76,7 @@ namespace MediaBrowser.Api.Playback
         protected IAuthorizationContext AuthorizationContext { get; private set; }
 
         protected EncodingHelper EncodingHelper { get; set; }
+        protected NumberFormatInfo _ffmpegTimeDeltaFormat { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseStreamingService" /> class.
@@ -96,6 +97,12 @@ namespace MediaBrowser.Api.Playback
             IsoManager = isoManager;
             MediaEncoder = mediaEncoder;
             EncodingHelper = new EncodingHelper(MediaEncoder, FileSystem, SubtitleEncoder);
+
+            _ffmpegTimeDeltaFormat = new NumberFormatInfo() {
+                NumberDecimalDigits = 3,
+                NumberDecimalSeparator = ".",
+                NumberGroupSeparator = ""
+            };
         }
 
         /// <summary>

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -939,7 +939,8 @@ namespace MediaBrowser.Api.Playback.Hls
             if (isEncoding && startNumber > 0)
             {
                 var startTime = state.SegmentLength * startNumber;
-                timeDeltaParam = string.Format("-segment_time_delta -{0}", startTime);
+                string startTimeString = startTime.ToString(_ffmpegTimeDeltaFormat);
+                timeDeltaParam = string.Format("-segment_time_delta {0}", startTimeString);
             }
 
             var segmentFormat = GetSegmentFileExtension(state.Request).TrimStart('.');

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -938,7 +938,9 @@ namespace MediaBrowser.Api.Playback.Hls
 
             if (isEncoding && startNumber > 0)
             {
+                //format requirements for the segment_time_delta parameter are: no negative numbers, and a decimal '.' has to be used for floating numbers. (So no ',')
                 var startTime = state.SegmentLength * startNumber;
+                if (startTime < 0) { startTime *= -1; }//make sure the startTime is a positive number.
                 string startTimeString = startTime.ToString(_ffmpegTimeDeltaFormat);
                 timeDeltaParam = string.Format("-segment_time_delta {0}", startTimeString);
             }


### PR DESCRIPTION
**Changes** 
In some locales, Jellyfin passes a comma ',' instead of a dot '.' to ffmpeg which causes it to fail parsing the time. This implements a fixed locale.

There are things I'd like to fix here, such as moving the definition and removing the trailing whitespace. As well as using it whenever string formatting for ffmpeg happens.
(text written by @hawken93)

**Issues**
#674 

**History**
Some branching issues caused this pull request to be remade. Here are some references to older conversations: #675 #683 

**Addition context**
The issue which caused a number with decimal values to be parsed at all was solved.
