### PR TITLE
WAN Address should use public ports instead of local ports. Advertise DNS WAN if available

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1376,9 +1376,6 @@ namespace Emby.Server.Implementations
             if (string.IsNullOrEmpty(ServerConfiguration.WanDdns)){
                 var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
             } else {
-                // Use the (dynmic) domain name set in the configuration if available instead of querying 
-                // an external service to get the IP address
-                // The domain resolution to the ip should be part of the client, not the server.
                 var wanAddress = ServerConfiguration.WanDdns;
             }
 
@@ -1498,13 +1495,13 @@ namespace Emby.Server.Implementations
         {
             if (ipAddress.AddressFamily == IpAddressFamily.InterNetworkV6)
             {
-                return GetLocalApiUrlWithPort("[" + ipAddress.Address + "]");
+                return GetLocalApiUrl("[" + ipAddress.Address + "]");
             }
 
-            return GetLocalApiUrlWithPort(ipAddress.Address);
+            return GetLocalApiUrl(ipAddress.Address);
         }
 
-        public string GetLocalApiUrlWithPort(string host)
+        public string GetLocalApiUrl(string host)
         {
             if (EnableHttps)
             {
@@ -1521,13 +1518,13 @@ namespace Emby.Server.Implementations
         {
             if (ipAddress.AddressFamily == IpAddressFamily.InterNetworkV6)
             {
-                return GetWanApiUrlWithPort("[" + ipAddress.Address + "]");
+                return GetWanApiUrl("[" + ipAddress.Address + "]");
             }
 
-            return GetWanApiUrlWithPort(ipAddress.Address);
+            return GetWanApiUrl(ipAddress.Address);
         }
 
-        public string GetWanApiUrlWithPort(string host)
+        public string GetWanApiUrl(string host)
         {
             if (EnableHttps)
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1476,7 +1476,7 @@ namespace Emby.Server.Implementations
                     CancellationToken = cancellationToken
                 }).ConfigureAwait(false))
                 {
-                    return GetLocalApiUrl(response.ReadToEnd().Trim());
+                    return GetWanApiUrl(response.ReadToEnd().Trim());
                 }
             }
             catch (Exception ex)
@@ -1493,16 +1493,45 @@ namespace Emby.Server.Implementations
                 return GetLocalApiUrl("[" + ipAddress.Address + "]");
             }
 
-            return GetLocalApiUrl(ipAddress.Address);
+            return GetLocalApiUrlWithPort(ipAddress.Address);
         }
 
-        public string GetLocalApiUrl(string host)
+        public string GetLocalApiUrlWithPort(string host)
         {
+            if (EnableHttps)
+            {
+                return string.Format("http://{0}:{1}",
+                    host,
+                    HttpsPort.ToString(CultureInfo.InvariantCulture));
+            }
             return string.Format("http://{0}:{1}",
-                host,
-                HttpPort.ToString(CultureInfo.InvariantCulture));
+                    host,
+                    HttpPort.ToString(CultureInfo.InvariantCulture));      
         }
 
