### PR TITLE
Clean up UDP responders, and move ProductName to Public endpoint

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1425,7 +1425,6 @@ namespace Emby.Server.Implementations
                 HasPendingRestart = HasPendingRestart,
                 IsShuttingDown = IsShuttingDown,
                 Version = ApplicationVersion,
-                ProductName = ApplicationProductName,
                 WebSocketPortNumber = HttpPort,
                 CompletedInstallations = InstallationManager.CompletedInstallations.ToArray(),
                 Id = SystemId,
@@ -1482,6 +1481,7 @@ namespace Emby.Server.Implementations
             return new PublicSystemInfo
             {
                 Version = ApplicationVersion,
+                ProductName = ApplicationProductName,
                 Id = SystemId,
                 OperatingSystem = OperatingSystem.Id.ToString(),
                 WanAddress = wanAddress,

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -41,8 +41,6 @@ namespace Emby.Server.Implementations.Udp
             _socketFactory = socketFactory;
 
             AddMessageResponder("who is JellyfinServer?", true, RespondToV2Message);
-            AddMessageResponder("who is EmbyServer?", true, RespondToV2Message);
-            AddMessageResponder("who is MediaBrowserServer_v2?", false, RespondToV2Message);
         }
 
         private void AddMessageResponder(string message, bool isSubstring, Func<string, IpEndPointInfo, Encoding, CancellationToken, Task> responder)

--- a/MediaBrowser.Model/System/PublicSystemInfo.cs
+++ b/MediaBrowser.Model/System/PublicSystemInfo.cs
@@ -25,6 +25,11 @@ namespace MediaBrowser.Model.System
         /// </summary>
         /// <value>The version.</value>
         public string Version { get; set; }
+        
+        /// <summary>
+        /// The product name. This is the AssemblyProduct name.
+        /// </summary>
+        public string ProductName { get; set; }
 
         /// <summary>
         /// Gets or sets the operating system.

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -32,10 +32,6 @@ namespace MediaBrowser.Model.System
         /// <value>The display name of the operating system.</value>
         public string OperatingSystemDisplayName { get; set; }
 
-        /// <summary>
-        /// The product name. This is the AssemblyProduct name.
-        /// </summary>
-        public string ProductName { get; set; }
 
         /// <summary>
         /// Get or sets the package name.


### PR DESCRIPTION
**Changes**
In `UdpServer.cs`, remove the other UDP responders (embyserver, MediaBrowser_v2), and only keeps Jellyfin.

In `ApplicationHost.cs`, moves the ProductBame entry from the “.../system/info” endpoint to the “…/system/info/public” one instead.

**Issues**
Start of the work for #1222.
