### PR TITLE
Fix #2088

### DIFF
--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeImageProvider.cs
@@ -57,7 +57,8 @@ namespace MediaBrowser.Providers.TV.TheTVDB
                     {
                         IndexNumber = episode.IndexNumber.Value,
                         ParentIndexNumber = episode.ParentIndexNumber.Value,
-                        SeriesProviderIds = series.ProviderIds
+                        SeriesProviderIds = series.ProviderIds,
+                        SeriesDisplayOrder = series.DisplayOrder
                     };
                     string episodeTvdbId = await _tvDbClientManager
                         .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Includes `series.DisplayOrder` in call to `GetEpisodeTvdbId` to ensure series display order is used when searching for episode images.

**Issues**
Fixes #2088