### PR TITLE
Clean up IFileSystem wrappers around stdlib.

### DIFF
--- a/BDInfo/BDROM.cs
+++ b/BDInfo/BDROM.cs
@@ -150,7 +150,7 @@ namespace BDInfo
                 Is3D = true;
             }
 
-            if (_fileSystem.FileExists(Path.Combine(DirectoryRoot.FullName, "FilmIndex.xml")))
+            if (File.Exists(Path.Combine(DirectoryRoot.FullName, "FilmIndex.xml")))
             {
                 IsDBOX = true;
             }

--- a/BDInfo/BDROM.cs
+++ b/BDInfo/BDROM.cs
@@ -92,7 +92,7 @@ namespace BDInfo
             }
 
             DirectoryRoot =
-                _fileSystem.GetDirectoryInfo(_fileSystem.GetDirectoryName(DirectoryBDMV.FullName));
+                _fileSystem.GetDirectoryInfo(Path.GetDirectoryName(DirectoryBDMV.FullName));
             DirectoryBDJO =
                 GetDirectory("BDJO", DirectoryBDMV, 0);
             DirectoryCLIPINF =
@@ -345,7 +345,7 @@ namespace BDInfo
                 {
                     return dir;
                 }
-                var parentFolder = _fileSystem.GetDirectoryName(dir.FullName);
+                var parentFolder = Path.GetDirectoryName(dir.FullName);
                 if (string.IsNullOrEmpty(parentFolder))
                 {
                     dir = null;

--- a/BDInfo/TSPlaylistFile.cs
+++ b/BDInfo/TSPlaylistFile.cs
@@ -1,4 +1,4 @@
-﻿//============================================================================
+//============================================================================
 // BDInfo - Blu-ray Video and Audio Analysis Tool
 // Copyright © 2010 Cinema Squid
 //
@@ -231,7 +231,7 @@ namespace BDInfo
                 Streams.Clear();
                 StreamClips.Clear();
 
-                fileStream = _fileSystem.OpenRead(FileInfo.FullName);
+                fileStream = File.OpenRead(FileInfo.FullName);
                 fileReader = new BinaryReader(fileStream);
 
                 byte[] data = new byte[fileStream.Length];

--- a/BDInfo/TSStreamClipFile.cs
+++ b/BDInfo/TSStreamClipFile.cs
@@ -1,4 +1,4 @@
-﻿//============================================================================
+//============================================================================
 // BDInfo - Blu-ray Video and Audio Analysis Tool
 // Copyright © 2010 Cinema Squid
 //
@@ -57,7 +57,7 @@ namespace BDInfo
 #endif
                 Streams.Clear();
 
-                fileStream = _fileSystem.OpenRead(FileInfo.FullName);
+                fileStream = File.OpenRead(FileInfo.FullName);
                 fileReader = new BinaryReader(fileStream);
 
                 byte[] data = new byte[fileStream.Length];

--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -379,7 +379,7 @@ namespace Emby.Dlna
 
                     if (!fileInfo.Exists || fileInfo.Length != stream.Length)
                     {
-                        _fileSystem.CreateDirectory(systemProfilesPath);
+                        Directory.CreateDirectory(systemProfilesPath);
 
                         using (var fileStream = _fileSystem.GetFileStream(path, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
                         {
@@ -390,7 +390,7 @@ namespace Emby.Dlna
             }
 
             // Not necessary, but just to make it easy to find
-            _fileSystem.CreateDirectory(UserProfilesPath);
+            Directory.CreateDirectory(UserProfilesPath);
         }
 
         public void DeleteProfile(string id)

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -631,7 +631,7 @@ namespace Emby.Drawing
                     return (enhancedImagePath, treatmentRequiresTransparency);
                 }
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(enhancedImagePath));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(enhancedImagePath));
 
                 await ExecuteImageEnhancers(supportedEnhancers, originalImagePath, enhancedImagePath, item, imageType, imageIndex).ConfigureAwait(false);
 

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -631,7 +631,7 @@ namespace Emby.Drawing
                     return (enhancedImagePath, treatmentRequiresTransparency);
                 }
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(enhancedImagePath));
+                Directory.CreateDirectory(Path.GetDirectoryName(enhancedImagePath));
 
                 await ExecuteImageEnhancers(supportedEnhancers, originalImagePath, enhancedImagePath, item, imageType, imageIndex).ConfigureAwait(false);
 

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -244,7 +244,7 @@ namespace Emby.Drawing
 
             try
             {
-                if (!_fileSystem.FileExists(cacheFilePath))
+                if (!File.Exists(cacheFilePath))
                 {
                     if (options.CropWhiteSpace && !SupportsTransparency(originalImagePath))
                     {
@@ -626,7 +626,7 @@ namespace Emby.Drawing
             try
             {
                 // Check again in case of contention
-                if (_fileSystem.FileExists(enhancedImagePath))
+                if (File.Exists(enhancedImagePath))
                 {
                     return (enhancedImagePath, treatmentRequiresTransparency);
                 }

--- a/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
+++ b/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
@@ -327,7 +327,7 @@ namespace IsoMounter
 
             try
             {
-                FileSystem.CreateDirectory(mountPoint);
+                Directory.CreateDirectory(mountPoint);
             }
             catch (UnauthorizedAccessException)
             {
@@ -377,7 +377,7 @@ namespace IsoMounter
 
                 try
                 {
-                    FileSystem.DeleteDirectory(mountPoint, false);
+                    Directory.Delete(mountPoint, false);
                 }
                 catch (Exception ex)
                 {
@@ -455,7 +455,7 @@ namespace IsoMounter
 
             try
             {
-                FileSystem.DeleteDirectory(mount.MountedPath, false);
+                Directory.Delete(mount.MountedPath, false);
             }
             catch (Exception ex)
             {

--- a/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
+++ b/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
@@ -214,7 +214,7 @@ namespace IsoMounter
             {
                 string path = test.Trim();
 
-                if (!string.IsNullOrEmpty(path) && FileSystem.FileExists(path = Path.Combine(path, name)))
+                if (!string.IsNullOrEmpty(path) && File.Exists(path = Path.Combine(path, name)))
                 {
                     return Path.GetFullPath(path);
                 }

--- a/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
+++ b/Emby.IsoMounting/IsoMounter/LinuxIsoManager.cs
@@ -39,7 +39,7 @@ namespace IsoMounter
             _logger = logger;
             ProcessFactory = processFactory;
 
-            MountPointRoot = FileSystem.DirectorySeparatorChar + "tmp" + FileSystem.DirectorySeparatorChar + "Emby";
+            MountPointRoot = Path.DirectorySeparatorChar + "tmp" + Path.DirectorySeparatorChar + "Emby";
 
             _logger.LogDebug(
                 "[{0}] System PATH is currently set to [{1}].",
@@ -216,7 +216,7 @@ namespace IsoMounter
 
                 if (!string.IsNullOrEmpty(path) && FileSystem.FileExists(path = Path.Combine(path, name)))
                 {
-                    return FileSystem.GetFullPath(path);
+                    return Path.GetFullPath(path);
                 }
             }
 

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -210,7 +210,8 @@ namespace Emby.Server.Implementations.AppBase
         {
             var file = Path.Combine(path, Guid.NewGuid().ToString());
 
-            FileSystem.WriteAllText(file, string.Empty);
+            string text = string.Empty;
+            File.WriteAllText(file, text);
             FileSystem.DeleteFile(file);
         }
 

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -127,7 +127,7 @@ namespace Emby.Server.Implementations.AppBase
             Logger.LogInformation("Saving system configuration");
             var path = CommonApplicationPaths.SystemConfigurationFilePath;
 
-            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configurationSyncLock)
             {
@@ -294,7 +294,7 @@ namespace Emby.Server.Implementations.AppBase
             _configurations.AddOrUpdate(key, configuration, (k, v) => configuration);
 
             var path = GetConfigurationFile(key);
-            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configurationSyncLock)
             {

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -197,7 +197,7 @@ namespace Emby.Server.Implementations.AppBase
                 && !string.Equals(CommonConfiguration.CachePath ?? string.Empty, newPath))
             {
                 // Validate
-                if (!FileSystem.DirectoryExists(newPath))
+                if (!Directory.Exists(newPath))
                 {
                     throw new FileNotFoundException(string.Format("{0} does not exist.", newPath));
                 }

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -209,7 +209,6 @@ namespace Emby.Server.Implementations.AppBase
         protected void EnsureWriteAccess(string path)
         {
             var file = Path.Combine(path, Guid.NewGuid().ToString());
-            
             File.WriteAllText(file, string.Empty);
             FileSystem.DeleteFile(file);
         }

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -127,7 +127,7 @@ namespace Emby.Server.Implementations.AppBase
             Logger.LogInformation("Saving system configuration");
             var path = CommonApplicationPaths.SystemConfigurationFilePath;
 
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(path));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configurationSyncLock)
             {
@@ -294,7 +294,7 @@ namespace Emby.Server.Implementations.AppBase
             _configurations.AddOrUpdate(key, configuration, (k, v) => configuration);
 
             var path = GetConfigurationFile(key);
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(path));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configurationSyncLock)
             {

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -209,9 +209,8 @@ namespace Emby.Server.Implementations.AppBase
         protected void EnsureWriteAccess(string path)
         {
             var file = Path.Combine(path, Guid.NewGuid().ToString());
-
-            string text = string.Empty;
-            File.WriteAllText(file, text);
+            
+            File.WriteAllText(file, string.Empty);
             FileSystem.DeleteFile(file);
         }
 

--- a/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
+++ b/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
@@ -48,7 +48,7 @@ namespace Emby.Server.Implementations.AppBase
                 // If the file didn't exist before, or if something has changed, re-save
                 if (buffer == null || !buffer.SequenceEqual(newBytes))
                 {
-                    fileSystem.CreateDirectory(fileSystem.GetDirectoryName(path));
+                    fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                     // Save it after load in case we got new items
                     fileSystem.WriteAllBytes(path, newBytes);

--- a/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
+++ b/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
@@ -29,7 +29,7 @@ namespace Emby.Server.Implementations.AppBase
             // Use try/catch to avoid the extra file system lookup using File.Exists
             try
             {
-                buffer = fileSystem.ReadAllBytes(path);
+                buffer = File.ReadAllBytes(path);
 
                 configuration = xmlSerializer.DeserializeFromBytes(type, buffer);
             }
@@ -51,7 +51,7 @@ namespace Emby.Server.Implementations.AppBase
                     Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                     // Save it after load in case we got new items
-                    fileSystem.WriteAllBytes(path, newBytes);
+                    File.WriteAllBytes(path, newBytes);
                 }
 
                 return configuration;

--- a/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
+++ b/Emby.Server.Implementations/AppBase/ConfigurationHelper.cs
@@ -48,7 +48,7 @@ namespace Emby.Server.Implementations.AppBase
                 // If the file didn't exist before, or if something has changed, re-save
                 if (buffer == null || !buffer.SequenceEqual(newBytes))
                 {
-                    fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                     // Save it after load in case we got new items
                     fileSystem.WriteAllBytes(path, newBytes);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1008,7 +1008,7 @@ namespace Emby.Server.Implementations
 
             try
             {
-                if (!FileSystemManager.FileExists(certificateLocation))
+                if (!File.Exists(certificateLocation))
                 {
                     return null;
                 }
@@ -1434,7 +1434,7 @@ namespace Emby.Server.Implementations
 
             //if (generateCertificate)
             //{
-            //    if (!FileSystemManager.FileExists(certPath))
+            //    if (!File.Exists(certPath))
             //    {
             //        FileSystemManager.CreateDirectory(FileSystemManager.GetDirectoryName(certPath));
 

--- a/Emby.Server.Implementations/Archiving/ZipClient.cs
+++ b/Emby.Server.Implementations/Archiving/ZipClient.cs
@@ -29,7 +29,7 @@ namespace Emby.Server.Implementations.Archiving
         /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
         public void ExtractAll(string sourceFile, string targetPath, bool overwriteExistingFiles)
         {
-            using (var fileStream = _fileSystem.OpenRead(sourceFile))
+            using (var fileStream = File.OpenRead(sourceFile))
             {
                 ExtractAll(fileStream, targetPath, overwriteExistingFiles);
             }
@@ -115,7 +115,7 @@ namespace Emby.Server.Implementations.Archiving
         /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
         public void ExtractAllFrom7z(string sourceFile, string targetPath, bool overwriteExistingFiles)
         {
-            using (var fileStream = _fileSystem.OpenRead(sourceFile))
+            using (var fileStream = File.OpenRead(sourceFile))
             {
                 ExtractAllFrom7z(fileStream, targetPath, overwriteExistingFiles);
             }
@@ -155,7 +155,7 @@ namespace Emby.Server.Implementations.Archiving
         /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
         public void ExtractAllFromTar(string sourceFile, string targetPath, bool overwriteExistingFiles)
         {
-            using (var fileStream = _fileSystem.OpenRead(sourceFile))
+            using (var fileStream = File.OpenRead(sourceFile))
             {
                 ExtractAllFromTar(fileStream, targetPath, overwriteExistingFiles);
             }

--- a/Emby.Server.Implementations/Channels/ChannelManager.cs
+++ b/Emby.Server.Implementations/Channels/ChannelManager.cs
@@ -355,7 +355,7 @@ namespace Emby.Server.Implementations.Channels
                 return;
             }
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             _jsonSerializer.SerializeToFile(mediaSources, path);
         }
@@ -834,7 +834,7 @@ namespace Emby.Server.Implementations.Channels
         {
             try
             {
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                 _jsonSerializer.SerializeToFile(result, path);
             }

--- a/Emby.Server.Implementations/Channels/ChannelManager.cs
+++ b/Emby.Server.Implementations/Channels/ChannelManager.cs
@@ -355,7 +355,7 @@ namespace Emby.Server.Implementations.Channels
                 return;
             }
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             _jsonSerializer.SerializeToFile(mediaSources, path);
         }
@@ -834,7 +834,7 @@ namespace Emby.Server.Implementations.Channels
         {
             try
             {
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                 _jsonSerializer.SerializeToFile(result, path);
             }

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -76,7 +76,7 @@ namespace Emby.Server.Implementations.Collections
                 return null;
             }
 
-            _fileSystem.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             var libraryOptions = new LibraryOptions
             {
@@ -133,7 +133,7 @@ namespace Emby.Server.Implementations.Collections
 
             try
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 var collection = new BoxSet
                 {

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -359,7 +359,7 @@ namespace Emby.Server.Implementations.Collections
             {
                 var path = _collectionManager.GetCollectionsFolderPath();
 
-                if (_fileSystem.DirectoryExists(path))
+                if (Directory.Exists(path))
                 {
                     try
                     {

--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -148,7 +148,7 @@ namespace Emby.Server.Implementations.Configuration
                 && !string.Equals(Configuration.CertificatePath ?? string.Empty, newPath))
             {
                 // Validate
-                if (!FileSystem.FileExists(newPath))
+                if (!File.Exists(newPath))
                 {
                     throw new FileNotFoundException(string.Format("Certificate file '{0}' does not exist.", newPath));
                 }
@@ -168,7 +168,7 @@ namespace Emby.Server.Implementations.Configuration
                 && !string.Equals(Configuration.MetadataPath ?? string.Empty, newPath))
             {
                 // Validate
-                if (!FileSystem.DirectoryExists(newPath))
+                if (!Directory.Exists(newPath))
                 {
                     throw new FileNotFoundException(string.Format("{0} does not exist.", newPath));
                 }

--- a/Emby.Server.Implementations/Devices/DeviceId.cs
+++ b/Emby.Server.Implementations/Devices/DeviceId.cs
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.Devices
             {
                 var path = CachePath;
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                 lock (_syncLock)
                 {

--- a/Emby.Server.Implementations/Devices/DeviceId.cs
+++ b/Emby.Server.Implementations/Devices/DeviceId.cs
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.Devices
             {
                 var path = CachePath;
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                 lock (_syncLock)
                 {

--- a/Emby.Server.Implementations/Devices/DeviceId.cs
+++ b/Emby.Server.Implementations/Devices/DeviceId.cs
@@ -57,7 +57,7 @@ namespace Emby.Server.Implementations.Devices
 
                 lock (_syncLock)
                 {
-                    _fileSystem.WriteAllText(path, id, Encoding.UTF8);
+                    File.WriteAllText(path, id, Encoding.UTF8);
                 }
             }
             catch (Exception ex)

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -76,7 +76,7 @@ namespace Emby.Server.Implementations.Devices
         public void SaveCapabilities(string deviceId, ClientCapabilities capabilities)
         {
             var path = Path.Combine(GetDevicePath(deviceId), "capabilities.json");
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_capabilitiesSyncLock)
             {
@@ -239,7 +239,7 @@ namespace Emby.Server.Implementations.Devices
             path = Path.Combine(path, file.Name);
             path = Path.ChangeExtension(path, MimeTypes.ToExtension(file.MimeType) ?? "jpg");
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             await EnsureLibraryFolder(uploadPathInfo.Item2, uploadPathInfo.Item3).ConfigureAwait(false);
 
@@ -275,7 +275,7 @@ namespace Emby.Server.Implementations.Devices
         private void AddCameraUpload(string deviceId, LocalFileInfo file)
         {
             var path = Path.Combine(GetDevicePath(deviceId), "camerauploads.json");
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_cameraUploadSyncLock)
             {
@@ -317,7 +317,7 @@ namespace Emby.Server.Implementations.Devices
                 return Task.CompletedTask;
             }
 
-            _fileSystem.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             var libraryOptions = new LibraryOptions
             {

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -431,7 +431,7 @@ namespace Emby.Server.Implementations.Devices
             {
                 var path = _deviceManager.GetUploadsPath();
 
-                if (_fileSystem.DirectoryExists(path))
+                if (Directory.Exists(path))
                 {
                     try
                     {

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -76,7 +76,7 @@ namespace Emby.Server.Implementations.Devices
         public void SaveCapabilities(string deviceId, ClientCapabilities capabilities)
         {
             var path = Path.Combine(GetDevicePath(deviceId), "capabilities.json");
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_capabilitiesSyncLock)
             {
@@ -239,7 +239,7 @@ namespace Emby.Server.Implementations.Devices
             path = Path.Combine(path, file.Name);
             path = Path.ChangeExtension(path, MimeTypes.ToExtension(file.MimeType) ?? "jpg");
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             await EnsureLibraryFolder(uploadPathInfo.Item2, uploadPathInfo.Item3).ConfigureAwait(false);
 
@@ -275,7 +275,7 @@ namespace Emby.Server.Implementations.Devices
         private void AddCameraUpload(string deviceId, LocalFileInfo file)
         {
             var path = Path.Combine(GetDevicePath(deviceId), "camerauploads.json");
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_cameraUploadSyncLock)
             {

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -48,7 +48,7 @@ namespace Emby.Server.Implementations.FFMpeg
             var prebuiltFolder = _appPaths.ProgramSystemPath;
             var prebuiltffmpeg = Path.Combine(prebuiltFolder, downloadInfo.FFMpegFilename);
             var prebuiltffprobe = Path.Combine(prebuiltFolder, downloadInfo.FFProbeFilename);
-            if (_fileSystem.FileExists(prebuiltffmpeg) && _fileSystem.FileExists(prebuiltffprobe))
+            if (File.Exists(prebuiltffmpeg) && File.Exists(prebuiltffprobe))
             {
                 return new FFMpegInfo
                 {
@@ -79,7 +79,7 @@ namespace Emby.Server.Implementations.FFMpeg
 
             var excludeFromDeletions = new List<string> { versionedDirectoryPath };
 
-            if (!_fileSystem.FileExists(info.ProbePath) || !_fileSystem.FileExists(info.EncoderPath))
+            if (!File.Exists(info.ProbePath) || !File.Exists(info.EncoderPath))
             {
                 // ffmpeg not present. See if there's an older version we can start with
                 var existingVersion = GetExistingVersion(info, rootEncoderPath);

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -92,7 +92,7 @@ namespace Emby.Server.Implementations.FFMpeg
                 else
                 {
                     info = existingVersion;
-                    versionedDirectoryPath = _fileSystem.GetDirectoryName(info.EncoderPath);
+                    versionedDirectoryPath = Path.GetDirectoryName(info.EncoderPath);
                     excludeFromDeletions.Add(versionedDirectoryPath);
                 }
             }
@@ -130,7 +130,7 @@ namespace Emby.Server.Implementations.FFMpeg
                     {
                         EncoderPath = encoder,
                         ProbePath = probe,
-                        Version = Path.GetFileName(_fileSystem.GetDirectoryName(probe))
+                        Version = Path.GetFileName(Path.GetDirectoryName(probe))
                     };
                 }
             }

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -75,7 +75,7 @@ namespace Emby.Server.Implementations.FFMpeg
                 Version = version
             };
 
-            _fileSystem.CreateDirectory(versionedDirectoryPath);
+            Directory.CreateDirectory(versionedDirectoryPath);
 
             var excludeFromDeletions = new List<string> { versionedDirectoryPath };
 

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -305,7 +305,7 @@ namespace Emby.Server.Implementations.HttpClientManager
 
         private async Task CacheResponse(HttpResponseInfo response, string responseCachePath)
         {
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(responseCachePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(responseCachePath));
 
             using (var fileStream = _fileSystem.GetFileStream(responseCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.None, true))
             {

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -305,7 +305,7 @@ namespace Emby.Server.Implementations.HttpClientManager
 
         private async Task CacheResponse(HttpResponseInfo response, string responseCachePath)
         {
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(responseCachePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(responseCachePath));
 
             using (var fileStream = _fileSystem.GetFileStream(responseCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.None, true))
             {
@@ -513,7 +513,7 @@ namespace Emby.Server.Implementations.HttpClientManager
         {
             ValidateParams(options);
 
-            _fileSystem.CreateDirectory(_appPaths.TempDirectory);
+            Directory.CreateDirectory(_appPaths.TempDirectory);
 
             var tempFile = Path.Combine(_appPaths.TempDirectory, Guid.NewGuid() + ".tmp");
 

--- a/Emby.Server.Implementations/IO/FileRefresher.cs
+++ b/Emby.Server.Implementations/IO/FileRefresher.cs
@@ -189,7 +189,7 @@ namespace Emby.Server.Implementations.IO
             {
                 item = LibraryManager.FindByPath(path, null);
 
-                path = _fileSystem.GetDirectoryName(path);
+                path = System.IO.Path.GetDirectoryName(path);
             }
 
             if (item != null)

--- a/Emby.Server.Implementations/IO/FileRefresher.cs
+++ b/Emby.Server.Implementations/IO/FileRefresher.cs
@@ -195,7 +195,7 @@ namespace Emby.Server.Implementations.IO
             if (item != null)
             {
                 // If the item has been deleted find the first valid parent that still exists
-                while (!_fileSystem.DirectoryExists(item.Path) && !_fileSystem.FileExists(item.Path))
+                while (!Directory.Exists(item.Path) && !File.Exists(item.Path))
                 {
                     item = item.GetOwner() ?? item.GetParent();
 

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -483,7 +483,7 @@ namespace Emby.Server.Implementations.IO
                 }
 
                 // Go up a level
-                var parent = _fileSystem.GetDirectoryName(i);
+                var parent = Path.GetDirectoryName(i);
                 if (!string.IsNullOrEmpty(parent))
                 {
                     if (_fileSystem.AreEqual(parent, path))
@@ -509,7 +509,7 @@ namespace Emby.Server.Implementations.IO
 
         private void CreateRefresher(string path)
         {
-            var parentPath = _fileSystem.GetDirectoryName(path);
+            var parentPath = Path.GetDirectoryName(path);
 
             lock (_activeRefreshers)
             {
@@ -538,7 +538,7 @@ namespace Emby.Server.Implementations.IO
                     }
 
                     // They are siblings. Rebase the refresher to the parent folder.
-                    if (string.Equals(parentPath, _fileSystem.GetDirectoryName(refresher.Path), StringComparison.Ordinal))
+                    if (string.Equals(parentPath, Path.GetDirectoryName(refresher.Path), StringComparison.Ordinal))
                     {
                         refresher.ResetPath(parentPath, path);
                         return;

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -277,7 +277,7 @@ namespace Emby.Server.Implementations.IO
         /// <param name="path">The path.</param>
         private void StartWatchingPath(string path)
         {
-            if (!_fileSystem.DirectoryExists(path))
+            if (!Directory.Exists(path))
             {
                 // Seeing a crash in the mono runtime due to an exception being thrown on a different thread
                 Logger.LogInformation("Skipping realtime monitor for {0} because the path does not exist", path);

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -50,7 +50,7 @@ namespace Emby.Server.Implementations.IO
             _isEnvironmentCaseInsensitive = environmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.Windows;
         }
 
-        public string DefaultDirectory
+        public virtual string DefaultDirectory
         {
             get
             {
@@ -60,7 +60,7 @@ namespace Emby.Server.Implementations.IO
                 {
                     try
                     {
-                        if (DirectoryExists(value))
+                        if (Directory.Exists(value))
                         {
                             return value;
                         }
@@ -75,7 +75,7 @@ namespace Emby.Server.Implementations.IO
             }
         }
 
-        public void AddShortcutHandler(IShortcutHandler handler)
+        public virtual void AddShortcutHandler(IShortcutHandler handler)
         {
             _shortcutHandlers.Add(handler);
         }
@@ -92,13 +92,6 @@ namespace Emby.Server.Implementations.IO
                 // https://referencesource.microsoft.com/#mscorlib/system/io/path.cs
                 _invalidFileNameChars = new char[] { '\"', '<', '>', '|', '\0', (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, (char)31, ':', '*', '?', '\\', '/' };
             }
-        }
-
-        public char DirectorySeparatorChar => Path.DirectorySeparatorChar;
-
-        public string GetFullPath(string path)
-        {
-            return Path.GetFullPath(path);
         }
 
         /// <summary>
@@ -142,7 +135,7 @@ namespace Emby.Server.Implementations.IO
             return null;
         }
 
-        public string MakeAbsolutePath(string folderPath, string filePath)
+        public virtual string MakeAbsolutePath(string folderPath, string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath)) return filePath;
 
@@ -195,7 +188,7 @@ namespace Emby.Server.Implementations.IO
         /// or
         /// target
         /// </exception>
-        public void CreateShortcut(string shortcutPath, string target)
+        public virtual void CreateShortcut(string shortcutPath, string target)
         {
             if (string.IsNullOrEmpty(shortcutPath))
             {
@@ -227,7 +220,7 @@ namespace Emby.Server.Implementations.IO
         /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
         /// <remarks>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
         /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and all other properties will reflect the properties of the directory.</remarks>
-        public FileSystemMetadata GetFileSystemInfo(string path)
+        public virtual FileSystemMetadata GetFileSystemInfo(string path)
         {
             // Take a guess to try and avoid two file system hits, but we'll double-check by calling Exists
             if (Path.HasExtension(path))
@@ -262,7 +255,7 @@ namespace Emby.Server.Implementations.IO
         /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
         /// <see cref="FileSystemMetadata.IsDirectory"/> property and the <see cref="FileSystemMetadata.Exists"/> property will both be set to false.</para>
         /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
-        public FileSystemMetadata GetFileInfo(string path)
+        public virtual FileSystemMetadata GetFileInfo(string path)
         {
             var fileInfo = new FileInfo(path);
 
@@ -277,7 +270,7 @@ namespace Emby.Server.Implementations.IO
         /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata"/> object's
         /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and the <see cref="FileSystemMetadata.Exists"/> property will be set to false.</para>
         /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
-        public FileSystemMetadata GetDirectoryInfo(string path)
+        public virtual FileSystemMetadata GetDirectoryInfo(string path)
         {
             var fileInfo = new DirectoryInfo(path);
 
@@ -340,23 +333,18 @@ namespace Emby.Server.Implementations.IO
         }
 
         /// <summary>
-        /// The space char
-        /// </summary>
-        private const char SpaceChar = ' ';
-
-        /// <summary>
         /// Takes a filename and removes invalid characters
         /// </summary>
         /// <param name="filename">The filename.</param>
         /// <returns>System.String.</returns>
         /// <exception cref="ArgumentNullException">filename</exception>
-        public string GetValidFilename(string filename)
+        public virtual string GetValidFilename(string filename)
         {
             var builder = new StringBuilder(filename);
 
             foreach (var c in _invalidFileNameChars)
             {
-                builder = builder.Replace(c, SpaceChar);
+                builder = builder.Replace(c, ' ');
             }
 
             return builder.ToString();
@@ -386,17 +374,17 @@ namespace Emby.Server.Implementations.IO
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>DateTime.</returns>
-        public DateTime GetCreationTimeUtc(string path)
+        public virtual DateTime GetCreationTimeUtc(string path)
         {
             return GetCreationTimeUtc(GetFileSystemInfo(path));
         }
 
-        public DateTime GetCreationTimeUtc(FileSystemMetadata info)
+        public virtual DateTime GetCreationTimeUtc(FileSystemMetadata info)
         {
             return info.CreationTimeUtc;
         }
 
-        public DateTime GetLastWriteTimeUtc(FileSystemMetadata info)
+        public virtual DateTime GetLastWriteTimeUtc(FileSystemMetadata info)
         {
             return info.LastWriteTimeUtc;
         }
@@ -425,7 +413,7 @@ namespace Emby.Server.Implementations.IO
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>DateTime.</returns>
-        public DateTime GetLastWriteTimeUtc(string path)
+        public virtual DateTime GetLastWriteTimeUtc(string path)
         {
             return GetLastWriteTimeUtc(GetFileSystemInfo(path));
         }
@@ -439,7 +427,7 @@ namespace Emby.Server.Implementations.IO
         /// <param name="share">The share.</param>
         /// <param name="isAsync">if set to <c>true</c> [is asynchronous].</param>
         /// <returns>FileStream.</returns>
-        public Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, bool isAsync = false)
+        public virtual Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, bool isAsync = false)
         {
             if (_supportsAsyncFileStreams && isAsync)
             {
@@ -449,7 +437,7 @@ namespace Emby.Server.Implementations.IO
             return GetFileStream(path, mode, access, share, FileOpenOptions.None);
         }
 
-        public Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, FileOpenOptions fileOpenOptions)
+        public virtual Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, FileOpenOptions fileOpenOptions)
             => new FileStream(path, GetFileMode(mode), GetFileAccess(access), GetFileShare(share), 4096, GetFileOptions(fileOpenOptions));
 
         private static FileOptions GetFileOptions(FileOpenOptions mode)
@@ -511,7 +499,7 @@ namespace Emby.Server.Implementations.IO
             }
         }
 
-        public void SetHidden(string path, bool isHidden)
+        public virtual void SetHidden(string path, bool isHidden)
         {
             if (_environmentInfo.OperatingSystem != MediaBrowser.Model.System.OperatingSystem.Windows)
             {
@@ -535,7 +523,7 @@ namespace Emby.Server.Implementations.IO
             }
         }
 
-        public void SetReadOnly(string path, bool isReadOnly)
+        public virtual void SetReadOnly(string path, bool isReadOnly)
         {
             if (_environmentInfo.OperatingSystem != MediaBrowser.Model.System.OperatingSystem.Windows)
             {
@@ -559,7 +547,7 @@ namespace Emby.Server.Implementations.IO
             }
         }
 
-        public void SetAttributes(string path, bool isHidden, bool isReadOnly)
+        public virtual void SetAttributes(string path, bool isHidden, bool isReadOnly)
         {
             if (_environmentInfo.OperatingSystem != MediaBrowser.Model.System.OperatingSystem.Windows)
             {
@@ -611,7 +599,7 @@ namespace Emby.Server.Implementations.IO
         /// </summary>
         /// <param name="file1">The file1.</param>
         /// <param name="file2">The file2.</param>
-        public void SwapFiles(string file1, string file2)
+        public virtual void SwapFiles(string file1, string file2)
         {
             if (string.IsNullOrEmpty(file1))
             {
@@ -630,18 +618,13 @@ namespace Emby.Server.Implementations.IO
             SetHidden(file2, false);
 
             Directory.CreateDirectory(_tempPath);
-            CopyFile(file1, temp1, true);
+            File.Copy(file1, temp1, true);
 
-            CopyFile(file2, file1, true);
-            CopyFile(temp1, file2, true);
+            File.Copy(file2, file1, true);
+            File.Copy(temp1, file2, true);
         }
 
-        private static char GetDirectorySeparatorChar(string path)
-        {
-            return Path.DirectorySeparatorChar;
-        }
-
-        public bool ContainsSubPath(string parentPath, string path)
+        public virtual bool ContainsSubPath(string parentPath, string path)
         {
             if (string.IsNullOrEmpty(parentPath))
             {
@@ -653,19 +636,19 @@ namespace Emby.Server.Implementations.IO
                 throw new ArgumentNullException(nameof(path));
             }
 
-            var separatorChar = GetDirectorySeparatorChar(parentPath);
+            var separatorChar = Path.DirectorySeparatorChar;
 
             return path.IndexOf(parentPath.TrimEnd(separatorChar) + separatorChar, StringComparison.OrdinalIgnoreCase) != -1;
         }
 
-        public bool IsRootPath(string path)
+        public virtual bool IsRootPath(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
                 throw new ArgumentNullException(nameof(path));
             }
 
-            var parent = GetDirectoryName(path);
+            var parent = Path.GetDirectoryName(path);
 
             if (!string.IsNullOrEmpty(parent))
             {
@@ -675,12 +658,7 @@ namespace Emby.Server.Implementations.IO
             return true;
         }
 
-        public string GetDirectoryName(string path)
-        {
-            return Path.GetDirectoryName(path);
-        }
-
-        public string NormalizePath(string path)
+        public virtual string NormalizePath(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -692,10 +670,10 @@ namespace Emby.Server.Implementations.IO
                 return path;
             }
 
-            return path.TrimEnd(GetDirectorySeparatorChar(path));
+            return path.TrimEnd(Path.DirectorySeparatorChar);
         }
 
-        public bool AreEqual(string path1, string path2)
+        public virtual bool AreEqual(string path1, string path2)
         {
             if (path1 == null && path2 == null)
             {
@@ -710,7 +688,7 @@ namespace Emby.Server.Implementations.IO
             return string.Equals(NormalizePath(path1), NormalizePath(path2), StringComparison.OrdinalIgnoreCase);
         }
 
-        public string GetFileNameWithoutExtension(FileSystemMetadata info)
+        public virtual string GetFileNameWithoutExtension(FileSystemMetadata info)
         {
             if (info.IsDirectory)
             {
@@ -720,12 +698,7 @@ namespace Emby.Server.Implementations.IO
             return Path.GetFileNameWithoutExtension(info.FullName);
         }
 
-        public string GetFileNameWithoutExtension(string path)
-        {
-            return Path.GetFileNameWithoutExtension(path);
-        }
-
-        public bool IsPathFile(string path)
+        public virtual bool IsPathFile(string path)
         {
             // Cannot use Path.IsPathRooted because it returns false under mono when using windows-based paths, e.g. C:\\
 
@@ -740,23 +713,13 @@ namespace Emby.Server.Implementations.IO
             //return Path.IsPathRooted(path);
         }
 
-        public void DeleteFile(string path)
+        public virtual void DeleteFile(string path)
         {
             SetAttributes(path, false, false);
             File.Delete(path);
         }
-
-        public void DeleteDirectory(string path, bool recursive)
-        {
-            Directory.Delete(path, recursive);
-        }
-
-        public void CreateDirectory(string path)
-        {
-            Directory.CreateDirectory(path);
-        }
-
-        public List<FileSystemMetadata> GetDrives()
+        
+        public virtual List<FileSystemMetadata> GetDrives()
         {
             // Only include drives in the ready state or this method could end up being very slow, waiting for drives to timeout
             return DriveInfo.GetDrives().Where(d => d.IsReady).Select(d => new FileSystemMetadata
@@ -768,19 +731,19 @@ namespace Emby.Server.Implementations.IO
             }).ToList();
         }
 
-        public IEnumerable<FileSystemMetadata> GetDirectories(string path, bool recursive = false)
+        public virtual IEnumerable<FileSystemMetadata> GetDirectories(string path, bool recursive = false)
         {
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
             return ToMetadata(new DirectoryInfo(path).EnumerateDirectories("*", searchOption));
         }
 
-        public IEnumerable<FileSystemMetadata> GetFiles(string path, bool recursive = false)
+        public virtual IEnumerable<FileSystemMetadata> GetFiles(string path, bool recursive = false)
         {
             return GetFiles(path, null, false, recursive);
         }
 
-        public IEnumerable<FileSystemMetadata> GetFiles(string path, string[] extensions, bool enableCaseSensitiveExtensions, bool recursive = false)
+        public virtual IEnumerable<FileSystemMetadata> GetFiles(string path, string[] extensions, bool enableCaseSensitiveExtensions, bool recursive = false)
         {
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
@@ -809,7 +772,7 @@ namespace Emby.Server.Implementations.IO
             return ToMetadata(files);
         }
 
-        public IEnumerable<FileSystemMetadata> GetFileSystemEntries(string path, bool recursive = false)
+        public virtual IEnumerable<FileSystemMetadata> GetFileSystemEntries(string path, bool recursive = false)
         {
             var directoryInfo = new DirectoryInfo(path);
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
@@ -827,89 +790,19 @@ namespace Emby.Server.Implementations.IO
         {
             return infos.Select(GetFileSystemMetadata);
         }
-
-        public string[] ReadAllLines(string path)
-        {
-            return File.ReadAllLines(path);
-        }
-
-        public void WriteAllLines(string path, IEnumerable<string> lines)
-        {
-            File.WriteAllLines(path, lines);
-        }
-
-        public Stream OpenRead(string path)
-        {
-            return File.OpenRead(path);
-        }
-
-        public void CopyFile(string source, string target, bool overwrite)
-        {
-            File.Copy(source, target, overwrite);
-        }
-
-        public void MoveFile(string source, string target)
-        {
-            File.Move(source, target);
-        }
-
-        public void MoveDirectory(string source, string target)
-        {
-            Directory.Move(source, target);
-        }
-
-        public bool DirectoryExists(string path)
-        {
-            return Directory.Exists(path);
-        }
-
-        public bool FileExists(string path)
-        {
-            return File.Exists(path);
-        }
-
-        public string ReadAllText(string path)
-        {
-            return File.ReadAllText(path);
-        }
-
-        public byte[] ReadAllBytes(string path)
-        {
-            return File.ReadAllBytes(path);
-        }
-
-        public void WriteAllText(string path, string text, Encoding encoding)
-        {
-            File.WriteAllText(path, text, encoding);
-        }
-
-        public void WriteAllText(string path, string text)
-        {
-            File.WriteAllText(path, text);
-        }
-
-        public void WriteAllBytes(string path, byte[] bytes)
-        {
-            File.WriteAllBytes(path, bytes);
-        }
-
-        public string ReadAllText(string path, Encoding encoding)
-        {
-            return File.ReadAllText(path, encoding);
-        }
-
-        public IEnumerable<string> GetDirectoryPaths(string path, bool recursive = false)
+        
+        public virtual IEnumerable<string> GetDirectoryPaths(string path, bool recursive = false)
         {
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
             return Directory.EnumerateDirectories(path, "*", searchOption);
         }
 
-        public IEnumerable<string> GetFilePaths(string path, bool recursive = false)
+        public virtual IEnumerable<string> GetFilePaths(string path, bool recursive = false)
         {
             return GetFilePaths(path, null, false, recursive);
         }
 
-        public IEnumerable<string> GetFilePaths(string path, string[] extensions, bool enableCaseSensitiveExtensions, bool recursive = false)
+        public virtual IEnumerable<string> GetFilePaths(string path, string[] extensions, bool enableCaseSensitiveExtensions, bool recursive = false)
         {
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
@@ -938,7 +831,7 @@ namespace Emby.Server.Implementations.IO
             return files;
         }
 
-        public IEnumerable<string> GetFileSystemEntryPaths(string path, bool recursive = false)
+        public virtual IEnumerable<string> GetFileSystemEntryPaths(string path, bool recursive = false)
         {
             var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
             return Directory.EnumerateFileSystemEntries(path, "*", searchOption);
@@ -948,7 +841,7 @@ namespace Emby.Server.Implementations.IO
         {
             if (_environmentInfo.OperatingSystem == MediaBrowser.Model.System.OperatingSystem.OSX)
             {
-                RunProcess("chmod", "+x \"" + path + "\"", GetDirectoryName(path));
+                RunProcess("chmod", "+x \"" + path + "\"", Path.GetDirectoryName(path));
             }
         }
 

--- a/Emby.Server.Implementations/IO/MbLinkShortcutHandler.cs
+++ b/Emby.Server.Implementations/IO/MbLinkShortcutHandler.cs
@@ -24,7 +24,7 @@ namespace Emby.Server.Implementations.IO
 
             if (string.Equals(Path.GetExtension(shortcutPath), ".mblink", StringComparison.OrdinalIgnoreCase))
             {
-                var path = _fileSystem.ReadAllText(shortcutPath);
+                var path = File.ReadAllText(shortcutPath);
 
                 return _fileSystem.NormalizePath(path);
             }
@@ -44,7 +44,7 @@ namespace Emby.Server.Implementations.IO
                 throw new ArgumentNullException(nameof(targetPath));
             }
 
-            _fileSystem.WriteAllText(shortcutPath, targetPath);
+            File.WriteAllText(shortcutPath, targetPath);
         }
     }
 }

--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -99,7 +99,7 @@ namespace Emby.Server.Implementations.Images
             CancellationToken cancellationToken)
         {
             var outputPathWithoutExtension = Path.Combine(ApplicationPaths.TempDirectory, Guid.NewGuid().ToString("N"));
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(outputPathWithoutExtension));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPathWithoutExtension));
             string outputPath = CreateImage(item, itemsWithImages, outputPathWithoutExtension, imageType, 0);
 
             if (string.IsNullOrEmpty(outputPath))
@@ -165,7 +165,7 @@ namespace Emby.Server.Implementations.Images
 
         private string CreateCollage(BaseItem primaryItem, List<BaseItem> items, string outputPath, int width, int height)
         {
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(outputPath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var options = new ImageCollageOptions
             {

--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -99,7 +99,7 @@ namespace Emby.Server.Implementations.Images
             CancellationToken cancellationToken)
         {
             var outputPathWithoutExtension = Path.Combine(ApplicationPaths.TempDirectory, Guid.NewGuid().ToString("N"));
-            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPathWithoutExtension));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPathWithoutExtension));
             string outputPath = CreateImage(item, itemsWithImages, outputPathWithoutExtension, imageType, 0);
 
             if (string.IsNullOrEmpty(outputPath))
@@ -165,7 +165,7 @@ namespace Emby.Server.Implementations.Images
 
         private string CreateCollage(BaseItem primaryItem, List<BaseItem> items, string outputPath, int width, int height)
         {
-            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var options = new ImageCollageOptions
             {

--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -300,7 +300,7 @@ namespace Emby.Server.Implementations.Images
             var ext = Path.GetExtension(image);
 
             var outputPath = Path.ChangeExtension(outputPathWithoutExtension, ext);
-            FileSystem.CopyFile(image, outputPath, true);
+            File.Copy(image, outputPath, true);
 
             return outputPath;
         }

--- a/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -146,7 +147,7 @@ namespace Emby.Server.Implementations.Library
                 if (parent != null)
                 {
                     // Don't resolve these into audio files
-                    if (string.Equals(_fileSystem.GetFileNameWithoutExtension(filename), BaseItem.ThemeSongFilename) && _libraryManager.IsAudioFile(filename))
+                    if (string.Equals(Path.GetFileNameWithoutExtension(filename), BaseItem.ThemeSongFilename) && _libraryManager.IsAudioFile(filename))
                     {
                         return true;
                     }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2863,7 +2863,7 @@ namespace Emby.Server.Implementations.Library
             var rootFolderPath = ConfigurationManager.ApplicationPaths.DefaultUserViewsPath;
 
             var virtualFolderPath = Path.Combine(rootFolderPath, name);
-            while (_fileSystem.DirectoryExists(virtualFolderPath))
+            while (Directory.Exists(virtualFolderPath))
             {
                 name += "1";
                 virtualFolderPath = Path.Combine(rootFolderPath, name);
@@ -2872,7 +2872,7 @@ namespace Emby.Server.Implementations.Library
             var mediaPathInfos = options.PathInfos;
             if (mediaPathInfos != null)
             {
-                var invalidpath = mediaPathInfos.FirstOrDefault(i => !_fileSystem.DirectoryExists(i.Path));
+                var invalidpath = mediaPathInfos.FirstOrDefault(i => !Directory.Exists(i.Path));
                 if (invalidpath != null)
                 {
                     throw new ArgumentException("The specified path does not exist: " + invalidpath.Path + ".");
@@ -2935,7 +2935,7 @@ namespace Emby.Server.Implementations.Library
             //    // We can't validate protocol-based paths, so just allow them
             //    if (path.IndexOf("://", StringComparison.OrdinalIgnoreCase) == -1)
             //    {
-            //        return _fileSystem.DirectoryExists(path);
+            //        return Directory.Exists(path);
             //    }
             //}
 
@@ -2963,7 +2963,7 @@ namespace Emby.Server.Implementations.Library
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (!_fileSystem.DirectoryExists(path))
+            if (!Directory.Exists(path))
             {
                 throw new FileNotFoundException("The path does not exist.");
             }
@@ -2980,7 +2980,7 @@ namespace Emby.Server.Implementations.Library
 
             var lnk = Path.Combine(virtualFolderPath, shortcutFilename + ShortcutFileExtension);
 
-            while (_fileSystem.FileExists(lnk))
+            while (File.Exists(lnk))
             {
                 shortcutFilename += "1";
                 lnk = Path.Combine(virtualFolderPath, shortcutFilename + ShortcutFileExtension);
@@ -3073,7 +3073,7 @@ namespace Emby.Server.Implementations.Library
 
             var path = Path.Combine(rootFolderPath, name);
 
-            if (!_fileSystem.DirectoryExists(path))
+            if (!Directory.Exists(path))
             {
                 throw new FileNotFoundException("The media folder does not exist");
             }
@@ -3145,7 +3145,7 @@ namespace Emby.Server.Implementations.Library
             var rootFolderPath = ConfigurationManager.ApplicationPaths.DefaultUserViewsPath;
             var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
 
-            if (!_fileSystem.DirectoryExists(virtualFolderPath))
+            if (!Directory.Exists(virtualFolderPath))
             {
                 throw new FileNotFoundException(string.Format("The media collection {0} does not exist", virtualFolderName));
             }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -375,7 +375,7 @@ namespace Emby.Server.Implementations.Library
 
                 try
                 {
-                    _fileSystem.DeleteDirectory(metadataPath, true);
+                    Directory.Delete(metadataPath, true);
                 }
                 catch (IOException)
                 {
@@ -402,11 +402,11 @@ namespace Emby.Server.Implementations.Library
                             _logger.LogDebug("Deleting path {path}", fileSystemInfo.FullName);
                             if (fileSystemInfo.IsDirectory)
                             {
-                                _fileSystem.DeleteDirectory(fileSystemInfo.FullName, true);
+                                Directory.Delete(fileSystemInfo.FullName, true);
                             }
                             else
                             {
-                                _fileSystem.DeleteFile(fileSystemInfo.FullName);
+                                File.Delete(fileSystemInfo.FullName);
                             }
                         }
                         catch (IOException)
@@ -720,7 +720,7 @@ namespace Emby.Server.Implementations.Library
         {
             var rootFolderPath = ConfigurationManager.ApplicationPaths.RootFolderPath;
 
-            _fileSystem.CreateDirectory(rootFolderPath);
+            Directory.CreateDirectory(rootFolderPath);
 
             var rootFolder = GetItemById(GetNewItemId(rootFolderPath, typeof(AggregateFolder))) as AggregateFolder ?? ((Folder)ResolvePath(_fileSystem.GetDirectoryInfo(rootFolderPath))).DeepCopy<Folder, AggregateFolder>();
 
@@ -734,7 +734,7 @@ namespace Emby.Server.Implementations.Library
             // Add in the plug-in folders
             var path = Path.Combine(ConfigurationManager.ApplicationPaths.DataPath, "playlists");
 
-            _fileSystem.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             Folder folder = new PlaylistsFolder
             {
@@ -785,7 +785,7 @@ namespace Emby.Server.Implementations.Library
                     {
                         var userRootPath = ConfigurationManager.ApplicationPaths.DefaultUserViewsPath;
 
-                        _fileSystem.CreateDirectory(userRootPath);
+                        Directory.CreateDirectory(userRootPath);
 
                         var tmpItem = GetItemById(GetNewItemId(userRootPath, typeof(UserRootFolder))) as UserRootFolder;
 
@@ -999,7 +999,7 @@ namespace Emby.Server.Implementations.Library
         public Task ValidatePeople(CancellationToken cancellationToken, IProgress<double> progress)
         {
             // Ensure the location is available.
-            _fileSystem.CreateDirectory(ConfigurationManager.ApplicationPaths.PeoplePath);
+            Directory.CreateDirectory(ConfigurationManager.ApplicationPaths.PeoplePath);
 
             return new PeopleValidator(this, _logger, ConfigurationManager, _fileSystem).ValidatePeople(cancellationToken, progress);
         }
@@ -2146,7 +2146,7 @@ namespace Emby.Server.Implementations.Library
 
             if (item == null || !string.Equals(item.Path, path, StringComparison.OrdinalIgnoreCase))
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 item = new UserView
                 {
@@ -2191,7 +2191,7 @@ namespace Emby.Server.Implementations.Library
 
             if (item == null)
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 item = new UserView
                 {
@@ -2256,7 +2256,7 @@ namespace Emby.Server.Implementations.Library
 
             if (item == null)
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 item = new UserView
                 {
@@ -2324,7 +2324,7 @@ namespace Emby.Server.Implementations.Library
 
             if (item == null)
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 item = new UserView
                 {
@@ -2883,7 +2883,7 @@ namespace Emby.Server.Implementations.Library
 
             try
             {
-                _fileSystem.CreateDirectory(virtualFolderPath);
+                Directory.CreateDirectory(virtualFolderPath);
 
                 if (!string.IsNullOrEmpty(collectionType))
                 {
@@ -3082,7 +3082,7 @@ namespace Emby.Server.Implementations.Library
 
             try
             {
-                _fileSystem.DeleteDirectory(path, true);
+                Directory.Delete(path, true);
             }
             finally
             {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1228,7 +1228,7 @@ namespace Emby.Server.Implementations.Library
         private string GetCollectionType(string path)
         {
             return _fileSystem.GetFilePaths(path, new[] { ".collection" }, true, false)
-                .Select(i => _fileSystem.GetFileNameWithoutExtension(i))
+                .Select(i => Path.GetFileNameWithoutExtension(i))
                 .FirstOrDefault(i => !string.IsNullOrEmpty(i));
         }
 
@@ -2976,7 +2976,7 @@ namespace Emby.Server.Implementations.Library
             var rootFolderPath = ConfigurationManager.ApplicationPaths.DefaultUserViewsPath;
             var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
 
-            var shortcutFilename = _fileSystem.GetFileNameWithoutExtension(path);
+            var shortcutFilename = Path.GetFileNameWithoutExtension(path);
 
             var lnk = Path.Combine(virtualFolderPath, shortcutFilename + ShortcutFileExtension);
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2889,7 +2889,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     var path = Path.Combine(virtualFolderPath, collectionType + ".collection");
 
-                    _fileSystem.WriteAllBytes(path, Array.Empty<byte>());
+                    File.WriteAllBytes(path, Array.Empty<byte>());
                 }
 
                 CollectionFolder.SaveLibraryOptions(virtualFolderPath, options);

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -670,7 +670,7 @@ namespace Emby.Server.Implementations.Library
 
                 if (cacheFilePath != null)
                 {
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(cacheFilePath));
+                    Directory.CreateDirectory(Path.GetDirectoryName(cacheFilePath));
                     _jsonSerializer.SerializeToFile(mediaInfo, cacheFilePath);
 
                     //_logger.LogDebug("Saved media info to {0}", cacheFilePath);

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -670,7 +670,7 @@ namespace Emby.Server.Implementations.Library
 
                 if (cacheFilePath != null)
                 {
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(cacheFilePath));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(cacheFilePath));
                     _jsonSerializer.SerializeToFile(mediaInfo, cacheFilePath);
 
                     //_logger.LogDebug("Saved media info to {0}", cacheFilePath);

--- a/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
@@ -43,7 +43,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
                         var filename = Path.GetFileNameWithoutExtension(args.Path);
 
                         // Make sure the image doesn't belong to a video file
-                        var files = args.DirectoryService.GetFiles(_fileSystem.GetDirectoryName(args.Path));
+                        var files = args.DirectoryService.GetFiles(Path.GetDirectoryName(args.Path));
                         var libraryOptions = args.GetLibraryOptions();
 
                         foreach (var file in files)

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -1080,7 +1080,7 @@ namespace Emby.Server.Implementations.Library
 
             var path = GetPolicyFilePath(user);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_policySyncLock)
             {
@@ -1176,7 +1176,7 @@ namespace Emby.Server.Implementations.Library
                 config = _jsonSerializer.DeserializeFromString<UserConfiguration>(json);
             }
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configSyncLock)
             {

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -904,7 +904,7 @@ namespace Emby.Server.Implementations.Library
             // Tuesday, 22 August 2006 06:30 AM
             text.AppendLine("The pin code will expire at " + localExpirationTime.ToString("f1", CultureInfo.CurrentCulture));
 
-            _fileSystem.WriteAllText(path, text.ToString(), Encoding.UTF8);
+            File.WriteAllText(path, text.ToString(), Encoding.UTF8);
 
             var result = new PasswordPinCreationResult
             {

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -1080,7 +1080,7 @@ namespace Emby.Server.Implementations.Library
 
             var path = GetPolicyFilePath(user);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_policySyncLock)
             {
@@ -1176,7 +1176,7 @@ namespace Emby.Server.Implementations.Library
                 config = _jsonSerializer.DeserializeFromString<UserConfiguration>(json);
             }
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             lock (_configSyncLock)
             {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
@@ -41,7 +42,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
         private async Task RecordFromDirectStreamProvider(IDirectStreamProvider directStreamProvider, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
         {
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(targetFile));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
 
             using (var output = _fileSystem.GetFileStream(targetFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
             {
@@ -77,7 +78,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             {
                 _logger.LogInformation("Opened recording stream from tuner provider");
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(targetFile));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
 
                 using (var output = _fileSystem.GetFileStream(targetFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
                 {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
@@ -42,7 +42,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
         private async Task RecordFromDirectStreamProvider(IDirectStreamProvider directStreamProvider, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
         {
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
 
             using (var output = _fileSystem.GetFileStream(targetFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
             {
@@ -78,7 +78,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             {
                 _logger.LogInformation("Opened recording stream from tuner provider");
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
+                Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
 
                 using (var output = _fileSystem.GetFileStream(targetFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
                 {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1489,7 +1489,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             _logger.LogInformation("Triggering refresh on {path}", path);
 
-            var item = GetAffectedBaseItem(_fileSystem.GetDirectoryName(path));
+            var item = GetAffectedBaseItem(Path.GetDirectoryName(path));
 
             if (item != null)
             {
@@ -1500,8 +1500,8 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     RefreshPaths = new string[]
                     {
                         path,
-                        _fileSystem.GetDirectoryName(path),
-                        _fileSystem.GetDirectoryName(_fileSystem.GetDirectoryName(path))
+                        Path.GetDirectoryName(path),
+                        Path.GetDirectoryName(Path.GetDirectoryName(path))
                     }
 
                 }, RefreshPriority.High);
@@ -1512,13 +1512,13 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             BaseItem item = null;
 
-            var parentPath = _fileSystem.GetDirectoryName(path);
+            var parentPath = Path.GetDirectoryName(path);
 
             while (item == null && !string.IsNullOrEmpty(path))
             {
                 item = _libraryManager.FindByPath(path, null);
 
-                path = _fileSystem.GetDirectoryName(path);
+                path = Path.GetDirectoryName(path);
             }
 
             if (item != null)
@@ -1676,7 +1676,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
             while (FileExists(path, timerId))
             {
-                var parent = _fileSystem.GetDirectoryName(originalPath);
+                var parent = Path.GetDirectoryName(originalPath);
                 var name = Path.GetFileNameWithoutExtension(originalPath);
                 name += " - " + index.ToString(CultureInfo.InvariantCulture);
 
@@ -1822,7 +1822,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 return;
             }
 
-            var imageSavePath = Path.Combine(_fileSystem.GetDirectoryName(recordingPath), imageSaveFilenameWithoutExtension);
+            var imageSavePath = Path.Combine(Path.GetDirectoryName(recordingPath), imageSaveFilenameWithoutExtension);
 
             // preserve original image extension
             imageSavePath = Path.ChangeExtension(imageSavePath, Path.GetExtension(image.Path));

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1827,7 +1827,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             // preserve original image extension
             imageSavePath = Path.ChangeExtension(imageSavePath, Path.GetExtension(image.Path));
 
-            _fileSystem.CopyFile(image.Path, imageSavePath, true);
+            File.Copy(image.Path, imageSavePath, true);
         }
 
         private async Task SaveRecordingImages(string recordingPath, LiveTvProgram program)

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1427,7 +1427,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 timer.RetryCount++;
                 _timerProvider.AddOrUpdate(timer);
             }
-            else if (_fileSystem.FileExists(recordPath))
+            else if (File.Exists(recordPath))
             {
                 timer.RecordingPath = recordPath;
                 timer.Status = RecordingStatus.Completed;
@@ -1573,7 +1573,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     .Where(i => i.Status == RecordingStatus.Completed && !string.IsNullOrWhiteSpace(i.RecordingPath))
                     .Where(i => string.Equals(i.SeriesTimerId, seriesTimerId, StringComparison.OrdinalIgnoreCase))
                     .OrderByDescending(i => i.EndDate)
-                    .Where(i => _fileSystem.FileExists(i.RecordingPath))
+                    .Where(i => File.Exists(i.RecordingPath))
                     .Skip(seriesTimer.KeepUpTo - 1)
                     .ToList();
 
@@ -1595,7 +1595,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     DtoOptions = new DtoOptions(true)
 
                 }))
-                    .Where(i => i.IsFileProtocol && _fileSystem.FileExists(i.Path))
+                    .Where(i => i.IsFileProtocol && File.Exists(i.Path))
                     .Skip(seriesTimer.KeepUpTo - 1)
                     .ToList();
 
@@ -1689,7 +1689,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
         private bool FileExists(string path, string timerId)
         {
-            if (_fileSystem.FileExists(path))
+            if (File.Exists(path))
             {
                 return true;
             }
@@ -1961,7 +1961,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             var nfoPath = Path.Combine(seriesPath, "tvshow.nfo");
 
-            if (_fileSystem.FileExists(nfoPath))
+            if (File.Exists(nfoPath))
             {
                 return;
             }
@@ -2023,7 +2023,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             var nfoPath = Path.ChangeExtension(recordingPath, ".nfo");
 
-            if (_fileSystem.FileExists(nfoPath))
+            if (File.Exists(nfoPath))
             {
                 return;
             }
@@ -2688,7 +2688,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             var defaultFolder = RecordingPath;
             var defaultName = "Recordings";
 
-            if (_fileSystem.DirectoryExists(defaultFolder))
+            if (Directory.Exists(defaultFolder))
             {
                 list.Add(new VirtualFolderInfo
                 {
@@ -2698,7 +2698,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
 
             var customPath = GetConfiguration().MovieRecordingPath;
-            if ((!string.IsNullOrWhiteSpace(customPath) && !string.Equals(customPath, defaultFolder, StringComparison.OrdinalIgnoreCase)) && _fileSystem.DirectoryExists(customPath))
+            if ((!string.IsNullOrWhiteSpace(customPath) && !string.Equals(customPath, defaultFolder, StringComparison.OrdinalIgnoreCase)) && Directory.Exists(customPath))
             {
                 list.Add(new VirtualFolderInfo
                 {
@@ -2709,7 +2709,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
 
             customPath = GetConfiguration().SeriesRecordingPath;
-            if ((!string.IsNullOrWhiteSpace(customPath) && !string.Equals(customPath, defaultFolder, StringComparison.OrdinalIgnoreCase)) && _fileSystem.DirectoryExists(customPath))
+            if ((!string.IsNullOrWhiteSpace(customPath) && !string.Equals(customPath, defaultFolder, StringComparison.OrdinalIgnoreCase)) && Directory.Exists(customPath))
             {
                 list.Add(new VirtualFolderInfo
                 {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
@@ -79,7 +79,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         private Task RecordFromFile(MediaSourceInfo mediaSource, string inputFile, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
         {
             _targetPath = targetFile;
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(targetFile));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
 
             var process = _processFactory.Create(new ProcessOptions
             {
@@ -105,7 +105,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             _logger.LogInformation(commandLineLogMessage);
 
             var logFilePath = Path.Combine(_appPaths.LogDirectoryPath, "record-transcode-" + Guid.NewGuid() + ".txt");
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(logFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             _logFileStream = _fileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
@@ -79,7 +79,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         private Task RecordFromFile(MediaSourceInfo mediaSource, string inputFile, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
         {
             _targetPath = targetFile;
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(targetFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
 
             var process = _processFactory.Create(new ProcessOptions
             {
@@ -105,7 +105,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             _logger.LogInformation(commandLineLogMessage);
 
             var logFilePath = Path.Combine(_appPaths.LogDirectoryPath, "record-transcode-" + Guid.NewGuid() + ".txt");
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             _logFileStream = _fileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
@@ -70,7 +70,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
 
             var file = _dataPath + ".json";
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(file));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(file));
 
             lock (_fileDataLock)
             {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
@@ -70,7 +70,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
 
             var file = _dataPath + ".json";
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(file));
+            Directory.CreateDirectory(Path.GetDirectoryName(file));
 
             lock (_fileDataLock)
             {

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
             }).ConfigureAwait(false);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(cacheFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(cacheFile));
 
             _fileSystem.CopyFile(tempFile, cacheFile, true);
 
@@ -125,7 +125,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
             using (var stream = _fileSystem.OpenRead(file))
             {
                 string tempFolder = Path.Combine(_config.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString());
-                _fileSystem.CreateDirectory(tempFolder);
+                Directory.CreateDirectory(tempFolder);
 
                 _zipClient.ExtractFirstFileFromGz(stream, tempFolder, "data.xml");
 
@@ -138,7 +138,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
             using (var stream = _fileSystem.OpenRead(file))
             {
                 string tempFolder = Path.Combine(_config.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString());
-                _fileSystem.CreateDirectory(tempFolder);
+                Directory.CreateDirectory(tempFolder);
 
                 _zipClient.ExtractAllFromGz(stream, tempFolder, true);
 

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
             }).ConfigureAwait(false);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(cacheFile));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(cacheFile));
 
             _fileSystem.CopyFile(tempFile, cacheFile, true);
 

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -61,7 +61,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
             string cacheFilename = DateTime.UtcNow.DayOfYear.ToString(CultureInfo.InvariantCulture) + "-" + DateTime.UtcNow.Hour.ToString(CultureInfo.InvariantCulture) + ".xml";
             string cacheFile = Path.Combine(_config.ApplicationPaths.CachePath, "xmltv", cacheFilename);
-            if (_fileSystem.FileExists(cacheFile))
+            if (File.Exists(cacheFile))
             {
                 return UnzipIfNeeded(path, cacheFile);
             }
@@ -255,7 +255,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
         public Task Validate(ListingsProviderInfo info, bool validateLogin, bool validateListings)
         {
             // Assume all urls are valid. check files for existence
-            if (!info.Path.StartsWith("http", StringComparison.OrdinalIgnoreCase) && !_fileSystem.FileExists(info.Path))
+            if (!info.Path.StartsWith("http", StringComparison.OrdinalIgnoreCase) && !File.Exists(info.Path))
             {
                 throw new FileNotFoundException("Could not find the XmlTv file specified:", info.Path);
             }

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -85,7 +85,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
             Directory.CreateDirectory(Path.GetDirectoryName(cacheFile));
 
-            _fileSystem.CopyFile(tempFile, cacheFile, true);
+            File.Copy(tempFile, cacheFile, true);
 
             return UnzipIfNeeded(path, cacheFile);
         }
@@ -122,7 +122,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
         private string ExtractFirstFileFromGz(string file)
         {
-            using (var stream = _fileSystem.OpenRead(file))
+            using (var stream = File.OpenRead(file))
             {
                 string tempFolder = Path.Combine(_config.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempFolder);
@@ -135,7 +135,7 @@ namespace Jellyfin.Server.Implementations.LiveTv.Listings
 
         private string ExtractGz(string file)
         {
-            using (var stream = _fileSystem.OpenRead(file))
+            using (var stream = File.OpenRead(file))
             {
                 string tempFolder = Path.Combine(_config.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempFolder);

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/BaseTunerHost.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/BaseTunerHost.cs
@@ -95,7 +95,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                     {
                         try
                         {
-                            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(channelCacheFile));
+                            FileSystem.CreateDirectory(Path.GetDirectoryName(channelCacheFile));
                             JsonSerializer.SerializeToFile(channels, channelCacheFile);
                         }
                         catch (IOException)

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/BaseTunerHost.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/BaseTunerHost.cs
@@ -95,7 +95,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                     {
                         try
                         {
-                            FileSystem.CreateDirectory(Path.GetDirectoryName(channelCacheFile));
+                            Directory.CreateDirectory(Path.GetDirectoryName(channelCacheFile));
                             JsonSerializer.SerializeToFile(channels, channelCacheFile);
                         }
                         catch (IOException)

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
             var uri = new Uri(mediaSource.Path);
             var localPort = _networkManager.GetRandomUnusedUdpPort();
 
-            FileSystem.CreateDirectory(Path.GetDirectoryName(TempFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(TempFilePath));
 
             Logger.LogInformation("Opening HDHR UDP Live stream from {host}", uri.Host);
 

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
             var uri = new Uri(mediaSource.Path);
             var localPort = _networkManager.GetRandomUnusedUdpPort();
 
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(TempFilePath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(TempFilePath));
 
             Logger.LogInformation("Opening HDHR UDP Live stream from {host}", uri.Host);
 

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
@@ -61,7 +61,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                     UserAgent = _appHost.ApplicationUserAgent
                 });
             }
-            return Task.FromResult(_fileSystem.OpenRead(url));
+            return Task.FromResult((Stream)File.OpenRead(url));
         }
 
         const string ExtInfPrefix = "#EXTINF:";

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
@@ -35,7 +36,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
 
             var url = mediaSource.Path;
 
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(TempFilePath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(TempFilePath));
 
             var typeName = GetType().Name;
             Logger.LogInformation("Opening " + typeName + " Live stream from {0}", url);

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
@@ -36,7 +36,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
 
             var url = mediaSource.Path;
 
-            FileSystem.CreateDirectory(Path.GetDirectoryName(TempFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(TempFilePath));
 
             var typeName = GetType().Name;
             Logger.LogInformation("Opening " + typeName + " Live stream from {0}", url);

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -337,7 +337,7 @@ namespace Emby.Server.Implementations.Localization
             .Where(i => i != null)
             .ToDictionary(i => i.Name, StringComparer.OrdinalIgnoreCase);
 
-            var countryCode = _fileSystem.GetFileNameWithoutExtension(file)
+            var countryCode = Path.GetFileNameWithoutExtension(file)
                 .Split('-')
                 .Last();
 

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -70,7 +70,7 @@ namespace Emby.Server.Implementations.Localization
 
             var localizationPath = LocalizationPath;
 
-            _fileSystem.CreateDirectory(localizationPath);
+            Directory.CreateDirectory(localizationPath);
 
             var existingFiles = GetRatingsFiles(localizationPath)
                 .Select(Path.GetFileName)

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -316,7 +316,7 @@ namespace Emby.Server.Implementations.Localization
         /// <returns>Dictionary{System.StringParentalRating}.</returns>
         private void LoadRatings(string file)
         {
-            var dict = _fileSystem.ReadAllLines(file).Select(i =>
+            var dict = File.ReadAllLines(file).Select(i =>
             {
                 if (!string.IsNullOrWhiteSpace(i))
                 {

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -141,7 +141,7 @@ namespace Emby.Server.Implementations.MediaEncoder
 
                             var inputPath = MediaEncoderHelpers.GetInputArgument(_fileSystem, video.Path, protocol, null, Array.Empty<string>());
 
-                            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                             var container = video.Container;
 

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -141,7 +141,7 @@ namespace Emby.Server.Implementations.MediaEncoder
 
                             var inputPath = MediaEncoderHelpers.GetInputArgument(_fileSystem, video.Path, protocol, null, Array.Empty<string>());
 
-                            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                             var container = video.Container;
 

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -146,7 +146,7 @@ namespace Emby.Server.Implementations.MediaEncoder
                             var container = video.Container;
 
                             var tempFile = await _encoder.ExtractVideoImage(inputPath, container, protocol, video.GetDefaultVideoStream(), video.Video3DFormat, time, cancellationToken).ConfigureAwait(false);
-                            _fileSystem.CopyFile(tempFile, path, true);
+                            File.Copy(tempFile, path, true);
 
                             try
                             {

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -340,7 +340,8 @@ namespace Emby.Server.Implementations.Playlists
                     playlist.PlaylistEntries.Add(entry);
                 }
 
-                _fileSystem.WriteAllText(playlistPath, new WplContent().ToText(playlist));
+                string text = new WplContent().ToText(playlist);
+                File.WriteAllText(playlistPath, text);
             }
             if (string.Equals(".zpl", extension, StringComparison.OrdinalIgnoreCase))
             {
@@ -373,7 +374,8 @@ namespace Emby.Server.Implementations.Playlists
                     playlist.PlaylistEntries.Add(entry);
                 }
 
-                _fileSystem.WriteAllText(playlistPath, new ZplContent().ToText(playlist));
+                string text = new ZplContent().ToText(playlist);
+                File.WriteAllText(playlistPath, text);
             }
             if (string.Equals(".m3u", extension, StringComparison.OrdinalIgnoreCase))
             {
@@ -401,7 +403,8 @@ namespace Emby.Server.Implementations.Playlists
                     playlist.PlaylistEntries.Add(entry);
                 }
 
-                _fileSystem.WriteAllText(playlistPath, new M3uContent().ToText(playlist));
+                string text = new M3uContent().ToText(playlist);
+                File.WriteAllText(playlistPath, text);
             }
             if (string.Equals(".m3u8", extension, StringComparison.OrdinalIgnoreCase))
             {
@@ -429,7 +432,8 @@ namespace Emby.Server.Implementations.Playlists
                     playlist.PlaylistEntries.Add(entry);
                 }
 
-                _fileSystem.WriteAllText(playlistPath, new M3u8Content().ToText(playlist));
+                string text = new M3u8Content().ToText(playlist);
+                File.WriteAllText(playlistPath, text);
             }
             if (string.Equals(".pls", extension, StringComparison.OrdinalIgnoreCase))
             {
@@ -449,7 +453,8 @@ namespace Emby.Server.Implementations.Playlists
                     playlist.PlaylistEntries.Add(entry);
                 }
 
-                _fileSystem.WriteAllText(playlistPath, new PlsContent().ToText(playlist));
+                string text = new PlsContent().ToText(playlist);
+                File.WriteAllText(playlistPath, text);
             }
         }
 

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -455,7 +455,7 @@ namespace Emby.Server.Implementations.Playlists
 
         private string NormalizeItemPath(string playlistPath, string itemPath)
         {
-            return MakeRelativePath(_fileSystem.GetDirectoryName(playlistPath), itemPath);
+            return MakeRelativePath(Path.GetDirectoryName(playlistPath), itemPath);
         }
 
         private static string MakeRelativePath(string folderPath, string fileAbsolutePath)

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -119,7 +119,7 @@ namespace Emby.Server.Implementations.Playlists
 
             try
             {
-                _fileSystem.CreateDirectory(path);
+                Directory.CreateDirectory(path);
 
                 var playlist = new Playlist
                 {

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -164,7 +164,7 @@ namespace Emby.Server.Implementations.Playlists
 
         private string GetTargetPath(string path)
         {
-            while (_fileSystem.DirectoryExists(path))
+            while (Directory.Exists(path))
             {
                 path += "1";
             }

--- a/Emby.Server.Implementations/ResourceFileManager.cs
+++ b/Emby.Server.Implementations/ResourceFileManager.cs
@@ -42,11 +42,11 @@ namespace Emby.Server.Implementations
 
         private string GetResourcePath(string basePath, string virtualPath)
         {
-            var fullPath = Path.Combine(basePath, virtualPath.Replace('/', _fileSystem.DirectorySeparatorChar));
+            var fullPath = Path.Combine(basePath, virtualPath.Replace('/', Path.DirectorySeparatorChar));
 
             try
             {
-                fullPath = _fileSystem.GetFullPath(fullPath);
+                fullPath = Path.GetFullPath(fullPath);
             }
             catch (Exception ex)
             {

--- a/Emby.Server.Implementations/ResourceFileManager.cs
+++ b/Emby.Server.Implementations/ResourceFileManager.cs
@@ -37,7 +37,7 @@ namespace Emby.Server.Implementations
 
         public string ReadAllText(string basePath, string virtualPath)
         {
-            return _fileSystem.ReadAllText(GetResourcePath(basePath, virtualPath));
+            return File.ReadAllText(GetResourcePath(basePath, virtualPath));
         }
 
         private string GetResourcePath(string basePath, string virtualPath)

--- a/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
@@ -139,7 +139,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                     {
                         previouslyFailedImages.Add(key);
 
-                        var parentPath = _fileSystem.GetDirectoryName(failHistoryPath);
+                        var parentPath = Path.GetDirectoryName(failHistoryPath);
 
                         _fileSystem.CreateDirectory(parentPath);
 

--- a/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
@@ -141,7 +141,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
                         var parentPath = Path.GetDirectoryName(failHistoryPath);
 
-                        _fileSystem.CreateDirectory(parentPath);
+                        Directory.CreateDirectory(parentPath);
 
                         _fileSystem.WriteAllText(failHistoryPath, string.Join("|", previouslyFailedImages.ToArray()));
                     }

--- a/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
@@ -105,7 +105,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
             {
                 try
                 {
-                    previouslyFailedImages = _fileSystem.ReadAllText(failHistoryPath)
+                    previouslyFailedImages = File.ReadAllText(failHistoryPath)
                         .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
                         .ToList();
                 }
@@ -143,7 +143,8 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
                         Directory.CreateDirectory(parentPath);
 
-                        _fileSystem.WriteAllText(failHistoryPath, string.Join("|", previouslyFailedImages.ToArray()));
+                        string text = string.Join("|", previouslyFailedImages.ToArray());
+                        File.WriteAllText(failHistoryPath, text);
                     }
 
                     numComplete++;

--- a/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
@@ -143,7 +143,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
                         Directory.CreateDirectory(parentPath);
 
-                        string text = string.Join("|", previouslyFailedImages.ToArray());
+                        string text = string.Join("|", previouslyFailedImages);
                         File.WriteAllText(failHistoryPath, text);
                     }
 

--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -151,7 +151,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 _lastExecutionResult = value;
 
                 var path = GetHistoryFilePath();
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                 lock (_lastExecutionResultSyncLock)
                 {
@@ -565,7 +565,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         {
             var path = GetConfigurationFilePath();
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             JsonSerializer.SerializeToFile(triggers, path);
         }

--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -151,7 +151,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 _lastExecutionResult = value;
 
                 var path = GetHistoryFilePath();
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                 lock (_lastExecutionResultSyncLock)
                 {
@@ -565,7 +565,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         {
             var path = GetConfigurationFilePath();
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             JsonSerializer.SerializeToFile(triggers, path);
         }

--- a/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
@@ -86,7 +86,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
             try
             {
-                lines = _fileSystem.ReadAllLines(path).Where(i => !string.IsNullOrWhiteSpace(i)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                lines = File.ReadAllLines(path).Where(i => !string.IsNullOrWhiteSpace(i)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 
                 foreach (var key in lines)
                 {

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
@@ -128,7 +128,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
                 {
                     try
                     {
-                        _fileSystem.DeleteDirectory(directory, false);
+                        Directory.Delete(directory, false);
                     }
                     catch (UnauthorizedAccessException ex)
                     {

--- a/Emby.Server.Implementations/Serialization/XmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/XmlSerializer.cs
@@ -107,7 +107,7 @@ namespace Emby.Server.Implementations.Serialization
         public object DeserializeFromFile(Type type, string file)
         {
             _logger.LogDebug("Deserializing file {0}", file);
-            using (var stream = _fileSystem.OpenRead(file))
+            using (var stream = File.OpenRead(file))
             {
                 return DeserializeFromStream(type, stream);
             }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -570,7 +570,7 @@ namespace Emby.Server.Implementations.Updates
             // Success - move it to the real target
             try
             {
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(target));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(target));
                 _fileSystem.CopyFile(tempFile, target, true);
                 //If it is an archive - write out a version file so we know what it is
                 if (isArchive)
@@ -611,7 +611,7 @@ namespace Emby.Server.Implementations.Updates
             _logger.LogInformation("Deleting plugin file {0}", path);
 
             // Make this case-insensitive to account for possible incorrect assembly naming
-            var file = _fileSystem.GetFilePaths(_fileSystem.GetDirectoryName(path))
+            var file = _fileSystem.GetFilePaths(Path.GetDirectoryName(path))
                 .FirstOrDefault(i => string.Equals(i, path, StringComparison.OrdinalIgnoreCase));
 
             if (!string.IsNullOrWhiteSpace(file))

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -570,7 +570,7 @@ namespace Emby.Server.Implementations.Updates
             // Success - move it to the real target
             try
             {
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(target));
+                Directory.CreateDirectory(Path.GetDirectoryName(target));
                 _fileSystem.CopyFile(tempFile, target, true);
                 //If it is an archive - write out a version file so we know what it is
                 if (isArchive)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -575,7 +575,7 @@ namespace Emby.Server.Implementations.Updates
                 //If it is an archive - write out a version file so we know what it is
                 if (isArchive)
                 {
-                    _fileSystem.WriteAllText(target + ".ver", package.versionStr);
+                    File.WriteAllText(target + ".ver", package.versionStr);
                 }
             }
             catch (IOException ex)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -555,7 +555,7 @@ namespace Emby.Server.Implementations.Updates
             var packageChecksum = string.IsNullOrWhiteSpace(package.checksum) ? Guid.Empty : new Guid(package.checksum);
             if (!packageChecksum.Equals(Guid.Empty)) // support for legacy uploads for now
             {
-                using (var stream = _fileSystem.OpenRead(tempFile))
+                using (var stream = File.OpenRead(tempFile))
                 {
                     var check = Guid.Parse(BitConverter.ToString(_cryptographyProvider.ComputeMD5(stream)).Replace("-", string.Empty));
                     if (check != packageChecksum)
@@ -571,7 +571,7 @@ namespace Emby.Server.Implementations.Updates
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(target));
-                _fileSystem.CopyFile(tempFile, target, true);
+                File.Copy(tempFile, target, true);
                 //If it is an archive - write out a version file so we know what it is
                 if (isArchive)
                 {

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -219,7 +219,7 @@ namespace Jellyfin.Drawing.Skia
 
             var tempPath = Path.Combine(_appPaths.TempDirectory, Guid.NewGuid() + Path.GetExtension(path) ?? string.Empty);
 
-            fileSystem.CreateDirectory(fileSystem.GetDirectoryName(tempPath));
+            fileSystem.CreateDirectory(Path.GetDirectoryName(tempPath));
             fileSystem.CopyFile(path, tempPath, true);
 
             return tempPath;
@@ -532,7 +532,7 @@ namespace Jellyfin.Drawing.Skia
                     // If all we're doing is resizing then we can stop now
                     if (!hasBackgroundColor && !hasForegroundColor && blur == 0 && !hasIndicator)
                     {
-                        _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(outputPath));
+                        _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
                         using (var outputStream = new SKFileWStream(outputPath))
                         using (var pixmap = new SKPixmap(new SKImageInfo(width, height), resizedBitmap.GetPixels()))
                         {
@@ -584,7 +584,7 @@ namespace Jellyfin.Drawing.Skia
                             DrawIndicator(canvas, width, height, options);
                         }
 
-                        _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(outputPath));
+                        _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
                         using (var outputStream = new SKFileWStream(outputPath))
                         {
                             using (var pixmap = new SKPixmap(new SKImageInfo(width, height), saveBitmap.GetPixels()))

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -219,7 +219,7 @@ namespace Jellyfin.Drawing.Skia
 
             var tempPath = Path.Combine(_appPaths.TempDirectory, Guid.NewGuid() + Path.GetExtension(path) ?? string.Empty);
 
-            fileSystem.CreateDirectory(Path.GetDirectoryName(tempPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
             fileSystem.CopyFile(path, tempPath, true);
 
             return tempPath;
@@ -532,7 +532,7 @@ namespace Jellyfin.Drawing.Skia
                     // If all we're doing is resizing then we can stop now
                     if (!hasBackgroundColor && !hasForegroundColor && blur == 0 && !hasIndicator)
                     {
-                        _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+                        Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                         using (var outputStream = new SKFileWStream(outputPath))
                         using (var pixmap = new SKPixmap(new SKImageInfo(width, height), resizedBitmap.GetPixels()))
                         {
@@ -584,7 +584,7 @@ namespace Jellyfin.Drawing.Skia
                             DrawIndicator(canvas, width, height, options);
                         }
 
-                        _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+                        Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                         using (var outputStream = new SKFileWStream(outputPath))
                         {
                             using (var pixmap = new SKPixmap(new SKImageInfo(width, height), saveBitmap.GetPixels()))

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -220,7 +220,7 @@ namespace Jellyfin.Drawing.Skia
             var tempPath = Path.Combine(_appPaths.TempDirectory, Guid.NewGuid() + Path.GetExtension(path) ?? string.Empty);
 
             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
-            fileSystem.CopyFile(path, tempPath, true);
+            File.Copy(path, tempPath, true);
 
             return tempPath;
         }

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -257,7 +257,7 @@ namespace Jellyfin.Drawing.Skia
 
         internal static SKBitmap Decode(string path, bool forceCleanBitmap, IFileSystem fileSystem, ImageOrientation? orientation, out SKEncodedOrigin origin)
         {
-            if (!fileSystem.FileExists(path))
+            if (!File.Exists(path))
             {
                 throw new FileNotFoundException("File not found", path);
             }

--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -646,7 +646,7 @@ namespace MediaBrowser.Api
         /// <param name="outputFilePath">The output file path.</param>
         private void DeleteHlsPartialStreamFiles(string outputFilePath)
         {
-            var directory = _fileSystem.GetDirectoryName(outputFilePath);
+            var directory = Path.GetDirectoryName(outputFilePath);
             var name = Path.GetFileNameWithoutExtension(outputFilePath);
 
             var filesToDelete = _fileSystem.GetFilePaths(directory)

--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -303,7 +303,7 @@ namespace MediaBrowser.Api
 
         public object Get(GetParentPath request)
         {
-            var parent = _fileSystem.GetDirectoryName(request.Path);
+            var parent = Path.GetDirectoryName(request.Path);
 
             if (string.IsNullOrEmpty(parent))
             {

--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -137,14 +137,14 @@ namespace MediaBrowser.Api
             {
                 if (request.IsFile.Value)
                 {
-                    if (!_fileSystem.FileExists(request.Path))
+                    if (!File.Exists(request.Path))
                     {
                         throw new FileNotFoundException("File not found", request.Path);
                     }
                 }
                 else
                 {
-                    if (!_fileSystem.DirectoryExists(request.Path))
+                    if (Directory.Exists(request.Path))
                     {
                         throw new FileNotFoundException("File not found", request.Path);
                     }
@@ -153,7 +153,7 @@ namespace MediaBrowser.Api
 
             else
             {
-                if (!_fileSystem.FileExists(request.Path) && !_fileSystem.DirectoryExists(request.Path))
+                if (!File.Exists(request.Path) && Directory.Exists(request.Path))
                 {
                     throw new FileNotFoundException("Path not found", request.Path);
                 }

--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -169,7 +169,7 @@ namespace MediaBrowser.Api
         {
             var file = Path.Combine(path, Guid.NewGuid().ToString());
 
-            _fileSystem.WriteAllText(file, string.Empty);
+            File.WriteAllText(file, string.Empty);
             _fileSystem.DeleteFile(file);
         }
 

--- a/MediaBrowser.Api/Images/ImageByNameService.cs
+++ b/MediaBrowser.Api/Images/ImageByNameService.cs
@@ -185,7 +185,7 @@ namespace MediaBrowser.Api.Images
 
             var paths = BaseItem.SupportedImageExtensions.Select(i => Path.Combine(_appPaths.GeneralPath, request.Name, filename + i)).ToList();
 
-            var path = paths.FirstOrDefault(_fileSystem.FileExists) ?? paths.FirstOrDefault();
+            var path = paths.FirstOrDefault(File.Exists) ?? paths.FirstOrDefault();
 
             return _resultFactory.GetStaticFileResult(Request, path);
         }
@@ -199,11 +199,11 @@ namespace MediaBrowser.Api.Images
         {
             var themeFolder = Path.Combine(_appPaths.RatingsPath, request.Theme);
 
-            if (_fileSystem.DirectoryExists(themeFolder))
+            if (Directory.Exists(themeFolder))
             {
                 var path = BaseItem.SupportedImageExtensions
                     .Select(i => Path.Combine(themeFolder, request.Name + i))
-                    .FirstOrDefault(_fileSystem.FileExists);
+                    .FirstOrDefault(File.Exists);
 
                 if (!string.IsNullOrEmpty(path))
                 {
@@ -213,14 +213,14 @@ namespace MediaBrowser.Api.Images
 
             var allFolder = Path.Combine(_appPaths.RatingsPath, "all");
 
-            if (_fileSystem.DirectoryExists(allFolder))
+            if (Directory.Exists(allFolder))
             {
                 // Avoid implicitly captured closure
                 var currentRequest = request;
 
                 var path = BaseItem.SupportedImageExtensions
                     .Select(i => Path.Combine(allFolder, currentRequest.Name + i))
-                    .FirstOrDefault(_fileSystem.FileExists);
+                    .FirstOrDefault(File.Exists);
 
                 if (!string.IsNullOrEmpty(path))
                 {
@@ -240,10 +240,10 @@ namespace MediaBrowser.Api.Images
         {
             var themeFolder = Path.Combine(_appPaths.MediaInfoImagesPath, request.Theme);
 
-            if (_fileSystem.DirectoryExists(themeFolder))
+            if (Directory.Exists(themeFolder))
             {
                 var path = BaseItem.SupportedImageExtensions.Select(i => Path.Combine(themeFolder, request.Name + i))
-                    .FirstOrDefault(_fileSystem.FileExists);
+                    .FirstOrDefault(File.Exists);
 
                 if (!string.IsNullOrEmpty(path))
                 {
@@ -253,13 +253,13 @@ namespace MediaBrowser.Api.Images
 
             var allFolder = Path.Combine(_appPaths.MediaInfoImagesPath, "all");
 
-            if (_fileSystem.DirectoryExists(allFolder))
+            if (Directory.Exists(allFolder))
             {
                 // Avoid implicitly captured closure
                 var currentRequest = request;
 
                 var path = BaseItem.SupportedImageExtensions.Select(i => Path.Combine(allFolder, currentRequest.Name + i))
-                    .FirstOrDefault(_fileSystem.FileExists);
+                    .FirstOrDefault(File.Exists);
 
                 if (!string.IsNullOrEmpty(path))
                 {

--- a/MediaBrowser.Api/Images/ImageByNameService.cs
+++ b/MediaBrowser.Api/Images/ImageByNameService.cs
@@ -158,7 +158,7 @@ namespace MediaBrowser.Api.Images
 
         private string GetThemeName(string path, string rootImagePath)
         {
-            var parentName = _fileSystem.GetDirectoryName(path);
+            var parentName = Path.GetDirectoryName(path);
 
             if (string.Equals(parentName, rootImagePath, StringComparison.OrdinalIgnoreCase))
             {

--- a/MediaBrowser.Api/Images/RemoteImageService.cs
+++ b/MediaBrowser.Api/Images/RemoteImageService.cs
@@ -222,7 +222,7 @@ namespace MediaBrowser.Api.Images
             {
                 contentPath = _fileSystem.ReadAllText(pointerCachePath);
 
-                if (_fileSystem.FileExists(contentPath))
+                if (File.Exists(contentPath))
                 {
                     return await ResultFactory.GetStaticFileResult(Request, contentPath).ConfigureAwait(false);
                 }

--- a/MediaBrowser.Api/Images/RemoteImageService.cs
+++ b/MediaBrowser.Api/Images/RemoteImageService.cs
@@ -264,7 +264,7 @@ namespace MediaBrowser.Api.Images
 
                 var fullCachePath = GetFullCachePath(urlHash + "." + ext);
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(fullCachePath));
+                Directory.CreateDirectory(Path.GetDirectoryName(fullCachePath));
                 using (var stream = result.Content)
                 {
                     using (var filestream = _fileSystem.GetFileStream(fullCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
@@ -273,7 +273,7 @@ namespace MediaBrowser.Api.Images
                     }
                 }
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
+                Directory.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
                 _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
             }
         }

--- a/MediaBrowser.Api/Images/RemoteImageService.cs
+++ b/MediaBrowser.Api/Images/RemoteImageService.cs
@@ -220,7 +220,7 @@ namespace MediaBrowser.Api.Images
 
             try
             {
-                contentPath = _fileSystem.ReadAllText(pointerCachePath);
+                contentPath = File.ReadAllText(pointerCachePath);
 
                 if (File.Exists(contentPath))
                 {
@@ -239,7 +239,7 @@ namespace MediaBrowser.Api.Images
             await DownloadImage(request.ImageUrl, urlHash, pointerCachePath).ConfigureAwait(false);
 
             // Read the pointer file again
-            contentPath = _fileSystem.ReadAllText(pointerCachePath);
+            contentPath = File.ReadAllText(pointerCachePath);
 
             return await ResultFactory.GetStaticFileResult(Request, contentPath).ConfigureAwait(false);
         }
@@ -274,7 +274,7 @@ namespace MediaBrowser.Api.Images
                 }
 
                 Directory.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
-                _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
+                File.WriteAllText(pointerCachePath, fullCachePath);
             }
         }
 

--- a/MediaBrowser.Api/Images/RemoteImageService.cs
+++ b/MediaBrowser.Api/Images/RemoteImageService.cs
@@ -264,7 +264,7 @@ namespace MediaBrowser.Api.Images
 
                 var fullCachePath = GetFullCachePath(urlHash + "." + ext);
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(fullCachePath));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(fullCachePath));
                 using (var stream = result.Content)
                 {
                     using (var filestream = _fileSystem.GetFileStream(fullCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
@@ -273,7 +273,7 @@ namespace MediaBrowser.Api.Images
                     }
                 }
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(pointerCachePath));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
                 _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
             }
         }

--- a/MediaBrowser.Api/ItemLookupService.cs
+++ b/MediaBrowser.Api/ItemLookupService.cs
@@ -267,7 +267,7 @@ namespace MediaBrowser.Api
             {
                 contentPath = _fileSystem.ReadAllText(pointerCachePath);
 
-                if (_fileSystem.FileExists(contentPath))
+                if (File.Exists(contentPath))
                 {
                     return await ResultFactory.GetStaticFileResult(Request, contentPath).ConfigureAwait(false);
                 }

--- a/MediaBrowser.Api/ItemLookupService.cs
+++ b/MediaBrowser.Api/ItemLookupService.cs
@@ -265,7 +265,7 @@ namespace MediaBrowser.Api
 
             try
             {
-                contentPath = _fileSystem.ReadAllText(pointerCachePath);
+                contentPath = File.ReadAllText(pointerCachePath);
 
                 if (File.Exists(contentPath))
                 {
@@ -284,7 +284,7 @@ namespace MediaBrowser.Api
             await DownloadImage(request.ProviderName, request.ImageUrl, urlHash, pointerCachePath).ConfigureAwait(false);
 
             // Read the pointer file again
-            contentPath = _fileSystem.ReadAllText(pointerCachePath);
+            contentPath = File.ReadAllText(pointerCachePath);
 
             return await ResultFactory.GetStaticFileResult(Request, contentPath).ConfigureAwait(false);
         }
@@ -315,7 +315,7 @@ namespace MediaBrowser.Api
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
-            _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
+            File.WriteAllText(pointerCachePath, fullCachePath);
         }
 
         /// <summary>

--- a/MediaBrowser.Api/ItemLookupService.cs
+++ b/MediaBrowser.Api/ItemLookupService.cs
@@ -305,7 +305,7 @@ namespace MediaBrowser.Api
 
             var fullCachePath = GetFullCachePath(urlHash + "." + ext);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(fullCachePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullCachePath));
             using (var stream = result.Content)
             {
                 using (var filestream = _fileSystem.GetFileStream(fullCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
@@ -314,7 +314,7 @@ namespace MediaBrowser.Api
                 }
             }
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
             _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
         }
 

--- a/MediaBrowser.Api/ItemLookupService.cs
+++ b/MediaBrowser.Api/ItemLookupService.cs
@@ -305,7 +305,7 @@ namespace MediaBrowser.Api
 
             var fullCachePath = GetFullCachePath(urlHash + "." + ext);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(fullCachePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(fullCachePath));
             using (var stream = result.Content)
             {
                 using (var filestream = _fileSystem.GetFileStream(fullCachePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
@@ -314,7 +314,7 @@ namespace MediaBrowser.Api
                 }
             }
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(pointerCachePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(pointerCachePath));
             _fileSystem.WriteAllText(pointerCachePath, fullCachePath);
         }
 

--- a/MediaBrowser.Api/Library/LibraryStructureService.cs
+++ b/MediaBrowser.Api/Library/LibraryStructureService.cs
@@ -255,12 +255,12 @@ namespace MediaBrowser.Api.Library
             var currentPath = Path.Combine(rootFolderPath, request.Name);
             var newPath = Path.Combine(rootFolderPath, request.NewName);
 
-            if (!_fileSystem.DirectoryExists(currentPath))
+            if (Directory.Exists(currentPath))
             {
                 throw new FileNotFoundException("The media collection does not exist");
             }
 
-            if (!string.Equals(currentPath, newPath, StringComparison.OrdinalIgnoreCase) && _fileSystem.DirectoryExists(newPath))
+            if (!string.Equals(currentPath, newPath, StringComparison.OrdinalIgnoreCase) && Directory.Exists(newPath))
             {
                 throw new ArgumentException("Media library already exists at " + newPath + ".");
             }
@@ -273,11 +273,11 @@ namespace MediaBrowser.Api.Library
                 if (string.Equals(currentPath, newPath, StringComparison.OrdinalIgnoreCase))
                 {
                     var tempPath = Path.Combine(rootFolderPath, Guid.NewGuid().ToString("N"));
-                    _fileSystem.MoveDirectory(currentPath, tempPath);
+                    Directory.Move(currentPath, tempPath);
                     currentPath = tempPath;
                 }
 
-                _fileSystem.MoveDirectory(currentPath, newPath);
+                Directory.Move(currentPath, newPath);
             }
             finally
             {

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -192,7 +192,7 @@ namespace MediaBrowser.Api.Playback
             CancellationTokenSource cancellationTokenSource,
             string workingDirectory = null)
         {
-            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             await AcquireResources(state, cancellationTokenSource).ConfigureAwait(false);
 
@@ -258,7 +258,7 @@ namespace MediaBrowser.Api.Playback
             }
 
             var logFilePath = Path.Combine(ServerConfigurationManager.ApplicationPaths.LogDirectoryPath, logFilePrefix + "-" + Guid.NewGuid() + ".txt");
-            FileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             state.LogFileStream = FileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -192,7 +192,7 @@ namespace MediaBrowser.Api.Playback
             CancellationTokenSource cancellationTokenSource,
             string workingDirectory = null)
         {
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(outputPath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             await AcquireResources(state, cancellationTokenSource).ConfigureAwait(false);
 
@@ -258,7 +258,7 @@ namespace MediaBrowser.Api.Playback
             }
 
             var logFilePath = Path.Combine(ServerConfigurationManager.ApplicationPaths.LogDirectoryPath, logFilePrefix + "-" + Guid.NewGuid() + ".txt");
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(logFilePath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             state.LogFileStream = FileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -290,7 +290,7 @@ namespace MediaBrowser.Api.Playback
             new JobLogger(Logger).StartStreamingLog(state, process.StandardError.BaseStream, state.LogFileStream);
 
             // Wait for the file to exist before proceeeding
-            while (!FileSystem.FileExists(state.WaitForPath ?? outputPath) && !transcodingJob.HasExited)
+            while (!File.Exists(state.WaitForPath ?? outputPath) && !transcodingJob.HasExited)
             {
                 await Task.Delay(100, cancellationTokenSource.Token).ConfigureAwait(false);
             }

--- a/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
@@ -83,13 +83,13 @@ namespace MediaBrowser.Api.Playback.Hls
             TranscodingJob job = null;
             var playlist = state.OutputFilePath;
 
-            if (!FileSystem.FileExists(playlist))
+            if (!File.Exists(playlist))
             {
                 var transcodingLock = ApiEntryPoint.Instance.GetTranscodingLock(playlist);
                 await transcodingLock.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
                 try
                 {
-                    if (!FileSystem.FileExists(playlist))
+                    if (!File.Exists(playlist))
                     {
                         // If the playlist doesn't already exist, startup ffmpeg
                         try

--- a/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
@@ -264,7 +264,7 @@ namespace MediaBrowser.Api.Playback.Hls
             var useGenericSegmenter = true;
             if (useGenericSegmenter)
             {
-                var outputTsArg = Path.Combine(FileSystem.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath)) + "%d" + GetSegmentFileExtension(state.Request);
+                var outputTsArg = Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath)) + "%d" + GetSegmentFileExtension(state.Request);
 
                 var timeDeltaParam = string.Empty;
 

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -458,7 +458,7 @@ namespace MediaBrowser.Api.Playback.Hls
             {
                 try
                 {
-                    var text = FileSystem.ReadAllText(playlistPath, Encoding.UTF8);
+                    var text = File.ReadAllText(playlistPath, Encoding.UTF8);
 
                     // If it appears in the playlist, it's done
                     if (text.IndexOf(segmentFilename, StringComparison.OrdinalIgnoreCase) != -1)

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -381,7 +381,7 @@ namespace MediaBrowser.Api.Playback.Hls
 
         private static FileSystemMetadata GetLastTranscodingFile(string playlist, string segmentExtension, IFileSystem fileSystem)
         {
-            var folder = fileSystem.GetDirectoryName(playlist);
+            var folder = Path.GetDirectoryName(playlist);
 
             var filePrefix = Path.GetFileNameWithoutExtension(playlist) ?? string.Empty;
 
@@ -418,7 +418,7 @@ namespace MediaBrowser.Api.Playback.Hls
 
         private string GetSegmentPath(StreamState state, string playlist, int index)
         {
-            var folder = FileSystem.GetDirectoryName(playlist);
+            var folder = Path.GetDirectoryName(playlist);
 
             var filename = Path.GetFileNameWithoutExtension(playlist);
 
@@ -932,7 +932,7 @@ namespace MediaBrowser.Api.Playback.Hls
 
             var mapArgs = state.IsOutputVideo ? EncodingHelper.GetMapArgs(state) : string.Empty;
 
-            var outputTsArg = Path.Combine(FileSystem.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath)) + "%d" + GetSegmentFileExtension(state.Request);
+            var outputTsArg = Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath)) + "%d" + GetSegmentFileExtension(state.Request);
 
             var timeDeltaParam = string.Empty;
 

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -164,7 +164,7 @@ namespace MediaBrowser.Api.Playback.Hls
 
             TranscodingJob job = null;
 
-            if (FileSystem.FileExists(segmentPath))
+            if (File.Exists(segmentPath))
             {
                 job = ApiEntryPoint.Instance.OnTranscodeBeginRequest(playlistPath, TranscodingJobType);
                 return await GetSegmentResult(state, playlistPath, segmentPath, segmentExtension, requestedIndex, job, cancellationToken).ConfigureAwait(false);
@@ -177,7 +177,7 @@ namespace MediaBrowser.Api.Playback.Hls
 
             try
             {
-                if (FileSystem.FileExists(segmentPath))
+                if (File.Exists(segmentPath))
                 {
                     job = ApiEntryPoint.Instance.OnTranscodeBeginRequest(playlistPath, TranscodingJobType);
                     transcodingLock.Release();
@@ -433,7 +433,7 @@ namespace MediaBrowser.Api.Playback.Hls
             TranscodingJob transcodingJob,
             CancellationToken cancellationToken)
         {
-            var segmentFileExists = FileSystem.FileExists(segmentPath);
+            var segmentFileExists = File.Exists(segmentPath);
 
             // If all transcoding has completed, just return immediately
             if (transcodingJob != null && transcodingJob.HasExited && segmentFileExists)
@@ -465,7 +465,7 @@ namespace MediaBrowser.Api.Playback.Hls
                     {
                         if (!segmentFileExists)
                         {
-                            segmentFileExists = FileSystem.FileExists(segmentPath);
+                            segmentFileExists = File.Exists(segmentPath);
                         }
                         if (segmentFileExists)
                         {

--- a/MediaBrowser.Api/Playback/Progressive/BaseProgressiveStreamingService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/BaseProgressiveStreamingService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
@@ -153,7 +154,7 @@ namespace MediaBrowser.Api.Playback.Progressive
             }
 
             var outputPath = state.OutputFilePath;
-            var outputPathExists = FileSystem.FileExists(outputPath);
+            var outputPathExists = File.Exists(outputPath);
 
             var transcodingJob = ApiEntryPoint.Instance.GetTranscodingJob(outputPath, TranscodingJobType.Progressive);
             var isTranscodeCached = outputPathExists && transcodingJob != null;
@@ -377,7 +378,7 @@ namespace MediaBrowser.Api.Playback.Progressive
             {
                 TranscodingJob job;
 
-                if (!FileSystem.FileExists(outputPath))
+                if (!File.Exists(outputPath))
                 {
                     job = await StartFfMpeg(state, outputPath, cancellationTokenSource).ConfigureAwait(false);
                 }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -228,7 +228,7 @@ namespace MediaBrowser.Controller.Entities
                     return Path;
                 }
 
-                return FileSystem.GetDirectoryName(Path);
+                return System.IO.Path.GetDirectoryName(Path);
             }
         }
 
@@ -2208,7 +2208,7 @@ namespace MediaBrowser.Controller.Entities
         {
             var allFiles = ImageInfos
                 .Where(i => i.IsLocalFile)
-                .Select(i => FileSystem.GetDirectoryName(i.Path))
+                .Select(i => System.IO.Path.GetDirectoryName(i.Path))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .SelectMany(i => directoryService.GetFilePaths(i))
                 .ToList();
@@ -2396,7 +2396,7 @@ namespace MediaBrowser.Controller.Entities
             var extensions = new List<string> { ".nfo", ".xml", ".srt", ".vtt", ".sub", ".idx", ".txt", ".edl", ".bif", ".smi", ".ttml" };
             extensions.AddRange(SupportedImageExtensions);
 
-            return FileSystem.GetFiles(FileSystem.GetDirectoryName(Path), extensions.ToArray(), false, false)
+            return FileSystem.GetFiles(System.IO.Path.GetDirectoryName(Path), extensions.ToArray(), false, false)
                 .Where(i => System.IO.Path.GetFileNameWithoutExtension(i.FullName).StartsWith(filename, StringComparison.OrdinalIgnoreCase))
                 .ToList();
         }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -2343,7 +2344,7 @@ namespace MediaBrowser.Controller.Entities
                 var newImagePaths = images.Select(i => i.FullName).ToList();
 
                 var deleted = existingImages
-                    .Where(i => i.IsLocalFile && !newImagePaths.Contains(i.Path, StringComparer.OrdinalIgnoreCase) && !FileSystem.FileExists(i.Path))
+                    .Where(i => i.IsLocalFile && !newImagePaths.Contains(i.Path, StringComparer.OrdinalIgnoreCase) && !File.Exists(i.Path))
                     .ToList();
 
                 if (deleted.Count > 0)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2509,7 +2509,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(Path))
             {
-                Name = FileSystem.GetFileNameWithoutExtension(Path);
+                Name = System.IO.Path.GetFileNameWithoutExtension(Path);
                 hasChanges = true;
             }
 

--- a/MediaBrowser.Controller/Entities/Game.cs
+++ b/MediaBrowser.Controller/Entities/Game.cs
@@ -87,7 +87,7 @@ namespace MediaBrowser.Controller.Entities
                 return new[] {
                     new FileSystemMetadata
                     {
-                        FullName = FileSystem.GetDirectoryName(Path),
+                        FullName = System.IO.Path.GetDirectoryName(Path),
                         IsDirectory = true
                     }
                 };

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -97,7 +97,7 @@ namespace MediaBrowser.Controller.Entities.TV
                     return series.Path;
                 }
 
-                return FileSystem.GetDirectoryName(Path);
+                return System.IO.Path.GetDirectoryName(Path);
             }
         }
 

--- a/MediaBrowser.Controller/Entities/User.cs
+++ b/MediaBrowser.Controller/Entities/User.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
@@ -169,7 +170,7 @@ namespace MediaBrowser.Controller.Entities
                 // Exceptions will be thrown if these paths already exist
                 if (FileSystem.DirectoryExists(newConfigDirectory))
                 {
-                    FileSystem.DeleteDirectory(newConfigDirectory, true);
+                    Directory.Delete(newConfigDirectory, true);
                 }
 
                 if (FileSystem.DirectoryExists(oldConfigurationDirectory))
@@ -178,7 +179,7 @@ namespace MediaBrowser.Controller.Entities
                 }
                 else
                 {
-                    FileSystem.CreateDirectory(newConfigDirectory);
+                    Directory.CreateDirectory(newConfigDirectory);
                 }
             }
 

--- a/MediaBrowser.Controller/Entities/User.cs
+++ b/MediaBrowser.Controller/Entities/User.cs
@@ -168,14 +168,14 @@ namespace MediaBrowser.Controller.Entities
                 var oldConfigurationDirectory = ConfigurationDirectoryPath;
 
                 // Exceptions will be thrown if these paths already exist
-                if (FileSystem.DirectoryExists(newConfigDirectory))
+                if (Directory.Exists(newConfigDirectory))
                 {
                     Directory.Delete(newConfigDirectory, true);
                 }
 
-                if (FileSystem.DirectoryExists(oldConfigurationDirectory))
+                if (Directory.Exists(oldConfigurationDirectory))
                 {
-                    FileSystem.MoveDirectory(oldConfigurationDirectory, newConfigDirectory);
+                    Directory.Move(oldConfigurationDirectory, newConfigDirectory);
                 }
                 else
                 {

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -345,7 +345,7 @@ namespace MediaBrowser.Controller.Entities
             {
                 if (IsStacked)
                 {
-                    return FileSystem.GetDirectoryName(Path);
+                    return System.IO.Path.GetDirectoryName(Path);
                 }
 
                 if (!IsPlaceHolder)

--- a/MediaBrowser.Controller/Library/ItemResolveArgs.cs
+++ b/MediaBrowser.Controller/Library/ItemResolveArgs.cs
@@ -85,7 +85,7 @@ namespace MediaBrowser.Controller.Library
                     return false;
                 }
 
-                var parentDir = BaseItem.FileSystem.GetDirectoryName(Path) ?? string.Empty;
+                var parentDir = System.IO.Path.GetDirectoryName(Path) ?? string.Empty;
 
                 return parentDir.Length > _appPaths.RootFolderPath.Length
                        && parentDir.StartsWith(_appPaths.RootFolderPath, StringComparison.OrdinalIgnoreCase);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -434,7 +434,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     if (string.Equals(Path.GetExtension(subtitlePath), ".sub", StringComparison.OrdinalIgnoreCase))
                     {
                         var idxFile = Path.ChangeExtension(subtitlePath, ".idx");
-                        if (_fileSystem.FileExists(idxFile))
+                        if (File.Exists(idxFile))
                         {
                             subtitlePath = idxFile;
                         }
@@ -542,7 +542,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // var fallbackFontPath = Path.Combine(_appPaths.ProgramDataPath, "fonts", "DroidSansFallback.ttf");
             // string fallbackFontParam = string.Empty;
 
-            // if (!_fileSystem.FileExists(fallbackFontPath))
+            // if (!File.Exists(fallbackFontPath))
             // {
             //     _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(fallbackFontPath));
             //     using (var stream = _assemblyInfo.GetManifestResourceStream(GetType(), GetType().Namespace + ".DroidSansFallback.ttf"))

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -50,7 +50,7 @@ namespace MediaBrowser.Controller.Playlists
 
                 if (IsPlaylistFile(path))
                 {
-                    return FileSystem.GetDirectoryName(path);
+                    return System.IO.Path.GetDirectoryName(path);
                 }
 
                 return path;

--- a/MediaBrowser.LocalMetadata/Images/EpisodeLocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/EpisodeLocalImageProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -29,7 +30,7 @@ namespace MediaBrowser.LocalMetadata.Images
 
         public List<LocalImageInfo> GetImages(BaseItem item, IDirectoryService directoryService)
         {
-            var parentPath = _fileSystem.GetDirectoryName(item.Path);
+            var parentPath = Path.GetDirectoryName(item.Path);
 
             var parentPathFiles = directoryService.GetFiles(parentPath);
 

--- a/MediaBrowser.LocalMetadata/Images/EpisodeLocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/EpisodeLocalImageProvider.cs
@@ -34,7 +34,7 @@ namespace MediaBrowser.LocalMetadata.Images
 
             var parentPathFiles = directoryService.GetFiles(parentPath);
 
-            var nameWithoutExtension = _fileSystem.GetFileNameWithoutExtension(item.Path);
+            var nameWithoutExtension = Path.GetFileNameWithoutExtension(item.Path);
 
             return GetFilesFromParentFolder(nameWithoutExtension, parentPathFiles);
         }

--- a/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
+++ b/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
@@ -102,7 +102,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
         {
             item.ResetPeople();
 
-            using (var fileStream = FileSystem.OpenRead(metadataFile))
+            using (var fileStream = File.OpenRead(metadataFile))
             {
                 using (var streamReader = new StreamReader(fileStream, encoding))
                 {

--- a/MediaBrowser.LocalMetadata/Providers/GameXmlProvider.cs
+++ b/MediaBrowser.LocalMetadata/Providers/GameXmlProvider.cs
@@ -33,7 +33,7 @@ namespace MediaBrowser.LocalMetadata.Providers
             var specificFile = Path.ChangeExtension(info.Path, ".xml");
             var file = FileSystem.GetFileInfo(specificFile);
 
-            return info.IsInMixedFolder || file.Exists ? file : FileSystem.GetFileInfo(Path.Combine(FileSystem.GetDirectoryName(info.Path), "game.xml"));
+            return info.IsInMixedFolder || file.Exists ? file : FileSystem.GetFileInfo(Path.Combine(Path.GetDirectoryName(info.Path), "game.xml"));
         }
     }
 }

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -94,7 +94,7 @@ namespace MediaBrowser.LocalMetadata.Savers
 
         private void SaveToFile(Stream stream, string path)
         {
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(path));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
             // On Windows, savint the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -94,7 +94,7 @@ namespace MediaBrowser.LocalMetadata.Savers
 
         private void SaveToFile(Stream stream, string path)
         {
-            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
             // On Windows, savint the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 

--- a/MediaBrowser.MediaEncoding/Configuration/EncodingConfigurationFactory.cs
+++ b/MediaBrowser.MediaEncoding/Configuration/EncodingConfigurationFactory.cs
@@ -46,7 +46,7 @@ namespace MediaBrowser.MediaEncoding.Configuration
                 && !string.Equals(oldEncodingConfig.TranscodingTempPath ?? string.Empty, newPath))
             {
                 // Validate
-                if (Directory.Exists(newPath))
+                if (!Directory.Exists(newPath))
                 {
                     throw new FileNotFoundException(string.Format("{0} does not exist.", newPath));
                 }

--- a/MediaBrowser.MediaEncoding/Configuration/EncodingConfigurationFactory.cs
+++ b/MediaBrowser.MediaEncoding/Configuration/EncodingConfigurationFactory.cs
@@ -46,7 +46,7 @@ namespace MediaBrowser.MediaEncoding.Configuration
                 && !string.Equals(oldEncodingConfig.TranscodingTempPath ?? string.Empty, newPath))
             {
                 // Validate
-                if (!_fileSystem.DirectoryExists(newPath))
+                if (Directory.Exists(newPath))
                 {
                     throw new FileNotFoundException(string.Format("{0} does not exist.", newPath));
                 }

--- a/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
@@ -67,7 +67,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 .CreateJob(options, EncodingHelper, IsVideoEncoder, progress, cancellationToken).ConfigureAwait(false);
 
             encodingJob.OutputFilePath = GetOutputFilePath(encodingJob);
-            FileSystem.CreateDirectory(Path.GetDirectoryName(encodingJob.OutputFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(encodingJob.OutputFilePath));
 
             encodingJob.ReadInputAtNativeFramerate = options.ReadInputAtNativeFramerate;
 
@@ -105,7 +105,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             Logger.LogInformation(commandLineLogMessage);
 
             var logFilePath = Path.Combine(ConfigurationManager.CommonApplicationPaths.LogDirectoryPath, "transcode-" + Guid.NewGuid() + ".txt");
-            FileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             encodingJob.LogFileStream = FileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
@@ -137,7 +137,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             new JobLogger(Logger).StartStreamingLog(encodingJob, process.StandardError.BaseStream, encodingJob.LogFileStream);
 
             // Wait for the file to exist before proceeeding
-            while (!FileSystem.FileExists(encodingJob.OutputFilePath) && !encodingJob.HasExited)
+            while (!File.Exists(encodingJob.OutputFilePath) && !encodingJob.HasExited)
             {
                 await Task.Delay(100, cancellationToken).ConfigureAwait(false);
             }

--- a/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/BaseEncoder.cs
@@ -67,7 +67,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 .CreateJob(options, EncodingHelper, IsVideoEncoder, progress, cancellationToken).ConfigureAwait(false);
 
             encodingJob.OutputFilePath = GetOutputFilePath(encodingJob);
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(encodingJob.OutputFilePath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(encodingJob.OutputFilePath));
 
             encodingJob.ReadInputAtNativeFramerate = options.ReadInputAtNativeFramerate;
 
@@ -105,7 +105,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             Logger.LogInformation(commandLineLogMessage);
 
             var logFilePath = Path.Combine(ConfigurationManager.CommonApplicationPaths.LogDirectoryPath, "transcode-" + Guid.NewGuid() + ".txt");
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(logFilePath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
             // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             encodingJob.LogFileStream = FileSystem.GetFileStream(logFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -214,7 +214,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     throw new ArgumentNullException(nameof(path));
                 }
 
-                if (!FileSystem.FileExists(path) && !FileSystem.DirectoryExists(path))
+                if (!File.Exists(path) && Directory.Exists(path))
                 {
                     throw new ResourceNotFoundException();
                 }
@@ -288,12 +288,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             if (!string.IsNullOrWhiteSpace(appPath))
             {
-                if (FileSystem.DirectoryExists(appPath))
+                if (Directory.Exists(appPath))
                 {
                     return GetPathsFromDirectory(appPath);
                 }
 
-                if (FileSystem.FileExists(appPath))
+                if (File.Exists(appPath))
                 {
                     return new Tuple<string, string>(appPath, GetProbePathFromEncoderPath(appPath));
                 }
@@ -336,7 +336,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var ffmpegPath = files.FirstOrDefault(i => string.Equals(Path.GetFileNameWithoutExtension(i), "ffmpeg", StringComparison.OrdinalIgnoreCase) && !excludeExtensions.Contains(Path.GetExtension(i) ?? string.Empty));
             var ffprobePath = files.FirstOrDefault(i => string.Equals(Path.GetFileNameWithoutExtension(i), "ffprobe", StringComparison.OrdinalIgnoreCase) && !excludeExtensions.Contains(Path.GetExtension(i) ?? string.Empty));
 
-            if (string.IsNullOrWhiteSpace(ffmpegPath) || !FileSystem.FileExists(ffmpegPath))
+            if (string.IsNullOrWhiteSpace(ffmpegPath) || !File.Exists(ffmpegPath))
             {
                 files = FileSystem.GetFilePaths(path, true);
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -608,7 +608,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             var tempExtractPath = Path.Combine(ConfigurationManager.ApplicationPaths.TempDirectory, Guid.NewGuid() + ".jpg");
-            FileSystem.CreateDirectory(Path.GetDirectoryName(tempExtractPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(tempExtractPath));
 
             // apply some filters to thumbnail extracted below (below) crop any black lines that we made and get the correct ar then scale to width 600.
             // This filter chain may have adverse effects on recorded tv thumbnails if ar changes during presentation ex. commercials @ diff ar
@@ -770,7 +770,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 vf += string.Format(",scale=min(iw\\,{0}):trunc(ow/dar/2)*2", maxWidthParam);
             }
 
-            FileSystem.CreateDirectory(targetDirectory);
+            Directory.CreateDirectory(targetDirectory);
             var outputPath = Path.Combine(targetDirectory, filenamePrefix + "%05d.jpg");
 
             var args = string.Format("-i {0} -threads 0 -v quiet -vf \"{2}\" -f image2 \"{1}\"", inputArgument, outputPath, vf);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -214,7 +214,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     throw new ArgumentNullException(nameof(path));
                 }
 
-                if (!File.Exists(path) && Directory.Exists(path))
+                if (!File.Exists(path) && !Directory.Exists(path))
                 {
                     throw new ResourceNotFoundException();
                 }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -353,7 +353,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private string GetProbePathFromEncoderPath(string appPath)
         {
-            return FileSystem.GetFilePaths(FileSystem.GetDirectoryName(appPath))
+            return FileSystem.GetFilePaths(Path.GetDirectoryName(appPath))
                 .FirstOrDefault(i => string.Equals(Path.GetFileNameWithoutExtension(i), "ffprobe", StringComparison.OrdinalIgnoreCase));
         }
 
@@ -608,7 +608,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             var tempExtractPath = Path.Combine(ConfigurationManager.ApplicationPaths.TempDirectory, Guid.NewGuid() + ".jpg");
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(tempExtractPath));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(tempExtractPath));
 
             // apply some filters to thumbnail extracted below (below) crop any black lines that we made and get the correct ar then scale to width 600.
             // This filter chain may have adverse effects on recorded tv thumbnails if ar changes during presentation ex. commercials @ diff ar

--- a/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
@@ -269,7 +269,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             var subLanguageId = NormalizeLanguage(request.Language);
             string hash;
 
-            using (var fileStream = _fileSystem.OpenRead(request.MediaPath))
+            using (var fileStream = File.OpenRead(request.MediaPath))
             {
                 hash = Utilities.ComputeHash(fileStream);
             }

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -422,7 +422,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var encodingParam = await GetSubtitleFileCharacterSet(inputPath, language, inputProtocol, cancellationToken).ConfigureAwait(false);
 
@@ -565,7 +565,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var processArgs = string.Format("-i {0} -map 0:{1} -an -vn -c:s {2} \"{3}\"", inputPath,
                 subtitleStreamIndex, outputCodec, outputPath);

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -210,7 +210,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
             }
 
-            return _fileSystem.OpenRead(path);
+            return File.OpenRead(path);
         }
 
         private async Task<SubtitleInfo> GetReadableFile(
@@ -672,7 +672,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             string text;
             Encoding encoding;
 
-            using (var fileStream = _fileSystem.OpenRead(file))
+            using (var fileStream = File.OpenRead(file))
             using (var reader = new StreamReader(fileStream, true))
             {
                 encoding = reader.CurrentEncoding;

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -747,7 +747,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
             if (protocol == MediaProtocol.File)
             {
-                return _fileSystem.ReadAllBytes(path);
+                return File.ReadAllBytes(path);
             }
 
             throw new ArgumentOutOfRangeException(nameof(protocol));

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -422,7 +422,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(outputPath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var encodingParam = await GetSubtitleFileCharacterSet(inputPath, language, inputProtocol, cancellationToken).ConfigureAwait(false);
 
@@ -565,7 +565,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(outputPath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(outputPath));
 
             var processArgs = string.Format("-i {0} -map 0:{1} -an -vn -c:s {2} \"{3}\"", inputPath,
                 subtitleStreamIndex, outputCodec, outputPath);

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -386,7 +386,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             try
             {
-                if (!_fileSystem.FileExists(outputPath))
+                if (!File.Exists(outputPath))
                 {
                     await ConvertTextSubtitleToSrtInternal(inputPath, language, inputProtocol, outputPath, cancellationToken).ConfigureAwait(false);
                 }
@@ -481,7 +481,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 failed = true;
 
-                if (_fileSystem.FileExists(outputPath))
+                if (File.Exists(outputPath))
                 {
                     try
                     {
@@ -494,7 +494,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
                 }
             }
-            else if (!_fileSystem.FileExists(outputPath))
+            else if (!File.Exists(outputPath))
             {
                 failed = true;
             }
@@ -537,7 +537,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             try
             {
-                if (!_fileSystem.FileExists(outputPath))
+                if (!File.Exists(outputPath))
                 {
                     await ExtractTextSubtitleInternal(_mediaEncoder.GetInputArgument(inputFiles, protocol), subtitleStreamIndex, outputCodec, outputPath, cancellationToken).ConfigureAwait(false);
                 }
@@ -634,7 +634,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     _logger.LogError(ex, "Error deleting extracted subtitle {Path}", outputPath);
                 }
             }
-            else if (!_fileSystem.FileExists(outputPath))
+            else if (!File.Exists(outputPath))
             {
                 failed = true;
             }

--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -36,32 +36,32 @@ namespace MediaBrowser.Model.IO
         string MakeAbsolutePath(string folderPath, string filePath);
 
         /// <summary>
-        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file or directory path.
+        /// Returns a <see cref="FileSystemMetadata" /> object for the specified file or directory path.
         /// </summary>
         /// <param name="path">A path to a file or directory.</param>
-        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
-        /// <remarks>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
-        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and all other properties will reflect the properties of the directory.</remarks>
+        /// <returns>A <see cref="FileSystemMetadata" /> object.</returns>
+        /// <remarks>If the specified path points to a directory, the returned <see cref="FileSystemMetadata" /> object's
+        /// <see cref="FileSystemMetadata.IsDirectory" /> property will be set to true and all other properties will reflect the properties of the directory.</remarks>
         FileSystemMetadata GetFileSystemInfo(string path);
 
         /// <summary>
-        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file path.
+        /// Returns a <see cref="FileSystemMetadata" /> object for the specified file path.
         /// </summary>
         /// <param name="path">A path to a file.</param>
-        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
-        /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
-        /// <see cref="FileSystemMetadata.IsDirectory"/> property and the <see cref="FileSystemMetadata.Exists"/> property will both be set to false.</para>
-        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
+        /// <returns>A <see cref="FileSystemMetadata" /> object.</returns>
+        /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata" /> object's
+        /// <see cref="FileSystemMetadata.IsDirectory" /> property and the <see cref="FileSystemMetadata.Exists" /> property will both be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="M:IFileSystem.GetFileSystemInfo(System.String)" />.</para></remarks>
         FileSystemMetadata GetFileInfo(string path);
 
         /// <summary>
-        /// Returns a <see cref="FileSystemMetadata"/> object for the specified directory path.
+        /// Returns a <see cref="FileSystemMetadata" /> object for the specified directory path.
         /// </summary>
         /// <param name="path">A path to a directory.</param>
-        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
-        /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata"/> object's
-        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and the <see cref="FileSystemMetadata.Exists"/> property will be set to false.</para>
-        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
+        /// <returns>A <see cref="FileSystemMetadata" /> object.</returns>
+        /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata" /> object's
+        /// <see cref="FileSystemMetadata.IsDirectory" /> property will be set to true and the <see cref="FileSystemMetadata.Exists" /> property will be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="M:IFileSystem.GetFileSystemInfo(System.String)" />.</para></remarks>
         FileSystemMetadata GetDirectoryInfo(string path);
 
         /// <summary>
@@ -110,14 +110,8 @@ namespace MediaBrowser.Model.IO
         /// <returns>FileStream.</returns>
         Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, bool isAsync = false);
 
-        Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share, FileOpenOptions fileOpenOptions);
-
-        /// <summary>
-        /// Opens the read.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>Stream.</returns>
-        Stream OpenRead(string path);
+        Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share,
+            FileOpenOptions fileOpenOptions);
 
         string DefaultDirectory { get; }
 
@@ -152,21 +146,12 @@ namespace MediaBrowser.Model.IO
         /// <returns>System.String.</returns>
         string NormalizePath(string path);
 
-        string GetDirectoryName(string path);
-
         /// <summary>
         /// Gets the file name without extension.
         /// </summary>
         /// <param name="info">The information.</param>
         /// <returns>System.String.</returns>
         string GetFileNameWithoutExtension(FileSystemMetadata info);
-
-        /// <summary>
-        /// Gets the file name without extension.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>System.String.</returns>
-        string GetFileNameWithoutExtension(string path);
 
         /// <summary>
         /// Determines whether [is path file] [the specified path].
@@ -180,13 +165,6 @@ namespace MediaBrowser.Model.IO
         /// </summary>
         /// <param name="path">The path.</param>
         void DeleteFile(string path);
-
-        /// <summary>
-        /// Deletes the directory.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="recursive">if set to <c>true</c> [recursive].</param>
-        void DeleteDirectory(string path, bool recursive);
 
         /// <summary>
         /// Gets the directories.
@@ -212,86 +190,6 @@ namespace MediaBrowser.Model.IO
         IEnumerable<FileSystemMetadata> GetFileSystemEntries(string path, bool recursive = false);
 
         /// <summary>
-        /// Creates the directory.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        void CreateDirectory(string path);
-
-        /// <summary>
-        /// Copies the file.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="target">The target.</param>
-        /// <param name="overwrite">if set to <c>true</c> [overwrite].</param>
-        void CopyFile(string source, string target, bool overwrite);
-
-        /// <summary>
-        /// Moves the file.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="target">The target.</param>
-        void MoveFile(string source, string target);
-
-        /// <summary>
-        /// Moves the directory.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="target">The target.</param>
-        void MoveDirectory(string source, string target);
-
-        /// <summary>
-        /// Directories the exists.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
-        bool DirectoryExists(string path);
-
-        /// <summary>
-        /// Files the exists.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
-        bool FileExists(string path);
-
-        /// <summary>
-        /// Reads all text.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>System.String.</returns>
-        string ReadAllText(string path);
-
-        byte[] ReadAllBytes(string path);
-
-        void WriteAllBytes(string path, byte[] bytes);
-
-        /// <summary>
-        /// Writes all text.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="text">The text.</param>
-        void WriteAllText(string path, string text);
-
-        /// <summary>
-        /// Writes all text.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="text">The text.</param>
-        /// <param name="encoding">The encoding.</param>
-        void WriteAllText(string path, string text, Encoding encoding);
-
-        /// <summary>
-        /// Reads all text.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="encoding">The encoding.</param>
-        /// <returns>System.String.</returns>
-        string ReadAllText(string path, Encoding encoding);
-
-        string[] ReadAllLines(string path);
-
-        void WriteAllLines(string path, IEnumerable<string> lines);
-
-        /// <summary>
         /// Gets the directory paths.
         /// </summary>
         /// <param name="path">The path.</param>
@@ -306,6 +204,7 @@ namespace MediaBrowser.Model.IO
         /// <param name="recursive">if set to <c>true</c> [recursive].</param>
         /// <returns>IEnumerable&lt;System.String&gt;.</returns>
         IEnumerable<string> GetFilePaths(string path, bool recursive = false);
+
         IEnumerable<string> GetFilePaths(string path, string[] extensions, bool enableCaseSensitiveExtensions, bool recursive);
 
         /// <summary>
@@ -319,15 +218,10 @@ namespace MediaBrowser.Model.IO
         void SetHidden(string path, bool isHidden);
         void SetReadOnly(string path, bool readOnly);
         void SetAttributes(string path, bool isHidden, bool readOnly);
-
-        char DirectorySeparatorChar { get; }
-
-        string GetFullPath(string path);
-
         List<FileSystemMetadata> GetDrives();
-
         void SetExecutable(string path);
     }
+
     //TODO Investigate if can be replaced by the one from System.IO ?
     public enum FileOpenMode
     {

--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
@@ -156,7 +156,7 @@ namespace MediaBrowser.Providers.BoxSets
 
             var dataFilePath = GetDataFilePath(_config.ApplicationPaths, tmdbId, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _json.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
@@ -156,7 +156,7 @@ namespace MediaBrowser.Providers.BoxSets
 
             var dataFilePath = GetDataFilePath(_config.ApplicationPaths, tmdbId, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _json.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -233,14 +233,14 @@ namespace MediaBrowser.Providers.Manager
         {
             _logger.LogDebug("Saving image to {0}", path);
 
-            var parentFolder = _fileSystem.GetDirectoryName(path);
+            var parentFolder = Path.GetDirectoryName(path);
 
             try
             {
                 _libraryMonitor.ReportFileSystemChangeBeginning(path);
                 _libraryMonitor.ReportFileSystemChangeBeginning(parentFolder);
 
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                 _fileSystem.SetAttributes(path, false, false);
 
@@ -437,7 +437,7 @@ namespace MediaBrowser.Providers.Manager
             {
                 if (type == ImageType.Primary && item is Episode)
                 {
-                    path = Path.Combine(_fileSystem.GetDirectoryName(item.Path), "metadata", filename + extension);
+                    path = Path.Combine(Path.GetDirectoryName(item.Path), "metadata", filename + extension);
                 }
 
                 else if (item.IsInMixedFolder)
@@ -569,7 +569,7 @@ namespace MediaBrowser.Providers.Manager
 
                 if (item is Episode)
                 {
-                    var seasonFolder = _fileSystem.GetDirectoryName(item.Path);
+                    var seasonFolder = Path.GetDirectoryName(item.Path);
 
                     var imageFilename = _fileSystem.GetFileNameWithoutExtension(item.Path) + "-thumb" + extension;
 
@@ -617,7 +617,7 @@ namespace MediaBrowser.Providers.Manager
             {
                 imageFilename = "poster";
             }
-            var folder = _fileSystem.GetDirectoryName(item.Path);
+            var folder = Path.GetDirectoryName(item.Path);
 
             return Path.Combine(folder, _fileSystem.GetFileNameWithoutExtension(item.Path) + "-" + imageFilename + extension);
         }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -240,7 +240,7 @@ namespace MediaBrowser.Providers.Manager
                 _libraryMonitor.ReportFileSystemChangeBeginning(path);
                 _libraryMonitor.ReportFileSystemChangeBeginning(parentFolder);
 
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                 _fileSystem.SetAttributes(path, false, false);
 

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -411,7 +411,7 @@ namespace MediaBrowser.Providers.Manager
                     filename = item is MusicAlbum ? "cdart" : "disc";
                     break;
                 case ImageType.Primary:
-                    filename = saveLocally && item is Episode ? _fileSystem.GetFileNameWithoutExtension(item.Path) : folderName;
+                    filename = saveLocally && item is Episode ? Path.GetFileNameWithoutExtension(item.Path) : folderName;
                     break;
                 case ImageType.Backdrop:
                     filename = GetBackdropSaveFilename(item.GetImages(type), "backdrop", "backdrop", imageIndex);
@@ -471,7 +471,7 @@ namespace MediaBrowser.Providers.Manager
                 return zeroIndexFilename;
             }
 
-            var filenames = images.Select(i => _fileSystem.GetFileNameWithoutExtension(i.Path)).ToList();
+            var filenames = images.Select(i => Path.GetFileNameWithoutExtension(i.Path)).ToList();
 
             var current = 1;
             while (filenames.Contains(numberedIndexPrefix + current.ToString(UsCulture), StringComparer.OrdinalIgnoreCase))
@@ -571,7 +571,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                     var seasonFolder = Path.GetDirectoryName(item.Path);
 
-                    var imageFilename = _fileSystem.GetFileNameWithoutExtension(item.Path) + "-thumb" + extension;
+                    var imageFilename = Path.GetFileNameWithoutExtension(item.Path) + "-thumb" + extension;
 
                     return new[] { Path.Combine(seasonFolder, imageFilename) };
                 }
@@ -619,7 +619,7 @@ namespace MediaBrowser.Providers.Manager
             }
             var folder = Path.GetDirectoryName(item.Path);
 
-            return Path.Combine(folder, _fileSystem.GetFileNameWithoutExtension(item.Path) + "-" + imageFilename + extension);
+            return Path.Combine(folder, Path.GetFileNameWithoutExtension(item.Path) + "-" + imageFilename + extension);
         }
     }
 }

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -387,7 +387,7 @@ namespace MediaBrowser.Providers.Manager
                     var existing = item.GetImageInfo(type, 0);
                     if (existing != null)
                     {
-                        if (existing.IsLocalFile && !_fileSystem.FileExists(existing.Path))
+                        if (existing.IsLocalFile && !File.Exists(existing.Path))
                         {
                             item.RemoveImage(existing);
                             changed = true;

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -703,7 +703,7 @@ namespace MediaBrowser.Providers.Manager
 
                                 // Manual edit occurred
                                 // Even if save local is off, save locally anyway if the metadata file already exists
-                                if (fileSaver == null || !_fileSystem.FileExists(fileSaver.GetSavePath(item)))
+                                if (fileSaver == null || !File.Exists(fileSaver.GetSavePath(item)))
                                 {
                                     return false;
                                 }

--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -60,7 +60,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (!_fileSystem.FileExists(path))
             {
-                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                 var imageStream = imageStreams.FirstOrDefault(i => (i.Comment ?? string.Empty).IndexOf("front", StringComparison.OrdinalIgnoreCase) != -1) ??
                     imageStreams.FirstOrDefault(i => (i.Comment ?? string.Empty).IndexOf("cover", StringComparison.OrdinalIgnoreCase) != -1) ??

--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -60,7 +60,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (!_fileSystem.FileExists(path))
             {
-                _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                 var imageStream = imageStreams.FirstOrDefault(i => (i.Comment ?? string.Empty).IndexOf("front", StringComparison.OrdinalIgnoreCase) != -1) ??
                     imageStreams.FirstOrDefault(i => (i.Comment ?? string.Empty).IndexOf("cover", StringComparison.OrdinalIgnoreCase) != -1) ??

--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Providers.MediaInfo
         {
             var path = GetAudioImagePath(item);
 
-            if (!_fileSystem.FileExists(path))
+            if (!File.Exists(path))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
 

--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -70,7 +70,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 var tempFile = await _mediaEncoder.ExtractAudioImage(item.Path, imageStreamIndex, cancellationToken).ConfigureAwait(false);
 
-                _fileSystem.CopyFile(tempFile, path, true);
+                File.Copy(tempFile, path, true);
 
                 try
                 {

--- a/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -196,7 +197,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
         private void FetchShortcutInfo(BaseItem item)
         {
-            item.ShortcutPath = _fileSystem.ReadAllLines(item.Path)
+            item.ShortcutPath = File.ReadAllLines(item.Path)
                 .Select(NormalizeStrmLine)
                 .FirstOrDefault(i => !string.IsNullOrWhiteSpace(i) && !i.StartsWith("#", StringComparison.OrdinalIgnoreCase));
         }

--- a/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
@@ -98,7 +98,7 @@ namespace MediaBrowser.Providers.MediaInfo
             int startIndex,
             string[] files)
         {
-            var videoFileNameWithoutExtension = _fileSystem.GetFileNameWithoutExtension(videoPath);
+            var videoFileNameWithoutExtension = Path.GetFileNameWithoutExtension(videoPath);
             videoFileNameWithoutExtension = NormalizeFilenameForSubtitleComparison(videoFileNameWithoutExtension);
 
             foreach (var fullName in files)
@@ -110,7 +110,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     continue;
                 }
 
-                var fileNameWithoutExtension = _fileSystem.GetFileNameWithoutExtension(fullName);
+                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fullName);
                 fileNameWithoutExtension = NormalizeFilenameForSubtitleComparison(fileNameWithoutExtension);
 
                 if (!string.Equals(videoFileNameWithoutExtension, fileNameWithoutExtension, StringComparison.OrdinalIgnoreCase) &&

--- a/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
@@ -254,7 +254,7 @@ namespace MediaBrowser.Providers.Movies
 
             var path = GetFanartJsonPath(id);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             try
             {

--- a/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
@@ -254,7 +254,7 @@ namespace MediaBrowser.Providers.Movies
 
             var path = GetFanartJsonPath(id);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             try
             {

--- a/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
+++ b/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
@@ -92,7 +92,7 @@ namespace MediaBrowser.Providers.Movies
                     tmdbId = movieInfo.id.ToString(_usCulture);
 
                     dataFilePath = MovieDbProvider.Current.GetDataFilePath(tmdbId, language);
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+                    Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
                     _jsonSerializer.SerializeToFile(movieInfo, dataFilePath);
                 }
             }

--- a/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
+++ b/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -91,7 +92,7 @@ namespace MediaBrowser.Providers.Movies
                     tmdbId = movieInfo.id.ToString(_usCulture);
 
                     dataFilePath = MovieDbProvider.Current.GetDataFilePath(tmdbId, language);
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
                     _jsonSerializer.SerializeToFile(movieInfo, dataFilePath);
                 }
             }

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -198,7 +198,7 @@ namespace MediaBrowser.Providers.Movies
 
             var dataFilePath = GetDataFilePath(id, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -198,7 +198,7 @@ namespace MediaBrowser.Providers.Movies
 
             var dataFilePath = GetDataFilePath(id, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/Music/AudioDbAlbumProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbAlbumProvider.cs
@@ -153,7 +153,7 @@ namespace MediaBrowser.Providers.Music
 
             var path = GetAlbumInfoPath(_config.ApplicationPaths, musicBrainzReleaseGroupId);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             using (var httpResponse = await _httpClient.SendAsync(new HttpRequestOptions
             {

--- a/MediaBrowser.Providers/Music/AudioDbAlbumProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbAlbumProvider.cs
@@ -153,7 +153,7 @@ namespace MediaBrowser.Providers.Music
 
             var path = GetAlbumInfoPath(_config.ApplicationPaths, musicBrainzReleaseGroupId);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             using (var httpResponse = await _httpClient.SendAsync(new HttpRequestOptions
             {

--- a/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
@@ -151,7 +151,7 @@ namespace MediaBrowser.Providers.Music
             {
                 using (var response = httpResponse.Content)
                 {
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
                     using (var xmlFileStream = _fileSystem.GetFileStream(path, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
@@ -151,7 +151,7 @@ namespace MediaBrowser.Providers.Music
             {
                 using (var response = httpResponse.Content)
                 {
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
 
                     using (var xmlFileStream = _fileSystem.GetFileStream(path, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
@@ -233,7 +233,7 @@ namespace MediaBrowser.Providers.Music
 
             var jsonPath = GetArtistJsonPath(_config.ApplicationPaths, musicBrainzId);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(jsonPath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(jsonPath));
 
             try
             {

--- a/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
@@ -233,7 +233,7 @@ namespace MediaBrowser.Providers.Music
 
             var jsonPath = GetArtistJsonPath(_config.ApplicationPaths, musicBrainzId);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(jsonPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(jsonPath));
 
             try
             {

--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -294,7 +294,7 @@ namespace MediaBrowser.Providers.Omdb
                 using (var stream = response.Content)
                 {
                     var rootObject = await _jsonSerializer.DeserializeFromStreamAsync<RootObject>(stream).ConfigureAwait(false);
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
                     _jsonSerializer.SerializeToFile(rootObject, path);
                 }
             }
@@ -331,7 +331,7 @@ namespace MediaBrowser.Providers.Omdb
                 using (var stream = response.Content)
                 {
                     var rootObject = await _jsonSerializer.DeserializeFromStreamAsync<SeasonRootObject>(stream).ConfigureAwait(false);
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
                     _jsonSerializer.SerializeToFile(rootObject, path);
                 }
             }

--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -294,7 +294,7 @@ namespace MediaBrowser.Providers.Omdb
                 using (var stream = response.Content)
                 {
                     var rootObject = await _jsonSerializer.DeserializeFromStreamAsync<RootObject>(stream).ConfigureAwait(false);
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
                     _jsonSerializer.SerializeToFile(rootObject, path);
                 }
             }
@@ -331,7 +331,7 @@ namespace MediaBrowser.Providers.Omdb
                 using (var stream = response.Content)
                 {
                     var rootObject = await _jsonSerializer.DeserializeFromStreamAsync<SeasonRootObject>(stream).ConfigureAwait(false);
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
                     _jsonSerializer.SerializeToFile(rootObject, path);
                 }
             }

--- a/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
+++ b/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
@@ -229,7 +229,7 @@ namespace MediaBrowser.Providers.People
             {
                 using (var json = response.Content)
                 {
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+                    Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
                     using (var fs = _fileSystem.GetFileStream(dataFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
+++ b/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
@@ -229,7 +229,7 @@ namespace MediaBrowser.Providers.People
             {
                 using (var json = response.Content)
                 {
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
                     using (var fs = _fileSystem.GetFileStream(dataFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
@@ -45,7 +45,7 @@ namespace MediaBrowser.Providers.Playlists
                 return Task.FromResult(ItemUpdateType.None);
             }
 
-            using (var stream = _fileSystem.OpenRead(path))
+            using (var stream = File.OpenRead(path))
             {
                 var items = GetItems(stream, extension).ToArray();
 

--- a/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
+++ b/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
@@ -151,7 +151,7 @@ namespace MediaBrowser.Providers.Studios
 
                 }).ConfigureAwait(false);
 
-                fileSystem.CreateDirectory(fileSystem.GetDirectoryName(file));
+                fileSystem.CreateDirectory(Path.GetDirectoryName(file));
 
                 try
                 {

--- a/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
+++ b/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
@@ -155,7 +155,7 @@ namespace MediaBrowser.Providers.Studios
 
                 try
                 {
-                    fileSystem.CopyFile(temp, file, true);
+                    File.Copy(temp, file, true);
                 }
                 catch
                 {

--- a/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
+++ b/MediaBrowser.Providers/Studios/StudiosImageProvider.cs
@@ -151,7 +151,7 @@ namespace MediaBrowser.Providers.Studios
 
                 }).ConfigureAwait(false);
 
-                fileSystem.CreateDirectory(Path.GetDirectoryName(file));
+                Directory.CreateDirectory(Path.GetDirectoryName(file));
 
                 try
                 {

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -217,7 +217,7 @@ namespace MediaBrowser.Providers.Subtitles
 
                 try
                 {
-                    _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(savePath));
+                    _fileSystem.CreateDirectory(Path.GetDirectoryName(savePath));
 
                     using (var fs = _fileSystem.GetFileStream(savePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -217,7 +217,7 @@ namespace MediaBrowser.Providers.Subtitles
 
                 try
                 {
-                    _fileSystem.CreateDirectory(Path.GetDirectoryName(savePath));
+                    Directory.CreateDirectory(Path.GetDirectoryName(savePath));
 
                     using (var fs = _fileSystem.GetFileStream(savePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -168,7 +168,7 @@ namespace MediaBrowser.Providers.Subtitles
                         memoryStream.Position = 0;
 
                         var savePaths = new List<string>();
-                        var saveFileName = _fileSystem.GetFileNameWithoutExtension(video.Path) + "." + response.Language.ToLower();
+                        var saveFileName = Path.GetFileNameWithoutExtension(video.Path) + "." + response.Language.ToLower();
 
                         if (response.IsForced)
                         {

--- a/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
@@ -298,7 +298,7 @@ namespace MediaBrowser.Providers.TV
 
             var path = GetFanartJsonPath(tvdbId);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             try
             {

--- a/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
@@ -298,7 +298,7 @@ namespace MediaBrowser.Providers.TV
 
             var path = GetFanartJsonPath(tvdbId);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(path));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(path));
 
             try
             {

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Providers.TV
             }
 
             // Check this in order to avoid logging an exception due to directory not existing
-            if (!_fileSystem.DirectoryExists(seriesDataPath))
+            if (Directory.Exists(seriesDataPath))
             {
                 return false;
             }

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Providers.TV
             }
 
             // Check this in order to avoid logging an exception due to directory not existing
-            if (Directory.Exists(seriesDataPath))
+            if (!Directory.Exists(seriesDataPath))
             {
                 return false;
             }

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbProviderBase.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbProviderBase.cs
@@ -101,7 +101,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, seasonNumber, episodeNumber, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbProviderBase.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbProviderBase.cs
@@ -101,7 +101,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, seasonNumber, episodeNumber, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeasonProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeasonProvider.cs
@@ -188,7 +188,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, seasonNumber, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeasonProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeasonProvider.cs
@@ -188,7 +188,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, seasonNumber, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesProvider.cs
@@ -187,7 +187,7 @@ namespace MediaBrowser.Providers.TV
             tmdbId = seriesInfo.id.ToString(_usCulture);
 
             string dataFilePath = GetDataFilePath(tmdbId, language);
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(seriesInfo, dataFilePath);
 
             await EnsureSeriesInfo(tmdbId, language, cancellationToken).ConfigureAwait(false);
@@ -351,7 +351,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(_fileSystem.GetDirectoryName(dataFilePath));
+            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesProvider.cs
@@ -187,7 +187,7 @@ namespace MediaBrowser.Providers.TV
             tmdbId = seriesInfo.id.ToString(_usCulture);
 
             string dataFilePath = GetDataFilePath(tmdbId, language);
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
             _jsonSerializer.SerializeToFile(seriesInfo, dataFilePath);
 
             await EnsureSeriesInfo(tmdbId, language, cancellationToken).ConfigureAwait(false);
@@ -351,7 +351,7 @@ namespace MediaBrowser.Providers.TV
 
             var dataFilePath = GetDataFilePath(id, preferredMetadataLanguage);
 
-            _fileSystem.CreateDirectory(Path.GetDirectoryName(dataFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dataFilePath));
 
             _jsonSerializer.SerializeToFile(mainResult, dataFilePath);
         }

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -197,7 +197,7 @@ namespace MediaBrowser.Providers.TV
 
             if (searchInfo.IndexNumber.HasValue)
             {
-                var files = GetEpisodeXmlFiles(searchInfo.SeriesDisplayOrder, searchInfo.ParentIndexNumber, searchInfo.IndexNumber, searchInfo.IndexNumberEnd, _fileSystem.GetDirectoryName(xmlFile));
+                var files = GetEpisodeXmlFiles(searchInfo.SeriesDisplayOrder, searchInfo.ParentIndexNumber, searchInfo.IndexNumber, searchInfo.IndexNumberEnd, Path.GetDirectoryName(xmlFile));
 
                 list = files.Select(GetXmlReader).ToList();
             }

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -296,7 +296,7 @@ namespace MediaBrowser.Providers.TV
 
         private XmlReader GetXmlReader(FileSystemMetadata xmlFile)
         {
-            return GetXmlReader(_fileSystem.ReadAllText(xmlFile.FullName, Encoding.UTF8));
+            return GetXmlReader(File.ReadAllText(xmlFile.FullName, Encoding.UTF8));
         }
 
         private XmlReader GetXmlReader(string xml)

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbPrescanTask.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbPrescanTask.cs
@@ -82,7 +82,7 @@ namespace MediaBrowser.Providers.TV
         {
             var path = TvdbSeriesProvider.GetSeriesDataPath(_config.CommonApplicationPaths);
 
-            _fileSystem.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             var timestampFile = Path.Combine(path, "time.txt");
 
@@ -390,7 +390,7 @@ namespace MediaBrowser.Providers.TV
 
             seriesDataPath = Path.Combine(seriesDataPath, id);
 
-            _fileSystem.CreateDirectory(seriesDataPath);
+            Directory.CreateDirectory(seriesDataPath);
 
             return TvdbSeriesProvider.Current.DownloadSeriesZip(id, MetadataProviders.Tvdb.ToString(), null, null, seriesDataPath, lastTvDbUpdateTime, preferredMetadataLanguage, cancellationToken);
         }

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbPrescanTask.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbPrescanTask.cs
@@ -95,7 +95,7 @@ namespace MediaBrowser.Providers.TV
             }
 
             // Find out the last time we queried tvdb for updates
-            var lastUpdateTime = timestampFileInfo.Exists ? _fileSystem.ReadAllText(timestampFile, Encoding.UTF8) : string.Empty;
+            var lastUpdateTime = timestampFileInfo.Exists ? File.ReadAllText(timestampFile, Encoding.UTF8) : string.Empty;
 
             string newUpdateTime;
 
@@ -171,7 +171,7 @@ namespace MediaBrowser.Providers.TV
                 await UpdateSeries(listToUpdate, path, nullableUpdateValue, progress, cancellationToken).ConfigureAwait(false);
             }
 
-            _fileSystem.WriteAllText(timestampFile, newUpdateTime, Encoding.UTF8);
+            File.WriteAllText(timestampFile, newUpdateTime, Encoding.UTF8);
             progress.Report(100);
         }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -1526,7 +1526,7 @@ namespace MediaBrowser.Providers.TV
             var file = Path.Combine(seriesDataPath, string.Format("episode-{0}-{1}.xml", seasonNumber, episodeNumber));
 
             // Only save the file if not already there, or if the episode has changed
-            if (hasEpisodeChanged || !_fileSystem.FileExists(file))
+            if (hasEpisodeChanged || !File.Exists(file))
             {
                 using (var fileStream = _fileSystem.GetFileStream(file, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.None, true))
                 {
@@ -1546,7 +1546,7 @@ namespace MediaBrowser.Providers.TV
                 file = Path.Combine(seriesDataPath, string.Format("episode-abs-{0}.xml", absoluteNumber));
 
                 // Only save the file if not already there, or if the episode has changed
-                if (hasEpisodeChanged || !_fileSystem.FileExists(file))
+                if (hasEpisodeChanged || !File.Exists(file))
                 {
                     using (var fileStream = _fileSystem.GetFileStream(file, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.None, true))
                     {
@@ -1567,7 +1567,7 @@ namespace MediaBrowser.Providers.TV
                 file = Path.Combine(seriesDataPath, string.Format("episode-dvd-{0}-{1}.xml", dvdSeasonNumber, dvdEpisodeNumber));
 
                 // Only save the file if not already there, or if the episode has changed
-                if (hasEpisodeChanged || !_fileSystem.FileExists(file))
+                if (hasEpisodeChanged || !File.Exists(file))
                 {
                     using (var fileStream = _fileSystem.GetFileStream(file, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.None, true))
                     {

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -263,7 +263,7 @@ namespace MediaBrowser.Providers.TV
 
             if (!string.Equals(downloadLangaugeXmlFile, saveAsLanguageXmlFile, StringComparison.OrdinalIgnoreCase))
             {
-                _fileSystem.CopyFile(downloadLangaugeXmlFile, saveAsLanguageXmlFile, true);
+                File.Copy(downloadLangaugeXmlFile, saveAsLanguageXmlFile, true);
             }
 
             await ExtractEpisodes(seriesDataPath, downloadLangaugeXmlFile, lastTvDbUpdateTime).ConfigureAwait(false);

--- a/MediaBrowser.WebDashboard/Api/DashboardService.cs
+++ b/MediaBrowser.WebDashboard/Api/DashboardService.cs
@@ -443,7 +443,7 @@ namespace MediaBrowser.WebDashboard.Api
 
             //Copy all the files & Replaces any files with the same name
             foreach (var newPath in _fileSystem.GetFiles(source, true))
-                _fileSystem.CopyFile(newPath.FullName, newPath.FullName.Replace(source, destination), true);
+                File.Copy(newPath.FullName, newPath.FullName.Replace(source, destination), true);
         }
     }
 

--- a/MediaBrowser.WebDashboard/Api/DashboardService.cs
+++ b/MediaBrowser.WebDashboard/Api/DashboardService.cs
@@ -390,7 +390,7 @@ namespace MediaBrowser.WebDashboard.Api
             {
                 try
                 {
-                    _fileSystem.DeleteDirectory(targetPath, true);
+                    Directory.Delete(targetPath, true);
                 }
                 catch (IOException)
                 {
@@ -435,11 +435,11 @@ namespace MediaBrowser.WebDashboard.Api
 
         private void CopyDirectory(string source, string destination)
         {
-            _fileSystem.CreateDirectory(destination);
+            Directory.CreateDirectory(destination);
 
             //Now Create all of the directories
             foreach (var dirPath in _fileSystem.GetDirectories(source, true))
-                _fileSystem.CreateDirectory(dirPath.FullName.Replace(source, destination));
+                Directory.CreateDirectory(dirPath.FullName.Replace(source, destination));
 
             //Copy all the files & Replaces any files with the same name
             foreach (var newPath in _fileSystem.GetFiles(source, true))

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -108,7 +108,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
         {
             if (!SupportsUrlAfterClosingXmlTag)
             {
-                using (var fileStream = FileSystem.OpenRead(metadataFile))
+                using (var fileStream = File.OpenRead(metadataFile))
                 {
                     using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
                     {
@@ -140,7 +140,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 return;
             }
 
-            using (var fileStream = FileSystem.OpenRead(metadataFile))
+            using (var fileStream = File.OpenRead(metadataFile))
             {
                 using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
                 {

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -28,7 +28,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
         protected override void Fetch(MetadataResult<Episode> item, string metadataFile, XmlReaderSettings settings, CancellationToken cancellationToken)
         {
-            using (var fileStream = FileSystem.OpenRead(metadataFile))
+            using (var fileStream = File.OpenRead(metadataFile))
             {
                 using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
                 {

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -974,7 +974,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
             settings.IgnoreProcessingInstructions = true;
             settings.IgnoreComments = true;
 
-            using (var fileStream = fileSystem.OpenRead(path))
+            using (var fileStream = File.OpenRead(path))
             {
                 using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
                 {

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -193,7 +193,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private void SaveToFile(Stream stream, string path)
         {
-            FileSystem.CreateDirectory(FileSystem.GetDirectoryName(path));
+            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
             // On Windows, savint the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -193,7 +193,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private void SaveToFile(Stream stream, string path)
         {
-            FileSystem.CreateDirectory(Path.GetDirectoryName(path));
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
             // On Windows, savint the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 

--- a/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
@@ -36,7 +36,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 return false;
             }
 
-            return updateType >= MinimumUpdateType || (updateType >= ItemUpdateType.MetadataImport && FileSystem.FileExists(GetSavePath(item)));
+            return updateType >= MinimumUpdateType || (updateType >= ItemUpdateType.MetadataImport && File.Exists(GetSavePath(item)));
         }
 
         protected override void WriteCustomElements(BaseItem item, XmlWriter writer)


### PR DESCRIPTION
**Changes**
This unwraps some non-static members that call stdlib static methods.

For now `GetFullName`, `GetDirectoryName`, `GetFileNameWithoutExtension`, `DirectorySeperatorChar`.

The IFileSystem.cs files and ManagedFileSystem.cs will follow later, since I had to convert the interface to an abstract class to make Resharper not choke on project boundaries.

