### PR TITLE
Fix q6fn dlna seek for direct play

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -158,7 +158,7 @@ namespace Emby.Dlna.Didl
 
             AddGeneralProperties(item, null, context, writer, filter);
 
-            AddSamsungBookmarkInfo(item, user, writer);
+            AddSamsungBookmarkInfo(item, user, writer, streamInfo);
 
             // refID?
             // storeAttribute(itemNode, object, ClassProperties.REF_ID, false);
@@ -581,7 +581,7 @@ namespace Emby.Dlna.Didl
             writer.WriteFullEndElement();
         }
 
-        private void AddSamsungBookmarkInfo(BaseItem item, User user, XmlWriter writer)
+        private void AddSamsungBookmarkInfo(BaseItem item, User user, XmlWriter writer, StreamInfo streamInfo)
         {
             if (!item.SupportsPositionTicksResume || item is Folder)
             {
@@ -605,10 +605,11 @@ namespace Emby.Dlna.Didl
             }
 
             var userdata = _userDataManager.GetUserData(user, item);
+            var playbackPositionTicks = (streamInfo != null && streamInfo.StartPositionTicks > 0) ? streamInfo.StartPositionTicks : userdata.PlaybackPositionTicks;
 
-            if (userdata.PlaybackPositionTicks > 0)
+            if (playbackPositionTicks > 0)
             {
-                var elementValue = string.Format("BM={0}", Convert.ToInt32(TimeSpan.FromTicks(userdata.PlaybackPositionTicks).TotalSeconds).ToString(_usCulture));
+                var elementValue = string.Format("BM={0}", Convert.ToInt32(TimeSpan.FromTicks(playbackPositionTicks).TotalSeconds).ToString(_usCulture));
                 AddValue(writer, "sec", "dcmInfo", elementValue, secAttribute.Value);
             }
         }


### PR DESCRIPTION
During DLNA video playback on a Samsung Q6FN any usage of the pause+play/seek functions will restart the video.

The issue with the restart happens in both Transcoding and DirectPlay.

By providing streamInfo.StartPositionTicks to the AddSamsungBookmarkInfo function we fix the DirectPlay scenario but the Transcoded videos will continue to manifest the same issue.

As I do not have other Samsung devices these changes should be further tested.
