### PR TITLE
Update username regex to string literal with escaped -

### DIFF
--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -216,10 +216,10 @@ namespace Emby.Server.Implementations.Library
 
         public static bool IsValidUsername(string username)
         {
-            //This is some regex that matches only on unicode "word" characters, as well as -, _ and @
-            //In theory this will cut out most if not all 'control' characters which should help minimize any weirdness
+            // This is some regex that matches only on unicode "word" characters, as well as -, _ and @
+            // In theory this will cut out most if not all 'control' characters which should help minimize any weirdness
             // Usernames can contain letters (a-z + whatever else unicode is cool with), numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)
-            return Regex.IsMatch(username, "^[\\w-'._@]*$");
+            return Regex.IsMatch(username, @"^[\w\-'._@]*$");
         }
 
         private static bool IsValidUsernameCharacter(char i)

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -218,7 +218,7 @@ namespace Emby.Server.Implementations.Library
         {
             // This is some regex that matches only on unicode "word" characters, as well as -, _ and @
             // In theory this will cut out most if not all 'control' characters which should help minimize any weirdness
-            // Usernames can contain letters (a-z + whatever else unicode is cool with), numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)
+             // Usernames can contain letters (a-z + whatever else unicode is cool with), numbers (0-9), at-signs (@), dashes (-), underscores (_), apostrophes ('), and periods (.)
             return Regex.IsMatch(username, @"^[\w\-'._@]*$");
         }
 


### PR DESCRIPTION
**Changes**
The username regex was hard to parse because of the double \\ and the unescaped -

Even though it worked this minor fix makes it clearer what it is doing