### PR TITLE
Fix issue #1436: media folders appear empty unless user has all libraries access

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@
  - [Lynxy](https://github.com/Lynxy)
  - [fasheng](https://github.com/fasheng)
  - [ploughpuff](https://github.com/ploughpuff) 
+ - [pjeanjean](https://github.com/pjeanjean)
 
 # Emby Contributors
 

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -224,7 +224,7 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            if (!user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id))
+            if (!(item is UserRootFolder) && !user.Policy.EnableAllFolders && !user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id))
             {
                 Logger.LogWarning("{UserName} is not permitted to access Library {ItemName}.", user.Name, item.Name);
                 return new QueryResult<BaseItem>


### PR DESCRIPTION
**Changes**

This removes user access checking introduced by #930 for `UserRootFolder`.
These folders are all the generated virtual folders that exist outside of libraries (i.e. Actors, Artists, Genres, ...).
It doesn't make sense to check if a user has access to the library in which they exist (`Media Folders`) since it is not even a real library.

**Issues**

Fixes #1436