### PR TITLE
Always set ffmpeg flag +genpts when video stream is being copied

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@
  - [WillWill56](https://github.com/WillWill56)
  - [Liggy](https://github.com/Liggy)
  - [fruhnow](https://github.com/fruhnow)
+ - [Lynxy](https://github.com/Lynxy)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2436,8 +2436,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(videoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
-                args += " -flags -global_header -fflags +genpts";
-
                 if (state.VideoStream != null && IsH264(state.VideoStream) &&
                     string.Equals(state.OutputContainer, "ts", StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(state.VideoStream.NalLengthSize, "0", StringComparison.OrdinalIgnoreCase))
@@ -2448,6 +2446,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (state.RunTimeTicks.HasValue && state.BaseRequest.CopyTimestamps)
                 {
                     args += " -copyts -avoid_negative_ts disabled -start_at_zero";
+                }
+
+                if (!state.RunTimeTicks.HasValue)
+                {
+                    args += " -flags -global_header -fflags +genpts";
                 }
             }
             else

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1904,7 +1904,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 flags.Add("+ignidx");
             }
-            if (state.GenPtsInput)
+            if (state.GenPtsInput || string.Equals(state.OutputVideoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
                 flags.Add("+genpts");
             }
@@ -2436,6 +2436,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(videoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
+                args += " -flags -global_header -fflags +genpts";
+
                 if (state.VideoStream != null && IsH264(state.VideoStream) &&
                     string.Equals(state.OutputContainer, "ts", StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(state.VideoStream.NalLengthSize, "0", StringComparison.OrdinalIgnoreCase))
@@ -2446,11 +2448,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (state.RunTimeTicks.HasValue && state.BaseRequest.CopyTimestamps)
                 {
                     args += " -copyts -avoid_negative_ts disabled -start_at_zero";
-                }
-
-                if (!state.RunTimeTicks.HasValue)
-                {
-                    args += " -flags -global_header -fflags +genpts";
                 }
             }
             else


### PR DESCRIPTION
**Changes**
Ensure ffmpeg flag `+genpts` is set if target codec is `copy`.

**Issues**
Transcoding fails on video streams that lack PTS data. When ffmpeg is copying a video stream which lacks PTS data or for some other reason PTS is not passed along correctly, the ffmpeg decoder is bypassed and PTS data is not ever generated, resulting in a stream that never plays.

Output of ffmpeg in such a case:

```
[NULL @ 0x5bfc8c0] Failed to parse extradata
[segment @ 0x5c20900] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
[mpegts @ 0x5c2b140] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
[mpegts @ 0x5c2b140] first pts value must be set
av_interleaved_write_frame(): Invalid data found when processing input
[mpegts @ 0x5c2b140] first pts value must be set
[segment @ 0x5c20900] Opening '/var/lib/jellyfin/transcoding-temp/e0cc15376cab26c8563e0be01117a4cd.m3u8.tmp' for writing
Error writing trailer of /var/lib/jellyfin/transcoding-temp/e0cc15376cab26c8563e0be01117a4cd%d.ts: Invalid data found when processing input
```

The `+genpts` flag will generate missing PTS if DTS is present. Relevant Stack Exchange answer: https://superuser.com/questions/710008/how-to-get-rid-of-ffmpeg-pts-has-no-value-error