### PR TITLE
Rework ParseLogLine in JobLogger

### DIFF
--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -250,15 +250,30 @@ namespace MediaBrowser.Api
 
                 _activeTranscodingJobs.Add(job);
 
-                ReportTranscodingProgress(job, state, null, null, null, null, null);
+                ReportTranscodingProgress(job, state, null, null, null, null);
 
                 return job;
             }
         }
 
-        public void ReportTranscodingProgress(TranscodingJob job, StreamState state, TimeSpan? transcodingPosition, float? framerate, double? percentComplete, long? bytesTranscoded, int? bitRate)
+        public void ReportTranscodingProgress(TranscodingJob job, StreamState state, TimeSpan? transcodingPosition, float? framerate, long? bytesTranscoded, int? bitRate)
         {
             var ticks = transcodingPosition.HasValue ? transcodingPosition.Value.Ticks : (long?)null;
+
+            double? percentComplete = null;
+            if (transcodingPosition.HasValue)
+            {
+                var startMs = state.BaseRequest.StartTimeTicks.HasValue
+                    ? TimeSpan.FromTicks(state.BaseRequest.StartTimeTicks.Value).TotalMilliseconds
+                    : 0;
+
+                var totalMs = state.RunTimeTicks.HasValue
+                    ? TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalMilliseconds
+                    : 0;
+
+                var currentMs = startMs + transcodingPosition.Value.TotalMilliseconds;
+                percentComplete = 100.0 * currentMs / totalMs;
+            }
 
             if (job != null)
             {

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -285,7 +285,7 @@ namespace MediaBrowser.Api.Playback
             state.TranscodingJob = transcodingJob;
 
             // Important - don't await the log task or we won't be able to kill ffmpeg when the user stops playback
-            _ = new JobLogger(Logger).StartStreamingLog(state, process.StandardError.BaseStream, logStream);
+            _ = new FFmpegJobLogger(Logger).StartStreamingLog(process.StandardError.BaseStream, logStream, state.ReportTranscodingProgress);
 
             // Wait for the file to exist before proceeeding
             var ffmpegTargetFile = state.WaitForPath ?? outputPath;

--- a/MediaBrowser.Api/Playback/StreamState.cs
+++ b/MediaBrowser.Api/Playback/StreamState.cs
@@ -103,9 +103,9 @@ namespace MediaBrowser.Api.Playback
             _mediaSourceManager = mediaSourceManager;
         }
 
-        public override void ReportTranscodingProgress(TimeSpan? transcodingPosition, float? framerate, double? percentComplete, long? bytesTranscoded, int? bitRate)
+        public override void ReportTranscodingProgress(TimeSpan? transcodingPosition, float? framerate, long? bytesTranscoded, int? bitRate)
         {
-            ApiEntryPoint.Instance.ReportTranscodingProgress(TranscodingJob, this, transcodingPosition, framerate, percentComplete, bytesTranscoded, bitRate);
+            ApiEntryPoint.Instance.ReportTranscodingProgress(TranscodingJob, this, transcodingPosition, framerate, bytesTranscoded, bitRate);
         }
 
         public void Dispose()

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -663,11 +663,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return count;
         }
-
-        public IProgress<double> Progress { get; set; }
-        public virtual void ReportTranscodingProgress(TimeSpan? transcodingPosition, float? framerate, double? percentComplete, long? bytesTranscoded, int? bitRate)
+        public virtual void ReportTranscodingProgress(TimeSpan? transcodingPosition, float? framerate, long? bytesTranscoded, int? bitRate)
         {
-            Progress.Report(percentComplete.Value);
+
         }
     }
 


### PR DESCRIPTION
**Changes**
FFmpeg log progress parsing was re-implemented with the following motivations:

- reduce logic complexity
- enhance maintainability
- enable easier adaptions
- separate concerns (parse only the progress)
- reduce SLOC
- optimize performance

Motivation is **not** to fully re-implement the whole progress infrastructure as mentioned in https://github.com/jellyfin/jellyfin/pull/2368. This should be part of a newly designed transcoding infrastructure.

I tried several implementations which very highly optimized, but unfortunately all being too complex to maintain. This is why I came up with this solution.
The existing implementation is already very performant due to it's optimized operations in parameter splitting and comparing.

Here are the results, which compares the new `ParseLogLine` to the existing implementation. 
For a fair comparison all references of the `EncodingJobInfo` of the existing `ParseLogLine` were removed for the benchmark test.

```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Pentium Silver N5000 CPU 1.10GHz, 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  Job-KQNYII : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT

IterationCount=100  LaunchCount=1  WarmupCount=10  

|           Method |     Mean |     Error |    StdDev | Rank |
|----------------- |---------:|----------:|----------:|-----:|
| ParseLogLine_new | 2.280 us | 0.0269 us | 0.0751 us |    1 |
| ParseLogLine_old | 3.364 us | 0.0391 us | 0.1036 us |    2 |
```

New `ParseLogLine` is now a internal static method in order to only parse the output of FFmpeg and can be reused easily within the assembly. All dependent information has been out of the method.

## Further improvements in this PR

- Skip `ParseLogLine` if not a progress line
- Move `percent` calculation to `ApiEntryPoint`
- Rename `JobLogger` to `FFmpegJobLogger`