### PR TITLE
Update deps and add MultiThreading analyzer

### DIFF
--- a/Emby.Naming/Emby.Naming.csproj
+++ b/Emby.Naming/Emby.Naming.csproj
@@ -24,8 +24,9 @@
   <!-- Code analysers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\Emby.Naming\Emby.Naming.csproj" />
@@ -29,9 +29,9 @@
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="ServiceStack.Text.Core" Version="5.6.0" />
     <PackageReference Include="sharpcompress" Version="0.24.0" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="2.0.1" />
@@ -47,16 +47,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- We need at least C# 7.3 to compare tuples-->
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
   <!-- Code analysers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -28,43 +28,10 @@ namespace Emby.Server.Implementations.Updates
     /// </summary>
     public class InstallationManager : IInstallationManager
     {
-        public event EventHandler<InstallationEventArgs> PackageInstalling;
-        public event EventHandler<InstallationEventArgs> PackageInstallationCompleted;
-        public event EventHandler<InstallationFailedEventArgs> PackageInstallationFailed;
-        public event EventHandler<InstallationEventArgs> PackageInstallationCancelled;
-
         /// <summary>
-        /// The current installations
-        /// </summary>
-        private List<(InstallationInfo info, CancellationTokenSource token)> _currentInstallations { get; set; }
-
-        /// <summary>
-        /// The completed installations
-        /// </summary>
-        private ConcurrentBag<InstallationInfo> _completedInstallationsInternal;
-
-        public IEnumerable<InstallationInfo> CompletedInstallations => _completedInstallationsInternal;
-
-        /// <summary>
-        /// Occurs when [plugin uninstalled].
-        /// </summary>
-        public event EventHandler<GenericEventArgs<IPlugin>> PluginUninstalled;
-
-        /// <summary>
-        /// Occurs when [plugin updated].
-        /// </summary>
-        public event EventHandler<GenericEventArgs<(IPlugin, PackageVersionInfo)>> PluginUpdated;
-
-        /// <summary>
-        /// Occurs when [plugin updated].
-        /// </summary>
-        public event EventHandler<GenericEventArgs<PackageVersionInfo>> PluginInstalled;
-
-        /// <summary>
-        /// The _logger
+        /// The _logger.
         /// </summary>
         private readonly ILogger _logger;
-
         private readonly IApplicationPaths _appPaths;
         private readonly IHttpClient _httpClient;
         private readonly IJsonSerializer _jsonSerializer;
@@ -78,6 +45,18 @@ namespace Emby.Server.Implementations.Updates
         private readonly IApplicationHost _applicationHost;
 
         private readonly IZipClient _zipClient;
+
+        private readonly object _currentInstallationsLock = new object();
+
+        /// <summary>
+        /// The current installations.
+        /// </summary>
+        private List<(InstallationInfo info, CancellationTokenSource token)> _currentInstallations;
+
+        /// <summary>
+        /// The completed installations.
+        /// </summary>
+        private ConcurrentBag<InstallationInfo> _completedInstallationsInternal;
 
         public InstallationManager(
             ILogger<InstallationManager> logger,
@@ -106,6 +85,31 @@ namespace Emby.Server.Implementations.Updates
             _fileSystem = fileSystem;
             _zipClient = zipClient;
         }
+
+        public event EventHandler<InstallationEventArgs> PackageInstalling;
+
+        public event EventHandler<InstallationEventArgs> PackageInstallationCompleted;
+
+        public event EventHandler<InstallationFailedEventArgs> PackageInstallationFailed;
+
+        public event EventHandler<InstallationEventArgs> PackageInstallationCancelled;
+
+        /// <summary>
+        /// Occurs when [plugin uninstalled].
+        /// </summary>
+        public event EventHandler<GenericEventArgs<IPlugin>> PluginUninstalled;
+
+        /// <summary>
+        /// Occurs when [plugin updated].
+        /// </summary>
+        public event EventHandler<GenericEventArgs<(IPlugin, PackageVersionInfo)>> PluginUpdated;
+
+        /// <summary>
+        /// Occurs when [plugin updated].
+        /// </summary>
+        public event EventHandler<GenericEventArgs<PackageVersionInfo>> PluginInstalled;
+
+        public IEnumerable<InstallationInfo> CompletedInstallations => _completedInstallationsInternal;
 
         /// <summary>
         /// Gets all available packages.
@@ -330,7 +334,7 @@ namespace Emby.Server.Implementations.Updates
             var tuple = (installationInfo, innerCancellationTokenSource);
 
             // Add it to the in-progress list
-            lock (_currentInstallations)
+            lock (_currentInstallationsLock)
             {
                 _currentInstallations.Add(tuple);
             }
@@ -349,7 +353,7 @@ namespace Emby.Server.Implementations.Updates
             {
                 await InstallPackageInternal(package, linkedToken).ConfigureAwait(false);
 
-                lock (_currentInstallations)
+                lock (_currentInstallationsLock)
                 {
                     _currentInstallations.Remove(tuple);
                 }
@@ -360,7 +364,7 @@ namespace Emby.Server.Implementations.Updates
             }
             catch (OperationCanceledException)
             {
-                lock (_currentInstallations)
+                lock (_currentInstallationsLock)
                 {
                     _currentInstallations.Remove(tuple);
                 }
@@ -375,7 +379,7 @@ namespace Emby.Server.Implementations.Updates
             {
                 _logger.LogError(ex, "Package installation failed");
 
-                lock (_currentInstallations)
+                lock (_currentInstallationsLock)
                 {
                     _currentInstallations.Remove(tuple);
                 }
@@ -535,7 +539,7 @@ namespace Emby.Server.Implementations.Updates
         /// <inheritdoc/>
         public bool CancelInstallation(Guid id)
         {
-            lock (_currentInstallations)
+            lock (_currentInstallationsLock)
             {
                 var install = _currentInstallations.Find(x => x.Item1.Id == id);
                 if (install == default((InstallationInfo, CancellationTokenSource)))
@@ -563,7 +567,7 @@ namespace Emby.Server.Implementations.Updates
         {
             if (dispose)
             {
-                lock (_currentInstallations)
+                lock (_currentInstallationsLock)
                 {
                     foreach (var tuple in _currentInstallations)
                     {

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -95,17 +95,17 @@ namespace Emby.Server.Implementations.Updates
         public event EventHandler<InstallationEventArgs> PackageInstallationCancelled;
 
         /// <summary>
-        /// Occurs when [plugin uninstalled].
+        /// Occurs when a plugin is uninstalled.
         /// </summary>
         public event EventHandler<GenericEventArgs<IPlugin>> PluginUninstalled;
 
         /// <summary>
-        /// Occurs when [plugin updated].
+        /// Occurs when a plugin plugin is updated.
         /// </summary>
         public event EventHandler<GenericEventArgs<(IPlugin, PackageVersionInfo)>> PluginUpdated;
 
         /// <summary>
-        /// Occurs when [plugin updated].
+        /// Occurs when a plugin plugin is installed.
         /// </summary>
         public event EventHandler<GenericEventArgs<PackageVersionInfo>> PluginInstalled;
 

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- We need at least C# 7.1 for async main-->
-    <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -25,8 +23,9 @@
   <!-- Code analyzers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -35,8 +34,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.0" />
   </ItemGroup>
 

--- a/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
+++ b/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
     <PackageReference Include="UTF.Unknown" Version="2.1.0" />
   </ItemGroup>
 

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
     <PackageReference Include="PlaylistsNET" Version="1.0.4" />
     <PackageReference Include="TvDbSharper" Version="2.0.0" />
@@ -28,5 +28,5 @@
     <!-- We need at least C# 7.1 -->
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-   
+
 </Project>

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -10,6 +10,8 @@
     <Rule Id="SA1101" Action="None" />
     <!-- disable warning SA1108: Block statements should not contain embedded comments -->
     <Rule Id="SA1108" Action="None" />
+    <!-- disable warning SA1128:: Put constructor initializers on their own line -->
+    <Rule Id="SA1128" Action="None" />
     <!-- disable warning SA1130: Use lambda syntax -->
     <Rule Id="SA1130" Action="None" />
     <!-- disable warning SA1200: 'using' directive must appear within a namespace declaration -->


### PR DESCRIPTION
`SmartAnalyzers.MultithreadingAnalyzer` prevents potential issues related to multithreading.
Ref: - [Avoid multithreading traps with Roslyn: Lock object selection](https://cezarypiatek.github.io/post/avoid-multithreading-traps-p1/)
- [Avoid thread synchronization problems with Roslyn: Synchronization primitives traps](https://cezarypiatek.github.io/post/avoid-multithreading-traps-p2/)