### PR TITLE
Fix broken webserver caused by dotnet publish. Temp Fix for #2255

### DIFF
--- a/deployment/linux-x64/docker-build.sh
+++ b/deployment/linux-x64/docker-build.sh
@@ -26,7 +26,7 @@ rm -rf ${web_build_dir}
 version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 
 # Build archives
-dotnet publish --configuration Release --self-contained --runtime linux-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime linux-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
 tar -cvzf /jellyfin_${version}.portable.tar.gz -C /dist jellyfin_${version}
 rm -rf /dist/jellyfin_${version}
 

--- a/deployment/macos/docker-build.sh
+++ b/deployment/macos/docker-build.sh
@@ -26,7 +26,7 @@ rm -rf ${web_build_dir}
 version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 
 # Build archives
-dotnet publish --configuration Release --self-contained --runtime osx-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
 tar -cvzf /jellyfin_${version}.portable.tar.gz -C /dist jellyfin_${version}
 rm -rf /dist/jellyfin_${version}
 

--- a/deployment/portable/docker-build.sh
+++ b/deployment/portable/docker-build.sh
@@ -26,7 +26,7 @@ rm -rf ${web_build_dir}
 version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 
 # Build archives
-dotnet publish --configuration Release --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"
+dotnet publish Jellyfin.Server --configuration Release --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"
 tar -cvzf /jellyfin_${version}.portable.tar.gz -C /dist jellyfin_${version}
 rm -rf /dist/jellyfin_${version}
 

--- a/deployment/win-x64/docker-build.sh
+++ b/deployment/win-x64/docker-build.sh
@@ -32,7 +32,7 @@ rm -rf ${web_build_dir}
 version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 
 # Build binary
-dotnet publish --configuration Release --self-contained --runtime win-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime win-x64 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
 
 # Prepare addins
 addin_build_dir="$( mktemp -d )"

--- a/deployment/win-x86/docker-build.sh
+++ b/deployment/win-x86/docker-build.sh
@@ -32,7 +32,7 @@ rm -rf ${web_build_dir}
 version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 
 # Build binary
-dotnet publish --configuration Release --self-contained --runtime win-x86 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime win-x86 --output /dist/jellyfin_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"
 
 # Prepare addins
 addin_build_dir="$( mktemp -d )"


### PR DESCRIPTION
This should be considered a temp fix, as it fixes the symptom and not
the actual root cause of the issue. Why this works? I *feel like* this is
a dependency issue and this change forces it to evaluate dependency's in a
different order, avoiding the bug.

