### PR TITLE
Feature Request Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,6 +8,6 @@ assignees: ''
 
 **PLEASE DO NOT OPEN FEATURE REQUEST ISSUES ON GITHUB**
 
-**Feature requests should be opened up on our dedicated [feature request hub](https://features.jellyfin.org/) so that they can be appropriately discussed and prioritized.**
+**Feature requests should be opened on our dedicated [feature request](https://features.jellyfin.org/) hub so they can be appropriately discussed and prioritized.**
 
-However, if you are willing to contribute to the project by adding a new feature yourself, then please ensure that you first review our [documentation on contributing code](https://jellyfin.org/docs/general/contributing/development.html). Once you have reviewed the documentation feel free to come back here and open an issue here outlining your proposed approach so that it can be documented, tracked and discussed by other team members.
+However, if you are willing to contribute to the project by adding a new feature yourself, then please ensure that you first review our [documentation](https://docs.jellyfin.org/general/contributing/development.html) on contributing code. Once you have reviewed the documentation, feel free to come back here and open an issue here outlining your proposed approach so that it can be documented, tracked, and discussed by other team members.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Request a new feature
 title: ''
-labels: feature
+labels: feature-request
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Request a new feature
+title: ''
+labels: feature
+assignees: ''
+---
+
+**PLEASE DO NOT OPEN FEATURE REQUEST ISSUES ON GITHUB**
+
+**Feature requests should be opened up on our dedicated [feature request hub](https://features.jellyfin.org/) so that they can be appropriately discussed and prioritized.**
+
+If you are willing to contribute to the project by adding a new feature yourself, then please ensure that you first review our [documentation on contributing code](https://jellyfin.org/docs/general/contributing/development.html). Once you have reviewed the documentation feel free to come back here and open an issue here outlining your proposed approach so that it can be documented, tracked and discussed by other team members.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,4 +10,4 @@ assignees: ''
 
 **Feature requests should be opened up on our dedicated [feature request hub](https://features.jellyfin.org/) so that they can be appropriately discussed and prioritized.**
 
-If you are willing to contribute to the project by adding a new feature yourself, then please ensure that you first review our [documentation on contributing code](https://jellyfin.org/docs/general/contributing/development.html). Once you have reviewed the documentation feel free to come back here and open an issue here outlining your proposed approach so that it can be documented, tracked and discussed by other team members.
+However, if you are willing to contribute to the project by adding a new feature yourself, then please ensure that you first review our [documentation on contributing code](https://jellyfin.org/docs/general/contributing/development.html). Once you have reviewed the documentation feel free to come back here and open an issue here outlining your proposed approach so that it can be documented, tracked and discussed by other team members.


### PR DESCRIPTION
Add a template for feature request issues, instructing user to not create them on GitHub and directing to the Fider instance instead. The template also provides direction for users who are willing to contribute code for new features themselves.

Definitely open to feedback on this, I'm opening this PR as a proposal for discussion as well.

~~This template can be previewed on my fork: https://github.com/mark-monteiro/jellyfin/issues/new?template=feature_request.md~~