### PR TITLE
Check if an item is a child of an EnabledFolder

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@
  - [ploughpuff](https://github.com/ploughpuff)
  - [pjeanjean](https://github.com/pjeanjean)
  - [DrPandemic](https://github.com/drpandemic)
+ - [joern-h](https://github.com/joern-h)
 
 # Emby Contributors
 

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -224,7 +224,17 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            if (!(item is UserRootFolder) && !user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id))
+            bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id);
+            var collectionFolders = _libraryManager.GetCollectionFolders(item);
+            foreach (var collectionFolder in collectionFolders)
+            {
+                if (user.Policy.EnabledFolders.Contains(collectionFolder.Id.ToString("N"), StringComparer.OrdinalIgnoreCase))
+                {
+                    isInEnabledFolder = true;
+                }
+            }
+
+            if (!(item is UserRootFolder) && !user.Policy.EnableAllFolders && !isInEnabledFolder)
             {
                 Logger.LogWarning("{UserName} is not permitted to access Library {ItemName}.", user.Name, item.Name);
                 return new QueryResult<BaseItem>


### PR DESCRIPTION
**Changes**
In GetQueryResult:

`user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id)`
returns only true if the item is the media folder.

So now it checks if an item is a child of a EnabledFolder.

Fixes issue #1347 
Introduced in #930

Feel free to criticise everything you want, i am open for improvements :)