### PR TITLE
Update stalebot timings and message

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 120
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 21
 # Issues with these labels will never be considered stale
 exemptLabels:
   - regression
@@ -16,8 +16,10 @@ exemptLabels:
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  Issues go stale after 90d of inactivity. Mark the issue as fresh by adding a comment or commit. Stale issues close after an additional 14d of inactivity.
-  If this issue is safe to close now please do so.
-  If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
+  This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.
+  
+  If you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or nightlies, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.
+
+  This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
**Changes**
1. Bump up the timings, since the project releases have slowed down a
   fair bit. 120 days stale with 21 days for a response still gets us
   the desired effect while loosening the timeline for issue submitters.
2. Revamp the wording to better explain what the author (or others) need
   to do, and why this bot exists.

**Issues**
N/A - addressing some feedback from Reddit https://old.reddit.com/r/jellyfin/comments/dxm4u8/please_dont_use_autoclose_bots_on_issues/ in the hopes that the message stalebot leaves can better explain its purpose.
