### PR TITLE
Fix exception when handling error, log errors better

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 * text=auto eol=lf
+*.png binary
+*.jpg binary
 
 CONTRIBUTORS.md merge=union

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -233,8 +233,10 @@ namespace Emby.Server.Implementations.HttpServer
                 var statusCode = GetStatusCode(ex);
                 httpRes.StatusCode = statusCode;
 
-                httpRes.ContentType = "text/html";
-                await httpRes.WriteAsync(NormalizeExceptionMessage(ex.Message)).ConfigureAwait(false);
+                var errContent = NormalizeExceptionMessage(ex.Message);
+                httpRes.ContentType = "text/plain";
+                httpRes.ContentLength = errContent.Length;
+                await httpRes.WriteAsync(errContent).ConfigureAwait(false);
             }
             catch (Exception errorEx)
             {

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -208,7 +208,7 @@ namespace Emby.Server.Implementations.HttpServer
             }
         }
 
-        private async Task ErrorHandler(Exception ex, IRequest httpReq, bool logExceptionStackTrace, bool logExceptionMessage)
+        private async Task ErrorHandler(Exception ex, IRequest httpReq, bool logExceptionStackTrace)
         {
             try
             {
@@ -218,9 +218,9 @@ namespace Emby.Server.Implementations.HttpServer
                 {
                     _logger.LogError(ex, "Error processing request");
                 }
-                else if (logExceptionMessage)
+                else
                 {
-                    _logger.LogError(ex.Message);
+                    _logger.LogError("Error processing request: {0}", ex.Message);
                 }
 
                 var httpRes = httpReq.Response;
@@ -511,22 +511,22 @@ namespace Emby.Server.Implementations.HttpServer
                 }
                 else
                 {
-                    await ErrorHandler(new FileNotFoundException(), httpReq, false, false).ConfigureAwait(false);
+                    await ErrorHandler(new FileNotFoundException(), httpReq, false).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex is SocketException || ex is IOException || ex is OperationCanceledException)
             {
-                await ErrorHandler(ex, httpReq, false, false).ConfigureAwait(false);
+                await ErrorHandler(ex, httpReq, false).ConfigureAwait(false);
             }
             catch (SecurityException ex)
             {
-                await ErrorHandler(ex, httpReq, false, true).ConfigureAwait(false);
+                await ErrorHandler(ex, httpReq, false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 var logException = !string.Equals(ex.GetType().Name, "SocketException", StringComparison.OrdinalIgnoreCase);
 
-                await ErrorHandler(ex, httpReq, logException, false).ConfigureAwait(false);
+                await ErrorHandler(ex, httpReq, logException).ConfigureAwait(false);
             }
             finally
             {

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -220,7 +220,7 @@ namespace Emby.Server.Implementations.HttpServer
                 }
                 else
                 {
-                    _logger.LogError("Error processing request: {0}", ex.Message);
+                    _logger.LogError("Error processing request: {Message}", ex.Message);
                 }
 
                 var httpRes = httpReq.Response;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Set correct content type and length when reporting an issue - this should prevent exceptions like
```
[ERR] Error this.ProcessRequest(context)(Exception while writing error to the response)
System.InvalidOperationException: Response Content-Length mismatch: too many bytes written (89 of 0).
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ThrowTooManyBytesWritten(Int32 count)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.VerifyAndUpdateWrite(Int32 count)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.InitializeResponseAsync(Int32 firstWriteByteCount)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.WriteAsync(ReadOnlyMemory`1 data, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Http.HttpResponseWritingExtensions.WriteAsync(HttpResponse response, String text, Encoding encoding, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Http.HttpResponseWritingExtensions.WriteAsync(HttpResponse response, String text, CancellationToken cancellationToken)
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.ErrorHandler(Exception ex, IRequest httpReq, Boolean logExceptionStackTrace, Boolean logExceptionMessage)
```

Also now log at least the error message during request processing - I have no idea why most request errors went unlogged, this is most unhelpful during any issue investigation.

**Note**: I cannot test anything except my changes compile as I now have no means to reliably reproduce errors.