### PR TITLE
Add Tmdb as a Provider for Season Images

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@
  - [fhriley](https://github.com/fhriley)
  - [nevado](https://github.com/nevado)
  - [mark-monteiro](https://github.com/mark-monteiro)
+ - [ullmie02](https://github.com/ullmie02)
 
 # Emby Contributors
 

--- a/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -55,8 +55,6 @@ namespace MediaBrowser.Providers.Tmdb.TV
 
             var seriesId = series != null ? series.GetProviderId(MetadataProviders.Tmdb) : null;
 
-            var list = new List<RemoteImageInfo>();
-
             if (string.IsNullOrEmpty(seriesId))
             {
                 return Enumerable.Empty<RemoteImageInfo>();
@@ -77,7 +75,7 @@ namespace MediaBrowser.Providers.Tmdb.TV
 
             var tmdbImageUrl = tmdbSettings.images.GetImageUrl("original");
 
-            list.AddRange(results.Select(i => new RemoteImageInfo
+            var list = results.Select(i => new RemoteImageInfo
             {
                 Url = tmdbImageUrl + i.File_Path,
                 CommunityRating = i.Vote_Average,
@@ -88,8 +86,7 @@ namespace MediaBrowser.Providers.Tmdb.TV
                 ProviderName = Name,
                 Type = ImageType.Primary,
                 RatingType = RatingType.Score
-            }).ToList());
-
+            }).ToList();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 

--- a/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -59,14 +59,14 @@ namespace MediaBrowser.Providers.Tmdb.TV
 
             if (string.IsNullOrEmpty(seriesId))
             {
-                return list;
+                return Enumerable.Empty<RemoteImageInfo>();
             }
 
             var seasonNumber = season.IndexNumber;
 
             if (!seasonNumber.HasValue)
             {
-                return list;
+                return Enumerable.Empty<RemoteImageInfo>();
             }
 
             var language = item.GetPreferredMetadataLanguage();
@@ -88,7 +88,7 @@ namespace MediaBrowser.Providers.Tmdb.TV
                 ProviderName = Name,
                 Type = ImageType.Primary,
                 RatingType = RatingType.Score
-            }));
+            }).ToList());
 
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);

