### PR TITLE
DLNA: Fix race condition leading to missing device names

### DIFF
--- a/Emby.Dlna/PlayTo/PlayToManager.cs
+++ b/Emby.Dlna/PlayTo/PlayToManager.cs
@@ -89,11 +89,6 @@ namespace Emby.Dlna.PlayTo
                 return;
             }
 
-            if (_sessionManager.Sessions.Any(i => usn.IndexOf(i.DeviceId, StringComparison.OrdinalIgnoreCase) != -1))
-            {
-                return;
-            }
-
             var cancellationToken = _disposeCancellationTokenSource.Token;
 
             await _sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -101,6 +96,11 @@ namespace Emby.Dlna.PlayTo
             try
             {
                 if (_disposed)
+                {
+                    return;
+                }
+
+                if (_sessionManager.Sessions.Any(i => usn.IndexOf(i.DeviceId, StringComparison.OrdinalIgnoreCase) != -1))
                 {
                     return;
                 }


### PR DESCRIPTION
**Changes**
On device discovery the current code checks if the session contains the discovered device. If it exists, nothing more is done. However, when a device is first discovered, different methods are called to (1) add the device to the session and (2) set the device's name. 

This race condition can occur:
1. Device is discovered (does not exist in sessions).
2. Device is added/updated (GetOrAdd) with null as name. <-- here it's added for the first time
3. Name is set. <-- only called if device was not already added 
4. Device is discovered (again) (still does not exist in sessions)
5. Device is added/updated (GetOrAdd) with null as name. <-- second time. Now it just updates with null as the name
6. Device added to session.

The code is not that easy to fix so the proposed patch simply moves the "is device already added" check inside the lock.
