### PR TITLE
[DOCKER] Add support for using UID,GID,GIDLIST environment variables. To let jellyfin run as under different UID.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}
 # libfontconfig1 is required for Skia
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y \
-   libfontconfig1 \
+   libfontconfig1 acl \
  && apt-get clean autoclean \
  && apt-get autoremove \
  && rm -rf /var/lib/apt/lists/* \
@@ -28,7 +28,5 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
 
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
-    --datadir /config \
-    --cachedir /cache \
-    --ffmpeg /usr/local/bin/ffmpeg
+COPY deployment/docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -24,7 +24,7 @@ RUN bash -c "source deployment/common.build.sh && \
 FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}-stretch-slim-arm32v7
 COPY --from=qemu_extract qemu-arm-static /usr/bin
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg acl \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
@@ -37,7 +37,5 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
 
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
-    --datadir /config \
-    --cachedir /cache \
-    --ffmpeg /usr/bin/ffmpeg
+COPY deployment/docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -25,7 +25,7 @@ RUN bash -c "source deployment/common.build.sh && \
 FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}-stretch-slim-arm64v8
 COPY --from=qemu_extract qemu-aarch64-static /usr/bin
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
+ && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg acl \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
@@ -38,7 +38,5 @@ RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/v${JELLYFIN_WEB_VER
 
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
-    --datadir /config \
-    --cachedir /cache \
-    --ffmpeg /usr/bin/ffmpeg
+COPY deployment/docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+UIDProvided=true
+
+if ! id -u jellyfin > /dev/null; then
+  echo "Creating jellyfin user"
+  adduser --system --group --disabled-login --uid 1000 jellyfin
+fi
+
+if [ -z "${UID}" ]
+then
+  UIDProvided=false
+fi
+
+if [ $UIDProvided = true ]; then
+  if [ -z "${GID}" ]
+  then
+    export GID="${UID}"
+  fi
+  echo "Setting jellyfin UID to ${UID} and GID to ${GID}"
+  usermod -u ${UID} jellyfin
+  groupmod -g ${GID} jellyfin
+  for i in $(echo ${GIDLIST} | sed "s/,/ /g")
+  do
+    echo "add extra group $i"
+    addgroup jellygroup$i --gid $i
+    usermod -G jellygroup$i jellyfin
+  done
+fi
+
+JellyfinCommand="dotnet /jellyfin/jellyfin.dll --datadir /config --cachedir /cache --ffmpeg /usr/local/bin/ffmpeg"
+
+chown -R jellyfin:jellyfin /config
+chown -R jellyfin:jellyfin /cache
+su -s /bin/bash -c "$JellyfinCommand" jellyfin
+exit $?


### PR DESCRIPTION
**Changes**
This change makes Jellyfin run under the UID and GID of 1000 by default when using the docker image, which is much more secure than running as root.
This can be changed to what the user would like using environment variables UID and GID.
adding GIDLIST allows the user to give jellyfin access to extra groups. (comma-separated)
I also added the acl package as some people including myself use [ACLs](https://help.ubuntu.com/community/FilePermissionsACLs) to control their media permissions.


**Issues**
https://github.com/jellyfin/jellyfin/issues/1350
https://github.com/jellyfin/jellyfin/issues/117
