### PR TITLE
Let HLS fallback to mpegts in case device reports unsupported container

### DIFF
--- a/MediaBrowser.Api/Playback/UniversalAudioService.cs
+++ b/MediaBrowser.Api/Playback/UniversalAudioService.cs
@@ -301,6 +301,7 @@ namespace MediaBrowser.Api.Playback
                 var transcodingProfile = deviceProfile.TranscodingProfiles[0];
 
                 // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
+                // TODO: remove this when we switch back to the segment muxer
                 var supportedHLSContainers = new string[] { "mpegts", "fmp4" };
 
                 var newRequest = new GetMasterHlsAudioPlaylist

--- a/MediaBrowser.Api/Playback/UniversalAudioService.cs
+++ b/MediaBrowser.Api/Playback/UniversalAudioService.cs
@@ -300,8 +300,8 @@ namespace MediaBrowser.Api.Playback
 
                 var transcodingProfile = deviceProfile.TranscodingProfiles[0];
 
-                //HLS Segment container can only be mpegts or fmp4 per ffmpeg documentation
-                var supoortedHLSContainer = new string[] { "mpegts", "fmp4" };
+                // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
+                var supportedHLSContainers = new string[] { "mpegts", "fmp4" };
 
                 var newRequest = new GetMasterHlsAudioPlaylist
                 {
@@ -315,8 +315,8 @@ namespace MediaBrowser.Api.Playback
                     PlaySessionId = playbackInfoResult.PlaySessionId,
                     StartTimeTicks = request.StartTimeTicks,
                     Static = isStatic,
-                    //fallback to mpegts if device reports some wierd value that is not supported by HLS
-                    SegmentContainer = Array.Exists(supoortedHLSContainer, element => element == request.TranscodingContainer) ? request.TranscodingContainer : "mpegts",
+                    // fallback to mpegts if device reports some weird value unsupported by hls
+                    SegmentContainer = Array.Exists(supportedHLSContainers, element => element == request.TranscodingContainer) ? request.TranscodingContainer : "mpegts",
                     AudioSampleRate = request.MaxAudioSampleRate,
                     MaxAudioBitDepth = request.MaxAudioBitDepth,
                     BreakOnNonKeyFrames = transcodingProfile.BreakOnNonKeyFrames,

--- a/MediaBrowser.Api/Playback/UniversalAudioService.cs
+++ b/MediaBrowser.Api/Playback/UniversalAudioService.cs
@@ -300,6 +300,9 @@ namespace MediaBrowser.Api.Playback
 
                 var transcodingProfile = deviceProfile.TranscodingProfiles[0];
 
+                //HLS Segment container can only be mpegts or fmp4 per ffmpeg documentation
+                var supoortedHLSContainer = new string[] { "mpegts", "fmp4" };
+
                 var newRequest = new GetMasterHlsAudioPlaylist
                 {
                     AudioBitRate = isStatic ? (int?)null : Convert.ToInt32(Math.Min(request.MaxStreamingBitrate ?? 192000, int.MaxValue)),
@@ -312,7 +315,8 @@ namespace MediaBrowser.Api.Playback
                     PlaySessionId = playbackInfoResult.PlaySessionId,
                     StartTimeTicks = request.StartTimeTicks,
                     Static = isStatic,
-                    SegmentContainer = request.TranscodingContainer,
+                    //fallback to mpegts if device reports some wierd value that is not supported by HLS
+                    SegmentContainer = Array.Exists(supoortedHLSContainer, element => element == request.TranscodingContainer) ? request.TranscodingContainer : "mpegts",
                     AudioSampleRate = request.MaxAudioSampleRate,
                     MaxAudioBitDepth = request.MaxAudioBitDepth,
                     BreakOnNonKeyFrames = transcodingProfile.BreakOnNonKeyFrames,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR will fallback the segment container to `mpegts` if the device reports a invalid container format. This fixes transcoded music playback on some devices (particularly Apple devices).  For more details please refer to the issue below.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2214
