### PR TITLE
Fix restart script in OS packages

### DIFF
--- a/deployment/debian-package-x64/pkg-src/bin/restart.sh
+++ b/deployment/debian-package-x64/pkg-src/bin/restart.sh
@@ -2,10 +2,12 @@
 
 NAME=jellyfin
 
-restart_cmds=("s6-svc -t /var/run/s6/services/${NAME}" \
-  "systemctl restart ${NAME}" \
-  "service ${NAME} restart" \
-  "/etc/init.d/${NAME} restart") 
+restart_cmds=(
+  "systemctl restart ${NAME}"
+  "service ${NAME} restart"
+  "/etc/init.d/${NAME} restart"
+  "s6-svc -t /var/run/s6/services/${NAME}"
+)
 
 for restart_cmd in "${restart_cmds[@]}"; do
   cmd=$(echo "$restart_cmd" | awk '{print $1}')

--- a/deployment/debian-package-x64/pkg-src/conf/jellyfin-sudoers
+++ b/deployment/debian-package-x64/pkg-src/conf/jellyfin-sudoers
@@ -10,15 +10,15 @@ Cmnd_Alias STARTSERVER_INITD = /etc/init.d/jellyfin start
 Cmnd_Alias STOPSERVER_INITD = /etc/init.d/jellyfin stop
 
 
-%jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSV
-%jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSV
-%jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSV
-%jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
-%jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD
-%jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSTEMD
-%jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_INITD
-%jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_INITD
-%jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_INITD
+jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSV
+jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSV
+jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSV
+jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_INITD
+jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_INITD
+jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_INITD
 
 Defaults!RESTARTSERVER_SYSV !requiretty
 Defaults!STARTSERVER_SYSV !requiretty
@@ -31,7 +31,7 @@ Defaults!STARTSERVER_INITD !requiretty
 Defaults!STOPSERVER_INITD !requiretty
 
 #Allow the server to mount iso images
-%jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-%jellyfin ALL=(ALL) NOPASSWD: /bin/umount
+jellyfin ALL=(ALL) NOPASSWD: /bin/mount
+jellyfin ALL=(ALL) NOPASSWD: /bin/umount
 
-Defaults:%jellyfin !requiretty
+Defaults:jellyfin !requiretty

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.sudoers
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.sudoers
@@ -12,8 +12,8 @@ Defaults!RESTARTSERVER_SYSTEMD !requiretty
 Defaults!STARTSERVER_SYSTEMD !requiretty
 Defaults!STOPSERVER_SYSTEMD !requiretty
 
-# Uncomment to allow the server to mount iso images
-# jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-# jellyfin ALL=(ALL) NOPASSWD: /bin/umount
+# Allow the server to mount iso images
+jellyfin ALL=(ALL) NOPASSWD: /bin/mount
+jellyfin ALL=(ALL) NOPASSWD: /bin/umount
 
 Defaults:jellyfin !requiretty

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.sudoers
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.sudoers
@@ -4,16 +4,16 @@ Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemctl start jellyfin, /bin/systemc
 Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemctl stop jellyfin, /bin/systemctl stop jellyfin
 
 
-%jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
-%jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD
-%jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD
+jellyfin ALL=(ALL) NOPASSWD: STOPSERVER_SYSTEMD
 
 Defaults!RESTARTSERVER_SYSTEMD !requiretty
 Defaults!STARTSERVER_SYSTEMD !requiretty
 Defaults!STOPSERVER_SYSTEMD !requiretty
 
 # Uncomment to allow the server to mount iso images
-# %jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-# %jellyfin ALL=(ALL) NOPASSWD: /bin/umount
+# jellyfin ALL=(ALL) NOPASSWD: /bin/mount
+# jellyfin ALL=(ALL) NOPASSWD: /bin/umount
 
-Defaults:%jellyfin !requiretty
+Defaults:jellyfin !requiretty


### PR DESCRIPTION
**Changes**
The restart script was broken on Debian, and possibly everywhere, by making some bad assumptions about sudoer permissions (assigned on the group level, rather than user level), as well as trying to run `s6-svc` first, which caused the `restart.sh` script to terminate prematurely on `systemd` at least. This PR fixes both issues for both Debian and Fedora/CentOS, i.e. grant `sudo` to the `jellyfin` user specifically rather than the group, and fix the order of the list of restart commands.

**Issues**
References #408