### PR TITLE
Add nicer restart script

### DIFF
--- a/deployment/debian-package-x64/pkg-src/bin/restart.sh
+++ b/deployment/debian-package-x64/pkg-src/bin/restart.sh
@@ -21,7 +21,7 @@ get_service_command() {
 }
 
 cmd="$( get_service_command )"
-echo "Using system control command '$cmd' to restart Jellyfin..."
+echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
         echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 

--- a/deployment/debian-package-x64/pkg-src/bin/restart.sh
+++ b/deployment/debian-package-x64/pkg-src/bin/restart.sh
@@ -24,10 +24,10 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo /sbin/service jellyfin restart" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart" | at now 
         ;;
     'sysv')
         echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now 

--- a/deployment/debian-package-x64/pkg-src/bin/restart.sh
+++ b/deployment/debian-package-x64/pkg-src/bin/restart.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 
-NAME=jellyfin
+# restart.sh - Jellyfin server restart script
+# Part of the Jellyfin project (https://github.com/jellyfin)
+#
+# This script restarts the Jellyfin daemon on Linux when using
+# the Restart button on the admin dashboard. It supports the
+# systemctl, service, and traditional /etc/init.d (sysv) restart
+# methods, chosen automatically by which one is found first (in
+# that order).
+#
+# This script is used by the Debian/Ubuntu/Fedora/CentOS packages.
 
-restart_cmds=(
-  "systemctl restart ${NAME}"
-  "service ${NAME} restart"
-  "/etc/init.d/${NAME} restart"
-  "s6-svc -t /var/run/s6/services/${NAME}"
-)
+get_service_command() {
+    for command in systemctl service; do
+        if which $command &>/dev/null; then
+            echo $command && return
+        fi
+    done
+    echo "sysv"
+}
 
-for restart_cmd in "${restart_cmds[@]}"; do
-  cmd=$(echo "$restart_cmd" | awk '{print $1}')
-  cmd_loc=$(command -v ${cmd})
-  if [[ -n "$cmd_loc" ]]; then
-    restart_cmd=$(echo "$restart_cmd" | sed -e "s%${cmd}%${cmd_loc}%")
-    echo "sleep 2; sudo $restart_cmd > /dev/null 2>&1" | at now > /dev/null 2>&1
-    exit 0
-  fi
-done
+cmd="$( get_service_command )"
+echo "Using system control command '$cmd' to restart Jellyfin..."
+case $cmd in
+    'systemctl')
+        echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 
+        ;;
+    'service')
+        echo "sleep 2; /usr/bin/sudo /sbin/service jellyfin restart" | at now 
+        ;;
+    'sysv')
+        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now 
+        ;;
+esac
+exit 0

--- a/deployment/fedora-package-x64/pkg-src/restart.sh
+++ b/deployment/fedora-package-x64/pkg-src/restart.sh
@@ -21,7 +21,7 @@ get_service_command() {
 }
 
 cmd="$( get_service_command )"
-echo "Using system control command '$cmd' to restart Jellyfin..."
+echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
         echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 

--- a/deployment/fedora-package-x64/pkg-src/restart.sh
+++ b/deployment/fedora-package-x64/pkg-src/restart.sh
@@ -1,6 +1,36 @@
-#!/bin/sh
+#!/bin/bash
 
-NAME=jellyfin
-restart_cmd="/usr/bin/systemctl restart ${NAME}"
-echo "sleep 2; sudo $restart_cmd > /dev/null 2>&1" | at now > /dev/null 2>&1
+# restart.sh - Jellyfin server restart script
+# Part of the Jellyfin project (https://github.com/jellyfin)
+#
+# This script restarts the Jellyfin daemon on Linux when using
+# the Restart button on the admin dashboard. It supports the
+# systemctl, service, and traditional /etc/init.d (sysv) restart
+# methods, chosen automatically by which one is found first (in
+# that order).
+#
+# This script is used by the Debian/Ubuntu/Fedora/CentOS packages.
+
+get_service_command() {
+    for command in systemctl service; do
+        if which $command &>/dev/null; then
+            echo $command && return
+        fi
+    done
+    echo "sysv"
+}
+
+cmd="$( get_service_command )"
+echo "Using system control command '$cmd' to restart Jellyfin..."
+case $cmd in
+    'systemctl')
+        echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 
+        ;;
+    'service')
+        echo "sleep 2; /usr/bin/sudo /sbin/service jellyfin restart" | at now 
+        ;;
+    'sysv')
+        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now 
+        ;;
+esac
 exit 0

--- a/deployment/fedora-package-x64/pkg-src/restart.sh
+++ b/deployment/fedora-package-x64/pkg-src/restart.sh
@@ -24,10 +24,10 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo /usr/bin/systemctl restart jellyfin" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo /sbin/service jellyfin restart" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart" | at now 
         ;;
     'sysv')
         echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now 


### PR DESCRIPTION
**Changes**
The old restart script was buggy, as reported in #1320. This updated
script seems to work far more reliably and conforms to the existing
jellyfin-sudoers packages sudo configuration.

**Issues**
Fixes #1320
