### PR TITLE
Add an exemption for the confirmed label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - future
   - feature
   - enhancement
+  - confirmed
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Adds an exemption we can use to keep issues open when they are confirmed/real.