### PR TITLE
Integrate web build into Debuntu package build steps

### DIFF
--- a/deployment/debian-package-arm64/Dockerfile.amd64
+++ b/deployment/debian-package-arm64/Dockerfile.amd64
@@ -12,7 +12,7 @@ ENV ARCH=amd64
 
 # Prepare Debian build environment
 RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv 
+ && apt-get install -y apt-transport-https debhelper gnupg wget npm devscripts mmv 
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
@@ -28,12 +28,6 @@ RUN dpkg --add-architecture arm64 \
  && TARGET_LIST="arm64" cross-gcc-gensource 8 \
  && cd cross-gcc-packages-amd64/cross-gcc-8-arm64 \
  && apt-get install -y gcc-8-source libstdc++-8-dev-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 libssl-dev:arm64 liblttng-ust0:arm64 libstdc++-8-dev:arm64
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/debian-package-arm64/Dockerfile.arm64
+++ b/deployment/debian-package-arm64/Dockerfile.arm64
@@ -12,7 +12,7 @@ ENV ARCH=arm64
 
 # Prepare Debian build environment
 RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev liblttng-ust0
+ && apt-get install -y apt-transport-https debhelper gnupg wget npm devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev liblttng-ust0
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current

--- a/deployment/debian-package-arm64/docker-build.sh
+++ b/deployment/debian-package-arm64/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -aarm64

--- a/deployment/debian-package-armhf/Dockerfile.amd64
+++ b/deployment/debian-package-armhf/Dockerfile.amd64
@@ -12,7 +12,7 @@ ENV ARCH=amd64
 
 # Prepare Debian build environment
 RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv 
+ && apt-get install -y apt-transport-https debhelper gnupg wget npm devscripts mmv 
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
@@ -28,12 +28,6 @@ RUN dpkg --add-architecture armhf \
  && TARGET_LIST="armhf" cross-gcc-gensource 8 \
  && cd cross-gcc-packages-amd64/cross-gcc-8-armhf \
  && apt-get install -y gcc-8-source libstdc++-8-dev-armhf-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip binutils-arm-linux-gnueabihf libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf libssl-dev:armhf liblttng-ust0:armhf libstdc++-8-dev:armhf
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/debian-package-armhf/Dockerfile.armhf
+++ b/deployment/debian-package-armhf/Dockerfile.armhf
@@ -12,7 +12,7 @@ ENV ARCH=armhf
 
 # Prepare Debian build environment
 RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev liblttng-ust0
+ && apt-get install -y apt-transport-https debhelper gnupg wget npm devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev liblttng-ust0
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
@@ -20,12 +20,6 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/3cb1d917-19cc-4
  && mkdir -p dotnet-sdk \
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/debian-package-armhf/docker-build.sh
+++ b/deployment/debian-package-armhf/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -aarmhf

--- a/deployment/debian-package-x64/Dockerfile
+++ b/deployment/debian-package-x64/Dockerfile
@@ -12,7 +12,7 @@ ENV ARCH=amd64
 
 # Prepare Debian build environment
 RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+ && apt-get install -y apt-transport-https debhelper gnupg wget npm devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
@@ -20,12 +20,6 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/228832ea-805f-4
  && mkdir -p dotnet-sdk \
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/debian-package-x64/docker-build.sh
+++ b/deployment/debian-package-x64/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 dpkg-buildpackage -us -uc
 

--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -8,7 +8,9 @@ Build-Depends:  debhelper (>= 9),
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,
                 libfreetype6-dev,
-                libssl-dev
+                libssl-dev,
+                wget,
+                npm | nodejs
 Standards-Version: 3.9.4
 Homepage: https://jellyfin.media/
 Vcs-Git: https://github.org/jellyfin/jellyfin.git

--- a/deployment/debian-package-x64/pkg-src/rules
+++ b/deployment/debian-package-x64/pkg-src/rules
@@ -2,6 +2,8 @@
 CONFIG := Release
 TERM := xterm
 SHELL := /bin/bash
+WEB_TARGET := $(CURDIR)/MediaBrowser.WebDashboard/jellyfin-web
+WEB_VERSION := $(shell sed -n -e 's/^version: "\(.*\)"/\1/p' $(CURDIR)/build.yaml)
 
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
@@ -39,12 +41,25 @@ override_dh_auto_test:
 override_dh_clistrip:
 
 override_dh_auto_build:
