### PR TITLE
Fix Playlist Deletion

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
@@ -1,34 +1,27 @@
-#pragma warning disable CS1591
-#pragma warning disable SA1600
-
 using System;
 using System.IO;
 using System.Linq;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Controller.Resolvers;
 using MediaBrowser.LocalMetadata.Savers;
 using MediaBrowser.Model.Entities;
 
 namespace Emby.Server.Implementations.Library.Resolvers
 {
+    /// <summary>
+    /// <see cref="IItemResolver"/> for <see cref="Playlist"/> library items.
+    /// </summary>
     public class PlaylistResolver : FolderResolver<Playlist>
     {
-        private string[] SupportedCollectionTypes = new string[] {
-
+        private string[] _musicPlaylistCollectionTypes = new string[] {
             string.Empty,
             CollectionType.Music
         };
 
-        /// <summary>
-        /// Resolves the specified args.
-        /// </summary>
-        /// <param name="args">The args.</param>
-        /// <returns>BoxSet.</returns>
+        /// <inheritdoc/>
         protected override Playlist Resolve(ItemResolveArgs args)
         {
-            // It's a boxset if all of the following conditions are met:
-            // Is a Directory
-            // Contains [playlist] in the path
             if (args.IsDirectory)
             {
                 // It's a boxset if the path is a directory with [playlist] in it's the name
@@ -56,20 +49,20 @@ namespace Emby.Server.Implementations.Library.Resolvers
                     };
                 }
             }
-            else
+
+            // Check if this is a music playlist file
+            // It should have the correct collection type and a supported file extension
+            else if (_musicPlaylistCollectionTypes.Contains(args.CollectionType ?? string.Empty, StringComparer.OrdinalIgnoreCase))
             {
-                if (SupportedCollectionTypes.Contains(args.CollectionType ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                var extension = Path.GetExtension(args.Path);
+                if (Playlist.SupportedExtensions.Contains(extension ?? string.Empty, StringComparer.OrdinalIgnoreCase))
                 {
-                    var extension = Path.GetExtension(args.Path);
-                    if (Playlist.SupportedExtensions.Contains(extension ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                    return new Playlist
                     {
-                        return new Playlist
-                        {
-                            Path = args.Path,
-                            Name = Path.GetFileNameWithoutExtension(args.Path),
-                            IsInMixedFolder = true
-                        };
-                    }
+                        Path = args.Path,
+                        Name = Path.GetFileNameWithoutExtension(args.Path),
+                        IsInMixedFolder = true
+                    };
                 }
             }
 

--- a/MediaBrowser.LocalMetadata/Savers/PlaylistXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/PlaylistXmlSaver.cs
@@ -11,6 +11,9 @@ namespace MediaBrowser.LocalMetadata.Savers
 {
     public class PlaylistXmlSaver : BaseXmlSaver
     {
+        public const string DefaultPlaylistFilename = "playlist.xml";
+
+
         public override bool IsEnabledFor(BaseItem item, ItemUpdateType updateType)
         {
             if (!item.SupportsLocalMetadata)
@@ -45,7 +48,7 @@ namespace MediaBrowser.LocalMetadata.Savers
                 return Path.ChangeExtension(itemPath, ".xml");
             }
 
-            return Path.Combine(path, "playlist.xml");
+            return Path.Combine(path, DefaultPlaylistFilename);
         }
 
         public PlaylistXmlSaver(IFileSystem fileSystem, IServerConfigurationManager configurationManager, ILibraryManager libraryManager, IUserManager userManager, IUserDataManager userDataManager, ILogger logger)

--- a/MediaBrowser.LocalMetadata/Savers/PlaylistXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/PlaylistXmlSaver.cs
@@ -11,8 +11,10 @@ namespace MediaBrowser.LocalMetadata.Savers
 {
     public class PlaylistXmlSaver : BaseXmlSaver
     {
+        /// <summary>
+        /// The default file name to use when creating a new playlist.
+        /// </summary>
         public const string DefaultPlaylistFilename = "playlist.xml";
-
 
         public override bool IsEnabledFor(BaseItem item, ItemUpdateType updateType)
         {


### PR DESCRIPTION
This fixes the issue with playlists being removed from the library during library scans.

**Changes**
Updated the `PlaylistResolver` to correctly resolve playlist items that are stored in the library using a directory.

**Issues**
Fixes #2425 
