### PR TITLE
Always fetch episode id as EpisodeInfo does not contain it

### DIFF
--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
@@ -64,7 +64,9 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                     if (string.IsNullOrEmpty(episodeTvdbId))
                     {
                         _logger.LogError("Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
-                            episodeInfo.ParentIndexNumber, episodeInfo.IndexNumber, series.GetProviderId(MetadataProviders.Tvdb));
+                            episodeInfo.ParentIndexNumber,
+                            episodeInfo.IndexNumber,
+                            series.GetProviderId(MetadataProviders.Tvdb));
                         return imageResult;
                     }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
@@ -50,27 +50,22 @@ namespace MediaBrowser.Providers.TV.TheTVDB
             var language = item.GetPreferredMetadataLanguage();
             if (series != null && TvdbSeriesProvider.IsValidSeries(series.ProviderIds))
             {
-                var episodeTvdbId = episode.GetProviderId(MetadataProviders.Tvdb);
-
                 // Process images
                 try
                 {
+                    var episodeInfo = new EpisodeInfo
+                    {
+                        IndexNumber = episode.IndexNumber.Value,
+                        ParentIndexNumber = episode.ParentIndexNumber.Value,
+                        SeriesProviderIds = series.ProviderIds
+                    };
+                    string episodeTvdbId = await _tvDbClientManager
+                        .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
                     if (string.IsNullOrEmpty(episodeTvdbId))
                     {
-                        var episodeInfo = new EpisodeInfo
-                        {
-                            IndexNumber = episode.IndexNumber.Value,
-                            ParentIndexNumber = episode.ParentIndexNumber.Value,
-                            SeriesProviderIds = series.ProviderIds
-                        };
-                        episodeTvdbId = await _tvDbClientManager
-                            .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
-                        if (string.IsNullOrEmpty(episodeTvdbId))
-                        {
-                            _logger.LogError("Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
-                                episodeInfo.ParentIndexNumber, episodeInfo.IndexNumber, series.GetProviderId(MetadataProviders.Tvdb));
-                            return imageResult;
-                        }
+                        _logger.LogError("Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
+                            episodeInfo.ParentIndexNumber, episodeInfo.IndexNumber, series.GetProviderId(MetadataProviders.Tvdb));
+                        return imageResult;
                     }
 
                     var episodeResult =
@@ -86,7 +81,7 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                 }
                 catch (TvDbServerException e)
                 {
-                    _logger.LogError(e, "Failed to retrieve episode images for {TvDbId}", episodeTvdbId);
+                    _logger.LogError(e, "Failed to retrieve episode images for series {TvDbId}", series.GetProviderId(MetadataProviders.Tvdb));
                 }
             }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
@@ -63,7 +63,8 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                         .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
                     if (string.IsNullOrEmpty(episodeTvdbId))
                     {
-                        _logger.LogError("Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
+                        _logger.LogError(
+                            "Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
                             episodeInfo.ParentIndexNumber,
                             episodeInfo.IndexNumber,
                             series.GetProviderId(MetadataProviders.Tvdb));

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -118,7 +118,7 @@ namespace MediaBrowser.Providers.TV.TheTVDB
             }
             catch (TvDbServerException e)
             {
-                _logger.LogError(e, "Failed to retrieve episode with id {TvDbId}", episodeTvdbId ?? seriesTvdbId);
+                _logger.LogError(e, "Failed to retrieve episode with id {EpisodeTvDbId}, series id {SeriesTvdbId}", episodeTvdbId, seriesTvdbId);
             }
 
             return result;


### PR DESCRIPTION
**Changes**
Apparently, EpisodeInfo.ProviderIds == EpisodeInfo.SeriesProviderIds because who doesn't love duplicated data...

Credit goes to @marius-luca-87
**Issues**
Fixes #1467