### PR TITLE
Move Skia back into it's own project

### DIFF
--- a/Emby.Drawing/Emby.Drawing.csproj
+++ b/Emby.Drawing/Emby.Drawing.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.0" />
-    <PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />
     <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
     <ProjectReference Include="..\MediaBrowser.Common\MediaBrowser.Common.csproj" />

--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedVersion.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="1.68.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.0" />
+    <PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />
+    <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
+    <ProjectReference Include="..\MediaBrowser.Common\MediaBrowser.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jellyfin.Drawing.Skia/PercentPlayedDrawer.cs
+++ b/Jellyfin.Drawing.Skia/PercentPlayedDrawer.cs
@@ -2,7 +2,7 @@ using System;
 using MediaBrowser.Model.Drawing;
 using SkiaSharp;
 
-namespace Emby.Drawing
+namespace Jellyfin.Drawing.Skia
 {
     public static class PercentPlayedDrawer
     {

--- a/Jellyfin.Drawing.Skia/PlayedIndicatorDrawer.cs
+++ b/Jellyfin.Drawing.Skia/PlayedIndicatorDrawer.cs
@@ -1,7 +1,7 @@
 using MediaBrowser.Model.Drawing;
 using SkiaSharp;
 
-namespace Emby.Drawing
+namespace Jellyfin.Drawing.Skia
 {
     public static class PlayedIndicatorDrawer
     {

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -72,16 +72,11 @@ namespace Jellyfin.Drawing.Skia
             _logger.LogInformation("SkiaSharp version: " + GetVersion());
         }
 
-        public static string GetVersion()
-        {
-            return typeof(SKBitmap).GetTypeInfo().Assembly.GetName().Version.ToString();
-        }
+        public static Version GetVersion()
+            => typeof(SKBitmap).GetTypeInfo().Assembly.GetName().Version;
 
         private static bool IsTransparent(SKColor color)
-        {
-
-            return (color.Red == 255 && color.Green == 255 && color.Blue == 255) || color.Alpha == 0;
-        }
+            => (color.Red == 255 && color.Green == 255 && color.Blue == 255) || color.Alpha == 0;
 
         public static SKEncodedImageFormat GetImageFormat(ImageFormat selectedFormat)
         {
@@ -130,33 +125,51 @@ namespace Jellyfin.Drawing.Skia
             for (int row = 0; row < bitmap.Height; ++row)
             {
                 if (IsTransparentRow(bitmap, row))
+                {
                     topmost = row + 1;
-                else break;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             int bottommost = bitmap.Height;
             for (int row = bitmap.Height - 1; row >= 0; --row)
             {
                 if (IsTransparentRow(bitmap, row))
+                {
                     bottommost = row;
-                else break;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             int leftmost = 0, rightmost = bitmap.Width;
             for (int col = 0; col < bitmap.Width; ++col)
             {
                 if (IsTransparentColumn(bitmap, col))
+                {
                     leftmost = col + 1;
+                }
                 else
+                {
                     break;
+                }
             }
 
             for (int col = bitmap.Width - 1; col >= 0; --col)
             {
                 if (IsTransparentColumn(bitmap, col))
+                {
                     rightmost = col;
+                }
                 else
+                {
                     break;
+                }
             }
 
             var newRect = SKRectI.Create(leftmost, topmost, rightmost - leftmost, bottommost - topmost);
@@ -180,9 +193,7 @@ namespace Jellyfin.Drawing.Skia
         }
 
         private static bool HasDiacritics(string text)
-        {
-            return !string.Equals(text, text.RemoveDiacritics(), StringComparison.Ordinal);
-        }
+            => !string.Equals(text, text.RemoveDiacritics(), StringComparison.Ordinal);
 
         private static bool RequiresSpecialCharacterHack(string path)
         {
@@ -243,6 +254,7 @@ namespace Jellyfin.Drawing.Skia
         }
 
         private static string[] TransparentImageTypes = new string[] { ".png", ".gif", ".webp" };
+
         internal static SKBitmap Decode(string path, bool forceCleanBitmap, IFileSystem fileSystem, ImageOrientation? orientation, out SKEncodedOrigin origin)
         {
             if (!fileSystem.FileExists(path))
@@ -267,7 +279,7 @@ namespace Jellyfin.Drawing.Skia
                     var bitmap = new SKBitmap(codec.Info.Width, codec.Info.Height, !requiresTransparencyHack);
 
                     // decode
-                    codec.GetPixels(bitmap.Info, bitmap.GetPixels());
+                    var _ = codec.GetPixels(bitmap.Info, bitmap.GetPixels());
 
                     origin = codec.EncodedOrigin;
 
@@ -316,14 +328,11 @@ namespace Jellyfin.Drawing.Skia
             {
                 var bitmap = GetBitmap(path, cropWhitespace, true, orientation, out origin);
 
-                if (bitmap != null)
+                if (bitmap != null && origin != SKEncodedOrigin.TopLeft)
                 {
-                    if (origin != SKEncodedOrigin.TopLeft)
+                    using (bitmap)
                     {
-                        using (bitmap)
-                        {
-                            return OrientImage(bitmap, origin);
-                        }
+                        return OrientImage(bitmap, origin);
                     }
                 }
 
@@ -347,7 +356,6 @@ namespace Jellyfin.Drawing.Skia
 
             switch (origin)
             {
-
                 case SKEncodedOrigin.TopRight:
                     {
                         var rotated = new SKBitmap(bitmap.Width, bitmap.Height);
@@ -366,11 +374,8 @@ namespace Jellyfin.Drawing.Skia
                         var rotated = new SKBitmap(bitmap.Width, bitmap.Height);
                         using (var surface = new SKCanvas(rotated))
                         {
-                            float px = bitmap.Width;
-                            px /= 2;
-
-                            float py = bitmap.Height;
-                            py /= 2;
+                            float px = (float)bitmap.Width / 2;
+                            float py = (float)bitmap.Height / 2;
 
                             surface.RotateDegrees(180, px, py);
                             surface.DrawBitmap(bitmap, 0, 0);
@@ -384,11 +389,9 @@ namespace Jellyfin.Drawing.Skia
                         var rotated = new SKBitmap(bitmap.Width, bitmap.Height);
                         using (var surface = new SKCanvas(rotated))
                         {
-                            float px = bitmap.Width;
-                            px /= 2;
+                            float px = (float)bitmap.Width / 2;
 
-                            float py = bitmap.Height;
-                            py /= 2;
+                            float py = (float)bitmap.Height / 2;
 
                             surface.Translate(rotated.Width, 0);
                             surface.Scale(-1, 1);
@@ -412,7 +415,6 @@ namespace Jellyfin.Drawing.Skia
                                 surface.RotateDegrees(90);
 
                                 surface.DrawBitmap(bitmap, 0, 0);
-
                             }
 
                             var flippedBitmap = new SKBitmap(rotated.Width, rotated.Height);
@@ -477,8 +479,7 @@ namespace Jellyfin.Drawing.Skia
                         return rotated;
                     }
 
-                default:
-                    return bitmap;
+                default: return bitmap;
             }
         }
 
@@ -488,6 +489,7 @@ namespace Jellyfin.Drawing.Skia
             {
                 throw new ArgumentNullException(nameof(inputPath));
             }
+
             if (string.IsNullOrWhiteSpace(inputPath))
             {
                 throw new ArgumentNullException(nameof(outputPath));
@@ -507,11 +509,11 @@ namespace Jellyfin.Drawing.Skia
                     throw new ArgumentOutOfRangeException(string.Format("Skia unable to read image {0}", inputPath));
                 }
 
-                //_logger.LogInformation("Color type {0}", bitmap.Info.ColorType);
-
                 var originalImageSize = new ImageDimensions(bitmap.Width, bitmap.Height);
 
-                if (!options.CropWhiteSpace && options.HasDefaultOptions(inputPath, originalImageSize) && !autoOrient)
+                if (!options.CropWhiteSpace
+                    && options.HasDefaultOptions(inputPath, originalImageSize)
+                    && !autoOrient)
                 {
                     // Just spit out the original file if all the options are default
                     return inputPath;
@@ -522,7 +524,7 @@ namespace Jellyfin.Drawing.Skia
                 var width = newImageSize.Width;
                 var height = newImageSize.Height;
 
-                using (var resizedBitmap = new SKBitmap(width, height))//, bitmap.ColorType, bitmap.AlphaType))
+                using (var resizedBitmap = new SKBitmap(width, height, bitmap.ColorType, bitmap.AlphaType))
                 {
                     // scale image
                     bitmap.ScalePixels(resizedBitmap, SKFilterQuality.High);
@@ -532,12 +534,10 @@ namespace Jellyfin.Drawing.Skia
                     {
                         _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(outputPath));
                         using (var outputStream = new SKFileWStream(outputPath))
+                        using (var pixmap = new SKPixmap(new SKImageInfo(width, height), resizedBitmap.GetPixels()))
                         {
-                            using (var pixmap = new SKPixmap(new SKImageInfo(width, height), resizedBitmap.GetPixels()))
-                            {
-                                pixmap.Encode(outputStream, skiaOutputFormat, quality);
-                                return outputPath;
-                            }
+                            pixmap.Encode(outputStream, skiaOutputFormat, quality);
+                            return outputPath;
                         }
                     }
 
@@ -600,8 +600,7 @@ namespace Jellyfin.Drawing.Skia
 
         public void CreateImageCollage(ImageCollageOptions options)
         {
-            double ratio = options.Width;
-            ratio /= options.Height;
+            double ratio = (double)options.Width / options.Height;
 
             if (ratio >= 1.4)
             {
@@ -613,7 +612,7 @@ namespace Jellyfin.Drawing.Skia
             }
             else
             {
-                // @todo create Poster collage capability
+                // TODO: Create Poster collage capability
                 new StripCollageBuilder(_appPaths, _fileSystem).BuildSquareCollage(options.InputPaths, options.OutputPath, options.Width, options.Height);
             }
         }

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -12,7 +12,7 @@ using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 
-namespace Emby.Drawing
+namespace Jellyfin.Drawing.Skia
 {
     public class SkiaEncoder : IImageEncoder
     {

--- a/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.IO;
 using SkiaSharp;
 
-namespace Emby.Drawing
+namespace Jellyfin.Drawing.Skia
 {
     public class StripCollageBuilder
     {
@@ -43,21 +43,14 @@ namespace Emby.Drawing
             return SKEncodedImageFormat.Png;
         }
 
-        public void BuildPosterCollage(string[] paths, string outputPath, int width, int height)
-        {
-            // @todo
-        }
-
         public void BuildSquareCollage(string[] paths, string outputPath, int width, int height)
         {
             using (var bitmap = BuildSquareCollageBitmap(paths, width, height))
+            using (var outputStream = new SKFileWStream(outputPath))
             {
-                using (var outputStream = new SKFileWStream(outputPath))
+                using (var pixmap = new SKPixmap(new SKImageInfo(width, height), bitmap.GetPixels()))
                 {
-                    using (var pixmap = new SKPixmap(new SKImageInfo(width, height), bitmap.GetPixels()))
-                    {
-                        pixmap.Encode(outputStream, GetEncodedFormat(outputPath), 90);
-                    }
+                    pixmap.Encode(outputStream, GetEncodedFormat(outputPath), 90);
                 }
             }
         }

--- a/Jellyfin.Drawing.Skia/UnplayedCountIndicator.cs
+++ b/Jellyfin.Drawing.Skia/UnplayedCountIndicator.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using MediaBrowser.Model.Drawing;
 using SkiaSharp;
 
-namespace Emby.Drawing
+namespace Jellyfin.Drawing.Skia
 {
     public static class UnplayedCountIndicator
     {

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -49,6 +49,7 @@
     <ProjectReference Include="..\Emby.Drawing\Emby.Drawing.csproj" />
     <ProjectReference Include="..\Emby.IsoMounting\IsoMounter\IsoMounter.csproj" />
     <ProjectReference Include="..\Emby.Server.Implementations\Emby.Server.Implementations.csproj" />
+    <ProjectReference Include="..\Jellyfin.Drawing.Skia\Jellyfin.Drawing.Skia.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -13,6 +13,7 @@ using Emby.Server.Implementations;
 using Emby.Server.Implementations.EnvironmentInfo;
 using Emby.Server.Implementations.IO;
 using Emby.Server.Implementations.Networking;
+using Jellyfin.Drawing.Skia;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Model.Globalization;

--- a/MediaBrowser.sln
+++ b/MediaBrowser.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -55,6 +55,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		SharedVersion.cs = SharedVersion.cs
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Drawing.Skia", "Jellyfin.Drawing.Skia\Jellyfin.Drawing.Skia.csproj", "{154872D9-6C12-4007-96E3-8F70A58386CE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -158,6 +160,10 @@ Global
 		{07E39F42-A2C6-4B32-AF8C-725F957A73FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07E39F42-A2C6-4B32-AF8C-725F957A73FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07E39F42-A2C6-4B32-AF8C-725F957A73FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{154872D9-6C12-4007-96E3-8F70A58386CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{154872D9-6C12-4007-96E3-8F70A58386CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{154872D9-6C12-4007-96E3-8F70A58386CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{154872D9-6C12-4007-96E3-8F70A58386CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I don't know why it got moved into `Emby.Drawing` but we lost modularity when doing that.