### PR TITLE
Ignore warning CA1308 and SA1108

### DIFF
--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -8,6 +8,8 @@
 
     <!-- disable warning SA1101: Prefix local calls with 'this.' -->
     <Rule Id="SA1101" Action="None" />
+    <!-- disable warning SA1108: Block statements should not contain embedded comments -->
+    <Rule Id="SA1108" Action="None" />
     <!-- disable warning SA1130: Use lambda syntax -->
     <Rule Id="SA1130" Action="None" />
     <!-- disable warning SA1200: 'using' directive must appear within a namespace declaration -->

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -38,6 +38,8 @@
     <Rule Id="CA1054" Action="None" />
     <!-- disable warning CA1303: Do not pass literals as localized parameters -->
     <Rule Id="CA1303" Action="None" />
+    <!-- disable warning CA1308: Normalize strings to uppercase -->
+    <Rule Id="CA1308" Action="None" />
     <!-- disable warning CA2000: Dispose objects before losing scope -->
     <Rule Id="CA2000" Action="None" />
   </Rules>


### PR DESCRIPTION
CA1308: This doesn't matter for our use case since we never convert them back to upper case.
SA1108: Rule about comments :man_shrugging: 