### PR TITLE
Change default aspect ratio to 2/3 from 0

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1518,7 +1518,7 @@ namespace MediaBrowser.Controller.Entities
 
         public virtual double GetDefaultPrimaryImageAspectRatio()
         {
-            return 0;
+            return 2.0 / 3;
         }
 
         public virtual string CreatePresentationUniqueKey()


### PR DESCRIPTION
**Changes**
Changed BaseItem's default aspect ratio to 2/3, which was the pre-GPL value. It's used in a division, where 0 is obviously a terrible default

**Issues**
```

[21:58:54] [ERR] Error processing request
System.OverflowException: Value was either too large or too small for an Int32.
at System.Convert.ToInt32(Double value)
at MediaBrowser.Controller.Drawing.ImageHelper.GetSizeEstimate(ImageProcessingOptions options) in /Users/me/RiderProjects/jellyfin/MediaBrowser.Controller/Drawing/ImageHelper.cs:line 37
```