### PR TITLE
Log 'JELLYFIN_' environment variables at application start

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -897,6 +897,18 @@ namespace Emby.Server.Implementations
                 .GetCommandLineArgs()
                 .Distinct();
 
+            // Get all 'JELLYFIN_' prefixed environment variables
+            var allEnvVars = Environment.GetEnvironmentVariables();
+            var jellyfinEnvVars = new Dictionary<object, object>();
+            foreach (var key in allEnvVars.Keys)
+            {
+                if (key.ToString().StartsWith("JELLYFIN_", StringComparison.OrdinalIgnoreCase))
+                {
+                    jellyfinEnvVars.Add(key, allEnvVars[key]);
+                }
+            }
+
+            logger.LogInformation("Environment Variables: {EnvVars}", jellyfinEnvVars);
             logger.LogInformation("Arguments: {Args}", commandLineArgs);
             logger.LogInformation("Operating system: {OS}", OperatingSystem.Name);
             logger.LogInformation("Architecture: {Architecture}", RuntimeInformation.OSArchitecture);


### PR DESCRIPTION
Update startup logging to also include `JELLYFIN_` prefixed environment variables. These variables are [loaded into the configuration framework](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server/Program.cs#L488), so we should be logging them.
