### PR TITLE
Update Docs to docs.jellyfin.org URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
-For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
+For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
 -->
 
 **Changes**

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,6 +17,6 @@ staleLabel: stale
 markComment: >
   Issues go stale after 90d of inactivity. Mark the issue as fresh by adding a comment or commit. Stale issues close after an additional 14d of inactivity.
   If this issue is safe to close now please do so.
-  If you have any questions you can reach us on [Matrix or Social Media](https://jellyfin.readthedocs.io/en/latest/getting-help/).
+  If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@
 
 Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!
 
-For further details, please see [our documentation page](https://jellyfin.org/docs/). To receive the latest updates, get help with Jellyfin, and join the community, please visit [one of our communication channels on Matrix/Riot or social media](https://jellyfin.org/docs/general/getting-help.html).
+For further details, please see [our documentation page](https://docs.jellyfin.org/). To receive the latest updates, get help with Jellyfin, and join the community, please visit [one of our communication channels on Matrix/Riot or social media](https://docs.jellyfin.org/general/getting-help.html).
 
-For more information about the project, please see our [about page](https://jellyfin.org/docs/general/about.html).
+For more information about the project, please see our [about page](https://docs.jellyfin.org/general/about.html).
 
 <p align="center">
 <strong>Want to get started?</strong>
-<em>Choose from <a href="https://jellyfin.org/docs/general/administration/installing.html">Prebuilt Packages</a> or <a href="https://jellyfin.org/docs/general/administration/building.html">Build from Source</a>, then see our <a href="https://jellyfin.org/docs/general/administration/quick-start.html">quick start guide</a>.</em>
+<em>Choose from <a href="https://docs.jellyfin.org/general/administration/installing.html">Prebuilt Packages</a> or <a href="https://docs.jellyfin.org/general/administration/building.html">Build from Source</a>, then see our <a href="https://docs.jellyfin.org/general/administration/quick-start.html">quick start guide</a>.</em>
 </p>
 <p align="center">
 <strong>Want to contribute?</strong>
-<em>Check out <a href="https://jellyfin.org/docs/general/contributing/index.html">our documentation for guidelines</a>.</em>
+<em>Check out <a href="https://docs.jellyfin.org/general/contributing/index.html">our documentation for guidelines</a>.</em>
 </p>
 <p align="center">
 <strong>New idea or improvement?</strong>
@@ -41,5 +41,5 @@ For more information about the project, please see our [about page](https://jell
 </p>
 <p align="center">
 <strong>Something not working right?</strong>
-<em>Open an <a href="https://jellyfin.org/docs/general/contributing/issues.html">Issue</a>.</em>
+<em>Open an <a href="https://docs.jellyfin.org/general/contributing/issues.html">Issue</a>.</em>
 </p>


### PR DESCRIPTION
**Changes**
As per discussions on Riot, pull docs out of main site and create a separate site for them. This just updates the URL for now, work required on the infra side to actually support this.

**Issues**
N/A
