### PR TITLE
Add CentOS and update rpm spec for the cachedir option

### DIFF
--- a/bump_version
+++ b/bump_version
@@ -68,8 +68,7 @@ new_version="$1"
 # Parse the version from the AssemblyVersion
 old_version="$(
     grep "AssemblyVersion" ${shared_version_file} \
-        | sed -E 's/\[assembly: ?AssemblyVersion\("([0-9\.]+)"\)\]/\1/' \
-        | sed -E 's/.0$//'
+        | sed -E 's/\[assembly: ?AssemblyVersion\("([0-9\.]+)"\)\]/\1/'
 )"
 
 # Set the shared version to the specified new_version

--- a/deployment/centos-package-x64/Dockerfile
+++ b/deployment/centos-package-x64/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:7
+ARG HOME=/build
+RUN mkdir /build && \
+    yum install -y @buildsys-build rpmdevtools yum-plugins-core && \
+    rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm && \
+    rpmdev-setuptree
+
+WORKDIR /build/rpmbuild
+COPY ./deployment/centos-package-x64/pkg-src/jellyfin.spec SPECS
+COPY ./deployment/centos-package-x64/pkg-src/ SOURCES
+
+RUN spectool -g -R SPECS/jellyfin.spec && \
+    rpmbuild -bs SPECS/jellyfin.spec && \
+    yum-builddep  -y SRPMS/jellyfin-*.src.rpm && \
+    rpmbuild -bb SPECS/jellyfin.spec;

--- a/deployment/centos-package-x64/clean.sh
+++ b/deployment/centos-package-x64/clean.sh
@@ -1,0 +1,1 @@
+../fedora-package-x64/clean.sh

--- a/deployment/centos-package-x64/package.sh
+++ b/deployment/centos-package-x64/package.sh
@@ -1,0 +1,1 @@
+../fedora-package-x64/package.sh

--- a/deployment/centos-package-x64/pkg-src
+++ b/deployment/centos-package-x64/pkg-src
@@ -1,0 +1,1 @@
+../fedora-package-x64/pkg-src

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.env
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.env
@@ -21,7 +21,7 @@
 JELLYFIN_DATA_DIRECTORY="/var/lib/jellyfin"
 JELLYFIN_CONFIG_DIRECTORY="/etc/jellyfin"
 JELLYFIN_LOG_DIRECTORY="/var/log/jellyfin"
-JELLYFIN_CACHE_DIRECTORY="/var/log/jellyfin"
+JELLYFIN_CACHE_DIRECTORY="/var/cache/jellyfin"
 # In-App service control
 JELLYFIN_RESTART_OPT="--restartpath /usr/libexec/jellyfin/restart.sh"
 # Additional options for the binary

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -1,9 +1,10 @@
 %global         debug_package %{nil}
-# jellyfin tag to package
-%global         gittag v10.1.0
-# Taglib-sharp commit of the submodule since github archive doesn't include submodules
-%global         taglib_commit ee5ab21742b71fd1b87ee24895582327e9e04776
-%global         taglib_shortcommit %(c=%{taglib_commit}; echo ${c:0:7})
+# Set the dotnet runtime
+%if 0%{?fedora}
+%global         dotnet_runtime  fedora-x64
+%else
+%global         dotnet_runtime  centos-x64
+%endif
 
 AutoReq:        no
 Name:           jellyfin
@@ -51,7 +52,7 @@ Jellyfin is a free software media system that puts you in control of managing an
 %install
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-dotnet publish --configuration Release --output='%{buildroot}%{_libdir}/jellyfin' --self-contained --runtime fedora-x64 Jellyfin.Server
+dotnet publish --configuration Release --output='%{buildroot}%{_libdir}/jellyfin' --self-contained --runtime %{dotnet_runtime} Jellyfin.Server
 %{__install} -D -m 0644 LICENSE %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
 %{__install} -D -m 0644 %{SOURCE5} %{buildroot}%{_sysconfdir}/systemd/system/%{name}.service.d/override.conf
 %{__install} -D -m 0644 Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/%{name}/logging.json

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -6,7 +6,6 @@
 %global         dotnet_runtime  centos-x64
 %endif
 
-AutoReq:        no
 Name:           jellyfin
 Version:        10.1.0
 Release:        1%{?dist}
@@ -32,13 +31,11 @@ BuildRequires:  dotnet-sdk-2.2
 # RPMfusion free
 Requires:       ffmpeg
 
-# For the update-db-paths.sh script to fix emby paths to jellyfin
-%{?fedora:Recommends: sqlite}
-
 # Fedora has openssl1.1 which is incompatible with dotnet 
 %{?fedora:Requires: compat-openssl10}
-# Disable Automatic Dependency Processing for Centos
-%{?el7:AutoReqProv: no}
+
+# Disable Automatic Dependency Processing
+AutoReqProv:    no
 
 %description
 Jellyfin is a free software media system that puts you in control of managing and streaming your media.


### PR DESCRIPTION
**Changes**
Added CentOS package, integrated the `cachedir`  option into the `.spec` and cleaned the RPM Dependencies (so that the RPM does not claim to provide libraries which it simply does not provide or demand a version of `libc` which is not available on CentOS)

Also removed the `sed -E 's/.0$//'` from the `bump_version` script like in the `common.build.sh` script to prevent the removal of trailing zeros in the version number.

