### PR TITLE
Fix emby/user/public API leaking sensitive data

### DIFF
--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -613,6 +613,31 @@ namespace Emby.Server.Implementations.Library
             return dto;
         }
 
+        public PublicUserDto GetPublicUserDto(User user, string remoteEndPoint = null)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            bool hasConfiguredPassword = GetAuthenticationProvider(user).HasPassword(user);
+            bool hasConfiguredEasyPassword = !string.IsNullOrEmpty(GetAuthenticationProvider(user).GetEasyPasswordHash(user));
+
+            bool hasPassword = user.Configuration.EnableLocalPassword &&
+                !string.IsNullOrEmpty(remoteEndPoint) &&
+                _networkManager.IsInLocalNetwork(remoteEndPoint) ? hasConfiguredEasyPassword : hasConfiguredPassword;
+
+
+            PublicUserDto dto = new PublicUserDto
+            {
+                Name = user.Name,
+                HasPassword = hasPassword,
+                HasConfiguredPassword = hasConfiguredPassword,
+            };
+
+            return dto;
+        }
+
         public UserDto GetOfflineUserDto(User user)
         {
             var dto = GetUserDto(user);

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -627,7 +627,6 @@ namespace Emby.Server.Implementations.Library
                 !string.IsNullOrEmpty(remoteEndPoint) &&
                 _networkManager.IsInLocalNetwork(remoteEndPoint) ? hasConfiguredEasyPassword : hasConfiguredPassword;
 
-
             PublicUserDto dto = new PublicUserDto
             {
                 Name = user.Name,

--- a/Emby.Server.Implementations/Library/UserManager.cs
+++ b/Emby.Server.Implementations/Library/UserManager.cs
@@ -620,8 +620,9 @@ namespace Emby.Server.Implementations.Library
                 throw new ArgumentNullException(nameof(user));
             }
 
-            bool hasConfiguredPassword = GetAuthenticationProvider(user).HasPassword(user);
-            bool hasConfiguredEasyPassword = !string.IsNullOrEmpty(GetAuthenticationProvider(user).GetEasyPasswordHash(user));
+            IAuthenticationProvider authenticationProvider = GetAuthenticationProvider(user);
+            bool hasConfiguredPassword = authenticationProvider.HasPassword(user);
+            bool hasConfiguredEasyPassword = !string.IsNullOrEmpty(authenticationProvider.GetEasyPasswordHash(user));
 
             bool hasPassword = user.Configuration.EnableLocalPassword &&
                 !string.IsNullOrEmpty(remoteEndPoint) &&

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -275,8 +275,8 @@ namespace MediaBrowser.Api
         {
             var users = _userManager
                 .Users
-                .Where(item => item.Policy.IsDisabled == false)
-                .Where(item => item.Policy.IsHidden == false);
+                .Where(item => !item.Policy.IsDisabled)
+                .Where(item => !item.Policy.IsHidden);
 
             var deviceId = _authContext.GetAuthorizationInfo(Request).DeviceId;
 

--- a/MediaBrowser.Controller/Library/IUserManager.cs
+++ b/MediaBrowser.Controller/Library/IUserManager.cs
@@ -144,6 +144,14 @@ namespace MediaBrowser.Controller.Library
         UserDto GetUserDto(User user, string remoteEndPoint = null);
 
         /// <summary>
+        /// Gets the user public dto.
+        /// </summary>
+        /// <param name="user">Ther user.</param>\
+        /// <param name="remoteEndPoint">The remote end point.</param>
+        /// <returns>A public UserDto, aka a UserDto stripped of personal data.</returns>
+        PublicUserDto GetPublicUserDto(User user, string remoteEndPoint = null);
+
+        /// <summary>
         /// Authenticates the user.
         /// </summary>
         Task<User> AuthenticateUser(string username, string password, string passwordSha1, string remoteEndPoint, bool isUserSession);

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -1,0 +1,48 @@
+using System;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Users;
+
+namespace MediaBrowser.Model.Dto
+{
+    /// <summary>
+    /// Class PublicUserDto. Its goal is to show only public information about a user
+    /// </summary>
+    public class PublicUserDto : IItemDto
+    {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary image tag.
+        /// </summary>
+        /// <value>The primary image tag.</value>
+        public string PrimaryImageTag { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has password.
+        /// </summary>
+        /// <value><c>true</c> if this instance has password; otherwise, <c>false</c>.</value>
+        public bool HasPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has configured password.
+        /// </summary>
+        /// <value><c>true</c> if this instance has configured password; otherwise, <c>false</c>.</value>
+        public bool HasConfiguredPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary image aspect ratio.
+        /// </summary>
+        /// <value>The primary image aspect ratio.</value>
+        public double? PrimaryImageAspectRatio { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Name ?? base.ToString();
+        }
+    }
+}

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -27,7 +27,7 @@ namespace MediaBrowser.Model.Dto
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance has configured password.
-        /// Note that in this case this method should not be here, but it is necessary when changeing password at the
+        /// Note that in this case this method should not be here, but it is necessary when changing password at the
         /// first login.
         /// </summary>
         /// <value><c>true</c> if this instance has configured password; otherwise, <c>false</c>.</value>

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -31,6 +31,7 @@ namespace MediaBrowser.Model.Dto
         /// Gets or sets a value indicating whether this instance has configured password.
         /// </summary>
         /// <value><c>true</c> if this instance has configured password; otherwise, <c>false</c>.</value>
+        // FIXME this shouldn't be here, but it's necessary when changing password at the first login
         public bool HasConfiguredPassword { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -1,6 +1,4 @@
 using System;
-using MediaBrowser.Model.Configuration;
-using MediaBrowser.Model.Users;
 
 namespace MediaBrowser.Model.Dto
 {
@@ -29,9 +27,10 @@ namespace MediaBrowser.Model.Dto
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance has configured password.
+        /// Note that in this case this method should not be here, but it is necessary when changeing password at the
+        /// first login.
         /// </summary>
         /// <value><c>true</c> if this instance has configured password; otherwise, <c>false</c>.</value>
-        // FIXME this shouldn't be here, but it's necessary when changing password at the first login
         public bool HasConfiguredPassword { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
As described in the commit message, these are the changes: this commit fixes the emby/user/public API that was returning more data than necessary. Now only the following information are returned:
- the account name
- the primary image tag
- the field hasPassword
- the field hasConfiguredPassword, useful for the first wizard only (see https://github.com/jellyfin/jellyfin/issues/880#issuecomment-465370051)
- the primary image aspect ratio

A new DTO class, PrivateUserDTO has been created, and the route has been modified in order to return that data object.

Finally, I tested it locally and nothing seems to be broken, but please check it out as I'm not a C# developer and I could have missed something!

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #880 