### PR TITLE
Remove code for pre-installed plugins & properly check if file exists

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -246,13 +246,14 @@ namespace Emby.Server.Implementations.AppBase
 
         private object LoadConfiguration(string path, Type configurationType)
         {
+            if (!File.Exists(path))
+            {
+                return Activator.CreateInstance(configurationType);
+            }
+
             try
             {
                 return XmlSerializer.DeserializeFromFile(configurationType, path);
-            }
-            catch (FileNotFoundException)
-            {
-                return Activator.CreateInstance(configurationType);
             }
             catch (IOException)
             {

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -286,28 +286,18 @@ namespace Emby.Server.Implementations.HttpClientManager
 
         private HttpResponseInfo GetCachedResponse(string responseCachePath, TimeSpan cacheLength, string url)
         {
-            try
+            if (File.Exists(responseCachePath)
+                && _fileSystem.GetLastWriteTimeUtc(responseCachePath).Add(cacheLength) > DateTime.UtcNow)
             {
-                if (_fileSystem.GetLastWriteTimeUtc(responseCachePath).Add(cacheLength) > DateTime.UtcNow)
+                var stream = _fileSystem.GetFileStream(responseCachePath, FileOpenMode.Open, FileAccessMode.Read, FileShareMode.Read, true);
+
+                return new HttpResponseInfo
                 {
-                    var stream = _fileSystem.GetFileStream(responseCachePath, FileOpenMode.Open, FileAccessMode.Read, FileShareMode.Read, true);
-
-                    return new HttpResponseInfo
-                    {
-                        ResponseUrl = url,
-                        Content = stream,
-                        StatusCode = HttpStatusCode.OK,
-                        ContentLength = stream.Length
-                    };
-                }
-            }
-            catch (FileNotFoundException) // REVIEW: @bond Is this really faster?
-            {
-
-            }
-            catch (DirectoryNotFoundException)
-            {
-
+                    ResponseUrl = url,
+                    Content = stream,
+                    StatusCode = HttpStatusCode.OK,
+                    ContentLength = stream.Length
+                };
             }
 
             return null;

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -395,38 +395,33 @@ namespace Emby.Server.Implementations.Library
 
                 foreach (var fileSystemInfo in item.GetDeletePaths().ToList())
                 {
-                    try
+                    if (File.Exists(fileSystemInfo.FullName))
                     {
-                        _logger.LogDebug("Deleting path {path}", fileSystemInfo.FullName);
-                        if (fileSystemInfo.IsDirectory)
+                        try
                         {
-                            _fileSystem.DeleteDirectory(fileSystemInfo.FullName, true);
+                            _logger.LogDebug("Deleting path {path}", fileSystemInfo.FullName);
+                            if (fileSystemInfo.IsDirectory)
+                            {
+                                _fileSystem.DeleteDirectory(fileSystemInfo.FullName, true);
+                            }
+                            else
+                            {
+                                _fileSystem.DeleteFile(fileSystemInfo.FullName);
+                            }
                         }
-                        else
+                        catch (IOException)
                         {
-                            _fileSystem.DeleteFile(fileSystemInfo.FullName);
+                            if (isRequiredForDelete)
+                            {
+                                throw;
+                            }
                         }
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        // may have already been deleted manually by user
-                    }
-                    catch (DirectoryNotFoundException)
-                    {
-                        // may have already been deleted manually by user
-                    }
-                    catch (IOException)
-                    {
-                        if (isRequiredForDelete)
+                        catch (UnauthorizedAccessException)
                         {
-                            throw;
-                        }
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        if (isRequiredForDelete)
-                        {
-                            throw;
+                            if (isRequiredForDelete)
+                            {
+                                throw;
+                            }
                         }
                     }
 

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -1029,16 +1029,17 @@ namespace Emby.Server.Implementations.Library
         {
             var path = GetPolicyFilePath(user);
 
+            if (!File.Exists(path))
+            {
+                return GetDefaultPolicy(user);
+            }
+
             try
             {
                 lock (_policySyncLock)
                 {
                     return (UserPolicy)_xmlSerializer.DeserializeFromFile(typeof(UserPolicy), path);
                 }
-            }
-            catch (FileNotFoundException)
-            {
-                return GetDefaultPolicy(user);
             }
             catch (IOException)
             {
@@ -1128,16 +1129,17 @@ namespace Emby.Server.Implementations.Library
         {
             var path = GetConfigurationFilePath(user);
 
+            if (!File.Exists(path))
+            {
+                return new UserConfiguration();
+            }
+
             try
             {
                 lock (_configSyncLock)
                 {
                     return (UserConfiguration)_xmlSerializer.DeserializeFromFile(typeof(UserConfiguration), path);
                 }
-            }
-            catch (FileNotFoundException)
-            {
-                return new UserConfiguration();
             }
             catch (IOException)
             {

--- a/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ChapterImagesTask.cs
@@ -101,17 +101,20 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
             List<string> previouslyFailedImages;
 
-            try
+            if (File.Exists(failHistoryPath))
             {
-                previouslyFailedImages = _fileSystem.ReadAllText(failHistoryPath)
-                    .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
-                    .ToList();
+                try
+                {
+                    previouslyFailedImages = _fileSystem.ReadAllText(failHistoryPath)
+                        .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
+                        .ToList();
+                }
+                catch (IOException)
+                {
+                    previouslyFailedImages = new List<string>();
+                }
             }
-            catch (FileNotFoundException)
-            {
-                previouslyFailedImages = new List<string>();
-            }
-            catch (IOException)
+            else
             {
                 previouslyFailedImages = new List<string>();
             }

--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -129,21 +129,16 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 {
                     if (_lastExecutionResult == null && !_readFromFile)
                     {
-                        try
+                        if (File.Exists(path))
                         {
-                            _lastExecutionResult = JsonSerializer.DeserializeFromFile<TaskResult>(path);
-                        }
-                        catch (DirectoryNotFoundException)
-                        {
-                            // File doesn't exist. No biggie
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            // File doesn't exist. No biggie
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogError(ex, "Error deserializing {path}", path);
+                            try
+                            {
+                                _lastExecutionResult = JsonSerializer.DeserializeFromFile<TaskResult>(path);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.LogError(ex, "Error deserializing {File}", path);
+                            }
                         }
                         _readFromFile = true;
                     }
@@ -532,28 +527,16 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
         private TaskTriggerInfo[] LoadTriggerSettings()
         {
-            try
-            {
-                var list = JsonSerializer.DeserializeFromFile<IEnumerable<TaskTriggerInfo>>(GetConfigurationFilePath());
-
-                if (list != null)
-                {
-                    return list.ToArray();
-                }
-            }
-            catch (FileNotFoundException)
+            string path = GetConfigurationFilePath();
+            if (!File.Exists(path))
             {
                 // File doesn't exist. No biggie. Return defaults.
+                GetDefaultTriggers();
             }
-            catch (DirectoryNotFoundException)
-            {
-                // File doesn't exist. No biggie. Return defaults.
-            }
-            catch
-            {
 
-            }
-            return GetDefaultTriggers();
+            var list = JsonSerializer.DeserializeFromFile<TaskTriggerInfo[]>(path);
+
+            return list ?? GetDefaultTriggers();
         }
 
         private TaskTriggerInfo[] GetDefaultTriggers()


### PR DESCRIPTION
* Remove code for pre-installed plugins 
* Check if file exists instead of catching exceptions 

Benchmarks show that catching the exceptions is way slower:
```
           Method |      Mean |     Error |    StdDev | Rank |
----------------- |----------:|----------:|----------:|-----:|
       FileExists |  5.249 us | 0.0417 us | 0.0390 us |    3 |
           FileEx |  4.068 us | 0.0278 us | 0.0260 us |    2 |
 FileDoesntExists |  1.193 us | 0.0046 us | 0.0041 us |    1 |
     FileDoesntEx | 27.005 us | 0.0668 us | 0.0592 us |    4 |
```