### PR TITLE
Fix help message to indicate the right output folder

### DIFF
--- a/build
+++ b/build
@@ -29,7 +29,7 @@ usage() {
     echo -e "The web_branch defaults to the same branch name as the current main branch or can be 'local' to not touch the submodule branching."
     echo -e "To build all platforms, use 'all'."
     echo -e "To perform all build actions, use 'all'."
-    echo -e "Build output files are collected at '../jellyfin-build/<platform>'."
+    echo -e "Build output files are collected at '../bin/<platform>'."
 }
 
 # Show usage on stderr with exit 1 on argless


### PR DESCRIPTION
The `./build` help message mentions that the output folder is `../jellyfin-build/<platform>` but the script outputs the archive to `../bin/<platform>`. This PR update the message to mention `../bin/<platform>`. I actually think `../jellyfin-build/<platform>` is better, but I didn't want to disturb your build processes by changing the actual output folder.

Kinda related to https://github.com/jellyfin/jellyfin-docs/pull/66