### PR TITLE
Add jellyfin-ffmpeg and versioning to package deps

### DIFF
--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -18,6 +18,11 @@ Replaces: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Breaks: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
-Depends: at, libsqlite3-0, ffmpeg, libfontconfig1, libfreetype6, libssl1.0.0 | libssl1.0.2
+Depends: at,
+         libsqlite3-0,
+         ffmpeg (<7:4.1) | jellyfin-ffmpeg,
+         libfontconfig1,
+         libfreetype6,
+         libssl1.0.0 | libssl1.0.2
 Description: Jellyfin is a home media server.
  It is built on top of other popular open source technologies such as Service Stack, jQuery, jQuery mobile, and Mono. It features a REST-based api with built-in documentation to facilitate client development. We also have client libraries for our api to enable rapid development.


### PR DESCRIPTION
**Changes**
Adds explicit versioning (<4.1) for ffmpeg in the package specs, and the `jellyfin-ffmpeg` optional dependency to provide ffmpeg instead. This facilitates providing a Jellyfin-specific ffmpeg build into our package repositories that provides a version we can use going forward as distros move to 4.1. The version constraint will be removed once ffmpeg 4.1 support is working, or we move to our own build exclusively.

CC @Wuerfelbecher for verifying compatibility of the RPM config (based on https://serverfault.com/a/761187/188250).

**Issues**
N/A
