### PR TITLE
Add check if output container supports "global_header" flag

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2750,6 +2750,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 args += " -mpegts_m2ts_mode 1";
             }
 
+            var supportsGlobalHeaderFlag = state.OutputContainer != "mkv";
+
             if (string.Equals(videoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
                 if (state.VideoStream != null
@@ -2770,7 +2772,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (!state.RunTimeTicks.HasValue)
                 {
-                    args += " -flags -global_header -fflags +genpts";
+                    if(supportsGlobalHeaderFlag)
+                    {
+                        args += " -flags -global_header";
+                    }
+
+                    args += " -fflags +genpts";
                 }
             }
             else
@@ -2816,7 +2823,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     args += " " + qualityParam.Trim();
                 }
 
-                if (!state.RunTimeTicks.HasValue)
+                if (supportsGlobalHeaderFlag && !state.RunTimeTicks.HasValue)
                 {
                     args += " -flags -global_header";
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2750,8 +2750,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 args += " -mpegts_m2ts_mode 1";
             }
 
-            var supportsGlobalHeaderFlag = state.OutputContainer != "mkv";
-
             if (string.Equals(videoCodec, "copy", StringComparison.OrdinalIgnoreCase))
             {
                 if (state.VideoStream != null
@@ -2772,11 +2770,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (!state.RunTimeTicks.HasValue)
                 {
-                    if(supportsGlobalHeaderFlag)
-                    {
-                        args += " -flags -global_header";
-                    }
-
                     args += " -fflags +genpts";
                 }
             }
@@ -2821,11 +2814,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (!string.IsNullOrEmpty(qualityParam))
                 {
                     args += " " + qualityParam.Trim();
-                }
-
-                if (supportsGlobalHeaderFlag && !state.RunTimeTicks.HasValue)
-                {
-                    args += " -flags -global_header";
                 }
             }
 


### PR DESCRIPTION
**Changes**
The "mkv" container apparently does not support the "global_header" flag. This PR adds a small check if the container supports the flag and does not add it if it's not supported. This is mostly relevant when using the Live TV feature on Android.

**Issues**
Fix #1945
