### PR TITLE
Fix the ffmpeg compatibility

### DIFF
--- a/deployment/debian-package-x64/pkg-src/conf/jellyfin
+++ b/deployment/debian-package-x64/pkg-src/conf/jellyfin
@@ -21,9 +21,9 @@ JELLYFIN_CACHE_DIRECTORY="/var/cache/jellyfin"
 # Restart script for in-app server control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/lib/jellyfin/restart.sh"
 
-# [OPTIONAL] ffmpeg binary paths, overriding the UI-configured values
-#JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/bin/ffmpeg"
-#JELLYFIN_FFPROBE_OPT="--ffprobe=/usr/bin/ffprobe"
+# ffmpeg binary paths, overriding the system values
+JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/share/jellyfin-ffmpeg/ffmpeg"
+JELLYFIN_FFPROBE_OPT="--ffprobe=/usr/share/jellyfin-ffmpeg/ffprobe"
 
 # [OPTIONAL] run Jellyfin as a headless service
 #JELLYFIN_SERVICE_OPT="--service"

--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -20,7 +20,7 @@ Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         ffmpeg (<7:4.1) | jellyfin-ffmpeg,
+         jellyfin-ffmpeg,
          libfontconfig1,
          libfreetype6,
          libssl1.0.0 | libssl1.0.2


### PR DESCRIPTION
**Changes**
Doing this the other way was just complex and prone to failures with various usecases involving other `ffmpeg`s. No longer try to override the system ffmpeg, just put ours somewhere else and depend on that package entirely for all Debian/Ubuntu releases.

Requires a rebuild of the `jellyfin-ffmpeg` package which is forthcoming.

**Issues**
Fixes #974 