### PR TITLE
Add configurable webdir option

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -36,9 +36,9 @@ namespace Emby.Server.Implementations.AppBase
         public string ProgramDataPath { get; private set; }
 
         /// <summary>
-        /// Gets the path to the web resources folder
+        /// Gets the path to the web UI resources folder
         /// </summary>
-        /// <value>The web resources path.</value>
+        /// <value>The web UI resources path.</value>
         public string WebPath { get; set; }
 
         /// <summary>

--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -17,12 +17,14 @@ namespace Emby.Server.Implementations.AppBase
             string programDataPath,
             string logDirectoryPath,
             string configurationDirectoryPath,
-            string cacheDirectoryPath)
+            string cacheDirectoryPath,
+            string webDirectoryPath)
         {
             ProgramDataPath = programDataPath;
             LogDirectoryPath = logDirectoryPath;
             ConfigurationDirectoryPath = configurationDirectoryPath;
             CachePath = cacheDirectoryPath;
+            WebPath = webDirectoryPath;
 
             DataPath = Path.Combine(ProgramDataPath, "data");
         }

--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -36,6 +36,12 @@ namespace Emby.Server.Implementations.AppBase
         public string ProgramDataPath { get; private set; }
 
         /// <summary>
+        /// Gets the path to the web resources folder
+        /// </summary>
+        /// <value>The web resources path.</value>
+        public string WebPath { get; set; }
+
+        /// <summary>
         /// Gets the path to the system folder
         /// </summary>
         public string ProgramSystemPath { get; } = AppContext.BaseDirectory;

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -621,7 +621,7 @@ namespace Emby.Server.Implementations
             string contentRoot = ServerConfigurationManager.Configuration.DashboardSourcePath;
             if (string.IsNullOrEmpty(contentRoot))
             {
-                contentRoot = Path.Combine(ServerConfigurationManager.ApplicationPaths.ApplicationResourcesPath, "jellyfin-web", "src");
+                contentRoot = Path.Combine(ServerConfigurationManager.ApplicationPaths,WebPath, "src");
             }
 
             var host = new WebHostBuilder()

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -621,7 +621,7 @@ namespace Emby.Server.Implementations
             string contentRoot = ServerConfigurationManager.Configuration.DashboardSourcePath;
             if (string.IsNullOrEmpty(contentRoot))
             {
-                contentRoot = Path.Combine(ServerConfigurationManager.ApplicationPaths,WebPath, "src");
+                contentRoot = Path.Combine(ServerConfigurationManager.ApplicationPaths.WebPath, "src");
             }
 
             var host = new WebHostBuilder()
@@ -921,6 +921,7 @@ namespace Emby.Server.Implementations
             logger.LogInformation("User Interactive: {IsUserInteractive}", Environment.UserInteractive);
             logger.LogInformation("Processor count: {ProcessorCount}", Environment.ProcessorCount);
             logger.LogInformation("Program data path: {ProgramDataPath}", appPaths.ProgramDataPath);
+            logger.LogInformation("Web resources path: {WebPath}", appPaths.WebPath);
             logger.LogInformation("Application directory: {ApplicationPath}", appPaths.ProgramSystemPath);
         }
 
@@ -1393,6 +1394,7 @@ namespace Emby.Server.Implementations
                 CompletedInstallations = InstallationManager.CompletedInstallations.ToArray(),
                 Id = SystemId,
                 ProgramDataPath = ApplicationPaths.ProgramDataPath,
+                WebPath = ApplicationPaths.WebPath,
                 LogPath = ApplicationPaths.LogDirectoryPath,
                 ItemsByNamePath = ApplicationPaths.InternalMetadataPath,
                 InternalMetadataPath = ApplicationPaths.InternalMetadataPath,

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -621,7 +621,7 @@ namespace Emby.Server.Implementations
             string contentRoot = ServerConfigurationManager.Configuration.DashboardSourcePath;
             if (string.IsNullOrEmpty(contentRoot))
             {
-                contentRoot = Path.Combine(ServerConfigurationManager.ApplicationPaths.WebPath, "src");
+                contentRoot = ServerConfigurationManager.ApplicationPaths.WebPath;
             }
 
             var host = new WebHostBuilder()

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -17,11 +17,13 @@ namespace Emby.Server.Implementations
             string programDataPath,
             string logDirectoryPath,
             string configurationDirectoryPath,
