### PR TITLE
Fix docker exec args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -21,4 +21,4 @@ RUN apt-get update \
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -30,4 +30,4 @@ COPY --from=qemu_extract qemu-* /usr/bin
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll -programdata /config
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config


### PR DESCRIPTION
After the changes in #749 we did not update docker to use the new args. This addresses that.