### PR TITLE
Fix Cryptography Provider and Syntax Error 

### DIFF
--- a/Emby.Server.Implementations/Cryptography/CryptographyProvider.cs
+++ b/Emby.Server.Implementations/Cryptography/CryptographyProvider.cs
@@ -14,6 +14,7 @@ namespace Emby.Server.Implementations.Cryptography
         private static readonly HashSet<string> _supportedHashMethods = new HashSet<string>()
             {
                 "MD5",
+                "PBKDF2",
                 "System.Security.Cryptography.MD5",
                 "SHA",
                 "SHA1",
@@ -136,7 +137,7 @@ namespace Emby.Server.Implementations.Cryptography
         {
             return PBKDF2(DefaultHashMethod, bytes, salt, _defaultIterations);
         }
-        
+
         public byte[] ComputeHash(PasswordHash hash)
         {
             int iterations = _defaultIterations;

--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -77,12 +77,12 @@ namespace MediaBrowser.LocalMetadata.Images
                 return directoryService.GetFileSystemEntries(path)
                 .Where(i => BaseItem.SupportedImageExtensions.Contains(i.Extension, StringComparer.OrdinalIgnoreCase) || i.IsDirectory)
 
-                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions, i.Extension ?? string.Empty));
+                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions.ToArray(), i.Extension ?? string.Empty));
             }
 
             return directoryService.GetFiles(path)
                 .Where(i => BaseItem.SupportedImageExtensions.Contains(i.Extension, StringComparer.OrdinalIgnoreCase))
-                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions, i.Extension ?? string.Empty));
+                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions.ToArray(), i.Extension ?? string.Empty));
         }
 
         public List<LocalImageInfo> GetImages(BaseItem item, IDirectoryService directoryService)
@@ -106,7 +106,7 @@ namespace MediaBrowser.LocalMetadata.Images
             IEnumerable<FileSystemMetadata> files = paths.SelectMany(i => _fileSystem.GetFiles(i, BaseItem.SupportedImageExtensions, true, false));
 
             files = files
-                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions, i.Extension ?? string.Empty));
+                .OrderBy(i => Array.IndexOf(BaseItem.SupportedImageExtensions.ToArray(), i.Extension ?? string.Empty));
 
             var list = new List<LocalImageInfo>();
 


### PR DESCRIPTION
Fixes a syntax error caused by not converting a `IReadOnlyList` to an `Array` as well as adds `PBKDF2` into the list of hashes offered by `CryptographyProvider`

