### PR TITLE
Fix ApplicationHost Dispose() method

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1803,7 +1803,7 @@ namespace Emby.Server.Implementations
                 }
 
                 _userRepository?.Dispose();
-                _displayPreferencesRepository.Dispose();
+                _displayPreferencesRepository?.Dispose();
             }
 
             _userRepository = null;


### PR DESCRIPTION
There is a missing null check in the `ApplicationHost.Dispose()` method that throws a `NullReferenceException` if `_displayPreferencesRepository` has not been initialized.

An example of this happening: https://github.com/jellyfin/jellyfin-plugin-autoorganize/issues/29#issuecomment-603984114