### PR TITLE
Use NVM to install nodejs v8 and yarn for CentOS

### DIFF
--- a/deployment/centos-package-x64/Dockerfile
+++ b/deployment/centos-package-x64/Dockerfile
@@ -13,16 +13,18 @@ RUN yum update -y \
  && yum install -y epel-release
 
 # Install build dependencies
-RUN yum install -y @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel nodejs wget git
+RUN yum install -y @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel wget git
+
+# Install recent NodeJS and Yarn
+RUN wget -O- https://raw.githubusercontent.com/creationix/nvm/v0.35.0/install.sh | /bin/bash \
+ && source "$HOME/.nvm/nvm.sh" \
+ && nvm install v8 \
+ && npm install -g yarn
 
 # Install DotNET SDK
 RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm \
  && rpmdev-setuptree \
  && yum install -y dotnet-sdk-${SDK_VERSION}
-
-# Install yarn package manager
-RUN wget -q -O /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo \
- && yum install -y yarn
 
 # Create symlinks and directories
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh \

--- a/deployment/centos-package-x64/docker-build.sh
+++ b/deployment/centos-package-x64/docker-build.sh
@@ -18,6 +18,8 @@ pushd ${web_build_dir}
 if [[ -n ${web_branch} ]]; then
     checkout -b origin/${web_branch}
 fi
+source "$HOME/.nvm/nvm.sh"
+nvm use v8
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/


### PR DESCRIPTION
**Changes**
Prevents failure of the installation of jellyfin-web dependencies due to the NodeJS version in EPEL being too old. v8 might be a little conservative but is the earliest compatible version. Instead of using their repo to install Yarn, use the new nvm binary to install Yarn, thus forcing it to use the updated NodeJS version.

**Issues**
N/A (failing release builds for CentOS)