### PR TITLE
add support for AMD AMF hardware encoding on Windows & Linux

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2644,8 +2644,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
                     else
                     {
-                        //h264_amf is now supported on linux with 'amdgpu-pro' installed and '--enable-amf' when compiling ffmpeg
-                        //using vaapi decode and h264_amf encode on linux platform can avoid some weird transcoding errors in h264_vaapi with amd gpu
                         return "-hwaccel vaapi";
                     }
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2642,22 +2642,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                         else
                             return "-hwaccel dxva2";
                     }
-
-                    switch (videoStream.Codec.ToLowerInvariant())
+                    else
                     {
-                        case "avc":
-                        case "h264":
-                            if (_mediaEncoder.SupportsDecoder("h264_amf") && encodingOptions.HardwareDecodingCodecs.Contains("h264", StringComparer.OrdinalIgnoreCase))
-                            {
-                                return "-c:v h264_amf";
-                            }
-                            break;
-                        case "mpeg2video":
-                            if (_mediaEncoder.SupportsDecoder("hevc_amf") && encodingOptions.HardwareDecodingCodecs.Contains("mpeg2video", StringComparer.OrdinalIgnoreCase))
-                            {
-                                return "-c:v mpeg2_mmal";
-                            }
-                            break;
+                        //h264_amf is now supported on linux with 'amdgpu-pro' installed and '--enable-amf' when compiling ffmpeg
+                        //using vaapi decode and h264_amf encode on linux platform can avoid some weird transcoding errors in h264_vaapi with amd gpu
+                        return "-hwaccel vaapi";
                     }
                 }
             }

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -56,8 +56,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "hevc_vaapi",
             "h264_v4l2m2m",
             "ac3",
-			"h264_amf",
-			"hevc_amf"
+            "h264_amf",
+            "hevc_amf"
         };
 
         // Try and use the individual library versions to determine a FFmpeg version

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -55,7 +55,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "h264_vaapi",
             "hevc_vaapi",
             "h264_v4l2m2m",
-            "ac3"
+            "ac3",
+			"h264_amf",
+			"hevc_amf"
         };
 
         // Try and use the individual library versions to determine a FFmpeg version


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
1) Add support for AMD AMF hardware encoding on Windows and Linux which can reduce cpu usage instead of using default libx264 in ffmpeg.
2) h264_amf is [now supported on linux](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4#issuecomment-572301302) with ['amdgpu-pro'](https://amdgpu-install.readthedocs.io/en/latest/) installed and '--enable-amf' when compiling [ffmpeg](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/f8ad2ddd7a51df5d6e768ba2a6f65ee64b94e29b).
3) Using vaapi decode and h264_amf encode on linux platform can avoid some weird transcoding [errors in h264_vaapi with amd gpu](https://github.com/jellyfin/jellyfin/issues/1527).

It works like [this](https://imgur.com/Q3GrwkS) on windows now.
ffmpeg h264_amf on linux encoding succeed [logs](https://raw.githubusercontent.com/nyanmisaka/notepad/master/ffmpeg_h264_amf_on_linux_log?token=ADSCUQFAXHGMECH37SDK6EC6ERPD6) 


**Fixes**
issue #1420

<!-- Describe your changes here in 1-5 sentences. -->

