### PR TITLE
Add baseURL to attachments API url

### DIFF
--- a/MediaBrowser.Api/Playback/MediaInfoService.cs
+++ b/MediaBrowser.Api/Playback/MediaInfoService.cs
@@ -573,7 +573,8 @@ namespace MediaBrowser.Api.Playback
             {
                 attachment.DeliveryUrl = string.Format(
                     CultureInfo.InvariantCulture,
-                    "/Videos/{0}/{1}/Attachments/{2}",
+                    "{0}/Videos/{1}/{2}/Attachments/{3}",
+                    ServerConfigurationManager.Configuration.BaseUrl,
                     item.Id,
                     mediaSource.Id,
                     attachment.Index);


### PR DESCRIPTION
**Changes**

Adds the baseURL to the URL returning attachments. Prevents the case of attachments returning a 302 when using a baseURL.

**Issues**


