### PR TITLE
Use CommandLineParser package for handling CLI args

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -142,7 +142,7 @@ namespace Emby.Server.Implementations
                     return false;
                 }
 
-                if (StartupOptions.ContainsOption("-service"))
+                if (StartupOptions.Service)
                 {
                     return false;
                 }
@@ -1748,7 +1748,7 @@ namespace Emby.Server.Implementations
                 EncoderLocationType = MediaEncoder.EncoderLocationType,
                 SystemArchitecture = EnvironmentInfo.SystemArchitecture,
                 SystemUpdateLevel = SystemUpdateLevel,
-                PackageName = StartupOptions.GetOption("-package")
+                PackageName = StartupOptions.PackageName
             };
         }
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -43,7 +43,6 @@ using Emby.Server.Implementations.ScheduledTasks;
 using Emby.Server.Implementations.Security;
 using Emby.Server.Implementations.Serialization;
 using Emby.Server.Implementations.Session;
-using Emby.Server.Implementations.ParsedStartupOptions;
 using Emby.Server.Implementations.Threading;
 using Emby.Server.Implementations.TV;
 using Emby.Server.Implementations.Updates;

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -43,6 +43,7 @@ using Emby.Server.Implementations.ScheduledTasks;
 using Emby.Server.Implementations.Security;
 using Emby.Server.Implementations.Serialization;
 using Emby.Server.Implementations.Session;
+using Emby.Server.Implementations.ParsedStartupOptions;
 using Emby.Server.Implementations.Threading;
 using Emby.Server.Implementations.TV;
 using Emby.Server.Implementations.Updates;
@@ -142,7 +143,7 @@ namespace Emby.Server.Implementations
                     return false;
                 }
 
-                if (StartupOptions.Service)
+                if (StartupOptions.IsService)
                 {
                     return false;
                 }
@@ -344,7 +345,7 @@ namespace Emby.Server.Implementations
         protected IHttpResultFactory HttpResultFactory { get; private set; }
         protected IAuthService AuthService { get; private set; }
 
-        public StartupOptions StartupOptions { get; private set; }
+        public IStartupOptions StartupOptions { get; private set; }
 
         internal IImageEncoder ImageEncoder { get; private set; }
 
