### PR TITLE
Release 10.2.z copr autobuild

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,8 @@
+srpm:
+	dnf -y install git
+	git submodule update --init --recursive
+	cd deployment/fedora-package-x64;                    \
+	./create_tarball.sh;                                 \
+	rpmbuild -bs pkg-src/jellyfin.spec                   \
+	         --define "_sourcedir $$PWD/pkg-src/"        \
+		 --define "_srcrpmdir $(outdir)"

--- a/deployment/fedora-package-x64/create_tarball.sh
+++ b/deployment/fedora-package-x64/create_tarball.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source ../common.build.sh
+
+WORKDIR="$( pwd )"
+VERSION="$( sed -ne '/^Version:/s/.*  *//p' "${WORKDIR}"/pkg-src/jellyfin.spec )"
+
+package_temporary_dir="${WORKDIR}/pkg-dist-tmp"
+pkg_src_dir="${WORKDIR}/pkg-src"
+
+GNU_TAR=1
+echo "Bundling all sources for RPM build."
+tar \
+--transform "s,^\.,jellyfin-${VERSION}," \
+--exclude='.git*' \
+--exclude='**/.git' \
+--exclude='**/.hg' \
+--exclude='**/.vs' \
+--exclude='**/.vscode' \
+--exclude='deployment' \
+--exclude='**/bin' \
+--exclude='**/obj' \
+--exclude='**/.nuget' \
+--exclude='*.deb' \
+--exclude='*.rpm' \
+-czf "$pkg_src_dir/jellyfin-${VERSION}.tar.gz" \
+-C "../.." ./ || GNU_TAR=0
+
+if [ $GNU_TAR -eq 0 ]; then
+    echo "The installed tar binary did not support --transform. Using workaround."
+    mkdir -p "${package_temporary_dir}/jellyfin"{,-"${VERSION}"}
+    # Not GNU tar
+    tar \
+    --exclude='.git*' \
+    --exclude='**/.git' \
+    --exclude='**/.hg' \
+    --exclude='**/.vs' \
+    --exclude='**/.vscode' \
+    --exclude='deployment' \
+    --exclude='**/bin' \
+    --exclude='**/obj' \
+    --exclude='**/.nuget' \
+    --exclude='*.deb' \
+    --exclude='*.rpm' \
+    -zcf \
+    "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
+    -C "../.." ./
+    echo "Extracting filtered package."
+    tar -xzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
+    echo "Removing filtered package."
+    rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"
+    echo "Repackaging package into final tarball."
+    tar -czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
+fi

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -21,52 +21,7 @@ else
     docker_sudo=""
 fi
 
-# Create RPM source archive
-GNU_TAR=1
-mkdir -p "${package_temporary_dir}"
-echo "Bundling all sources for RPM build."
-tar \
---transform "s,^\.,jellyfin-${VERSION}," \
---exclude='.git*' \
---exclude='**/.git' \
---exclude='**/.hg' \
---exclude='**/.vs' \
---exclude='**/.vscode' \
---exclude='deployment' \
---exclude='**/bin' \
---exclude='**/obj' \
---exclude='**/.nuget' \
---exclude='*.deb' \
---exclude='*.rpm' \
--czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" \
--C "../.." ./ || GNU_TAR=0
-
-if [ $GNU_TAR -eq 0 ]; then
-    echo "The installed tar binary did not support --transform. Using workaround."
-    mkdir -p "${package_temporary_dir}/jellyfin"
-    # Not GNU tar
-    tar \
-    --exclude='.git*' \
-    --exclude='**/.git' \
-    --exclude='**/.hg' \
-    --exclude='**/.vs' \
-    --exclude='**/.vscode' \
-    --exclude='deployment' \
-    --exclude='**/bin' \
-    --exclude='**/obj' \
-    --exclude='**/.nuget' \
-    --exclude='*.deb' \
-    --exclude='*.rpm' \
-    -zcf \
-    "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
-    -C "../.." ./
-    echo "Extracting filtered package."
-    tar -xzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"
-    echo "Removing filtered package."
-    rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"
-    echo "Repackaging package into final tarball."
-    tar -czf "${pkg_src_dir}/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"
-fi
+./create_tarball.sh
 
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -143,6 +143,7 @@ fi
 * Thu Feb 21 2019 Brian J. Murrell <brian@interlinx.bc.ca>
 - jellyfin:
 - dotnet seems to have moved to dotnet-runtime
+- COPR auto-build
 * Wed Feb 20 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - jellyfin:
 - PR920 Fix cachedir missing from Docker container


### PR DESCRIPTION
**Changes**
This adds enhancements so that Fedora/EL packages can be automatically
built in COPR when a webhook is received. A typical webhook could be
for tagging events for example or even in the future when COPR supports it,
a "Release" webhook to only build releases.

**Issues**
Backport of #902 