### PR TITLE
Use the username for the user config path

### DIFF
--- a/MediaBrowser.Controller/Entities/User.cs
+++ b/MediaBrowser.Controller/Entities/User.cs
@@ -228,7 +228,15 @@ namespace MediaBrowser.Controller.Entities
                 return System.IO.Path.Combine(ConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath, safeFolderName);
             }
 
-            return System.IO.Path.Combine(parentPath, Id.ToString("N"));
+            // TODO: Remove idPath and just use usernamePath for future releases
+            var usernamePath = System.IO.Path.Combine(parentPath, username);
+            var idPath = System.IO.Path.Combine(parentPath, Id.ToString("N"));
+            if (!Directory.Exists(usernamePath) && Directory.Exists(idPath))
+            {
+                Directory.Move(idPath, usernamePath);
+            }
+
+            return usernamePath;
         }
 
         public bool IsParentalScheduleAllowed()


### PR DESCRIPTION
**Changes**
Use the username to construct the UserConfigurationDirectory,
instead of the user ID, and move the old ID-based path to the new 
path if needed when loading (temporary transitional code). Removes
administrator guesswork as to what user each directory belongs to, 
which I found very annoying when investigating user configs.   

This might not be the "best" or "proper" place for this migration, but
it seems simplest to just move it when looking up the dir. Remove this
migration in a future release.

**Issues**
N/A
