### PR TITLE
Add codecs, resolution and frame-rate fields to HLS master playlist

### DIFF
--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -856,6 +856,24 @@ namespace MediaBrowser.Api.Playback.Hls
             }
         }
 
+        /// <summary>
+        /// Appends a RESOLUTION field containing the resolution of the output stream.
+        /// </summary>
+        /// <seealso cref="AppendPlaylist(StringBuilder, StreamState, string, int, string)"/>
+        /// <param name="builder">StringBuilder to append the field to.</param>
+        /// <param name="state">StreamState of the current stream.</param>
+        private void AppendPlaylistResolutionField(StringBuilder builder, StreamState state)
+        {
+            if (state.OutputWidth.HasValue && state.OutputHeight.HasValue)
+            {
+                builder.Append(",RESOLUTION=\"")
+                    .Append(state.OutputWidth.GetValueOrDefault())
+                    .Append('x')
+                    .Append(state.OutputHeight.GetValueOrDefault())
+                    .Append('"');
+            }
+        }
+
         private void AppendPlaylist(StringBuilder builder, StreamState state, string url, int bitrate, string subtitleGroup)
         {
             builder.Append("#EXT-X-STREAM-INF:BANDWIDTH=")
@@ -863,13 +881,9 @@ namespace MediaBrowser.Api.Playback.Hls
                 .Append(",AVERAGE-BANDWIDTH=")
                 .Append(bitrate.ToString(CultureInfo.InvariantCulture));
 
-            // tvos wants resolution, codecs, framerate
-            //if (state.TargetFramerate.HasValue)
-            //{
-            //    header += string.Format(",FRAME-RATE=\"{0}\"", state.TargetFramerate.Value.ToString(CultureInfo.InvariantCulture));
-            //}
-
             AppendPlaylistCodecsField(builder, state);
+
+            AppendPlaylistResolutionField(builder, state);
 
             AppendPlaylistFramerateField(builder, state);
 

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -830,6 +830,32 @@ namespace MediaBrowser.Api.Playback.Hls
             }
         }
 
