### PR TITLE
Fix instant crash.

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -124,7 +124,7 @@ namespace Emby.Server.Implementations.Data
             }
 
             WriteConnection.Execute("PRAGMA temp_store=" + (int)TempStore);
-            
+
             // Configuration and pragmas can affect VACUUM so it needs to be last.
             WriteConnection.Execute("VACUUM");
 
@@ -218,7 +218,7 @@ namespace Emby.Server.Implementations.Data
                 WriteLock.Wait();
                 try
                 {
-                    WriteConnection.Dispose();
+                    WriteConnection?.Dispose();
                 }
                 finally
                 {

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.14" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3.netstandard11" Version="1.1.14" />
   </ItemGroup>
 


### PR DESCRIPTION
Can't upgrade to SQLitePCLRaw.bundle_e_sqlite3 v2 until we release a
compatible SQLitePCLRaw.provider.sqlite3.netstandard11

PR: https://github.com/jellyfin/SQLitePCL.pretty.netstandard/pull/5