### PR TITLE
Differentiate between entrypoints and long running tasks

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -532,9 +532,11 @@ namespace Emby.Dlna
             _xmlSerializer = xmlSerializer;
         }
 
-        public void Run()
+        /// <inheritdoc />
+        public Task RunAsync()
         {
             DumpProfiles();
+            return Task.CompletedTask;
         }
 
         private void DumpProfiles()
@@ -579,10 +581,6 @@ namespace Emby.Dlna
 
                 _xmlSerializer.SerializeToFile(item, path);
             }
-        }
-
-        public void Dispose()
-        {
         }
     }*/
 }

--- a/Emby.Notifications/Notifications.cs
+++ b/Emby.Notifications/Notifications.cs
@@ -23,7 +23,7 @@ namespace Emby.Notifications
     /// <summary>
     /// Creates notifications for various system events
     /// </summary>
-    public class Notifications : IServerEntryPoint
+    public class Notifications : ILongRunningTask
     {
         private readonly ILogger _logger;
 
@@ -40,6 +40,8 @@ namespace Emby.Notifications
         private readonly IActivityManager _activityManager;
 
         private string[] _coreNotificationTypes;
+
+        private readonly List<BaseItem> _itemsAdded = new List<BaseItem>();
 
         public Notifications(
             IActivityManager activityManager,
@@ -61,6 +63,7 @@ namespace Emby.Notifications
             _coreNotificationTypes = new CoreNotificationTypes(localization).GetNotificationTypes().Select(i => i.Type).ToArray();
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _libraryManager.ItemAdded += _libraryManager_ItemAdded;
@@ -136,7 +139,6 @@ namespace Emby.Notifications
             await SendNotification(notification, null).ConfigureAwait(false);
         }
 
-        private readonly List<BaseItem> _itemsAdded = new List<BaseItem>();
         private void _libraryManager_ItemAdded(object sender, ItemChangeEventArgs e)
         {
             if (!FilterItem(e.Item))
@@ -268,6 +270,7 @@ namespace Emby.Notifications
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             DisposeLibraryUpdateTimer();

--- a/Emby.Server.Implementations/Activity/ActivityLogEntryPoint.cs
+++ b/Emby.Server.Implementations/Activity/ActivityLogEntryPoint.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Activity
 {
-    public class ActivityLogEntryPoint : IServerEntryPoint
+    public class ActivityLogEntryPoint : ILongRunningTask
     {
         private readonly ILogger _logger;
         private readonly IInstallationManager _installationManager;
@@ -62,6 +62,7 @@ namespace Emby.Server.Implementations.Activity
             _appHost = appHost;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _taskManager.TaskCompleted += OnTaskCompleted;
@@ -431,6 +432,7 @@ namespace Emby.Server.Implementations.Activity
         private void CreateLogEntry(ActivityLogEntry entry)
             => _activityManager.Create(entry);
 
+        /// <inheritdoc />
         public void Dispose()
         {
             _taskManager.TaskCompleted -= OnTaskCompleted;

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -342,15 +342,19 @@ namespace Emby.Server.Implementations.Collections
     {
         private readonly CollectionManager _collectionManager;
         private readonly IServerConfigurationManager _config;
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
-        public CollectionManagerEntryPoint(ICollectionManager collectionManager, IServerConfigurationManager config, ILogger logger)
+        public CollectionManagerEntryPoint(
+            ICollectionManager collectionManager,
+            IServerConfigurationManager config,
+            ILogger logger)
         {
             _collectionManager = (CollectionManager)collectionManager;
             _config = config;
             _logger = logger;
         }
 
+        /// <inheritdoc />
         public async Task RunAsync()
         {
             if (!_config.Configuration.CollectionsUpgraded && _config.Configuration.IsStartupWizardCompleted)
@@ -373,40 +377,5 @@ namespace Emby.Server.Implementations.Collections
                 }
             }
         }
-
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects).
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
-            }
-        }
-
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~CollectionManagerEntryPoint() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
-        }
-        #endregion
     }
 }

