### PR TITLE
Remove leading / from baseurl

### DIFF
--- a/Emby.Dlna/Api/DlnaServerService.cs
+++ b/Emby.Dlna/Api/DlnaServerService.cs
@@ -220,7 +220,7 @@ namespace Emby.Dlna.Api
             {
                 index++;
             }
-            else if (string.Equals(first, baseUrl))
+            else if (string.Equals(first, baseUrl.Remove(0, 1)))
             {
                 index++;
                 var second = pathInfo[1];

--- a/MediaBrowser.Api/BaseApiService.cs
+++ b/MediaBrowser.Api/BaseApiService.cs
@@ -306,7 +306,7 @@ namespace MediaBrowser.Api
             {
                 index++;
             }
-            else if (string.Equals(first, baseUrl))
+            else if (string.Equals(first, baseUrl.Remove(0, 1)))
             {
                 index++;
                 var second = pathInfo[1];


### PR DESCRIPTION
`BaseUrl` always starts with a leading `/` (unless empty), remove it before comparing.
This is a quick hotfix as I'm currently rewriting all the logic surrounding this to allow multi segment base urls.