### PR TITLE
Docker - Build jellyfin-web

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -3,6 +3,16 @@
 ARG DOTNET_VERSION=3.0
 
 
+FROM node:alpine as web-builder
+ARG JELLYFIN_WEB_VERSION=v10.4.0
+RUN apk add curl \
+ && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && cd jellyfin-web-* \
+ && yarn install \
+ && yarn build \
+ && mv dist /dist
+
+
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo
 COPY . .
@@ -25,11 +35,7 @@ RUN apt-get update \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
-
-ARG JELLYFIN_WEB_VERSION=v10.4.0
-RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
- && rm -rf /jellyfin/jellyfin-web \
- && mv jellyfin-web-* /jellyfin/jellyfin-web
+COPY --from=web-builder /dist /jellyfin/jellyfin-web/src
 
 EXPOSE 8096
 VOLUME /cache /config /media

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,6 +3,16 @@
 ARG DOTNET_VERSION=3.0
 
 
+FROM node:alpine as web-builder
+ARG JELLYFIN_WEB_VERSION=v10.4.0
+RUN apk add curl \
+ && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && cd jellyfin-web-* \
+ && yarn install \
+ && yarn build \
+ && mv dist /dist
+
+
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo
 COPY . .
@@ -25,11 +35,7 @@ RUN apt-get update \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media
 COPY --from=builder /jellyfin /jellyfin
-
-ARG JELLYFIN_WEB_VERSION=v10.4.0
-RUN curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
- && rm -rf /jellyfin/jellyfin-web \
- && mv jellyfin-web-* /jellyfin/jellyfin-web
+COPY --from=web-builder /dist /jellyfin/jellyfin-web/src
 
 EXPOSE 8096
 VOLUME /cache /config /media


### PR DESCRIPTION
**Changes**
Build's jellyfin-web now that hls.js is a third-party module.
https://github.com/jellyfin/jellyfin-web/pull/456
