### PR TITLE
Fix inconsistent BaseUrl behavior

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -89,7 +89,7 @@ namespace Emby.Server.Implementations.HttpServer
             return _appHost.CreateInstance(type);
         }
 
-        private string NormalizeUrlPath(string path)
+        private static string NormalizeUrlPath(string path)
         {
             if (path.StartsWith("/"))
             {

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -168,31 +168,26 @@ namespace MediaBrowser.Model.Configuration
             get => _baseUrl;
             set
             {
-                _baseUrl = value;
-
                 // Normalize the start of the string
-                if (string.IsNullOrWhiteSpace(_baseUrl))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     // If baseUrl is empty, set an empty prefix string
-                    _baseUrl = string.Empty;
+                    value = string.Empty;
                 }
-                else if (!_baseUrl.StartsWith("/"))
+                else if (!value.StartsWith("/"))
                 {
                     // If baseUrl was not configured with a leading slash, append one for consistency
-                    _baseUrl = "/" + _baseUrl;
-                }
-                else
-                {
-                    // If baseUrl was configured with a leading slash, just return it as-is
-                    _baseUrl = _baseUrl;
+                    value = "/" + value;
                 }
 
                 // Normalize the end of the string
-                if (_baseUrl.EndsWith("/"))
+                if (value.EndsWith("/"))
                 {
                     // If baseUrl was configured with a trailing slash, remove it for consistency
-                    _baseUrl = _baseUrl.Remove(_baseUrl.Length - 1);
+                    value = value.Remove(value.Length - 1);
                 }
+
+                _baseUrl = value;
             }
         }
 

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -169,7 +169,8 @@ namespace MediaBrowser.Model.Configuration
             set
             {
                 _baseUrl = value;
-				// Normalize the start of the string
+
+                // Normalize the start of the string
                 if (string.IsNullOrWhiteSpace(_baseUrl))
                 {
                     // If baseUrl is empty, set an empty prefix string
@@ -185,6 +186,7 @@ namespace MediaBrowser.Model.Configuration
                     // If baseUrl was configured with a leading slash, just return it as-is
                     _baseUrl = _baseUrl;
                 }
+
                 // Normalize the end of the string
                 if (_baseUrl.EndsWith("/"))
                 {

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -10,6 +10,7 @@ namespace MediaBrowser.Model.Configuration
     {
         public const int DefaultHttpPort = 8096;
         public const int DefaultHttpsPort = 8920;
+        private string _baseUrl;
 
         /// <summary>
         /// Gets or sets a value indicating whether [enable u pn p].
@@ -162,7 +163,36 @@ namespace MediaBrowser.Model.Configuration
         public bool SkipDeserializationForBasicTypes { get; set; }
 
         public string ServerName { get; set; }
-        public string BaseUrl { get; set; }
+        public string BaseUrl
+        {
+            get => _baseUrl;
+            set
+            {
+                _baseUrl = value;
+				// Normalize the start of the string
+                if (string.IsNullOrWhiteSpace(_baseUrl))
+                {
+                    // If baseUrl is empty, set an empty prefix string
+                    _baseUrl = string.Empty;
+                }
+                else if (!_baseUrl.StartsWith("/"))
+                {
+                    // If baseUrl was not configured with a leading slash, append one for consistency
+                    _baseUrl = "/" + _baseUrl;
+                }
+                else
+                {
+                    // If baseUrl was configured with a leading slash, just return it as-is
+                    _baseUrl = _baseUrl;
+                }
+                // Normalize the end of the string
+                if (_baseUrl.EndsWith("/"))
+                {
+                    // If baseUrl was configured with a trailing slash, remove it for consistency
+                    _baseUrl = _baseUrl.Remove(_baseUrl.Length - 1);
+                }
+            }
+        }
 
         public string UICulture { get; set; }
 
@@ -243,7 +273,7 @@ namespace MediaBrowser.Model.Configuration
             SortRemoveCharacters = new[] { ",", "&", "-", "{", "}", "'" };
             SortRemoveWords = new[] { "the", "a", "an" };
 
-            BaseUrl = "jellyfin";
+            BaseUrl = string.Empty;
             UICulture = "en-US";
 
             MetadataOptions = new[]


### PR DESCRIPTION
**Changes**
Fixes the inconsistent BaseUrl behaviour to better match standard behaviour for this sort of feature. This will now always append a configured BaseUrl to the default redirects, which should then work for all other URLs as well. Also includes a normalization of the static URLs (`/emby` and `/mediabrowser`) with the BaseUrl, such that the expected path scheme will continue to work.

To complement this, the default BaseUrl is now set to an empty string rather than `jellyfin`.

**Issues**
Fixes #1851