### PR TITLE
Adding support for "tvg-chno"-Tag in M3U Channel Lists

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
@@ -204,6 +204,14 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 }
             }
 
+            if (!IsValidChannelNumber(numberString))
+            {
+                if (attributes.TryGetValue("tvg-chno", out string value))
+                {
+                    numberString = value;
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(numberString))
             {
                 numberString = numberString.Trim();


### PR DESCRIPTION
**Changes**
Emby announced this back in July of 2018 (ref.: [https://emby.media/community/index.php?/topic/56691-m3u-channel-numbers/?p=601373](url)). Implemented this and tested it with a playlist.m3u generated from TVHeadend which is using the "tvg-chno"-Tag.

![image](https://user-images.githubusercontent.com/6041926/52539859-3c786680-2d83-11e9-92c3-d5d712f58594.png)
![image](https://user-images.githubusercontent.com/6041926/52539871-4d28dc80-2d83-11e9-9fab-96c224ad6f91.png)

**Issues**
This fixes #820 in my test environment
