### PR TITLE
Ignore exception when attempting to kill ffmpeg that has exited

### DIFF
--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -610,9 +610,8 @@ namespace MediaBrowser.Api
                             process.Kill();
                         }
                     }
-                    catch (Exception ex)
+                    catch (InvalidOperationException)
                     {
-                        Logger.LogError(ex, "Error killing transcoding job for {Path}", job.Path);
                     }
                 }
             }


### PR DESCRIPTION
**Changes**
A race condition where this code attempts to kill an already exited
ffmpeg process is possible. This results in unnecessary error logging.

This change replaces the generic exception handling with the above
mentioned exception. No log output is produced. Ignoring this exception seems safe per the docs https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=netframework-4.8#System_Diagnostics_Process_Kill