### PR TITLE
Fix possible nullref when updating packages

### DIFF
--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="ServiceStack.Text.Core" Version="5.7.0" />
     <PackageReference Include="sharpcompress" Version="0.24.0" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="2.0.1" />
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PluginUpdateTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PluginUpdateTask.cs
@@ -52,7 +52,9 @@ namespace Emby.Server.Implementations.ScheduledTasks
         {
             progress.Report(0);
 
-            var packagesToInstall = (await _installationManager.GetAvailablePluginUpdates(cancellationToken).ConfigureAwait(false)).ToList();
+            var packagesToInstall = await _installationManager.GetAvailablePluginUpdates(cancellationToken)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             progress.Report(10);
 

--- a/MediaBrowser.Common/Updates/IInstallationManager.cs
+++ b/MediaBrowser.Common/Updates/IInstallationManager.cs
@@ -92,7 +92,7 @@ namespace MediaBrowser.Common.Updates
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The available plugin updates.</returns>
-        Task<IEnumerable<PackageVersionInfo>> GetAvailablePluginUpdates(CancellationToken cancellationToken = default);
+        IAsyncEnumerable<PackageVersionInfo> GetAvailablePluginUpdates(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Installs the package.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21289123/70181380-14773c80-16e2-11ea-9f01-5b3b05ac6976.png)

```cs
Value cannot be null. (Parameter 'source') at
System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument) at
System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable'1 source, Func'2 predicate, Boolean& found) at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable'1 source, Func'2 predicate) at Emby.Server.Implementations.Updates.InstallationManager.<>c__DisplayClass39_0.b__0(IPlugin x) in /home/pi/dev/jellyfin/Emby.Server.Implementations/Updates/InstallationManager.cs:line 203 at
System.Linq.Enumerable.SelectArrayIterator'2.MoveNext() at
System.Linq.Enumerable.WhereEnumerableIterator'1.ToList() at
System.Linq.Enumerable.ToList[TSource](IEnumerable'1 source) at
Emby.Server.Implementations.ScheduledTasks.PluginUpdateTask.Execute(CancellationToken cancellationToken, IProgress'1 progress) in /home/pi/dev/jellyfin/Emby.Server.Implementations/ScheduledTasks/Tasks/PluginUpdateTask.cs:line 55 at
Emby.Server.Implementations.ScheduledTasks.ScheduledTaskWorker.ExecuteInternal(TaskOptions options) in /home/pi/dev/jellyfin/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs:line 435
```