### PR TITLE
Correctly set ViewType on UserView

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2111,6 +2111,8 @@ namespace Emby.Server.Implementations.Library
 
             var item = GetItemById(id) as UserView;
 
+            item.ViewType ??= viewType;
+
             var refresh = false;
 
             if (item == null || !string.Equals(item.Path, path, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
When a UserView was available from the repository, the correct ViewType/CollectionType was not set on the constructed object. 

This could lead to the LiveTv programs and channels having a null reference in the database after a guide refresh and becoming unavailable from the frontend. 

**Issues**
Fixes #1952 
