### PR TITLE
Add VSTest support to CI

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -39,12 +39,12 @@ jobs:
         arguments: '--configuration $(BuildConfiguration) --output $(build.artifactstagingdirectory)'
         zipAfterPublish: false
 
-    # - task: PublishBuildArtifacts@1
-    #   displayName: 'Publish Artifact'
-    #   inputs:
-    #     PathtoPublish: '$(build.artifactstagingdirectory)'
-    #     artifactName: 'jellyfin-build-$(BuildConfiguration)'
-    #     zipAfterPublish: true
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish Test Artifacts'
+      condition: and(eq(variables['BuildConfiguration'], 'Debug'), succeeded())
+      inputs:
+        targetPath: '$(build.artifactstagingdirectory)'
+        artifactName: 'Jellyfin Tests'
 
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Artifact Naming'
@@ -78,11 +78,18 @@ jobs:
     displayName: Main Test
     pool:
       vmImage: windows-latest
+    dependsOn: main_build
+    condition: and(succeeded(), variables['System.PullRequest.PullRequestNumber']) # Only execute if the pullrequest numer is defined. (So not for normal CI builds)
     steps:
-    - checkout: self
-      clean: true
-      submodules: true
-      persistCredentials: false
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download the Test Artifacts
+      inputs:
+        source: 'current' # Options: current, specific
+        artifact: 'Jellyfin Tests' # Optional
+        #patterns: '**' # Optional
+        path: '$(System.DefaultWorkingDirectory)'
 
     - task: VisualStudioTestPlatformInstaller@1
       inputs:
@@ -101,7 +108,7 @@ jobs:
         #testSuite: # Required when testSelector == TestPlan
         #testConfiguration: # Required when testSelector == TestPlan
         #tcmTestRun: '$(test.RunId)' # Optional
-        #searchFolder: '$(System.DefaultWorkingDirectory)'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
         #testFiltercriteria: # Optional
         #runOnlyImpactedTests: False # Optional
         #runAllTestsAfterXBuilds: '50' # Optional

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -74,6 +74,78 @@ jobs:
         targetPath: '$(build.artifactstagingdirectory)/Jellyfin.Server/MediaBrowser.Common.dll'
         artifactName: 'Jellyfin.Common'
 
+  - job: main_test
+    displayName: Main Test
+    pool:
+      vmImage: windows-latest
+    steps:
+    - checkout: self
+      clean: true
+      submodules: true
+      persistCredentials: false
+
+    - task: VisualStudioTestPlatformInstaller@1
+      inputs:
+        packageFeedSelector: 'nugetOrg' # Options: nugetOrg, customFeed, netShare
+        versionSelector: 'latestPreRelease' # Required when packageFeedSelector == NugetOrg || PackageFeedSelector == CustomFeed# Options: latestPreRelease, latestStable, specificVersion
+
+    - task: VSTest@2
+      inputs:
+        testSelector: 'testAssemblies' # Options: testAssemblies, testPlan, testRun
+        testAssemblyVer2: | # Required when testSelector == TestAssemblies
+          **\bin\$(BuildConfiguration)\**\*test*.dll
+          !**\obj\**
+          !**\xunit.runner.visualstudio.testadapter.dll
+          !**\xunit.runner.visualstudio.dotnetcore.testadapter.dll
+        #testPlan: # Required when testSelector == TestPlan
+        #testSuite: # Required when testSelector == TestPlan
+        #testConfiguration: # Required when testSelector == TestPlan
+        #tcmTestRun: '$(test.RunId)' # Optional
+        #searchFolder: '$(System.DefaultWorkingDirectory)'
+        #testFiltercriteria: # Optional
+        #runOnlyImpactedTests: False # Optional
+        #runAllTestsAfterXBuilds: '50' # Optional
+        #uiTests: false # Optional
+        #vstestLocationMethod: 'version' # Optional. Options: version, location
+        #vsTestVersion: 'latest' # Optional. Options: latest, 16.0, 15.0, 14.0, toolsInstaller
+        #vstestLocation: # Optional
+        #runSettingsFile: # Optional
+        #overrideTestrunParameters: # Optional
+        #pathtoCustomTestAdapters: # Optional
+        runInParallel: True # Optional
+        runTestsInIsolation: True # Optional
+        codeCoverageEnabled: True # Optional
+        #otherConsoleOptions: # Optional
+        #distributionBatchType: 'basedOnTestCases' # Optional. Options: basedOnTestCases, basedOnExecutionTime, basedOnAssembly
+        #batchingBasedOnAgentsOption: 'autoBatchSize' # Optional. Options: autoBatchSize, customBatchSize
+        #customBatchSizeValue: '10' # Required when distributionBatchType == BasedOnTestCases && BatchingBasedOnAgentsOption == CustomBatchSize
+        #batchingBasedOnExecutionTimeOption: 'autoBatchSize' # Optional. Options: autoBatchSize, customTimeBatchSize
+        #customRunTimePerBatchValue: '60' # Required when distributionBatchType == BasedOnExecutionTime && BatchingBasedOnExecutionTimeOption == CustomTimeBatchSize
+        #dontDistribute: False # Optional
+        #testRunTitle: # Optional
+        #platform: # Optional
+        configuration: 'Debug' # Optional
+        publishRunAttachments: true # Optional
+        #diagnosticsEnabled: false # Optional
+        #collectDumpOn: 'onAbortOnly' # Optional. Options: onAbortOnly, always, never
+        #rerunFailedTests: False # Optional
+        #rerunType: 'basedOnTestFailurePercentage' # Optional. Options: basedOnTestFailurePercentage, basedOnTestFailureCount
+        #rerunFailedThreshold: '30' # Optional
+        #rerunFailedTestCasesMaxLimit: '5' # Optional
+        #rerunMaxAttempts: '3' # Optional
+
+    # - task: PublishTestResults@2
+    #   inputs:
+    #     testResultsFormat: 'VSTest' # Options: JUnit, NUnit, VSTest, xUnit, cTest
+    #     testResultsFiles: '**/*.trx'
+    #     #searchFolder: '$(System.DefaultWorkingDirectory)' # Optional
+    #     mergeTestResults: true # Optional
+    #     #failTaskOnFailedTests: false # Optional
+    #     #testRunTitle: # Optional
+    #     #buildPlatform: # Optional
+    #     #buildConfiguration: # Optional
+    #     #publishRunAttachments: true # Optional
+
   - job: main_build_win
     displayName: Main Build Windows
     pool:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -2,7 +2,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)
 
 variables:
   - name: TestProjects
