### PR TITLE
Fix skia segfault

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,8 +23,9 @@
  - [fruhnow](https://github.com/fruhnow)
  - [Lynxy](https://github.com/Lynxy)
  - [fasheng](https://github.com/fasheng)
- - [ploughpuff](https://github.com/ploughpuff) 
+ - [ploughpuff](https://github.com/ploughpuff)
  - [pjeanjean](https://github.com/pjeanjean)
+ - [DrPandemic](https://github.com/drpandemic)
 
 # Emby Contributors
 

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -185,6 +185,11 @@ namespace Jellyfin.Drawing.Skia
 
         public ImageDimensions GetImageSize(string path)
         {
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException("File not found", path);
+            }
+
             using (var s = new SKFileStream(path))
             using (var codec = SKCodec.Create(s))
             {


### PR DESCRIPTION
**Changes**
According to https://github.com/jellyfin/jellyfin/issues/1298, skia was segfaulting the server when trying to reach an image that didn't exist. This should prevent that problem.

**Issues**
It might close https://github.com/jellyfin/jellyfin/issues/1298 but I'm unsure since I wasn't able to reproduce.

@cvium 	you might be able to test it to see if it fixed your issue.