### PR TITLE
add filesize limit for logfiles and a maximum logfile count

### DIFF
--- a/Jellyfin.Server/Resources/Configuration/logging.json
+++ b/Jellyfin.Server/Resources/Configuration/logging.json
@@ -17,6 +17,9 @@
                             "Args": {
                                 "path": "%JELLYFIN_LOG_DIR%//log_.log",
                                 "rollingInterval": "Day",
+                                "retainedFileCountLimit": 3,
+                                "rollOnFileSizeLimit": true,
+                                "fileSizeLimitBytes": 100000000,
                                 "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] {Message}{NewLine}{Exception}"
                             }
                         }


### PR DESCRIPTION
**Changes**
Adds default values to logger config by using the loggers configuration arguments.

**Issues**
Fixes #2056 
Fixes #2069 

**Detailed description**
This PR adds the following default values to the shipped logging configuration:
- 100MB filesize limit
- activates filesize based logrotation
- sets the number of retained logfiles to three

The number of the retained logfiles is derived from the default value of the logfile cleanup task that sets the age of logfiles to three days. Since the time based  logfile rotation is set to "Days" interval this would result in three logfiles to keep.

The default logfile size was chosen to ensure that limited memory devices like a raspberry can handle the logfile size with still sufficient ressources left for other processes.
Looking at personal logfile sizes of a 5 user instance with multiple day-to-day usage files range between 10MB to 30MB), a default value of 100MB should cover a large percentage of the userbase without adjustments.