### PR TITLE
Enable `TreatWarningsAsErrors` for MediaBrowser.Common and Emby.Photos

### DIFF
--- a/Emby.Photos/Emby.Photos.csproj
+++ b/Emby.Photos/Emby.Photos.csproj
@@ -17,6 +17,18 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!-- Code analysers-->
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 </Project>

--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -59,10 +59,7 @@ namespace Emby.Server.Implementations.AppBase
             private set => _dataPath = Directory.CreateDirectory(value).FullName;
         }
 
-        /// <summary>
-        /// Gets the magic string used for virtual path manipulation.
-        /// </summary>
-        /// <value>The magic string used for virtual path manipulation.</value>
+        /// <inheritdoc />
         public string VirtualDataPath { get; } = "%AppDataPath%";
 
         /// <summary>

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -49,7 +51,6 @@ using MediaBrowser.Api;
 using MediaBrowser.Common;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Events;
-using MediaBrowser.Common.Extensions;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
@@ -117,7 +118,7 @@ using OperatingSystem = MediaBrowser.Common.System.OperatingSystem;
 namespace Emby.Server.Implementations
 {
     /// <summary>
-    /// Class CompositionRoot
+    /// Class CompositionRoot.
     /// </summary>
     public abstract class ApplicationHost : IServerApplicationHost, IDisposable
     {
@@ -166,6 +167,7 @@ namespace Emby.Server.Implementations
         /// <value><c>true</c> if this instance has pending application restart; otherwise, <c>false</c>.</value>
         public bool HasPendingRestart { get; private set; }
 
+        /// <inheritdoc />
         public bool IsShuttingDown { get; private set; }
 
         /// <summary>
@@ -217,6 +219,7 @@ namespace Emby.Server.Implementations
 
         public IFileSystem FileSystemManager { get; set; }
 
+        /// <inheritdoc />
         public PackageVersionClass SystemUpdateLevel
         {
             get

--- a/MediaBrowser.Common/Configuration/ConfigurationUpdateEventArgs.cs
+++ b/MediaBrowser.Common/Configuration/ConfigurationUpdateEventArgs.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 
 namespace MediaBrowser.Common.Configuration
@@ -9,6 +11,7 @@ namespace MediaBrowser.Common.Configuration
         /// </summary>
         /// <value>The key.</value>
         public string Key { get; set; }
+
         /// <summary>
         /// Gets or sets the new configuration.
         /// </summary>

--- a/MediaBrowser.Common/Configuration/IApplicationPaths.cs
+++ b/MediaBrowser.Common/Configuration/IApplicationPaths.cs
@@ -77,7 +77,10 @@ namespace MediaBrowser.Common.Configuration
         /// <value>The temp directory.</value>
         string TempDirectory { get; }
 
+        /// <summary>
+        /// Gets the magic string used for virtual path manipulation.
+        /// </summary>
+        /// <value>The magic string used for virtual path manipulation.</value>
         string VirtualDataPath { get; }
     }
-
 }

--- a/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
+++ b/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 

--- a/MediaBrowser.Common/Configuration/IConfigurationManager.cs
+++ b/MediaBrowser.Common/Configuration/IConfigurationManager.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 using MediaBrowser.Model.Configuration;

--- a/MediaBrowser.Common/Cryptography/PasswordHash.cs
+++ b/MediaBrowser.Common/Cryptography/PasswordHash.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/MediaBrowser.Common/Events/EventHelper.cs
+++ b/MediaBrowser.Common/Events/EventHelper.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/MediaBrowser.Common/Extensions/CollectionExtensions.cs
+++ b/MediaBrowser.Common/Extensions/CollectionExtensions.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System.Collections.Generic;
 
 namespace MediaBrowser.Common.Extensions

--- a/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
+++ b/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 
 namespace MediaBrowser.Common.Extensions

--- a/MediaBrowser.Common/HexHelper.cs
+++ b/MediaBrowser.Common/HexHelper.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Globalization;
 

--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Plugins;
-using MediaBrowser.Model.Events;
 using MediaBrowser.Model.Updates;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -31,6 +30,10 @@ namespace MediaBrowser.Common
         /// <value><c>true</c> if this instance has pending kernel reload; otherwise, <c>false</c>.</value>
         bool HasPendingRestart { get; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is currently shutting down.
+        /// </summary>
+        /// <value><c>true</c> if this instance is shutting down; otherwise, <c>false</c>.</value>
         bool IsShuttingDown { get; }
 
         /// <summary>
@@ -38,6 +41,12 @@ namespace MediaBrowser.Common
         /// </summary>
         /// <value><c>true</c> if this instance can self restart; otherwise, <c>false</c>.</value>
         bool CanSelfRestart { get; }
+
+        /// <summary>
+        /// Get the version class of the system.
+        /// </summary>
+        /// <value><see cref="PackageVersionClass.Release" /> or <see cref="PackageVersionClass.Beta" />.</value>
+        PackageVersionClass SystemUpdateLevel { get; }
 
         /// <summary>
         /// Occurs when [has pending restart changed].
@@ -115,7 +124,5 @@ namespace MediaBrowser.Common
         /// <param name="type">The type.</param>
         /// <returns>System.Object.</returns>
         object CreateInstance(Type type);
-
-        PackageVersionClass SystemUpdateLevel { get; }
     }
 }

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -24,6 +24,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MediaBrowser.Common/Net/CustomHeaderNames.cs
+++ b/MediaBrowser.Common/Net/CustomHeaderNames.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 namespace MediaBrowser.Common.Net
 {
     public static class CustomHeaderNames

--- a/MediaBrowser.Common/Net/HttpRequestOptions.cs
+++ b/MediaBrowser.Common/Net/HttpRequestOptions.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/MediaBrowser.Common/Net/HttpResponseInfo.cs
+++ b/MediaBrowser.Common/Net/HttpResponseInfo.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.IO;
 using System.Net;
@@ -69,6 +71,7 @@ namespace MediaBrowser.Common.Net
             ContentHeaders = contentHeader;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             // Only IDisposable for backwards compatibility

--- a/MediaBrowser.Common/Net/IHttpClient.cs
+++ b/MediaBrowser.Common/Net/IHttpClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Net.Http;
@@ -25,12 +26,13 @@ namespace MediaBrowser.Common.Net
 
         /// <summary>
         /// Warning: Deprecated function,
-        /// use 'Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, HttpMethod httpMethod);' instead
+        /// use 'Task{HttpResponseInfo} SendAsync(HttpRequestOptions options, HttpMethod httpMethod);' instead
         /// Sends the asynchronous.
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="httpMethod">The HTTP method.</param>
         /// <returns>Task{HttpResponseInfo}.</returns>
+        [Obsolete("Use 'Task{HttpResponseInfo} SendAsync(HttpRequestOptions options, HttpMethod httpMethod);' instead")]
         Task<HttpResponseInfo> SendAsync(HttpRequestOptions options, string httpMethod);
 
         /// <summary>

--- a/MediaBrowser.Common/Net/INetworkManager.cs
+++ b/MediaBrowser.Common/Net/INetworkManager.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/MediaBrowser.Common/Plugins/BasePlugin.cs
+++ b/MediaBrowser.Common/Plugins/BasePlugin.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.IO;
 using MediaBrowser.Common.Configuration;

--- a/MediaBrowser.Common/Plugins/IPlugin.cs
+++ b/MediaBrowser.Common/Plugins/IPlugin.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using MediaBrowser.Model.Plugins;
 

--- a/MediaBrowser.Common/Progress/ActionableProgress.cs
+++ b/MediaBrowser.Common/Progress/ActionableProgress.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 
 namespace MediaBrowser.Common.Progress
@@ -25,16 +27,9 @@ namespace MediaBrowser.Common.Progress
 
         public void Report(T value)
         {
-            if (ProgressChanged != null)
-            {
-                ProgressChanged(this, value);
-            }
+            ProgressChanged?.Invoke(this, value);
 
-            var action = _action;
-            if (action != null)
-            {
-                action(value);
-            }
+            _action?.Invoke(value);
         }
     }
 
