### PR TITLE
Add dotnet-compat ABI testing and Debug configuration building to drone-CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ README.md
 deployment/*/dist
 deployment/*/pkg-dist
 deployment/collect-dist/
+ci/

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,103 +10,70 @@ steps:
 - name: build
   image: microsoft/dotnet:2-sdk
   commands:
-    - dotnet publish --configuration release --output /release Jellyfin.Server
+    - dotnet publish "Jellyfin.Server" --configuration Release --output "../ci/ci-release"
 
 - name: clone-dotnet-compat
   image: docker:git
   commands:
-    - git clone --depth 1 https://github.com/EraYaN/dotnet-compatibility
-  when:
-    event:
-    - pull_request
+    - git clone --depth 1 https://github.com/EraYaN/dotnet-compatibility ci/dotnet-compatibility
 
 - name: build-dotnet-compat
   image: microsoft/dotnet:2-sdk
   commands:
-    - dotnet publish --runtime debian.9-x64 --configuration release --output /tools dotnet-compatibility/CompatibilityCheckerCoreCLI
-  when:
-    event:
-    - pull_request
+    - dotnet publish "ci/dotnet-compatibility/CompatibilityCheckerCoreCLI" --configuration Release --output "../../ci-tools"
 
 - name: download-last-nuget-release-common
   image: plugins/download
   settings:
     source: https://www.nuget.org/api/v2/package/Jellyfin.Common
-    destination: Jellyfin.Common.nupkg
-  when:
-    event:
-    - pull_request
+    destination: ci/Jellyfin.Common.nupkg
 
 - name: download-last-nuget-release-model
   image: plugins/download
   settings:
     source: https://www.nuget.org/api/v2/package/Jellyfin.Model
-    destination: Jellyfin.Model.nupkg
-  when:
-    event:
-    - pull_request
+    destination: ci/Jellyfin.Model.nupkg
 
 - name: download-last-nuget-release-controller
   image: plugins/download
   settings:
     source: https://www.nuget.org/api/v2/package/Jellyfin.Controller
-    destination: Jellyfin.Controller.nupkg
-  when:
-    event:
-    - pull_request
+    destination: ci/Jellyfin.Controller.nupkg
 
 - name: download-last-nuget-release-naming
   image: plugins/download
   settings:
     source: https://www.nuget.org/api/v2/package/Jellyfin.Naming
-    destination: Jellyfin.Naming.nupkg
-  when:
-    event:
-    - pull_request
+    destination: ci/Jellyfin.Naming.nupkg
 
 - name: extract-downloaded-nuget-packages
   image: garthk/unzip
   commands:
-  - unzip -j Jellyfin.Common.nupkg  "*.dll" -d /current-release
-  - unzip -j Jellyfin.Model.nupkg  "*.dll" -d /current-release
-  - unzip -j Jellyfin.Controller.nupkg  "*.dll" -d /current-release
-  - unzip -j Jellyfin.Naming.nupkg  "*.dll" -d /current-release
-  when:
-    event:
-    - pull_request
+  - unzip -j ci/Jellyfin.Common.nupkg  "*.dll" -d ci/nuget-packages
+  - unzip -j ci/Jellyfin.Model.nupkg  "*.dll" -d ci/nuget-packages
+  - unzip -j ci/Jellyfin.Controller.nupkg  "*.dll" -d ci/nuget-packages
+  - unzip -j ci/Jellyfin.Naming.nupkg  "*.dll" -d ci/nuget-packages
 
 - name: run-dotnet-compat-common
-  image: debian:stretch
+  image: microsoft/dotnet:2-runtime
   err_ignore: true
   commands:
-  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
-  when:
-    event:
-    - pull_request
+  - dotnet ci/ci-tools/CompatibilityCheckerCoreCLI.dll ci/nuget-packages/Jellyfin.Common.dll ci/ci-release/Jellyfin.Common.dll
 
 - name: run-dotnet-compat-model
-  image: debian:stretch
+  image: microsoft/dotnet:2-runtime
   err_ignore: true
   commands:
-  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
-  when:
-    event:
-    - pull_request
+  - dotnet ci/ci-tools/CompatibilityCheckerCoreCLI.dll ci/nuget-packages/Jellyfin.Model.dll ci/ci-release/Jellyfin.Model.dll
 
 - name: run-dotnet-compat-controller
-  image: debian:stretch
+  image: microsoft/dotnet:2-runtime
   err_ignore: true
   commands:
-  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
-  when:
-    event:
-    - pull_request
+  - dotnet ci/ci-tools/CompatibilityCheckerCoreCLI.dll ci/nuget-packages/Jellyfin.Controller.dll ci/ci-release/Jellyfin.Controller.dll
 
 - name: run-dotnet-compat-naming
-  image: debian:stretch
+  image: microsoft/dotnet:2-runtime
   err_ignore: true
   commands:
-  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
-  when:
-    event:
-    - pull_request
+  - dotnet ci/ci-tools/CompatibilityCheckerCoreCLI.dll ci/nuget-packages/Jellyfin.Naming.dll ci/ci-release/Jellyfin.Naming.dll

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,37 @@
+---
 kind: pipeline
-name: build
+name: build-debug
+
+steps:
+- name: submodules
+  image: docker:git
+  commands:
+    - git submodule update --init --recursive
+
+- name: build
+  image: microsoft/dotnet:2-sdk
+  commands:
+    - dotnet publish "Jellyfin.Server" --configuration Debug --output "../ci/ci-debug"
+
+---
+kind: pipeline
+name: build-release
+
+steps:
+- name: submodules
+  image: docker:git
+  commands:
+    - git submodule update --init --recursive
+
+- name: build
+  image: microsoft/dotnet:2-sdk
+  commands:
+    - dotnet publish "Jellyfin.Server" --configuration Release --output "../ci/ci-release"
+
+---
+
+kind: pipeline
+name: check-abi
 
 steps:
 - name: submodules

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,32 +77,36 @@ steps:
 
 - name: run-dotnet-compat-common
   image: microsoft/dotnet:2-runtime
