### PR TITLE
Fix RPM package build for fedora

### DIFF
--- a/deployment/common.build.sh
+++ b/deployment/common.build.sh
@@ -23,8 +23,7 @@ get_version()
 (
     local ROOT=${1-$DEFAULT_ROOT}
     grep "AssemblyVersion" ${ROOT}/SharedVersion.cs \
-        | sed -E 's/\[assembly: ?AssemblyVersion\("([0-9\.]+)"\)\]/\1/' \
-        | sed -E 's/.0$//'
+        | sed -E 's/\[assembly: ?AssemblyVersion\("([0-9\.]+)"\)\]/\1/' 
 )
 
 # Run a build

--- a/deployment/fedora-package-x64/clean.sh
+++ b/deployment/fedora-package-x64/clean.sh
@@ -8,7 +8,7 @@ package_temporary_dir="`pwd`/pkg-dist-tmp"
 pkg_src_dir="`pwd`/pkg-src"
 image_name="jellyfin-rpmbuild"
 docker_sudo=""
-if ! $(id -Gn | grep -q 'docker') && [ ! $EUID -eq 0 ]; then
+if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && [ ! $USER == "root" ]; then
     docker_sudo=sudo
 fi
 

--- a/deployment/fedora-package-x64/clean.sh
+++ b/deployment/fedora-package-x64/clean.sh
@@ -8,7 +8,8 @@ package_temporary_dir="`pwd`/pkg-dist-tmp"
 pkg_src_dir="`pwd`/pkg-src"
 image_name="jellyfin-rpmbuild"
 docker_sudo=""
-if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && [ ! $USER == "root" ]; then
+if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && \
+ [ ! $USER == "root" ] && ! $(echo "$OSTYPE" | grep -q "darwin"); then
     docker_sudo=sudo
 fi
 

--- a/deployment/fedora-package-x64/clean.sh
+++ b/deployment/fedora-package-x64/clean.sh
@@ -4,4 +4,14 @@ source ../common.build.sh
 
 VERSION=`get_version ../..`
 
-clean_jellyfin ../.. Release `pwd`/dist/jellyfin_${VERSION}
+package_temporary_dir="`pwd`/pkg-dist-tmp"
+pkg_src_dir="`pwd`/pkg-src"
+image_name="jellyfin-rpmbuild"
+docker_sudo=""
+if ! $(id -Gn | grep -q 'docker') && [ ! $EUID -eq 0 ]; then
+    docker_sudo=sudo
+fi
+
+$docker_sudo docker image rm $image_name --force
+rm -rf "$package_temporary_dir"
+rm -rf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz"

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -19,7 +19,8 @@ pkg_src_dir="`pwd`/pkg-src"
 current_user="`whoami`"
 image_name="jellyfin-rpmbuild"
 docker_sudo=""
-if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && [ ! $USER == "root" ]; then
+if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && \
+ [ ! $USER == "root" ] && ! $(echo "$OSTYPE" | grep -q "darwin"); then
     docker_sudo=sudo
 fi
 

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -19,7 +19,7 @@ pkg_src_dir="`pwd`/pkg-src"
 current_user="`whoami`"
 image_name="jellyfin-rpmbuild"
 docker_sudo=""
-if ! $(id -Gn | grep -q 'docker') && [ ! $EUID -eq 0 ]; then
+if ! $(id -Gn | grep -q 'docker') && [ ! ${EUID:-1000} -eq 0 ] && [ ! $USER == "root" ]; then
     docker_sudo=sudo
 fi
 

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -18,10 +18,14 @@ output_dir="`pwd`/pkg-dist"
 pkg_src_dir="`pwd`/pkg-src"
 current_user="`whoami`"
 image_name="jellyfin-rpmbuild"
+docker_sudo=""
+if ! $(id -Gn | grep -q 'docker') && [ ! $EUID -eq 0 ]; then
+    docker_sudo=sudo
+fi
 
 cleanup() {
     set +o errexit
-    docker image rm $image_name --force
+    $docker_sudo docker image rm $image_name --force
     rm -rf "$package_temporary_dir"
     rm -rf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz"
 }
@@ -30,7 +34,7 @@ GNU_TAR=1
 mkdir -p "$package_temporary_dir"
 echo "Bundling all sources for RPM build."
 tar \
---transform "s,^\.,jellyfin-${VERSION}" \
+--transform "s,^\.,jellyfin-${VERSION}," \
 --exclude='.git*' \
 --exclude='**/.git' \
 --exclude='**/.hg' \
@@ -42,10 +46,8 @@ tar \
 --exclude='**/.nuget' \
 --exclude='*.deb' \
 --exclude='*.rpm' \
--Jcvf \
-"$package_temporary_dir/jellyfin-${VERSION}.tar.xz" \
--C "../.." \
-./ || true && GNU_TAR=0
+-zcf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz" \
+-C "../.." ./ || GNU_TAR=0
 
 if [ $GNU_TAR -eq 0 ]; then
     echo "The installed tar binary did not support --transform. Using workaround."
@@ -75,9 +77,9 @@ if [ $GNU_TAR -eq 0 ]; then
     tar -zcf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz" -C "$package_temporary_dir" "jellyfin-${VERSION}"
 fi
 
-docker build ../.. -t "$image_name" -f ./Dockerfile
+$docker_sudo docker build ../.. -t "$image_name" -f ./Dockerfile
 mkdir -p "$output_dir"
-docker run --rm -v "$package_temporary_dir:/temp" "$image_name" sh -c 'find /build/rpmbuild -maxdepth 3 -type f -name "jellyfin*.rpm" -exec mv {} /temp \;'
+$docker_sudo docker run --rm -v "$package_temporary_dir:/temp" "$image_name" sh -c 'find /build/rpmbuild -maxdepth 3 -type f -name "jellyfin*.rpm" -exec mv {} /temp \;'
 chown -R "$current_user" "$package_temporary_dir" \
 || sudo chown -R "$current_user" "$package_temporary_dir"
 mv "$package_temporary_dir"/*.rpm "$output_dir"


### PR DESCRIPTION
**Changes**

The deployment scripts trims of any trailing `0` in the `${VERSION}` variable which breaks rpm packaging, 
since the build script creates a `jellyfin-10.1.tar.gz` source tarball when `rpmbuild` expects a `jellyfin-10.1.0.tar.gz` tarball.

Added a check that prepends `sudo` for  each `docker` command when the user is not in the `docker` group, since RH distros don't have a `docker` group by default.

Fixed GNU tar source tarball creation which had the wrong format (`.tar.xz` instead of `.tar.gz`) and would always fallback to a two part tarball filtering and re-packing to change the directory name.