### PR TITLE
Fix embedded mkv subtitles.

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -183,9 +183,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
         private async Task<Stream> GetSubtitleStream(string path, MediaProtocol protocol, bool requiresCharset, CancellationToken cancellationToken)
         {
-            using (var stream = await GetStream(path, protocol, cancellationToken).ConfigureAwait(false))
+            if (requiresCharset)
             {
-                if (requiresCharset)
+                using (var stream = await GetStream(path, protocol, cancellationToken).ConfigureAwait(false))
                 {
                     var result = CharsetDetector.DetectFromStream(stream).Detected;
                     stream.Position = 0;
@@ -200,9 +200,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         return new MemoryStream(Encoding.UTF8.GetBytes(text));
                     }
                 }
-
-                return stream;
             }
+
+            return File.OpenRead(path);
         }
 
         private async Task<SubtitleInfo> GetReadableFile(


### PR DESCRIPTION
This PR fixes embedded MKV subtitles. There was a problem where the stream that needed to be send was closed before the stream could be served to the client. It retains the fix that enables UTF-8 subtitles in srt format to be streamed.

I have tested this with:
 - Embedded MKV subtitles in SRT and ASS format.
 - External UTF-8 ASS and SRT subtitles without BOM.

Tests were performed in MPV Shim and the web client.

**Changes**
Change GetSubtitleStream to return a file stream instead of a stream that will be closed by the using block.

**Issues**
Fixes #2650