### PR TITLE
Update TVDB provider to search based on series display order

### DIFF
--- a/MediaBrowser.Providers/TV/TheTVDB/TvDbClientManager.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvDbClientManager.cs
@@ -167,7 +167,8 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                     case "absolute":
                         episodeQuery.AbsoluteNumber = searchInfo.IndexNumber.Value;
                         break;
-                    default: //aired order
+                    default:
+                        //aired order
                         episodeQuery.AiredEpisode = searchInfo.IndexNumber.Value;
                         episodeQuery.AiredSeason = searchInfo.ParentIndexNumber.Value;
                         break;

--- a/MediaBrowser.Providers/TV/TheTVDB/TvDbClientManager.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvDbClientManager.cs
@@ -158,8 +158,20 @@ namespace MediaBrowser.Providers.TV.TheTVDB
             // Prefer SxE over premiere date as it is more robust
             if (searchInfo.IndexNumber.HasValue && searchInfo.ParentIndexNumber.HasValue)
             {
-                episodeQuery.AiredEpisode = searchInfo.IndexNumber.Value;
-                episodeQuery.AiredSeason = searchInfo.ParentIndexNumber.Value;
+                switch (searchInfo.SeriesDisplayOrder)
+                {
+                    case "dvd":
+                        episodeQuery.DvdEpisode = searchInfo.IndexNumber.Value;
+                        episodeQuery.DvdSeason = searchInfo.ParentIndexNumber.Value;
+                        break;
+                    case "absolute":
+                        episodeQuery.AbsoluteNumber = searchInfo.IndexNumber.Value;
+                        break;
+                    default: //aired order
+                        episodeQuery.AiredEpisode = searchInfo.IndexNumber.Value;
+                        episodeQuery.AiredSeason = searchInfo.ParentIndexNumber.Value;
+                        break;
+                }
             }
             else if (searchInfo.PremiereDate.HasValue)
             {


### PR DESCRIPTION
This PR fixes #1477 for both DVD and absolute ordering.

Episode indexnumber, parentIndexNumber, and providerIDs should be cleared on Series display order change. Otherwise, metadata will still be pulled using tvdbid already saved for episodes. Work around is to change series display order, remove episodes from JF, scan, re-add episodes to JF. Metadata is correct.

It does break TMDB metadata and image pulling when not using air date, because that service only uses air date order for the default query. TMDB supports episode groups, but I have not noticed a way to query by that yet.