### PR TITLE
Document all public/internal members of Emby.Drawing

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/DvdLib/DvdLib.csproj
+++ b/DvdLib/DvdLib.csproj
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Emby.Dlna/Emby.Dlna.csproj
+++ b/Emby.Dlna/Emby.Dlna.csproj
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Emby.Drawing/Emby.Drawing.csproj
+++ b/Emby.Drawing/Emby.Drawing.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Emby.Drawing/NullImageEncoder.cs
+++ b/Emby.Drawing/NullImageEncoder.cs
@@ -5,36 +5,40 @@ using MediaBrowser.Model.Drawing;
 
 namespace Emby.Drawing
 {
+    /// <summary>
+    /// A fallback implementation of <see cref="IImageEncoder" />.
+    /// </summary>
     public class NullImageEncoder : IImageEncoder
     {
+        /// <inheritdoc />
         public IReadOnlyCollection<string> SupportedInputFormats
             => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "png", "jpeg", "jpg" };
 
+        /// <inheritdoc />
         public IReadOnlyCollection<ImageFormat> SupportedOutputFormats
         => new HashSet<ImageFormat>() { ImageFormat.Jpg, ImageFormat.Png };
 
-        public void CropWhiteSpace(string inputPath, string outputPath)
-        {
-            throw new NotImplementedException();
-        }
+        /// <inheritdoc />
+        public string Name => "Null Image Encoder";
 
+        /// <inheritdoc />
+        public bool SupportsImageCollageCreation => false;
+
+        /// <inheritdoc />
+        public bool SupportsImageEncoding => false;
+
+        /// <inheritdoc />
+        public ImageDimensions GetImageSize(string path)
+            => throw new NotImplementedException();
+
+        /// <inheritdoc />
         public string EncodeImage(string inputPath, DateTime dateModified, string outputPath, bool autoOrient, ImageOrientation? orientation, int quality, ImageProcessingOptions options, ImageFormat selectedOutputFormat)
         {
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc />
         public void CreateImageCollage(ImageCollageOptions options)
-        {
-            throw new NotImplementedException();
-        }
-
-        public string Name => "Null Image Encoder";
-
-        public bool SupportsImageCollageCreation => false;
-
-        public bool SupportsImageEncoding => false;
-
-        public ImageDimensions GetImageSize(string path)
         {
             throw new NotImplementedException();
         }

--- a/Emby.IsoMounting/IsoMounter/IsoMounter.csproj
+++ b/Emby.IsoMounting/IsoMounter/IsoMounter.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Emby.Notifications/Emby.Notifications.csproj
+++ b/Emby.Notifications/Emby.Notifications.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Emby.Photos/Emby.Photos.csproj
+++ b/Emby.Photos/Emby.Photos.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -510,13 +510,8 @@ namespace Emby.Server.Implementations
             return AllConcreteTypes.Where(i => currentType.IsAssignableFrom(i));
         }
 
-        /// <summary>
-        /// Gets the exports.
-        /// </summary>
-        /// <typeparam name="T">The type</typeparam>
-        /// <param name="manageLifetime">if set to <c>true</c> [manage lifetime].</param>
-        /// <returns>IEnumerable{``0}.</returns>
-        public IEnumerable<T> GetExports<T>(bool manageLifetime = true)
+        /// <inheritdoc />
+        public IReadOnlyCollection<T> GetExports<T>(bool manageLifetime = true)
         {
             var parts = GetExportTypes<T>()
                 .Select(CreateInstanceSafe)
@@ -538,6 +533,7 @@ namespace Emby.Server.Implementations
         /// <summary>
         /// Runs the startup tasks.
         /// </summary>
+        /// <returns><see cref="Task" />.</returns>
         public async Task RunStartupTasksAsync()
         {
             Logger.LogInformation("Running startup tasks");
@@ -550,7 +546,7 @@ namespace Emby.Server.Implementations
 
             Logger.LogInformation("ServerId: {0}", SystemId);
 
-            var entryPoints = GetExports<IServerEntryPoint>().ToList();
+            var entryPoints = GetExports<IServerEntryPoint>();
 
             var stopWatch = new Stopwatch();
             stopWatch.Start();
@@ -801,7 +797,7 @@ namespace Emby.Server.Implementations
 
             serviceCollection.AddSingleton(HttpServer);
 
-            ImageProcessor = GetImageProcessor();
+            ImageProcessor = new ImageProcessor(LoggerFactory.CreateLogger<ImageProcessor>(), ServerConfigurationManager.ApplicationPaths, FileSystemManager, ImageEncoder, () => LibraryManager, () => MediaEncoder);
             serviceCollection.AddSingleton(ImageProcessor);
 
             TVSeriesManager = new TVSeriesManager(UserManager, UserDataManager, LibraryManager, ServerConfigurationManager);
@@ -953,11 +949,6 @@ namespace Emby.Server.Implementations
             }
         }
 
-        private IImageProcessor GetImageProcessor()
-        {
-            return new ImageProcessor(LoggerFactory, ServerConfigurationManager.ApplicationPaths, FileSystemManager, ImageEncoder, () => LibraryManager, () => MediaEncoder);
-        }
-
         /// <summary>
         /// Gets the user repository.
         /// </summary>
@@ -1087,7 +1078,7 @@ namespace Emby.Server.Implementations
                 GetExports<IMetadataSaver>(),
                 GetExports<IExternalId>());
 
