### PR TITLE
Change PRAGMA mode from WAL to TRUNCATE

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -53,10 +53,10 @@ namespace Emby.Server.Implementations.Data
         protected virtual int? CacheSize => null;
 
         /// <summary>
-        /// Gets the journal mode.
+        /// Gets the journal mode. https://www.sqlite.org/pragma.html#pragma_journal_mode
         /// </summary>
         /// <value>The journal mode.</value>
-        protected virtual string JournalMode => "WAL";
+        protected virtual string JournalMode => "TRUNCATE";
 
         /// <summary>
         /// Gets the page size.

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.Data
         protected virtual int? CacheSize => null;
 
         /// <summary>
-        /// Gets the journal mode. https://www.sqlite.org/pragma.html#pragma_journal_mode
+        /// Gets the journal mode. <see href="https://www.sqlite.org/pragma.html#pragma_journal_mode" />
         /// </summary>
         /// <value>The journal mode.</value>
         protected virtual string JournalMode => "TRUNCATE";


### PR DESCRIPTION
**Changes**
As-is, the WAL mode for SQLite3 has problems where the WAL isn't flushed properly, resulting in the file ballooning to massive sizes and filling up disks. Instead, we change to TRUNCATE mode. This mode (as per https://www.sqlite.org/pragma.html#pragma_journal_mode) uses a traditional journal which is flushed via a truncation (rather than file delete), which removes the WAL problems, preserving write journaling, while also not having any overhead for file deletion/creation to the system.

**Issues**
Fixes #1655
