### PR TITLE
fix(build): update docker build for centos

### DIFF
--- a/deployment/centos-package-x64/Dockerfile
+++ b/deployment/centos-package-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG PLATFORM_DIR=/jellyfin/deployment/centos-package-x64
@@ -13,12 +13,12 @@ RUN yum update -y \
  && yum install -y epel-release
 
 # Install build dependencies
-RUN yum install -y @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel git
+RUN yum install -y make rpmdevtools libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel git
 
 # Install recent NodeJS and Yarn
 RUN curl -fSsLo /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo \
- && rpm -i https://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
- && yum install -y yarn
+ && curl -sL https://rpm.nodesource.com/setup_12.x | bash - \
+ && yum install -y nodejs yarn
 
 # Install DotNET SDK
 RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm \


### PR DESCRIPTION
I decided to see if I could get a working build for CentOS 8 and was successful.

Testing of the RPM build was done within a CentOS 8 Vagrant box, but with 1 issue.
I was able to use `curl -L` and `wget` to display the install wizard HTML, but was unable to get it to work with port forwarding with Vagrant.

**Changes**
This updates the Dockerfile for CentOS with the following changes:
* Switch to CentOS 8
* Move to NodeJS 12 [LTS](https://nodejs.org/en/)
* Remove `yum-plugins-core`
* Add `make` package

**NOTE:** I'm still not sure if epel-release is needed, but I decided to leave it for now.

**Issues**
Possibly fixes #2563 

Let me know if there are any required changes.