-            ImageProcessor.AddParts(GetExports<IImageEnhancer>());
+            ImageProcessor.ImageEnhancers = GetExports<IImageEnhancer>();
 
             LiveTvManager.AddParts(GetExports<ILiveTvService>(), GetExports<ITunerHost>(), GetExports<IListingsProvider>());
 

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1364,7 +1364,7 @@ namespace Emby.Server.Implementations.Dto
                 return null;
             }
 
-            var supportedEnhancers = _imageProcessor.GetSupportedEnhancers(item, ImageType.Primary);
+            var supportedEnhancers = _imageProcessor.GetSupportedEnhancers(item, ImageType.Primary).ToArray();
 
             ImageDimensions size;
 

--- a/Emby.XmlTv/Emby.XmlTv/Emby.XmlTv.csproj
+++ b/Emby.XmlTv/Emby.XmlTv/Emby.XmlTv.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MediaBrowser.Api/Images/ImageService.cs
+++ b/MediaBrowser.Api/Images/ImageService.cs
@@ -550,14 +550,14 @@ namespace MediaBrowser.Api.Images
             }
 
             IImageEnhancer[] supportedImageEnhancers;
-            if (_imageProcessor.ImageEnhancers.Length > 0)
+            if (_imageProcessor.ImageEnhancers.Count > 0)
             {
                 if (item == null)
                 {
                     item = _libraryManager.GetItemById(itemId);
                 }
 
-                supportedImageEnhancers = request.EnableImageEnhancers ? _imageProcessor.GetSupportedEnhancers(item, request.Type) : Array.Empty<IImageEnhancer>();
+                supportedImageEnhancers = request.EnableImageEnhancers ? _imageProcessor.GetSupportedEnhancers(item, request.Type).ToArray() : Array.Empty<IImageEnhancer>();
             }
             else
             {
@@ -606,8 +606,8 @@ namespace MediaBrowser.Api.Images
             ImageRequest request,
             ItemImageInfo image,
             bool cropwhitespace,
-            ImageFormat[] supportedFormats,
-            IImageEnhancer[] enhancers,
+            IReadOnlyCollection<ImageFormat> supportedFormats,
+            IReadOnlyCollection<IImageEnhancer> enhancers,
             TimeSpan? cacheDuration,
             IDictionary<string, string> headers,
             bool isHeadRequest)

--- a/MediaBrowser.Api/MediaBrowser.Api.csproj
+++ b/MediaBrowser.Api/MediaBrowser.Api.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -75,10 +75,10 @@ namespace MediaBrowser.Common
         /// <summary>
         /// Gets the exports.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="manageLiftime">if set to <c>true</c> [manage liftime].</param>
-        /// <returns>IEnumerable{``0}.</returns>
-        IEnumerable<T> GetExports<T>(bool manageLifetime = true);
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="manageLifetime">If set to <c>true</c> [manage lifetime].</param>
+        /// <returns><see cref="IReadOnlyCollection{T}" />.</returns>
+        IReadOnlyCollection<T> GetExports<T>(bool manageLifetime = true);
 
         /// <summary>
         /// Resolves this instance.

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.Controller/Drawing/IImageEncoder.cs
+++ b/MediaBrowser.Controller/Drawing/IImageEncoder.cs
@@ -18,16 +18,6 @@ namespace MediaBrowser.Controller.Drawing
         IReadOnlyCollection<ImageFormat> SupportedOutputFormats { get; }
 
         /// <summary>
-        /// Encodes the image.
-        /// </summary>
-        string EncodeImage(string inputPath, DateTime dateModified, string outputPath, bool autoOrient, ImageOrientation? orientation, int quality, ImageProcessingOptions options, ImageFormat outputFormat);
-
-        /// <summary>
-        /// Creates the image collage.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        void CreateImageCollage(ImageCollageOptions options);
-        /// <summary>
         /// Gets the name.
         /// </summary>
         /// <value>The name.</value>
@@ -46,5 +36,16 @@ namespace MediaBrowser.Controller.Drawing
         bool SupportsImageEncoding { get; }
 
         ImageDimensions GetImageSize(string path);
