### PR TITLE
Fix incorrect hasPassword flag when easy pin set

### DIFF
--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -596,7 +596,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             bool hasConfiguredPassword = GetAuthenticationProvider(user).HasPassword(user).Result;
-            bool hasConfiguredEasyPassword = string.IsNullOrEmpty(GetLocalPasswordHash(user));
+            bool hasConfiguredEasyPassword = !string.IsNullOrEmpty(GetLocalPasswordHash(user));
 
             bool hasPassword = user.Configuration.EnableLocalPassword && !string.IsNullOrEmpty(remoteEndPoint) && _networkManager.IsInLocalNetwork(remoteEndPoint) ?
                 hasConfiguredEasyPassword :


### PR DESCRIPTION
**Changes**
A cleanup inverted the check for hasConfiguredEasyPassword, this resolves that problem.
(see https://github.com/jellyfin/jellyfin/commit/bef665be364ce1477d09ed268f68c19e0099922f#diff-0cad5db83844b175e1fe7dd334e0e705 )

**Issues**
Resolves (part of?) #1329