+        public string GetWanApiUrl(IpAddressInfo ipAddress)
+        {
+            if (ipAddress.AddressFamily == IpAddressFamily.InterNetworkV6)
+            {
+                return GetLocalApiUrl("[" + ipAddress.Address + "]");
+            }
+
+            return GetWanApiUrlWithPort(ipAddress.Address);
+        }
+
+        public string GetWanApiUrlWithPort(string host)
+        {
+            if (EnableHttps)
+            {
+                return string.Format("http://{0}:{1}",
+                    host,
+                    ServerConfiguration.PublicHttpsPort.ToString(CultureInfo.InvariantCulture));
+            }
+            return string.Format("http://{0}:{1}",
+                    host,
+                    ServerConfiguration.PublicPort.ToString(CultureInfo.InvariantCulture));      
+        }
+        
         public Task<List<IpAddressInfo>> GetLocalIpAddresses(CancellationToken cancellationToken)
         {
             return GetLocalIpAddressesInternal(true, 0, cancellationToken);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,7 +1372,7 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = ServerConfigurationManager.Configuration.WanDdns;
+            var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             
             if (string.IsNullOrEmpty(wanAddress)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
@@ -1426,7 +1426,7 @@ namespace Emby.Server.Implementations
         public async Task<PublicSystemInfo> GetPublicSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = ServerConfigurationManager.Configuration.WanDdns;
+            var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             
             if (string.IsNullOrEmpty(wanAddress)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1376,7 +1376,8 @@ namespace Emby.Server.Implementations
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
-            } else 
+            }
+            else
             {
                 wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1375,7 +1375,7 @@ namespace Emby.Server.Implementations
             var wanAddress = ServerConfigurationManager.Configuration.WanDdns;
             
             if (string.IsNullOrEmpty(wanAddress)){
-                var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+                wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
             }
 
             return new SystemInfo
@@ -1426,7 +1426,11 @@ namespace Emby.Server.Implementations
         public async Task<PublicSystemInfo> GetPublicSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            var wanAddress = ServerConfigurationManager.Configuration.WanDdns;
+            
+            if (string.IsNullOrEmpty(wanAddress)){
+                wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            }
             return new PublicSystemInfo
             {
                 Version = ApplicationVersion,

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1373,7 +1373,7 @@ namespace Emby.Server.Implementations
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
             
-            if ( String.IsNullOrEmpty(ServerConfiguration.WanDdns) ){
+            if (string.IsNullOrEmpty(ServerConfiguration.WanDdns)){
                 var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
             } else {
                 // Use the (dynmic) domain name set in the configuration if available instead of querying 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,7 +1372,7 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = System.String.Empty;
+            var wanAddress = string.Empty;
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1436,7 +1436,8 @@ namespace Emby.Server.Implementations
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
-            } else 
+            }
+            else
             {
                 wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,11 +1372,10 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
+            var wanAddress = ServerConfigurationManager.Configuration.WanDdns;
             
-            if (string.IsNullOrEmpty(ServerConfiguration.WanDdns)){
+            if (string.IsNullOrEmpty(wanAddress)){
                 var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
-            } else {
-                var wanAddress = ServerConfiguration.WanDdns;
             }
 
             return new SystemInfo
@@ -1530,11 +1529,11 @@ namespace Emby.Server.Implementations
             {
                 return string.Format("https://{0}:{1}",
                     host,
-                    ServerConfiguration.PublicHttpsPort.ToString(CultureInfo.InvariantCulture));
+                    ServerConfigurationManager.Configuration.PublicHttpsPort.ToString(CultureInfo.InvariantCulture));
             }
             return string.Format("http://{0}:{1}",
                     host,
-                    ServerConfiguration.PublicPort.ToString(CultureInfo.InvariantCulture));      
+                    ServerConfigurationManager.Configuration.PublicPort.ToString(CultureInfo.InvariantCulture));      
         }
         
         public Task<List<IpAddressInfo>> GetLocalIpAddresses(CancellationToken cancellationToken)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1433,7 +1433,8 @@ namespace Emby.Server.Implementations
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);            
             var wanAddress = string.Empty;
             
-            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
+            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
+            {
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
             } else 
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1430,7 +1430,7 @@ namespace Emby.Server.Implementations
         public async Task<PublicSystemInfo> GetPublicSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);            
