### PR TITLE
Adjust detection of 'sample' in filenames to use regex boundaries

### DIFF
--- a/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Resolvers;
@@ -148,15 +149,9 @@ namespace Emby.Server.Implementations.Library
                 }
 
                 // Ignore samples
-                var sampleFilename = " " + filename.Replace(".", " ", StringComparison.OrdinalIgnoreCase)
-                    .Replace("-", " ", StringComparison.OrdinalIgnoreCase)
-                    .Replace("_", " ", StringComparison.OrdinalIgnoreCase)
-                    .Replace("!", " ", StringComparison.OrdinalIgnoreCase);
+                Match m = Regex.Match(filename,"\bsample\b",RegexOptions.IgnoreCase);
 
-                if (sampleFilename.IndexOf(" sample ", StringComparison.OrdinalIgnoreCase) != -1)
-                {
-                    return true;
-                }
+                return m.Success;
             }
 
             return false;

--- a/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
@@ -149,7 +149,7 @@ namespace Emby.Server.Implementations.Library
                 }
 
                 // Ignore samples
-                Match m = Regex.Match(filename,"\bsample\b",RegexOptions.IgnoreCase);
+                Match m = Regex.Match(filename,@"\bsample\b",RegexOptions.IgnoreCase);
 
                 return m.Success;
             }

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Emby.Naming.Video;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
@@ -167,17 +168,9 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
         private static bool IsIgnored(string filename)
         {
             // Ignore samples
-            var sampleFilename = " " + filename.Replace(".", " ", StringComparison.OrdinalIgnoreCase)
-                .Replace("-", " ", StringComparison.OrdinalIgnoreCase)
-                .Replace("_", " ", StringComparison.OrdinalIgnoreCase)
-                .Replace("!", " ", StringComparison.OrdinalIgnoreCase);
+            Match m = Regex.Match(filename,@"\bsample\b",RegexOptions.IgnoreCase);
 
-            if (sampleFilename.IndexOf(" sample ", StringComparison.OrdinalIgnoreCase) != -1)
-            {
-                return true;
-            }
-
-            return false;
+            return m.Success;
         }
 
         private bool ContainsFile(List<VideoInfo> result, FileSystemMetadata file)


### PR DESCRIPTION
**Changes**
This changes the string comparison (with a list of potential boundary characters) into a regular expression search for "sample" surrounded by any regex-recognized boundaries. This allows ignorance of files with e.g. (Sample), [sample] or `~sample~`.

