### PR TITLE
Add full Raspberry Pi hardware accelerated decoding support

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2529,13 +2529,25 @@ namespace MediaBrowser.Controller.MediaEncoding
                         case "h264":
                             if (_mediaEncoder.SupportsDecoder("h264_mmal") && encodingOptions.HardwareDecodingCodecs.Contains("h264", StringComparer.OrdinalIgnoreCase))
                             {
-                                return "-c:v h264_mmal";
+                                return "-c:v h264_mmal ";
                             }
                             break;
                         case "mpeg2video":
                             if (_mediaEncoder.SupportsDecoder("mpeg2_mmal") && encodingOptions.HardwareDecodingCodecs.Contains("mpeg2video", StringComparer.OrdinalIgnoreCase))
                             {
-                                return "-c:v mpeg2_mmal";
+                                return "-c:v mpeg2_mmal ";
+                            }
+                            break;
+                        case "mpeg4":
+                            if (_mediaEncoder.SupportsDecoder("mpeg4_mmal") && encodingOptions.HardwareDecodingCodecs.Contains("mpeg4", StringComparer.OrdinalIgnoreCase))
+                            {
+                                return "-c:v mpeg4_mmal ";
+                            }
+                            break;
+                        case "vc1":
+                            if (_mediaEncoder.SupportsDecoder("vc1_mmal") && encodingOptions.HardwareDecodingCodecs.Contains("vc1", StringComparer.OrdinalIgnoreCase))
+                            {
+                                return "-c:v vc1_mmal ";
                             }
                             break;
                     }

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -18,7 +18,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "h264_qsv",
             "hevc_qsv",
             "mpeg2_qsv",
+            "mpeg2_mmal",
+            "mpeg4_mmal",
             "vc1_qsv",
+            "vc1_mmal",
             "h264_cuvid",
             "hevc_cuvid",
             "dts",
@@ -26,6 +29,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "aac",
             "mp3",
             "h264",
+            "h264_mmal",
             "hevc"
         };
 


### PR DESCRIPTION
Although support to the Broadcom Multimedia Abstraction Layer [has been added to jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/pull/14) and h264_mmal [was already handled in the logic of the server](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L2530), it seems that it wasn't registered as a valid one in the validator and it's simply skipped.

This quick PR aims to add full support for all the hardware accelerated codecs that the Pi and MMAL-capable devices provides. Although it can be instantly merged, it should be considered as a WIP, as I'm still testing in my environment all the filetypes and bitrates possible.