### PR TITLE
Fix pagination for DLNA root folder list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@
  - [nevado](https://github.com/nevado)
  - [mark-monteiro](https://github.com/mark-monteiro)
  - [ullmie02](https://github.com/ullmie02)
+ - [pR0Ps](https://github.com/pR0Ps)
 
 # Emby Contributors
 

--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -771,11 +771,11 @@ namespace Emby.Dlna.ContentDirectory
                 })
                 .ToArray();
 
-            return new QueryResult<ServerItem>
+            return ApplyPaging(new QueryResult<ServerItem>
             {
                 Items = folders,
                 TotalRecordCount = folders.Length
-            };
+            }, startIndex, limit);
         }
 
         private QueryResult<ServerItem> GetTvFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)


### PR DESCRIPTION
Previously, when responding to a DLNA "Browse" request, the `StartingIndex` was not respected and all of the root items were returned each time. This caused infinite loops with in DLNA clients that ignored the `TotalMatches` data in the response and just continued asking for the next page until they got an empty response.

This fix makes the root folder list respect the `StartingIndex` and `RequestedCount` parameters like all other responses.

Fixes issue #2303