### PR TITLE
Allow valid https requests in .NET Core

### DIFF
--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -59,7 +59,17 @@ namespace Emby.Server.Implementations.HttpClientManager
 
             if (!_httpClients.TryGetValue(key, out var client))
             {
-                client = new HttpClient()
+                var httpClientHandler = new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                    {
+                        var success = errors == System.Net.Security.SslPolicyErrors.None;
+                        _logger.LogDebug("Validating certificate {Cert}. Success {1}", cert, success);
+                        return success;
+                    }
+                };
+
+                client = new HttpClient(httpClientHandler)
                 {
                     BaseAddress = new Uri(url)
                 };


### PR DESCRIPTION
ServerCertificateValidationCallback is not supported in .NET Core and outgoing https requests will fail if the certificate is not trusted. This will most likely be an issue in Docker environments and will manifest as "The remote certificate is invalid according to the validation procedure" on an outgoing https request

**Changes**
This adds the equivalent functionality that existed in Program.cs with a call to  ServicePointManager.ServerCertificateValidationCallback by adding a custom HttpClientHandler to the HttpClient created by HttpClientManager
