### PR TITLE
Fix another issue with DLNA responses not properly paginating

### DIFF
--- a/MediaBrowser.Controller/Entities/UserRootFolder.cs
+++ b/MediaBrowser.Controller/Entities/UserRootFolder.cs
@@ -60,14 +60,7 @@ namespace MediaBrowser.Controller.Entities
                 PresetViews = query.PresetViews
             });
 
-            var itemsArray = result;
-            var totalCount = itemsArray.Length;
-
-            return new QueryResult<BaseItem>
-            {
-                TotalRecordCount = totalCount,
-                Items = itemsArray //TODO Fix The co-variant conversion between Folder[] and BaseItem[], this can generate runtime issues.
-            };
+            return UserViewBuilder.SortAndPage(result, null, query, LibraryManager, true);
         }
 
         public override int GetChildCount(User user)


### PR DESCRIPTION
The `UserRootFolder.GetItemsInternal` method now applies any sorting and
pagination requested by the `InternalItemsQuery` that was passed to it.

Previous pagination fix: #2304
Original issue #2303
