### PR TITLE
Change XMLReader getChannels to return a sorted list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,3 +87,4 @@
  - [tikuf](https://github.com/tikuf/)
  - [Tim Hobbs](https://github.com/timhobbs)
  - [SvenVandenbrande](https://github.com/SvenVandenbrande)
+ - [Peter McNeil](https://github.com/petermcneil)

--- a/Emby.XmlTv/Emby.XmlTv/Classes/XmlTvReader.cs
+++ b/Emby.XmlTv/Emby.XmlTv/Classes/XmlTvReader.cs
@@ -78,6 +78,8 @@ namespace Emby.XmlTv.Classes
                 }
             }
 
+            list.Sort(((c1, c2) => string.Compare(c1.DisplayName, c2.DisplayName, StringComparison.Ordinal)));
+
             return list;
         }
 
@@ -522,7 +524,7 @@ namespace Emby.XmlTv.Classes
                 if (int.TryParse(res.Groups[2].Value, out parsedInt))
                 {
                     result.Episode.Episode = parsedInt;
-                }   
+                }
             }
         }
 


### PR DESCRIPTION
**Changes**
XMLReader has been updated to returned a sorted channel list by channel name. This change makes it easier to map channels to sources in the Live TV dashboard.

Updated dropdown list.
<img width="276" alt="Sorted list of channels" src="https://user-images.githubusercontent.com/19857510/58752634-69739500-84aa-11e9-83d8-1701a7cff61a.png">


**Issues**
Fixes #1429 
