### PR TITLE
Add base url option to server configuration

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -602,6 +602,13 @@ namespace Emby.Server.Implementations.HttpServer
                     Priority = route.Priority,
                     Summary = route.Summary
                 });
+
+                routes.Add(new RouteAttribute(NormalizeOldRoutePath(route.Path), route.Verbs)
+                {
+                    Notes = route.Notes,
+                    Priority = route.Priority,
+                    Summary = route.Summary
+                });
             }
 
             return routes.ToArray();
@@ -635,6 +642,17 @@ namespace Emby.Server.Implementations.HttpServer
         public Task ProcessWebSocketRequest(HttpContext context)
         {
             return _socketListener.ProcessWebSocketRequest(context);
+        }
+
+        // this method was left for compatibility with third party clients
+        private static string NormalizeOldRoutePath(string path)
+        {
+            if (path.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                return "/emby" + path;
+            }
+
+            return "emby/" + path;
         }
 
         private static string NormalizeCustomRoutePath(string baseUrl, string path)

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -484,53 +484,6 @@ namespace Emby.Server.Implementations.HttpServer
                     return;
                 }
 
-                if (localPath.IndexOf("mediabrowser/web", StringComparison.OrdinalIgnoreCase) != -1)
-                {
-                    httpRes.StatusCode = 200;
-                    httpRes.ContentType = "text/html";
-                    var newUrl = urlString.Replace("mediabrowser", "emby", StringComparison.OrdinalIgnoreCase)
-                        .Replace("/dashboard/", "/web/", StringComparison.OrdinalIgnoreCase);
-
-                    if (!string.Equals(newUrl, urlString, StringComparison.OrdinalIgnoreCase))
-                    {
-                        await httpRes.WriteAsync(
-                            "<!doctype html><html><head><title>Emby</title></head><body>Please update your Emby bookmark to <a href=\"" +
-                            newUrl + "\">" + newUrl + "</a></body></html>",
-                            cancellationToken).ConfigureAwait(false);
-                        return;
-                    }
-                }
-
-                if (localPath.IndexOf("dashboard/", StringComparison.OrdinalIgnoreCase) != -1 &&
-                    localPath.IndexOf("web/dashboard", StringComparison.OrdinalIgnoreCase) == -1)
-                {
-                    httpRes.StatusCode = 200;
-                    httpRes.ContentType = "text/html";
-                    var newUrl = urlString.Replace("mediabrowser", "emby", StringComparison.OrdinalIgnoreCase)
-                        .Replace("/dashboard/", "/web/", StringComparison.OrdinalIgnoreCase);
-
-                    if (!string.Equals(newUrl, urlString, StringComparison.OrdinalIgnoreCase))
-                    {
-                        await httpRes.WriteAsync(
-                            "<!doctype html><html><head><title>Emby</title></head><body>Please update your Emby bookmark to <a href=\"" +
-                            newUrl + "\">" + newUrl + "</a></body></html>",
-                            cancellationToken).ConfigureAwait(false);
-                        return;
-                    }
-                }
-
-                if (string.Equals(localPath, "/web", StringComparison.OrdinalIgnoreCase))
-                {
-                    httpRes.Redirect(_defaultRedirectPath);
-                    return;
-                }
-
-                if (string.Equals(localPath, "/web/", StringComparison.OrdinalIgnoreCase))
-                {
-                    httpRes.Redirect("../" + _defaultRedirectPath);
-                    return;
-                }
-
                 if (string.Equals(localPath, "/", StringComparison.OrdinalIgnoreCase))
                 {
                     httpRes.Redirect(_defaultRedirectPath);
@@ -541,19 +494,6 @@ namespace Emby.Server.Implementations.HttpServer
                 {
                     httpRes.Redirect("/" + _defaultRedirectPath);
                     return;
-                }
-
-                if (!string.Equals(httpReq.QueryString["r"], "0", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (localPath.EndsWith("web/dashboard.html", StringComparison.OrdinalIgnoreCase))
-                    {
-                        httpRes.Redirect("index.html#!/dashboard.html");
-                    }
-
-                    if (localPath.EndsWith("web/home.html", StringComparison.OrdinalIgnoreCase))
-                    {
-                        httpRes.Redirect("index.html");
-                    }
                 }
 
                 if (!string.IsNullOrEmpty(GlobalResponse))
@@ -569,7 +509,6 @@ namespace Emby.Server.Implementations.HttpServer
                 }
 
                 var handler = GetServiceHandler(httpReq);
-
                 if (handler != null)
                 {
                     await handler.ProcessRequestAsync(this, httpReq, httpRes, _logger, cancellationToken).ConfigureAwait(false);

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -163,6 +163,7 @@ namespace MediaBrowser.Model.Configuration
 
         public string ServerName { get; set; }
         public string WanDdns { get; set; }
+        public string BaseUrl { get; set; }
 
         public string UICulture { get; set; }
 
@@ -243,6 +244,7 @@ namespace MediaBrowser.Model.Configuration
             SortRemoveCharacters = new[] { ",", "&", "-", "{", "}", "'" };
             SortRemoveWords = new[] { "the", "a", "an" };
 
+            BaseUrl = "jellyfin";
             UICulture = "en-US";
 
             MetadataOptions = new[]


### PR DESCRIPTION
I have the work done for android, apiclient-java, and web but Android TV and Kodi might need some UI changes. The easiest way to not break any setups would be to update all the clients to drop the `emby` prefix on API requests. The server always accepts connections with no base URL so any existing setups should work fine.