### PR TITLE
Remove "EXPOSED 8096" from all dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
 
-EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
     --datadir /config \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -35,7 +35,6 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
 
-EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
     --datadir /config \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -36,7 +36,6 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
 
-EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
     --datadir /config \


### PR DESCRIPTION
**Changes**
Removed "EXPOSE 8096" from all dockerfiles.

**Issues**
Fixes #1339 