### PR TITLE
Correct BuildRequires and NodeJS for Fedora/CentOS

### DIFF
--- a/deployment/centos-package-x64/Dockerfile
+++ b/deployment/centos-package-x64/Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fo
 
 # Install recent NodeJS and Yarn
 RUN curl -fSsLo /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo \
- && rpm -i https://rpm.nodesource.com/pub_8.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
+ && rpm -i https://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
  && yum install -y yarn
 
 # Install DotNET SDK

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -26,13 +26,13 @@ Source16:       jellyfin-firewalld.xml
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, glibc-devel, libicu-devel
+BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, glibc-devel, libicu-devel, git
 %if 0%{?fedora}
-BuildRequires:  nodejs-yarn
+BuildRequires:  nodejs-yarn, git
 %else
 # Requirements not packaged in main repos
-# From https://rpm.nodesource.com/pub_8.x/el/7/x86_64/
-BuildRequires:  nodejs >= 8 yarn
+# From https://rpm.nodesource.com/pub_10.x/el/7/x86_64/
+BuildRequires:  nodejs >= 10 yarn
 %endif
 Requires:       libcurl, fontconfig, freetype, openssl, glibc libicu
 # Requirements not packaged in main repos


### PR DESCRIPTION
**Changes**
Fixes the build issues for Fedora and CentOS on 10.5.0.

**Issues**
Addresses #2550 short-term
Fixes #2563
