### PR TITLE
Add a task to clean up transcode cache

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodingTempTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodingTempTask.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks
+{
+    /// <summary>
+    /// Deletes all transcoding temp files
+    /// </summary>
+    public class DeleteTranscodingTempTask : IScheduledTask, IConfigurableScheduledTask
+    {
+        /// <summary>
+        /// Gets or sets the application paths.
+        /// </summary>
+        /// <value>The application paths.</value>
+        //private IApplicationPaths ApplicationPaths { get; set; }
+        protected ServerApplicationPaths ApplicationPaths { get; set; }
+
+
+        private readonly ILogger _logger;
+
+        private readonly IFileSystem _fileSystem;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteTranscodingTempTask" /> class.
+        /// </summary>
+        public DeleteTranscodingTempTask(ServerApplicationPaths appPaths, ILogger logger, IFileSystem fileSystem)
+        {
+            ApplicationPaths = appPaths;
+            _logger = logger;
+            _fileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Creates the triggers that define when the task will run
+        /// </summary>
+        /// <returns>IEnumerable{BaseTaskTrigger}.</returns>
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => new List<TaskTriggerInfo>();
+
+        /// <summary>
+        /// Returns the task to be executed
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="progress">The progress.</param>
+        /// <returns>Task.</returns>
+        public Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+        {
+            var minDateModified = DateTime.UtcNow.AddDays(-1);
+            progress.Report(50);
+
+            try
+            {
+                DeleteTempFilesFromDirectory(cancellationToken, ApplicationPaths.TranscodingTempPath, minDateModified, progress);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // No biggie here. Nothing to delete
+            }
+
+            return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        /// Deletes the transcoded temp files from directory with a last write time less than a given date
+        /// </summary>
+        /// <param name="cancellationToken">The task cancellation token.</param>
+        /// <param name="directory">The directory.</param>
+        /// <param name="minDateModified">The min date modified.</param>
+        /// <param name="progress">The progress.</param>
+        private void DeleteTempFilesFromDirectory(CancellationToken cancellationToken, string directory, DateTime minDateModified, IProgress<double> progress)
+        {
+            var filesToDelete = _fileSystem.GetFiles(directory, true)
+                .Where(f => _fileSystem.GetLastWriteTimeUtc(f) < minDateModified)
+                .ToList();
+
+            var index = 0;
+
+            foreach (var file in filesToDelete)
+            {
+                double percent = index;
+                percent /= filesToDelete.Count;
+
+                progress.Report(100 * percent);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                DeleteFile(file.FullName);
+
+                index++;
+            }
+
+            DeleteEmptyFolders(directory);
+
+            progress.Report(100);
+        }
+
+        private void DeleteEmptyFolders(string parent)
+        {
+            foreach (var directory in _fileSystem.GetDirectoryPaths(parent))
+            {
+                DeleteEmptyFolders(directory);
+                if (!_fileSystem.GetFileSystemEntryPaths(directory).Any())
+                {
+                    try
+                    {
+                        Directory.Delete(directory, false);
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogError(ex, "Error deleting directory {path}", directory);
+                    }
+                    catch (IOException ex)
+                    {
+                        _logger.LogError(ex, "Error deleting directory {path}", directory);
+                    }
+                }
+            }
+        }
+
+        private void DeleteFile(string path)
+        {
+            try
+            {
+                _fileSystem.DeleteFile(path);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogError(ex, "Error deleting file {path}", path);
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "Error deleting file {path}", path);
+            }
+        }
+
+        public string Name => "Transcoding temp cleanup";
+
+        public string Description => "Deletes transcoding temp files older than 24 hours.";
+
+        public string Category => "Maintenance";
+
+        public string Key => "DeleteTranscodingTempFiles";
+
+        public bool IsHidden => false;
+
+        public bool IsEnabled => false;
+
+        public bool IsLogged => true;
+    }
+}

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodingTempTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodingTempTask.cs
@@ -19,7 +19,6 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         /// Gets or sets the application paths.
         /// </summary>
         /// <value>The application paths.</value>
-        //private IApplicationPaths ApplicationPaths { get; set; }
         protected ServerApplicationPaths ApplicationPaths { get; set; }
 
 


### PR DESCRIPTION
**Changes**
Adds a scheduled task that will delete files older than 24h in the transcoding-temp folder. The task is disabled by default, but can be enabled to run on any of the possible triggers.

(This is pretty much a straight copy of the delete cache task, just modified for the transcoding-temp folder.)

**Issues**
Partial fix for #1277.