### PR TITLE
Add support for recoverable HTTP status codes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@
  - [Khinenw](https://github.com/HelloWorld017)
  - [fhriley](https://github.com/fhriley)
  - [nevado](https://github.com/nevado)
+ - [Trae](https://github.com/flyer280)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1629,6 +1629,7 @@ namespace Emby.Server.Implementations
                     {
                         Url = apiUrl,
                         LogErrorResponseBody = false,
+                        LogErrorResponseHeaders = false,
                         BufferContent = false,
                         CancellationToken = cancellationToken
                     }, HttpMethod.Post).ConfigureAwait(false))

--- a/MediaBrowser.Common/Net/HttpRequestOptions.cs
+++ b/MediaBrowser.Common/Net/HttpRequestOptions.cs
@@ -74,6 +74,7 @@ namespace MediaBrowser.Common.Net
         public bool BufferContent { get; set; }
 
         public bool LogErrorResponseBody { get; set; }
+        public bool LogErrorResponseHeaders { get; set; }
         public bool EnableKeepAlive { get; set; }
 
         public CacheMode CacheMode { get; set; }

--- a/MediaBrowser.Common/Net/IHttpClient.cs
+++ b/MediaBrowser.Common/Net/IHttpClient.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Net.Http;
+using System.Net;
 
 namespace MediaBrowser.Common.Net
 {
@@ -25,7 +26,7 @@ namespace MediaBrowser.Common.Net
 
         /// <summary>
         /// Warning: Deprecated function,
-        /// use 'Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, HttpMethod httpMethod);' instead
+        /// use 'Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, HttpMethod httpMethod, HttpStatusCode[] allowedStatusCodes);' instead
         /// Sends the asynchronous.
         /// </summary>
         /// <param name="options">The options.</param>
@@ -38,14 +39,16 @@ namespace MediaBrowser.Common.Net
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="allowedStatusCodes">An array of status codes that should be treated as a success.</param>
         /// <returns>Task{HttpResponseInfo}.</returns>
-        Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, HttpMethod httpMethod);
+        Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, HttpMethod httpMethod, HttpStatusCode[] allowedStatusCodes = null);
 
         /// <summary>
         /// Posts the specified options.
         /// </summary>
         /// <param name="options">The options.</param>
+        /// <param name="allowedStatusCodes">An array of status codes that should be treated as a success.</param>
         /// <returns>Task{HttpResponseInfo}.</returns>
-        Task<HttpResponseInfo> Post(HttpRequestOptions options);
+        Task<HttpResponseInfo> Post(HttpRequestOptions options, HttpStatusCode[] allowedStatusCodes = null);
     }
 }


### PR DESCRIPTION
**Changes**
Adding the ability to support a status code outside of the "success" 2XX codes. Many 4xx codes can be recoverable or handled and this will allow plugins to react to client errors more gracefully. This currently is intended to be used with my work in jellyfin-plugin-opensubtitles to allow the plugin to react to the 429 response for too many requests.

Also adding support to log headers since some sites put meaningful failure data in the headers.

**Issues**
Fixes #1828 