--- a/Emby.Server.Implementations/Devices/DeviceManager.cs
+++ b/Emby.Server.Implementations/Devices/DeviceManager.cs
@@ -408,15 +408,19 @@ namespace Emby.Server.Implementations.Devices
     {
         private readonly DeviceManager _deviceManager;
         private readonly IServerConfigurationManager _config;
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
-        public DeviceManagerEntryPoint(IDeviceManager deviceManager, IServerConfigurationManager config, ILogger logger)
+        public DeviceManagerEntryPoint(
+            IDeviceManager deviceManager,
+            IServerConfigurationManager config,
+            ILogger logger)
         {
             _deviceManager = (DeviceManager)deviceManager;
             _config = config;
             _logger = logger;
         }
 
+        /// <inheritdoc />
         public async Task RunAsync()
         {
             if (!_config.Configuration.CameraUploadUpgraded && _config.Configuration.IsStartupWizardCompleted)
@@ -439,41 +443,6 @@ namespace Emby.Server.Implementations.Devices
                 }
             }
         }
-
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects).
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
-            }
-        }
-
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~DeviceManagerEntryPoint() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
-        }
-        #endregion
     }
 
     public class DevicesConfigStore : IConfigurationFactory

--- a/Emby.Server.Implementations/EntryPoints/AutomaticRestartEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/AutomaticRestartEntryPoint.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.EntryPoints
 {
-    public class AutomaticRestartEntryPoint : IServerEntryPoint
+    public class AutomaticRestartEntryPoint : ILongRunningTask
     {
         private readonly IServerApplicationHost _appHost;
         private readonly ILogger _logger;
@@ -34,6 +34,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _liveTvManager = liveTvManager;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             if (_appHost.CanSelfRestart)
@@ -106,6 +107,7 @@ namespace Emby.Server.Implementations.EntryPoints
             return !_sessionManager.Sessions.Any(i => (now - i.LastActivityDate).TotalMinutes < 30);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             _appHost.HasPendingRestartChanged -= _appHost_HasPendingRestartChanged;

--- a/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
+++ b/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
@@ -15,7 +15,7 @@ using Mono.Nat;
 
 namespace Emby.Server.Implementations.EntryPoints
 {
-    public class ExternalPortForwarding : IServerEntryPoint
+    public class ExternalPortForwarding : ILongRunningTask
     {
         private readonly IServerApplicationHost _appHost;
         private readonly ILogger _logger;
@@ -26,6 +26,11 @@ namespace Emby.Server.Implementations.EntryPoints
         private Timer _timer;
 
         private NatManager _natManager;
+
+        private List<string> _createdRules = new List<string>();
+        private List<string> _usnsHandled = new List<string>();
+
+        private bool _disposed = false;
 
         public ExternalPortForwarding(ILoggerFactory loggerFactory, IServerApplicationHost appHost, IServerConfigurationManager config, IDeviceDiscovery deviceDiscovery, IHttpClient httpClient)
         {
@@ -68,6 +73,7 @@ namespace Emby.Server.Implementations.EntryPoints
             }
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             if (_config.Configuration.EnableUPnP && _config.Configuration.EnableRemoteAccess)
@@ -196,7 +202,7 @@ namespace Emby.Server.Implementations.EntryPoints
             }
         }
 
-        void NatUtility_DeviceFound(object sender, DeviceEventArgs e)
+        private void NatUtility_DeviceFound(object sender, DeviceEventArgs e)
         {
             if (_disposed)
             {
@@ -216,8 +222,6 @@ namespace Emby.Server.Implementations.EntryPoints
             }
         }
 
-        private List<string> _createdRules = new List<string>();
-        private List<string> _usnsHandled = new List<string>();
         private async void CreateRules(INatDevice device)
         {
             if (_disposed)
@@ -273,7 +277,7 @@ namespace Emby.Server.Implementations.EntryPoints
             });
         }
 
