### PR TITLE
Support libssl1.1 for Ubuntu Disco

### DIFF
--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -23,6 +23,6 @@ Depends: at,
          jellyfin-ffmpeg,
          libfontconfig1,
          libfreetype6,
-         libssl1.0.0 | libssl1.0.2
+         libssl1.0.0 | libssl1.0.2 | libssl1.1
 Description: Jellyfin is a home media server.
  It is built on top of other popular open source technologies such as Service Stack, jQuery, jQuery mobile, and Mono. It features a REST-based api with built-in documentation to facilitate client development. We also have client libraries for our api to enable rapid development.


### PR DESCRIPTION
**Changes**
Add an option for libssl1.1 dependency to support Ubuntu Disco (19.04).

**Issues**
Closes #1300