### PR TITLE
Fix ArgumentOutOfRangeException in ParseTimeSeekHeader 

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -634,7 +634,7 @@ namespace MediaBrowser.Api.Playback
             }
             else
             {
-                value = value.Substring(Npt.Length, index);
+                value = value.Substring(Npt.Length, index - Npt.Length);
             }
 
             if (value.IndexOf(':') == -1)


### PR DESCRIPTION
This fixes minor a issue were the second argument passed to substring was the end position instead of the length.

`
System.ArgumentOutOfRangeException: Index and length must refer to a location within the string.
Parameter name: length
   at System.String.Substring(Int32 startIndex, Int32 length)
   at MediaBrowser.Api.Playback.BaseStreamingService.ParseTimeSeekHeader(String value) in d:\OpenSource\jellyfin\MediaBrowser.Api\Playback\BaseStreamingService.cs:line 637
   at MediaBrowser.Api.Playback.BaseStreamingService.ParseDlnaHeaders(StreamRequest request) in d:\OpenSource\jellyfin\MediaBrowser.Api\Playback\BaseStreamingService.cs:line 611
   at MediaBrowser.Api.Playback.BaseStreamingService.GetState(StreamRequest request, CancellationToken cancellationToken) in d:\OpenSource\jellyfin\MediaBrowser.Api\Playback\BaseStreamingService.cs:line 679
   at MediaBrowser.Api.Playback.Progressive.BaseProgressiveStreamingService.ProcessRequest(StreamRequest request, Boolean isHeadRequest) in d:\OpenSource\jellyfin\MediaBrowser.Api\Playback\Progressive\BaseProgressiveStreamingService.cs:line 141
   at Emby.Server.Implementations.Services.ServiceExecGeneral.GetTaskResult(Task task) in d:\OpenSource\jellyfin\Emby.Server.Implementations\Services\ServiceExec.cs:line 110
   at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost httpHost, IRequest httpReq, HttpResponse httpRes, ILogger logger, CancellationToken cancellationToken) in d:\OpenSource\jellyfin\Emby.Server.Implementations\Services\ServiceHandler.cs:line 80
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken) in d:\OpenSource\jellyfin\Emby.Server.Implementations\HttpServer\HttpListenerHost.cs:line 508
`