### PR TITLE
Support Running Jellyfin Server Without Static Web Content

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations.AppBase
         /// <summary>
         /// Gets the path to the web UI resources folder.
         /// </summary>
-        /// <value>The web UI resources path.</value>
+        /// <value>The web UI resources path, or null if the server is not hosting any web content.</value>
         public string WebPath { get; }
 
         /// <summary>

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -240,7 +240,7 @@ namespace Emby.Server.Implementations
         public int HttpsPort { get; private set; }
 
         /// <summary>
-        /// Gets the content root for the webhost.
+        /// Gets the content root for the webhost. If the webhost is not serving static web content, this will be null.
         /// </summary>
         public string ContentRoot { get; private set; }
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -244,6 +244,9 @@ namespace Emby.Server.Implementations
         /// </summary>
         public string ContentRoot { get; private set; }
 
+        /// <inheritdoc/>
+        public bool IsHostingContent => ContentRoot != null;
+
         /// <summary>
         /// Gets the server configuration manager.
         /// </summary>

--- a/Emby.Server.Implementations/Browser/BrowserLauncher.cs
+++ b/Emby.Server.Implementations/Browser/BrowserLauncher.cs
@@ -30,6 +30,16 @@ namespace Emby.Server.Implementations.Browser
         }
 
         /// <summary>
+        /// Opens the swagger API page.
+        /// </summary>
+        /// <param name="appHost">The app host.</param>
+        public static void OpenSwaggerPage(IServerApplicationHost appHost)
+        {
+            var url = appHost.GetLocalApiUrl("localhost") + "/swagger/index.html";
+            OpenUrl(appHost, url);
+        }
+
+        /// <summary>
         /// Opens the URL.
         /// </summary>
         /// <param name="appHost">The application host instance.</param>

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -9,7 +9,7 @@ namespace Emby.Server.Implementations
     public static class ConfigurationOptions
     {
         /// <summary>
-        /// Gets the default configuration options.
+        /// Gets a new copy of the default configuration options.
         /// </summary>
         public static Dictionary<string, string> DefaultConfiguration => new Dictionary<string, string>
         {

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -3,9 +3,15 @@ using static MediaBrowser.Controller.Extensions.ConfigurationExtensions;
 
 namespace Emby.Server.Implementations
 {
+    /// <summary>
+    /// Static class containing the default configuration options for the web server.
+    /// </summary>
     public static class ConfigurationOptions
     {
-        public static Dictionary<string, string> Configuration => new Dictionary<string, string>
+        /// <summary>
+        /// Gets the default configuration options.
+        /// </summary>
+        public static Dictionary<string, string> DefaultConfiguration => new Dictionary<string, string>
         {
             { "HttpListenerHost:DefaultRedirectPath", "web/index.html" },
             { "MusicBrainz:BaseUrl", "https://www.musicbrainz.org" },

--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -36,7 +36,11 @@ namespace Emby.Server.Implementations.EntryPoints
                 return Task.CompletedTask;
             }
 
-            if (!_config.Configuration.IsStartupWizardCompleted)
+            if (!_appHost.IsHostingContent)
+            {
+                BrowserLauncher.OpenSwaggerPage(_appHost);
+            }
+            else if (!_config.Configuration.IsStartupWizardCompleted)
             {
                 BrowserLauncher.OpenWebApp(_appHost);
             }

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -268,7 +268,7 @@ namespace Jellyfin.Server
                 .UseStartup<Startup>();
 
             // Set the root directory for static content, if one exists
-            if (!string.IsNullOrEmpty(appHost.ContentRoot))
+            if (appHost.IsHostingContent)
             {
                 webhostBuilder.UseContentRoot(appHost.ContentRoot);
             }

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -392,7 +392,6 @@ namespace Jellyfin.Server
             // ELSE IF $JELLYFIN_WEB_DIR
             // ELSE    <bindir>/jellyfin-web
             var webDir = options.WebDir;
-
             if (string.IsNullOrEmpty(webDir))
             {
                 webDir = Environment.GetEnvironmentVariable("JELLYFIN_WEB_DIR");
@@ -407,7 +406,6 @@ namespace Jellyfin.Server
             // Reset webDir if the directory does not exist, or is empty
             if (!Directory.Exists(webDir) || !Directory.GetFiles(webDir).Any())
             {
-                _logger.LogInformation("Server will not host static content because the web content directory does not exist or is empty: {ContentRoot}", webDir);
                 webDir = null;
             }
 

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -468,9 +468,16 @@ namespace Jellyfin.Server
                 await resource.CopyToAsync(dst).ConfigureAwait(false);
             }
 
+            // Use the swagger API page as the default redirect path if not hosting the jellyfin-web content
+            var inMemoryDefaultConfig = ConfigurationOptions.DefaultConfiguration;
+            if (string.IsNullOrEmpty(appPaths.WebPath))
+            {
+                inMemoryDefaultConfig["HttpListenerHost:DefaultRedirectPath"] = "swagger/index.html";
+            }
+
             return new ConfigurationBuilder()
                 .SetBasePath(appPaths.ConfigurationDirectoryPath)
-                .AddInMemoryCollection(ConfigurationOptions.Configuration)
+                .AddInMemoryCollection(inMemoryDefaultConfig)
                 .AddJsonFile("logging.json", false, true)
                 .AddEnvironmentVariables("JELLYFIN_")
                 .Build();

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -17,6 +17,11 @@ namespace MediaBrowser.Controller
         event EventHandler HasUpdateAvailableChanged;
 
         /// <summary>
+        /// Gets a value indicating whether the server is hosting the static web content from jellyfin-web.
+        /// </summary>
+        bool IsHostingContent { get; }
+
+        /// <summary>
         /// Gets the system info.
         /// </summary>
         /// <returns>SystemInfo.</returns>

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -149,9 +149,9 @@ namespace MediaBrowser.Model.Configuration
         public bool EnableDashboardResponseCaching { get; set; }
 
         /// <summary>
-        /// Allows the dashboard to be served from a custom path.
+        /// Gets or sets a custom path to serve the dashboard from.
         /// </summary>
-        /// <value>The dashboard source path.</value>
+        /// <value>The dashboard source path, or null if the default path should be used.</value>
         public string DashboardSourcePath { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
Allow server to start up correctly without hosting any of the `jellyfin-web` static content. This will allow a better experience for developers wanting the host jellyfin-web resources separately (i.e. using the Webpack dev server).

When the web content directory does not exist (or is empty), the following behavior changes:
- No call is made to `UseContentRoot()` on the `WebHostBuilder` so that no static content is served from the server
- Instead of opening the web home page on server start, the server opens up the swagger API page by instead
- The swagger API page is also used as the default redirect URL for the server
