### PR TITLE
Prevent null reference when request content type is x-www-form-urlencoded

### DIFF
--- a/Emby.Server.Implementations/Services/ServiceHandler.cs
+++ b/Emby.Server.Implementations/Services/ServiceHandler.cs
@@ -26,7 +26,10 @@ namespace Emby.Server.Implementations.Services
             if (!string.IsNullOrEmpty(contentType) && httpReq.ContentLength > 0)
             {
                 var deserializer = RequestHelper.GetRequestReader(host, contentType);
-                return deserializer?.Invoke(requestType, httpReq.InputStream);
+                if (deserializer != null)
+                {
+                    return deserializer.Invoke(requestType, httpReq.InputStream);
+                }
             }
 
             return Task.FromResult(host.CreateInstance(requestType));


### PR DESCRIPTION
**Changes**
Reverted behavior of ServiceHandler.CreateContentTypeRequest to return Task.FromResult(host.CreateInstance(requestType) when deserializer is null. 
Previous change prevented calling Invoke on a null deserializer, but would return null to the caller.
**Issues**
Resolves #1270 
