### PR TITLE
Fix passwordless authentication with non-json content-types

### DIFF
--- a/Emby.Server.Implementations/Services/StringMapTypeDeserializer.cs
+++ b/Emby.Server.Implementations/Services/StringMapTypeDeserializer.cs
@@ -71,7 +71,7 @@ namespace Emby.Server.Implementations.Services
                 string propertyName = pair.Key;
                 string propertyTextValue = pair.Value;
 
-                if (string.IsNullOrEmpty(propertyTextValue)
+                if (propertyTextValue == null
                     || !propertySetterMap.TryGetValue(propertyName, out propertySerializerEntry)
                     || propertySerializerEntry.PropertySetFn == null)
                 {


### PR DESCRIPTION
Resolves a null reference when Pw is an empty string and the request content type is not json

**Changes**
Removes an isnullorempty check for a string and changes it to only check for null in order to prevent coalescing an empty string to a null object. 

In particular, the Pw parameter carries different connotations when null or empty and when both Pw and password are null, the auth fails with a null reference.

**Issues**
Resolves #1299 
