### PR TITLE
Use better path configuration for packages

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -174,7 +174,7 @@ namespace Jellyfin.Server
         {
             // dataDir
             // IF      --datadir
-            // ELSE IF $JELLYFIN_DATA_PATH
+            // ELSE IF $JELLYFIN_DATA_DIR
             // ELSE IF windows, use <%APPDATA%>/jellyfin
             // ELSE IF $XDG_DATA_HOME then use $XDG_DATA_HOME/jellyfin
             // ELSE    use $HOME/.local/share/jellyfin
@@ -182,7 +182,7 @@ namespace Jellyfin.Server
 
             if (string.IsNullOrEmpty(dataDir))
             {
-                dataDir = Environment.GetEnvironmentVariable("JELLYFIN_DATA_PATH");
+                dataDir = Environment.GetEnvironmentVariable("JELLYFIN_DATA_DIR");
 
                 if (string.IsNullOrEmpty(dataDir))
                 {

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -191,8 +191,6 @@ namespace Jellyfin.Server
                 }
             }
 
-            Directory.CreateDirectory(dataDir);
-
             // configDir
             // IF      --configdir
             // ELSE IF $JELLYFIN_CONFIG_DIR
@@ -285,6 +283,7 @@ namespace Jellyfin.Server
             // Ensure the main folders exist before we continue
             try
             {
+                Directory.CreateDirectory(dataDir);
                 Directory.CreateDirectory(logDir);
                 Directory.CreateDirectory(configDir);
                 Directory.CreateDirectory(cacheDir);

--- a/deployment/debian-package-x64/pkg-src/conf/jellyfin
+++ b/deployment/debian-package-x64/pkg-src/conf/jellyfin
@@ -13,10 +13,10 @@
 #
 
 # Program directories
-JELLYFIN_DATA_DIRECTORY="/var/lib/jellyfin"
-JELLYFIN_CONFIG_DIRECTORY="/etc/jellyfin"
-JELLYFIN_LOG_DIRECTORY="/var/log/jellyfin"
-JELLYFIN_CACHE_DIRECTORY="/var/cache/jellyfin"
+JELLYFIN_DATA_DIR="/var/lib/jellyfin"
+JELLYFIN_CONFIG_DIR="/etc/jellyfin"
+JELLYFIN_LOG_DIR="/var/log/jellyfin"
+JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 
 # Restart script for in-app server control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/lib/jellyfin/restart.sh"
@@ -38,4 +38,4 @@ JELLYFIN_FFPROBE_OPT="--ffprobe=/usr/share/jellyfin-ffmpeg/ffprobe"
 # Application username
 JELLYFIN_USER="jellyfin"
 # Full application command
-JELLYFIN_ARGS="--datadir=$JELLYFIN_DATA_DIRECTORY --configdir=$JELLYFIN_CONFIG_DIRECTORY --logdir=$JELLYFIN_LOG_DIRECTORY --cachedir=$JELLYFIN_CACHE_DIRECTORY $JELLYFIN_RESTART_OPT $JELLYFIN_FFMPEG_OPT $JELLYFIN_FFPROBE_OPT $JELLYFIN_SERVICE_OPT $JELLFIN_NOWEBAPP_OPT"
+JELLYFIN_ARGS="$JELLYFIN_RESTART_OPT $JELLYFIN_FFMPEG_OPT $JELLYFIN_FFPROBE_OPT $JELLYFIN_SERVICE_OPT $JELLFIN_NOWEBAPP_OPT"

--- a/deployment/debian-package-x64/pkg-src/jellyfin.service
+++ b/deployment/debian-package-x64/pkg-src/jellyfin.service
@@ -6,7 +6,7 @@ After = network.target
 Type = simple
 EnvironmentFile = /etc/default/jellyfin
 User = jellyfin
-ExecStart = /usr/bin/jellyfin --datadir=${JELLYFIN_DATA_DIRECTORY} --configdir=${JELLYFIN_CONFIG_DIRECTORY} --logdir=${JELLYFIN_LOG_DIRECTORY} --cachedir=${JELLYFIN_CACHE_DIRECTORY} ${JELLYFIN_RESTART_OPT} ${JELLYFIN_FFMPEG_OPT} ${JELLYFIN_FFPROBE_OPT} ${JELLYFIN_SERVICE_OPT} ${JELLYFIN_NOWEBAPP_OPT}
+ExecStart = /usr/bin/jellyfin ${JELLYFIN_RESTART_OPT} ${JELLYFIN_FFMPEG_OPT} ${JELLYFIN_FFPROBE_OPT} ${JELLYFIN_SERVICE_OPT} ${JELLYFIN_NOWEBAPP_OPT}
 Restart = on-failure
 TimeoutSec = 15
 

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.env
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.env
@@ -15,10 +15,10 @@
 #
 
 # Program directories
-JELLYFIN_DATA_DIRECTORY="/var/lib/jellyfin"
-JELLYFIN_CONFIG_DIRECTORY="/etc/jellyfin"
-JELLYFIN_LOG_DIRECTORY="/var/log/jellyfin"
-JELLYFIN_CACHE_DIRECTORY="/var/cache/jellyfin"
+JELLYFIN_DATA_DIR="/var/lib/jellyfin"
+JELLYFIN_CONFIG_DIR="/etc/jellyfin"
+JELLYFIN_LOG_DIR="/var/log/jellyfin"
+JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 
 # In-App service control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/libexec/jellyfin/restart.sh"

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.service
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.service
@@ -5,7 +5,7 @@ Description=Jellyfin is a free software media system that puts you in control of
 [Service]
 EnvironmentFile=/etc/sysconfig/jellyfin
 WorkingDirectory=/var/lib/jellyfin
-ExecStart=/usr/bin/jellyfin --datadir=${JELLYFIN_DATA_DIRECTORY} --configdir=${JELLYFIN_CONFIG_DIRECTORY} --logdir=${JELLYFIN_LOG_DIRECTORY} --cachedir=${JELLYFIN_CACHE_DIRECTORY} ${JELLYFIN_RESTART_OPT} ${JELLYFIN_FFMPEG_OPT} ${JELLYFIN_FFPROBE_OPT} ${JELLYFIN_SERVICE_OPT} ${JELLYFIN_NOWEBAPP_OPT}
+ExecStart=/usr/bin/jellyfin ${JELLYFIN_RESTART_OPT} ${JELLYFIN_FFMPEG_OPT} ${JELLYFIN_FFPROBE_OPT} ${JELLYFIN_SERVICE_OPT} ${JELLYFIN_NOWEBAPP_OPT}
 TimeoutSec=15
 Restart=on-failure
 User=jellyfin


### PR DESCRIPTION
**Changes**
We (read: I) were configuring the paths in the packages in a very convoluted way. Simplify this to use use the envvars for configuration. Also fixes two small bugs related to this:
1. The name of the datadir envvar was PATH rather than DIR; updated it to match the others.
1. The dataDir creation was happening outside the try block of the others; move it in there.

**Issues**
N/A