### PR TITLE
Check that ffmpeg log target isn't disposed before writing to it

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -24,14 +24,19 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 using (var reader = new StreamReader(source))
                 {
-                    // If ffmpeg process is closed, the state is disposed, so don't write to target in that case
-                    while (!reader.EndOfStream && target.CanWrite)
+                    while (!reader.EndOfStream)
                     {
                         var line = await reader.ReadLineAsync().ConfigureAwait(false);
 
                         ParseLogLine(line, state);
 
                         var bytes = Encoding.UTF8.GetBytes(Environment.NewLine + line);
+
+                        // If ffmpeg process is closed, the state is disposed, so don't write to target in that case
+                        if (!target.CanWrite)
+                        {
+                            break;
+                        }
 
                         await target.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
                         await target.FlushAsync().ConfigureAwait(false);

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -24,7 +24,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 using (var reader = new StreamReader(source))
                 {
-                    while (!reader.EndOfStream)
+                    // If ffmpeg process is closed, the state is disposed, so don't write to target in that case
+                    while (!reader.EndOfStream && target.CanWrite)
                     {
                         var line = await reader.ReadLineAsync().ConfigureAwait(false);
 
@@ -36,11 +37,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                         await target.FlushAsync().ConfigureAwait(false);
                     }
                 }
-            }
-            catch (ObjectDisposedException)
-            {
-                //TODO Investigate and properly fix.
-                // Don't spam the log. This doesn't seem to throw in windows, but sometimes under linux
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
**Changes**
Added a check to make sure the ffmpeg log is writeable.

When the ffmpeg process exits, the stream state is immediately disposed, which also disposes the ffmpeg log. https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Api/Playback/BaseStreamingService.cs#L369

Not sure if it's the proper solution though.