### PR TITLE
Implement InvalidAuthProvider

### DIFF
--- a/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
+++ b/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Net;
 
 namespace Emby.Server.Implementations.Library
 {
@@ -15,7 +16,7 @@ namespace Emby.Server.Implementations.Library
 
         public Task<ProviderAuthenticationResult> Authenticate(string username, string password)
         {
-            throw new Exception("User Account cannot login with this provider. The Normal provider for this user cannot be found");
+            throw new SecurityException("User Account cannot login with this provider. The Normal provider for this user cannot be found");
         }
 
         public Task<bool> HasPassword(User user)

--- a/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
+++ b/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Entities;
+
+namespace Emby.Server.Implementations.Library
+{
+    public class InvalidAuthProvider : IAuthenticationProvider
+    {
+        public string Name => "InvalidorMissingAuthenticationProvider";
+
+        public bool IsEnabled => true;
+
+        public Task<ProviderAuthenticationResult> Authenticate(string username, string password)
+        {
+            throw new Exception("User Account cannot login with this provider. The Normal provider for this user cannot be found");
+        }
+
+        public Task<bool> HasPassword(User user)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task ChangePassword(User user, string newPassword)
+        {
+            return Task.FromResult(true);
+        }
+
+        public void ChangeEasyPassword(User user, string newPassword, string newPasswordHash)
+        {
+            // Nothing here   
+        }
+
+        public string GetPasswordHash(User user)
+        {
+            return "";
+        }
+
+        public string GetEasyPasswordHash(User user)
+        {
+            return "";
+        }
+    }
+}

--- a/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
+++ b/Emby.Server.Implementations/Library/InvalidAuthProvider.cs
@@ -9,7 +9,7 @@ namespace Emby.Server.Implementations.Library
 {
     public class InvalidAuthProvider : IAuthenticationProvider
     {
-        public string Name => "InvalidorMissingAuthenticationProvider";
+        public string Name => "InvalidOrMissingAuthenticationProvider";
 
         public bool IsEnabled => true;
 
@@ -25,7 +25,7 @@ namespace Emby.Server.Implementations.Library
 
         public Task ChangePassword(User user, string newPassword)
         {
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
 
         public void ChangeEasyPassword(User user, string newPassword, string newPasswordHash)
@@ -35,12 +35,12 @@ namespace Emby.Server.Implementations.Library
 
         public string GetPasswordHash(User user)
         {
-            return "";
+            return string.Empty;
         }
 
         public string GetEasyPasswordHash(User user)
         {
-            return "";
+            return string.Empty;
         }
     }
 }

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -313,8 +313,7 @@ namespace Emby.Server.Implementations.Library
 
                     if (authenticationProvider.GetType() != typeof(InvalidAuthProvider))
                     {
-                        var hasNewUserPolicy = authenticationProvider as IHasNewUserPolicy;
-                        if (hasNewUserPolicy != null)
+                        if (authenticationProvider is IHasNewUserPolicy hasNewUserPolicy)
                         {
                             var policy = hasNewUserPolicy.GetNewUserPolicy();
                             UpdateUserPolicy(user, policy, true);
@@ -408,7 +407,7 @@ namespace Emby.Server.Implementations.Library
             if (providers.Length == 0)
             {
                 // Assign the user to the InvalidAuthProvider since no configured auth provider was valid/found
-                _logger.LogWarning("User {0} was found with invalid/missing Authentication Provider {1}. Assigning user to InvalidAuthProvider until this is corrected", user.Name, user.Policy.AuthenticationProviderId);
+                _logger.LogWarning("User {UserName} was found with invalid/missing Authentication Provider {AuthenticationProviderId}. Assigning user to InvalidAuthProvider until this is corrected", user.Name, user.Policy.AuthenticationProviderId);
                 providers = new IAuthenticationProvider[] { _invalidAuthProvider };
             }
 

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -311,13 +311,10 @@ namespace Emby.Server.Implementations.Library
                     user = Users
                         .FirstOrDefault(i => string.Equals(username, i.Name, StringComparison.OrdinalIgnoreCase));
 
-                    if (authenticationProvider.GetType() != typeof(InvalidAuthProvider))
+                    if (authenticationProvider is IHasNewUserPolicy hasNewUserPolicy)
                     {
-                        if (authenticationProvider is IHasNewUserPolicy hasNewUserPolicy)
-                        {
-                            var policy = hasNewUserPolicy.GetNewUserPolicy();
-                            UpdateUserPolicy(user, policy, true);
-                        }
+                        var policy = hasNewUserPolicy.GetNewUserPolicy();
+                        UpdateUserPolicy(user, policy, true);
                     }
                 }
             }

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -422,6 +422,11 @@ namespace Emby.Server.Implementations.Library
                 providers = providers.Where(i => string.Equals(passwordResetProviderId, GetPasswordResetProviderId(i), StringComparison.OrdinalIgnoreCase)).ToArray();
             }
 
+            if (providers.Length == 0)
+            {
+                providers = new IPasswordResetProvider[] { _defaultPasswordResetProvider };
+            }
+
             return providers;
         }
 

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -407,9 +407,8 @@ namespace Emby.Server.Implementations.Library
 
             if (providers.Length == 0)
             {
-                // this function used to assign any user without an auth provider to the default.
-                // we're going to have it use a new function now.
-                _logger.LogWarning($"The user {user.Name} was found but no Authentication Provider with ID: {user.Policy.AuthenticationProviderId} was found. Assigning user to InvalidAuthProvider temporarily");
+                // Assign the user to the InvalidAuthProvider since no configured auth provider was valid/found
+                _logger.LogWarning("User {0} was found with invalid/missing Authentication Provider {1}. Assigning user to InvalidAuthProvider until this is corrected", user.Name, user.Policy.AuthenticationProviderId);
                 providers = new IAuthenticationProvider[] { _invalidAuthProvider };
             }
 

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -425,11 +425,6 @@ namespace Emby.Server.Implementations.Library
                 providers = providers.Where(i => string.Equals(passwordResetProviderId, GetPasswordResetProviderId(i), StringComparison.OrdinalIgnoreCase)).ToArray();
             }
 
-            if (providers.Length == 0)
-            {
-                providers = new IPasswordResetProvider[] { _defaultPasswordResetProvider };
-            }
-
             return providers;
         }
 


### PR DESCRIPTION
**Changes**
Implements the InvalidAuthProvider, which acts as a fallback if a
configured authentication provider, e.g. LDAP, is unavailable due
to a load failure or removal. Until the user or the authentication
plugin is corrected, this will cause users with the missing provider
to be locked out, while throwing errors in the logs about the issue.

Thanks to @LogicalPhallacy for the majority of the code.

**Issues**
Fixes #1445 part 2