### PR TITLE
Add password field to initial setup

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [wtayl0r](https://github.com/wtayl0r)
  - [TtheCreator](https://github.com/Tthecreator)
  - [LogicalPhallacy](https://github.com/LogicalPhallacy/)
+ - [RazeLighter777](https://github.com/RazeLighter777)
 
 # Emby Contributors
 

--- a/MediaBrowser.Api/StartupWizardService.cs
+++ b/MediaBrowser.Api/StartupWizardService.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Services;
+using MediaBrowser.Controller.Entities;
 
 namespace MediaBrowser.Api
 {
@@ -102,7 +103,8 @@ namespace MediaBrowser.Api
             return new StartupUser
             {
                 Name = user.Name,
-                ConnectUserName = user.ConnectUserName
+                ConnectUserName = user.ConnectUserName,
+                Password = user.Password
             };
         }
 
@@ -111,7 +113,9 @@ namespace MediaBrowser.Api
             var user = _userManager.Users.First();
 
             user.Name = request.Name;
+
             _userManager.UpdateUser(user);
+            await _userManager.ChangePassword(user, request.Password).ConfigureAwait(false);
 
             var result = new UpdateStartupUserResult();
 
@@ -130,6 +134,7 @@ namespace MediaBrowser.Api
     {
         public string Name { get; set; }
         public string ConnectUserName { get; set; }
+        public string Password { get; set; }
     }
 
     public class UpdateStartupUserResult

--- a/MediaBrowser.Api/StartupWizardService.cs
+++ b/MediaBrowser.Api/StartupWizardService.cs
@@ -8,7 +8,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Services;
-using MediaBrowser.Controller.Entities;
 
 namespace MediaBrowser.Api
 {
@@ -115,7 +114,10 @@ namespace MediaBrowser.Api
             user.Name = request.Name;
 
             _userManager.UpdateUser(user);
-            await _userManager.ChangePassword(user, request.Password).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(request.Password)) {
+                await _userManager.ChangePassword(user, request.Password).ConfigureAwait(false);
+            }
 
             var result = new UpdateStartupUserResult();
 


### PR DESCRIPTION
**Issue**
#187 
**Changes**
Adds a field to the Startup service API allowing the user to set a password for the admin account upon setup.

Note that the functionality won't work without a change to the frontend here: https://github.com/jellyfin/jellyfin-web/pull/92

However, this can be safely pulled without affecting anything, as the password field is not necessary.