### PR TITLE
Fix crash when trying to deserialize a non-existing scheduled task

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -528,14 +528,13 @@ namespace Emby.Server.Implementations.ScheduledTasks
         private TaskTriggerInfo[] LoadTriggerSettings()
         {
             string path = GetConfigurationFilePath();
-            if (!File.Exists(path))
+            TaskTriggerInfo[] list = null;
+            if (File.Exists(path))
             {
-                // File doesn't exist. No biggie. Return defaults.
-                GetDefaultTriggers();
+                list = JsonSerializer.DeserializeFromFile<TaskTriggerInfo[]>(path);
             }
 
-            var list = JsonSerializer.DeserializeFromFile<TaskTriggerInfo[]>(path);
-
+            // Return defaults if file doesn't exist.
             return list ?? GetDefaultTriggers();
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Made it not crash. It tried to deserialize a file that doesn't exist.
**Issues**
Caused by https://github.com/jellyfin/jellyfin/pull/740
