### PR TITLE
Switch ffmpeg to hls muxer (from segment) to fix premature stop on non-patched ffmpeg

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -543,6 +543,7 @@ namespace Emby.Server.Implementations.HttpServer
                 {
                     _logger.LogDebug("Sending HTTP Response 500 in response to {Url}", urlToLog);
                 }
+
                 stopWatch.Stop();
                 var elapsed = stopWatch.Elapsed;
                 if (elapsed.TotalMilliseconds > 500)

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -539,6 +539,10 @@ namespace Emby.Server.Implementations.HttpServer
             }
             finally
             {
+                if (httpRes.StatusCode >= 500)
+                {
+                    _logger.LogDebug("Sending HTTP Response 500 in response to {Url}", urlToLog);
+                }
                 stopWatch.Stop();
                 var elapsed = stopWatch.Elapsed;
                 if (elapsed.TotalMilliseconds > 500)

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -321,7 +321,6 @@ namespace MediaBrowser.Api.Playback
             }
             Logger.LogDebug("StartFfMpeg() finished successfully");
 
-
             return transcodingJob;
         }
 

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -297,12 +297,12 @@ namespace MediaBrowser.Api.Playback
 
             // Wait for the file to exist before proceeeding
             var waitFor = state.WaitForPath ?? outputPath;
-            Logger.LogDebug("Waiting for the creation of '{0}'", waitFor);
+            Logger.LogDebug("Waiting for the creation of {0}", waitFor);
             while (!File.Exists(waitFor) && !transcodingJob.HasExited)
             {
                 await Task.Delay(100, cancellationTokenSource.Token).ConfigureAwait(false);
             }
-            Logger.LogDebug("File '{0}' created or transcoding has finished", waitFor);
+            Logger.LogDebug("File {0} created or transcoding has finished", waitFor);
 
             if (state.IsInputVideo && transcodingJob.Type == TranscodingJobType.Progressive && !transcodingJob.HasExited)
             {

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -302,6 +302,7 @@ namespace MediaBrowser.Api.Playback
             {
                 await Task.Delay(100, cancellationTokenSource.Token).ConfigureAwait(false);
             }
+
             Logger.LogDebug("File {0} created or transcoding has finished", ffmpegTargetFile);
 
             if (state.IsInputVideo && transcodingJob.Type == TranscodingJobType.Progressive && !transcodingJob.HasExited)

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -296,13 +296,13 @@ namespace MediaBrowser.Api.Playback
             _ = new JobLogger(Logger).StartStreamingLog(state, process.StandardError.BaseStream, logStream);
 
             // Wait for the file to exist before proceeeding
-            var waitFor = state.WaitForPath ?? outputPath;
-            Logger.LogDebug("Waiting for the creation of {0}", waitFor);
-            while (!File.Exists(waitFor) && !transcodingJob.HasExited)
+            var ffmpegTargetFile = state.WaitForPath ?? outputPath;
+            Logger.LogDebug("Waiting for the creation of {0}", ffmpegTargetFile);
+            while (!File.Exists(ffmpegTargetFile) && !transcodingJob.HasExited)
             {
                 await Task.Delay(100, cancellationTokenSource.Token).ConfigureAwait(false);
             }
-            Logger.LogDebug("File {0} created or transcoding has finished", waitFor);
+            Logger.LogDebug("File {0} created or transcoding has finished", ffmpegTargetFile);
 
             if (state.IsInputVideo && transcodingJob.Type == TranscodingJobType.Progressive && !transcodingJob.HasExited)
             {

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -321,6 +321,7 @@ namespace MediaBrowser.Api.Playback
             }
             Logger.LogDebug("StartFfMpeg() finished successfully");
 
+
             return transcodingJob;
         }
 

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -965,14 +965,6 @@ namespace MediaBrowser.Api.Playback.Hls
 
             var outputTsArg = Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath)) + "%d" + GetSegmentFileExtension(state.Request);
 
