### PR TITLE
Add BaseUrl postinst migration for Debuntu

### DIFF
--- a/deployment/debian-package-x64/pkg-src/postinst
+++ b/deployment/debian-package-x64/pkg-src/postinst
@@ -52,6 +52,13 @@ case "$1" in
     # Install jellyfin symlink into /usr/bin
     ln -sf /usr/lib/jellyfin/bin/jellyfin /usr/bin/jellyfin
 
+    #
+    # MIGRATIONS
+    #
+
+    # Changelog: 10.4.0 -> 10.4.1+ | Remove default BaseUrl path to prevent strange behavior with fix #1863
+    sed -i '/BaseUrl/s/\/jellyfin//' /etc/jellyfin/system.xml &>/dev/null || true
+
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION
**Changes**
Adds a Debian postinst migration to remove the previous erroneous BaseUrl value from system.xml.

**Issues**
Related to #1863