### PR TITLE
Update the GitHub token to a Grant Auth token

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -173,7 +173,7 @@ jobs:
     - task: DownloadGitHubRelease@0
       displayName: Download ABI compatibility check tool from GitHub
       inputs:
-        connection: jellyfin
+        connection: Jellyfin Release Download
         userRepository: EraYaN/dotnet-compatibility
         defaultVersionType: 'latest' # Options: latest, specificVersion, specificTag
         #version: # Required when defaultVersionType != Latest


### PR DESCRIPTION
To avoid this error: 
```
The pipeline is not valid. Job Job: Step DownloadGitHubRelease input connection expects a service connection of type github with authentication scheme OAuth,PersonalAccessToken but the provided service connection jellyfin is of type GitHub using authentication scheme InstallationToken.
```