+
+        /// <summary>
+        /// Encodes the image.
+        /// </summary>
+        string EncodeImage(string inputPath, DateTime dateModified, string outputPath, bool autoOrient, ImageOrientation? orientation, int quality, ImageProcessingOptions options, ImageFormat outputFormat);
+
+        /// <summary>
+        /// Creates the image collage.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        void CreateImageCollage(ImageCollageOptions options);
     }
 }

--- a/MediaBrowser.Controller/Drawing/IImageProcessor.cs
+++ b/MediaBrowser.Controller/Drawing/IImageProcessor.cs
@@ -24,7 +24,15 @@ namespace MediaBrowser.Controller.Drawing
         /// Gets the image enhancers.
         /// </summary>
         /// <value>The image enhancers.</value>
-        IImageEnhancer[] ImageEnhancers { get; }
+        IReadOnlyCollection<IImageEnhancer> ImageEnhancers { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether [supports image collage creation].
+        /// </summary>
+        /// <value><c>true</c> if [supports image collage creation]; otherwise, <c>false</c>.</value>
+        bool SupportsImageCollageCreation { get; }
+
+        IImageEncoder ImageEncoder { get; set; }
 
         /// <summary>
         /// Gets the dimensions of the image.
@@ -51,18 +59,12 @@ namespace MediaBrowser.Controller.Drawing
         ImageDimensions GetImageDimensions(BaseItem item, ItemImageInfo info, bool updateItem);
 
         /// <summary>
-        /// Adds the parts.
-        /// </summary>
-        /// <param name="enhancers">The enhancers.</param>
-        void AddParts(IEnumerable<IImageEnhancer> enhancers);
-
-        /// <summary>
         /// Gets the supported enhancers.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="imageType">Type of the image.</param>
         /// <returns>IEnumerable{IImageEnhancer}.</returns>
-        IImageEnhancer[] GetSupportedEnhancers(BaseItem item, ImageType imageType);
+        IEnumerable<IImageEnhancer> GetSupportedEnhancers(BaseItem item, ImageType imageType);
 
         /// <summary>
         /// Gets the image cache tag.
@@ -80,7 +82,7 @@ namespace MediaBrowser.Controller.Drawing
         /// <param name="image">The image.</param>
         /// <param name="imageEnhancers">The image enhancers.</param>
         /// <returns>Guid.</returns>
-        string GetImageCacheTag(BaseItem item, ItemImageInfo image, IImageEnhancer[] imageEnhancers);
+        string GetImageCacheTag(BaseItem item, ItemImageInfo image, IReadOnlyCollection<IImageEnhancer> imageEnhancers);
 
         /// <summary>
         /// Processes the image.
@@ -109,7 +111,7 @@ namespace MediaBrowser.Controller.Drawing
         /// <summary>
         /// Gets the supported image output formats.
         /// </summary>
-        /// <returns>IReadOnlyCollection{ImageOutput}.</returns>
+        /// <returns><see cref="IReadOnlyCollection{ImageOutput}" />.</returns>
         IReadOnlyCollection<ImageFormat> GetSupportedImageOutputFormats();
 
         /// <summary>
@@ -117,14 +119,6 @@ namespace MediaBrowser.Controller.Drawing
         /// </summary>
         /// <param name="options">The options.</param>
         void CreateImageCollage(ImageCollageOptions options);
-
-        /// <summary>
-        /// Gets a value indicating whether [supports image collage creation].
-        /// </summary>
-        /// <value><c>true</c> if [supports image collage creation]; otherwise, <c>false</c>.</value>
-        bool SupportsImageCollageCreation { get; }
-
-        IImageEncoder ImageEncoder { get; set; }
 
         bool SupportsTransparency(string path);
     }

--- a/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
+++ b/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using MediaBrowser.Controller.Entities;
@@ -33,9 +34,9 @@ namespace MediaBrowser.Controller.Drawing
 
         public int Quality { get; set; }
 
-        public IImageEnhancer[] Enhancers { get; set; }
+        public IReadOnlyCollection<IImageEnhancer> Enhancers { get; set; }
 
-        public ImageFormat[] SupportedOutputFormats { get; set; }
+        public IReadOnlyCollection<ImageFormat> SupportedOutputFormats { get; set; }
 
         public bool AddPlayedIndicator { get; set; }
 

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.LocalMetadata/MediaBrowser.LocalMetadata.csproj
+++ b/MediaBrowser.LocalMetadata/MediaBrowser.LocalMetadata.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
+++ b/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.WebDashboard/MediaBrowser.WebDashboard.csproj
+++ b/MediaBrowser.WebDashboard/MediaBrowser.WebDashboard.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MediaBrowser.XbmcMetadata/MediaBrowser.XbmcMetadata.csproj
+++ b/MediaBrowser.XbmcMetadata/MediaBrowser.XbmcMetadata.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Forces all new public/internal members to be documented.
Enables TreatWarningsAsErrors for Emby.Drawing.
Generate doc files for all projects.