### PR TITLE
Recursively zip Windows packages

### DIFF
--- a/deployment/win-x64/docker-build.sh
+++ b/deployment/win-x64/docker-build.sh
@@ -51,7 +51,7 @@ cp ${SOURCE_DIR}/deployment/windows/legacy/install.bat /dist/jellyfin_${version}
 
 # Create zip package
 pushd /dist
-zip /jellyfin_${version}.portable.zip jellyfin_${version}
+zip -r /jellyfin_${version}.portable.zip jellyfin_${version}
 popd
 rm -rf /dist/jellyfin_${version}
 

--- a/deployment/win-x86/docker-build.sh
+++ b/deployment/win-x86/docker-build.sh
@@ -51,7 +51,7 @@ cp ${SOURCE_DIR}/deployment/windows/legacy/install.bat /dist/jellyfin_${version}
 
 # Create zip package
 pushd /dist
-zip /jellyfin_${version}.portable.zip jellyfin_${version}
+zip -r /jellyfin_${version}.portable.zip jellyfin_${version}
 popd
 rm -rf /dist/jellyfin_${version}
 


### PR DESCRIPTION
**Changes**
Recursively zip the data in the Windows packages. Without -r the directory is not properly zipped up.

**Issues**
Fixes #1784 (for real this time)
