### PR TITLE
Clean `WebSocketSharpRequest.PathInfo`

### DIFF
--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -327,10 +327,7 @@ namespace Emby.Server.Implementations.SocketSharp
                     if (pos != -1)
                     {
                         var path = RawUrl.Substring(0, pos);
-                        this.pathInfo = GetPathInfo(
-                            path,
-                            mode,
-                            mode ?? string.Empty);
+                        this.pathInfo = path;
                     }
                     else
                     {
@@ -343,65 +340,6 @@ namespace Emby.Server.Implementations.SocketSharp
 
                 return this.pathInfo;
             }
-        }
-
-        private static string GetPathInfo(string fullPath, string mode, string appPath)
-        {
-            var pathInfo = ResolvePathInfoFromMappedPath(fullPath, mode);
-            if (!string.IsNullOrEmpty(pathInfo))
-            {
-                return pathInfo;
-            }
-
-            // Wildcard mode relies on this to work out the handlerPath
-            pathInfo = ResolvePathInfoFromMappedPath(fullPath, appPath);
-            if (!string.IsNullOrEmpty(pathInfo))
-            {
-                return pathInfo;
-            }
-
-            return fullPath;
-        }
-
-        private static string ResolvePathInfoFromMappedPath(string fullPath, string mappedPathRoot)
-        {
-            if (mappedPathRoot == null)
-            {
-                return null;
-            }
-
-            var sbPathInfo = new StringBuilder();
-            var fullPathParts = fullPath.Split('/');
-            var mappedPathRootParts = mappedPathRoot.Split('/');
-            var fullPathIndexOffset = mappedPathRootParts.Length - 1;
-            var pathRootFound = false;
-
-            for (var fullPathIndex = 0; fullPathIndex < fullPathParts.Length; fullPathIndex++)
-            {
-                if (pathRootFound)
-                {
-                    sbPathInfo.Append("/" + fullPathParts[fullPathIndex]);
-                }
-                else if (fullPathIndex - fullPathIndexOffset >= 0)
-                {
-                    pathRootFound = true;
-                    for (var mappedPathRootIndex = 0; mappedPathRootIndex < mappedPathRootParts.Length; mappedPathRootIndex++)
-                    {
-                        if (!string.Equals(fullPathParts[fullPathIndex - fullPathIndexOffset + mappedPathRootIndex], mappedPathRootParts[mappedPathRootIndex], StringComparison.OrdinalIgnoreCase))
-                        {
-                            pathRootFound = false;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (!pathRootFound)
-            {
-                return null;
-            }
-
-            return sbPathInfo.Length > 1 ? sbPathInfo.ToString().TrimEnd('/') : "/";
         }
 
         public string UserAgent => request.Headers[HeaderNames.UserAgent];

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -335,7 +335,6 @@ namespace Emby.Server.Implementations.SocketSharp
                     }
 
                     this.pathInfo = WebUtility.UrlDecode(pathInfo);
-                    this.pathInfo = NormalizePathInfo(pathInfo, mode).ToString();
                 }
 
                 return this.pathInfo;
@@ -437,20 +436,6 @@ namespace Emby.Server.Implementations.SocketSharp
 
                 return httpFiles;
             }
-        }
-
-        public static ReadOnlySpan<char> NormalizePathInfo(string pathInfo, string handlerPath)
-        {
-            if (handlerPath != null)
-            {
-                var trimmed = pathInfo.AsSpan().TrimStart('/');
-                if (trimmed.StartsWith(handlerPath.AsSpan(), StringComparison.OrdinalIgnoreCase))
-                {
-                    return trimmed.Slice(handlerPath.Length).ToString().AsSpan();
-                }
-            }
-
-            return pathInfo.AsSpan();
         }
     }
 }

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -98,46 +98,40 @@ namespace Emby.Server.Implementations.SocketSharp
                 switch (crlf)
                 {
                     case 0:
+                        if (c == '\r')
                         {
-                            if (c == '\r')
-                            {
-                                crlf = 1;
-                            }
-                            else if (c == '\n')
-                            {
-                                // Technically this is bad HTTP.  But it would be a breaking change to throw here.
-                                // Is there an exploit?
-                                crlf = 2;
-                            }
-                            else if (c == 127 || (c < ' ' && c != '\t'))
-                            {
-                                throw new ArgumentException("net_WebHeaderInvalidControlChars", nameof(name));
-                            }
+                            crlf = 1;
+                        }
+                        else if (c == '\n')
+                        {
+                            // Technically this is bad HTTP.  But it would be a breaking change to throw here.
+                            // Is there an exploit?
+                            crlf = 2;
+                        }
+                        else if (c == 127 || (c < ' ' && c != '\t'))
+                        {
+                            throw new ArgumentException("net_WebHeaderInvalidControlChars", nameof(name));
+                        }
 
+                        break;
+
+                    case 1:
+                        if (c == '\n')
+                        {
+                            crlf = 2;
                             break;
                         }
 
-                    case 1:
-                        {
-                            if (c == '\n')
-                            {
-                                crlf = 2;
-                                break;
-                            }
-
-                            throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
-                        }
+                        throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
 
                     case 2:
+                        if (c == ' ' || c == '\t')
                         {
-                            if (c == ' ' || c == '\t')
-                            {
-                                crlf = 0;
-                                break;
-                            }
-
-                            throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
+                            crlf = 0;
+                            break;
                         }
+
+                        throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
                 }
             }
 

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -310,16 +310,9 @@ namespace Emby.Server.Implementations.SocketSharp
             return pos == -1 ? strVal : strVal.Slice(0, pos);
         }
 