--- a/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Providers;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Providers.Tmdb.Models.General;
+using MediaBrowser.Providers.Tmdb.Movies;
+
+namespace MediaBrowser.Providers.Tmdb.TV
+{
+    public class TmdbSeasonImageProvider : IRemoteImageProvider, IHasOrder
+    {
+        private readonly IJsonSerializer _jsonSerializer;
+        private readonly IHttpClient _httpClient;
+        private readonly IFileSystem _fileSystem;
+        private readonly ILocalizationManager _localization;
+
+        public TmdbSeasonImageProvider(IJsonSerializer jsonSerializer, IHttpClient httpClient, IFileSystem fileSystem, ILocalizationManager localization)
+        {
+            _jsonSerializer = jsonSerializer;
+            _httpClient = httpClient;
+            _fileSystem = fileSystem;
+            _localization = localization;
+        }
+
+        public int Order => 1;
+
+        public string Name => ProviderName;
+
+        public static string ProviderName => TmdbUtils.ProviderName;
+
+        public Task<HttpResponseInfo> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _httpClient.GetResponse(new HttpRequestOptions
+            {
+                CancellationToken = cancellationToken,
+                Url = url
+            });
+        }
+
+        public async Task<IEnumerable<RemoteImageInfo>> GetImages(BaseItem item, CancellationToken cancellationToken)
+        {
+            var season = (Season)item;
+            var series = season.Series;
+
+            var seriesId = series != null ? series.GetProviderId(MetadataProviders.Tmdb) : null;
+
+            var list = new List<RemoteImageInfo>();
+
+            if (string.IsNullOrEmpty(seriesId))
+            {
+                return list;
+            }
+
+            var seasonNumber = season.IndexNumber;
+
+            if (!seasonNumber.HasValue)
+            {
+                return list;
+            }
+
+            var language = item.GetPreferredMetadataLanguage();
+
+            var results = await FetchImages(season, seriesId, language, _jsonSerializer, cancellationToken).ConfigureAwait(false);
+
+            var tmdbSettings = await TmdbMovieProvider.Current.GetTmdbSettings(cancellationToken).ConfigureAwait(false);
+
+            var tmdbImageUrl = tmdbSettings.images.GetImageUrl("original");
+
+            list.AddRange(results.Select(i => new RemoteImageInfo
+            {
+                Url = tmdbImageUrl + i.File_Path,
+                CommunityRating = i.Vote_Average,
+                VoteCount = i.Vote_Count,
+                Width = i.Width,
+                Height = i.Height,
+                Language = TmdbMovieProvider.AdjustImageLanguage(i.Iso_639_1, language),
+                ProviderName = Name,
+                Type = ImageType.Primary,
+                RatingType = RatingType.Score
+            }));
+
+
+            var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
+
+            return list.OrderByDescending(i =>
+            {
+                if (string.Equals(language, i.Language, StringComparison.OrdinalIgnoreCase))
+                {
+                    return 3;
+                }
+                if (!isLanguageEn)
+                {
+                    if (string.Equals("en", i.Language, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return 2;
+                    }
+                }
+                if (string.IsNullOrEmpty(i.Language))
+                {
+                    return isLanguageEn ? 3 : 2;
+                }
+                return 0;
+            })
+                .ThenByDescending(i => i.CommunityRating ?? 0)
+                .ThenByDescending(i => i.VoteCount ?? 0);
+        }
+
+        private async Task<List<Poster>> FetchImages(Season item, string tmdbId, string language, IJsonSerializer jsonSerializer,
+            CancellationToken cancellationToken)
+        {
+            await TmdbSeasonProvider.Current.EnsureSeasonInfo(tmdbId, item.IndexNumber.GetValueOrDefault(), language, cancellationToken).ConfigureAwait(false);
+
+            var path = TmdbSeriesProvider.Current.GetDataFilePath(tmdbId, language);
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                var fileInfo = _fileSystem.GetFileInfo(path);
+
+                if (fileInfo.Exists)
+                {
+                    return jsonSerializer.DeserializeFromFile<Models.TV.SeasonResult>(path).Images.Posters;
+                }
+            }
+
+            return null;
+        }
+
+        public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
+        {
+            return new List<ImageType>
+            {
+                ImageType.Primary
+            };
+        }
+
+        public bool Supports(BaseItem item)
+        {
+            return item is Season;
+        }
+    }
+}

--- a/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -50,7 +50,7 @@ namespace MediaBrowser.Providers.Tmdb.TV
             var season = (Season)item;
             var series = season.Series;
 
-            var seriesId = series != null ? series.GetProviderId(MetadataProviders.Tmdb) : null;
+            var seriesId = series?.GetProviderId(MetadataProviders.Tmdb);
 
             if (string.IsNullOrEmpty(seriesId))
             {

--- a/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Tmdb/TV/TmdbSeasonProvider.cs
@@ -32,6 +32,8 @@ namespace MediaBrowser.Providers.Tmdb.TV
         private readonly ILocalizationManager _localization;
         private readonly ILogger _logger;
 
+        internal static TmdbSeasonProvider Current { get; private set; }
+
         public TmdbSeasonProvider(IHttpClient httpClient, IServerConfigurationManager configurationManager, IFileSystem fileSystem, ILocalizationManager localization, IJsonSerializer jsonSerializer, ILoggerFactory loggerFactory)
         {
             _httpClient = httpClient;
@@ -40,6 +42,7 @@ namespace MediaBrowser.Providers.Tmdb.TV
             _localization = localization;
             _jsonSerializer = jsonSerializer;
             _logger = loggerFactory.CreateLogger(GetType().Name);
+            Current = this;
         }
 
         public async Task<MetadataResult<Season>> GetMetadata(SeasonInfo info, CancellationToken cancellationToken)


### PR DESCRIPTION
**Changes**
Adds TheMovieDb as a provider for the TV Season Posters. As I am very new to this project, I looked up how things are done in the Series Provider and added the Provider for Seasons accordingly.

**Issues**
Fixes #1034 