### PR TITLE
Speed up BaseItem deserialization

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -1300,7 +1300,7 @@ namespace Emby.Server.Implementations.Data
             {
                 try
                 {
-                    item = _jsonSerializer.DeserializeFromString(reader[1].ToString(), type) as BaseItem;
+                    item = _jsonSerializer.DeserializeFromString(reader.GetString(1), type) as BaseItem;
                 }
                 catch (SerializationException ex)
                 {

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -1298,18 +1298,13 @@ namespace Emby.Server.Implementations.Data
 
             if (TypeRequiresDeserialization(type))
             {
-                using (var stream = new MemoryStream(reader[1].ToBlob()))
+                try
                 {
-                    stream.Position = 0;
-
-                    try
-                    {
-                        item = _jsonSerializer.DeserializeFromStream(stream, type) as BaseItem;
-                    }
-                    catch (SerializationException ex)
-                    {
-                        Logger.LogError(ex, "Error deserializing item");
-                    }
+                    item = _jsonSerializer.DeserializeFromString(reader[1].ToString(), type) as BaseItem;
+                }
+                catch (SerializationException ex)
+                {
+                    Logger.LogError(ex, "Error deserializing item");
                 }
             }
 


### PR DESCRIPTION
**Changes**
Call ToString() instead of ToBlob() and deserialize the string. Most queries are basically instant (as verified in SQLiteBrowser), but deserializing them to POCO is what made requests so slow.
