### PR TITLE
Fix Client Build Scripts

### DIFF
--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -43,7 +43,7 @@ jobs:
         displayName: "Build Web Client"
         condition: and(succeeded(), or(contains(variables['System.PullRequest.TargetBranch'], 'release'), contains(variables['System.PullRequest.TargetBranch'], 'master'), contains(variables['Build.SourceBranch'], 'release'), contains(variables['Build.SourceBranch'], 'master')), eq(variables['BuildConfiguration'], 'Release'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
         inputs:
-          script: yarn install && yarn build
+          script: yarn install && yarn build:production
           workingDirectory: $(Agent.TempDirectory)/jellyfin-web
 
       - task: CopyFiles@2

--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -43,7 +43,7 @@ jobs:
         displayName: "Build Web Client"
         condition: and(succeeded(), or(contains(variables['System.PullRequest.TargetBranch'], 'release'), contains(variables['System.PullRequest.TargetBranch'], 'master'), contains(variables['Build.SourceBranch'], 'release'), contains(variables['Build.SourceBranch'], 'master')), eq(variables['BuildConfiguration'], 'Release'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
         inputs:
-          script: yarn install && yarn build:production
+          script: yarn install
           workingDirectory: $(Agent.TempDirectory)/jellyfin-web
 
       - task: CopyFiles@2

--- a/.ci/azure-pipelines-windows.yml
+++ b/.ci/azure-pipelines-windows.yml
@@ -36,7 +36,7 @@ jobs:
         displayName: "Build Web Client"
         condition: and(succeeded(), or(contains(variables['System.PullRequest.TargetBranch'], 'release'), contains(variables['System.PullRequest.TargetBranch'], 'master'), contains(variables['Build.SourceBranch'], 'release'), contains(variables['Build.SourceBranch'], 'master')), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
         inputs:
-          script: yarn install && yarn build:production
+          script: yarn install
           workingDirectory: $(Agent.TempDirectory)/jellyfin-web
 
       - task: CopyFiles@2

--- a/.ci/azure-pipelines-windows.yml
+++ b/.ci/azure-pipelines-windows.yml
@@ -36,7 +36,7 @@ jobs:
         displayName: "Build Web Client"
         condition: and(succeeded(), or(contains(variables['System.PullRequest.TargetBranch'], 'release'), contains(variables['System.PullRequest.TargetBranch'], 'master'), contains(variables['Build.SourceBranch'], 'release'), contains(variables['Build.SourceBranch'], 'master')), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
         inputs:
-          script: yarn install && yarn build
+          script: yarn install && yarn build:production
           workingDirectory: $(Agent.TempDirectory)/jellyfin-web
 
       - task: CopyFiles@2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && yarn build \
+ && yarn build:production \
  && mv dist /dist
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install \
- && yarn build:production \
+ && yarn install
  && mv dist /dist
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install
+ && yarn install \
  && mv dist /dist
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -10,8 +10,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install \
- && yarn build:production \
+ && yarn install
  && mv dist /dist
 
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -11,7 +11,7 @@ RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && yarn build \
+ && yarn build:production \
  && mv dist /dist
 
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -10,7 +10,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install
+ && yarn install \
  && mv dist /dist
 
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@ RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && yarn build \
+ && yarn build:production \
  && mv dist /dist
 
 
@@ -35,7 +35,7 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
-RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \ 
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
  ffmpeg \
  libssl-dev \
  ca-certificates \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -10,8 +10,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install \
- && yarn build:production \
+ && yarn install
  && mv dist /dist
 
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -10,7 +10,7 @@ ARG JELLYFIN_WEB_VERSION=master
 RUN apk add curl git \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
- && yarn install
+ && yarn install \
  && mv dist /dist
 
 


### PR DESCRIPTION
Use `yarn install` on its own instead of `yarn:build` in Azure build scripts and Docker files.

This brings the build scripts up to date with changes made in jellyfin-web: https://github.com/jellyfin/jellyfin-web/pull/953/files