### PR TITLE
Make variables binding correspond with column names

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -6288,8 +6288,8 @@ where AncestorIdText not null and ItemValues.Value not null and ItemValues.Type 
                         statement.TryBind("@Codec" + index, attachment.Codec);
                         statement.TryBind("@CodecTag" + index, attachment.CodecTag);
                         statement.TryBind("@Comment" + index, attachment.Comment);
-                        statement.TryBind("@FileName" + index, attachment.FileName);
-                        statement.TryBind("@MimeType" + index, attachment.MimeType);
+                        statement.TryBind("@Filename" + index, attachment.FileName);
+                        statement.TryBind("@MIMEType" + index, attachment.MimeType);
                     }
 
                     statement.Reset();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
When building a SQL statement, variables being bound must correspond to placeholder names.
The insert query was using `_mediaAttachmentSaveColumns` for names, so I'm fixing bindings to use same names.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Without this patch saving scanned attachments for me are completely broken erroring out with

```
[ERR] [22] App: Error in ffprobe
System.ArgumentException: Invalid param name: @FileName0 (Parameter 'name')
   at Emby.Server.Implementations.Data.SqliteExtensions.CheckName(String name) in jf-src\jellyfin\Emby.Server.Implementations\Data\SqliteExtensions.cs:line 184
   at Emby.Server.Implementations.Data.SqliteExtensions.TryBind(IStatement statement, String name, String value) in jf-src\jellyfin\Emby.Server.Implementations\Data\SqliteExtensions.cs:line 215
   at Emby.Server.Implementations.Data.SqliteItemRepository.InsertMediaAttachments(Byte[] idBlob, IReadOnlyList`1 attachments, IDatabaseConnection db, CancellationToken cancellationToken) in jf-src\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 6291
   at Emby.Server.Implementations.Data.SqliteItemRepository.<>c__DisplayClass127_0.<SaveMediaAttachments>b__0(IDatabaseConnection db) in jf-src\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 6238
   at SQLitePCL.pretty.DatabaseConnection.<>c__DisplayClass20_0.<RunInTransaction>b__0(IDatabaseConnection db)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction[T](IDatabaseConnection This, Func`2 f, TransactionMode mode)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction(IDatabaseConnection This, Action`1 action, TransactionMode mode)
   at Emby.Server.Implementations.Data.ManagedConnection.RunInTransaction(Action`1 action, TransactionMode mode) in jf-src\jellyfin\Emby.Server.Implementations\Data\ManagedConnection.cs:line 50
   at Emby.Server.Implementations.Data.SqliteItemRepository.SaveMediaAttachments(Guid id, IReadOnlyList`1 attachments, CancellationToken cancellationToken) in jf-src\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 6232
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.Fetch(Video video, CancellationToken cancellationToken, MediaInfo mediaInfo, BlurayDiscInfo blurayInfo, MetadataRefreshOptions options) in jf-src\jellyfin\MediaBrowser.Providers\MediaInfo\FFProbeVideoInfo.cs:line 229
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.ProbeVideo[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken) in jf-src\jellyfin\MediaBrowser.Providers\MediaInfo\FFProbeVideoInfo.cs:line 119
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken) in jf-src\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 804
```