-        private bool _disposed = false;
+        /// <inheritdoc />
         public void Dispose()
         {
             _disposed = true;

--- a/Emby.Server.Implementations/EntryPoints/RecordingNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/RecordingNotifier.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.EntryPoints
 {
-    public class RecordingNotifier : IServerEntryPoint
+    public class RecordingNotifier : ILongRunningTask
     {
         private readonly ILiveTvManager _liveTvManager;
         private readonly ISessionManager _sessionManager;
@@ -25,6 +25,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _liveTvManager = liveTvManager;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _liveTvManager.TimerCancelled += _liveTvManager_TimerCancelled;
@@ -73,6 +74,7 @@ namespace Emby.Server.Implementations.EntryPoints
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             _liveTvManager.TimerCancelled -= _liveTvManager_TimerCancelled;

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -16,12 +16,12 @@ namespace Emby.Server.Implementations.EntryPoints
         /// The _app host
         /// </summary>
         private readonly IServerApplicationHost _appHost;
+
         /// <summary>
         /// The _user manager
         /// </summary>
         private readonly ILogger _logger;
-
-        private IServerConfigurationManager _config;
+        private readonly IServerConfigurationManager _config;
 
         public StartupWizard(IServerApplicationHost appHost, ILogger logger, IServerConfigurationManager config)
         {
@@ -30,9 +30,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _config = config;
         }
 
-        /// <summary>
-        /// Runs this instance.
-        /// </summary>
+        /// <inheritdoc />
         public Task RunAsync()
         {
             if (!_appHost.CanLaunchWebBrowser)
@@ -55,13 +53,6 @@ namespace Emby.Server.Implementations.EntryPoints
             }
 
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
         }
     }
 }

--- a/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
@@ -8,13 +8,12 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.EntryPoints
 {
-    public class UserDataChangeNotifier : IServerEntryPoint
+    public class UserDataChangeNotifier : ILongRunningTask
     {
         private readonly ISessionManager _sessionManager;
         private readonly ILogger _logger;
@@ -35,6 +34,7 @@ namespace Emby.Server.Implementations.EntryPoints
             _userManager = userManager;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _userDataManager.UserDataSaved += _userDataManager_UserDataSaved;
@@ -42,7 +42,7 @@ namespace Emby.Server.Implementations.EntryPoints
             return Task.CompletedTask;
         }
 
-        void _userDataManager_UserDataSaved(object sender, UserDataSaveEventArgs e)
+        private void _userDataManager_UserDataSaved(object sender, UserDataSaveEventArgs e)
         {
             if (e.SaveReason == UserDataSaveReason.PlaybackProgress)
             {
@@ -140,6 +140,7 @@ namespace Emby.Server.Implementations.EntryPoints
             };
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             if (UpdateTimer != null)

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -574,14 +574,11 @@ namespace Emby.Server.Implementations.IO
             _monitor = monitor;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _monitor.Start();
             return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
         }
     }
 }

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -1113,7 +1113,7 @@ namespace Emby.Server.Implementations.Library
         }
     }
 
-    public class DeviceAccessEntryPoint : IServerEntryPoint
+    public class DeviceAccessEntryPoint : ILongRunningTask
     {
         private IUserManager _userManager;
         private IAuthenticationRepository _authRepo;
@@ -1128,6 +1128,7 @@ namespace Emby.Server.Implementations.Library
             _sessionManager = sessionManager;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
             _userManager.UserPolicyUpdated += _userManager_UserPolicyUpdated;
@@ -1161,9 +1162,10 @@ namespace Emby.Server.Implementations.Library
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
-
+            _userManager.UserPolicyUpdated -= _userManager_UserPolicyUpdated;
         }
     }
 }

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EntryPoint.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EntryPoint.cs
@@ -5,13 +5,10 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 {
     public class EntryPoint : IServerEntryPoint
     {
+        /// <inheritdoc />
         public Task RunAsync()
         {
             return EmbyTV.Current.Start();
-        }
-
-        public void Dispose()
-        {
         }
     }
 }

--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -25,7 +25,7 @@ namespace MediaBrowser.Api
     /// <summary>
     /// Class ServerEntryPoint
     /// </summary>
