### PR TITLE
Rewrite rules for determining app paths and use XDG_CONFIG_HOME for configDir

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using MediaBrowser.Common.Configuration;
 
@@ -14,50 +15,44 @@ namespace Emby.Server.Implementations.AppBase
         /// </summary>
         protected BaseApplicationPaths(
             string programDataPath,
-            string appFolderPath,
-            string logDirectoryPath = null,
-            string configurationDirectoryPath = null,
-            string cacheDirectoryPath = null)
+            string logDirectoryPath,
+            string configurationDirectoryPath,
+            string cacheDirectoryPath)
         {
             ProgramDataPath = programDataPath;
-            ProgramSystemPath = appFolderPath;
             LogDirectoryPath = logDirectoryPath;
             ConfigurationDirectoryPath = configurationDirectoryPath;
             CachePath = cacheDirectoryPath;
+
+            DataPath = Path.Combine(ProgramDataPath, "data");
         }
 
+        /// <summary>
+        /// Gets the path to the program data folder
+        /// </summary>
+        /// <value>The program data path.</value>
         public string ProgramDataPath { get; private set; }
 
         /// <summary>
         /// Gets the path to the system folder
         /// </summary>
-        public string ProgramSystemPath { get; private set; }
+        public string ProgramSystemPath { get; } = AppContext.BaseDirectory;
 
-        /// <summary>
-        /// The _data directory
-        /// </summary>
-        private string _dataDirectory;
         /// <summary>
         /// Gets the folder path to the data directory
         /// </summary>
         /// <value>The data directory.</value>
+        private string _dataPath;
         public string DataPath
         {
-            get
-            {
-                if (_dataDirectory == null)
-                {
-                    _dataDirectory = Path.Combine(ProgramDataPath, "data");
-
-                    Directory.CreateDirectory(_dataDirectory);
-                }
-
-                return _dataDirectory;
-            }
+            get => _dataPath;
+            private set => _dataPath = Directory.CreateDirectory(value).FullName;
         }
 
-        private const string _virtualDataPath = "%AppDataPath%";
-        public string VirtualDataPath => _virtualDataPath;
+        /// <summary>
+        /// Gets the magic strings used for virtual path manipulation.
+        /// </summary>
+        public string VirtualDataPath { get; } = "%AppDataPath%";
 
         /// <summary>
         /// Gets the image cache path.
@@ -84,54 +79,16 @@ namespace Emby.Server.Implementations.AppBase
         public string TempUpdatePath => Path.Combine(ProgramDataPath, "updates");
 
         /// <summary>
-        /// The _log directory
-        /// </summary>
-        private string _logDirectoryPath;
-
-        /// <summary>
         /// Gets the path to the log directory
         /// </summary>
         /// <value>The log directory path.</value>
-        public string LogDirectoryPath
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_logDirectoryPath))
-                {
-                    _logDirectoryPath = Path.Combine(ProgramDataPath, "logs");
-
-                    Directory.CreateDirectory(_logDirectoryPath);
-                }
-
-                return _logDirectoryPath;
-            }
-            set => _logDirectoryPath = value;
-        }
-
-        /// <summary>
-        /// The _config directory
-        /// </summary>
-        private string _configurationDirectoryPath;
+        public string LogDirectoryPath { get; private set; }
 
         /// <summary>
         /// Gets the path to the application configuration root directory
         /// </summary>
         /// <value>The configuration directory path.</value>
-        public string ConfigurationDirectoryPath
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_configurationDirectoryPath))
-                {
-                    _configurationDirectoryPath = Path.Combine(ProgramDataPath, "config");
-
-                    Directory.CreateDirectory(_configurationDirectoryPath);
-                }
-
-                return _configurationDirectoryPath;
-            }
-            set => _configurationDirectoryPath = value;
-        }
+        public string ConfigurationDirectoryPath { get; private set; }
 
         /// <summary>
         /// Gets the path to the system configuration file
@@ -140,28 +97,10 @@ namespace Emby.Server.Implementations.AppBase
         public string SystemConfigurationFilePath => Path.Combine(ConfigurationDirectoryPath, "system.xml");
 
         /// <summary>
-        /// The _cache directory
-        /// </summary>
-        private string _cachePath;
-        /// <summary>
         /// Gets the folder path to the cache directory
         /// </summary>
         /// <value>The cache directory.</value>
-        public string CachePath
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_cachePath))
-                {
-                    _cachePath = Path.Combine(ProgramDataPath, "cache");
-
-                    Directory.CreateDirectory(_cachePath);
-                }
-
-                return _cachePath;
-            }
-            set => _cachePath = value;
-        }
+        public string CachePath { get; set; }
 
         /// <summary>
         /// Gets the folder path to the temp directory within the cache folder

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -15,21 +15,17 @@ namespace Emby.Server.Implementations
         /// </summary>
         public ServerApplicationPaths(
             string programDataPath,
-            string appFolderPath,
-            string applicationResourcesPath,
-            string logDirectoryPath = null,
-            string configurationDirectoryPath = null,
-            string cacheDirectoryPath = null)
+            string logDirectoryPath,
+            string configurationDirectoryPath,
+            string cacheDirectoryPath)
             : base(programDataPath,
-                appFolderPath,
                 logDirectoryPath,
                 configurationDirectoryPath,
                 cacheDirectoryPath)
         {
-            ApplicationResourcesPath = applicationResourcesPath;
         }
 
-        public string ApplicationResourcesPath { get; private set; }
+        public string ApplicationResourcesPath { get; } = AppContext.BaseDirectory;
 
         /// <summary>
         /// Gets the path to the base root media directory
@@ -148,7 +144,6 @@ namespace Emby.Server.Implementations
             set => _internalMetadataPath = value;
         }
 
-        private const string _virtualInternalMetadataPath = "%MetadataPath%";
-        public string VirtualInternalMetadataPath => _virtualInternalMetadataPath;
+        public string VirtualInternalMetadataPath { get; } = "%MetadataPath%";
     }
 }

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -273,7 +273,7 @@ namespace Jellyfin.Server
                 }
             }
 
-            // Ensure the three main folders exist before we continue
+            // Ensure the main folders exist before we continue
             try
             {
                 Directory.CreateDirectory(dataDir);


### PR DESCRIPTION
**Changes**
Rewrite rules for determining dataDir, configDir and logDir locations.  Generally, arguments from command line take precedence, then JELLYFIN env vars, then APPDATA if Windows, otherwise follow XDG standard.

**Issues**
#698