### PR TITLE
Fix always false condition

### DIFF
--- a/MediaBrowser.Api/UserLibrary/PersonsService.cs
+++ b/MediaBrowser.Api/UserLibrary/PersonsService.cs
@@ -109,7 +109,7 @@ namespace MediaBrowser.Api.UserLibrary
                 NameContains = query.NameContains ?? query.SearchTerm
             });
 
-            if (query.IsFavorite ?? false && query.User != null)
+            if ((query.IsFavorite ?? false) && query.User != null)
             {
                 items = items.Where(i => UserDataRepository.GetUserData(query.User, i).IsFavorite).ToList();
             }


### PR DESCRIPTION
Before it would be evaluated as `query.IsFavorite ?? (false && query.User != null)`