### PR TITLE
Fix issues with HttpClientManager

### DIFF
--- a/Emby.Dlna/PlayTo/SsdpHttpClient.cs
+++ b/Emby.Dlna/PlayTo/SsdpHttpClient.cs
@@ -34,16 +34,13 @@ namespace Emby.Dlna.PlayTo
         {
             var cancellationToken = CancellationToken.None;
 
-            using (var response = await PostSoapDataAsync(NormalizeServiceUrl(baseUrl, service.ControlUrl), "\"" + service.ServiceType + "#" + command + "\"", postData, header, logRequest, cancellationToken)
+            var url = NormalizeServiceUrl(baseUrl, service.ControlUrl);
+            using (var response = await PostSoapDataAsync(url, '\"' + service.ServiceType + '#' + command + '\"', postData, header, logRequest, cancellationToken)
                 .ConfigureAwait(false))
+            using (var stream = response.Content)
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
             {
-                using (var stream = response.Content)
-                {
-                    using (var reader = new StreamReader(stream, Encoding.UTF8))
-                    {
-                        return XDocument.Parse(reader.ReadToEnd(), LoadOptions.PreserveWhitespace);
-                    }
-                }
+                return XDocument.Parse(reader.ReadToEnd(), LoadOptions.PreserveWhitespace);
             }
         }
 
@@ -121,15 +118,18 @@ namespace Emby.Dlna.PlayTo
             }
         }
 
-        private Task<HttpResponseInfo> PostSoapDataAsync(string url,
+        private Task<HttpResponseInfo> PostSoapDataAsync(
+            string url,
             string soapAction,
             string postData,
             string header,
             bool logRequest,
             CancellationToken cancellationToken)
         {
-            if (!soapAction.StartsWith("\""))
-                soapAction = "\"" + soapAction + "\"";
+            if (soapAction[0] != '\"')
+            {
+                soapAction = '\"' + soapAction + '\"';
+            }
 
             var options = new HttpRequestOptions
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -430,7 +430,7 @@ namespace Emby.Server.Implementations
         /// Gets the current application user agent
         /// </summary>
         /// <value>The application user agent.</value>
-        public string ApplicationUserAgent => Name.Replace(' ','-') + "/" + ApplicationVersion;
+        public string ApplicationUserAgent => Name.Replace(' ','-') + '/' + ApplicationVersion;
 
         /// <summary>
         /// Gets the email address for use within a comment section of a user agent field.
@@ -690,11 +690,6 @@ namespace Emby.Server.Implementations
             await HttpServer.RequestHandler(req, request.GetDisplayUrl(), request.Host.ToString(), localPath, CancellationToken.None).ConfigureAwait(false);
         }
 
-        protected virtual IHttpClient CreateHttpClient()
-        {
-            return new HttpClientManager.HttpClientManager(ApplicationPaths, LoggerFactory, FileSystemManager, () => ApplicationUserAgent);
-        }
-
         public static IStreamHelper StreamHelper { get; set; }
 
         /// <summary>
@@ -720,7 +715,11 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton(FileSystemManager);
             serviceCollection.AddSingleton<TvDbClientManager>();
 
-            HttpClient = CreateHttpClient();
+            HttpClient = new HttpClientManager.HttpClientManager(
+                ApplicationPaths,
+                LoggerFactory.CreateLogger<HttpClientManager.HttpClientManager>(),
+                FileSystemManager,
+                () => ApplicationUserAgent);
             serviceCollection.AddSingleton(HttpClient);
 
             serviceCollection.AddSingleton(NetworkManager);

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/DirectRecorder.cs
@@ -71,7 +71,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 UserAgent = "Emby/3.0",
 
                 // Shouldn't matter but may cause issues
-                EnableHttpCompression = false
+                DecompressionMethod = CompressionMethod.None
             };
 
             using (var response = await _httpClient.SendAsync(httpRequestOptions, "GET").ConfigureAwait(false))

--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -627,15 +627,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             ListingsProviderInfo providerInfo)
         {
             // Schedules direct requires that the client support compression and will return a 400 response without it
-            options.EnableHttpCompression = true;
-
-            // On windows 7 under .net core, this header is not getting added
-#if NETSTANDARD2_0
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                options.RequestHeaders[HeaderNames.AcceptEncoding] = "deflate";
-            }
-#endif
+            options.DecompressionMethod = CompressionMethod.Deflate;
 
             try
             {
@@ -665,15 +657,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             ListingsProviderInfo providerInfo)
         {
             // Schedules direct requires that the client support compression and will return a 400 response without it
-            options.EnableHttpCompression = true;
-
-            // On windows 7 under .net core, this header is not getting added
-#if NETSTANDARD2_0
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                options.RequestHeaders[HeaderNames.AcceptEncoding] = "deflate";
-            }
-#endif
+            options.DecompressionMethod = CompressionMethod.Deflate;
 
             try
             {

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -73,11 +73,9 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                 CancellationToken = cancellationToken,
                 Url = path,
                 Progress = new SimpleProgress<double>(),
-                DecompressionMethod = CompressionMethod.Gzip,
-
                 // It's going to come back gzipped regardless of this value
                 // So we need to make sure the decompression method is set to gzip
-                EnableHttpCompression = true,
+                DecompressionMethod = CompressionMethod.Gzip,
 
                 UserAgent = "Emby/3.0"
 

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
@@ -47,7 +47,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 CancellationToken = CancellationToken.None,
                 BufferContent = false,
 
-                EnableHttpCompression = false,
+                DecompressionMethod = CompressionMethod.None,
             };
 
             foreach (var header in mediaSource.RequiredHttpHeaders)

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -118,8 +118,20 @@ namespace Jellyfin.Server
 
             SQLitePCL.Batteries_V2.Init();
 
