### PR TITLE
Correct the list of series types

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2279,11 +2279,10 @@ namespace Emby.Server.Implementations.Data
 
         private static readonly HashSet<string> _seriesTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "Audio",
-            "MusicAlbum",
-            "MusicVideo",
+            "Book",
             "AudioBook",
-            "AudioPodcast"
+            "Episode",
+            "Season"
         };
 
         private bool HasSeriesFields(InternalItemsQuery query)


### PR DESCRIPTION
**Changes**
This PR fixes series type list values that PR #848 accidentally changed.

**Issues**
Incorrect fields were being returned for series, resulting in Jellyfin for Kodi addon not being able to fetch new series (i.e. TV Shows). More information on this can be found in the comments of PR #848.