### PR TITLE
Fix SchedulesDirect authentication

### DIFF
--- a/MediaBrowser.Api/LiveTv/LiveTvService.cs
+++ b/MediaBrowser.Api/LiveTv/LiveTvService.cs
@@ -25,6 +25,7 @@ using MediaBrowser.Model.LiveTv;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Services;
 using Microsoft.Net.Http.Headers;
+using static MediaBrowser.Common.HexHelper;
 
 namespace MediaBrowser.Api.LiveTv
 {
@@ -886,10 +887,10 @@ namespace MediaBrowser.Api.LiveTv
         {
             // SchedulesDirect requires a SHA1 hash of the user's password
             // https://github.com/SchedulesDirect/JSON-Service/wiki/API-20141201#obtain-a-token
-            SHA1 sha = SHA1.Create();
-            return BitConverter.ToString(
-                sha.ComputeHash(Encoding.UTF8.GetBytes(str)))
-                    .Replace("-", string.Empty).ToLowerInvariant();
+            using (SHA1 sha = SHA1.Create()) {
+                return ToHexString(
+                    sha.ComputeHash(Encoding.UTF8.GetBytes(str)));
+            }
         }
 
         public void Delete(DeleteListingProvider request)


### PR DESCRIPTION
**Changes**
Restores the SHA1 hashing of SchedulesDirect passwords.
Refs: https://github.com/SchedulesDirect/JSON-Service/wiki/API-20141201#obtain-a-token

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/495
