### PR TITLE
add tests for Emby.Naming/TV/EpisodePathParser.cs

### DIFF
--- a/MediaBrowser.sln
+++ b/MediaBrowser.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Common.Tests", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.MediaEncoding.Tests", "tests\Jellyfin.MediaEncoding.Tests\Jellyfin.MediaEncoding.Tests.csproj", "{28464062-0939-4AA7-9F7B-24DDDA61A7C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Naming.Tests", "tests\Jellyfin.Naming.Tests\Jellyfin.Naming.Tests.csproj", "{3998657B-1CCC-49DD-A19F-275DC8495F57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +167,10 @@ Global
 		{28464062-0939-4AA7-9F7B-24DDDA61A7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28464062-0939-4AA7-9F7B-24DDDA61A7C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28464062-0939-4AA7-9F7B-24DDDA61A7C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3998657B-1CCC-49DD-A19F-275DC8495F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3998657B-1CCC-49DD-A19F-275DC8495F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3998657B-1CCC-49DD-A19F-275DC8495F57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3998657B-1CCC-49DD-A19F-275DC8495F57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,5 +199,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{DF194677-DFD3-42AF-9F75-D44D5A416478} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
 		{28464062-0939-4AA7-9F7B-24DDDA61A7C0} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
+		{3998657B-1CCC-49DD-A19F-275DC8495F57} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
 	EndGlobalSection
 EndGlobal

--- a/tests/Jellyfin.Naming.Tests/EpisodePathParserTest.cs
+++ b/tests/Jellyfin.Naming.Tests/EpisodePathParserTest.cs
@@ -1,0 +1,25 @@
+namespace Emby.Naming.TV
+{
+    using Emby.Naming.Common;
+    using Xunit;
+
+    public class EpisodePathParserTest
+    {
+        [Theory]
+        [InlineData("/media/Foo/Foo-S01E01", "Foo", 1, 1)]
+        [InlineData("/media/Foo - S04E011", "Foo", 4, 11)]
+        [InlineData("/media/Foo/Foo s01x01", "Foo", 1, 1)]
+        [InlineData("/media/Foo/Foo s01x03 - the bar of foo", "Foo", 1, 3)]
+        public void ParseEpisodesCorrectly(string path, string name, int season, int episode)
+        {
+            NamingOptions o = new NamingOptions();
+            EpisodePathParser p = new EpisodePathParser(o);
+            var res = p.Parse(path, false);
+
+            Assert.True(res.Success);
+            Assert.Equal(name, res.SeriesName);
+            Assert.Equal(season, res.SeasonNumber);
+            Assert.Equal(episode, res.EpisodeNumber);
+        }
+    }
+}

--- a/tests/Jellyfin.Naming.Tests/EpisodePathParserTest.cs
+++ b/tests/Jellyfin.Naming.Tests/EpisodePathParserTest.cs
@@ -9,7 +9,7 @@ namespace Emby.Naming.TV
         [InlineData("/media/Foo/Foo-S01E01", "Foo", 1, 1)]
         [InlineData("/media/Foo - S04E011", "Foo", 4, 11)]
         [InlineData("/media/Foo/Foo s01x01", "Foo", 1, 1)]
-        [InlineData("/media/Foo/Foo s01x03 - the bar of foo", "Foo", 1, 3)]
+        [InlineData("/media/Foo (2019)/Season 4/Foo (2019).S04E03", "Foo (2019)", 4, 3)]
         public void ParseEpisodesCorrectly(string path, string name, int season, int episode)
         {
             NamingOptions o = new NamingOptions();
@@ -20,6 +20,34 @@ namespace Emby.Naming.TV
             Assert.Equal(name, res.SeriesName);
             Assert.Equal(season, res.SeasonNumber);
             Assert.Equal(episode, res.EpisodeNumber);
+
+            //testing other paths delimeter
+            var res2 = p.Parse(path.Replace("/", "\\"), false);
+            Assert.True(res2.Success);
+            Assert.Equal(name, res2.SeriesName);
+            Assert.Equal(season, res2.SeasonNumber);
+            Assert.Equal(episode, res2.EpisodeNumber);
+        }
+
+        [Theory]
+        [InlineData("/media/Foo/Foo 889.avi", "Foo", 889)]
+        public void ParseEpisodeWithoutSeason(string path, string name, int episode)
+        {
+            NamingOptions o = new NamingOptions();
+            EpisodePathParser p = new EpisodePathParser(o);
+            var res = p.Parse(path, false, null, null, true);
+
+            Assert.True(res.Success);
+            Assert.Equal(name, res.SeriesName);
+            Assert.True(res.SeasonNumber == null);
+            Assert.Equal(episode, res.EpisodeNumber);
+
+            //testing other paths delimeter
+            var res2 = p.Parse(path.Replace("/", "\\"), false, null, null, true);
+            Assert.True(res2.Success);
+            Assert.Equal(name, res2.SeriesName);
+            Assert.True(res2.SeasonNumber == null);
+            Assert.Equal(episode, res2.EpisodeNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/Jellyfin.Naming.Tests.csproj
+++ b/tests/Jellyfin.Naming.Tests/Jellyfin.Naming.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Emby.Naming\Emby.Naming.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This should in the future help to detect working and non working name matchings

**Changes**
Adding tests for Emby.Naming/TV/EpisodePathParser.cs and working tests cases.
There are still a lot of common file names not covered by this test because I prioritized successful tests over tests that are supposed to work.

This should hopefully help in the future to improve the parser.