-    value: 'Jellyfin.Server.Tests/Jellyfin.Server.Tests.csproj'
+    value: 'tests/Jellyfin.Common.Tests/Jellyfin.Common.Tests.csproj'
   - name: RestoreBuildProjects
     value: 'Jellyfin.Server/Jellyfin.Server.csproj'
 
@@ -40,13 +40,6 @@ jobs:
         zipAfterPublish: false
 
     - task: PublishPipelineArtifact@0
-      displayName: 'Publish Test Artifacts'
-      condition: and(eq(variables['BuildConfiguration'], 'Debug'), succeeded())
-      inputs:
-        targetPath: '$(build.artifactstagingdirectory)'
-        artifactName: 'Jellyfin Tests'
-
-    - task: PublishPipelineArtifact@0
       displayName: 'Publish Artifact Naming'
       condition: and(eq(variables['BuildConfiguration'], 'Release'), succeeded())
       inputs:
@@ -81,15 +74,19 @@ jobs:
     dependsOn: main_build
     condition: and(succeeded(), variables['System.PullRequest.PullRequestNumber']) # Only execute if the pullrequest numer is defined. (So not for normal CI builds)
     steps:
-    - checkout: none
+    - checkout: self
+      clean: true
+      submodules: true
+      persistCredentials: false
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download the Test Artifacts
+    - task: DotNetCoreCLI@2
+      displayName: Build
       inputs:
-        source: 'current' # Options: current, specific
-        artifact: 'Jellyfin Tests' # Optional
-        #patterns: '**' # Optional
-        path: '$(System.DefaultWorkingDirectory)'
+        command: build
+        publishWebProjects: false
+        projects: '$(TestProjects)'
+        arguments: '--configuration $(BuildConfiguration)'
+        zipAfterPublish: false
 
     - task: VisualStudioTestPlatformInstaller@1
       inputs:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -71,8 +71,6 @@ jobs:
     displayName: Main Test
     pool:
       vmImage: windows-latest
-    dependsOn: main_build
-    condition: and(succeeded(), variables['System.PullRequest.PullRequestNumber']) # Only execute if the pullrequest numer is defined. (So not for normal CI builds)
     steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
**Changes**
This will run any xUnit tests available using the VSTest runner.

`xunit.runner.visualstudio` Nuget dependency is required for at least one test project.

@Bond-009 Please review if this is what you need. There are also some old MSTest based tests in the project right now, this might clash.

EDIT: seems like #1677 takes care of most of this.
