### PR TITLE
Fix download file with non-ASCII filename

### DIFF
--- a/MediaBrowser.Api/Library/LibraryService.cs
+++ b/MediaBrowser.Api/Library/LibraryService.cs
@@ -815,7 +815,7 @@ namespace MediaBrowser.Api.Library
             if (!string.IsNullOrWhiteSpace(filename))
             {
                 // Kestrel doesn't support non-ASCII characters in headers
-                if (Regex.IsMatch(filename, "[^[:ascii:]]"))
+                if (Regex.IsMatch(filename, @"[^\p{IsBasicLatin}]"))
                 {
                     // Manually encoding non-ASCII characters, following https://tools.ietf.org/html/rfc5987#section-3.2.2
                     headers[HeaderNames.ContentDisposition] = "attachment; filename*=UTF-8''" + WebUtility.UrlEncode(filename);


### PR DESCRIPTION
.Net Regex doesn't support Posix character classes. It will throw the following exception when the filename contains non-ASCII character:
```
Emby.Server.Implementations.HttpServer.HttpListenerHost: Error processing request
System.InvalidOperationException: Invalid non-ASCII or control character in header: 0x6E2C
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ThrowInvalidHeaderCharacter(Char ch)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ValidateHeaderValueCharacters(StringValues headerValues)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseHeaders.AddValueFast(String key, StringValues value)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.System.Collections.Generic.IDictionary<System.String,Microsoft.Extensions.Primitives.StringValues>.Add(String key, StringValues value)
   at Emby.Server.Implementations.Services.ResponseHelper.WriteToResponse(HttpResponse response, IRequest request, Object result, CancellationToken cancellationToken) in /jellyfin/Emby.Server.Implementations/Services/ResponseHelper.cs:line 57
   at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost httpHost, IRequest httpReq, HttpResponse httpRes, ILogger logger, CancellationToken cancellationToken) in /jellyfin/Emby.Server.Implementations/Services/ServiceHandler.cs:line 88
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken) in /jellyfin/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs:line 518
```

The request will response:
`Invalid non-ASCII or control character in header: 0x6E2C`
