### PR TITLE
Avoid exceptions due to folder and file not found

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/ItemDataProvider.cs
@@ -43,12 +43,14 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             var jsonFile = path + ".json";
 
+            if (!File.Exists(jsonFile))
+            {
+                return new List<T>();
+            }
+
             try
             {
                 return _jsonSerializer.DeserializeFromFile<List<T>>(jsonFile) ?? new List<T>();
-            }
-            catch (FileNotFoundException)
-            {
             }
             catch (IOException)
             {
@@ -57,6 +59,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             {
                 Logger.LogError(ex, "Error deserializing {jsonFile}", jsonFile);
             }
+
             return new List<T>();
         }
 

--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -170,7 +170,7 @@ namespace MediaBrowser.Api
         /// </summary>
         private void DeleteEncodedMediaCache()
         {
-            var path = _config.ApplicationPaths.TranscodingTempPath;
+            var path = _config.ApplicationPaths.GetTranscodingTempPath();
 
             foreach (var file in _fileSystem.GetFilePaths(path, true))
             {


### PR DESCRIPTION
1) Use function to return path to temp transcode path which has benefit of creating temp folder if not exists, thereby avoiding the exception when GetFilePaths is used.
2) Check json files exists before attempting to read from it.  Avoids having to mask FileNotFound exceptions when debugging.