### PR TITLE
Fix missing image on seasons without posters

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1099,6 +1099,8 @@ namespace Emby.Server.Implementations.Dto
 
                 Series episodeSeries = null;
 
+                // this block will add the series poster for episodes without a poster
+                // TODO maybe remove the if statement entirely
                 //if (options.ContainsField(ItemFields.SeriesPrimaryImage))
                 {
                     episodeSeries = episodeSeries ?? episode.Series;
@@ -1143,6 +1145,8 @@ namespace Emby.Server.Implementations.Dto
                     }
                 }
 
+                // this block will add the series poster for seasons without a poster
+                // TODO maybe remove the if statement entirely
                 //if (options.ContainsField(ItemFields.SeriesPrimaryImage))
                 {
                     series = series ?? season.Series;

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1099,7 +1099,7 @@ namespace Emby.Server.Implementations.Dto
 
                 Series episodeSeries = null;
 
-                if (options.ContainsField(ItemFields.SeriesPrimaryImage))
+                //if (options.ContainsField(ItemFields.SeriesPrimaryImage))
                 {
                     episodeSeries = episodeSeries ?? episode.Series;
                     if (episodeSeries != null)
@@ -1143,7 +1143,7 @@ namespace Emby.Server.Implementations.Dto
                     }
                 }
 
-                if (options.ContainsField(ItemFields.SeriesPrimaryImage))
+                //if (options.ContainsField(ItemFields.SeriesPrimaryImage))
                 {
                     series = series ?? season.Series;
                     if (series != null)


### PR DESCRIPTION
@thornbill let me know [this change](https://github.com/jellyfin/jellyfin/pull/1665/files#diff-d49e134bc3b3dfd158111f2a66b9e6fcR1105) might have been responsible for the missing images. I tested this branch and it fixed the issue for me. I'd like to get this in 10.4.0 and then we can find a more permanent fix later.