-            var timeDeltaParam = string.Empty;
-
-            if (isEncoding && state.TargetFramerate > 0)
-            {
-                float startTime = 1 / (state.TargetFramerate.Value * 2);
-                timeDeltaParam = string.Format(CultureInfo.InvariantCulture, "-segment_time_delta {0:F3}", startTime);
-            }
-
             var segmentFormat = GetSegmentFileExtension(state.Request).TrimStart('.');
             if (string.Equals(segmentFormat, "ts", StringComparison.OrdinalIgnoreCase))
             {
@@ -980,7 +972,7 @@ namespace MediaBrowser.Api.Playback.Hls
             }
 
             return string.Format(
-                "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -f segment -max_delay 5000000 -avoid_negative_ts disabled -start_at_zero -segment_time {6} {10} -individual_header_trailer 0 -segment_format {11} -segment_list_type m3u8 -segment_start_number {7} -segment_list \"{8}\" -y \"{9}\"",
+                "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -f hls -max_delay 5000000 -avoid_negative_ts disabled -start_at_zero -hls_time {6} -individual_header_trailer 0 -hls_segment_type {7} -start_number {8} -hls_segment_filename \"{9}\" -hls_playlist_type vod -hls_list_size 0 -y \"{10}\"",
                 inputModifier,
                 EncodingHelper.GetInputArgument(state, encodingOptions),
                 threads,
@@ -988,11 +980,10 @@ namespace MediaBrowser.Api.Playback.Hls
                 GetVideoArguments(state, encodingOptions),
                 GetAudioArguments(state, encodingOptions),
                 state.SegmentLength.ToString(CultureInfo.InvariantCulture),
+                segmentFormat,
                 startNumberParam,
-                outputPath,
                 outputTsArg,
-                timeDeltaParam,
-                segmentFormat
+                outputPath
             ).Trim();
         }
     }

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -476,7 +476,7 @@ namespace MediaBrowser.Api.Playback.Hls
                 // If requested segment is less than transcoding position, we can't transcode backwards, so assume it's ready
                 if (segmentIndex < currentTranscodingIndex)
                 {
-                    Logger.LogDebug("serving up {0} as transcode index {1} is past requested point {2}", segmentPath, segmentIndex, currentTranscodingIndex);
+                    Logger.LogDebug("serving up {0} as transcode index {1} is past requested point {2}", segmentPath, currentTranscodingIndex, segmentIndex);
                     return await GetSegmentResult(state, segmentPath, segmentIndex, transcodingJob).ConfigureAwait(false);
                 }
             }

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -931,7 +931,7 @@ namespace MediaBrowser.Api.Playback.Hls
                 {
                     // This is to make sure keyframe interval is limited to our segment,
                     // as forcing keyframes is not enough.
-                    // Example: we ecoded half of desired length, then codec detected
+                    // Example: we encoded half of desired length, then codec detected
                     // scene cut and inserted a keyframe; next forced keyframe would
                     // be created outside of segment, which breaks seeking.
                     keyFrameArg += string.Format(

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -504,6 +504,7 @@ namespace MediaBrowser.Api.Playback.Hls
                             continue; // avoid unnecessary waiting if segment just became available
                         }
                     }
+
                     await Task.Delay(100, cancellationToken).ConfigureAwait(false);
                 }
 
