### PR TITLE
Make Fedora package.sh script use bash

### DIFF
--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 source ../common.build.sh
 


### PR DESCRIPTION
**Changes**
Make the Fedora (and CentOS) `package.sh` script use `bash` instead of `sh`, as this causes a failure to load the version. This is the simplest method to fix this and makes it the same as the Debian script.

**Issues**
N/A
