### PR TITLE
Fix poor handling of cache directories

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -178,7 +178,7 @@ namespace Emby.Server.Implementations.AppBase
                 if (string.IsNullOrWhiteSpace(((BaseApplicationPaths)CommonApplicationPaths).CachePath))
                 {
                     // Set cachePath to a default value under ProgramDataPath
-                    cachePath = (((BaseApplicationPaths)CommonApplicationPaths).ProgramDataPath + "/cache");
+                    cachePath = Path.Combine(((BaseApplicationPaths)CommonApplicationPaths).ProgramDataPath, "cache");
                 }
                 else
                 {

--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -171,16 +171,29 @@ namespace Emby.Server.Implementations.AppBase
         private void UpdateCachePath()
         {
             string cachePath;
-
+            // If the configuration file has no entry (i.e. not set in UI)
             if (string.IsNullOrWhiteSpace(CommonConfiguration.CachePath))
             {
-                cachePath = null;
+                // If the current live configuration has no entry (i.e. not set on CLI/envvars, during startup)
+                if (string.IsNullOrWhiteSpace(((BaseApplicationPaths)CommonApplicationPaths).CachePath))
+                {
+                    // Set cachePath to a default value under ProgramDataPath
+                    cachePath = (((BaseApplicationPaths)CommonApplicationPaths).ProgramDataPath + "/cache");
+                }
+                else
+                {
+                    // Set cachePath to the existing live value; will require restart if UI value is removed (but not replaced)
+                    // TODO: Figure out how to re-grab this from the CLI/envvars while running
+                    cachePath = ((BaseApplicationPaths)CommonApplicationPaths).CachePath;
+                }
             }
             else
             {
-                cachePath = Path.Combine(CommonConfiguration.CachePath, "cache");
+                // Set cachePath to the new UI-set value
+                cachePath = CommonConfiguration.CachePath;
             }
 
+            Logger.LogInformation("Setting cache path to " + cachePath);
             ((BaseApplicationPaths)CommonApplicationPaths).CachePath = cachePath;
         }
 


### PR DESCRIPTION
**Changes**
Allows the CLI and envvar `CacheDir` value to be respected and not overwritten by defaults when the UI/`system.xml` is empty.

**Issues**
N/A
