### PR TITLE
Set log level to debug for HTTP range requests

### DIFF
--- a/Emby.Server.Implementations/HttpServer/FileWriter.cs
+++ b/Emby.Server.Implementations/HttpServer/FileWriter.cs
@@ -181,7 +181,7 @@ namespace Emby.Server.Implementations.HttpServer
             var rangeString = $"bytes {RangeStart}-{RangeEnd}/{TotalContentLength}";
             Headers[HeaderNames.ContentRange] = rangeString;
 
-            _logger.LogInformation("Setting range response values for {0}. RangeRequest: {1} Content-Length: {2}, Content-Range: {3}", Path, RangeHeader, lengthString, rangeString);
+            _logger.LogDebug("Setting range response values for {0}. RangeRequest: {1} Content-Length: {2}, Content-Range: {3}", Path, RangeHeader, lengthString, rangeString);
         }
 
         public async Task WriteToAsync(HttpResponse response, CancellationToken cancellationToken)


### PR DESCRIPTION
This removes some spam when a DLNA renderer uses byte seeking.

**Changes**
Use debug log level as this will easily spam the log.

Playing a simple 1G file on my TV produced 68 lines of "Setting range response values..." 
