### PR TITLE
Do not allow new users to delete content by default

### DIFF
--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -77,7 +77,7 @@ namespace MediaBrowser.Model.Users
 
         public UserPolicy()
         {
-            EnableContentDeletion = true;
+            EnableContentDeletion = false;
             EnableContentDeletionFromFolders = Array.Empty<string>();
 
             EnableSyncTranscoding = true;


### PR DESCRIPTION
**Changes**
Modify class `UserPolicy` to have property `EnableContentDeletion` set to `false` by default. This affects any newly created users; the initial user created from setup still has the delete option enabled by default (see [`Emby.Server.Implementations/Library/UserManager.cs:514`](https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/Library/UserManager.cs#L514)).

**Issues**
Fixes #989 and partially addresses #79.