### PR TITLE
Replace primitive injection with IConfiguration

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Emby.Server.Implementations.IO;
+
+namespace Emby.Server.Implementations
+{
+    public static class ConfigurationOptions
+    {
+        public static readonly Dictionary<string, string> Configuration = new Dictionary<string, string>
+        {
+            {"ManagedFileSystem:DefaultDirectory", null},
+            {"ManagedFileSystem:EnableSeparateFileAndDirectoryQueries", "True"}
+        };
+    }
+}

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Emby.Server.Implementations.IO;
 
 namespace Emby.Server.Implementations
 {

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -6,8 +6,7 @@ namespace Emby.Server.Implementations
     {
         public static readonly Dictionary<string, string> Configuration = new Dictionary<string, string>
         {
-            {"ManagedFileSystem:DefaultDirectory", null},
-            {"ManagedFileSystem:EnableSeparateFileAndDirectoryQueries", "True"}
+            {"HttpListenerHost:DefaultRedirectPath", "web/index.html"}
         };
     }
 }

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="ServiceStack.Text.Core" Version="5.4.0" />
     <PackageReference Include="sharpcompress" Version="0.22.0" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="1.0.0" />
@@ -44,12 +45,6 @@
     <EmbeddedResource Include="Localization\countries.json" />
     <EmbeddedResource Include="Localization\Core\*.json" />
     <EmbeddedResource Include="Localization\Ratings\*.csv" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-      <HintPath>..\..\..\.nuget\packages\microsoft.extensions.configuration.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -46,4 +46,10 @@
     <EmbeddedResource Include="Localization\Ratings\*.csv" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\.nuget\packages\microsoft.extensions.configuration.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -19,7 +19,9 @@ using MediaBrowser.Model.Events;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using ServiceStack.Text.Jsv;
 
 namespace Emby.Server.Implementations.HttpServer
 {
@@ -53,20 +55,20 @@ namespace Emby.Server.Implementations.HttpServer
             IServerApplicationHost applicationHost,
             ILoggerFactory loggerFactory,
             IServerConfigurationManager config,
-            string defaultRedirectPath,
+            IConfiguration configuration,
             INetworkManager networkManager,
             IJsonSerializer jsonSerializer,
-            IXmlSerializer xmlSerializer,
-            Func<Type, Func<string, object>> funcParseFn)
+            IXmlSerializer xmlSerializer)
         {
             _appHost = applicationHost;
             _logger = loggerFactory.CreateLogger("HttpServer");
             _config = config;
-            DefaultRedirectPath = defaultRedirectPath;
+            DefaultRedirectPath = configuration["HttpListenerHost:DefaultRedirectPath"];
             _networkManager = networkManager;
             _jsonSerializer = jsonSerializer;
             _xmlSerializer = xmlSerializer;
-            _funcParseFn = funcParseFn;
+            
+            _funcParseFn = t => s => JsvReader.GetParseFn(t)(s);
 
             Instance = this;
             ResponseFilters = Array.Empty<Action<IRequest, IResponse, object>>();

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -5,14 +5,31 @@ using Emby.Server.Implementations.HttpServer;
 using Jellyfin.Server.SocketSharp;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Server
 {
     public class CoreAppHost : ApplicationHost
     {
-        public CoreAppHost(ServerApplicationPaths applicationPaths, ILoggerFactory loggerFactory, StartupOptions options, IFileSystem fileSystem, IEnvironmentInfo environmentInfo, MediaBrowser.Controller.Drawing.IImageEncoder imageEncoder, MediaBrowser.Common.Net.INetworkManager networkManager)
-            : base(applicationPaths, loggerFactory, options, fileSystem, environmentInfo, imageEncoder, networkManager)
+        public CoreAppHost(
+            ServerApplicationPaths applicationPaths,
+            ILoggerFactory loggerFactory,
+            StartupOptions options,
+            IFileSystem fileSystem,
+            IEnvironmentInfo environmentInfo,
+            MediaBrowser.Controller.Drawing.IImageEncoder imageEncoder,
+            MediaBrowser.Common.Net.INetworkManager networkManager,
+            IConfiguration configuration)
+            : base(
+                applicationPaths,
+                loggerFactory,
+                options,
+                fileSystem,
+                environmentInfo,
+                imageEncoder,
+                networkManager,
+                configuration)
         {
         }
 

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Server
             // Allow all https requests
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(delegate { return true; } );
 
-            var fileSystem = new ManagedFileSystem(_loggerFactory, environmentInfo, appPaths, appConfig);
+            var fileSystem = new ManagedFileSystem(_loggerFactory, environmentInfo, appPaths);
 
             using (var appHost = new CoreAppHost(
                 appPaths,
@@ -135,7 +135,8 @@ namespace Jellyfin.Server
                 fileSystem,
                 environmentInfo,
                 new NullImageEncoder(),
-                new NetworkManager(_loggerFactory, environmentInfo)))
+                new NetworkManager(_loggerFactory, environmentInfo),
+                appConfig))
             {
                 await appHost.Init(new ServiceCollection()).ConfigureAwait(false);
 

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -82,7 +82,7 @@ namespace Jellyfin.Server
 
             appConfig = await CreateConfiguration(appPaths).ConfigureAwait(false);
 
-            await CreateLogger(appConfig, appPaths).ConfigureAwait(false);
+            CreateLogger(appConfig, appPaths);
 
             _logger = _loggerFactory.CreateLogger("Main");
 
@@ -338,7 +338,7 @@ namespace Jellyfin.Server
                 .Build();
         }
 
-        private static async Task CreateLogger(IConfiguration configuration, IApplicationPaths appPaths)
+        private static void CreateLogger(IConfiguration configuration, IApplicationPaths appPaths)
         {
             try
             {

--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -173,14 +173,8 @@ namespace MediaBrowser.Api
             _fileSystem.DeleteFile(file);
         }
 
-        public object Get(GetDefaultDirectoryBrowser request)
-        {
-            var result = new DefaultDirectoryBrowserInfo();
-
-            result.Path = _fileSystem.DefaultDirectory;
-
-            return ToOptimizedResult(result);
-        }
+        public object Get(GetDefaultDirectoryBrowser request) =>
+            ToOptimizedResult(new DefaultDirectoryBrowserInfo {Path = null});
 
         /// <summary>
         /// Gets the specified request.

--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -113,8 +113,6 @@ namespace MediaBrowser.Model.IO
         Stream GetFileStream(string path, FileOpenMode mode, FileAccessMode access, FileShareMode share,
             FileOpenOptions fileOpenOptions);
 
-        string DefaultDirectory { get; }
-
         /// <summary>
         /// Swaps the files.
         /// </summary>


### PR DESCRIPTION
**Description**
Currently, we create all instances of our registered services manually in ApplicationHost. This is very much an anti pattern for Dependency Injection. The correct way is to create the dependency injection container and register services against it with the specified creation policy (singleton, per instance, per scope etc.). This allows the container to manage the lifetime of the objects that it creates and automatically calls Dispose on services that implement IDisposable.

This commit is just a start to removing the primitives from services that are manually created and registered. We need to do this to eventually get to a point where the container can be responsible for the creation of these services. 

I'm following the guidance from the dot net core developer reference -> https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1 