-    public class ApiEntryPoint : IServerEntryPoint
+    public class ApiEntryPoint : ILongRunningTask
     {
         /// <summary>
         /// The instance
@@ -127,7 +127,7 @@ namespace MediaBrowser.Api
             }
         }
 
-        void _sessionManager_PlaybackProgress(object sender, PlaybackProgressEventArgs e)
+        private void _sessionManager_PlaybackProgress(object sender, PlaybackProgressEventArgs e)
         {
             if (!string.IsNullOrWhiteSpace(e.PlaySessionId))
             {
@@ -135,9 +135,7 @@ namespace MediaBrowser.Api
             }
         }
 
-        /// <summary>
-        /// Runs this instance.
-        /// </summary>
+        /// <inheritdoc />
         public Task RunAsync()
         {
             try
@@ -183,9 +181,7 @@ namespace MediaBrowser.Api
             }
         }
 
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
+        /// <inheritdoc />
         public void Dispose()
         {
             Dispose(true);

--- a/MediaBrowser.Controller/Plugins/ILongRunningTask.cs
+++ b/MediaBrowser.Controller/Plugins/ILongRunningTask.cs
@@ -1,11 +1,12 @@
+using System;
 using System.Threading.Tasks;
 
 namespace MediaBrowser.Controller.Plugins
 {
     /// <summary>
-    /// Interface IServerEntryPoint
+    /// Interface ILongRunningTask
     /// </summary>
-    public interface IServerEntryPoint
+    public interface ILongRunningTask: IDisposable
     {
         /// <summary>
         /// Runs this instance.

--- a/MediaBrowser.WebDashboard/ServerEntryPoint.cs
+++ b/MediaBrowser.WebDashboard/ServerEntryPoint.cs
@@ -30,9 +30,5 @@ namespace MediaBrowser.WebDashboard
 
             return Task.CompletedTask;
         }
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/MediaBrowser.XbmcMetadata/EntryPoint.cs
+++ b/MediaBrowser.XbmcMetadata/EntryPoint.cs
@@ -12,31 +12,30 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.XbmcMetadata
 {
-    public class EntryPoint : IServerEntryPoint
+    public class EntryPoint : ILongRunningTask
     {
         private readonly IUserDataManager _userDataManager;
         private readonly ILogger _logger;
-        private readonly ILibraryManager _libraryManager;
         private readonly IProviderManager _providerManager;
         private readonly IConfigurationManager _config;
 
-        public EntryPoint(IUserDataManager userDataManager, ILibraryManager libraryManager, ILogger logger, IProviderManager providerManager, IConfigurationManager config)
+        public EntryPoint(IUserDataManager userDataManager, ILogger logger, IProviderManager providerManager, IConfigurationManager config)
         {
             _userDataManager = userDataManager;
-            _libraryManager = libraryManager;
             _logger = logger;
             _providerManager = providerManager;
             _config = config;
         }
 
+        /// <inheritdoc />
         public Task RunAsync()
         {
-            _userDataManager.UserDataSaved += _userDataManager_UserDataSaved;
+            _userDataManager.UserDataSaved += OnUserDataSaved;
 
             return Task.CompletedTask;
         }
 
-        void _userDataManager_UserDataSaved(object sender, UserDataSaveEventArgs e)
+        private void OnUserDataSaved(object sender, UserDataSaveEventArgs e)
         {
             if (e.SaveReason == UserDataSaveReason.PlaybackFinished || e.SaveReason == UserDataSaveReason.TogglePlayed || e.SaveReason == UserDataSaveReason.UpdateUserRating)
             {
@@ -47,9 +46,10 @@ namespace MediaBrowser.XbmcMetadata
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
-            _userDataManager.UserDataSaved -= _userDataManager_UserDataSaved;
+            _userDataManager.UserDataSaved -= OnUserDataSaved;
         }
 
         private void SaveMetadataForItem(BaseItem item, ItemUpdateType updateReason)


### PR DESCRIPTION
Entrypoints only get executed once on startup while the new
ILongRunningsTasks shouldn't be disposed until the app is shut down.

**This probably breaks some plugins**