### PR TITLE
Fix missing Unraid cache mount and name capitalization

### DIFF
--- a/deployment/unraid/docker-templates/jellyfin.xml
+++ b/deployment/unraid/docker-templates/jellyfin.xml
@@ -36,7 +36,7 @@
   </Networking>
   <Data>
     <Volume>
-      <HostDir>/mnt/user/appdata/jellyfin</HostDir>
+      <HostDir>/mnt/user/appdata/Jellyfin</HostDir>
       <ContainerDir>/config</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
@@ -46,7 +46,7 @@
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir>/mnt/user/appdata/jellyfin/cache/</HostDir>
+      <HostDir>/mnt/user/appdata/Jellyfin/cache/</HostDir>
       <ContainerDir>/cache</ContainerDir>
       <Mode>rw</Mode>
     </Volume>

--- a/deployment/unraid/docker-templates/jellyfin.xml
+++ b/deployment/unraid/docker-templates/jellyfin.xml
@@ -3,14 +3,15 @@
   <TemplateURL>https://raw.githubusercontent.com/jellyfin/jellyfin/deployment/unraid/docker-templates/jellyfin.xml</TemplateURL>
   <Beta>False</Beta>
   <Category>MediaApp:Video MediaApp:Music MediaApp:Photos MediaServer:Video MediaServer:Music MediaServer:Photos</Category>
-  <Name>JellyFin</Name>
+  <Name>Jellyfin</Name>
   <Description>
-	JellyFin is The Free Software Media Browser	Converted By Community Applications	Always verify this template (and values) against the dockerhub support page for the container!![br][br]
+	Jellyfin is The Free Software Media Browser	Converted By Community Applications	Always verify this template (and values) against the dockerhub support page for the container!![br][br]
   You can add as many mount points as needed for recordings, movies ,etc. [br][br]
   [b][span style='color: #E80000;']Directions:[/span][/b][br]
-  [b]/config[/b] : this is where Jellyfin will store it's databases and configuration.[br][br]
+  [b]/config[/b] : This is where Jellyfin will store it's databases and configuration.[br][br]
   [b]Port[/b] : This is the default port for Jellyfin. (Will add ssl port later)[br][br]
-  [b]Media[/b] : This is the mounting point of your media. When you access it in Jellyfin it will be /media or whatever you chose for a mount point
+  [b]Media[/b] : This is the mounting point of your media. When you access it in Jellyfin it will be /media or whatever you chose for a mount point[br][br]
+  [b]Cache[/b] : This is where Jellyfin will store and manage cached files like images to serve to clients. This is not where all images are stored.[br][br]
   [b]Tip:[/b] You can add more volume mappings if you wish Jellyfin has access to it.
   </Description>
   <Overview>
@@ -35,13 +36,18 @@
   </Networking>
   <Data>
     <Volume>
-      <HostDir>/mnt/cache/appdata/config</HostDir>
+      <HostDir>/mnt/user/appdata/jellyfin</HostDir>
       <ContainerDir>/config</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>
       <HostDir>/mnt/user</HostDir>
       <ContainerDir>/media</ContainerDir>
+      <Mode>rw</Mode>
+    </Volume>
+    <Volume>
+      <HostDir>/mnt/user/appdata/jellyfin/cache/</HostDir>
+      <ContainerDir>/cache</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
   </Data>


### PR DESCRIPTION
Forgive me if i should not have done these in a single pull request, or possibly needed a different title.


- Cache folder was not mounted outside of the Docker image since its separation from the config folder.

Current installations may have an issue with their docker image (VM) filling up as this change will not affect current installations. Unraid defaults to a 20GB docker image & there are reports of the cache folder in emby occasionally bloating to many, many GB in size! (14GB-140GB in one particular case!)

- Config HostDir was updated for consistency, directory is overridden by unraid into the user/appdata/appname folder anyway.

- Name capitalization was corrected as this is only used by new installations & does not affect current installations/updates/re-installs unless the template is removed, saved, re added & Jellyfin reinstalled.