### PR TITLE
Build improvements for wrapping infrastructure

### DIFF
--- a/build
+++ b/build
@@ -26,7 +26,7 @@ usage() {
     echo -e " $ build [-k/--keep-artifacts] [-b/--web-branch <web_branch>] <platform> <action>"
     echo -e ""
     echo -e "The 'keep-artifacts' option preserves build artifacts, e.g. Docker images for system package builds."
-    echo -e "The web_branch defaults to the same branch name as the current main branch."
+    echo -e "The web_branch defaults to the same branch name as the current main branch or can be 'local' to not touch the submodule branching."
     echo -e "To build all platforms, use 'all'."
     echo -e "To perform all build actions, use 'all'."
     echo -e "Build output files are collected at '../jellyfin-build/<platform>'."
@@ -164,37 +164,39 @@ for target_platform in ${platform[@]}; do
     fi
 done
 
-# Initialize submodules
-git submodule update --init --recursive
+if [[ ${web_branch} != 'local' ]]; then
+    # Initialize submodules
+    git submodule update --init --recursive
 
-# configure branch
-pushd MediaBrowser.WebDashboard/jellyfin-web
+    # configure branch
+    pushd MediaBrowser.WebDashboard/jellyfin-web
 
-if ! git diff-index --quiet HEAD --; then
+    if ! git diff-index --quiet HEAD --; then
+        popd
+        echo
+        echo "ERROR: Your 'jellyfin-web' submodule working directory is not clean!"
+        echo "This script will overwrite your unstaged and unpushed changes."
+        echo "Please do development on 'jellyfin-web' outside of the submodule."
+        exit 1
+    fi
+
+    git fetch --all
+    # If this is an official branch name, fetch it from origin
+    official_branches_regex="^master$|^dev$|^release-.*$|^hotfix-.*$"
+    if [[ ${web_branch} =~ ${official_branches_regex} ]]; then
+        git checkout origin/${web_branch} || {
+            echo "ERROR: 'jellyfin-web' branch 'origin/${web_branch}' is invalid."
+            exit 1
+        }
+    # Otherwise, just check out the local branch (for testing, etc.)
+    else
+        git checkout ${web_branch} || {
+            echo "ERROR: 'jellyfin-web' branch '${web_branch}' is invalid."
+            exit 1
+        }
+    fi
     popd
-    echo
-    echo "ERROR: Your 'jellyfin-web' submodule working directory is not clean!"
-    echo "This script will overwrite your unstaged and unpushed changes."
-    echo "Please do development on 'jellyfin-web' outside of the submodule."
-    exit 1
 fi
-
-git fetch --all
-# If this is an official branch name, fetch it from origin
-official_branches_regex="^master$|^dev$|^release-.*$|^hotfix-.*$"
-if [[ ${web_branch} =~ ${official_branches_regex} ]]; then
-    git checkout origin/${web_branch} || {
-        echo "ERROR: 'jellyfin-web' branch 'origin/${web_branch}' is invalid."
-        exit 1
-    }
-# Otherwise, just check out the local branch (for testing, etc.)
-else
-    git checkout ${web_branch} || {
-        echo "ERROR: 'jellyfin-web' branch '${web_branch}' is invalid."
-        exit 1
-    }
-fi
-popd
 
 # Execute each platform and action in order, if said action is enabled
 pushd deployment/

--- a/build
+++ b/build
@@ -217,7 +217,7 @@ for target_platform in ${platform[@]}; do
     done
     if [[ -d pkg-dist/ ]]; then
         echo -e ">> Collecting build artifacts"
-        target_dir="../../../jellyfin-build/${target_platform}"
+        target_dir="../../../bin/${target_platform}"
         mkdir -p ${target_dir}
         mv pkg-dist/* ${target_dir}/
     fi

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,15 @@
+---
+# We just wrap `build` so this is really it
+name: "jellyfin"
+version: "10.2.2"
+packages:
+  - debian-package-x64
+  - debian-package-armhf
+  - ubuntu-package-x64
+  - fedora-package-x64
+  - centos-package-x64
+  - linux-x64
+  - macos
+  - portable
+  - win-x64
+  - win-x86

--- a/deployment/win-x64/package.sh
+++ b/deployment/win-x64/package.sh
@@ -21,8 +21,8 @@ package_win64() (
         cp ${TEMP_DIR}/${FFMPEG_VERSION}/bin/ffmpeg.exe ${OUTPUT_DIR}/ffmpeg.exe
         cp ${TEMP_DIR}/${FFMPEG_VERSION}/bin/ffprobe.exe ${OUTPUT_DIR}/ffprobe.exe
         rm -r ${TEMP_DIR}
-        cp ${ROOT}/deployment/win-generic/install-jellyfin.ps1 ${OUTPUT_DIR}/install-jellyfin.ps1
-        cp ${ROOT}/deployment/win-generic/install.bat ${OUTPUT_DIR}/install.bat
+        cp ${ROOT}/deployment/windows/install-jellyfin.ps1 ${OUTPUT_DIR}/install-jellyfin.ps1
+        cp ${ROOT}/deployment/windows/install.bat ${OUTPUT_DIR}/install.bat
         mkdir -p ${PKG_DIR}
         pushd ${OUTPUT_DIR} 
         ${ARCHIVE_CMD} ${ROOT}/${PKG_DIR}/`basename "${OUTPUT_DIR}"`.zip .

--- a/deployment/win-x86/package.sh
+++ b/deployment/win-x86/package.sh
@@ -20,8 +20,8 @@ package_win32() (
         cp ${TEMP_DIR}/${FFMPEG_VERSION}/bin/ffmpeg.exe ${OUTPUT_DIR}/ffmpeg.exe
         cp ${TEMP_DIR}/${FFMPEG_VERSION}/bin/ffprobe.exe ${OUTPUT_DIR}/ffprobe.exe
         rm -r ${TEMP_DIR}
-        cp ${ROOT}/deployment/win-generic/install-jellyfin.ps1 ${OUTPUT_DIR}/install-jellyfin.ps1
-        cp ${ROOT}/deployment/win-generic/install.bat ${OUTPUT_DIR}/install.bat
+        cp ${ROOT}/deployment/windows/install-jellyfin.ps1 ${OUTPUT_DIR}/install-jellyfin.ps1
+        cp ${ROOT}/deployment/windows/install.bat ${OUTPUT_DIR}/install.bat
         mkdir -p ${PKG_DIR}
         pushd ${OUTPUT_DIR} 
         ${ARCHIVE_CMD} ${ROOT}/${PKG_DIR}/`basename "${OUTPUT_DIR}"`.zip .


### PR DESCRIPTION
**Changes**
Makes some minor modifications to better support the wrapping `jellyfin-build` infrastructure. Specifically:
1. Put the output in `../bin` rather than `../jellyfin-build`, which is more generic, cleaner, and easier to grab from.
1. Allow `-b local` to avoid touching the submodule at all. In my usecase, I replace the submodule with a symlink to the `jellyfin-web` repo. This is temporary until we can entirely remove the submodule somehow (either separate packaging for `jellyfin-web`, or something else).
1. Add a `build.yaml` configuration listing the available package types. `build` within the repo doesn't use this (yet).

**Issues**
N/A
