### PR TITLE
Hide new users from public API by default

### DIFF
--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -79,6 +79,8 @@ namespace MediaBrowser.Model.Users
 
         public UserPolicy()
         {
+            IsHidden = true;
+            
             EnableContentDeletion = false;
             EnableContentDeletionFromFolders = Array.Empty<string>();
 


### PR DESCRIPTION
Right now, when a new user is created they are exposed on a public API that can potentially lead to dangerous information leaks.

This PR makes it so by default new users are hidden. Existing users will not be effected and you can always unhide newly created users.

This improves security because usernames and if a password has been set are no longer exposed to the world by default. This does *not* address the underlying problem (it's just a massive issue that requires a ton of client side work and API breakage, so its a post 11.x thing).