### PR TITLE
Disable CA1720: Identifiers should not contain type names

### DIFF
--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -31,6 +31,8 @@
     <Rule Id="CA1031" Action="Info" />
     <!-- disable warning CA1062: Validate arguments of public methods -->
     <Rule Id="CA1062" Action="Info" />
+    <!-- disable warning CA1720: Identifiers should not contain type names -->
+    <Rule Id="CA1720" Action="Info" />
     <!-- disable warning CA1812: internal class that is apparently never instantiated.
         If so, remove the code from the assembly.
         If this class is intended to contain only static members, make it static -->


### PR DESCRIPTION
Ref: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1720?view=vs-2019
