### PR TITLE
Fix assembly visibility

### DIFF
--- a/Emby.Server.Implementations/Channels/RefreshChannelsScheduledTask.cs
+++ b/Emby.Server.Implementations/Channels/RefreshChannelsScheduledTask.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Channels
 {
-    class RefreshChannelsScheduledTask : IScheduledTask, IConfigurableScheduledTask
+    public class RefreshChannelsScheduledTask : IScheduledTask, IConfigurableScheduledTask
     {
         private readonly IChannelManager _channelManager;
         private readonly IUserManager _userManager;

--- a/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.EntryPoints
 {
-    class UserDataChangeNotifier : IServerEntryPoint
+    public class UserDataChangeNotifier : IServerEntryPoint
     {
         private readonly ISessionManager _sessionManager;
         private readonly ILogger _logger;

--- a/Emby.Server.Implementations/Library/Resolvers/SpecialFolderResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/SpecialFolderResolver.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Library.Resolvers
 {
-    class SpecialFolderResolver : FolderResolver<Folder>
+    public class SpecialFolderResolver : FolderResolver<Folder>
     {
         private readonly IFileSystem _fileSystem;
         private readonly IServerApplicationPaths _appPaths;

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
@@ -21,7 +21,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
     /// <summary>
     /// Class ChapterImagesTask
     /// </summary>
-    class ChapterImagesTask : IScheduledTask
+    public class ChapterImagesTask : IScheduledTask
     {
         /// <summary>
         /// The _logger

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Sorting
 {
-    class AiredEpisodeOrderComparer : IBaseItemComparer
+    public class AiredEpisodeOrderComparer : IBaseItemComparer
     {
         /// <summary>
         /// Compares the specified x.

--- a/Emby.Server.Implementations/Sorting/SeriesSortNameComparer.cs
+++ b/Emby.Server.Implementations/Sorting/SeriesSortNameComparer.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Sorting
 {
-    class SeriesSortNameComparer : IBaseItemComparer
+    public class SeriesSortNameComparer : IBaseItemComparer
     {
         /// <summary>
         /// Compares the specified x.

--- a/MediaBrowser.Api/Session/SessionInfoWebSocketListener.cs
+++ b/MediaBrowser.Api/Session/SessionInfoWebSocketListener.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Api.Session
     /// <summary>
     /// Class SessionInfoWebSocketListener
     /// </summary>
-    class SessionInfoWebSocketListener : BasePeriodicWebSocketListener<IEnumerable<SessionInfo>, WebSocketListenerState>
+    public class SessionInfoWebSocketListener : BasePeriodicWebSocketListener<IEnumerable<SessionInfo>, WebSocketListenerState>
     {
         /// <summary>
         /// Gets the name.

--- a/MediaBrowser.Api/System/ActivityLogWebSocketListener.cs
+++ b/MediaBrowser.Api/System/ActivityLogWebSocketListener.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Api.System
     /// <summary>
     /// Class SessionInfoWebSocketListener
     /// </summary>
-    class ActivityLogWebSocketListener : BasePeriodicWebSocketListener<List<ActivityLogEntry>, WebSocketListenerState>
+    public class ActivityLogWebSocketListener : BasePeriodicWebSocketListener<List<ActivityLogEntry>, WebSocketListenerState>
     {
         /// <summary>
         /// Gets the name.

--- a/MediaBrowser.LocalMetadata/Providers/PlaylistXmlProvider.cs
+++ b/MediaBrowser.LocalMetadata/Providers/PlaylistXmlProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.LocalMetadata.Providers
 {
-    class PlaylistXmlProvider : BaseXmlProvider<Playlist>
+    public class PlaylistXmlProvider : BaseXmlProvider<Playlist>
     {
         private readonly ILogger _logger;
         private readonly IProviderManager _providerManager;

--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
@@ -14,7 +14,7 @@ using MediaBrowser.Providers.Movies;
 
 namespace MediaBrowser.Providers.BoxSets
 {
-    class MovieDbBoxSetImageProvider : IRemoteImageProvider, IHasOrder
+    public class MovieDbBoxSetImageProvider : IRemoteImageProvider, IHasOrder
     {
         private readonly IHttpClient _httpClient;
 

--- a/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
@@ -16,7 +16,7 @@ using MediaBrowser.Model.Serialization;
 
 namespace MediaBrowser.Providers.Movies
 {
-    class MovieDbImageProvider : IRemoteImageProvider, IHasOrder
+    public class MovieDbImageProvider : IRemoteImageProvider, IHasOrder
     {
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IHttpClient _httpClient;

--- a/MediaBrowser.Providers/Music/MusicVideoMetadataService.cs
+++ b/MediaBrowser.Providers/Music/MusicVideoMetadataService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Music
 {
-    class MusicVideoMetadataService : MetadataService<MusicVideo, MusicVideoInfo>
+    public class MusicVideoMetadataService : MetadataService<MusicVideo, MusicVideoInfo>
     {
         protected override void MergeData(MetadataResult<MusicVideo> source, MetadataResult<MusicVideo> target, MetadataFields[] lockedFields, bool replaceData, bool mergeMetadataSettings)
         {

--- a/MediaBrowser.Providers/Photos/PhotoAlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Photos/PhotoAlbumMetadataService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Photos
 {
-    class PhotoAlbumMetadataService : MetadataService<PhotoAlbum, ItemLookupInfo>
+    public class PhotoAlbumMetadataService : MetadataService<PhotoAlbum, ItemLookupInfo>
     {
         protected override void MergeData(MetadataResult<PhotoAlbum> source, MetadataResult<PhotoAlbum> target, MetadataFields[] lockedFields, bool replaceData, bool mergeMetadataSettings)
         {

--- a/MediaBrowser.Providers/Photos/PhotoMetadataService.cs
+++ b/MediaBrowser.Providers/Photos/PhotoMetadataService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Photos
 {
-    class PhotoMetadataService : MetadataService<Photo, ItemLookupInfo>
+    public class PhotoMetadataService : MetadataService<Photo, ItemLookupInfo>
     {
         protected override void MergeData(MetadataResult<Photo> source, MetadataResult<Photo> target, MetadataFields[] lockedFields, bool replaceData, bool mergeMetadataSettings)
         {

--- a/MediaBrowser.Providers/Playlists/PlaylistMetadataService.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistMetadataService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Playlists
 {
-    class PlaylistMetadataService : MetadataService<Playlist, ItemLookupInfo>
+    public class PlaylistMetadataService : MetadataService<Playlist, ItemLookupInfo>
     {
         protected override IList<BaseItem> GetChildrenForMetadataUpdates(Playlist item)
         {

--- a/MediaBrowser.Providers/TV/Omdb/OmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/Omdb/OmdbEpisodeProvider.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.TV.Omdb
 {
-    class OmdbEpisodeProvider :
+    public class OmdbEpisodeProvider :
             IRemoteMetadataProvider<Episode, EpisodeInfo>,
             IHasOrder
     {

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeProvider.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.TV.TheMovieDb
 {
-    class MovieDbEpisodeProvider :
+    public class MovieDbEpisodeProvider :
             MovieDbProviderBase,
             IRemoteMetadataProvider<Episode, EpisodeInfo>,
             IHasOrder

--- a/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.XbmcMetadata.Parsers
 {
-    class MovieNfoParser : BaseNfoParser<Video>
+    public class MovieNfoParser : BaseNfoParser<Video>
     {
         protected override bool SupportsUrlAfterClosingXmlTag => true;
 


### PR DESCRIPTION
**Changes**
Made a lot of classes to Public.
<del>Changed to DefinedTypes.</del>

So the problem was that a lot of classes weren't public, which means they weren't loaded because `ExportedTypes` only retrieves public types.

I think I fixed all of them, but I still think we should use DefinedTypes just to avoid these kind of issues. We can't have any protected, internal or private classes implementing any of these interfaces in the core without this change. Thoughts?