@@ -365,7 +366,7 @@ namespace Emby.Server.Implementations
         /// </summary>
         public ApplicationHost(ServerApplicationPaths applicationPaths,
             ILoggerFactory loggerFactory,
-            StartupOptions options,
+            IStartupOptions options,
             IFileSystem fileSystem,
             IEnvironmentInfo environmentInfo,
             IImageEncoder imageEncoder,

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="ServiceStack.Text.Core" Version="5.4.0" />
     <PackageReference Include="sharpcompress" Version="0.22.0" />
     <PackageReference Include="SimpleInjector" Version="4.4.2" />

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\Emby.Naming\Emby.Naming.csproj" />
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="ServiceStack.Text.Core" Version="5.4.0" />
     <PackageReference Include="sharpcompress" Version="0.22.0" />
     <PackageReference Include="SimpleInjector" Version="4.4.2" />

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -47,7 +47,7 @@ namespace Emby.Server.Implementations.EntryPoints
             {
                 var options = ((ApplicationHost)_appHost).StartupOptions;
 
-                if (options.AutoRunWebApp)
+                if (!options.NoAutoRunWebApp)
                 {
                     BrowserLauncher.OpenWebApp(_appHost);
                 }

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -47,7 +47,7 @@ namespace Emby.Server.Implementations.EntryPoints
             {
                 var options = ((ApplicationHost)_appHost).StartupOptions;
 
-                if (!options.ContainsOption("-noautorunwebapp"))
+                if (!options.NoAutoRunWebApp)
                 {
                     BrowserLauncher.OpenWebApp(_appHost);
                 }

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -47,7 +47,7 @@ namespace Emby.Server.Implementations.EntryPoints
             {
                 var options = ((ApplicationHost)_appHost).StartupOptions;
 
-                if (!options.NoAutoRunWebApp)
+                if (options.AutoRunWebApp)
                 {
                     BrowserLauncher.OpenWebApp(_appHost);
                 }

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -6,6 +6,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
+using Emby.Server.Implementations.ParsedStartupOptions;
 
 namespace Emby.Server.Implementations.FFMpeg
 {
@@ -28,10 +29,10 @@ namespace Emby.Server.Implementations.FFMpeg
             _ffmpegInstallInfo = ffmpegInstallInfo;
         }
 
-        public FFMpegInfo GetFFMpegInfo(StartupOptions options)
+        public FFMpegInfo GetFFMpegInfo(IStartupOptions options)
         {
-            var customffMpegPath = options.FFmpeg;
-            var customffProbePath = options.FFprobe;
+            var customffMpegPath = options.FFmpegPath;
+            var customffProbePath = options.FFprobePath;
 
             if (!string.IsNullOrWhiteSpace(customffMpegPath) && !string.IsNullOrWhiteSpace(customffProbePath))
             {

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -30,8 +30,8 @@ namespace Emby.Server.Implementations.FFMpeg
 
         public FFMpegInfo GetFFMpegInfo(StartupOptions options)
         {
-            var customffMpegPath = options.GetOption("-ffmpeg");
-            var customffProbePath = options.GetOption("-ffprobe");
+            var customffMpegPath = options.FFmpeg;
+            var customffProbePath = options.FFprobe;
 
             if (!string.IsNullOrWhiteSpace(customffMpegPath) && !string.IsNullOrWhiteSpace(customffProbePath))
             {

--- a/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
+++ b/Emby.Server.Implementations/FFMpeg/FFMpegLoader.cs
@@ -6,7 +6,6 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
-using Emby.Server.Implementations.ParsedStartupOptions;
 
 namespace Emby.Server.Implementations.FFMpeg
 {

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -1,22 +1,7 @@
-namespace Emby.Server.Implementations.ParsedStartupOptions
+namespace Emby.Server.Implementations
 {
     public interface IStartupOptions
     {
-        /// <summary>
-        /// --datadir
-        /// </summary>
-        string DataDir { get; }
-
-        /// <summary>
-        /// --configdir
-        /// </summary>
-        string ConfigDir { get; }
-
-        /// <summary>
-        /// --logdir
-        /// </summary>
-        string LogDir { get; }
-
         /// <summary>
         /// --ffmpeg
         /// </summary>
@@ -35,7 +20,7 @@ namespace Emby.Server.Implementations.ParsedStartupOptions
         /// <summary>
         /// --noautorunwebapp
         /// </summary>
-        bool AutoRunWebApp { get; }
+        bool NoAutoRunWebApp { get; }
 
         /// <summary>
         /// --package-name

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -1,0 +1,55 @@
+namespace Emby.Server.Implementations.ParsedStartupOptions
+{
+    public interface IStartupOptions
+    {
+        /// <summary>
+        /// --datadir
+        /// </summary>
+        string DataDir { get; }
+
+        /// <summary>
+        /// --configdir
+        /// </summary>
+        string ConfigDir { get; }
+
+        /// <summary>
+        /// --logdir
+        /// </summary>
+        string LogDir { get; }
+
+        /// <summary>
+        /// --ffmpeg
+        /// </summary>
+        string FFmpegPath { get; }
+
+        /// <summary>
+        /// --ffprobe
+        /// </summary>
+        string FFprobePath { get; }
+
+        /// <summary>
+        /// --service
+        /// </summary>
+        bool IsService { get; }
+
+        /// <summary>
+        /// --noautorunwebapp
+        /// </summary>
+        bool AutoRunWebApp { get; }
+
+        /// <summary>
+        /// --package-name
+        /// </summary>
+        string PackageName { get; }
+
+        /// <summary>
+        /// --restartpath
+        /// </summary>
+        string RestartPath { get; }
+
+        /// <summary>
+        /// --restartargs
+        /// </summary>
+        string RestartArgs { get; }
+    }
+}

--- a/Emby.Server.Implementations/StartupOptions.cs
+++ b/Emby.Server.Implementations/StartupOptions.cs
@@ -7,8 +7,8 @@ namespace Emby.Server.Implementations
     /// </summary>
     public class StartupOptions
     {
-        [Option('d', "programdata", Required = false, HelpText = "Path to use for program data (databases files etc.).")]
-        public string PathProgramData { get; set; }
+        [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (databases files etc.).")]
+        public string PathData { get; set; }
 
         [Option('c', "configdir", Required = false, HelpText = "Path to use for config data (user policies and puctures).")]
         public string PathConfig { get; set; }

--- a/Emby.Server.Implementations/StartupOptions.cs
+++ b/Emby.Server.Implementations/StartupOptions.cs
@@ -1,30 +1,43 @@
-using System;
-using System.Linq;
-
 namespace Emby.Server.Implementations
 {
+    using CommandLine;
+
+    /// <summary>
+    /// Class used by CommandLine package when parsing the command line arguments.
+    /// </summary>
     public class StartupOptions
     {
-        private readonly string[] _options;
+        [Option('d', "programdata", Required = false, HelpText = "Path to use for program data (databases files etc.).")]
+        public string PathProgramData { get; set; }
 
-        public StartupOptions(string[] commandLineArgs)
-        {
-            _options = commandLineArgs;
-        }
+        [Option('c', "configdir", Required = false, HelpText = "Path to use for config data (user policies and puctures).")]
+        public string PathConfig { get; set; }
 
-        public bool ContainsOption(string option)
-            => _options.Contains(option, StringComparer.OrdinalIgnoreCase);
+        [Option('l', "logdir", Required = false, HelpText = "Path to use for writing log files.")]
+        public string PathLog { get; set; }
 
-        public string GetOption(string name)
-        {
-            int index = Array.IndexOf(_options, name);
 
-            if (index == -1)
-            {
-                return null;
-            }
+        [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg exe to use in place of built-in.")]
+        public string FFmpeg { get; set; }
 
-            return _options.ElementAtOrDefault(index + 1);
-        }
+        [Option("ffprobe", Required = false, HelpText = "ffmpeg and ffprobe switches must be supplied together.")]
+        public string FFprobe { get; set; }
+
+
+        [Option("service", Required = false, HelpText = "Run as headless service.")]
+        public bool Service { get; set; }
+
+        [Option("noautorunwebapp", Required = false, HelpText = "Run headless if startup wizard is complete.")]
+        public bool NoAutoRunWebApp { get; set; }
+
+        [Option("package-name", Required = false, HelpText = "Used when packaging Jellyfin (example, synology).")]
+        public string PackageName { get; set; }
+
+
+        [Option("restartpath", Required = false, HelpText = "Path to reset script.")]
+        public string RestartPath { get; set; }
+
+        [Option("restartargs", Required = false, HelpText = "Arguments for restart script.")]
+        public string RestartArgs { get; set; }
     }
-}
+ }

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -16,7 +16,7 @@ namespace Jellyfin.Server
         {
         }
 
-        public override bool CanSelfRestart => StartupOptions.ContainsOption("-restartpath");
+        public override bool CanSelfRestart => StartupOptions.RestartPath != null;
 
         protected override void RestartInternal() => Program.Restart();
 

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -6,8 +6,10 @@ using System.Net;
 using System.Net.Security;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using CommandLine;
 using Emby.Drawing;
 using Emby.Server.Implementations;
 using Emby.Server.Implementations.EnvironmentInfo;
@@ -26,9 +28,6 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Jellyfin.Server
 {
-    using CommandLine;
-    using System.Text.RegularExpressions;
-
     public static class Program
     {
         private static readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
@@ -41,8 +40,8 @@ namespace Jellyfin.Server
             // For backwards compatibility.
             // Modify any input arguments now which start with single-hyphen to POSIX standard
             // double-hyphen to allow parsing by CommandLineParser package.
-            var pattern = @"^(-[^-\s]{2})"; // Match -xx, not -x, not --xx, not xx
-            var substitution = @"-$1"; // Prepend with additional single-hyphen
+            const string pattern = @"^(-[^-\s]{2})"; // Match -xx, not -x, not --xx, not xx
+            const string substitution = @"-$1"; // Prepend with additional single-hyphen
             var regex = new Regex(pattern);
 
             for (var i = 0; i < args.Length; i++)
@@ -152,9 +151,9 @@ namespace Jellyfin.Server
             string programDataPath = Environment.GetEnvironmentVariable("JELLYFIN_DATA_PATH");
             if (string.IsNullOrEmpty(programDataPath))
             {
-                if (options.PathData != null)
+                if (options.DataDir != null)
                 {
-                    programDataPath = options.PathData;
+                    programDataPath = options.DataDir;
                 }
                 else
                 {
@@ -190,9 +189,9 @@ namespace Jellyfin.Server
             string configDir = Environment.GetEnvironmentVariable("JELLYFIN_CONFIG_DIR");
             if (string.IsNullOrEmpty(configDir))
             {
-                if (options.PathConfig != null)
+                if (options.ConfigDir != null)
                 {
-                    configDir = options.PathConfig;
+                    configDir = options.ConfigDir;
                 }
                 else
                 {
@@ -209,9 +208,9 @@ namespace Jellyfin.Server
             string logDir = Environment.GetEnvironmentVariable("JELLYFIN_LOG_DIR");
             if (string.IsNullOrEmpty(logDir))
             {
-                if (options.PathLog != null)
+                if (options.LogDir != null)
                 {
-                    logDir = options.PathLog;
+                    logDir = options.LogDir;
                 }
                 else
                 {

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -49,11 +49,8 @@ namespace Jellyfin.Server
                 args[i] = regex.Replace(args[i], substitution);
             }
 
-            // For CommandLine package, change default behaviour to output errors to stdout (instead of stderr)
-            var parser = new Parser(config => config.HelpWriter = Console.Out);
-
             // Parse the command line arguments and either start the app or exit indicating error
-            await parser.ParseArguments<StartupOptions>(args)
+            await Parser.Default.ParseArguments<StartupOptions>(args)
                 .MapResult(
                     options => StartApp(options),
                     errs => Task.FromResult(0)).ConfigureAwait(false);

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,43 +1,47 @@
-namespace Emby.Server.Implementations
-{
-    using CommandLine;
+using CommandLine;
+using Emby.Server.Implementations.ParsedStartupOptions;
 
+namespace Jellyfin.Server
+{
     /// <summary>
     /// Class used by CommandLine package when parsing the command line arguments.
     /// </summary>
-    public class StartupOptions
+    public class StartupOptions : IStartupOptions
     {
         [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (databases files etc.).")]
-        public string PathData { get; set; }
+        public string DataDir { get; set; }
 
         [Option('c', "configdir", Required = false, HelpText = "Path to use for config data (user policies and puctures).")]
-        public string PathConfig { get; set; }
+        public string ConfigDir { get; set; }
 
         [Option('l', "logdir", Required = false, HelpText = "Path to use for writing log files.")]
-        public string PathLog { get; set; }
-
+        public string LogDir { get; set; }
 
         [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg exe to use in place of built-in.")]
-        public string FFmpeg { get; set; }
+        public string FFmpegPath { get; set; }
 
         [Option("ffprobe", Required = false, HelpText = "ffmpeg and ffprobe switches must be supplied together.")]
-        public string FFprobe { get; set; }
-
+        public string FFprobePath { get; set; }
 
         [Option("service", Required = false, HelpText = "Run as headless service.")]
-        public bool Service { get; set; }
+        public bool IsService { get; set; }
 
         [Option("noautorunwebapp", Required = false, HelpText = "Run headless if startup wizard is complete.")]
-        public bool NoAutoRunWebApp { get; set; }
+        public bool AutoRunWebApp { get => !NoautoRunWebApp; set => NoautoRunWebApp = value; }
 
         [Option("package-name", Required = false, HelpText = "Used when packaging Jellyfin (example, synology).")]
         public string PackageName { get; set; }
-
 
         [Option("restartpath", Required = false, HelpText = "Path to reset script.")]
         public string RestartPath { get; set; }
 
         [Option("restartargs", Required = false, HelpText = "Arguments for restart script.")]
         public string RestartArgs { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run not run the web app.
+        /// Command line switch is --noautorunwebapp, which we store privately here, but provide inverse (AutoRunWebApp) for users.
+        /// </summary>
+        private bool NoautoRunWebApp { get; set; }
     }
- }
+}

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,5 +1,5 @@
 using CommandLine;
-using Emby.Server.Implementations.ParsedStartupOptions;
+using Emby.Server.Implementations;
 
 namespace Jellyfin.Server
 {
@@ -27,7 +27,7 @@ namespace Jellyfin.Server
         public bool IsService { get; set; }
 
         [Option("noautorunwebapp", Required = false, HelpText = "Run headless if startup wizard is complete.")]
-        public bool AutoRunWebApp { get => !NoautoRunWebApp; set => NoautoRunWebApp = value; }
+        public bool NoAutoRunWebApp { get; set; }
 
         [Option("package-name", Required = false, HelpText = "Used when packaging Jellyfin (example, synology).")]
         public string PackageName { get; set; }
@@ -37,11 +37,5 @@ namespace Jellyfin.Server
 
         [Option("restartargs", Required = false, HelpText = "Arguments for restart script.")]
         public string RestartArgs { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run not run the web app.
-        /// Command line switch is --noautorunwebapp, which we store privately here, but provide inverse (AutoRunWebApp) for users.
-        /// </summary>
-        private bool NoautoRunWebApp { get; set; }
     }
 }

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -8,19 +8,19 @@ namespace Jellyfin.Server
     /// </summary>
     public class StartupOptions : IStartupOptions
     {
-        [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (databases files etc.).")]
+        [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (database files, etc.).")]
         public string DataDir { get; set; }
 
-        [Option('c', "configdir", Required = false, HelpText = "Path to use for config data (user policies and puctures).")]
+        [Option('c', "configdir", Required = false, HelpText = "Path to use for configuration data (user settings and pictures).")]
         public string ConfigDir { get; set; }
 
         [Option('l', "logdir", Required = false, HelpText = "Path to use for writing log files.")]
         public string LogDir { get; set; }
 
-        [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg exe to use in place of built-in.")]
+        [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg executable to use in place of default found in PATH. Must be specified along with --ffprobe.")]
         public string FFmpegPath { get; set; }
 
-        [Option("ffprobe", Required = false, HelpText = "ffmpeg and ffprobe switches must be supplied together.")]
+        [Option("ffprobe", Required = false, HelpText = "Path to external FFprobe executable to use in place of default found in PATH. Must be specified along with --ffmpeg.")]
         public string FFprobePath { get; set; }
 
         [Option("service", Required = false, HelpText = "Run as headless service.")]
@@ -32,7 +32,7 @@ namespace Jellyfin.Server
         [Option("package-name", Required = false, HelpText = "Used when packaging Jellyfin (example, synology).")]
         public string PackageName { get; set; }
 
-        [Option("restartpath", Required = false, HelpText = "Path to reset script.")]
+        [Option("restartpath", Required = false, HelpText = "Path to restart script.")]
         public string RestartPath { get; set; }
 
         [Option("restartargs", Required = false, HelpText = "Arguments for restart script.")]


### PR DESCRIPTION
I've been working on this PR to address my issue #693 

It uses package CommandLineParser:
https://github.com/commandlineparser/commandline

I tested out a few parsers and this one appears to be popular and still actively maintained.  It automatically provides a help and versions page, and moves the our CLI switches to be POSIX standard.

Please review and provide your thoughts.

Example output:
```
ploughpuff@vb-deb-jelly:~/jellyfin$ ~/tmp/bin/jellyfin --help
Jellyfin.Server 10.1.0.0
Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License Version 2

  -d, --programdata    Path to use for program data (databases files etc.).

  -c, --configdir      Path to use for config data (user policies and puctures).

  -l, --logdir         Path to use for writing log files.

  --ffmpeg             Path to external FFmpeg exe to use in place of built-in.

  --ffprobe            ffmpeg and ffprobe switches must be supplied together.

  --service            Run as headless service.

  --noautorunwebapp    Run headless if startup wizard is complete.

  --package-name       Used when packaging Jellyfin (example, synology).

  --restartpath        Path to reset script.

  --restartargs        Arguments for restart script.

  --help               Display this help screen.

  --version            Display version information.

```
