### PR TITLE
Add Some XML Documentation

### DIFF
--- a/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
+++ b/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
@@ -1,6 +1,3 @@
-#pragma warning disable CS1591
-#pragma warning disable SA1600
-
 using System;
 using System.Collections.Generic;
 

--- a/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
+++ b/MediaBrowser.Common/Configuration/IConfigurationFactory.cs
@@ -6,20 +6,45 @@ using System.Collections.Generic;
 
 namespace MediaBrowser.Common.Configuration
 {
+    /// <summary>
+    /// Provides an interface to retrieve a configuration store. Classes with this interface are scanned for at
+    /// application start to dynamically register configuration for various modules/plugins.
+    /// </summary>
     public interface IConfigurationFactory
     {
+        /// <summary>
+        /// Get the configuration store for this module.
+        /// </summary>
+        /// <returns>The configuration store.</returns>
         IEnumerable<ConfigurationStore> GetConfigurations();
     }
 
+    /// <summary>
+    /// Describes a single entry in the application configuration.
+    /// </summary>
     public class ConfigurationStore
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the configuration.
+        /// </summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type used to store the data for this configuration entry.
+        /// </summary>
         public Type ConfigurationType { get; set; }
     }
 
+    /// <summary>
+    /// A configuration store that can be validated.
+    /// </summary>
     public interface IValidatingConfiguration
     {
+        /// <summary>
+        /// Validation method to be invoked before saving the configuration.
+        /// </summary>
+        /// <param name="oldConfig">The old configuration.</param>
+        /// <param name="newConfig">The new configuration.</param>
         void Validate(object oldConfig, object newConfig);
     }
 }

--- a/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
+++ b/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
@@ -6,7 +6,7 @@ namespace MediaBrowser.Controller.Plugins
     /// <summary>
     /// Represents an entry point for a module in the application. This interface is scanned for automatically and
     /// provides a hook to initialize the module at application start.
-    /// The entry point can additionally be flagged as a pre-startup task by applying the
+    /// The entry point can additionally be flagged as a pre-startup task by implementing the
     /// <see cref="IRunBeforeStartup"/> interface.
     /// </summary>
     public interface IServerEntryPoint : IDisposable

--- a/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
+++ b/MediaBrowser.Controller/Plugins/IServerEntryPoint.cs
@@ -4,16 +4,22 @@ using System.Threading.Tasks;
 namespace MediaBrowser.Controller.Plugins
 {
     /// <summary>
-    /// Interface IServerEntryPoint
+    /// Represents an entry point for a module in the application. This interface is scanned for automatically and
+    /// provides a hook to initialize the module at application start.
+    /// The entry point can additionally be flagged as a pre-startup task by applying the
+    /// <see cref="IRunBeforeStartup"/> interface.
     /// </summary>
     public interface IServerEntryPoint : IDisposable
     {
         /// <summary>
-        /// Runs this instance.
+        /// Run the initialization for this module. This method is invoked at application start.
         /// </summary>
         Task RunAsync();
     }
 
+    /// <summary>
+    /// Indicates that a <see cref="IServerEntryPoint"/> should be invoked as a pre-startup task.
+    /// </summary>
     public interface IRunBeforeStartup
     {
 

--- a/MediaBrowser.Model/Services/ApiMemberAttribute.cs
+++ b/MediaBrowser.Model/Services/ApiMemberAttribute.cs
@@ -1,6 +1,3 @@
-#pragma warning disable CS1591
-#pragma warning disable SA1600
-
 using System;
 
 namespace MediaBrowser.Model.Services

--- a/MediaBrowser.Model/Services/ApiMemberAttribute.cs
+++ b/MediaBrowser.Model/Services/ApiMemberAttribute.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace MediaBrowser.Model.Services
 {
+    /// <summary>
+    /// Identifies a single API endpoint.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
     public class ApiMemberAttribute : Attribute
     {


### PR DESCRIPTION
Some small additions to XML documentation. I documented these classes while working on a separate task for the auto-organize plugin.

**Changes**
Adds\updates XML documentation for `IConfigurationFactory`, `IServerEntryPoint ` and `ApiMemberAttribute `

**Issues**
Not related to any issue
