### PR TITLE
releated issue is : #1234

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -38,6 +38,8 @@ namespace Jellyfin.Server
 
         public static async Task Main(string[] args)
         {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+
             // For backwards compatibility.
             // Modify any input arguments now which start with single-hyphen to POSIX standard
             // double-hyphen to allow parsing by CommandLineParser package.


### PR DESCRIPTION
running jellyfin in ubuntu 18.04.2 x64 ,and locale is zh-cn.UTF-8, timezone is asia/shanghai.
that cause the DateTime.ToString() result like this: " 2019-04-25 下午9:30" ,
all the static file like *.js *.ico request from webbrowser will got exception :

```
System.InvalidOperationException: Invalid non-ASCII or control character in header: 0x4E0B 
at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ThrowInvalidHeaderCharacter(Char ch)
at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ValidateHeaderValueCharacters(StringValues& headerValues
at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseHeaders.AddValueFast(String key, StringValues& value)
at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.System.Collections.Generic.IDictionary<System.String,Microsoft.Extensions.Primitives.StringValues>.Add(String key, StringValues value)
at Emby.Server.Implementations.Services.ResponseHelper.WriteToResponse(IResponse response, IRequest request, Object result, CancellationToken cancellationToken)
at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost appHost, IRequest httpReq, IResponse httpRes, ILogger logger, String operationName, CancellationToken cancellationToken)
at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken)
```
