### PR TITLE
Enable Exynos MFC encoder and fix transcoding bitrate control

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1083,26 +1083,49 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             var bitrate = request.VideoBitRate;
 
-            // If specific values were requested, then force the caller to supply a bitrate as well
-            if (request.Height.HasValue && request.Width.HasValue)
-            {
-                return bitrate;
-            }
-
             if (videoStream != null)
             {
-                if (bitrate.HasValue)
-                {
-                    var inputVideoCodec = videoStream.Codec;
-                    bitrate = ScaleBitrate(bitrate.Value, inputVideoCodec, outputVideoCodec);
+                var isUpscaling = request.Height.HasValue && videoStream.Height.HasValue &&
+                                   request.Height.Value > videoStream.Height.Value && request.Width.HasValue && videoStream.Width.HasValue &&
+                    request.Width.Value > videoStream.Width.Value;
 
-                    // If a max bitrate was requested, don't let the scaled bitrate exceed it
-                    if (request.VideoBitRate.HasValue)
+                // Don't allow bitrate increases unless upscaling
+                if (!isUpscaling)
+                {
+                    if (bitrate.HasValue && videoStream.BitRate.HasValue)
                     {
-                        bitrate = Math.Min(bitrate.Value, request.VideoBitRate.Value);
+                        bitrate = GetMinBitrate(videoStream.BitRate.Value, bitrate.Value);
                     }
                 }
             }
+
+            if (bitrate.HasValue)
+            {
+                var inputVideoCodec = videoStream.Codec;
+                bitrate = ScaleBitrate(bitrate.Value, inputVideoCodec, outputVideoCodec);
+
+                // If a max bitrate was requested, don't let the scaled bitrate exceed it
+                if (request.VideoBitRate.HasValue)
+                {
+                    bitrate = Math.Min(bitrate.Value, request.VideoBitRate.Value);
+                }
+            }
+
+            return bitrate;
+        }
+
+        private int GetMinBitrate(int sourceBitrate, int requestedBitrate)
+        {
+            if (sourceBitrate <= 2000000)
+            {
+                sourceBitrate = Convert.ToInt32(sourceBitrate * 2.5);
+            }
+            else if (sourceBitrate <= 3000000)
+            {
+                sourceBitrate = Convert.ToInt32(sourceBitrate * 2);
+            }
+
+            var bitrate = Math.Min(sourceBitrate, requestedBitrate);
 
             return bitrate;
         }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1086,7 +1086,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (videoStream != null)
             {
                 var isUpscaling = request.Height.HasValue && videoStream.Height.HasValue &&
-                                   request.Height.Value > videoStream.Height.Value && request.Width.HasValue && videoStream.Width.HasValue &&
+                    request.Height.Value > videoStream.Height.Value && request.Width.HasValue && videoStream.Width.HasValue &&
                     request.Width.Value > videoStream.Width.Value;
 
                 // Don't allow bitrate increases unless upscaling
@@ -1116,6 +1116,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         private int GetMinBitrate(int sourceBitrate, int requestedBitrate)
         {
+            // these values were chosen from testing to improve low bitrate streams
             if (sourceBitrate <= 2000000)
             {
                 sourceBitrate = Convert.ToInt32(sourceBitrate * 2.5);

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -207,6 +207,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 "hevc_omx",
                 "h264_vaapi",
                 "hevc_vaapi",
+                "h264_v4l2m2m",
                 "ac3"
             };
 


### PR DESCRIPTION
**Enable Exynos MFC encoder and fix transcoding bitrate control**

***Changes:***

- Rebased against master per request.
- The Exynos MFC HW encoder is now enabled when selected in the pulldown menu at the "Transcoding" tab.
- Now Jellyfin selects a bitrate according to the original file, while before it was always fixed to a very high value of 139808000.