### PR TITLE
Fix Tvdb Provider Episode Search

### DIFF
--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -35,9 +35,8 @@ namespace MediaBrowser.Providers.TV.TheTVDB
         {
             var list = new List<RemoteSearchResult>();
 
-            // The search query must either provide an episode number or date
-            if (!searchInfo.IndexNumber.HasValue
-                || !searchInfo.PremiereDate.HasValue
+            // Either an episode number or date must be provided; and the dictionary of provider ids must be valid
+            if ((searchInfo.IndexNumber == null && searchInfo.PremiereDate == null)
                 || !TvdbSeriesProvider.IsValidSeries(searchInfo.SeriesProviderIds))
             {
                 return list;

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -170,11 +170,16 @@ namespace MediaBrowser.Providers.TV.TheTVDB
             return result?.Data.First().Id.ToString();
         }
 
+        /// <summary>
+        /// Check whether a dictionary of provider IDs includes an entry for a valid TV metadata provider.
+        /// </summary>
+        /// <param name="seriesProviderIds">The dictionary to check.</param>
+        /// <returns>True, if the dictionary contains a valid TV provider ID, otherwise false.</returns>
         internal static bool IsValidSeries(Dictionary<string, string> seriesProviderIds)
         {
-            return seriesProviderIds.TryGetValue(MetadataProviders.Tvdb.ToString(), out _) ||
-                   seriesProviderIds.TryGetValue(MetadataProviders.Imdb.ToString(), out _) ||
-                   seriesProviderIds.TryGetValue(MetadataProviders.Zap2It.ToString(), out _);
+            return seriesProviderIds.ContainsKey(MetadataProviders.Tvdb.ToString()) ||
+                   seriesProviderIds.ContainsKey(MetadataProviders.Imdb.ToString()) ||
+                   seriesProviderIds.ContainsKey(MetadataProviders.Zap2It.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue in `TvdbEpisodeProvider.GetSearchResults()` that was always preventing the search from executing.

**Changes**
The `GetSearchResults()` method checks to make sure either an episode number or premier date is included in the search before submitting the request, but the existing boolean logic was incorrect. I have fixed the boolean logic to correctly check for this condition.

**Issues**
Fixes: https://github.com/jellyfin/jellyfin-plugin-autoorganize/issues/13
