### PR TITLE
Use System.Text.Json api for databases

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -742,12 +742,11 @@ namespace Emby.Server.Implementations
 
             _displayPreferencesRepository = new SqliteDisplayPreferencesRepository(
                 LoggerFactory.CreateLogger<SqliteDisplayPreferencesRepository>(),
-                JsonSerializer,
                 ApplicationPaths,
                 FileSystemManager);
             serviceCollection.AddSingleton<IDisplayPreferencesRepository>(_displayPreferencesRepository);
 
-            ItemRepository = new SqliteItemRepository(ServerConfigurationManager, this, JsonSerializer, LoggerFactory, LocalizationManager);
+            ItemRepository = new SqliteItemRepository(ServerConfigurationManager, this, LoggerFactory.CreateLogger<SqliteItemRepository>(), LocalizationManager);
             serviceCollection.AddSingleton<IItemRepository>(ItemRepository);
 
             AuthenticationRepository = GetAuthenticationRepository();
@@ -948,8 +947,7 @@ namespace Emby.Server.Implementations
         {
             var repo = new SqliteUserRepository(
                 LoggerFactory.CreateLogger<SqliteUserRepository>(),
-                ApplicationPaths,
-                JsonSerializer);
+                ApplicationPaths);
 
             repo.Initialize();
 

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -5,8 +5,11 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using Emby.Server.Implementations.Playlists;
+using MediaBrowser.Common.Json;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Configuration;
@@ -38,14 +41,6 @@ namespace Emby.Server.Implementations.Data
     {
         private const string ChaptersTableName = "Chapters2";
 
-        private readonly TypeMapper _typeMapper;
-
-        /// <summary>
-        /// Gets the json serializer.
-        /// </summary>
-        /// <value>The json serializer.</value>
-        private readonly IJsonSerializer _jsonSerializer;
-
         /// <summary>
         /// The _app paths
         /// </summary>
@@ -53,32 +48,30 @@ namespace Emby.Server.Implementations.Data
         private readonly IServerApplicationHost _appHost;
         private readonly ILocalizationManager _localization;
 
+        private readonly TypeMapper _typeMapper;
+        private readonly JsonSerializerOptions _jsonOptions;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SqliteItemRepository"/> class.
         /// </summary>
         public SqliteItemRepository(
             IServerConfigurationManager config,
             IServerApplicationHost appHost,
-            IJsonSerializer jsonSerializer,
-            ILoggerFactory loggerFactory,
+            ILogger<SqliteItemRepository> logger,
             ILocalizationManager localization)
-            : base(loggerFactory.CreateLogger(nameof(SqliteItemRepository)))
+            : base(logger)
         {
             if (config == null)
             {
                 throw new ArgumentNullException(nameof(config));
             }
 
-            if (jsonSerializer == null)
-            {
-                throw new ArgumentNullException(nameof(jsonSerializer));
-            }
-
-            _appHost = appHost;
             _config = config;
-            _jsonSerializer = jsonSerializer;
-            _typeMapper = new TypeMapper();
+            _appHost = appHost;
             _localization = localization;
+
+            _typeMapper = new TypeMapper();
+            _jsonOptions = JsonDefaults.GetOptions();
 
             DbFilePath = Path.Combine(_config.ApplicationPaths.DataPath, "library.db");
         }
@@ -671,7 +664,7 @@ namespace Emby.Server.Implementations.Data
 
             if (TypeRequiresDeserialization(item.GetType()))
             {
-                saveItemStatement.TryBind("@data", _jsonSerializer.SerializeToBytes(item));
+                saveItemStatement.TryBind("@data", JsonSerializer.SerializeToUtf8Bytes(item, _jsonOptions));
             }
             else
             {
@@ -1302,11 +1295,11 @@ namespace Emby.Server.Implementations.Data
             {
                 try
                 {
-                    item = _jsonSerializer.DeserializeFromString(reader.GetString(1), type) as BaseItem;
+                    item = JsonSerializer.Deserialize(reader[1].ToBlob(), type, _jsonOptions) as BaseItem;
                 }
-                catch (SerializationException ex)
+                catch (JsonException ex)
                 {
-                    Logger.LogError(ex, "Error deserializing item");
+                    Logger.LogError(ex, "Error deserializing item with JSON: {Data}", reader.GetString(1));
                 }
             }
 

--- a/Emby.Server.Implementations/Data/SqliteUserRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserRepository.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
+using MediaBrowser.Common.Json;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Persistence;
-using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using SQLitePCL.pretty;
 
@@ -15,15 +16,14 @@ namespace Emby.Server.Implementations.Data
     /// </summary>
     public class SqliteUserRepository : BaseSqliteRepository, IUserRepository
     {
-        private readonly IJsonSerializer _jsonSerializer;
+        private readonly JsonSerializerOptions _jsonOptions;
 
         public SqliteUserRepository(
             ILogger<SqliteUserRepository> logger,
-            IServerApplicationPaths appPaths,
-            IJsonSerializer jsonSerializer)
+            IServerApplicationPaths appPaths)
             : base(logger)
         {
-            _jsonSerializer = jsonSerializer;
+            _jsonOptions = JsonDefaults.GetOptions();;
 
             DbFilePath = Path.Combine(appPaths.DataPath, "users.db");
         }
@@ -84,7 +84,7 @@ namespace Emby.Server.Implementations.Data
                 }
 
                 user.Password = null;
-                var serialized = _jsonSerializer.SerializeToBytes(user);
+                var serialized = JsonSerializer.SerializeToUtf8Bytes(user, _jsonOptions);
 
                 connection.RunInTransaction(db =>
                 {
@@ -108,7 +108,7 @@ namespace Emby.Server.Implementations.Data
                 throw new ArgumentNullException(nameof(user));
             }
 
-            var serialized = _jsonSerializer.SerializeToBytes(user);
+            var serialized = JsonSerializer.SerializeToUtf8Bytes(user, _jsonOptions);
 
             using (var connection = GetConnection())
             {
@@ -142,7 +142,7 @@ namespace Emby.Server.Implementations.Data
                 throw new ArgumentNullException(nameof(user));
             }
 
-            var serialized = _jsonSerializer.SerializeToBytes(user);
+            var serialized = JsonSerializer.SerializeToUtf8Bytes(user, _jsonOptions);
 
             using (var connection = GetConnection())
             {
@@ -179,7 +179,7 @@ namespace Emby.Server.Implementations.Data
             var id = row[0].ToInt64();
             var guid = row[1].ReadGuidFromBlob();
 
-            var user = _jsonSerializer.DeserializeFromString<User>(row.GetString(2));
+            var user = JsonSerializer.Deserialize<User>(row[2].ToBlob(), _jsonOptions);
             user.InternalId = id;
             user.Id = guid;
             return user;

--- a/MediaBrowser.Common/Json/Converters/GuidConverter.cs
+++ b/MediaBrowser.Common/Json/Converters/GuidConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MediaBrowser.Common.Json.Converters
+{
+    /// <summary>
+    /// Converts a GUID object or value to/from JSON.
+    /// </summary>
+    public class GuidConverter : JsonConverter<Guid>
+    {
+        /// <inheritdoc />
+        public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new Guid(reader.GetString());
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value);
+    }
+}

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MediaBrowser.Common.Json.Converters;
+
+namespace MediaBrowser.Common.Json
+{
+    /// <summary>
+    /// Helper class for having compatible JSON throughout the codebase.
+    /// </summary>
+    public static class JsonDefaults
+    {
+        /// <summary>
+        /// Gets the default <see cref="JsonSerializerOptions" /> options.
+        /// </summary>
+        /// <returns>The default <see cref="JsonSerializerOptions" /> options.</returns>
+        public static JsonSerializerOptions GetOptions()
+        {
+            var options = new JsonSerializerOptions()
+            {
+                ReadCommentHandling = JsonCommentHandling.Disallow,
+                WriteIndented = false
+            };
+
+            options.Converters.Add(new GuidConverter());
+            options.Converters.Add(new JsonStringEnumConverter());
+
+            return options;
+        }
+    }
+}

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.0" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`System.Text.Json` and is faster in my tests than the current json serializer. Mostly because doesn't need to convert to UTF-16 and can operate directly on the `ReadonlySpan<byte>` returned by the SQlite wrapper.