### PR TITLE
Enable HTTP/2 support

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -20,6 +20,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Model.Globalization;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -253,10 +254,11 @@ namespace Jellyfin.Server
 
                             if (appHost.EnableHttps && appHost.Certificate != null)
                             {
-                                options.Listen(
-                                    address,
-                                    appHost.HttpsPort,
-                                    listenOptions => listenOptions.UseHttps(appHost.Certificate));
+                                options.Listen(address, appHost.HttpsPort, listenOptions =>
+                                {
+                                    listenOptions.UseHttps(appHost.Certificate);
+                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                });
                             }
                         }
                     }
@@ -267,9 +269,11 @@ namespace Jellyfin.Server
 
                         if (appHost.EnableHttps && appHost.Certificate != null)
                         {
-                            options.ListenAnyIP(
-                                appHost.HttpsPort,
-                                listenOptions => listenOptions.UseHttps(appHost.Certificate));
+                            options.ListenAnyIP(appHost.HttpsPort, listenOptions =>
+                            {
+                                listenOptions.UseHttps(appHost.Certificate);
+                                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                            });
                         }
                     }
                 })


### PR DESCRIPTION
Enable HTTP/2 support in Kestrel for HTTPS ports.

**Changes**
All that was required is to set `listenOptions.Protocols = HttpProtocols.Http1AndHttp2` when binding to the port.

![image](https://user-images.githubusercontent.com/2626103/77234975-86e92b00-6bb2-11ea-9f9b-cafe6e6b4c79.png)

Note that there are certain [documented conditions](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#http2-support) that must be met for Kestrel to enable HTTP/2. In particuar:

> †HTTP/2 will be supported on macOS in a future release. ‡Kestrel has limited support for HTTP/2 on Windows Server 2012 R2 and Windows 8.1.

**I am assuming that Kestrel gracefully falls back to HTTP1 in these scenarios, but I do not have the hardware to test that for sure.**

**Issues**
Fixes #403
