### PR TITLE
Override the Debian installinit name

### DIFF
--- a/deployment/debian-package-x64/pkg-src/rules
+++ b/deployment/debian-package-x64/pkg-src/rules
@@ -45,3 +45,7 @@ override_dh_auto_build:
 override_dh_auto_clean:
 	dotnet clean -maxcpucount:1 --configuration $(CONFIG) Jellyfin.Server || true
 	rm -rf '$(CURDIR)/usr'
+
+# Force the service name to jellyfin even if we're building jellyfin-nightly
+override_dh_installinit:
+	dh_installinit --name=jellyfin


### PR DESCRIPTION
**Changes**
Without this, when building the `jellyfin-nightly` package, it attempts
to find service/init files with the name `jellyfin-nightly` instead of
the proper name. This override prevents this by forcing the name to
`jellyfin`. Required for nightly builds.

**Issues**
N/A