-            var wanAddress = System.String.Empty;
+            var wanAddress = string.Empty;
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1531,7 +1531,7 @@ namespace Emby.Server.Implementations
         {
             if (EnableHttps)
             {
-                return string.Format("http://{0}:{1}",
+                return string.Format("https://{0}:{1}",
                     host,
                     ServerConfiguration.PublicHttpsPort.ToString(CultureInfo.InvariantCulture));
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,7 +1372,15 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            
+            if ( String.IsNullOrEmpty(ServerConfiguration.WanDdns) ){
+                var wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            } else {
+                // Use the (dynmic) domain name set in the configuration if available instead of querying 
+                // an external service to get the IP address
+                // The domain resolution to the ip should be part of the client, not the server.
+                var wanAddress = ServerConfiguration.WanDdns;
+            }
 
             return new SystemInfo
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1498,7 +1498,7 @@ namespace Emby.Server.Implementations
         {
             if (ipAddress.AddressFamily == IpAddressFamily.InterNetworkV6)
             {
-                return GetLocalApiUrl("[" + ipAddress.Address + "]");
+                return GetLocalApiUrlWithPort("[" + ipAddress.Address + "]");
             }
 
             return GetLocalApiUrlWithPort(ipAddress.Address);
@@ -1521,7 +1521,7 @@ namespace Emby.Server.Implementations
         {
             if (ipAddress.AddressFamily == IpAddressFamily.InterNetworkV6)
             {
-                return GetLocalApiUrl("[" + ipAddress.Address + "]");
+                return GetWanApiUrlWithPort("[" + ipAddress.Address + "]");
             }
 
             return GetWanApiUrlWithPort(ipAddress.Address);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1376,7 +1376,7 @@ namespace Emby.Server.Implementations
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -1435,7 +1435,7 @@ namespace Emby.Server.Implementations
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -1478,7 +1478,7 @@ namespace Emby.Server.Implementations
             return null;
         }
 
-        public async Task<string> GetWanApiUrl(CancellationToken cancellationToken)
+        public async Task<string> GetWanApiUrlFromExternal(CancellationToken cancellationToken)
         {
             const string Url = "http://ipv4.icanhazip.com";
             try
@@ -1524,7 +1524,7 @@ namespace Emby.Server.Implementations
             }
             return string.Format("http://{0}:{1}",
                     host,
-                    HttpPort.ToString(CultureInfo.InvariantCulture));      
+                    HttpPort.ToString(CultureInfo.InvariantCulture));
         }
 
         public string GetWanApiUrl(IpAddressInfo ipAddress)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1508,7 +1508,7 @@ namespace Emby.Server.Implementations
         {
             if (EnableHttps)
             {
-                return string.Format("http://{0}:{1}",
+                return string.Format("https://{0}:{1}",
                     host,
                     HttpsPort.ToString(CultureInfo.InvariantCulture));
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1373,13 +1373,15 @@ namespace Emby.Server.Implementations
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
             
+            string wanAddress; 
+            
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                var wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
+                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
 
             return new SystemInfo
@@ -1431,13 +1433,15 @@ namespace Emby.Server.Implementations
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);            
             
+            string wanAddress;
+            
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                var wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
+                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
             return new PublicSystemInfo
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,15 +1372,14 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = string.Empty;
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
+                var wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+                var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
 
             return new SystemInfo
@@ -1431,15 +1430,14 @@ namespace Emby.Server.Implementations
         public async Task<PublicSystemInfo> GetPublicSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);            
-            var wanAddress = string.Empty;
             
             if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
             {
-                wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
+                var wanAddress = await GetWanApiUrlFromExternal(cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+                var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
             return new PublicSystemInfo
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1374,7 +1374,8 @@ namespace Emby.Server.Implementations
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
             var wanAddress = string.Empty;
             
-            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
+            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns))
+            {
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
             }
             else

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1372,10 +1372,13 @@ namespace Emby.Server.Implementations
         public async Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken)
         {
             var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+            var wanAddress = System.String.Empty;
             
-            if (string.IsNullOrEmpty(wanAddress)){
+            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            } else 
+            {
+                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
 
             return new SystemInfo
@@ -1425,11 +1428,14 @@ namespace Emby.Server.Implementations
 
         public async Task<PublicSystemInfo> GetPublicSystemInfo(CancellationToken cancellationToken)
         {
-            var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            var wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
+            var localAddress = await GetLocalApiUrl(cancellationToken).ConfigureAwait(false);            
+            var wanAddress = System.String.Empty;
             
-            if (string.IsNullOrEmpty(wanAddress)){
+            if (string.IsNullOrEmpty(ServerConfigurationManager.Configuration.WanDdns)){
                 wanAddress = await GetWanApiUrl(cancellationToken).ConfigureAwait(false);
+            } else 
+            {
+                wanAddress = GetWanApiUrl(ServerConfigurationManager.Configuration.WanDdns);
             }
             return new PublicSystemInfo
             {


### PR DESCRIPTION
See [this comment](https://github.com/jellyfin/jellyfin/issues/601#issuecomment-475941080)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Adds switch for https ports for local configuration depending on whether https is used.
Uses public ports for WAN address instead of local ports. Also switches to https if enabled. 
If configuration has a DNS WAN name, use this name instead: This might break clients such as jellyfin for kodi and/or the android app. The clients need to change accordingly. 

**Issues**
https://github.com/jellyfin/jellyfin/issues/1152

