### PR TITLE
Bump version to 10.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
 
-ARG JELLYFIN_WEB_VERSION=v10.3.7
+ARG JELLYFIN_WEB_VERSION=v10.4.0
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-* /jellyfin/jellyfin-web

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -26,7 +26,7 @@ RUN apt-get update \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
 
-ARG JELLYFIN_WEB_VERSION=v10.3.7
+ARG JELLYFIN_WEB_VERSION=v10.4.0
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-* /jellyfin/jellyfin-web

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -26,7 +26,7 @@ RUN apt-get update \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
 
-ARG JELLYFIN_WEB_VERSION=v10.3.7
+ARG JELLYFIN_WEB_VERSION=v10.4.0
 RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && rm -rf /jellyfin/jellyfin-web \
  && mv jellyfin-web-* /jellyfin/jellyfin-web

--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("10.3.7")]
-[assembly: AssemblyFileVersion("10.3.7")]
+[assembly: AssemblyVersion("10.4.0")]
+[assembly: AssemblyFileVersion("10.4.0")]

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin"
-version: "10.3.7"
+version: "10.4.0"
 packages:
   - debian-package-x64
   - debian-package-armhf

--- a/bump_version
+++ b/bump_version
@@ -24,7 +24,11 @@ fi
 shared_version_file="./SharedVersion.cs"
 build_file="./build.yaml"
 
-web_branch="$( git branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/' )"
+if [[ -z $2 ]]; then
+    web_branch="$( git branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/' )"
+else
+    web_branch="$2"
+fi
 
 # Initialize submodules
 git submodule update --init --recursive
@@ -80,7 +84,7 @@ fi
 # Set the Dockerfile web version to the specified new_version
 old_version="$(
     grep "JELLYFIN_WEB_VERSION=" Dockerfile \
-        | sed -E 's/ARG JELLYFIN_WEB_VERSION=([0-9\.]+[-a-z0-9]*)/\1/'
+        | sed -E 's/ARG JELLYFIN_WEB_VERSION=v([0-9\.]+[-a-z0-9]*)/\1/'
 )"
 echo $old_version
 

--- a/deployment/debian-package-x64/pkg-src/changelog
+++ b/deployment/debian-package-x64/pkg-src/changelog
@@ -1,3 +1,9 @@
+jellyfin (10.4.0-1) unstable; urgency=medium
+
+  * New upstream version 10.4.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.4.0
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  Sat, 31 Aug 2019 21:38:56 -0400
+
 jellyfin (10.3.7-1) unstable; urgency=medium
 
   * New upstream version 10.3.7; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.3.7

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -7,7 +7,7 @@
 %endif
 
 Name:           jellyfin
-Version:        10.3.7
+Version:        10.4.0
 Release:        1%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
@@ -140,6 +140,8 @@ fi
 %systemd_postun_with_restart jellyfin.service
 
 %changelog
+* Sat Aug 31 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
+- New upstream version 10.4.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.4.0
 * Wed Jul 24 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - New upstream version 10.3.7; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.3.7
 * Sat Jul 06 2019 Jellyfin Packaging Team <packaging@jellyfin.org>


### PR DESCRIPTION
**Changes**
Bump the version to 10.4.0 in prep for release, so that nightly builds have the correct version and we can begin updating plugins that don't work.

Also includes a bump of the jellyfin-web repo as of today, which is still not quite there, but this can be updated again closer to release (ideally at the time of the release branch creations). Nightly builds just check out the latest master branch anyways automatically.

Finally, includes a few fixes to the bump_version script to handle the above jellyfin-web branch config as well as the Docker versions.

**Issues**
N/A
