### PR TITLE
Treat jellyfin-web as just another dependency for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN apt-get update \
  && chmod 777 /cache /config /media
 COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
+
+ARG JELLYFIN_WEB_VERSION=10.2.2
+RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && rm -rf /jellyfin/jellyfin-web \
+ && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+
 EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -28,6 +28,12 @@ RUN apt-get update \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
+
+ARG JELLYFIN_WEB_VERSION=10.2.2
+RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && rm -rf /jellyfin/jellyfin-web \
+ && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+
 EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -29,6 +29,12 @@ RUN apt-get update \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
+
+ARG JELLYFIN_WEB_VERSION=10.2.2
+RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && rm -rf /jellyfin/jellyfin-web \
+ && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+
 EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \


### PR DESCRIPTION
**Changes**
Have Dockerfiles download a pinned version of jellyfin-web. This keeps the Dockerfile self-contained thus negating any additional scripts to be run before `docker build`. 

Also avoids version issues encountered with submodules.
