### PR TITLE
Add netstandard2.0 as TargetFramework

### DIFF
--- a/MediaBrowser.Model/Extensions/StringHelper.cs
+++ b/MediaBrowser.Model/Extensions/StringHelper.cs
@@ -22,6 +22,11 @@ namespace MediaBrowser.Model.Extensions
                 return str;
             }
 
+#if NETSTANDARD2_0
+            char[] a = str.ToCharArray();
+            a[0] = char.ToUpperInvariant(a[0]);
+            return new string(a);
+#else
             return string.Create(
                 str.Length,
                 str,
@@ -33,6 +38,7 @@ namespace MediaBrowser.Model.Extensions
                         chars[i] = buf[i];
                     }
                 });
+#endif
         }
     }
 }

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' ">true</TreatWarningsAsErrors>


### PR DESCRIPTION
**Changes**
Added netstandard 2.0 as TargetFramework to allow usage from UWP (netstandard 2.1 not available in UWP until .net 5)

**Issues**
N/A