@@ -923,7 +924,8 @@ namespace MediaBrowser.Api.Playback.Hls
             }
             else
             {
-                var keyFrameArg = string.Format(CultureInfo.InvariantCulture,
+                var keyFrameArg = string.Format(
+                    CultureInfo.InvariantCulture,
                     " -force_key_frames:0 \"expr:gte(t,{0}+n_forced*{1})\"",
                     GetStartNumber(state) * state.SegmentLength,
                     state.SegmentLength);
@@ -934,7 +936,8 @@ namespace MediaBrowser.Api.Playback.Hls
                     // Example: we encoded half of desired length, then codec detected
                     // scene cut and inserted a keyframe; next forced keyframe would
                     // be created outside of segment, which breaks seeking.
-                    keyFrameArg += string.Format(CultureInfo.InvariantCulture,
+                    keyFrameArg += string.Format(
+                        CultureInfo.InvariantCulture,
                         " -g {0} -keyint_min {0}",
                         (int)(state.SegmentLength * state.TargetFramerate)
                     );

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -508,7 +508,6 @@ namespace MediaBrowser.Api.Playback.Hls
                     await Task.Delay(100, cancellationToken).ConfigureAwait(false);
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
                 if (!File.Exists(segmentPath))
                 {
                     Logger.LogWarning("cannot serve {0} as transcoding quit before we got there", segmentPath);
@@ -517,6 +516,7 @@ namespace MediaBrowser.Api.Playback.Hls
                 {
                     Logger.LogDebug("serving {0} as it's on disk and transcoding stopped", segmentPath);
                 }
+                cancellationToken.ThrowIfCancellationRequested();
             }
             else
             {

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -923,10 +923,10 @@ namespace MediaBrowser.Api.Playback.Hls
             }
             else
             {
-                var keyFrameArg = string.Format(
+                var keyFrameArg = string.Format(CultureInfo.InvariantCulture,
                     " -force_key_frames:0 \"expr:gte(t,{0}+n_forced*{1})\"",
-                    (GetStartNumber(state) * state.SegmentLength).ToString(CultureInfo.InvariantCulture),
-                    state.SegmentLength.ToString(CultureInfo.InvariantCulture));
+                    GetStartNumber(state) * state.SegmentLength,
+                    state.SegmentLength);
                 if (state.TargetFramerate.HasValue)
                 {
                     // This is to make sure keyframe interval is limited to our segment,
@@ -934,9 +934,9 @@ namespace MediaBrowser.Api.Playback.Hls
                     // Example: we encoded half of desired length, then codec detected
                     // scene cut and inserted a keyframe; next forced keyframe would
                     // be created outside of segment, which breaks seeking.
-                    keyFrameArg += string.Format(
+                    keyFrameArg += string.Format(CultureInfo.InvariantCulture,
                         " -g {0} -keyint_min {0}",
-                        ((int)(state.SegmentLength * state.TargetFramerate)).ToString(CultureInfo.InvariantCulture)
+                        (int)(state.SegmentLength * state.TargetFramerate)
                     );
                 }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2168,7 +2168,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // Important: If this is ever re-enabled, make sure not to use it with wtv because it breaks seeking
                 if (!string.Equals(state.InputContainer, "wtv", StringComparison.OrdinalIgnoreCase)
                     && state.TranscodingType != TranscodingJobType.Progressive
-                    && state.EnableBreakOnNonKeyFrames(outputVideoCodec))
+                    && !state.EnableBreakOnNonKeyFrames(outputVideoCodec) &&
+                    (state.BaseRequest.StartTimeTicks ?? 0) > 0)
                 {
                     inputModifier += " -noaccurate_seek";
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2168,8 +2168,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // Important: If this is ever re-enabled, make sure not to use it with wtv because it breaks seeking
                 if (!string.Equals(state.InputContainer, "wtv", StringComparison.OrdinalIgnoreCase)
                     && state.TranscodingType != TranscodingJobType.Progressive
-                    && !state.EnableBreakOnNonKeyFrames(outputVideoCodec) &&
-                    (state.BaseRequest.StartTimeTicks ?? 0) > 0)
+                    && !state.EnableBreakOnNonKeyFrames(outputVideoCodec)
+                    && (state.BaseRequest.StartTimeTicks ?? 0) > 0)
                 {
                     inputModifier += " -noaccurate_seek";
                 }

--- a/deployment/debian-package-x64/docker-build.sh
+++ b/deployment/debian-package-x64/docker-build.sh
@@ -20,6 +20,7 @@ if [[ -n ${web_branch} ]]; then
     checkout -b origin/${web_branch}
 fi
 yarn install
+yarn build 
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
 popd

--- a/deployment/debian-package-x64/docker-build.sh
+++ b/deployment/debian-package-x64/docker-build.sh
@@ -20,7 +20,6 @@ if [[ -n ${web_branch} ]]; then
     checkout -b origin/${web_branch}
 fi
 yarn install
-yarn build 
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
 popd


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
* Change ffmpeg muxer used in HLS streaming from `segment` to `hls` (`segment` muxer has a bug patch for which is not yet accepted upstream)
* Add more options to enforce keyframes in full transcoding (it should help having segment lengths to be much closer to requested "segment length")
* Add even more debug logging - used for making this happen, but won't hurt to keep it there IMHO
* Fix the condition on "enable break on non-keyframes" - this might be a potentially breaking change, but its previous state (before my fix) didn't make _any sense_ to me whatsoever.

**Issues**
It should really fix https://github.com/jellyfin/jellyfin/issues/1694 without relying to use a patched ffmpeg
