### PR TITLE
Register Logging Services Correctly

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -673,7 +673,7 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton(JsonSerializer);
 
             // TODO: Support for injecting ILogger should be deprecated in favour of ILogger<T> and this removed
-            serviceCollection.AddSingleton<ILogger>(_logger);
+            serviceCollection.AddSingleton<ILogger>(Logger);
 
             serviceCollection.AddSingleton(FileSystemManager);
             serviceCollection.AddSingleton<TvDbClientManager>();

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -672,9 +672,8 @@ namespace Emby.Server.Implementations
 
             serviceCollection.AddSingleton(JsonSerializer);
 
-            serviceCollection.AddSingleton(LoggerFactory);
-            serviceCollection.AddLogging();
-            serviceCollection.AddSingleton(Logger);
+            // TODO: Support for injecting ILogger should be deprecated in favour of ILogger<T> and this removed
+            serviceCollection.AddSingleton<ILogger>(_logger);
 
             serviceCollection.AddSingleton(FileSystemManager);
             serviceCollection.AddSingleton<TvDbClientManager>();

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Serilog;
+using Serilog.Events;
 using Serilog.Extensions.Logging;
 using SQLitePCL;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -260,6 +261,7 @@ namespace Jellyfin.Server
                         }
                     }
                 })
+                .UseSerilog()
                 .UseContentRoot(appHost.ContentRoot)
                 .ConfigureServices(services =>
                 {

--- a/Jellyfin.Server/Resources/Configuration/logging.json
+++ b/Jellyfin.Server/Resources/Configuration/logging.json
@@ -1,6 +1,12 @@
 {
     "Serilog": {
-        "MinimumLevel": "Information",
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        },
         "WriteTo": [
             {
                 "Name": "Console",


### PR DESCRIPTION
Register logging services correctly with the DI container so they are resolved correctly.

**Changes**
* Replace existing DI type registrations with a call to [`UseSerilog()`](https://github.com/dotnet/extensions/blob/master/src/Logging/Logging/src/LoggingServiceCollectionExtensions.cs#L42) which registers `ILoggerFactory` and `ILogger<T>`
* Keep a registration for `ILogger` but add a TODO note to deprecate it in favour of `ILogger<T>`
* Reduce logging output from `Microsoft` and `System` namespaces to a min level of `Warning`, which is [recommended in the Serilog documentation](https://github.com/serilog/serilog-settings-configuration#level-overrides). If we don't to make this change, we need to at least reduce the output for `Microsoft.AspNetCore` which clogs up the logs with every single request to the server at level `Info`

**Still To Address**
We have no way to push an update to the logging configuration for existing users. At startup, if the user's `logging.json` settings file already exists, then it is loaded as-is and the bundled resource settings file is ignored.

**Issues**
Fixes #2498 
