### PR TITLE
Close the response stream after fetching temp files

### DIFF
--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -539,21 +539,10 @@ namespace Emby.Server.Implementations.HttpClientManager
 
                     var contentLength = GetContentLength(httpResponse);
 
-                    if (contentLength.HasValue)
+                    using (var stream = httpResponse.GetResponseStream())
+                    using (var fs = _fileSystem.GetFileStream(tempFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
                     {
-                        using (var fs = _fileSystem.GetFileStream(tempFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
-                        {
-                            await httpResponse.GetResponseStream().CopyToAsync(fs, StreamDefaults.DefaultCopyToBufferSize, options.CancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                    else
-                    {
-                        // We're not able to track progress
-                        using (var stream = httpResponse.GetResponseStream())
-                        using (var fs = _fileSystem.GetFileStream(tempFile, FileOpenMode.Create, FileAccessMode.Write, FileShareMode.Read, true))
-                        {
-                            await stream.CopyToAsync(fs, StreamDefaults.DefaultCopyToBufferSize, options.CancellationToken).ConfigureAwait(false);
-                        }
+                        await stream.CopyToAsync(fs, StreamDefaults.DefaultCopyToBufferSize, options.CancellationToken).ConfigureAwait(false);
                     }
 
                     options.Progress.Report(100);


### PR DESCRIPTION
**Changes**
Removed some duplicate code and in the process the http response stream should be properly disposed.

I did not test this, but nowhere in the calling code is the response stream closed explicitly, so I'm pretty confident it fixes the issue.

**Issues**
Fixes #965 
