### PR TITLE
Fix default aspect ratio

### DIFF
--- a/MediaBrowser.Controller/Drawing/ImageHelper.cs
+++ b/MediaBrowser.Controller/Drawing/ImageHelper.cs
@@ -63,7 +63,8 @@ namespace MediaBrowser.Controller.Drawing
                 case ImageType.Logo:
                     return 2.58;
                 case ImageType.Primary:
-                    return item.GetDefaultPrimaryImageAspectRatio();
+                    double defaultPrimaryImageAspectRatio = item.GetDefaultPrimaryImageAspectRatio();
+                    return defaultPrimaryImageAspectRatio > 0 ? defaultPrimaryImageAspectRatio : 2.0 / 3;
                 default:
                     return 1;
             }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1518,7 +1518,7 @@ namespace MediaBrowser.Controller.Entities
 
         public virtual double GetDefaultPrimaryImageAspectRatio()
         {
-            return 2.0 / 3;
+            return 0;
         }
 
         public virtual string CreatePresentationUniqueKey()


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Changed GetDefaultPrimaryImageAspectRatio back to its original behaviour. It used to be a `double?` though but that didn't work for some reason when serializing it.
**Issues**
Fixes #741
