### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder /jellyfin /jellyfin
 ARG JELLYFIN_WEB_VERSION=v10.3.7
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
- && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+ && mv jellyfin-web-* /jellyfin/jellyfin-web
 
 EXPOSE 8096
 VOLUME /cache /config /media

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -29,7 +29,7 @@ COPY --from=builder /jellyfin /jellyfin
 ARG JELLYFIN_WEB_VERSION=v10.3.7
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
- && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+ && mv jellyfin-web-* /jellyfin/jellyfin-web
 
 EXPOSE 8096
 VOLUME /cache /config /media

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -29,7 +29,7 @@ COPY --from=builder /jellyfin /jellyfin
 ARG JELLYFIN_WEB_VERSION=v10.3.7
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
- && mv jellyfin-web-${JELLYFIN_WEB_VERSION} /jellyfin/jellyfin-web
+ && mv jellyfin-web-* /jellyfin/jellyfin-web
 
 EXPOSE 8096
 VOLUME /cache /config /media


### PR DESCRIPTION
**Changes**
While https://github.com/jellyfin/jellyfin/pull/1593 made the build work with a version of `master`, it broke a tag-specific version. The extracted directory will *not* always match the version argument.