### PR TITLE
Enable VAAPI decoding without hardware encoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1796,6 +1796,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                     filters.Add("format=p010le");
                     filters.Add("format=nv12");
                 }
+                else
+                {
+                    filters.Add("format=nv12");
+                }
+
             }
 
             if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -459,7 +459,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.IsVideoRequest)
             {
-                if (GetVideoEncoder(state, encodingOptions).IndexOf("vaapi", StringComparison.OrdinalIgnoreCase) != -1)
+                if (string.Equals(encodingOptions.HardwareAccelerationType, "vaapi", StringComparison.OrdinalIgnoreCase))
                 {
                     var hasGraphicalSubs = state.SubtitleStream != null && !state.SubtitleStream.IsTextSubtitleStream && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode;
                     var hwOutputFormat = "vaapi";
@@ -1780,7 +1780,23 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var request = state.BaseRequest;
 
+            var videoStream = state.VideoStream;
             var filters = new List<string>();
+
+            // If we're hardware VAAPI decoding and software encoding, download frames from the decoder first
+            var hwType = options.HardwareAccelerationType ?? string.Empty;
+            if (string.Equals(hwType, "vaapi", StringComparison.OrdinalIgnoreCase) && !options.EnableHardwareEncoding )
+            {
+                filters.Add("hwdownload");
+
+                // If transcoding from 10 bit, transform colour spaces too
+                if ( !string.IsNullOrEmpty(videoStream.PixelFormat) && videoStream.PixelFormat.IndexOf( "p10", StringComparison.OrdinalIgnoreCase ) != -1
+                    && string.Equals(outputVideoCodec, "libx264", StringComparison.OrdinalIgnoreCase ) )
+                {
+                    filters.Add("format=p010le");
+                    filters.Add("format=nv12");
+                }
+            }
 
             if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
@@ -1792,8 +1808,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 filters.Add(string.Format("deinterlace_vaapi"));
             }
-
-            var videoStream = state.VideoStream;
 
             if ((state.DeInterlace("h264", true) || state.DeInterlace("h265", true) || state.DeInterlace("hevc", true)) &&
                 !string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Enable VAAPI command arguments to ffmpeg if VAAPI is selected
regardless of hardware encoding being enabled. To support hardware
decoding with software encoding, add the "hwdownload" filter.
Also support transforming 10 bit colourspace to 8-bit in hardware to
software transcoding, consistent with other hardware encoding 
behaviours, until client pixel formats are configurable.

Fixes #1675
