### PR TITLE
Do not hash empty strings

### DIFF
--- a/Emby.Server.Implementations/Library/DefaultAuthenticationProvider.cs
+++ b/Emby.Server.Implementations/Library/DefaultAuthenticationProvider.cs
@@ -52,7 +52,7 @@ namespace Emby.Server.Implementations.Library
 
         private bool IsPasswordEmpty(User user, string passwordHash)
         {
-            return string.Equals(passwordHash, GetEmptyHashedString(user), StringComparison.OrdinalIgnoreCase);
+            return string.IsNullOrEmpty(passwordHash);
         }
 
         public Task ChangePassword(User user, string newPassword)
@@ -76,14 +76,7 @@ namespace Emby.Server.Implementations.Library
 
         public string GetPasswordHash(User user)
         {
-            return string.IsNullOrEmpty(user.Password)
-                ? GetEmptyHashedString(user)
-                : user.Password;
-        }
-
-        public string GetEmptyHashedString(User user)
-        {
-            return GetHashedString(user, string.Empty);
+            return user.Password;
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -402,16 +402,16 @@ namespace Emby.Server.Implementations.Library
             bool success = false;
             IAuthenticationProvider authenticationProvider = null;
 
-            if (password != null && user != null)
+            if (!string.IsNullOrEmpty(password) && user != null)
             {
                 // Doesn't look like this is even possible to be used, because of password == null checks below
                 hashedPassword = _defaultAuthenticationProvider.GetHashedString(user, password);
             }
 
-            if (password == null)
+            if (string.IsNullOrEmpty(password))
             {
                 // legacy
-                success = string.Equals(_defaultAuthenticationProvider.GetPasswordHash(user), hashedPassword.Replace("-", string.Empty), StringComparison.OrdinalIgnoreCase);
+                success = string.Equals(_defaultAuthenticationProvider.GetPasswordHash(user), hashedPassword?.Replace("-", string.Empty), StringComparison.OrdinalIgnoreCase);
             }
             else
             {
@@ -478,13 +478,8 @@ namespace Emby.Server.Implementations.Library
         private string GetLocalPasswordHash(User user)
         {
             return string.IsNullOrEmpty(user.EasyPassword)
-                ? _defaultAuthenticationProvider.GetEmptyHashedString(user)
+                ? null
                 : user.EasyPassword;
-        }
-
-        private bool IsPasswordEmpty(User user, string passwordHash)
-        {
-            return string.Equals(passwordHash, _defaultAuthenticationProvider.GetEmptyHashedString(user), StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -530,7 +525,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             var hasConfiguredPassword = GetAuthenticationProvider(user).HasPassword(user).Result;
-            var hasConfiguredEasyPassword = !IsPasswordEmpty(user, GetLocalPasswordHash(user));
+            var hasConfiguredEasyPassword = !string.IsNullOrEmpty(GetLocalPasswordHash(user));
 
             var hasPassword = user.Configuration.EnableLocalPassword && !string.IsNullOrEmpty(remoteEndPoint) && _networkManager.IsInLocalNetwork(remoteEndPoint) ?
                 hasConfiguredEasyPassword :


### PR DESCRIPTION
**Changes**
Removed hashing of empty strings in authentication and added a migration to remove any such hash from the user table.

This PR is mostly to have a discussion related to https://github.com/jellyfin/jellyfin/pull/870 with a small example. It was discussed in Riot that it currently hashes the empty string _often_ which for pbkdf2 is super slow and can potentially waste a lot of CPU/GPU cycles as the number of users increases.