### PR TITLE
COPR auto building

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,9 @@
+srpm:
+	dnf -y install git
+	git submodule init
+	git submodule update
+	cd deployment/fedora-package-x64;                    \
+	./create_tarball.sh;                                 \
+	rpmbuild -bs pkg-src/jellyfin.spec                   \
+	         --define "_sourcedir $$PWD/pkg-src/"        \
+		 --define "_srcrpmdir $(outdir)"

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,6 @@
 srpm:
 	dnf -y install git
-	git submodule init
-	git submodule update
+	git submodule update --init --recursive
 	cd deployment/fedora-package-x64;                    \
 	./create_tarball.sh;                                 \
 	rpmbuild -bs pkg-src/jellyfin.spec                   \

--- a/deployment/fedora-package-x64/create_tarball.sh
+++ b/deployment/fedora-package-x64/create_tarball.sh
@@ -24,12 +24,12 @@ tar \
 --exclude='**/.nuget' \
 --exclude='*.deb' \
 --exclude='*.rpm' \
--Jcf "$pkg_src_dir/jellyfin-${VERSION}.tar.xz" \
+-czf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz" \
 -C "../.." ./ || GNU_TAR=0
 
 if [ $GNU_TAR -eq 0 ]; then
     echo "The installed tar binary did not support --transform. Using workaround."
-    mkdir -p "${package_temporary_dir}/jellyfin"
+    mkdir -p "${package_temporary_dir}/jellyfin"{,-"${VERSION}"}
     # Not GNU tar
     tar \
     --exclude='.git*' \
@@ -47,9 +47,9 @@ if [ $GNU_TAR -eq 0 ]; then
     "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
     -C "../.." ./
     echo "Extracting filtered package."
-    tar -Jzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
+    tar -xzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
     echo "Removing filtered package."
     rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"
     echo "Repackaging package into final tarball."
-    tar -Jzf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
+    tar -czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
 fi

--- a/deployment/fedora-package-x64/create_tarball.sh
+++ b/deployment/fedora-package-x64/create_tarball.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source ../common.build.sh
+
+WORKDIR="$( pwd )"
+VERSION="$( sed -ne '/^Version:/s/.*  *//p' "${WORKDIR}"/pkg-src/jellyfin.spec )"
+
+package_temporary_dir="${WORKDIR}/pkg-dist-tmp"
+pkg_src_dir="${WORKDIR}/pkg-src"
+
+GNU_TAR=1
+echo "Bundling all sources for RPM build."
+tar \
+--transform "s,^\.,jellyfin-${VERSION}," \
+--exclude='.git*' \
+--exclude='**/.git' \
+--exclude='**/.hg' \
+--exclude='**/.vs' \
+--exclude='**/.vscode' \
+--exclude='deployment' \
+--exclude='**/bin' \
+--exclude='**/obj' \
+--exclude='**/.nuget' \
+--exclude='*.deb' \
+--exclude='*.rpm' \
+-Jcf "$pkg_src_dir/jellyfin-${VERSION}.tar.xz" \
+-C "../.." ./ || GNU_TAR=0
+
+if [ $GNU_TAR -eq 0 ]; then
+    echo "The installed tar binary did not support --transform. Using workaround."
+    mkdir -p "${package_temporary_dir}/jellyfin"
+    # Not GNU tar
+    tar \
+    --exclude='.git*' \
+    --exclude='**/.git' \
+    --exclude='**/.hg' \
+    --exclude='**/.vs' \
+    --exclude='**/.vscode' \
+    --exclude='deployment' \
+    --exclude='**/bin' \
+    --exclude='**/obj' \
+    --exclude='**/.nuget' \
+    --exclude='*.deb' \
+    --exclude='*.rpm' \
+    -zcf \
+    "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
+    -C "../.." ./
+    echo "Extracting filtered package."
+    tar -Jzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
+    echo "Removing filtered package."
+    rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"
+    echo "Repackaging package into final tarball."
+    tar -Jzf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
+fi

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -21,52 +21,7 @@ else
     docker_sudo=""
 fi
 
-# Create RPM source archive
-GNU_TAR=1
-mkdir -p "${package_temporary_dir}"
-echo "Bundling all sources for RPM build."
-tar \
---transform "s,^\.,jellyfin-${VERSION}," \
---exclude='.git*' \
---exclude='**/.git' \
---exclude='**/.hg' \
---exclude='**/.vs' \
---exclude='**/.vscode' \
---exclude='deployment' \
---exclude='**/bin' \
---exclude='**/obj' \
---exclude='**/.nuget' \
---exclude='*.deb' \
---exclude='*.rpm' \
--czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" \
--C "../.." ./ || GNU_TAR=0
-
-if [ $GNU_TAR -eq 0 ]; then
-    echo "The installed tar binary did not support --transform. Using workaround."
-    mkdir -p "${package_temporary_dir}/jellyfin"
-    # Not GNU tar
-    tar \
-    --exclude='.git*' \
-    --exclude='**/.git' \
-    --exclude='**/.hg' \
-    --exclude='**/.vs' \
-    --exclude='**/.vscode' \
-    --exclude='deployment' \
-    --exclude='**/bin' \
-    --exclude='**/obj' \
-    --exclude='**/.nuget' \
-    --exclude='*.deb' \
-    --exclude='*.rpm' \
-    -zcf \
-    "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
-    -C "../.." ./
-    echo "Extracting filtered package."
-    tar -xzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
-    echo "Removing filtered package."
-    rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"
-    echo "Repackaging package into final tarball."
-    tar -czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
-fi
+./create_tarball.sh
 
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -12,7 +12,7 @@ Release:        1%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
 URL:            https://jellyfin.media
-Source0:        %{name}-%{version}.tar.xz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        jellyfin.service
 Source2:        jellyfin.env
 Source3:        jellyfin.sudoers

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -12,7 +12,7 @@ Release:        1%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
 URL:            https://jellyfin.media
-Source0:        %{name}-%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.xz
 Source1:        jellyfin.service
 Source2:        jellyfin.env
 Source3:        jellyfin.sudoers


### PR DESCRIPTION
This adds enhancements so that Fedora/EL packages can be automatically
built in [COPR](https://copr.fedorainfracloud.org/coprs/) when a webhook is received.  A typical webhook could be
for tagging events for example or even in the future when COPR supports it,
a "Release" webhook to only build releases.