+        /// <summary>
+        /// Appends a FRAME-RATE field containing the framerate of the output stream.
+        /// </summary>
+        /// <seealso cref="AppendPlaylist(StringBuilder, StreamState, string, int, string)"/>
+        /// <param name="builder">StringBuilder to append the field to.</param>
+        /// <param name="state">StreamState of the current stream.</param>
+        private void AppendPlaylistFramerateField(StringBuilder builder, StreamState state)
+        {
+            double? framerate = null;
+            if (state.TargetFramerate.HasValue)
+            {
+                framerate = Math.Round(state.TargetFramerate.GetValueOrDefault(), 3);
+            }
+            else if (state.VideoStream.RealFrameRate.HasValue)
+            {
+                framerate = Math.Round(state.VideoStream.RealFrameRate.GetValueOrDefault(), 3);
+            }
+
+            if (framerate.HasValue)
+            {
+                builder.Append(",FRAME-RATE=\"")
+                    .Append(framerate.Value)
+                    .Append('"');
+            }
+        }
+
         private void AppendPlaylist(StringBuilder builder, StreamState state, string url, int bitrate, string subtitleGroup)
         {
             builder.Append("#EXT-X-STREAM-INF:BANDWIDTH=")
@@ -844,6 +870,8 @@ namespace MediaBrowser.Api.Playback.Hls
             //}
 
             AppendPlaylistCodecsField(builder, state);
+
+            AppendPlaylistFramerateField(builder, state);
 
             if (!string.IsNullOrWhiteSpace(subtitleGroup))
             {

--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -724,7 +724,10 @@ namespace MediaBrowser.Api.Playback.Hls
 
         private void AppendPlaylist(StringBuilder builder, StreamState state, string url, int bitrate, string subtitleGroup)
         {
-            var header = "#EXT-X-STREAM-INF:BANDWIDTH=" + bitrate.ToString(CultureInfo.InvariantCulture) + ",AVERAGE-BANDWIDTH=" + bitrate.ToString(CultureInfo.InvariantCulture);
+            builder.Append("#EXT-X-STREAM-INF:BANDWIDTH=")
+                .Append(bitrate.ToString(CultureInfo.InvariantCulture))
+                .Append(",AVERAGE-BANDWIDTH=")
+                .Append(bitrate.ToString(CultureInfo.InvariantCulture));
 
             // tvos wants resolution, codecs, framerate
             //if (state.TargetFramerate.HasValue)
@@ -734,10 +737,12 @@ namespace MediaBrowser.Api.Playback.Hls
 
             if (!string.IsNullOrWhiteSpace(subtitleGroup))
             {
-                header += string.Format(",SUBTITLES=\"{0}\"", subtitleGroup);
+                builder.Append(",SUBTITLES=\"")
+                    .Append(subtitleGroup)
+                    .Append('"');
             }
 
-            builder.AppendLine(header);
+            builder.Append(Environment.NewLine);
             builder.AppendLine(url);
         }
 

--- a/MediaBrowser.Api/Playback/Hls/HlsCodecStringFactory.cs
+++ b/MediaBrowser.Api/Playback/Hls/HlsCodecStringFactory.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Text;
+
+
+namespace MediaBrowser.Api.Playback
+{
+    /// <summary>
+    /// Get various codec strings for use in HLS playlists.
+    /// </summary>
+    static class HlsCodecStringFactory
+    {
+
+        /// <summary>
+        /// Gets a MP3 codec string.
+        /// </summary>
+        /// <returns>MP3 codec string.</returns>
+        public static string GetMP3String()
+        {
+            return "mp4a.40.34";
+        }
+
+        /// <summary>
+        /// Gets an AAC codec string.
+        /// </summary>
+        /// <param name="profile">AAC profile.</param>
+        /// <returns>AAC codec string.</returns>
+        public static string GetAACString(string profile)
+        {
+            StringBuilder result = new StringBuilder("mp4a", 9);
+
+            if (string.Equals(profile, "HE", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Append(".40.5");
+            }
+            else
+            {
+                // Default to LC if profile is invalid
+                result.Append(".40.2");
+            }
+
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Gets a H.264 codec string.
+        /// </summary>
+        /// <param name="profile">H.264 profile.</param>
+        /// <param name="level">H.264 level.</param>
+        /// <returns>H.264 string.</returns>
+        public static string GetH264String(string profile, int level)
+        {
+            StringBuilder result = new StringBuilder("avc1", 11);
+
+            if (string.Equals(profile, "high", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Append(".6400");
+            }
+            else if (string.Equals(profile, "main", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Append(".4D40");
+            }
+            else if (string.Equals(profile, "baseline", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Append(".42E0");
+            }
+            else
+            {
+                // Default to constrained baseline if profile is invalid
+                result.Append(".4240");
+            }
+
+            string levelHex = level.ToString("X2");
+            result.Append(levelHex);
+
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Gets a H.265 codec string.
+        /// </summary>
+        /// <param name="profile">H.265 profile.</param>
+        /// <param name="level">H.265 level.</param>
+        /// <returns>H.265 string.</returns>
+        public static string GetH265String(string profile, int level)
+        {
+            // The h265 syntax is a bit of a mystery at the time this comment was written.
+            // This is what I've found through various sources:
+            // FORMAT: [codecTag].[profile].[constraint?].L[level * 30].[UNKNOWN]
+            StringBuilder result = new StringBuilder("hev1", 16);
+
+            if (string.Equals(profile, "main10", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Append(".2.6");
+            }
+            else
+            {
+                // Default to main if profile is invalid
+                result.Append(".1.6");
+            }
+
+            result.Append(".L")
+                .Append(level * 3)
+                .Append(".B0");
+
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Gets an AC-3 codec string.
+        /// </summary>
+        /// <returns>AC-3 codec string.</returns>
+        public static string GetAC3String()
+        {
+            return "mp4a.a5";
+        }
+
+        /// <summary>
+        /// Gets an E-AC-3 codec string.
+        /// </summary>
+        /// <returns>E-AC-3 codec string.</returns>
+        public static string GetEAC3String()
+        {
+            return "mp4a.a6";
+        }
+    }
+}


### PR DESCRIPTION
According to the HLS spec, these are all recommended fields a `EXT-X-STREAM-INF` should have.

[Spec](https://tools.ietf.org/html/rfc8216#section-4.3.4.2)

**Changes**
Adds CODECS field specifying what codecs the stream contains
Adds RESOLUTION field specifying what resolution the stream contains
Adds FRAME-RATE field specifying what framerate the video in the stream has

EDIT:
Move BANDWIDTH and AVERAGE-BANDWIDTH field generation to its own method
Move SUBTITLES field generation to its own method

**Issues**
#2505
