### PR TITLE
Correct missing mesa-va-drivers package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}
 COPY --from=ffmpeg / /
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
+# Install dependencies:
+#   libfontconfig1: needed for Skia
+#   mesa-va-drivers: needed for VAAPI
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y \
    libfontconfig1 mesa-va-drivers \


### PR DESCRIPTION
**Changes**
Reported on Reddit. The `mesa-va-drivers` package isn't getting installed in the final container for amd64, and thus VAAPI playback fails. I believe this is the optimal solution since the place added in #1727 doesn't seem to get copied into the final image. This might be suboptimal so suggestions welcome.

**Issues**
N/A