### PR TITLE
Bump version to 10.5.0 for next stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG DOTNET_VERSION=2.2
 ARG FFMPEG_VERSION=latest
 
 FROM node:alpine as web-builder
-ARG JELLYFIN_WEB_VERSION=v10.4.0
+ARG JELLYFIN_WEB_VERSION=v10.5.0
 RUN apk add curl \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -4,7 +4,7 @@ ARG DOTNET_VERSION=3.0
 
 
 FROM node:alpine as web-builder
-ARG JELLYFIN_WEB_VERSION=v10.4.0
+ARG JELLYFIN_WEB_VERSION=v10.5.0
 RUN apk add curl \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -4,7 +4,7 @@ ARG DOTNET_VERSION=3.0
 
 
 FROM node:alpine as web-builder
-ARG JELLYFIN_WEB_VERSION=v10.4.0
+ARG JELLYFIN_WEB_VERSION=v10.5.0
 RUN apk add curl \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \

--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("10.4.0")]
-[assembly: AssemblyFileVersion("10.4.0")]
+[assembly: AssemblyVersion("10.5.0")]
+[assembly: AssemblyFileVersion("10.5.0")]

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin"
-version: "10.4.0"
+version: "10.5.0"
 packages:
   - debian-package-x64
   - debian-package-armhf

--- a/deployment/debian-package-x64/pkg-src/changelog
+++ b/deployment/debian-package-x64/pkg-src/changelog
@@ -1,3 +1,9 @@
+jellyfin (10.5.0-1) unstable; urgency=medium
+
+  * New upstream version 10.5.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.5.0
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  Fri, 11 Oct 2019 20:12:38 -0400
+
 jellyfin (10.4.0-1) unstable; urgency=medium
 
   * New upstream version 10.4.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.4.0

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -7,7 +7,7 @@
 %endif
 
 Name:           jellyfin
-Version:        10.4.0
+Version:        10.5.0
 Release:        1%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
@@ -140,6 +140,8 @@ fi
 %systemd_postun_with_restart jellyfin.service
 
 %changelog
+* Fri Oct 11 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
+- New upstream version 10.5.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.5.0
 * Sat Aug 31 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - New upstream version 10.4.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.4.0
 * Wed Jul 24 2019 Jellyfin Packaging Team <packaging@jellyfin.org>


### PR DESCRIPTION
**Changes**
Bump `master` to 10.5.0 for next stable release.

**Issues**
N/A
