### PR TITLE
Fix slow local image validation

### DIFF
--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
@@ -62,8 +63,13 @@ namespace MediaBrowser.LocalMetadata.Images
             {
                 return new List<FileSystemMetadata>();
             }
-
             var path = item.ContainingFolderPath;
+
+            // Exit if the cache dir does not exist, alternative solution is to create it, but that's a lot of empty dirs...
+            if (!Directory.Exists(path))
+            {
+                return Array.Empty<FileSystemMetadata>();
+            }
 
             if (includeDirectories)
             {

--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -63,6 +63,7 @@ namespace MediaBrowser.LocalMetadata.Images
             {
                 return new List<FileSystemMetadata>();
             }
+
             var path = item.ContainingFolderPath;
 
             // Exit if the cache dir does not exist, alternative solution is to create it, but that's a lot of empty dirs...

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -92,10 +92,7 @@ namespace MediaBrowser.Providers.Manager
             catch (Exception ex)
             {
                 localImagesFailed = true;
-                if (!(item is IItemByName))
-                {
-                    Logger.LogError(ex, "Error validating images for {0}", item.Path ?? item.Name ?? "Unknown name");
-                }
+                Logger.LogError(ex, "Error validating images for {0}", item.Path ?? item.Name ?? "Unknown name");
             }
 
             var metadataResult = new MetadataResult<TItemType>


### PR DESCRIPTION
**Changes**
Added a check for directory existence. Refreshing 240 people just went from ~30 seconds to 0.
Also removed a weird check that swallows exceptions. Let's avoid them instead of handling them silently, eh?
**Issues**
Related to #951 (but doesn't help the issue that scheduled tasks lock up the server)