-            string cacheDirectoryPath)
+            string cacheDirectoryPath,
+            string webDirectoryPath)
             : base(programDataPath,
                 logDirectoryPath,
                 configurationDirectoryPath,
-                cacheDirectoryPath)
+                cacheDirectoryPath,
+                webDirectoryPath)
         {
         }
 

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -35,12 +35,6 @@ namespace Emby.Server.Implementations
         /// <value>The root folder path.</value>
         public string RootFolderPath => Path.Combine(ProgramDataPath, "root");
 
-/*        /// <summary>
-        /// Gets the path to the Web resources
-        /// </summary>
-        /// <value>The web folder path.</value>
-        public string WebPath => WebPath; */
-
         /// <summary>
         /// Gets the path to the default user view directory.  Used if no specific user view is defined.
         /// </summary>

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -35,6 +35,12 @@ namespace Emby.Server.Implementations
         /// <value>The root folder path.</value>
         public string RootFolderPath => Path.Combine(ProgramDataPath, "root");
 
+/*        /// <summary>
+        /// Gets the path to the Web resources
+        /// </summary>
+        /// <value>The web folder path.</value>
+        public string WebPath => WebPath; */
+
         /// <summary>
         /// Gets the path to the default user view directory.  Used if no specific user view is defined.
         /// </summary>

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -277,7 +277,7 @@ namespace Jellyfin.Server
                 if (string.IsNullOrEmpty(webDir))
                 {
                     // Use default location under ResourcesPath
-                    webDir = Path.Combine(AppContext.BaseDirectory, "jellyfin-web");
+                    webDir = Path.Combine(AppContext.BaseDirectory, "jellyfin-web", "src");
                 }
             }
 

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -277,7 +277,7 @@ namespace Jellyfin.Server
                 if (string.IsNullOrEmpty(webDir))
                 {
                     // Use default location under ResourcesPath
-                    webDir = Path.Combine(AppContext.BaseDirectory, "jellyfin-web")
+                    webDir = Path.Combine(AppContext.BaseDirectory, "jellyfin-web");
                 }
             }
 

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -264,6 +264,23 @@ namespace Jellyfin.Server
                 }
             }
 
+            // webDir
+            // IF      --webdir
+            // ELSE IF $JELLYFIN_WEB_DIR
+            // ELSE    use <bindir>/jellyfin-web
+            var webDir = options.WebDir;
+
+            if (string.IsNullOrEmpty(webDir))
+            {
+                webDir = Environment.GetEnvironmentVariable("JELLYFIN_WEB_DIR");
+
+                if (string.IsNullOrEmpty(webDir))
+                {
+                    // Use default location under ResourcesPath
+                    webDir = Path.Combine(AppContext.BaseDirectory, "jellyfin-web")
+                }
+            }
+
             // logDir
             // IF      --logdir
             // ELSE IF $JELLYFIN_LOG_DIR
@@ -296,7 +313,7 @@ namespace Jellyfin.Server
                 Environment.Exit(1);
             }
 
