### PR TITLE
Only delay making MusicBrainz request if necessary

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -428,6 +428,12 @@ namespace Emby.Server.Implementations
         /// <value>The application user agent.</value>
         public string ApplicationUserAgent => Name.Replace(' ','-') + "/" + ApplicationVersion;
 
+        /// <summary>
+        /// Gets the email address for use within a comment section of a user agent field.
+        /// Presently used to provide contact information to MusicBrainz service.
+        /// </summary>
+        public string ApplicationUserAgentAddress { get; } = "team@jellyfin.org";
+
         private string _productName;
 
         /// <summary>

--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -72,6 +72,12 @@ namespace MediaBrowser.Common
         string ApplicationUserAgent { get; }
 
         /// <summary>
+        /// Gets the email address for use within a comment section of a user agent field.
+        /// Presently used to provide contact information to MusicBrainz service.
+        /// </summary>
+        string ApplicationUserAgentAddress { get; }
+
+        /// <summary>
         /// Gets the exports.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/MediaBrowser.Providers/Music/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Music/MusicBrainzAlbumProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -735,7 +734,9 @@ namespace MediaBrowser.Providers.Music
             {
                 Url = MusicBrainzBaseUrl.TrimEnd('/') + url,
                 CancellationToken = cancellationToken,
-                UserAgent = _appHost.ApplicationUserAgent,
+                // MusicBrainz request a contact email address is supplied, as comment, in user agent field:
+                // https://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#User-Agent
+                UserAgent = string.Format("{0} ( {1} )", _appHost.ApplicationUserAgent, _appHost.ApplicationUserAgentAddress),
                 BufferContent = false
             };
 

--- a/MediaBrowser.Providers/Music/MusicBrainzArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/MusicBrainzArtistProvider.cs
@@ -31,7 +31,7 @@ namespace MediaBrowser.Providers.Music
             {
                 var url = string.Format("/ws/2/artist/?query=arid:{0}", musicBrainzId);
 
-                using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, false, cancellationToken).ConfigureAwait(false))
+                using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, cancellationToken).ConfigureAwait(false))
                 {
                     using (var stream = response.Content)
                     {
@@ -46,7 +46,7 @@ namespace MediaBrowser.Providers.Music
 
                 var url = string.Format("/ws/2/artist/?query=\"{0}\"&dismax=true", UrlEncode(nameToSearch));
 
-                using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, true, cancellationToken).ConfigureAwait(false))
+                using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, cancellationToken).ConfigureAwait(false))
                 {
                     using (var stream = response.Content)
                     {
@@ -64,7 +64,7 @@ namespace MediaBrowser.Providers.Music
                     // Try again using the search with accent characters url
                     url = string.Format("/ws/2/artist/?query=artistaccent:\"{0}\"", UrlEncode(nameToSearch));
 
-                    using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, true, cancellationToken).ConfigureAwait(false))
+                    using (var response = await MusicBrainzAlbumProvider.Current.GetMusicBrainzResponse(url, cancellationToken).ConfigureAwait(false))
                     {
                         using (var stream = response.Content)
                         {


### PR DESCRIPTION
When requesting data from MusicBrainz, only delay the request if previous request was less than rate limit ago, instead of always delaying for one second at start.  In addition, removed redundant input params to function GetMusicBrainzResponse() named isSearch and forceMusicBrainzProper.

**Performance evidence**
During testing, this change indicated a 25-40% reduction in time take to complete music scan.  Two test runs were made, as follows:

1) 59 albums, 703 songs.
Original code: 3 minute(s) and 3 seconds:
[run1_old.txt](https://github.com/jellyfin/jellyfin/files/2963624/run1_old.txt)
With this PR: 1 minute(s) and 48 seconds:
[run1_new.txt](https://github.com/jellyfin/jellyfin/files/2963627/run1_new.txt)

2) 141 albums, 2790 songs.
Original code: 17 minute(s) and 32 seconds:
[run2_old.txt](https://github.com/jellyfin/jellyfin/files/2963626/run2_old.txt)
With this PR: 12 minute(s) and 37 seconds:
[run2_new.txt](https://github.com/jellyfin/jellyfin/files/2963625/run2_new.txt)




