### PR TITLE
Set ffmpeg+ffprobe paths in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,8 @@ COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+    --datadir /config \
+    --cachedir /cache \
+    --ffmpeg /usr/local/bin/ffmpeg \
+    --ffprobe /usr/local/bin/ffprobe

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -30,4 +30,8 @@ RUN apt-get update \
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+    --datadir /config \
+    --cachedir /cache \
+    --ffmpeg /usr/bin/ffmpeg \
+    --ffprobe /usr/bin/ffprobe

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -31,4 +31,8 @@ RUN apt-get update \
 COPY --from=builder /jellyfin /jellyfin
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache
+ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+    --datadir /config \
+    --cachedir /cache \
+    --ffmpeg /usr/bin/ffmpeg \
+    --ffprobe /usr/bin/ffprobe


### PR DESCRIPTION
Will always ensure containers use correct path.

Resolves https://github.com/jellyfin/jellyfin/issues/478