### PR TITLE
Fix SetImage to avoid out of range exception

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2239,7 +2239,7 @@ namespace MediaBrowser.Controller.Entities
                 var newArr = new ItemImageInfo[currentCount + 1];
                 current.CopyTo(newArr, 0);
                 newArr[currentCount] = image;
-                ImageInfos = current;
+                ImageInfos = newArr;
             }
         }
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2238,7 +2238,7 @@ namespace MediaBrowser.Controller.Entities
                 var currentCount = current.Length;
                 var newArr = new ItemImageInfo[currentCount + 1];
                 current.CopyTo(newArr, 0);
-                current[currentCount] = image;
+                newArr[currentCount] = image;
                 ImageInfos = current;
             }
         }


### PR DESCRIPTION
**Changes**
Changes two lines in `...Controller/Entities/BaseItem.cs` to avoid an OutOfRangeException when scanning for new images, and to return the image info.