### PR TITLE
Fix default value for Expires header

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
@@ -100,7 +100,7 @@ namespace Emby.Server.Implementations.HttpServer
 
             if (addCachePrevention && !responseHeaders.TryGetValue(HeaderNames.Expires, out string expires))
             {
-                responseHeaders[HeaderNames.Expires] = "-1";
+                responseHeaders[HeaderNames.Expires] = "0";
             }
 
             AddResponseHeaders(result, responseHeaders);
@@ -146,7 +146,7 @@ namespace Emby.Server.Implementations.HttpServer
 
             if (addCachePrevention && !responseHeaders.TryGetValue(HeaderNames.Expires, out string _))
             {
-                responseHeaders[HeaderNames.Expires] = "-1";
+                responseHeaders[HeaderNames.Expires] = "0";
             }
 
             AddResponseHeaders(result, responseHeaders);
@@ -190,7 +190,7 @@ namespace Emby.Server.Implementations.HttpServer
 
             if (addCachePrevention && !responseHeaders.TryGetValue(HeaderNames.Expires, out string _))
             {
-                responseHeaders[HeaderNames.Expires] = "-1";
+                responseHeaders[HeaderNames.Expires] = "0";
             }
 
             AddResponseHeaders(result, responseHeaders);
@@ -215,7 +215,7 @@ namespace Emby.Server.Implementations.HttpServer
                 responseHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
-            responseHeaders[HeaderNames.Expires] = "-1";
+            responseHeaders[HeaderNames.Expires] = "0";
 
             return ToOptimizedResultInternal(requestContext, result, responseHeaders);
         }


### PR DESCRIPTION
**Changes**
Changes the default value of the `Expires` HTTP header to be `"0"` instead of `"-1"`. The [RFC](https://tools.ietf.org/html/rfc7234#section-5.3) specifically mentions using `"0"` to represent values that have already expired.

The Java apiclient uses Gson for serializing the response and it logs warnings for the use of `"-1"`.

**Issues**
N/A
