### PR TITLE
Replaces NSIS uninstaller icon so it's more visible

### DIFF
--- a/deployment/windows/jellyfin.nsi
+++ b/deployment/windows/jellyfin.nsi
@@ -73,7 +73,7 @@ Unicode True
 ; TODO: Replace with nice Jellyfin Icons
 !ifdef UXPATH
     !define MUI_ICON "${UXPATH}\branding\NSIS\modern-install.ico" ; Installer Icon
-    !define MUI_UNICON "${UXPATH}\branding\NSIS\modern-uninstall.ico" ; Uninstaller Icon
+    !define MUI_UNICON "${UXPATH}\branding\NSIS\modern-install.ico" ; Uninstaller Icon
 
     !define MUI_HEADERIMAGE
     !define MUI_HEADERIMAGE_BITMAP "${UXPATH}\branding\NSIS\installer-header.bmp"


### PR DESCRIPTION
You really need to pay attention to notice that there are icons there:

![Captura](https://user-images.githubusercontent.com/10274099/76010267-e8eb3480-5f12-11ea-9892-166835e024e1.PNG)

Without choosing Jellyfin is even worse:

![image](https://user-images.githubusercontent.com/10274099/76010342-06200300-5f13-11ea-91f6-b176cd887e33.png)

Now, the same icon of the installer is used, as it's far more visible, and probably users will recognixe it better as it's the same that it's in the tray:

![image](https://user-images.githubusercontent.com/10274099/76010432-2780ef00-5f13-11ea-823d-172d7859cb0e.png)
