### PR TITLE
Fix rmvb video can not play under DLNA

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@
  - [Liggy](https://github.com/Liggy)
  - [fruhnow](https://github.com/fruhnow)
  - [Lynxy](https://github.com/Lynxy)
+ - [fasheng](https://github.com/fasheng)
 
 # Emby Contributors
 

--- a/MediaBrowser.Api/Playback/Progressive/VideoService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/VideoService.cs
@@ -37,6 +37,7 @@ namespace MediaBrowser.Api.Playback.Progressive
     [Route("/Videos/{Id}/stream.mov", "GET")]
     [Route("/Videos/{Id}/stream.iso", "GET")]
     [Route("/Videos/{Id}/stream.flv", "GET")]
+    [Route("/Videos/{Id}/stream.rm", "GET")]
     [Route("/Videos/{Id}/stream", "GET")]
     [Route("/Videos/{Id}/stream.ts", "HEAD")]
     [Route("/Videos/{Id}/stream.webm", "HEAD")]


### PR DESCRIPTION
Or will report "Could not find handler for /videos/xxx/stream.rm" error
in server side.

Test OK with Kodi and gupnp-tools.