+            // Increase the max http request limit
+            // The default connection limit is 10 for ASP.NET hosted applications and 2 for all others.
+            ServicePointManager.DefaultConnectionLimit = Math.Max(96, ServicePointManager.DefaultConnectionLimit);
+
+            // Disable the "Expect: 100-Continue" header by default
+            // http://stackoverflow.com/questions/566437/http-post-returns-the-error-417-expectation-failed-c
+            ServicePointManager.Expect100Continue = false;
+
+// CA5359: Do Not Disable Certificate Validation
+#pragma warning disable CA5359
+
             // Allow all https requests
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(delegate { return true; });
+#pragma warning restore CA5359
 
             var fileSystem = new ManagedFileSystem(_loggerFactory, appPaths);
 

--- a/MediaBrowser.Common/Net/HttpRequestOptions.cs
+++ b/MediaBrowser.Common/Net/HttpRequestOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Microsoft.Net.Http.Headers;
 
@@ -17,7 +16,7 @@ namespace MediaBrowser.Common.Net
         /// <value>The URL.</value>
         public string Url { get; set; }
 
-        public CompressionMethod? DecompressionMethod { get; set; }
+        public CompressionMethod DecompressionMethod { get; set; }
 
         /// <summary>
         /// Gets or sets the accept header.
@@ -49,25 +48,27 @@ namespace MediaBrowser.Common.Net
         /// Gets or sets the referrer.
         /// </summary>
         /// <value>The referrer.</value>
-        public string Referer { get; set; }
+        public string Referer
+        {
+            get => GetHeaderValue(HeaderNames.Referer);
+            set => RequestHeaders[HeaderNames.Referer] = value;
+        }
 
         /// <summary>
         /// Gets or sets the host.
         /// </summary>
         /// <value>The host.</value>
-        public string Host { get; set; }
+        public string Host
+        {
+            get => GetHeaderValue(HeaderNames.Host);
+            set => RequestHeaders[HeaderNames.Host] = value;
+        }
 
         /// <summary>
         /// Gets or sets the progress.
         /// </summary>
         /// <value>The progress.</value>
         public IProgress<double> Progress { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [enable HTTP compression].
-        /// </summary>
-        /// <value><c>true</c> if [enable HTTP compression]; otherwise, <c>false</c>.</value>
-        public bool EnableHttpCompression { get; set; }
 
         public Dictionary<string, string> RequestHeaders { get; private set; }
 
@@ -104,13 +105,12 @@ namespace MediaBrowser.Common.Net
         /// </summary>
         public HttpRequestOptions()
         {
-            EnableHttpCompression = true;
-
             RequestHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             LogRequest = true;
             LogErrors = true;
             CacheMode = CacheMode.None;
+            DecompressionMethod = CompressionMethod.Deflate;
         }
     }
 
@@ -122,7 +122,8 @@ namespace MediaBrowser.Common.Net
 
     public enum CompressionMethod
     {
-        Deflate,
-        Gzip
+        None = 0b00000001,
+        Deflate = 0b00000010,
+        Gzip = 0b00000100
     }
 }

--- a/MediaBrowser.Common/Net/HttpRequestOptions.cs
+++ b/MediaBrowser.Common/Net/HttpRequestOptions.cs
@@ -120,6 +120,7 @@ namespace MediaBrowser.Common.Net
         Unconditional = 1
     }
 
+    [Flags]
     public enum CompressionMethod
     {
         None = 0b00000001,

--- a/MediaBrowser.Common/Net/HttpResponseInfo.cs
+++ b/MediaBrowser.Common/Net/HttpResponseInfo.cs
@@ -52,13 +52,6 @@ namespace MediaBrowser.Common.Net
         /// <value>The headers.</value>
         public Dictionary<string, string> Headers { get; set; }
 
-        private readonly IDisposable _disposable;
-
-        public HttpResponseInfo(IDisposable disposable)
-        {
-            _disposable = disposable;
-            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        }
         public HttpResponseInfo()
         {
             Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -66,10 +59,7 @@ namespace MediaBrowser.Common.Net
 
         public void Dispose()
         {
-            if (_disposable != null)
-            {
-                _disposable.Dispose();
-            }
+            // Only IDisposable for backwards compatibility
         }
     }
 }

--- a/MediaBrowser.Common/Net/HttpResponseInfo.cs
+++ b/MediaBrowser.Common/Net/HttpResponseInfo.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace MediaBrowser.Common.Net
 {
@@ -50,11 +50,16 @@ namespace MediaBrowser.Common.Net
         /// Gets or sets the headers.
         /// </summary>
         /// <value>The headers.</value>
-        public Dictionary<string, string> Headers { get; set; }
+        public HttpResponseHeaders Headers { get; set; }
 
         public HttpResponseInfo()
         {
-            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        }
+
+        public HttpResponseInfo(HttpResponseHeaders headers)
+        {
+            Headers = headers;
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes a crash when using the `Post` method with content that isn't a `byte` array.
Replaces #1460