### PR TITLE
Vacuum databases at startup

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -202,7 +202,7 @@ namespace Emby.Server.Implementations.Data
         protected void RunDefaultInitialization(ManagedConnection db)
         {
             var queries = new List<string>
-            {                
+            {
                 "PRAGMA journal_mode=WAL",
                 "PRAGMA page_size=4096",
                 "PRAGMA synchronous=Normal"

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -203,6 +203,7 @@ namespace Emby.Server.Implementations.Data
         {
             var queries = new List<string>
             {
+                "VACUUM",
                 "PRAGMA journal_mode=WAL",
                 "PRAGMA page_size=4096",
                 "PRAGMA synchronous=Normal"

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -202,8 +202,7 @@ namespace Emby.Server.Implementations.Data
         protected void RunDefaultInitialization(ManagedConnection db)
         {
             var queries = new List<string>
-            {
-                "VACUUM",
+            {                
                 "PRAGMA journal_mode=WAL",
                 "PRAGMA page_size=4096",
                 "PRAGMA synchronous=Normal"
@@ -224,6 +223,8 @@ namespace Emby.Server.Implementations.Data
                     "pragma temp_store = file"
                 });
             }
+            // Configuration and pragmas can affect VACUUM so it needs to be last.
+            queries.Add("VACUUM");
 
             db.ExecuteAll(string.Join(";", queries));
             Logger.LogInformation("PRAGMA synchronous=" + db.Query("PRAGMA synchronous").SelectScalarString().First());


### PR DESCRIPTION
**Changes**
Each database will be vacuumed when Jellyfin is started. Right now databases aren't fully vacuumed, which leads to fragmentation and potentially bigger query times. The database is also taking useless space after removing bigger libraries

**Issues**

I'm not sure if the implementation is the best one. Perhaps it should be inside a try/catch block instead? I can think (for example) that vacuuming needs extra space to accomodate the database while it's being vacuumed, among other exceptions that vacuuming can raise (and setting PRAGMA variables doesn't).

I think that the best implementation of this should also include an Scheduled Tasks to do it, so the user is aware that the database is being optimised automatically, as well as triggering the process on demand. However, I think this quick fix will improve the database situation to a lot of people from now on.