### PR TITLE
Start startup tasks async

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Emby.Dlna.Profiles;
 using Emby.Dlna.Server;
 using MediaBrowser.Common.Configuration;
@@ -48,11 +49,11 @@ namespace Emby.Dlna
             _assemblyInfo = assemblyInfo;
         }
 
-        public void InitProfiles()
+        public async Task InitProfilesAsync()
         {
             try
             {
-                ExtractSystemProfiles();
+                await ExtractSystemProfilesAsync();
                 LoadProfiles();
             }
             catch (Exception ex)
@@ -359,7 +360,7 @@ namespace Emby.Dlna
             };
         }
 
-        private void ExtractSystemProfiles()
+        private async Task ExtractSystemProfilesAsync()
         {
             var namespaceName = GetType().Namespace + ".Profiles.Xml.";
 
@@ -383,7 +384,7 @@ namespace Emby.Dlna
 
                         using (var fileStream = _fileSystem.GetFileStream(path, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
                         {
-                            stream.CopyTo(fileStream);
+                            await stream.CopyToAsync(fileStream);
                         }
                     }
                 }

--- a/Emby.Dlna/Main/DlnaEntryPoint.cs
+++ b/Emby.Dlna/Main/DlnaEntryPoint.cs
@@ -125,9 +125,9 @@ namespace Emby.Dlna.Main
             Current = this;
         }
 
-        public void Run()
+        public async Task RunAsync()
         {
-            ((DlnaManager)_dlnaManager).InitProfiles();
+            await ((DlnaManager)_dlnaManager).InitProfilesAsync().ConfigureAwait(false);
 
             ReloadComponents();
 

--- a/Emby.Notifications/Notifications.cs
+++ b/Emby.Notifications/Notifications.cs
@@ -71,12 +71,14 @@ namespace Emby.Notifications
             _coreNotificationTypes = new CoreNotificationTypes(localization, appHost).GetNotificationTypes().Select(i => i.Type).ToArray();
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _libraryManager.ItemAdded += _libraryManager_ItemAdded;
             _appHost.HasPendingRestartChanged += _appHost_HasPendingRestartChanged;
             _appHost.HasUpdateAvailableChanged += _appHost_HasUpdateAvailableChanged;
             _activityManager.EntryCreated += _activityManager_EntryCreated;
+
+            return Task.CompletedTask;
         }
 
         private async void _appHost_HasPendingRestartChanged(object sender, EventArgs e)

--- a/Emby.Server.Implementations/Activity/ActivityLogEntryPoint.cs
+++ b/Emby.Server.Implementations/Activity/ActivityLogEntryPoint.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
@@ -58,7 +59,7 @@ namespace Emby.Server.Implementations.Activity
             _deviceManager = deviceManager;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _taskManager.TaskCompleted += _taskManager_TaskCompleted;
 
@@ -90,6 +91,8 @@ namespace Emby.Server.Implementations.Activity
             _deviceManager.CameraImageUploaded += _deviceManager_CameraImageUploaded;
 
             _appHost.ApplicationUpdated += _appHost_ApplicationUpdated;
+
+            return Task.CompletedTask;
         }
 
         void _deviceManager_CameraImageUploaded(object sender, GenericEventArgs<CameraImageUploadInfo> e)

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -353,7 +353,7 @@ namespace Emby.Server.Implementations.Collections
             _logger = logger;
         }
 
