### PR TITLE
Fix invalid username handling

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1396,7 +1396,6 @@ namespace Emby.Server.Implementations.Session
             if (user == null)
             {
                 AuthenticationFailed?.Invoke(this, new GenericEventArgs<AuthenticationRequest>(request));
-
                 throw new SecurityException("Invalid user or password entered.");
             }
 

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1393,6 +1393,13 @@ namespace Emby.Server.Implementations.Session
                 }
             }
 
+            if (user == null)
+            {
+                AuthenticationFailed?.Invoke(this, new GenericEventArgs<AuthenticationRequest>(request));
+
+                throw new SecurityException("Invalid user or password entered.");
+            }
+
             if (enforcePassword)
             {
                 user = await _userManager.AuthenticateUser(
@@ -1401,13 +1408,6 @@ namespace Emby.Server.Implementations.Session
                     request.PasswordSha1,
                     request.RemoteEndPoint,
                     true).ConfigureAwait(false);
-            }
-
-            if (user == null)
-            {
-                AuthenticationFailed?.Invoke(this, new GenericEventArgs<AuthenticationRequest>(request));
-
-                throw new SecurityException("Invalid user or password entered.");
             }
 
             var token = GetAuthorizationToken(user, request.DeviceId, request.App, request.AppVersion, request.DeviceName);


### PR DESCRIPTION
`AuthenticateUser()` errors if `user` is `null` so the checks should be before that
