### PR TITLE
Disable buffering in HttpClient as it causes big requests to timeout

### DIFF
--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -284,7 +284,7 @@ namespace Emby.Server.Implementations.HttpClientManager
 
             if (!options.BufferContent)
             {
-                var response = await client.SendAsync(httpWebRequest, options.CancellationToken).ConfigureAwait(false);
+                var response = await client.SendAsync(httpWebRequest, HttpCompletionOption.ResponseHeadersRead, options.CancellationToken).ConfigureAwait(false);
 
                 await EnsureSuccessStatusCode(response, options).ConfigureAwait(false);
 
@@ -296,7 +296,7 @@ namespace Emby.Server.Implementations.HttpClientManager
                     Content = stream,
                     StatusCode = response.StatusCode,
                     ContentType = response.Content.Headers.ContentType?.MediaType,
-                    ContentLength = stream.Length,
+                    ContentLength = response.Content.Headers.ContentLength,
                     ResponseUrl = response.Content.Headers.ContentLocation?.ToString()
                 };
             }

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -301,7 +301,7 @@ namespace Emby.Server.Implementations.HttpClientManager
                 };
             }
 
-            using (var response = await client.SendAsync(httpWebRequest, options.CancellationToken).ConfigureAwait(false))
+            using (var response = await client.SendAsync(httpWebRequest, HttpCompletionOption.ResponseHeadersRead, options.CancellationToken).ConfigureAwait(false))
             {
                 await EnsureSuccessStatusCode(response, options).ConfigureAwait(false);
 


### PR DESCRIPTION
This is the same fix as #1551, but it simply restores the old HttpWebRequest behaviour. It might be more suitable for 10.3.7.

## Issues
- Fixes #1520 

## Summary
- `HttpWebRequest.BeginGetResponse` (old implementation) returns immediately after headers have been received. 
- Non-buffered content needs the unmodified stream to function properly (eg. Live TV).
- HttpClient always buffers by default, but can be disabled with `HttpCompletionOption.ResponseHeadersRead`.
- This PR makes HttpClient behave the same way as the previous HttpWebRequest implementation by allowing the response to be "completed" after the headers have been received.