### PR TITLE
Disable dotnet_compat part of pipeline

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
     pool:
       vmImage: ubuntu-16.04
     dependsOn: main_build
-    condition: and(succeeded(), variables['System.PullRequest.PullRequestNumber']) # Only execute if the pullrequest numer is defined. (So not for normal CI builds)
+    condition: false #and(succeeded(), variables['System.PullRequest.PullRequestNumber']) # Only execute if the pullrequest numer is defined. (So not for normal CI builds)
     strategy:
       matrix:
         Naming:


### PR DESCRIPTION
**Changes**
Disables dotnet_compat portion of Azure Pipelines CI, until #1111 can be resolved.

