### PR TITLE
Update image overlays to use Jellyfin blue

### DIFF
--- a/Jellyfin.Drawing.Skia/PercentPlayedDrawer.cs
+++ b/Jellyfin.Drawing.Skia/PercentPlayedDrawer.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Drawing.Skia
                 foregroundWidth *= percent;
                 foregroundWidth /= 100;
 
-                paint.Color = SKColor.Parse("#FF52B54B");
+                paint.Color = SKColor.Parse("#FF00A4DC");
                 canvas.DrawRect(SKRect.Create(0, (float)endY - IndicatorHeight, Convert.ToInt32(foregroundWidth), (float)endY), paint);
             }
         }

--- a/Jellyfin.Drawing.Skia/PlayedIndicatorDrawer.cs
+++ b/Jellyfin.Drawing.Skia/PlayedIndicatorDrawer.cs
@@ -13,7 +13,7 @@ namespace Jellyfin.Drawing.Skia
 
             using (var paint = new SKPaint())
             {
-                paint.Color = SKColor.Parse("#CC52B54B");
+                paint.Color = SKColor.Parse("#CC00A4DC");
                 paint.Style = SKPaintStyle.Fill;
                 canvas.DrawCircle((float)x, OffsetFromTopRightCorner, 20, paint);
             }

--- a/Jellyfin.Drawing.Skia/UnplayedCountIndicator.cs
+++ b/Jellyfin.Drawing.Skia/UnplayedCountIndicator.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Drawing.Skia
 
             using (var paint = new SKPaint())
             {
-                paint.Color = SKColor.Parse("#CC52B54B");
+                paint.Color = SKColor.Parse("#CC00A4DC");
                 paint.Style = SKPaintStyle.Fill;
                 canvas.DrawCircle((float)x, OffsetFromTopRightCorner, 20, paint);
             }


### PR DESCRIPTION
**Changes**
Replaces instances where "Emby green" was still being used for drawing progress bars and other overlays on images with "Jellyfin blue".

**Issues**

