### PR TITLE
Update to renamed DownloadGitHubRelease task (Microsoft/azure-pipelines-tasks#9481)

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
         overWrite: true # Optional
         flattenFolders: true # Optional
 
-    - task: DownloadGitHubReleases@0
+    - task: DownloadGitHubRelease@0
       displayName: Download ABI compatibility check tool from GitHub
       inputs:
         connection: Jellyfin GitHub


### PR DESCRIPTION
**Changes**
Changed DownloadGitHubReleases to DownloadGitHubRelease as it's renamed by Microsoft/azure-pipelines-tasks#9481