-        public async void Run()
+        public async Task RunAsync()
         {
             if (!_config.Configuration.CollectionsUpgraded && _config.Configuration.IsStartupWizardCompleted)
             {

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -425,7 +425,7 @@ namespace Emby.Server.Implementations.Devices
             _logger = logger;
         }
 
-        public async void Run()
+        public async Task RunAsync()
         {
             if (!_config.Configuration.CameraUploadUpgraded && _config.Configuration.IsStartupWizardCompleted)
             {

--- a/Emby.Server.Implementations/EntryPoints/AutomaticRestartEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/AutomaticRestartEntryPoint.cs
@@ -37,12 +37,14 @@ namespace Emby.Server.Implementations.EntryPoints
             _timerFactory = timerFactory;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             if (_appHost.CanSelfRestart)
             {
                 _appHost.HasPendingRestartChanged += _appHost_HasPendingRestartChanged;
             }
+
+            return Task.CompletedTask;
         }
 
         void _appHost_HasPendingRestartChanged(object sender, EventArgs e)

--- a/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
+++ b/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
@@ -61,17 +61,17 @@ namespace Emby.Server.Implementations.EntryPoints
             return string.Join("|", values.ToArray());
         }
 
-        void _config_ConfigurationUpdated(object sender, EventArgs e)
+        private async void _config_ConfigurationUpdated(object sender, EventArgs e)
         {
             if (!string.Equals(_lastConfigIdentifier, GetConfigIdentifier(), StringComparison.OrdinalIgnoreCase))
             {
                 DisposeNat();
 
-                Run();
+                await RunAsync();
             }
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             if (_config.Configuration.EnableUPnP && _config.Configuration.EnableRemoteAccess)
             {
@@ -80,6 +80,8 @@ namespace Emby.Server.Implementations.EntryPoints
 
             _config.ConfigurationUpdated -= _config_ConfigurationUpdated;
             _config.ConfigurationUpdated += _config_ConfigurationUpdated;
+
+            return Task.CompletedTask;
         }
 
         private void Start()

--- a/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
@@ -65,7 +66,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _providerManager = providerManager;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _libraryManager.ItemAdded += libraryManager_ItemAdded;
             _libraryManager.ItemUpdated += libraryManager_ItemUpdated;
@@ -74,6 +75,8 @@ namespace Emby.Server.Implementations.EntryPoints
             _providerManager.RefreshCompleted += _providerManager_RefreshCompleted;
             _providerManager.RefreshStarted += _providerManager_RefreshStarted;
             _providerManager.RefreshProgress += _providerManager_RefreshProgress;
+
+            return Task.CompletedTask;
         }
 
         private Dictionary<Guid, DateTime> _lastProgressMessageTimes = new Dictionary<Guid, DateTime>();

--- a/Emby.Server.Implementations/EntryPoints/RecordingNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/RecordingNotifier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Plugins;
@@ -24,12 +25,14 @@ namespace Emby.Server.Implementations.EntryPoints
             _liveTvManager = liveTvManager;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _liveTvManager.TimerCancelled += _liveTvManager_TimerCancelled;
             _liveTvManager.SeriesTimerCancelled += _liveTvManager_SeriesTimerCancelled;
             _liveTvManager.TimerCreated += _liveTvManager_TimerCreated;
             _liveTvManager.SeriesTimerCreated += _liveTvManager_SeriesTimerCreated;
+
+            return Task.CompletedTask;
         }
 
         private void _liveTvManager_SeriesTimerCreated(object sender, MediaBrowser.Model.Events.GenericEventArgs<TimerEventInfo> e)

--- a/Emby.Server.Implementations/EntryPoints/ServerEventNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/ServerEventNotifier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
 using MediaBrowser.Controller;
@@ -49,7 +50,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _sessionManager = sessionManager;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _userManager.UserDeleted += userManager_UserDeleted;
             _userManager.UserUpdated += userManager_UserUpdated;
@@ -65,6 +66,8 @@ namespace Emby.Server.Implementations.EntryPoints
             _installationManager.PackageInstallationFailed += _installationManager_PackageInstallationFailed;
 
             _taskManager.TaskCompleted += _taskManager_TaskCompleted;
+
+            return Task.CompletedTask;
         }
 
         void _installationManager_PackageInstalling(object sender, InstallationEventArgs e)

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Emby.Server.Implementations.Browser;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
@@ -32,11 +33,11 @@ namespace Emby.Server.Implementations.EntryPoints
         /// <summary>
         /// Runs this instance.
         /// </summary>
-        public void Run()
+        public Task RunAsync()
         {
             if (!_appHost.CanLaunchWebBrowser)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             if (!_config.Configuration.IsStartupWizardCompleted)
@@ -52,6 +53,8 @@ namespace Emby.Server.Implementations.EntryPoints
                     BrowserLauncher.OpenWebApp(_appHost);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Emby.Server.Implementations.Udp;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
@@ -43,7 +44,7 @@ namespace Emby.Server.Implementations.EntryPoints
         /// <summary>
         /// Runs this instance.
         /// </summary>
-        public void Run()
+        public Task RunAsync()
         {
             var udpServer = new UdpServer(_logger, _appHost, _json, _socketFactory);
 
@@ -57,6 +58,8 @@ namespace Emby.Server.Implementations.EntryPoints
             {
                 _logger.LogError(ex, "Failed to start UDP Server");
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
@@ -38,9 +38,11 @@ namespace Emby.Server.Implementations.EntryPoints
             _timerFactory = timerFactory;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _userDataManager.UserDataSaved += _userDataManager_UserDataSaved;
+
+            return Task.CompletedTask;
         }
 
         void _userDataManager_UserDataSaved(object sender, UserDataSaveEventArgs e)

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -627,9 +627,10 @@ namespace Emby.Server.Implementations.IO
             _monitor = monitor;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _monitor.Start();
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -1204,9 +1204,11 @@ namespace Emby.Server.Implementations.Library
             _sessionManager = sessionManager;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _userManager.UserPolicyUpdated += _userManager_UserPolicyUpdated;
+
+            return Task.CompletedTask;
         }
 
         private void _userManager_UserPolicyUpdated(object sender, GenericEventArgs<User> e)

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -124,7 +124,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
         }
 