@@ -44,10 +39,7 @@ namespace MediaBrowser.Common.Progress
 
         public void Report(T value)
         {
-            if (ProgressChanged != null)
-            {
-                ProgressChanged(this, value);
-            }
+            ProgressChanged?.Invoke(this, value);
         }
     }
 }

--- a/MediaBrowser.Common/Providers/SubtitleConfigurationFactory.cs
+++ b/MediaBrowser.Common/Providers/SubtitleConfigurationFactory.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System.Collections.Generic;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.Providers;
@@ -6,6 +8,7 @@ namespace MediaBrowser.Common.Providers
 {
     public class SubtitleConfigurationFactory : IConfigurationFactory
     {
+        /// <inheritdoc />
         public IEnumerable<ConfigurationStore> GetConfigurations()
         {
             yield return new ConfigurationStore()

--- a/MediaBrowser.Common/System/OperatingSystem.cs
+++ b/MediaBrowser.Common/System/OperatingSystem.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/MediaBrowser.Common/Updates/IInstallationManager.cs
+++ b/MediaBrowser.Common/Updates/IInstallationManager.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/MediaBrowser.Common/Updates/InstallationEventArgs.cs
+++ b/MediaBrowser.Common/Updates/InstallationEventArgs.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using MediaBrowser.Model.Updates;
 
 namespace MediaBrowser.Common.Updates

--- a/MediaBrowser.Common/Updates/InstallationFailedEventArgs.cs
+++ b/MediaBrowser.Common/Updates/InstallationFailedEventArgs.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS1591
+
 using System;
 
 namespace MediaBrowser.Common.Updates


### PR DESCRIPTION
Adds `#pragma warning disable CS1591` to all files in
MediaBrowser.Common containing undocumented members.