### PR TITLE
Use the correct dotnet runtime in Docker images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 RUN dotnet publish Jellyfin.Server --configuration Release --output="/jellyfin" --self-contained --runtime linux-x64 "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"
 
 FROM jellyfin/ffmpeg:${FFMPEG_VERSION} as ffmpeg
+FROM debian:stretch-slim
 
-FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}
 COPY --from=ffmpeg /opt/ffmpeg /opt/ffmpeg
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
@@ -38,9 +38,11 @@ RUN apt-get update \
  && ln -s /opt/ffmpeg/bin/ffmpeg /usr/local/bin \
  && ln -s /opt/ffmpeg/bin/ffprobe /usr/local/bin
 
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+ENTRYPOINT ./jellyfin/jellyfin \
     --datadir /config \
     --cachedir /cache \
     --ffmpeg /usr/local/bin/ffmpeg

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -24,7 +24,7 @@ RUN dotnet publish Jellyfin.Server --configuration Release --output="/jellyfin" 
 
 
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
-FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}-stretch-slim-arm32v7
+FROM debian:stretch-slim-arm32v7
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
@@ -34,9 +34,11 @@ RUN apt-get update \
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+ENTRYPOINT ./jellyfin/jellyfin \
     --datadir /config \
     --cachedir /cache \
     --ffmpeg /usr/bin/ffmpeg

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -24,7 +24,7 @@ RUN dotnet publish Jellyfin.Server --configuration Release --output="/jellyfin" 
 
 
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
-FROM mcr.microsoft.com/dotnet/core/runtime:${DOTNET_VERSION}-stretch-slim-arm64v8
+FROM debian:stretch-slim-arm64v8
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ffmpeg \
@@ -34,9 +34,11 @@ RUN apt-get update \
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
 EXPOSE 8096
 VOLUME /cache /config /media
-ENTRYPOINT dotnet /jellyfin/jellyfin.dll \
+ENTRYPOINT ./jellyfin/jellyfin \
     --datadir /config \
     --cachedir /cache \
     --ffmpeg /usr/bin/ffmpeg


### PR DESCRIPTION
The self contained packages already contains the dotnet runtime
No need to use the dotnet runtime base image.

This should decrease the size of the image.