### PR TITLE
Fix tvdb guest stars with multiple roles

### DIFF
--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -206,7 +206,7 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                 var roleStartIndex = currentActor.IndexOf('(');
 
                 string name = currentActor;
-                string role = "";
+                string role = string.Empty;
                 if (roleStartIndex != -1)
                 {
                     var roles = new List<string> {currentActor.Substring(roleStartIndex + 1)};

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -205,38 +205,41 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                 var currentActor = episode.GuestStars[i];
                 var roleStartIndex = currentActor.IndexOf('(');
 
-                string name = currentActor;
-                string role = string.Empty;
-                if (roleStartIndex != -1)
+                if (roleStartIndex == -1)
                 {
-                    var roles = new List<string> {currentActor.Substring(roleStartIndex + 1)};
-                    name = name.Substring(0, roleStartIndex).Trim();
-
-                    // Fetch all roles
-                    for (var j = i + 1; j < episode.GuestStars.Length; ++j)
+                    result.AddPerson(new PersonInfo
                     {
-                        var currentRole = episode.GuestStars[j];
-                        var roleEndIndex = currentRole.IndexOf(')');
+                        Type = PersonType.GuestStar,
+                        Name = currentActor,
+                        Role = string.Empty
+                    });
+                    continue;
+                }
 
-                        if (roleEndIndex != -1)
-                        {
-                            roles.Add(currentRole.TrimEnd(')'));
-                            // Update the outer index (keep in mind it adds 1 after the iteration)
-                            i = j;
-                            break;
-                        }
+                var roles = new List<string> {currentActor.Substring(roleStartIndex + 1)};
 
-                        roles.Add(currentRole);
+                // Fetch all roles
+                for (var j = i + 1; j < episode.GuestStars.Length; ++j)
+                {
+                    var currentRole = episode.GuestStars[j];
+                    var roleEndIndex = currentRole.IndexOf(')');
+
+                    if (roleEndIndex != -1)
+                    {
+                        roles.Add(currentRole.TrimEnd(')'));
+                        // Update the outer index (keep in mind it adds 1 after the iteration)
+                        i = j;
+                        break;
                     }
 
-                    role = string.Join(", ", roles);
+                    roles.Add(currentRole);
                 }
 
                 result.AddPerson(new PersonInfo
                 {
                     Type = PersonType.GuestStar,
-                    Name = name,
-                    Role = role
+                    Name = currentActor.Substring(0, roleStartIndex).Trim(),
+                    Role = string.Join(", ", roles)
                 });
             }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Net;

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -205,31 +205,38 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                 var currentActor = episode.GuestStars[i];
                 var roleStartIndex = currentActor.IndexOf('(');
 
-                var roles = new List<string> {currentActor.Substring(roleStartIndex + 1)};
-                var name = currentActor.Substring(0, roleStartIndex).Trim();
-
-                // Fetch all roles
-                for (var j = i + 1; j < episode.GuestStars.Length; ++j)
+                string name = currentActor;
+                string role = "";
+                if (roleStartIndex != -1)
                 {
-                    var currentRole = episode.GuestStars[j];
-                    var roleEndIndex = currentRole.IndexOf(')');
+                    var roles = new List<string> {currentActor.Substring(roleStartIndex + 1)};
+                    name = name.Substring(0, roleStartIndex).Trim();
 
-                    if (roleEndIndex != -1)
+                    // Fetch all roles
+                    for (var j = i + 1; j < episode.GuestStars.Length; ++j)
                     {
-                        roles.Add(currentRole.TrimEnd(')'));
-                        // Update the outer index (keep in mind it adds 1 after the iteration)
-                        i = j;
-                        break;
+                        var currentRole = episode.GuestStars[j];
+                        var roleEndIndex = currentRole.IndexOf(')');
+
+                        if (roleEndIndex != -1)
+                        {
+                            roles.Add(currentRole.TrimEnd(')'));
+                            // Update the outer index (keep in mind it adds 1 after the iteration)
+                            i = j;
+                            break;
+                        }
+
+                        roles.Add(currentRole);
                     }
 
-                    roles.Add(currentRole);
+                    role = string.Join(", ", roles);
                 }
 
                 result.AddPerson(new PersonInfo
                 {
                     Type = PersonType.GuestStar,
                     Name = name,
-                    Role = string.Join(", ", roles)
+                    Role = role
                 });
             }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -224,15 +224,15 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                     var currentRole = episode.GuestStars[j];
                     var roleEndIndex = currentRole.IndexOf(')');
 
-                    if (roleEndIndex != -1)
+                    if (roleEndIndex == -1)
                     {
-                        roles.Add(currentRole.TrimEnd(')'));
-                        // Update the outer index (keep in mind it adds 1 after the iteration)
-                        i = j;
-                        break;
+                        roles.Add(currentRole);
                     }
 
-                    roles.Add(currentRole);
+                    roles.Add(currentRole.TrimEnd(')'));
+                    // Update the outer index (keep in mind it adds 1 after the iteration)
+                    i = j;
+                    break;
                 }
 
                 result.AddPerson(new PersonInfo

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -227,6 +227,7 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                     if (roleEndIndex == -1)
                     {
                         roles.Add(currentRole);
+                        continue;
                     }
 
                     roles.Add(currentRole.TrimEnd(')'));


### PR DESCRIPTION
**Changes**
I'm not sure if it's TvdbSharper or the v2 api, but guest stars don't follow the pipe delimited format that the rest of the "persons" objects do.

**Issues**
Fixes #1586 
