### PR TITLE
Set EnableRaisingEvents to true for processes that require it

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -694,7 +694,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 FileName = FFMpegPath,
                 Arguments = args,
                 IsHidden = true,
-                ErrorDialog = false
+                ErrorDialog = false,
+                EnableRaisingEvents = true
             });
 
             _logger.LogDebug("{0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
@@ -816,7 +817,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 FileName = FFMpegPath,
                 Arguments = args,
                 IsHidden = true,
-                ErrorDialog = false
+                ErrorDialog = false,
+                EnableRaisingEvents = true
             });
 
             _logger.LogInformation(process.StartInfo.FileName + " " + process.StartInfo.Arguments);


### PR DESCRIPTION
**Changes**
Set EnableRaisingEvents to true for a few calls that required it.
Context: Without EnableRaisingEvents=true, calls to `WaitForExitAsync(timeoutMs)` will always wait out the timeout because the Exit event is never triggered.

Maybe it should default to true...