### PR TITLE
Hotfix authapi

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -203,6 +203,7 @@ namespace Emby.Server.Implementations.HttpServer
                 case DirectoryNotFoundException _:
                 case FileNotFoundException _:
                 case ResourceNotFoundException _: return 404;
+                case MethodNotAllowedException _: return 405;
                 case RemoteServiceUnavailableException _: return 502;
                 default: return 500;
             }

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -379,7 +379,7 @@ namespace MediaBrowser.Api
                 throw new ResourceNotFoundException("User not found");
             }
 
-            if (!string.IsNullOrEmpty(request.Password) || string.IsNullOrEmpty(request.Pw))
+            if (!string.IsNullOrEmpty(request.Password) && string.IsNullOrEmpty(request.Pw))
             {
                 throw new MethodNotAllowedException("Hashed-only passwords are not valid for this API.");
             }
@@ -387,7 +387,7 @@ namespace MediaBrowser.Api
             return Post(new AuthenticateUserByName
             {
                 Username = user.Name,
-                Password = request.Password,
+                Password = null, // This should always be null
                 Pw = request.Pw
             });
         }

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -379,6 +379,11 @@ namespace MediaBrowser.Api
                 throw new ResourceNotFoundException("User not found");
             }
 
+            if (!request.Pw)
+            {
+                throw new MethodNotAllowedException("Hashed-only passwords are not valid for this API.");
+            }
+
             return Post(new AuthenticateUserByName
             {
                 Username = user.Name,

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -379,7 +379,7 @@ namespace MediaBrowser.Api
                 throw new ResourceNotFoundException("User not found");
             }
 
-            if (!request.Pw)
+            if (request.Pw == "")
             {
                 throw new MethodNotAllowedException("Hashed-only passwords are not valid for this API.");
             }

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -379,7 +379,7 @@ namespace MediaBrowser.Api
                 throw new ResourceNotFoundException("User not found");
             }
 
-            if (request.Pw == "")
+            if (!string.IsNullOrEmpty(request.Password) || string.IsNullOrEmpty(request.Pw))
             {
                 throw new MethodNotAllowedException("Hashed-only passwords are not valid for this API.");
             }

--- a/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
+++ b/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
@@ -26,6 +26,30 @@ namespace MediaBrowser.Common.Extensions
         }
     }
 
+    /// <summary>
+    /// Class MethodNotAllowedException
+    /// </summary>
+    public class MethodNotAllowedException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MethodNotAllowedException" /> class.
+        /// </summary>
+        public MethodNotAllowedException()
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MethodNotAllowedException" /> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public MethodNotAllowedException(string message)
+            : base(message)
+        {
+
+        }
+    }
+
     public class RemoteServiceUnavailableException : Exception
     {
         public RemoteServiceUnavailableException()


### PR DESCRIPTION
**Changes**
Add a `MethodNotAllowedException` to the HTTP handler. Checks the `/Users/AuthenticateByName` API call to see if a plaintext password has been provided; if not, return the `MethodNotAllowedException` to the client.

**Issues**
Addresses #1222