### PR TITLE
[VA-API] Fix ffmpeg filters

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1439,7 +1439,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase) && outputSizeParam.Length == 0)
             {
-                outputSizeParam = ",format=nv12|vaapi,hwupload";
+                outputSizeParam = ",format=nv12|vaapi,hwupload,hwmap=mode=read+write+direct";
             }
 
             var videoSizeParam = string.Empty;
@@ -1742,6 +1742,13 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var subParam = GetTextSubtitleParam(state);
 
                 filters.Add(subParam);
+
+		// Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
+		// Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+		if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+		{
+		    filters.Add("hwmap");
+		}
 
                 if (allowTimeStampCopy)
                 {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1743,12 +1743,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 filters.Add(subParam);
 
-		// Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
-		// Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
-		if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
-		{
-		    filters.Add("hwmap");
-		}
+                // Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
+                // Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+                if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+                {
+                    filters.Add("hwmap");
+                }
 
                 if (allowTimeStampCopy)
                 {


### PR DESCRIPTION
**Changes**
ffmpeg is very picky about the filters to be used when using VA-API,
because most of them are incompatible. This is particularly evident when
burning-in subtitles.

This commit:

- adds new video filters to the VA-API ffmpeg command;
- ensures `hwmap` is also last in the line.

Tests done:

- Played a video file with subtitles
- Played a video file without subtitles

Note that far more testing is required to make sure all corner cases
are doing OK, especially with ffmpeg 4.0 (I only have access to 4.1).

Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI

*Issues**
Fixes issue #642.