### PR TITLE
dotnet-runtime is needed on Fedora now

### DIFF
--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -8,7 +8,7 @@
 
 Name:           jellyfin
 Version:        10.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
 URL:            https://jellyfin.media
@@ -27,7 +27,7 @@ BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, 
 Requires:       libcurl, fontconfig, freetype, openssl, glibc libicu
 # Requirements not packaged in main repos
 # COPR @dotnet-sig/dotnet
-BuildRequires:  dotnet-sdk-2.2
+BuildRequires:  dotnet-runtime-2.2, dotnet-sdk-2.2
 # RPMfusion free
 Requires:       ffmpeg
 
@@ -140,6 +140,9 @@ fi
 %systemd_postun_with_restart jellyfin.service
 
 %changelog
+* Thu Feb 21 2019 Brian J. Murrell <brian@interlinx.bc.ca>
+- jellyfin:
+- dotnet seems to have moved to dotnet-runtime
 * Wed Feb 20 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - jellyfin:
 - PR920 Fix cachedir missing from Docker container


### PR DESCRIPTION
**Changes**
dotnet-runtime is needed for the Fedora build now