### PR TITLE
Use new libexecdir location for jellyfin-ffmpeg

### DIFF
--- a/deployment/debian-package-x64/pkg-src/conf/jellyfin
+++ b/deployment/debian-package-x64/pkg-src/conf/jellyfin
@@ -22,7 +22,7 @@ JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 JELLYFIN_RESTART_OPT="--restartpath=/usr/lib/jellyfin/restart.sh"
 
 # ffmpeg binary paths, overriding the system values
-JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/share/jellyfin-ffmpeg/ffmpeg"
+JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
 # [OPTIONAL] run Jellyfin as a headless service
 #JELLYFIN_SERVICE_OPT="--service"


### PR DESCRIPTION
Update the location of the jellyfin-ffmpeg binaries as changed in commit d6bb1f3c in jellyfin-ffmpeg. The binaries are now located in `/usr/lib` instead of `/usr/share` to better comply with the specification for these directories.

References https://github.com/jellyfin/jellyfin-ffmpeg/issues/2