### PR TITLE
Only remove /var/lib/apt/lists/* in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
    libfontconfig1 \
  && apt-get clean autoclean \
  && apt-get autoremove \
- && rm -rf /var/lib/{apt,dpkg,cache,log} \
+ && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
 COPY --from=ffmpeg / /


### PR DESCRIPTION

**Changes**
Only remove files in /var/lib/apt/lists/* suggested by Docker best practices.
In the current form we can't update or install any packages.

````
Reading package lists... Error!
root@e38e07db2279:/# apt update
.......
E: flAbsPath on /var/lib/dpkg/status failed - realpath (2: No such file or directory)
E: Could not open file  - open (2: No such file or directory)
E: Problem opening
E: The package lists or status file could not be parsed or opened.
````
````
root@e38e07db2279:/# apt install nano
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (2: No such file or directory)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
````