### PR TITLE
Add descriptive TV episode titles for DLNA browsing

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -436,6 +436,29 @@ namespace Emby.Dlna.Didl
                     return number + " - " + item.Name;
                 }
             }
+            else if (item is Episode ep)
+            {
+                var parent = ep.GetParent();
+                var name = parent.Name + " - ";
+
+                if (ep.ParentIndexNumber.HasValue)
+                {
+                    name += "S" + ep.ParentIndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
+                }
+                else if (!item.IndexNumber.HasValue)
+                {
+                    return name + " - " + item.Name;
+                }
+
+                name += "E" + ep.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
+                if (ep.IndexNumberEnd.HasValue)
+                {
+                    name += "-" + ep.IndexNumberEnd.Value.ToString("00", CultureInfo.InvariantCulture);
+                }
+
+                name += " - " + item.Name;
+                return name;
+            }
 
             return item.Name;
         }


### PR DESCRIPTION
**Changes**
When browsing TV episodes in Next Up, etc via DLNA a more descriptive title should be used to easier identify the right episode.

Checks if it's an episode that's not in a season directory/context, if it isn't, then add series name, season and episode numbers to the title

**Issues**
Fixes #295

