### PR TITLE
Update init scripts for compatibility with Devuan

### DIFF
--- a/deployment/debian-package-x64/pkg-src/jellyfin.init
+++ b/deployment/debian-package-x64/pkg-src/jellyfin.init
@@ -8,42 +8,54 @@
 # Description:       Runs Jellyfin Server
 ### END INIT INFO
 
+set -e
+
 # Carry out specific functions when asked to by the system
 
-pidfile="/var/run/jellyfin.pid"
-pid=`cat $pidfile`
+if test -f /etc/default/jellyfin; then
+    . /etc/default/jellyfin
+fi
+
+. /lib/lsb/init-functions
+
+PIDFILE="/run/jellyfin.pid"
 
 case "$1" in
   start)
-        if [ "$pid" == "" ]; then
-                echo "Starting Jellyfin..."
-                . /etc/default/jellyfin
-                nohup su -u $JELLYFIN_USER -c /usr/bin/jellyfin $JELLYFIN_ARGS
-                echo ?? > $pidfile
-        else
-                echo "Jellyfin already running"
-        fi
+	log_daemon_msg "Starting Jellyfin Media Server" "jellyfin" || true
+
+	if start-stop-daemon --start --quiet --oknodo --background --pidfile $PIDFILE --make-pidfile --user $JELLYFIN_USER --chuid $JELLYFIN_USER --exec /usr/bin/jellyfin -- $JELLYFIN_ARGS; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
     ;;
+
   stop)
-        if [ "$pid" != "" ]; then
-                echo "Stopping Jellyfin..."
-                kill $pid
-                sleep 2
-                rm -f $pidfile
-        else
-                echo "Jellyfin not running"
-        fi
+	log_daemon_msg "Stopping Jellyfin Media Server" "jellyfin" || true
+	if start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE --remove-pidfile; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
     ;;
+
+  restart)
+	log_daemon_msg "Restarting Jellyfin Media Server" "jellyfin" || true
+	start-stop-daemon --stop --quiet --oknodo --retry 30 --pidfile $PIDFILE --remove-pidfile
+	if start-stop-daemon --start --quiet --oknodo --background --pidfile $PIDFILE --make-pidfile --user $JELLYFIN_USER --chuid $JELLYFIN_USER --exec /usr/bin/jellyfin -- $JELLYFIN_ARGS; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
+	;;
+
   status)
-        if [ "$pid" != "" ]; then
-                echo "Jellyfin running as $pid"
-                ps -f $pid
-        else
-                echo "Jellyfin is not running"
-        fi
+	status_of_proc -p $PIDFILE /usr/bin/jellyfin jellyfin && exit 0 || exit $?
   ;;
+
   *)
-    echo "Usage: $0 {start|stop}"
+    echo "Usage: $0 {start|stop|restart|status}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
**Changes**
Changed the script for /etc/init.d/jellyfin to use `start-stop-daemon` instead of the old mechanism using `nohup` and `su`. This makes it work on Debian and Devuan and mimics the behaviour of other init scripts

**Issues**
Fixes #1131 
