### PR TITLE
Add missing null check when retrieving extras

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -178,6 +178,7 @@ namespace MediaBrowser.Controller.Entities
 
         [JsonIgnore]
         public int? TotalBitrate { get; set; }
+
         [JsonIgnore]
         public ExtraType? ExtraType { get; set; }
 
@@ -2884,7 +2885,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType> extraTypes)
         {
-            return ExtraIds.Select(LibraryManager.GetItemById).Where(i => i != null && extraTypes.Contains(i.ExtraType.Value));
+            return ExtraIds.Select(LibraryManager.GetItemById).Where(i => i?.ExtraType != null && extraTypes.Contains(i.ExtraType.Value));
         }
 
         public IEnumerable<BaseItem> GetTrailers()


### PR DESCRIPTION
Exception was being thrown if `ExtraType` has a null value

**Issues**
Fixes #2484
