### PR TITLE
[VA-API] Fix filter order

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1439,7 +1439,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase) && outputSizeParam.Length == 0)
             {
-                outputSizeParam = ",format=nv12|vaapi,hwupload,hwmap=mode=read+write+direct";
+                outputSizeParam = ",format=nv12|vaapi,hwupload";
+
+                // Add parameters to use VAAPI with burn-in subttiles (GH issue #642)
+                if (state.SubtitleStream != null && state.SubtitleStream.IsTextSubtitleStream && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode) {
+                    outputSizeParam += ",hwmap=mode=read+write+direct";
+                }
             }
 
             var videoSizeParam = string.Empty;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1743,13 +1743,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 filters.Add(subParam);
 
-		// Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
-		// Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
-		if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
-		{
-		    filters.Add("hwmap");
-		}
-
                 // Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
                 // Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
                 if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1439,7 +1439,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase) && outputSizeParam.Length == 0)
             {
-                outputSizeParam = ",format=nv12|vaapi,hwupload";
+                outputSizeParam = ",format=nv12|vaapi,hwupload,hwmap=mode=read+write+direct";
             }
 
             var videoSizeParam = string.Empty;
@@ -1743,6 +1743,19 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 filters.Add(subParam);
 
+		// Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
+		// Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+		if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+		{
+		    filters.Add("hwmap");
+		}
+
+                // Ensure proper filters are passed to ffmpeg in case of hardware acceleration via VA-API
+                // Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+                if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+                {
+                    filters.Add("hwmap");
+                }
                 if (allowTimeStampCopy)
                 {
                     output += " -copyts";


### PR DESCRIPTION
ffmpeg is very picky about the filters to be used when using VA-API,   because most of them are incompatible. This is particularly evident when   burning-in subtitles.
 
This commit:   
    - adds new video filters to the VA-API ffmpeg command;
    - ensures `hwmap` is also last in the line.

 Tests done:    
    - Played a video file with subtitles
    - Played a video file without subtitles
    
Note that far more testing is required to make sure all corner cases are doing OK.
    
Fixes issue #642.

This is a rebased branch of my previous PR (#694) on the new master branch. I think I already answered the concerns raised there:

- Options for VA-API are there before ffmpeg 4.0
- They're only applied for x264, other cases aren't even covered.