### PR TITLE
Fix cachedir missing from Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN apt-get update \
    libfontconfig1 \
  && apt-get clean autoclean \
  && apt-get autoremove \
- && rm -rf /var/lib/{apt,dpkg,cache,log}
+ && rm -rf /var/lib/{apt,dpkg,cache,log} \
+ && mkdir -p /cache /config /media \
+ && chmod 777 /cache /config /media
 COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
-VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config
+VOLUME /cache /config /media
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -27,8 +27,10 @@ RUN dotnet publish \
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime-stretch-slim-arm32v7
 COPY --from=qemu_extract qemu-arm-static /usr/bin
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
+ && mkdir -p /cache /config /media \
+ && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
-VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config
+VOLUME /cache /config /media
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -28,8 +28,10 @@ RUN dotnet publish \
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime-stretch-slim-arm64v8
 COPY --from=qemu_extract qemu-aarch64-static /usr/bin
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
+ && mkdir -p /cache /config /media \
+ && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
-VOLUME /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config
+VOLUME /cache /config /media
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache


### PR DESCRIPTION
Adds the /cache volume and set it to writeable by all. This allows for
those using jellyfin to continue using it without modifying their
config. However, retaining cache will require one to mount the /cache
volume.

Also make the /config and /media dirs 777 by default. No permissions on
mounted volumes will be changed.