### PR TITLE
Fix curl for Jellyfin GPG key

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -38,7 +38,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl && \
- curl -s https://repo.jellyfin.org/debian/jellyfin_team.gpg.key | apt-key add - && \
+ curl -ks https://repo.jellyfin.org/debian/jellyfin_team.gpg.key | apt-key add - && \
  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
  echo 'deb [arch=armhf] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list && \
  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \


### PR DESCRIPTION
This curl command seems to fail inexplicably with an "unable to get
local issuer" error. Use `-k` instead so it doesn't complain.

The full error:

```
root@820864ddf7c3:/# curl https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```