### PR TITLE
added required nuget package to enable serilog based centralized logging in gelf format

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Graylog" Version="2.1.1" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.2" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3.netstandard11" Version="1.1.14" />
   </ItemGroup>


### PR DESCRIPTION
**Changes**
- added the nuget package to enable Serilog's GELF logging.

**Issues**
none

**feature requests**
[Add support for centralized logging](https://features.jellyfin.org/posts/343/add-support-for-centralized-logging)

**example configuration**
/config/logging.json
```
{
    "Serilog": {
        "MinimumLevel": "Information",
        "WriteTo": [
            {
                "Name": "Console",
                "Args": {
                    "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] {Message:lj}{NewLine}{Exception}"
                }
            },
            {
                "Name": "Graylog",
                "Args": {
                    "HostnameOrAddress": "localhost",
                    "Port": "12202",
                    "TransportType": "Udp"
                }
            }
        ]
    }
}
```

***alternative valid values:***
HostnameOrAddress can also be an IP Address like:
`"192.0.0.1"`
TransportType can also be one of these:
`"Tcp", "Http"`

**background**
The logging in Jellyfin is quite messy (read: non-uniform). This includes two Jellyfin modules logging to .txt files and the others to .log files. Also some modules use the more advanced way of enriching the log messages in a more "structured data" like way, while others don't. 

I think it would be a nice way to start a cleanup of the logger with easy way to evaluate the results.