### PR TITLE
Another baseurl related fix

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1522,7 +1522,7 @@ namespace Emby.Server.Implementations
             string baseUrl = ServerConfigurationManager.Configuration.BaseUrl;
             if (baseUrl.Length != 0)
             {
-                url.Append('/').Append(baseUrl);
+                url.Append(baseUrl);
             }
 
             return url.ToString();

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -165,6 +165,7 @@ namespace MediaBrowser.Model.Configuration
         public bool SkipDeserializationForBasicTypes { get; set; }
 
         public string ServerName { get; set; }
+
         public string BaseUrl
         {
             get => _baseUrl;


### PR DESCRIPTION
Baseurl always starts with a '/' (unless it's empty)

Fixes the error from #2380 (Don't know if it fixes the issue)