### PR TITLE
Require access type to be included in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,6 +30,7 @@ assignees: ''
  - OS: [e.g. Docker, Debian, Windows]
  - Browser: [e.g. Firefox, Chrome, Safari]
  - Jellyfin Version: [e.g. 10.0.1]
+ - Jellyfin access: [direct, reverse proxy via nginx, reverse proxy via apache, etc.]
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ assignees: ''
  - OS: [e.g. Docker, Debian, Windows]
  - Browser: [e.g. Firefox, Chrome, Safari]
  - Jellyfin Version: [e.g. 10.0.1]
- - Jellyfin access: [direct, reverse proxy via nginx, reverse proxy via apache, etc.]
+ - Reverse proxy: [e.g. no, nginx, apache, etc.]
 
 **Additional context**
 <!-- Add any other context about the problem here. -->


### PR DESCRIPTION
**Changes**
Inspired by https://github.com/jellyfin/jellyfin/issues/1085#issuecomment-473833591

It seems that the issue with "setup wizard" described there is only prominent when reverse-proxied, not when accessed directly. So this type of information should be gathered in the bug report as well.

Thus I'm adding another field to the bug report template to gather such information.