### PR TITLE
Add NVENC/CUVID >8-bit h264 fallback

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2443,8 +2443,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                     {
                         case "avc":
                         case "h264":
-                            if (_mediaEncoder.SupportsDecoder("h264_cuvid") && encodingOptions.HardwareDecodingCodecs.Contains("h264", StringComparer.OrdinalIgnoreCase))
+                            // cuvid decoder does not support >8 bits on h264, fall back onto h264.
+                            if ((videoStream.BitDepth ?? 8) > 8)
                             {
+                                encodingOptions.HardwareDecodingCodecs = Array.Empty<string>();
+                                return "-c:v h264";
+                            }
+                            else if (_mediaEncoder.SupportsDecoder("h264_cuvid") && encodingOptions.HardwareDecodingCodecs.Contains("h264", StringComparer.OrdinalIgnoreCase))
+                            {
+                                
                                 return "-c:v h264_cuvid ";
                             }
                             break;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2451,7 +2451,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                             }
                             else if (_mediaEncoder.SupportsDecoder("h264_cuvid") && encodingOptions.HardwareDecodingCodecs.Contains("h264", StringComparer.OrdinalIgnoreCase))
                             {
-                                
                                 return "-c:v h264_cuvid ";
                             }
                             break;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2444,7 +2444,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         case "avc":
                         case "h264":
                             // cuvid decoder does not support >8 bits on h264, fall back onto h264.
-                            if ((videoStream.BitDepth ?? 8) > 8)
+                            if (videoStream.BitDepth.HasValue && videoStream.BitDepth.Value > 8)
                             {
                                 encodingOptions.HardwareDecodingCodecs = Array.Empty<string>();
                                 return "-c:v h264";


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Adds a little bit of logic to EncodingHelper.cs to have CUVID (The NVIDIA decoder used in tandem with NVENC) fall back to regular software decoding (h264) when the video file is greater that 8 bit. This is helpful for allowing playback of 10-bit h264 files when NVENC is enabled for h264

This is because NVIDIA does not support greater than 8 bit h264 on ANY of their GPUs.
(According to https://devtalk.nvidia.com/default/topic/1039388/video-codec-and-optical-flow-sdk/is-there-nvidia-encoder-decoder-which-supports-hdr-10-bpp-for-avc-h-264-/)

Tested on Debian 10 with Quadro P400 on NVIDIA 430.50

The GPU will still use NVENC for the encoding, (!!!) it just will use software for the decoding. The CPU reduction from the NVENC without CUVID is about 10-20% by my informal testing

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes: #696 

