### PR TITLE
Fix framerate info not showing when mediasource is in H264 format.

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -146,7 +146,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (framerate.HasValue || percent.HasValue)
             {
-                state.ReportTranscodingProgress(transcodingPosition, 0, percent, 0, bitRate);
+                state.ReportTranscodingProgress(transcodingPosition, framerate, percent, bytesTranscoded, bitRate);
             }
         }
     }

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -90,7 +90,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         framerate = val;
                     }
                 }
-                else if (part.Contains("fps=", StringComparison.OrdinalIgnoreCase))
+                else if (part.StartsWith("fps=", StringComparison.OrdinalIgnoreCase))
                 {
                     var rate = part.Split(new[] { '=' }, 2).Last();
 

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -90,6 +90,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                         framerate = val;
                     }
                 }
+                else if (part.Contains("fps=", StringComparison.OrdinalIgnoreCase))
+                {
+                    var rate = part.Split(new[] { '=' }, 2).Last();
+
+                    if (float.TryParse(rate, NumberStyles.Any, _usCulture, out var val))
+                    {
+                        framerate = val;
+                    }
+                }
                 else if (state.RunTimeTicks.HasValue &&
                     part.StartsWith("time=", StringComparison.OrdinalIgnoreCase))
                 {

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -92,7 +92,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
                 else if (part.StartsWith("fps=", StringComparison.OrdinalIgnoreCase))
                 {
-                    var rate = part.Split(new[] { '=' }, 2).Last();
+                    var rate = part.Split(new[] { '=' }, 2)[^1];
 
                     if (float.TryParse(rate, NumberStyles.Any, _usCulture, out var val))
                     {


### PR DESCRIPTION
**Changes**
Fixed an issue that when the media source is in H264 format and the frame rate info is not displayed due to missing space characters in ffmpeg log.
