### PR TITLE
Include xml files in libdir for Fedora

### DIFF
--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -77,6 +77,7 @@ EOF
 %{_libdir}/%{name}/*.dll
 %{_libdir}/%{name}/*.so
 %{_libdir}/%{name}/*.a
+%{_libdir}/%{name}/*.xml
 %{_libdir}/%{name}/createdump
 # Needs 755 else only root can run it since binary build by dotnet is 722
 %attr(755,root,root) %{_libdir}/%{name}/jellyfin


### PR DESCRIPTION
**Changes**
Fixes an rpmbuild error on latest master that did not appear the other night during release builds. @Wuerfelbecher I don't see what changed, but feedback welcome!

```
error: Installed (but unpackaged) file(s) found:
/usr/lib64/jellyfin/jellyfin.xml
```

**Issues**
N/A
