### PR TITLE
checking user-permission in GetQueryResult

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@
  - [LogicalPhallacy](https://github.com/LogicalPhallacy/)
  - [RazeLighter777](https://github.com/RazeLighter777)
  - [WillWill56](https://github.com/WillWill56)
+ - [fruhnow](https://github.com/fruhnow)
 
 # Emby Contributors
 

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -228,7 +228,7 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            if (!user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i).Equals(item.Id)))
+            if (!user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id))
             {
                 Logger.LogWarning($"{user.Name} is not permitted to access Library {item.Name}.");
                 return new QueryResult<BaseItem>

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -230,7 +230,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             if (!user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id))
             {
-                Logger.LogWarning($"{user.Name} is not permitted to access Library {item.Name}.");
+                Logger.LogWarning("{UserName} is not permitted to access Library {ItemName}.", user.Name, item.Name);
                 return new QueryResult<BaseItem>
                 {
                     Items = Array.Empty<BaseItem>(),

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -228,12 +228,12 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            if (!user.Policy.EnabledFolders.Where(i => new Guid(i).Equals(item.Id)).Any() && !user.Policy.EnableAllFolders)
+            if (!user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i).Equals(item.Id)))
             {
                 Logger.LogWarning($"{user.Name} is not permitted to access Library {item.Name}.");
                 return new QueryResult<BaseItem>
                 {
-                    Items = new BaseItem[0],
+                    Items = Array.Empty<BaseItem>(),
                     TotalRecordCount = 0
                 };
             }

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Services;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Api.UserLibrary
 {
@@ -225,6 +226,16 @@ namespace MediaBrowser.Api.UserLibrary
             {
                 request.Recursive = true;
                 request.IncludeItemTypes = "Playlist";
+            }
+
+            if (!user.Policy.EnabledFolders.Where(i => new Guid(i).Equals(item.Id)).Any() && !user.Policy.EnableAllFolders)
+            {
+                Logger.LogWarning($"{user.Name} is not permitted to access Library {item.Name}.");
+                return new QueryResult<BaseItem>
+                {
+                    Items = new BaseItem[0],
+                    TotalRecordCount = 0
+                };
             }
 
             if (request.Recursive || !string.IsNullOrEmpty(request.Ids) || user == null)


### PR DESCRIPTION
When accessing `emby/Users/{UserId}/Items` you are able to access Libraries which you arent supposed to be able to access (ticked off in the AdminUI). There might be/are for sure other Endpoints which just blow out data without proper User-Authorization-Checks.

**Changes**
I added a short User-Access-Validation in GetQueryResult. This leads to Issue #837 being fixed (the View just stays empty). Unsuccessful tries to access a library will be logged as a warning.
(added myself to the Contributors.md, which i forgot last time)

**Issues**
#837 
