### PR TITLE
Add Stale app configuration starting point

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,12 +9,14 @@ exemptLabels:
   - dotnet-3.0-future
   - roadmap
   - future
+  - feature
+  - enhancement
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  Issues go stale after 60d of inactivity. Mark the issue as fresh by adding a comment or commit. Stale issues close after an additional 7d of inactivity.
+  If this issue is safe to close now please do so.
+  If you have any questions you can reach us on [Matrix or Social Media](https://jellyfin.readthedocs.io/en/latest/getting-help/).
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - regression
+  - security
+  - dotnet-3.0-future
+  - roadmap
+  - future
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
**Changes**
Adds a config file for the Stale App, to help keep the issues list fresh, I think 60 days is fair as a starting point. I added most tags I think should be exempt.

Link: https://github.com/apps/stale

EDIT Message proposal:

```
Issues go stale after 60d of inactivity.
Mark the issue as fresh by adding a comment or commit.
Stale issues close after an additional 7d of inactivity.

If this issue is safe to close now please do so.

If you have any questions you can reach us on [Matrix or Social Media](https://jellyfin.readthedocs.io/en/latest/getting-help/).
```
