### PR TITLE
Add mesa-va-drivers to main Dockerfile for AMD VAAPI transcoding

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@
  - [joern-h](https://github.com/joern-h)
  - [Khinenw](https://github.com/HelloWorld017)
  - [fhriley](https://github.com/fhriley)
+ - [nevado](https://github.com/nevado)
 
 # Emby Contributors
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}
 # libfontconfig1 is required for Skia
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y \
-   libfontconfig1 \
+   libfontconfig1 mesa-va-drivers \
  && apt-get clean autoclean \
  && apt-get autoremove \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
**Changes**
Add mesa-va-drivers to the docker image Dockerfile, which is needed for some AMD hardware to use VAAPI hardware transcoding

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/1587
Partially fixes https://github.com/jellyfin/jellyfin/issues/1609