-        public async void Start()
+        public async Task Start()
         {
             _timerProvider.RestartTimers();
 

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EntryPoint.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EntryPoint.cs
@@ -1,12 +1,13 @@
+using System.Threading.Tasks;
 using MediaBrowser.Controller.Plugins;
 
 namespace Emby.Server.Implementations.LiveTv.EmbyTV
 {
     public class EntryPoint : IServerEntryPoint
     {
-        public void Run()
+        public Task RunAsync()
         {
-            EmbyTV.Current.Start();
+            return EmbyTV.Current.Start();
         }
 
         public void Dispose()

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -103,8 +103,6 @@ namespace Jellyfin.Server
 
                 appHost.ImageProcessor.ImageEncoder = GetImageEncoder(fileSystem, appPaths, appHost.LocalizationManager);
 
-                _logger.LogInformation("Running startup tasks");
-
                 await appHost.RunStartupTasks();
 
                 // TODO: read input for a stop command
@@ -118,8 +116,6 @@ namespace Jellyfin.Server
                 {
                     // Don't throw on cancellation
                 }
-
-                _logger.LogInformation("Disposing app host");
             }
 
             if (_restartOnShutdown)

--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -130,7 +130,7 @@ namespace MediaBrowser.Api
         /// <summary>
         /// Runs this instance.
         /// </summary>
-        public void Run()
+        public Task RunAsync()
         {
             try
             {
@@ -148,6 +148,8 @@ namespace MediaBrowser.Api
             {
                 Logger.LogError(ex, "Error deleting encoded media cache");
             }
+
+            return Task.CompletedTask;
         }
 
         public EncodingOptions GetEncodingOptions()
@@ -162,8 +164,7 @@ namespace MediaBrowser.Api
         {
             var path = _config.ApplicationPaths.TranscodingTempPath;
 
-            foreach (var file in _fileSystem.GetFilePaths(path, true)
-                .ToList())
+            foreach (var file in _fileSystem.GetFilePaths(path, true))
             {
                 _fileSystem.DeleteFile(file);
             }

--- a/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
+++ b/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace MediaBrowser.Controller.Plugins
 {
@@ -10,7 +11,7 @@ namespace MediaBrowser.Controller.Plugins
         /// <summary>
         /// Runs this instance.
         /// </summary>
-        void Run();
+        Task RunAsync();
     }
 
     public interface IRunBeforeStartup

--- a/MediaBrowser.WebDashboard/Api/DashboardService.cs
+++ b/MediaBrowser.WebDashboard/Api/DashboardService.cs
@@ -425,11 +425,9 @@ namespace MediaBrowser.WebDashboard.Api
         private async Task DumpFile(PackageCreator packageCreator, string resourceVirtualPath, string destinationFilePath, string mode, string appVersion)
         {
             using (var stream = await packageCreator.GetResource(resourceVirtualPath, mode, null, appVersion).ConfigureAwait(false))
+            using (var fs = _fileSystem.GetFileStream(destinationFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
             {
-                using (var fs = _fileSystem.GetFileStream(destinationFilePath, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read))
-                {
-                    stream.CopyTo(fs);
-                }
+                await stream.CopyToAsync(fs);
             }
         }
 

--- a/MediaBrowser.WebDashboard/ServerEntryPoint.cs
+++ b/MediaBrowser.WebDashboard/ServerEntryPoint.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MediaBrowser.Common;
 using MediaBrowser.Controller.Plugins;
 
@@ -23,9 +24,11 @@ namespace MediaBrowser.WebDashboard
             Instance = this;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             PluginConfigurationPages = _appHost.GetExports<IPluginConfigurationPage>().ToList();
+
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/MediaBrowser.XbmcMetadata/EntryPoint.cs
+++ b/MediaBrowser.XbmcMetadata/EntryPoint.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -28,9 +29,11 @@ namespace MediaBrowser.XbmcMetadata
             _config = config;
         }
 
-        public void Run()
+        public Task RunAsync()
         {
             _userDataManager.UserDataSaved += _userDataManager_UserDataSaved;
+
+            return Task.CompletedTask;
         }
 
         void _userDataManager_UserDataSaved(object sender, UserDataSaveEventArgs e)


### PR DESCRIPTION
Before all startup tasks got executed synchronously, this change makes them all execute at the same time.