### PR TITLE
Fixed SMI Encoding Bug

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@
  - [pjeanjean](https://github.com/pjeanjean)
  - [DrPandemic](https://github.com/drpandemic)
  - [joern-h](https://github.com/joern-h)
+ - [Khinenw](https://github.com/HelloWorld017)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -425,7 +425,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             var encodingParam = await GetSubtitleFileCharacterSet(inputPath, language, inputProtocol, cancellationToken).ConfigureAwait(false);
 
-            if (!string.IsNullOrEmpty(encodingParam))
+            // FFmpeg automatically convert character encoding when it is UTF-16
+            // If we specify character encoding, it rejects with "do not specify a character encoding" and "Unable to recode subtitle event"
+            if ((inputPath.EndsWith(".smi") || inputPath.EndsWith(".sami")) && (encodingParam == "UTF-16BE" || encodingParam == "UTF-16LE"))
+            {
+                encodingParam = "";
+            }
+            else if (!string.IsNullOrEmpty(encodingParam))
             {
                 encodingParam = " -sub_charenc " + encodingParam;
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
* Disabled `-sub_charenc` flag for `*.smi` and `*.sami` subtitles when it is determined as UTF-16.

If we specify character encoding to sami subtitles, FFmpeg rejects it with "do not specify a character encoding" and "Unable to recode subtitle event" error.

It is because ffmpeg converts UTF-16 into UTF-8 in `ff_text_r8`. `ff_text_r8` is called from `ff_text_read` and `samidec.c` uses `ff_text_read`.

When I tested with UTF-16LE, UTF-16BE, CP949, UTF-8 the FFmpeg automatically did the conversion without the `-sub_charenc` flag.

**Issues**
Fixes #1539
