### PR TITLE
Fix docker arm builds

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,23 +1,30 @@
+# Requires binfm_misc registration for arm                                                               
+# https://github.com/multiarch/qemu-user-static#binfmt_misc-register 
 ARG DOTNET_VERSION=3.0
 
 
-FROM microsoft/dotnet:${DOTNET_VERSION}-sdk-stretch-arm32v7 as builder
+FROM multiarch/qemu-user-static:x86_64-arm as qemu                                                       
+FROM alpine as qemu_extract                                                                                  
+COPY --from=qemu /usr/bin qemu-arm-static.tar.gz                                                         
+RUN tar -xzvf qemu-arm-static.tar.gz
+
+FROM microsoft/dotnet:${DOTNET_VERSION}-sdk-stretch as builder
 WORKDIR /repo
 COPY . .
 #TODO Remove or update the sed line when we update dotnet version.
 RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
  && find . -type f -exec sed -i 's/netcoreapp2.1/netcoreapp3.0/g' {} \; \
- && dotnet clean -maxcpucount:1 \
  && dotnet publish \
-    -maxcpucount:1 \
+    -r linux-arm \
     --configuration release \
     --output /jellyfin \
     Jellyfin.Server
 
 
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime-stretch-slim-arm32v7
+COPY --from=qemu_extract qemu-arm-static /usr/bin
 RUN apt-get update \
- && apt-get install -y ffmpeg
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /config /media

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,28 +5,27 @@ ARG DOTNET_VERSION=3.0
 
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 FROM alpine as qemu_extract
-COPY --from=qemu /usr/bin qemu_user_static.tgz
-RUN tar -xzvf qemu_user_static.tgz
+COPY --from=qemu /usr/bin qemu-aarch64-static.tar.gz
+RUN tar -xzvf qemu-aarch64-static.tar.gz
 
 
-FROM microsoft/dotnet:${DOTNET_VERSION}-sdk-stretch-arm64v8 as builder
-COPY --from=qemu_extract qemu-* /usr/bin
+FROM microsoft/dotnet:${DOTNET_VERSION}-sdk-stretch as builder
 WORKDIR /repo
 COPY . .
 #TODO Remove or update the sed line when we update dotnet version.
 RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
  && find . -type f -exec sed -i 's/netcoreapp2.1/netcoreapp3.0/g' {} \; \
- && dotnet clean \
  && dotnet publish \
+    -r linux-arm64 \
     --configuration release \
     --output /jellyfin \
     Jellyfin.Server
 
 
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime-stretch-slim-arm64v8
+COPY --from=qemu_extract qemu-aarch64-static /usr/bin
 RUN apt-get update \
- && apt-get install -y ffmpeg
-COPY --from=qemu_extract qemu-* /usr/bin
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /config /media

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Register qemu-*-static for all supported processors except the 
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
Replaces #908 
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixes arm and arm64 builld to allow automated builds on docker.
1.  Adds docker post-build hook to setup qemu for docker hub build.
2.  arm and arm64 is built on x86-64 using net core runtime identifiers and copied to arm container
3.  Automated Builds will need to be setup for arm and arm64 in docker hub after merge.
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #665 
