### PR TITLE
Re-order the path statement to avoid file issues

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -109,7 +109,7 @@ namespace Emby.Server.Implementations.IO
             }
             try
             {
-                return Path.Combine(Path.GetFullPath(folderPath), filePath);
+                return Path.GetFullPath(Path.Combine(folderPath, filePath));
             }
             catch (ArgumentException)
             {


### PR DESCRIPTION

**Changes**
Re-orders the path statement to achieve the correct result.

Assuming:
```c#
string folderPath = "/Volumes/Library/Sample/Music/Playlists/";
string filePath = "../Beethoven/Misc/Moonlight Sonata.mp3";
```
The result before:
`/Volumes/Library/Sample/Music/Playlists/../Beethoven/Misc/Moonlight Sonata.mp3`

The new result:
`/Volumes/Library/Sample/Music/Beethoven/Misc/Moonlight Sonata.mp3`

This returns the output to what it was in 10.3.7 and older, prior to #1168.


**Issues**
Fixes #1874.
