### PR TITLE
Fix firewall-cmd: Error: INVALID_SERVICE: 'jellyfin' not among existing services

### DIFF
--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -68,7 +68,7 @@ EOF
 %{__install} -D -m 0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 %{__install} -D -m 0600 %{SOURCE3} %{buildroot}%{_sysconfdir}/sudoers.d/%{name}-sudoers
 %{__install} -D -m 0755 %{SOURCE4} %{buildroot}%{_libexecdir}/%{name}/restart.sh
-%{__install} -D -m 0644 %{SOURCE6} %{buildroot}%{_prefix}/lib/firewalld/service/%{name}.xml
+%{__install} -D -m 0644 %{SOURCE6} %{buildroot}%{_prefix}/lib/firewalld/services/%{name}.xml
 
 %files
 %{_libdir}/%{name}/jellyfin-web/*
@@ -83,7 +83,7 @@ EOF
 %{_libdir}/%{name}/sosdocsunix.txt
 %{_unitdir}/%{name}.service
 %{_libexecdir}/%{name}/restart.sh
-%{_prefix}/lib/firewalld/service/%{name}.xml
+%{_prefix}/lib/firewalld/services/%{name}.xml
 %attr(755,jellyfin,jellyfin) %dir %{_sysconfdir}/%{name}
 %config %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %attr(600,root,root) %{_sysconfdir}/sudoers.d/%{name}-sudoers


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fix rpm packaging of firewalld service file

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Without this changes i can't properly configure firewalld on my CentOS7 machine:
```
[root@jellyfin ~]# firewall-cmd --zone=public --add-service=jellyfin --permanent 
Error: INVALID_SERVICE: 'jellyfin' not among existing services
```
