### PR TITLE
Move artifact chown inside docker to avoid sudo

### DIFF
--- a/deployment/centos-package-x64/docker-build.sh
+++ b/deployment/centos-package-x64/docker-build.sh
@@ -18,3 +18,4 @@ rpmbuild -bb SPECS/jellyfin.spec --define "_sourcedir ${SOURCE_DIR}/SOURCES/pkg-
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/rpm
 mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm ${ARTIFACT_DIR}/rpm/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/centos-package-x64/package.sh
+++ b/deployment/centos-package-x64/package.sh
@@ -72,9 +72,6 @@ fi
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile
 # Build the RPMs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the RPMs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}"
 # Move the RPMs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/rpm/* "${output_dir}"

--- a/deployment/debian-package-arm64/docker-build.sh
+++ b/deployment/debian-package-arm64/docker-build.sh
@@ -18,3 +18,4 @@ dpkg-buildpackage -us -uc -aarm64
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/debian-package-arm64/package.sh
+++ b/deployment/debian-package-arm64/package.sh
@@ -30,13 +30,12 @@ case $ARCH in
     ;;
 esac
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./${DOCKERFILE}
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"

--- a/deployment/debian-package-armhf/docker-build.sh
+++ b/deployment/debian-package-armhf/docker-build.sh
@@ -18,3 +18,4 @@ dpkg-buildpackage -us -uc -aarmhf
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/debian-package-armhf/package.sh
+++ b/deployment/debian-package-armhf/package.sh
@@ -30,13 +30,12 @@ case $ARCH in
     ;;
 esac
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./${DOCKERFILE}
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"

--- a/deployment/debian-package-x64/docker-build.sh
+++ b/deployment/debian-package-x64/docker-build.sh
@@ -17,3 +17,4 @@ dpkg-buildpackage -us -uc
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/debian-package-x64/package.sh
+++ b/deployment/debian-package-x64/package.sh
@@ -19,13 +19,12 @@ else
     docker_sudo=""
 fi
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"

--- a/deployment/fedora-package-x64/docker-build.sh
+++ b/deployment/fedora-package-x64/docker-build.sh
@@ -18,3 +18,4 @@ rpmbuild -bb SPECS/jellyfin.spec --define "_sourcedir ${SOURCE_DIR}/SOURCES/pkg-
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/rpm
 mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm ${ARTIFACT_DIR}/rpm/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/fedora-package-x64/package.sh
+++ b/deployment/fedora-package-x64/package.sh
@@ -23,13 +23,12 @@ fi
 
 ./create_tarball.sh
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile
 # Build the RPMs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the RPMs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}"
 # Move the RPMs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/rpm/* "${output_dir}"

--- a/deployment/ubuntu-package-arm64/docker-build.sh
+++ b/deployment/ubuntu-package-arm64/docker-build.sh
@@ -18,3 +18,4 @@ dpkg-buildpackage -us -uc -aarm64
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/ubuntu-package-arm64/package.sh
+++ b/deployment/ubuntu-package-arm64/package.sh
@@ -30,13 +30,12 @@ case $ARCH in
     ;;
 esac
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./${DOCKERFILE}
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"

--- a/deployment/ubuntu-package-armhf/docker-build.sh
+++ b/deployment/ubuntu-package-armhf/docker-build.sh
@@ -18,3 +18,4 @@ dpkg-buildpackage -us -uc -aarmhf
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/ubuntu-package-armhf/package.sh
+++ b/deployment/ubuntu-package-armhf/package.sh
@@ -30,13 +30,12 @@ case $ARCH in
     ;;
 esac
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./${DOCKERFILE}
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"

--- a/deployment/ubuntu-package-x64/docker-build.sh
+++ b/deployment/ubuntu-package-x64/docker-build.sh
@@ -17,3 +17,4 @@ dpkg-buildpackage -us -uc
 # Move the artifacts out
 mkdir -p ${ARTIFACT_DIR}/deb
 mv /jellyfin_* ${ARTIFACT_DIR}/deb/
+chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}

--- a/deployment/ubuntu-package-x64/package.sh
+++ b/deployment/ubuntu-package-x64/package.sh
@@ -19,13 +19,12 @@ else
     docker_sudo=""
 fi
 
+# Prepare temporary package dir
+mkdir -p "${package_temporary_dir}"
 # Set up the build environment Docker image
 ${docker_sudo} docker build ../.. -t "${image_name}" -f ./Dockerfile
 # Build the DEBs and copy out to ${package_temporary_dir}
 ${docker_sudo} docker run --rm -v "${package_temporary_dir}:/dist" "${image_name}"
-# Correct ownership on the DEBs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the DEBs to the output directory
 mkdir -p "${output_dir}"
 mv "${package_temporary_dir}"/deb/* "${output_dir}"


### PR DESCRIPTION
I found the sudo prompt for moving the files into the final location annoying.