### PR TITLE
Fix problems with plugin installation

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1047,7 +1047,7 @@ namespace Emby.Server.Implementations
         private async void PluginInstalled(object sender, GenericEventArgs<PackageVersionInfo> args)
         {
             string dir = Path.Combine(ApplicationPaths.PluginsPath, Path.GetFileNameWithoutExtension(args.Argument.targetFilename));
-            var types = Directory.EnumerateFiles(dir, "*.dll", SearchOption.TopDirectoryOnly)
+            var types = Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories)
                         .Select(x => Assembly.LoadFrom(x))
                         .SelectMany(x => x.ExportedTypes)
                         .Where(x => x.IsClass && !x.IsAbstract && !x.IsInterface && !x.IsGenericType)
@@ -1346,7 +1346,7 @@ namespace Emby.Server.Implementations
         {
             if (Directory.Exists(ApplicationPaths.PluginsPath))
             {
-                foreach (var file in Directory.EnumerateFiles(ApplicationPaths.PluginsPath, "*.dll", SearchOption.TopDirectoryOnly))
+                foreach (var file in Directory.EnumerateFiles(ApplicationPaths.PluginsPath, "*.dll", SearchOption.AllDirectories))
                 {
                     Logger.LogInformation("Loading assembly {Path}", file);
                     yield return Assembly.LoadFrom(file);

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1046,7 +1046,7 @@ namespace Emby.Server.Implementations
 
         private async void PluginInstalled(object sender, GenericEventArgs<PackageVersionInfo> args)
         {
-            string dir = Path.Combine(ApplicationPaths.PluginsPath, Path.GetFileNameWithoutExtension(args.Argument.targetFilename));
+            string dir = Path.Combine(ApplicationPaths.PluginsPath, args.Argument.name);
             var types = Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories)
                         .Select(x => Assembly.LoadFrom(x))
                         .SelectMany(x => x.ExportedTypes)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -85,9 +85,11 @@ namespace Emby.Server.Implementations.Updates
         private void OnPluginInstalled(PackageVersionInfo package)
         {
             _logger.LogInformation("New plugin installed: {0} {1} {2}", package.name, package.versionStr ?? string.Empty, package.classification);
+            _logger.LogDebug("{String}", package.name);
 
             PluginInstalled?.Invoke(this, new GenericEventArgs<PackageVersionInfo> { Argument = package });
 
+            _logger.LogDebug("{String}", package.name);
             _applicationHost.NotifyPendingRestart();
         }
 
@@ -518,12 +520,12 @@ namespace Emby.Server.Implementations.Updates
                 return;
             }
 
-            if (target == null)
-            {
-                target = Path.Combine(_appPaths.PluginsPath, Path.GetFileNameWithoutExtension(package.targetFilename));
-            }
+            // Always override the passed-in target (which is a file) and figure it out again
+            target = Path.Combine(_appPaths.PluginsPath, package.name);
+            _logger.LogDebug("Installing plugin to {Filename}.", target);
 
             // Download to temporary file so that, if interrupted, it won't destroy the existing installation
+            _logger.LogDebug("Downloading ZIP.");
             var tempFile = await _httpClient.GetTempFile(new HttpRequestOptions
             {
                 Url = package.sourceUrl,
@@ -536,9 +538,17 @@ namespace Emby.Server.Implementations.Updates
 
             // TODO: Validate with a checksum, *properly*
 
+            // Check if the target directory already exists, and remove it if so
+            if (Directory.Exists(target))
+            {
+                _logger.LogDebug("Deleting existing plugin at {Filename}.", target);
+                Directory.Delete(target, true);
+            }
+
             // Success - move it to the real target
             try
             {
+                _logger.LogDebug("Extracting ZIP {TempFile} to {Filename}.", tempFile, target);
                 using (var stream = File.OpenRead(tempFile))
                 {
                     _zipClient.ExtractAllFromZip(stream, target, true);
@@ -552,6 +562,7 @@ namespace Emby.Server.Implementations.Updates
 
             try
             {
+                _logger.LogDebug("Deleting temporary file {Filename}.", tempFile);
                 _fileSystem.DeleteFile(tempFile);
             }
             catch (IOException ex)
@@ -574,7 +585,18 @@ namespace Emby.Server.Implementations.Updates
             _applicationHost.RemovePlugin(plugin);
 
             var path = plugin.AssemblyFilePath;
-            _logger.LogInformation("Deleting plugin file {0}", path);
+            bool is_path_directory = false;
+            // Check if we have a plugin directory we should remove too
+            if (Path.GetDirectoryName(plugin.AssemblyFilePath) != _appPaths.PluginsPath)
+            {
+                path = Path.GetDirectoryName(plugin.AssemblyFilePath);
+                is_path_directory = true;
+                _logger.LogInformation("Deleting plugin directory {0}", path);
+            }
+            else
+            {
+                _logger.LogInformation("Deleting plugin file {0}", path);
+            }
 
             // Make this case-insensitive to account for possible incorrect assembly naming
             var file = _fileSystem.GetFilePaths(Path.GetDirectoryName(path))
@@ -585,7 +607,14 @@ namespace Emby.Server.Implementations.Updates
                 path = file;
             }
 
-            _fileSystem.DeleteFile(path);
+            if (is_path_directory)
+            {
+                Directory.Delete(path, true);
+            }
+            else
+            {
+                _fileSystem.DeleteFile(path);
+            }
 
             var list = _config.Configuration.UninstalledPlugins.ToList();
             var filename = Path.GetFileName(path);

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -85,11 +85,9 @@ namespace Emby.Server.Implementations.Updates
         private void OnPluginInstalled(PackageVersionInfo package)
         {
             _logger.LogInformation("New plugin installed: {0} {1} {2}", package.name, package.versionStr ?? string.Empty, package.classification);
-            _logger.LogDebug("{String}", package.name);
 
             PluginInstalled?.Invoke(this, new GenericEventArgs<PackageVersionInfo> { Argument = package });
 
-            _logger.LogDebug("{String}", package.name);
             _applicationHost.NotifyPendingRestart();
         }
 
@@ -585,17 +583,12 @@ namespace Emby.Server.Implementations.Updates
             _applicationHost.RemovePlugin(plugin);
 
             var path = plugin.AssemblyFilePath;
-            bool is_path_directory = false;
+            bool isDirectory = false;
             // Check if we have a plugin directory we should remove too
             if (Path.GetDirectoryName(plugin.AssemblyFilePath) != _appPaths.PluginsPath)
             {
                 path = Path.GetDirectoryName(plugin.AssemblyFilePath);
-                is_path_directory = true;
-                _logger.LogInformation("Deleting plugin directory {0}", path);
-            }
-            else
-            {
-                _logger.LogInformation("Deleting plugin file {0}", path);
+                isDirectory = true;
             }
 
             // Make this case-insensitive to account for possible incorrect assembly naming
@@ -607,12 +600,14 @@ namespace Emby.Server.Implementations.Updates
                 path = file;
             }
 
-            if (is_path_directory)
+            if (isDirectory)
             {
+                _logger.LogInformation("Deleting plugin directory {0}", path);
                 Directory.Delete(path, true);
             }
             else
             {
+                _logger.LogInformation("Deleting plugin file {0}", path);
                 _fileSystem.DeleteFile(path);
             }
 

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -509,6 +509,8 @@ namespace Emby.Server.Implementations.Updates
 
         private async Task PerformPackageInstallation(IProgress<double> progress, string target, PackageVersionInfo package, CancellationToken cancellationToken)
         {
+            // TODO: Remove the `string target` argument as it is not used any longer
+
             var extension = Path.GetExtension(package.targetFilename);
             var isArchive = string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
### Changes

Fixes several breaking bugs around the installation, loading, and management of plugins.

1. Restore previous functionality to load plugins from subfolders of the PluginDir, which was potentially broken in #801 (or previously, not sure).
1. Use a directory name based only on the `Name` of the plugin, not the source filename, which contains the version and would be really confusing.
1. Use the new directory name for the deletes if it's present, so that installation and removal happen at that directory level and we don't leave empty folders laying around. Ensures we properly remove additional resources in plugins too, not just the main `.dll` file.
1. Ignore the incoming `target` when installing, and always set it ourself to the proper directory, which would matter when upgrading since the `target` is just the `.dll` filename.
1. Delete an existing target directory before installing if it exists, allowing plugin updates to function properly. Note that not calling any of the plugin removal code is intentional; I suspect that would delete configurations unexpectedly when upgrading which would be annoying. This way, it just replaces the files and then reloads.
1. (Minor) Added some actual debug messages around the plugin download section so failures can be more accurately seen.

The end result is that, for example, the `Anime` plugin will on Debian be installed in `/var/lib/jellyfin/plugins/Anime/` as `Anime.dll`. When removed, the whole `/var/lib/jellyfin/plugins/Anime` directory will be removed. When upgrading to a new version, the directory will be removed automatically as expected and the new plugin installed in its place.

### Issues
Fixes #1194