+  err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
+  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-model
   image: microsoft/dotnet:2-runtime
+  err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
+  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-controller
   image: microsoft/dotnet:2-runtime
+  err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
+  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-naming
   image: microsoft/dotnet:2-runtime
+  err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
+  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
   when:
     event:
     - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
 - name: build-dotnet-compat
   image: microsoft/dotnet:2-sdk
   commands:
-    - dotnet publish --configuration release --output /tools dotnet-compatibility/CompatibilityCheckerCoreCLI
+    - dotnet publish --runtime debian.9-x64 --configuration release --output /tools dotnet-compatibility/CompatibilityCheckerCoreCLI
   when:
     event:
     - pull_request
@@ -76,37 +76,37 @@ steps:
     - pull_request
 
 - name: run-dotnet-compat-common
-  image: microsoft/dotnet:2-runtime
+  image: debian:stretch
   err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
+  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-model
-  image: microsoft/dotnet:2-runtime
+  image: debian:stretch
   err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
+  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-controller
-  image: microsoft/dotnet:2-runtime
+  image: debian:stretch
   err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
+  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
   when:
     event:
     - pull_request
 
 - name: run-dotnet-compat-naming
-  image: microsoft/dotnet:2-runtime
+  image: debian:stretch
   err_ignore: true
   commands:
-  - dotnet /tools/CompatibilityCheckerCoreCLI.dll /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
+  - /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
   when:
     event:
     - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,103 @@ steps:
   image: docker:git
   commands:
     - git submodule update --init --recursive
+
 - name: build
   image: microsoft/dotnet:2-sdk
   commands:
     - dotnet publish --configuration release --output /release Jellyfin.Server
+
+- name: clone-dotnet-compat
+  image: docker:git
+  commands:
+    - git clone --depth 1 https://github.com/EraYaN/dotnet-compatibility
+  when:
+    event:
+    - pull_request
+
+- name: build-dotnet-compat
+  image: microsoft/dotnet:2-sdk
+  commands:
+    - dotnet publish --configuration release --output /tools dotnet-compatibility/CompatibilityCheckerCoreCLI
+  when:
+    event:
+    - pull_request
+
+- name: download-last-nuget-release-common
+  image: plugins/download
+  settings:
+    source: https://www.nuget.org/api/v2/package/Jellyfin.Common
+    destination: Jellyfin.Common.nupkg
+  when:
+    event:
+    - pull_request
+
+- name: download-last-nuget-release-model
+  image: plugins/download
+  settings:
+    source: https://www.nuget.org/api/v2/package/Jellyfin.Model
+    destination: Jellyfin.Model.nupkg
+  when:
+    event:
+    - pull_request
+
+- name: download-last-nuget-release-controller
+  image: plugins/download
+  settings:
+    source: https://www.nuget.org/api/v2/package/Jellyfin.Controller
+    destination: Jellyfin.Controller.nupkg
+  when:
+    event:
+    - pull_request
+
+- name: download-last-nuget-release-naming
+  image: plugins/download
+  settings:
+    source: https://www.nuget.org/api/v2/package/Jellyfin.Naming
+    destination: Jellyfin.Naming.nupkg
+  when:
+    event:
+    - pull_request
+
+- name: extract-downloaded-nuget-packages
+  image: garthk/unzip
+  commands:
+  - unzip -j Jellyfin.Common.nupkg  "*.dll" -d /current-release
+  - unzip -j Jellyfin.Model.nupkg  "*.dll" -d /current-release
+  - unzip -j Jellyfin.Controller.nupkg  "*.dll" -d /current-release
+  - unzip -j Jellyfin.Naming.nupkg  "*.dll" -d /current-release
+  when:
+    event:
+    - pull_request
+
+- name: run-dotnet-compat-common
+  image: microsoft/dotnet:2-runtime
+  commands:
+  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Common.dll /release/Jellyfin.Common.dll
+  when:
+    event:
+    - pull_request
+
+- name: run-dotnet-compat-model
+  image: microsoft/dotnet:2-runtime
+  commands:
+  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Model.dll /release/Jellyfin.Model.dll
+  when:
+    event:
+    - pull_request
+
+- name: run-dotnet-compat-controller
+  image: microsoft/dotnet:2-runtime
+  commands:
+  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Controller.dll /release/Jellyfin.Controller.dll
+  when:
+    event:
+    - pull_request
+
+- name: run-dotnet-compat-naming
+  image: microsoft/dotnet:2-runtime
+  commands:
+  - dotnet /tools/CompatibilityCheckerCoreCLI /current-release/Jellyfin.Naming.dll /release/Jellyfin.Naming.dll
+  when:
+    event:
+    - pull_request

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,10 @@ insert_final_newline = true
 end_of_line = lf
 max_line_length = null
 
+# YAML indentation
+[*.{yml,yaml}]
+indent_size = 2
+
 # XML indentation
 [*.{csproj,xml}]
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ deployment/**/pkg-dist-tmp/
 deployment/collect-dist/
 
 jellyfin_version.ini
+
+ci/


### PR DESCRIPTION
**Changes**
Adds a whole bunch of stages to the drone-ci (but only for pull-requests)
