### PR TITLE
Restore flac mime type

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -120,6 +120,7 @@ namespace MediaBrowser.Model.Net
             { ".m4b", "audio/m4b" },
             { ".xsp", "audio/xsp" },
             { ".dsp", "audio/dsp" },
+            { ".flac", "audio/flac" },
         };
 
         private static readonly Dictionary<string, string> _extensionLookup = CreateExtensionLookup();


### PR DESCRIPTION
**Changes**
Restores the flac mime type to fix flac playback in Safari on macOS and iOS.

**Issues**
N/A