-        private string pathInfo;
         public string PathInfo
         {
-            get
-            {
-                if (this.pathInfo is null)
-                    this.pathInfo = this.request.Path.Value;
-
-                return this.pathInfo;
-            }
+            get => this.request.Path.Value;
         }
 
         public string UserAgent => request.Headers[HeaderNames.UserAgent];

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -25,8 +25,6 @@ namespace Emby.Server.Implementations.SocketSharp
             this.OperationName = operationName;
             this.request = httpContext;
             this.Response = new WebSocketSharpResponse(logger, response);
-
-            // HandlerFactoryPath = GetHandlerPathIfAny(UrlPrefixes[0]);
         }
 
         public HttpRequest HttpRequest => request;
@@ -100,46 +98,46 @@ namespace Emby.Server.Implementations.SocketSharp
                 switch (crlf)
                 {
                     case 0:
-                    {
-                        if (c == '\r')
                         {
-                            crlf = 1;
-                        }
-                        else if (c == '\n')
-                        {
-                            // Technically this is bad HTTP.  But it would be a breaking change to throw here.
-                            // Is there an exploit?
-                            crlf = 2;
-                        }
-                        else if (c == 127 || (c < ' ' && c != '\t'))
-                        {
-                            throw new ArgumentException("net_WebHeaderInvalidControlChars", nameof(name));
-                        }
+                            if (c == '\r')
+                            {
+                                crlf = 1;
+                            }
+                            else if (c == '\n')
+                            {
+                                // Technically this is bad HTTP.  But it would be a breaking change to throw here.
+                                // Is there an exploit?
+                                crlf = 2;
+                            }
+                            else if (c == 127 || (c < ' ' && c != '\t'))
+                            {
+                                throw new ArgumentException("net_WebHeaderInvalidControlChars", nameof(name));
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
 
                     case 1:
-                    {
-                        if (c == '\n')
                         {
-                            crlf = 2;
-                            break;
-                        }
+                            if (c == '\n')
+                            {
+                                crlf = 2;
+                                break;
+                            }
 
-                        throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
-                    }
+                            throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
+                        }
 
                     case 2:
-                    {
-                        if (c == ' ' || c == '\t')
                         {
-                            crlf = 0;
-                            break;
-                        }
+                            if (c == ' ' || c == '\t')
+                            {
+                                crlf = 0;
+                                break;
+                            }
 
-                        throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
-                    }
+                            throw new ArgumentException("net_WebHeaderInvalidCRLFChars", nameof(name));
+                        }
                 }
             }
 
@@ -311,8 +309,6 @@ namespace Emby.Server.Implementations.SocketSharp
             var pos = strVal.IndexOf(needle);
             return pos == -1 ? strVal : strVal.Slice(0, pos);
         }
-
-        public static string HandlerFactoryPath;
 
         private string pathInfo;
         public string PathInfo

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -310,10 +310,7 @@ namespace Emby.Server.Implementations.SocketSharp
             return pos == -1 ? strVal : strVal.Slice(0, pos);
         }
 
-        public string PathInfo
-        {
-            get => this.request.Path.Value;
-        }
+        public string PathInfo => this.request.Path.Value;
 
         public string UserAgent => request.Headers[HeaderNames.UserAgent];
 

--- a/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
+++ b/Emby.Server.Implementations/SocketSharp/WebSocketSharpRequest.cs
@@ -319,23 +319,8 @@ namespace Emby.Server.Implementations.SocketSharp
         {
             get
             {
-                if (this.pathInfo == null)
-                {
-                    var mode = HandlerFactoryPath;
-
-                    var pos = RawUrl.IndexOf("?", StringComparison.Ordinal);
-                    if (pos != -1)
-                    {
-                        var path = RawUrl.Substring(0, pos);
-                        this.pathInfo = path;
-                    }
-                    else
-                    {
-                        this.pathInfo = RawUrl;
-                    }
-
-                    this.pathInfo = WebUtility.UrlDecode(pathInfo);
-                }
+                if (this.pathInfo is null)
+                    this.pathInfo = this.request.Path.Value;
 
                 return this.pathInfo;
             }


### PR DESCRIPTION
Hi, new dev here. I chose #1047 to start contributing because of the "good first issue" flag.

Issue was requesting a replacement of ad hoc URL parsing code in `WebSocketSharpRequest.PathInfo` by standard .NET Core methods.

This ad hoc parsing was dependent on a never-initialized (thus always `null`) member `HandlerFactoryPath` and doing nothing when it's null. That led to important simplification of the code.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Removed ` ResolvePathInfoFromMappedPath(string fullPath, string mappedPathRoot)` method because it is doing nothing (in a inefficient manner) when  `mappedPathRoot` is `null` and it always is.
- Removed `NormalizePathInfo` for the same reason
- Replaced usage of `RawUrl`, which is not a good fit because it contains the query part (`?..=..`) which is ignored, by `request.Path`.

**Need**
Some testing as usual, I am not sure how it can be done thoroughly. 
I just started the server and clicked around with a breakpoint configured to stop on any discrepancy between the old and new `pathInfo` implementations and everything seemed ok. 

**Issues**
Fixes #1047


