### PR TITLE
Fix playlist deletion and a few warning fixes

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -392,7 +392,7 @@ namespace Emby.Server.Implementations.Library
                 // Add this flag to GetDeletePaths if required in the future
                 var isRequiredForDelete = true;
 
-                 foreach (var fileSystemInfo in item.GetDeletePaths())
+                foreach (var fileSystemInfo in item.GetDeletePaths())
                 {
                     if (fileSystemInfo.IsDirectory ? Directory.Exists(fileSystemInfo.FullName) : File.Exists(fileSystemInfo.FullName))
                     {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -394,7 +394,7 @@ namespace Emby.Server.Implementations.Library
 
                 foreach (var fileSystemInfo in item.GetDeletePaths())
                 {
-                    if (fileSystemInfo.IsDirectory ? Directory.Exists(fileSystemInfo.FullName) : File.Exists(fileSystemInfo.FullName))
+                    if (Directory.Exists(fileSystemInfo.FullName) || File.Exists(fileSystemInfo.FullName))
                     {
                         try
                         {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -392,9 +392,9 @@ namespace Emby.Server.Implementations.Library
                 // Add this flag to GetDeletePaths if required in the future
                 var isRequiredForDelete = true;
 
-                foreach (var fileSystemInfo in item.GetDeletePaths().ToList())
+                 foreach (var fileSystemInfo in item.GetDeletePaths())
                 {
-                    if (File.Exists(fileSystemInfo.FullName) || Directory.Exists(fileSystemInfo.FullName))
+                    if (fileSystemInfo.IsDirectory ? Directory.Exists(fileSystemInfo.FullName) : File.Exists(fileSystemInfo.FullName))
                     {
                         try
                         {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -394,7 +394,7 @@ namespace Emby.Server.Implementations.Library
 
                 foreach (var fileSystemInfo in item.GetDeletePaths().ToList())
                 {
-                    if (File.Exists(fileSystemInfo.FullName))
+                    if (File.Exists(fileSystemInfo.FullName) || Directory.Exists(fileSystemInfo.FullName))
                     {
                         try
                         {

--- a/MediaBrowser.Api/Library/LibraryService.cs
+++ b/MediaBrowser.Api/Library/LibraryService.cs
@@ -1006,8 +1006,8 @@ namespace MediaBrowser.Api.Library
         public void Delete(DeleteItems request)
         {
             var ids = string.IsNullOrWhiteSpace(request.Ids)
-             ? Array.Empty<string>()
-             : request.Ids.Split(',');
+                ? Array.Empty<string>()
+                : request.Ids.Split(',');
 
             foreach (var i in ids)
             {
@@ -1028,7 +1028,6 @@ namespace MediaBrowser.Api.Library
                 _libraryManager.DeleteItem(item, new DeleteOptions
                 {
                     DeleteFileLocation = true
-
                 }, true);
             }
         }


### PR DESCRIPTION
Playlists are stored in directories, but there was a check for `File.Exists()` which doesn't return true for folders. @Bond-009 I tracked the issue back to a [commit](https://github.com/jellyfin/jellyfin/commit/ffe79c89829fb232e8ccb4ae4caf4b732ce51600) you made in January. I'm guessing this is the source of most of our deletion issues so we might need to go through and fix all the other changes from that commit and any similar changes.