### PR TITLE
4K files can have a lot higher bitrate than 35Mb/s. Increase top limit to 80

### DIFF
--- a/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Model.Dlna
                 new ResolutionConfiguration(720, 950000),
                 new ResolutionConfiguration(1280, 2500000),
                 new ResolutionConfiguration(1920, 4000000),
-                new ResolutionConfiguration(3840, 35000000)
+                new ResolutionConfiguration(3840, 80000000)
             };
 
         public static ResolutionOptions Normalize(int? inputBitrate,


### PR DESCRIPTION
There's an issue if a file has bitrate greater than 35Mbs, it will not downscale from 4K to 1080p. This fixes it.

**Issues**
#2093 