### PR TITLE
Use jellyfin/ffmpeg image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet publish \
     --output /jellyfin \
     Jellyfin.Server
 
-FROM jrottenberg/ffmpeg:4.0-vaapi as ffmpeg
+FROM jellyfin/ffmpeg as ffmpeg
 FROM microsoft/dotnet:${DOTNET_VERSION}-runtime
 # libfontconfig1 is required for Skia
 RUN apt-get update \


### PR DESCRIPTION
**Changes**
Use https://hub.docker.com/r/jellyfin/ffmpeg of https://github.com/jellyfin/ffmpeg-build

**Issues**
First step to resolving https://github.com/jellyfin/jellyfin/issues/926