-            return new ServerApplicationPaths(dataDir, logDir, configDir, cacheDir);
+            return new ServerApplicationPaths(dataDir, logDir, configDir, cacheDir, webDir);
         }
 
         private static async Task<IConfiguration> CreateConfiguration(IApplicationPaths appPaths)

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -11,7 +11,7 @@ namespace Jellyfin.Server
         [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (database files, etc.).")]
         public string DataDir { get; set; }
 
-        [Option('w', "webdir", Required = false, HelpText = "Path to the Jellyfin web resources.")]
+        [Option('w', "webdir", Required = false, HelpText = "Path to the Jellyfin web UI resources.")]
         public string WebDir { get; set; }
 
         [Option('C', "cachedir", Required = false, HelpText = "Path to use for caching.")]

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -11,6 +11,9 @@ namespace Jellyfin.Server
         [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (database files, etc.).")]
         public string DataDir { get; set; }
 
+        [Option('w', "webdir", Required = false, HelpText = "Path to the Jellyfin web resources.")]
+        public string WebDir { get; set; }
+
         [Option('C', "cachedir", Required = false, HelpText = "Path to use for caching.")]
         public string CacheDir { get; set; }
 

--- a/MediaBrowser.Common/Configuration/IApplicationPaths.cs
+++ b/MediaBrowser.Common/Configuration/IApplicationPaths.cs
@@ -12,9 +12,9 @@ namespace MediaBrowser.Common.Configuration
         string ProgramDataPath { get; }
 
         /// <summary>
-        /// Gets the path to the web resources folder
+        /// Gets the path to the web UI resources folder
         /// </summary>
-        /// <value>The web resources path.</value>
+        /// <value>The web UI resources path.</value>
         string WebPath { get; }
 
         /// <summary>

--- a/MediaBrowser.Common/Configuration/IApplicationPaths.cs
+++ b/MediaBrowser.Common/Configuration/IApplicationPaths.cs
@@ -12,6 +12,12 @@ namespace MediaBrowser.Common.Configuration
         string ProgramDataPath { get; }
 
         /// <summary>
+        /// Gets the path to the web resources folder
+        /// </summary>
+        /// <value>The web resources path.</value>
+        string WebPath { get; }
+
+        /// <summary>
         /// Gets the path to the program system folder
         /// </summary>
         /// <value>The program data path.</value>

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -84,9 +84,9 @@ namespace MediaBrowser.Model.System
         public string ProgramDataPath { get; set; }
 
         /// <summary>
-        /// Gets or sets the web resources path.
+        /// Gets or sets the web UI resources path.
         /// </summary>
-        /// <value>The web resources path.</value>
+        /// <value>The web UI resources path.</value>
         public string WebPath { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -84,6 +84,12 @@ namespace MediaBrowser.Model.System
         public string ProgramDataPath { get; set; }
 
         /// <summary>
+        /// Gets or sets the web resources path.
+        /// </summary>
+        /// <value>The web resources path.</value>
+        public string WebPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the items by name path.
         /// </summary>
         /// <value>The items by name path.</value>

--- a/MediaBrowser.WebDashboard/Api/DashboardService.cs
+++ b/MediaBrowser.WebDashboard/Api/DashboardService.cs
@@ -149,7 +149,7 @@ namespace MediaBrowser.WebDashboard.Api
                     return _serverConfigurationManager.Configuration.DashboardSourcePath;
                 }
 
-                return Path.Combine(_serverConfigurationManager.ApplicationPaths.WebPath, "src");
+                return _serverConfigurationManager.ApplicationPaths.WebPath;
             }
         }
 

--- a/MediaBrowser.WebDashboard/Api/DashboardService.cs
+++ b/MediaBrowser.WebDashboard/Api/DashboardService.cs
@@ -149,7 +149,7 @@ namespace MediaBrowser.WebDashboard.Api
                     return _serverConfigurationManager.Configuration.DashboardSourcePath;
                 }
 
-                return Path.Combine(_serverConfigurationManager.ApplicationPaths.ApplicationResourcesPath, "jellyfin-web", "src");
+                return Path.Combine(_serverConfigurationManager.ApplicationPaths.WebPath, "src");
             }
         }
 


### PR DESCRIPTION
**Changes**
Another step towards a total separation of Jellyfin and Jellyfin Web. Allows the configuration of the WebPath variable via a CLI flag or environment variable (similar to the other configurable paths). Defaults to the same location that was originally hardcoded. Will allow the Jellyfin Web repository to be packaged separately on some systems (e.g. Debian) and the server pointed to the right place.

**Issues**
N/A
