### PR TITLE
moves shows tests to Theory and InlineData format

### DIFF
--- a/tests/Jellyfin.Naming.Tests/TV/AbsoluteEpisodeNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/AbsoluteEpisodeNumberTests.cs
@@ -6,56 +6,22 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class AbsoluteEpisodeNumberTests
     {
-        [Fact]
-        public void TestAbsoluteEpisodeNumber1()
-        {
-            Assert.Equal(12, GetEpisodeNumberFromFile(@"The Simpsons/12.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber2()
-        {
-            Assert.Equal(12, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 12.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber3()
-        {
-            Assert.Equal(82, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 82.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber4()
-        {
-            Assert.Equal(112, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 112.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber5()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/Foo_ep_02.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber6()
-        {
-            Assert.Equal(889, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 889.avi"));
-        }
-
-        [Fact]
-        public void TestAbsoluteEpisodeNumber7()
-        {
-            Assert.Equal(101, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 101.avi"));
-        }
-
-        private int? GetEpisodeNumberFromFile(string path)
+        [Theory]
+        [InlineData("The Simpsons/12.avi", 12)]
+        [InlineData("The Simpsons/The Simpsons 12.avi", 12)]
+        [InlineData("The Simpsons/The Simpsons 82.avi", 82)]
+        [InlineData("The Simpsons/The Simpsons 112.avi", 112)]
+        [InlineData("The Simpsons/Foo_ep_02.avi", 2)]
+        [InlineData("The Simpsons/The Simpsons 889.avi", 889)]
+        [InlineData("The Simpsons/The Simpsons 101.avi", 101)]
+        public void GetEpisodeNumberFromFileTest(string path, int episodeNumber)
         {
             var options = new NamingOptions();
 
             var result = new EpisodeResolver(options)
                 .Resolve(path, false, null, null, true);
 
-            return result.EpisodeNumber;
+            Assert.Equal(episodeNumber, result.EpisodeNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
@@ -6,52 +6,17 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class DailyEpisodeTests
     {
-        [Fact]
-        public void TestDailyEpisode1()
-        {
-            Test(@"/server/anything_1996.11.14.mp4", "anything", 1996, 11, 14);
-        }
 
-        [Fact]
-        public void TestDailyEpisode2()
-        {
-            Test(@"/server/anything_1996-11-14.mp4", "anything", 1996, 11, 14);
-        }
 
-        // FIXME
-        // [Fact]
-        public void TestDailyEpisode3()
-        {
-            Test(@"/server/anything_14.11.1996.mp4", "anything", 1996, 11, 14);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestDailyEpisode4()
-        {
-            Test(@"/server/A Daily Show - (2015-01-15) - Episode Name - [720p].mkv", "A Daily Show", 2015, 01, 15);
-        }
-
-        [Fact]
-        public void TestDailyEpisode5()
-        {
-            Test(@"/server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv", "james.corden", 2017, 04, 20);
-        }
-
-        [Fact]
-        public void TestDailyEpisode6()
-        {
-            Test(@"/server/ABC News 2018_03_24_19_00_00.mkv", "ABC News", 2018, 03, 24);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestDailyEpisode7()
-        {
-            Test(@"/server/Last Man Standing_KTLADT_2018_05_25_01_28_00.wtv", "Last Man Standing", 2018, 05, 25);
-        }
-
-        private void Test(string path, string seriesName, int? year, int? month, int? day)
+        [Theory]
+        [InlineData(@"/server/anything_1996.11.14.mp4", "anything", 1996, 11, 14)]
+        [InlineData(@"/server/anything_1996-11-14.mp4", "anything", 1996, 11, 14)]
+        [InlineData(@"/server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv", "james.corden", 2017, 04, 20)]
+        [InlineData(@"/server/ABC News 2018_03_24_19_00_00.mkv", "ABC News", 2018, 03, 24)]
+        // TODO: [InlineData(@"/server/anything_14.11.1996.mp4", "anything", 1996, 11, 14)]
+        // TODO: [InlineData(@"/server/A Daily Show - (2015-01-15) - Episode Name - [720p].mkv", "A Daily Show", 2015, 01, 15)]
+        // TODO: [InlineData(@"/server/Last Man Standing_KTLADT_2018_05_25_01_28_00.wtv", "Last Man Standing", 2018, 05, 25)]
+        public void Test(string path, string seriesName, int? year, int? month, int? day)
         {
             var options = new NamingOptions();
 

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
@@ -6,122 +6,31 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class EpisodeNumberWithoutSeasonTests
     {
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason1()
-        {
-            Assert.Equal(8, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons.S25E08.Steal this episode.mp4"));
-        }
 
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason2()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons - 02 - Ep Name.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason3()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/02.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason4()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/02 - Ep Name.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason5()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/02-Ep Name.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason6()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/02.EpName.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason7()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons - 02.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason8()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons - 02 Ep Name.avi"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestEpisodeNumberWithoutSeason9()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 5 - 02 - Ep Name.avi"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestEpisodeNumberWithoutSeason10()
-        {
-            Assert.Equal(2, GetEpisodeNumberFromFile(@"The Simpsons/The Simpsons 5 - 02 Ep Name.avi"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestEpisodeNumberWithoutSeason11()
-        {
-            Assert.Equal(7, GetEpisodeNumberFromFile(@"Seinfeld/Seinfeld 0807 The Checks.avi"));
-            Assert.Equal(8, GetSeasonNumberFromFile(@"Seinfeld/Seinfeld 0807 The Checks.avi"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason12()
-        {
-            Assert.Equal(7, GetEpisodeNumberFromFile(@"GJ Club (2013)/GJ Club - 07.mkv"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestEpisodeNumberWithoutSeason13()
-        {
-            // This is not supported anymore after removing the episode number 365+ hack from EpisodePathParser
-            Assert.Equal(13, GetEpisodeNumberFromFile(@"Case Closed (1996-2007)/Case Closed - 13.mkv"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason14()
-        {
-            Assert.Equal(3, GetSeasonNumberFromFile(@"Case Closed (1996-2007)/Case Closed - 317.mkv"));
-            Assert.Equal(17, GetEpisodeNumberFromFile(@"Case Closed (1996-2007)/Case Closed - 317.mkv"));
-        }
-
-        [Fact]
-        public void TestEpisodeNumberWithoutSeason15()
-        {
-            Assert.Equal(2017, GetSeasonNumberFromFile(@"Running Man/Running Man S2017E368.mkv"));
-        }
-
-        private int? GetEpisodeNumberFromFile(string path)
+        [Theory]
+        [InlineData(8, @"The Simpsons/The Simpsons.S25E08.Steal this episode.mp4")]
+        [InlineData(2, @"The Simpsons/The Simpsons - 02 - Ep Name.avi")]
+        [InlineData(2, @"The Simpsons/02.avi")]
+        [InlineData(2, @"The Simpsons/02 - Ep Name.avi")]
+        [InlineData(2, @"The Simpsons/02-Ep Name.avi")]
+        [InlineData(2, @"The Simpsons/02.EpName.avi")]
+        [InlineData(2, @"The Simpsons/The Simpsons - 02.avi")]
+        [InlineData(2, @"The Simpsons/The Simpsons - 02 Ep Name.avi")]
+        [InlineData(7, @"GJ Club (2013)/GJ Club - 07.mkv")]
+        [InlineData(17, @"Case Closed (1996-2007)/Case Closed - 317.mkv")]
+        // TODO: [InlineData(2, @"The Simpsons/The Simpsons 5 - 02 - Ep Name.avi")]
+        // TODO: [InlineData(2, @"The Simpsons/The Simpsons 5 - 02 Ep Name.avi")]
+        // TODO: [InlineData(7, @"Seinfeld/Seinfeld 0807 The Checks.avi")]
+        // This is not supported anymore after removing the episode number 365+ hack from EpisodePathParser
+        // TODO: [InlineData(13, @"Case Closed (1996-2007)/Case Closed - 13.mkv")]
+        public void GetEpisodeNumberFromFileTest(int episodeNumber, string path)
         {
             var options = new NamingOptions();
 
             var result = new EpisodeResolver(options)
                 .Resolve(path, false);
 
-            return result.EpisodeNumber;
+            Assert.Equal(episodeNumber, result.EpisodeNumber);
         }
-
-        private int? GetSeasonNumberFromFile(string path)
-        {
-            var options = new NamingOptions();
-
-            var result = new EpisodeResolver(options)
-                .Resolve(path, false);
-
-            return result.SeasonNumber;
-        }
-
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodePathParserTest.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodePathParserTest.cs
@@ -33,7 +33,9 @@ namespace Jellyfin.Naming.Tests.TV
         // TODO: [InlineData("/Season 4/Uchuu.Senkan.Yamato.2199.E03.avi", "Uchuu Senkan Yamoto 2199", 4, 3)]
         // TODO: [InlineData("The Daily Show/The Daily Show 25x22 - [WEBDL-720p][AAC 2.0][x264] Noah Baumbach-TBS.mkv", "The Daily Show", 25, 22)]
         // TODO: [InlineData("Watchmen (2019)/Watchmen 1x03 [WEBDL-720p][EAC3 5.1][h264][-TBS] - She Was Killed by Space Junk.mkv", "Watchmen (2019)", 1, 3)]
+        // TODO: [InlineData("/The.Legend.of.Condor.Heroes.2017.V2.web-dl.1080p.h264.aac-hdctv/The.Legend.of.Condor.Heroes.2017.E07.V2.web-dl.1080p.h264.aac-hdctv.mkv", "The Legend of Condor Heroes 2017", 1, 7)]
         public void ParseEpisodesCorrectly(string path, string name, int season, int episode)
+
         {
             NamingOptions o = new NamingOptions();
             EpisodePathParser p = new EpisodePathParser(o);
@@ -42,24 +44,6 @@ namespace Jellyfin.Naming.Tests.TV
             Assert.True(res.Success);
             Assert.Equal(name, res.SeriesName);
             Assert.Equal(season, res.SeasonNumber);
-            Assert.Equal(episode, res.EpisodeNumber);
-        }
-
-        [Theory]
-        [InlineData("/media/Foo/Foo 889", "Foo", 889)]
-        [InlineData("/media/Foo/[Bar] Foo Baz - 11 [1080p]", "Foo Baz", 11)]
-        [InlineData("D:\\media\\Foo\\Foo 889", "Foo", 889)]
-        [InlineData("D:\\media\\Foo\\[Bar] Foo Baz - 11 [1080p]", "Foo Baz", 11)]
-        // TODO: [InlineData("/The.Legend.of.Condor.Heroes.2017.V2.web-dl.1080p.h264.aac-hdctv/The.Legend.of.Condor.Heroes.2017.E07.V2.web-dl.1080p.h264.aac-hdctv.mkv", "The Legend of Condor Heroes 2017", 1, 7)]
-        public void ParseEpisodeWithoutSeason(string path, string name, int episode)
-        {
-            NamingOptions o = new NamingOptions();
-            EpisodePathParser p = new EpisodePathParser(o);
-            var res = p.Parse(path, true, fillExtendedInfo: true);
-
-            Assert.True(res.Success);
-            Assert.Equal(name, res.SeriesName);
-            Assert.Null(res.SeasonNumber);
             Assert.Equal(episode, res.EpisodeNumber);
         }
     }

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeWithoutSeasonTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeWithoutSeasonTests.cs
@@ -6,42 +6,13 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class EpisodeWithoutSeasonTests
     {
-        // FIXME
-        // [Fact]
-        public void TestWithoutSeason1()
-        {
-            Test(@"/server/anything_ep02.mp4", "anything", null, 2);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestWithoutSeason2()
-        {
-            Test(@"/server/anything_ep_02.mp4", "anything", null, 2);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestWithoutSeason3()
-        {
-            Test(@"/server/anything_part.II.mp4", "anything", null, null);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestWithoutSeason4()
-        {
-            Test(@"/server/anything_pt.II.mp4", "anything", null, null);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestWithoutSeason5()
-        {
-            Test(@"/server/anything_pt_II.mp4", "anything", null, null);
-        }
-
-        private void Test(string path, string seriesName, int? seasonNumber, int? episodeNumber)
+        // TODO: [Theory]
+        // TODO: [InlineData(@"/server/anything_ep02.mp4", "anything", null, 2)]
+        // TODO: [InlineData(@"/server/anything_ep_02.mp4", "anything", null, 2)]
+        // TODO: [InlineData(@"/server/anything_part.II.mp4", "anything", null, null)]
+        // TODO: [InlineData(@"/server/anything_pt.II.mp4", "anything", null, null)]
+        // TODO: [InlineData(@"/server/anything_pt_II.mp4", "anything", null, null)]
+        public void Test(string path, string seriesName, int? seasonNumber, int? episodeNumber)
         {
             var options = new NamingOptions();
 

--- a/tests/Jellyfin.Naming.Tests/TV/MultiEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/MultiEpisodeTests.cs
@@ -6,100 +6,75 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class MultiEpisodeTests
     {
-        [Fact]
-        public void TestGetEndingEpisodeNumberFromFile()
-        {
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/4x01 – 20 Hours in America (1).mkv"));
-
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/01x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/S01x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/S01E02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/S01xE02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/seriesname 01x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/seriesname S01x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/seriesname S01E02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/seriesname S01xE02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2/02x03 - 04 Ep Name.mp4"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2/My show name 02x03 - 04 Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2/Elementary - 02x03 - 02x04 - 02x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2/02x03 - 02x04 - 02x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2/02x03-04-15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2/Elementary - 02x03-04-15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/02x03-E15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/Elementary - 02x03-E15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/02x03 - x04 - x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/Elementary - 02x03 - x04 - x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/02x03x04x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 02/Elementary - 02x03x04x15 - Ep Name.mp4"));
-            Assert.Equal(26, GetEndingEpisodeNumberFromFile(@"Season 1/Elementary - S01E23-E24-E26 - The Woman.mp4"));
-            Assert.Equal(26, GetEndingEpisodeNumberFromFile(@"Season 1/S01E23-E24-E26 - The Woman.mp4"));
-
-
-            // Four Digits seasons
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/2009x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/S2009x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/S2009E02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/S2009xE02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/seriesname 2009x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/seriesname S2009x02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/seriesname S2009E02 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2009/seriesname S2009xE02 blah.avi"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - 2009x03 - 2009x04 - 2009x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/2009x03 - 2009x04 - 2009x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/2009x03-04-15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - 2009x03-04-15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/2009x03-E15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - 2009x03-E15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/2009x03 - x04 - x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - 2009x03 - x04 - x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/2009x03x04x15 - Ep Name.mp4"));
-            Assert.Equal(15, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - 2009x03x04x15 - Ep Name.mp4"));
-            Assert.Equal(26, GetEndingEpisodeNumberFromFile(@"Season 2009/Elementary - S2009E23-E24-E26 - The Woman.mp4"));
-            Assert.Equal(26, GetEndingEpisodeNumberFromFile(@"Season 2009/S2009E23-E24-E26 - The Woman.mp4"));
-
-            // Without season number
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/02 - blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2/02 - blah 14 blah.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/02 - blah-02 a.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2/02.avi"));
-
-            Assert.Equal(3, GetEndingEpisodeNumberFromFile(@"Season 1/02-03 - blah.avi"));
-            Assert.Equal(4, GetEndingEpisodeNumberFromFile(@"Season 2/02-04 - blah 14 blah.avi"));
-            Assert.Equal(5, GetEndingEpisodeNumberFromFile(@"Season 1/02-05 - blah-02 a.avi"));
-            Assert.Equal(4, GetEndingEpisodeNumberFromFile(@"Season 2/02-04.avi"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 2/[HorribleSubs] Hunter X Hunter - 136 [720p].mkv"));
-
-            // With format specification that must not be detected as ending episode number
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/series-s09e14-1080p.mkv"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/series-s09e14-720p.mkv"));
-            Assert.Null(GetEndingEpisodeNumberFromFile(@"Season 1/series-s09e14-720i.mkv"));
-            Assert.Equal(4, GetEndingEpisodeNumberFromFile(@"Season 1/MOONLIGHTING_s01e01-e04.mkv"));
-        }
-
-        [Fact]
-        public void TestGetEndingEpisodeNumberFromFolder()
-        {
-            Assert.Equal(4, GetEndingEpisodeNumberFromFolder(@"Season 1/MOONLIGHTING_s01e01-e04"));
-        }
-
-        private int? GetEndingEpisodeNumberFromFolder(string path)
+        [Theory]
+        [InlineData(@"Season 1/4x01 – 20 Hours in America (1).mkv", null)]
+        [InlineData(@"Season 1/01x02 blah.avi", null)]
+        [InlineData(@"Season 1/S01x02 blah.avi", null)]
+        [InlineData(@"Season 1/S01E02 blah.avi", null)]
+        [InlineData(@"Season 1/S01xE02 blah.avi", null)]
+        [InlineData(@"Season 1/seriesname 01x02 blah.avi", null)]
+        [InlineData(@"Season 1/seriesname S01x02 blah.avi", null)]
+        [InlineData(@"Season 1/seriesname S01E02 blah.avi", null)]
+        [InlineData(@"Season 1/seriesname S01xE02 blah.avi", null)]
+        [InlineData(@"Season 2/02x03 - 04 Ep Name.mp4", null)]
+        [InlineData(@"Season 2/My show name 02x03 - 04 Ep Name.mp4", null)]
+        [InlineData(@"Season 2/Elementary - 02x03 - 02x04 - 02x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2/02x03 - 02x04 - 02x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2/02x03-04-15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2/Elementary - 02x03-04-15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/02x03-E15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/Elementary - 02x03-E15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/02x03 - x04 - x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/Elementary - 02x03 - x04 - x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/02x03x04x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 02/Elementary - 02x03x04x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 1/Elementary - S01E23-E24-E26 - The Woman.mp4", 26)]
+        [InlineData(@"Season 1/S01E23-E24-E26 - The Woman.mp4", 26)]
+        // Four Digits seasons
+        [InlineData(@"Season 2009/2009x02 blah.avi", null)]
+        [InlineData(@"Season 2009/S2009x02 blah.avi", null)]
+        [InlineData(@"Season 2009/S2009E02 blah.avi", null)]
+        [InlineData(@"Season 2009/S2009xE02 blah.avi", null)]
+        [InlineData(@"Season 2009/seriesname 2009x02 blah.avi", null)]
+        [InlineData(@"Season 2009/seriesname S2009x02 blah.avi", null)]
+        [InlineData(@"Season 2009/seriesname S2009E02 blah.avi", null)]
+        [InlineData(@"Season 2009/seriesname S2009xE02 blah.avi", null)]
+        [InlineData(@"Season 2009/Elementary - 2009x03 - 2009x04 - 2009x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/2009x03 - 2009x04 - 2009x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/2009x03-04-15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/Elementary - 2009x03-04-15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/2009x03-E15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/Elementary - 2009x03-E15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/2009x03 - x04 - x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/Elementary - 2009x03 - x04 - x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/2009x03x04x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/Elementary - 2009x03x04x15 - Ep Name.mp4", 15)]
+        [InlineData(@"Season 2009/Elementary - S2009E23-E24-E26 - The Woman.mp4", 26)]
+        [InlineData(@"Season 2009/S2009E23-E24-E26 - The Woman.mp4", 26)]
+        // Without season number
+        [InlineData(@"Season 1/02 - blah.avi", null)]
+        [InlineData(@"Season 2/02 - blah 14 blah.avi", null)]
+        [InlineData(@"Season 1/02 - blah-02 a.avi", null)]
+        [InlineData(@"Season 2/02.avi", null)]
+        [InlineData(@"Season 1/02-03 - blah.avi", 3)]
+        [InlineData(@"Season 2/02-04 - blah 14 blah.avi", 4)]
+        [InlineData(@"Season 1/02-05 - blah-02 a.avi", 5)]
+        [InlineData(@"Season 2/02-04.avi", 4)]
+        [InlineData(@"Season 2 /[HorribleSubs] Hunter X Hunter - 136[720p].mkv", null)]
+        // With format specification that must not be detected as ending episode number
+        [InlineData(@"Season 1/series-s09e14-1080p.mkv", null)]
+        [InlineData(@"Season 1/series-s09e14-720p.mkv", null)]
+        [InlineData(@"Season 1/series-s09e14-720i.mkv", null)]
+        [InlineData(@"Season 1/MOONLIGHTING_s01e01-e04.mkv", 4)]
+        [InlineData(@"Season 1/MOONLIGHTING_s01e01-e04", 4)]
+        public void TestGetEndingEpisodeNumberFromFile(string filename, int? endingEpisodeNumber)
         {
             var options = new NamingOptions();
 
             var result = new EpisodePathParser(options)
-                .Parse(path, true);
+                .Parse(filename, false);
 
-            return result.EndingEpsiodeNumber;
-        }
-
-        private int? GetEndingEpisodeNumberFromFile(string path)
-        {
-            var options = new NamingOptions();
-
-            var result = new EpisodePathParser(options)
-                .Parse(path, false);
-
-            return result.EndingEpsiodeNumber;
+            Assert.Equal(result.EndingEpsiodeNumber, endingEpisodeNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonFolderTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonFolderTests.cs
@@ -5,107 +5,27 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class SeasonFolderTests
     {
-        [Fact]
-        public void TestGetSeasonNumberFromPath1()
-        {
-            Assert.Equal(1, GetSeasonNumberFromPath(@"/Drive/Season 1"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath2()
-        {
-            Assert.Equal(2, GetSeasonNumberFromPath(@"/Drive/Season 2"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath3()
-        {
-            Assert.Equal(2, GetSeasonNumberFromPath(@"/Drive/Season 02"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath4()
-        {
-            Assert.Equal(1, GetSeasonNumberFromPath(@"/Drive/Season 1"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath5()
-        {
-            Assert.Equal(2, GetSeasonNumberFromPath(@"/Drive/Seinfeld/S02"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath6()
-        {
-            Assert.Equal(2, GetSeasonNumberFromPath(@"/Drive/Seinfeld/2"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath7()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromPath(@"/Drive/Season 2009"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath8()
-        {
-            Assert.Equal(1, GetSeasonNumberFromPath(@"/Drive/Season1"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath9()
-        {
-            Assert.Equal(4, GetSeasonNumberFromPath(@"The Wonder Years/The.Wonder.Years.S04.PDTV.x264-JCH"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath10()
-        {
-            Assert.Equal(7, GetSeasonNumberFromPath(@"/Drive/Season 7 (2016)"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath11()
-        {
-            Assert.Equal(7, GetSeasonNumberFromPath(@"/Drive/Staffel 7 (2016)"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath12()
-        {
-            Assert.Equal(7, GetSeasonNumberFromPath(@"/Drive/Stagione 7 (2016)"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath14()
-        {
-            Assert.Null(GetSeasonNumberFromPath(@"/Drive/Season (8)"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath13()
-        {
-            Assert.Equal(3, GetSeasonNumberFromPath(@"/Drive/3.Staffel"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath15()
-        {
-            Assert.Null(GetSeasonNumberFromPath(@"/Drive/s06e05"));
-        }
-
-        [Fact]
-        public void TestGetSeasonNumberFromPath16()
-        {
-            Assert.Null(GetSeasonNumberFromPath(@"/Drive/The.Legend.of.Condor.Heroes.2017.V2.web-dl.1080p.h264.aac-hdctv"));
-        }
-
-        private int? GetSeasonNumberFromPath(string path)
+        [Theory]
+        [InlineData(@"/Drive/Season 1", 1)]
+        [InlineData(@"/Drive/Season 2", 2)]
+        [InlineData(@"/Drive/Season 02", 2)]
+        [InlineData(@"/Drive/Seinfeld/S02", 2)]
+        [InlineData(@"/Drive/Seinfeld/2", 2)]
+        [InlineData(@"/Drive/Season 2009", 2009)]
+        [InlineData(@"/Drive/Season1", 1)]
+        [InlineData(@"The Wonder Years/The.Wonder.Years.S04.PDTV.x264-JCH", 4)]
+        [InlineData(@"/Drive/Season 7 (2016)", 7)]
+        [InlineData(@"/Drive/Staffel 7 (2016)", 7)]
+        [InlineData(@"/Drive/Stagione 7 (2016)", 7)]
+        [InlineData(@"/Drive/Season (8)", null)]
+        [InlineData(@"/Drive/3.Staffel", 3)]
+        [InlineData(@"/Drive/s06e05", null)]
+        [InlineData(@"/Drive/The.Legend.of.Condor.Heroes.2017.V2.web-dl.1080p.h264.aac-hdctv", null)]
+        public void GetSeasonNumberFromPathTest(string path, int? seasonNumber)
         {
             var result = SeasonPathParser.Parse(path, true, true);
 
-            return result.SeasonNumber;
+            Assert.Equal(result.SeasonNumber, seasonNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
@@ -10,306 +10,56 @@ namespace Jellyfin.Naming.Tests.TV
 
         [Theory]
         [InlineData("The Daily Show/The Daily Show 25x22 - [WEBDL-720p][AAC 2.0][x264] Noah Baumbach-TBS.mkv", 25)]
+        [InlineData("/Show/Season 02/S02E03 blah.avi", 2)]
+        [InlineData("Season 1/seriesname S01x02 blah.avi", 1)]
+        [InlineData("Season 1/S01x02 blah.avi", 1)]
+        [InlineData("Season 1/seriesname S01xE02 blah.avi", 1)]
+        [InlineData("Season 1/01x02 blah.avi", 1)]
+        [InlineData("Season 1/S01E02 blah.avi", 1)]
+        [InlineData("Season 1/S01xE02 blah.avi", 1)]
+        [InlineData("Season 1/seriesname 01x02 blah.avi", 1)]
+        [InlineData("Season 1/seriesname S01E02 blah.avi", 1)]
+        [InlineData("Season 2/Elementary - 02x03 - 02x04 - 02x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 2/02x03 - 02x04 - 02x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 2/02x03-04-15 - Ep Name.mp4", 2)]
+        [InlineData("Season 2/Elementary - 02x03-04-15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/02x03-E15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/Elementary - 02x03-E15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/02x03 - x04 - x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/Elementary - 02x03 - x04 - x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/02x03x04x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 02/Elementary - 02x03x04x15 - Ep Name.mp4", 2)]
+        [InlineData("Season 1/Elementary - S01E23-E24-E26 - The Woman.mp4", 1)]
+        [InlineData("Season 1/S01E23-E24-E26 - The Woman.mp4", 1)]
+        [InlineData("Season 25/The Simpsons.S25E09.Steal this episode.mp4", 25)]
+        [InlineData("The Simpsons/The Simpsons.S25E09.Steal this episode.mp4", 25)]
+        [InlineData("2016/Season s2016e1.mp4", 2016)]
+        [InlineData("2016/Season 2016x1.mp4", 2016)]
+        [InlineData("Season 2009/2009x02 blah.avi", 2009)]
+        [InlineData("Season 2009/S2009x02 blah.avi", 2009)]
+        [InlineData("Season 2009/S2009E02 blah.avi", 2009)]
+        [InlineData("Season 2009/S2009xE02 blah.avi", 2009)]
+        [InlineData("Season 2009/seriesname 2009x02 blah.avi", 2009)]
+        [InlineData("Season 2009/seriesname S2009x02 blah.avi", 2009)]
+        [InlineData("Season 2009/seriesname S2009E02 blah.avi", 2009)]
+        [InlineData("Season 2009/Elementary - 2009x03 - 2009x04 - 2009x15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/2009x03 - 2009x04 - 2009x15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/2009x03-04-15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/Elementary - 2009x03 - x04 - x15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/2009x03x04x15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/Elementary - 2009x03x04x15 - Ep Name.mp4", 2009)]
+        [InlineData("Season 2009/Elementary - S2009E23-E24-E26 - The Woman.mp4", 2009)]
+        [InlineData("Season 2009/S2009E23-E24-E26 - The Woman.mp4", 2009)]
+        [InlineData("Series/1-12 - The Woman.mp4", 1)]
+        [InlineData(@"Running Man/Running Man S2017E368.mkv", 2017)]
+        [InlineData(@"Case Closed (1996-2007)/Case Closed - 317.mkv", 3)]
+        // TODO: [InlineData(@"Seinfeld/Seinfeld 0807 The Checks.avi", 8)]
         public void GetSeasonNumberFromEpisodeFileTest(string path, int? expected)
         {
             var result = new EpisodeResolver(_namingOptions)
                 .Resolve(path, false);
 
             Assert.Equal(expected, result.SeasonNumber);
-        }
-
-        private int? GetSeasonNumberFromEpisodeFile(string path)
-        {
-            var result = new EpisodeResolver(_namingOptions)
-                .Resolve(path, false);
-
-            return result.SeasonNumber;
-        }
-
-        [Fact]
-        public void TestSeasonNumber1()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"/Show/Season 02/S02E03 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber2()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/seriesname S01x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber3()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/S01x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber4()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/seriesname S01xE02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber5()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/01x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber6()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/S01E02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber7()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/S01xE02 blah.avi"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestSeasonNumber8()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/seriesname 01x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber9()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/seriesname S01x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber10()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/seriesname S01E02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber11()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 2/Elementary - 02x03 - 02x04 - 02x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber12()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 2/02x03 - 02x04 - 02x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber13()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 2/02x03-04-15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber14()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 2/Elementary - 02x03-04-15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber15()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/02x03-E15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber16()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/Elementary - 02x03-E15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber17()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/02x03 - x04 - x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber18()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/Elementary - 02x03 - x04 - x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber19()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/02x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber20()
-        {
-            Assert.Equal(2, GetSeasonNumberFromEpisodeFile(@"Season 02/Elementary - 02x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber21()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/Elementary - S01E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber22()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Season 1/S01E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber23()
-        {
-            Assert.Equal(25, GetSeasonNumberFromEpisodeFile(@"Season 25/The Simpsons.S25E09.Steal this episode.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber24()
-        {
-            Assert.Equal(25, GetSeasonNumberFromEpisodeFile(@"The Simpsons/The Simpsons.S25E09.Steal this episode.mp4"));
-        }
-
-        [Fact]
-        public void TestSeasonNumber25()
-        {
-            Assert.Equal(2016, GetSeasonNumberFromEpisodeFile(@"2016/Season s2016e1.mp4"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestSeasonNumber26()
-        {
-            // This convention is not currently supported, just adding in case we want to look at it in the future
-            Assert.Equal(2016, GetSeasonNumberFromEpisodeFile(@"2016/Season 2016x1.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber1()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/2009x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber2()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/S2009x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber3()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/S2009E02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber4()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/S2009xE02 blah.avi"));
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestFourDigitSeasonNumber5()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/seriesname 2009x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber6()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/seriesname S2009x02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber7()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/seriesname S2009E02 blah.avi"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber8()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - 2009x03 - 2009x04 - 2009x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber9()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/2009x03 - 2009x04 - 2009x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber10()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/2009x03-04-15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber11()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - 2009x03 - x04 - x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber12()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/2009x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber13()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - 2009x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber14()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - S2009E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber15()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/S2009E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber16()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - 2009x03 - x04 - x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber17()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/2009x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber18()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - 2009x03x04x15 - Ep Name.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber19()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/Elementary - S2009E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestFourDigitSeasonNumber20()
-        {
-            Assert.Equal(2009, GetSeasonNumberFromEpisodeFile(@"Season 2009/S2009E23-E24-E26 - The Woman.mp4"));
-        }
-
-        [Fact]
-        public void TestNoSeriesFolder()
-        {
-            Assert.Equal(1, GetSeasonNumberFromEpisodeFile(@"Series/1-12 - The Woman.mp4"));
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/SimpleEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SimpleEpisodeTests.cs
@@ -6,81 +6,25 @@ namespace Jellyfin.Naming.Tests.TV
 {
     public class SimpleEpisodeTests
     {
-        [Fact]
-        public void TestSimpleEpisodePath1()
-        {
-            Test(@"/server/anything_s01e02.mp4", "anything", 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath2()
-        {
-            Test(@"/server/anything_s1e2.mp4", "anything", 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath3()
-        {
-            Test(@"/server/anything_s01.e02.mp4", "anything", 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath4()
-        {
-            Test(@"/server/anything_s01_e02.mp4", "anything", 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath5()
-        {
-            Test(@"/server/anything_102.mp4", "anything", 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath6()
-        {
-            Test(@"/server/anything_1x02.mp4", "anything", 1, 2);
-        }
-
-        // FIXME
-        // [Fact]
-        public void TestSimpleEpisodePath7()
-        {
-            Test(@"/server/The Walking Dead 4x01.mp4", "The Walking Dead", 4, 1);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath8()
-        {
-            Test(@"/server/the_simpsons-s02e01_18536.mp4", "the_simpsons", 2, 1);
-        }
-
-
-        [Fact]
-        public void TestSimpleEpisodePath9()
-        {
-            Test(@"/server/Temp/S01E02 foo.mp4", string.Empty, 1, 2);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath10()
-        {
-            Test(@"Series/4-12 - The Woman.mp4", string.Empty, 4, 12);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath11()
-        {
-            Test(@"Series/4x12 - The Woman.mp4", string.Empty, 4, 12);
-        }
-
-        [Fact]
-        public void TestSimpleEpisodePath12()
-        {
-            Test(@"Series/LA X, Pt. 1_s06e32.mp4", "LA X, Pt. 1", 6, 32);
-        }
-
-        private void Test(string path, string seriesName, int? seasonNumber, int? episodeNumber)
+        [Theory]
+        [InlineData("/server/anything_s01e02.mp4", "anything", 1, 2)]
+        [InlineData("/server/anything_s1e2.mp4", "anything", 1, 2)]
+        [InlineData("/server/anything_s01.e02.mp4", "anything", 1, 2)]
+        [InlineData("/server/anything_102.mp4", "anything", 1, 2)]
+        [InlineData("/server/anything_1x02.mp4", "anything", 1, 2)]
+        [InlineData("/server/The Walking Dead 4x01.mp4", "The Walking Dead", 4, 1)]
+        [InlineData("/server/the_simpsons-s02e01_18536.mp4", "the_simpsons", 2, 1)]
+        [InlineData("/server/Temp/S01E02 foo.mp4", "", 1, 2)]
+        [InlineData("Series/4-12 - The Woman.mp4", "", 4, 12)]
+        [InlineData("Series/4x12 - The Woman.mp4", "", 4, 12)]
+        [InlineData("Series/LA X, Pt. 1_s06e32.mp4", "LA X, Pt. 1", 6, 32)]
+        [InlineData("[Baz-Bar]Foo - [1080p][Multiple Subtitle]/[Baz-Bar] Foo - 05 [1080p][Multiple Subtitle].mkv", "Foo", null, 5)]
+        [InlineData(@"/Foo/The.Series.Name.S01E04.WEBRip.x264-Baz[Bar]/the.series.name.s01e04.webrip.x264-Baz[Bar].mkv", "The.Series.Name", 1, 4)]
+        [InlineData(@"Love.Death.and.Robots.S01.1080p.NF.WEB-DL.DDP5.1.x264-NTG/Love.Death.and.Robots.S01E01.Sonnies.Edge.1080p.NF.WEB-DL.DDP5.1.x264-NTG.mkv", "Love.Death.and.Robots", 1, 1)]
+        // TODO: [InlineData("[Baz-Bar]Foo - 01 - 12[1080p][Multiple Subtitle]/[Baz-Bar] Foo - 05 [1080p][Multiple Subtitle].mkv", "Foo", null, 5)]
+        // TODO: [InlineData("E:\\Anime\\Yahari Ore no Seishun Love Comedy wa Machigatteiru\\Yahari Ore no Seishun Love Comedy wa Machigatteiru. Zoku\\Oregairu Zoku 11 - Hayama Hayato Always Renconds to Everyone's Expectations..mkv", "Yahari Ore no Seishun Love Comedy wa Machigatteiru", null, 11)]
+        // TODO: [InlineData(@"/Library/Series/The Grand Tour (2016)/Season 1/S01E01 The Holy Trinity.mkv", "The Grand Tour", 1, 1)]
+        public void Test(string path, string seriesName, int? seasonNumber, int? episodeNumber)
         {
             var options = new NamingOptions();
 


### PR DESCRIPTION
This moves all current tests in tests/Jellyfin.Naming.Tests/TV to the [Theory] and [InlineData] format.
This makes the files much shorter and clearer imho. I also added a couple more testcases from issues I saw around my files and github issues.

All testcases included are passing, tests that would not pass are commented out and with a // TODO: 