### PR TITLE
Fix ffmpeg quit condition.

### DIFF
--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -604,7 +604,7 @@ namespace MediaBrowser.Api
                         process.StandardInput.WriteLine("q");
 
                         // Need to wait because killing is asynchronous
-                        if (!process.WaitForExit(5000))
+                        if (!(process.WaitForExit(5000)))
                         {
                             Logger.LogInformation("Killing ffmpeg process for {Path}", job.Path);
                             process.Kill();


### PR DESCRIPTION
**Changes**
Add an extra set of parentheses to the condition.

This stops this for happening:

```
[16:29:08] [INF] Stopping ffmpeg process with q command for <path>\jellyfin\transcoding-temp\15bc6c9162a82af671f3bd844ad44506.m3u8
[16:29:08] [INF] FFMpeg exited with code 0
[16:29:08] [ERR] Error killing transcoding job for <path>\jellyfin\transcoding-temp\15bc6c9162a82af671f3bd844ad44506.m3u8
System.InvalidOperationException: No process is associated with this object.
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_HasExited()
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_ExitCode()
   at MediaBrowser.Api.Playback.BaseStreamingService.OnFfMpegProcessExited(Process process, TranscodingJob job, StreamState state) in <path>\jellyfin\MediaBrowser.Api\Playback\BaseStreamingService.cs:line 359
   at MediaBrowser.Api.Playback.BaseStreamingService.<>c__DisplayClass63_0.<StartFfMpeg>b__0(Object sender, EventArgs args) in <path>\jellyfin\MediaBrowser.Api\Playback\BaseStreamingService.cs:line 277
   at System.Diagnostics.Process.OnExited()
   at System.Diagnostics.Process.RaiseOnExited()
   at System.Diagnostics.Process.WaitForExit(Int32 milliseconds)
   at MediaBrowser.Api.ApiEntryPoint.KillTranscodingJob(TranscodingJob job, Boolean closeLiveStream, Func`2 delete) in <path>\jellyfin\MediaBrowser.Api\ApiEntryPoint.cs:line 607
```