### PR TITLE
Fix broken symlinks in deployment

### DIFF
--- a/deployment/centos-package-x64/pkg-src
+++ b/deployment/centos-package-x64/pkg-src
@@ -1,1 +1,1 @@
-../fedora-package-x64/pkg-src
+../fedora-package-x64/pkg-src/

--- a/deployment/debian-package-armhf/pkg-src
+++ b/deployment/debian-package-armhf/pkg-src
@@ -1,1 +1,1 @@
-../debian-package-x64/pkg-src
+../debian-package-x64/pkg-src/

--- a/deployment/ubuntu-package-x64/pkg-src
+++ b/deployment/ubuntu-package-x64/pkg-src
@@ -1,1 +1,1 @@
-../debian-package-x64/pkg-src
+../debian-package-x64/pkg-src/


### PR DESCRIPTION

**Changes**
These were removed somehow in defc5f1cf9b486357b379c610663e1bad48428ad;
restore them to their proper link state.

**Issues**
N/A