+	echo $(WEB_VERSION)
+	# Clone down and build Web frontend
+	mkdir -p $(WEB_TARGET)
+	wget -O web-src.tgz https://github.com/jellyfin/jellyfin-web/archive/v$(WEB_VERSION).tar.gz || wget -O web-src.tgz https://github.com/jellyfin/jellyfin-web/archive/master.tar.gz
+	mkdir -p $(CURDIR)/web
+	tar -xzf web-src.tgz -C $(CURDIR)/web/ --strip 1
+	cd $(CURDIR)/web/ && npm install yarn
+	cd $(CURDIR)/web/ && node_modules/yarn/bin/yarn install
+	mv $(CURDIR)/web/dist/* $(WEB_TARGET)/
+	# Build the application
 	dotnet publish --configuration $(CONFIG) --output='$(CURDIR)/usr/lib/jellyfin/bin' --self-contained --runtime $(DOTNETRUNTIME) \
 		"-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none" Jellyfin.Server
 
 override_dh_auto_clean:
 	dotnet clean -maxcpucount:1 --configuration $(CONFIG) Jellyfin.Server || true
+	rm -f  '$(CURDIR)/web-src.tgz'
 	rm -rf '$(CURDIR)/usr'
+	rm -rf '$(CURDIR)/web'
+	rm -rf '$(WEB_TARGET)'
 
 # Force the service name to jellyfin even if we're building jellyfin-nightly
 override_dh_installinit:

--- a/deployment/ubuntu-package-arm64/Dockerfile.amd64
+++ b/deployment/ubuntu-package-arm64/Dockerfile.amd64
@@ -21,6 +21,12 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/69937b49-a877-4
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
+# Install npm package manager
+RUN wget -q -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_8.x $(lsb_release -s -c) main" > /etc/apt/sources.list.d/npm.list \
+ && apt update \
+ && apt install -y nodejs
+
 # Prepare the cross-toolchain
 RUN rm /etc/apt/sources.list \
  && export CODENAME="$( lsb_release -c -s )" \
@@ -39,12 +45,6 @@ RUN rm /etc/apt/sources.list \
  && cd cross-gcc-packages-amd64/cross-gcc-6-arm64 \
  && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
  && apt-get install -y gcc-6-source libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64 libssl-dev:arm64
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/ubuntu-package-arm64/Dockerfile.arm64
+++ b/deployment/ubuntu-package-arm64/Dockerfile.arm64
@@ -21,6 +21,12 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/d9f37b73-df8d-4
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
+# Install npm package manager
+RUN wget -q -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_8.x $(lsb_release -s -c) main" > /etc/apt/sources.list.d/npm.list \
+ && apt update \
+ && apt install -y nodejs
+
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh
 

--- a/deployment/ubuntu-package-arm64/docker-build.sh
+++ b/deployment/ubuntu-package-arm64/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -aarm64

--- a/deployment/ubuntu-package-armhf/Dockerfile.amd64
+++ b/deployment/ubuntu-package-armhf/Dockerfile.amd64
@@ -21,6 +21,12 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/69937b49-a877-4
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
+# Install npm package manager
+RUN wget -q -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_8.x $(lsb_release -s -c) main" > /etc/apt/sources.list.d/npm.list \
+ && apt update \
+ && apt install -y nodejs
+
 # Prepare the cross-toolchain
 RUN rm /etc/apt/sources.list \
  && export CODENAME="$( lsb_release -c -s )" \
@@ -39,12 +45,6 @@ RUN rm /etc/apt/sources.list \
  && cd cross-gcc-packages-amd64/cross-gcc-6-armhf \
  && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
  && apt-get install -y gcc-6-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf libssl-dev:armhf
-
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- && apt update \
- && apt install -y yarn
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/ubuntu-package-armhf/Dockerfile.armhf
+++ b/deployment/ubuntu-package-armhf/Dockerfile.armhf
@@ -21,11 +21,11 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/d9f37b73-df8d-4
  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+# Install npm package manager
+RUN wget -q -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_8.x $(lsb_release -s -c) main" > /etc/apt/sources.list.d/npm.list \
  && apt update \
- && apt install -y yarn
+ && apt install -y nodejs
 
 # Link to docker-build script
 RUN ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh

--- a/deployment/ubuntu-package-armhf/docker-build.sh
+++ b/deployment/ubuntu-package-armhf/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -aarmhf

--- a/deployment/ubuntu-package-x64/Dockerfile
+++ b/deployment/ubuntu-package-x64/Dockerfile
@@ -14,11 +14,11 @@ RUN apt-get update \
  && ln -sf ${PLATFORM_DIR}/docker-build.sh /docker-build.sh \
  && mkdir -p ${SOURCE_DIR} && ln -sf ${PLATFORM_DIR}/pkg-src ${SOURCE_DIR}/debian
 
-# Install yarn package manager
-RUN wget -q -O- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+# Install npm package manager
+RUN wget -q -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_8.x $(lsb_release -s -c) main" > /etc/apt/sources.list.d/npm.list \
  && apt update \
- && apt install -y yarn
+ && apt install -y nodejs
 
 VOLUME ${ARTIFACT_DIR}/
 

--- a/deployment/ubuntu-package-x64/docker-build.sh
+++ b/deployment/ubuntu-package-x64/docker-build.sh
@@ -11,20 +11,6 @@ pushd ${SOURCE_DIR}
 # Remove build-dep for dotnet-sdk-2.2, since it's not a package in this image
 sed -i '/dotnet-sdk-2.2,/d' debian/control
 
-# Clone down and build Web frontend
-web_build_dir="$( mktemp -d )"
-web_target="${SOURCE_DIR}/MediaBrowser.WebDashboard/jellyfin-web"
-git clone https://github.com/jellyfin/jellyfin-web.git ${web_build_dir}/
-pushd ${web_build_dir}
-if [[ -n ${web_branch} ]]; then
-    checkout -b origin/${web_branch}
-fi
-yarn install
-mkdir -p ${web_target}
-mv dist/* ${web_target}/
-popd
-rm -rf ${web_build_dir}
-
 # Build DEB
 dpkg-buildpackage -us -uc
 


### PR DESCRIPTION
**Changes**
Integrates the web build steps into the debuild framework, rather than performing them externally in the the `docker-build.sh` scripts. This allows for non-Dockerized builds to succeed.

This shouldn't need to be backported, but that might be a good QoL fix for anyone wanting this functionality. It won't affect our official releases though.

**Issues**
N/A