### PR TITLE
Display Extras With Unknown Types

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -506,14 +506,62 @@ namespace Emby.Naming.Common
                     Token = "-short",
                     MediaType = MediaType.Video
                 },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.BehindTheScenes, Token = "behind the scenes" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.DeletedScene, Token = "deleted scenes" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Interview, Token = "interviews" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Scene, Token = "scenes" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Sample, Token = "samples" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Clip, Token = "shorts" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Clip, Token = "featurettes" },
-                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Unknown, Token = "extras" },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.BehindTheScenes,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "behind the scenes",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.DeletedScene,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "deleted scenes",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Interview,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "interviews",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Scene,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "scenes",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Sample,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "samples",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Clip,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "shorts",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Clip,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "featurettes",
+                    MediaType = MediaType.Video,
+                },
+                new ExtraRule
+                {
+                    ExtraType = ExtraType.Unknown,
+                    RuleType = ExtraRuleType.DirectoryName,
+                    Token = "extras",
+                    MediaType = MediaType.Video,
+                },
             };
 
             Format3DRules = new[]

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -505,7 +505,15 @@ namespace Emby.Naming.Common
                     RuleType = ExtraRuleType.Suffix,
                     Token = "-short",
                     MediaType = MediaType.Video
-                }
+                },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.BehindTheScenes, Token = "behind the scenes" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.DeletedScene, Token = "deleted scenes" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Interview, Token = "interviews" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Scene, Token = "scenes" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Sample, Token = "samples" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Clip, Token = "shorts" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Clip, Token = "featurettes" },
+                new ExtraRule { RuleType = ExtraRuleType.DirectoryName, MediaType = MediaType.Video, ExtraType = ExtraType.Unknown, Token = "extras" },
             };
 
             Format3DRules = new[]

--- a/Emby.Naming/Video/ExtraResolver.cs
+++ b/Emby.Naming/Video/ExtraResolver.cs
@@ -80,6 +80,15 @@ namespace Emby.Naming.Video
                     result.Rule = rule;
                 }
             }
+            else if (rule.RuleType == ExtraRuleType.DirectoryName)
+            {
+                var directoryName = Path.GetFileName(Path.GetDirectoryName(path));
+                if (string.Equals(directoryName, rule.Token, StringComparison.OrdinalIgnoreCase))
+                {
+                    result.ExtraType = rule.ExtraType;
+                    result.Rule = rule;
+                }
+            }
 
             return result;
         }

--- a/Emby.Naming/Video/ExtraRule.cs
+++ b/Emby.Naming/Video/ExtraRule.cs
@@ -5,30 +5,29 @@ using MediaType = Emby.Naming.Common.MediaType;
 
 namespace Emby.Naming.Video
 {
+    /// <summary>
+    /// A rule used to match a file path with an <see cref="MediaBrowser.Model.Entities.ExtraType"/>.
+    /// </summary>
     public class ExtraRule
     {
         /// <summary>
-        /// Gets or sets the token.
+        /// Gets or sets the token to use for matching against the file path.
         /// </summary>
-        /// <value>The token.</value>
         public string Token { get; set; }
 
         /// <summary>
-        /// Gets or sets the type of the extra.
+        /// Gets or sets the type of the extra to return when matched.
         /// </summary>
-        /// <value>The type of the extra.</value>
         public ExtraType ExtraType { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the rule.
         /// </summary>
-        /// <value>The type of the rule.</value>
         public ExtraRuleType RuleType { get; set; }
 
         /// <summary>
-        /// Gets or sets the type of the media.
+        /// Gets or sets the type of the media to return when matched.
         /// </summary>
-        /// <value>The type of the media.</value>
         public MediaType MediaType { get; set; }
     }
 }

--- a/Emby.Naming/Video/ExtraRuleType.cs
+++ b/Emby.Naming/Video/ExtraRuleType.cs
@@ -5,18 +5,23 @@ namespace Emby.Naming.Video
     public enum ExtraRuleType
     {
         /// <summary>
-        /// The suffix
+        /// Match <see cref="ExtraRule.Token"/> against a suffix in the file name.
         /// </summary>
         Suffix = 0,
 
         /// <summary>
-        /// The filename
+        /// Match <see cref="ExtraRule.Token"/> against the file name.
         /// </summary>
         Filename = 1,
 
         /// <summary>
-        /// The regex
+        /// Match <see cref="ExtraRule.Token"/> against the a regex.
         /// </summary>
-        Regex = 2
+        Regex = 2,
+
+        /// <summary>
+        /// Match <see cref="ExtraRule.Token"/> against the directory name of the file.
+        /// </summary>
+        DirectoryName = 3,
     }
 }

--- a/Emby.Naming/Video/ExtraRuleType.cs
+++ b/Emby.Naming/Video/ExtraRuleType.cs
@@ -20,7 +20,7 @@ namespace Emby.Naming.Video
         Regex = 2,
 
         /// <summary>
-        /// Match <see cref="ExtraRule.Token"/> against the directory name of the file.
+        /// Match <see cref="ExtraRule.Token"/> against the name of the directory containing the file.
         /// </summary>
         DirectoryName = 3,
     }

--- a/Emby.Naming/Video/ExtraRuleType.cs
+++ b/Emby.Naming/Video/ExtraRuleType.cs
@@ -10,12 +10,12 @@ namespace Emby.Naming.Video
         Suffix = 0,
 
         /// <summary>
-        /// Match <see cref="ExtraRule.Token"/> against the file name.
+        /// Match <see cref="ExtraRule.Token"/> against the file name, excluding the file extension.
         /// </summary>
         Filename = 1,
 
         /// <summary>
-        /// Match <see cref="ExtraRule.Token"/> against the a regex.
+        /// Match <see cref="ExtraRule.Token"/> against the file name, including the file extension.
         /// </summary>
         Regex = 2,
 

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1062,7 +1062,7 @@ namespace Emby.Server.Implementations.Dto
 
             if (options.ContainsField(ItemFields.LocalTrailerCount))
             {
-                allExtras = allExtras ?? item.GetExtras().ToArray();
+                allExtras ??= item.GetExtras().ToArray();
                 dto.LocalTrailerCount = allExtras.Count(i => i.ExtraType == ExtraType.Trailer);
 
                 if (item is IHasTrailers hasTrailers)

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1056,30 +1056,19 @@ namespace Emby.Server.Implementations.Dto
 
             if (options.ContainsField(ItemFields.SpecialFeatureCount))
             {
-                if (allExtras == null)
-                {
-                    allExtras = item.GetExtras().ToArray();
-                }
-
-                dto.SpecialFeatureCount = allExtras.Count(i => i.ExtraType.HasValue && BaseItem.DisplayExtraTypes.Contains(i.ExtraType.Value));
+                allExtras = item.GetExtras().ToArray();
+                dto.SpecialFeatureCount = allExtras.Count(i => i.HasExtraType(BaseItem.DisplayExtraTypes, true));
             }
 
             if (options.ContainsField(ItemFields.LocalTrailerCount))
             {
-                int trailerCount = 0;
-                if (allExtras == null)
-                {
-                    allExtras = item.GetExtras().ToArray();
-                }
-
-                trailerCount += allExtras.Count(i => i.ExtraType.HasValue && i.ExtraType.Value == ExtraType.Trailer);
+                allExtras = allExtras ?? item.GetExtras().ToArray();
+                dto.LocalTrailerCount = allExtras.Count(i => i.HasExtraType(new[] { ExtraType.Trailer }, false));
 
                 if (item is IHasTrailers hasTrailers)
                 {
-                    trailerCount += hasTrailers.GetTrailerCount();
+                    dto.LocalTrailerCount += hasTrailers.GetTrailerCount();
                 }
-
-                dto.LocalTrailerCount = trailerCount;
             }
 
             // Add EpisodeInfo

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1057,13 +1057,13 @@ namespace Emby.Server.Implementations.Dto
             if (options.ContainsField(ItemFields.SpecialFeatureCount))
             {
                 allExtras = item.GetExtras().ToArray();
-                dto.SpecialFeatureCount = allExtras.Count(i => i.HasExtraType(BaseItem.DisplayExtraTypes, true));
+                dto.SpecialFeatureCount = allExtras.Count(i => BaseItem.DisplayExtraTypes.Contains(i.ExtraType));
             }
 
             if (options.ContainsField(ItemFields.LocalTrailerCount))
             {
                 allExtras = allExtras ?? item.GetExtras().ToArray();
-                dto.LocalTrailerCount = allExtras.Count(i => i.HasExtraType(new[] { ExtraType.Trailer }, false));
+                dto.LocalTrailerCount = allExtras.Count(i => i.ExtraType == ExtraType.Trailer);
 
                 if (item is IHasTrailers hasTrailers)
                 {

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1057,7 +1057,7 @@ namespace Emby.Server.Implementations.Dto
             if (options.ContainsField(ItemFields.SpecialFeatureCount))
             {
                 allExtras = item.GetExtras().ToArray();
-                dto.SpecialFeatureCount = allExtras.Count(i => BaseItem.DisplayExtraTypes.Contains(i.ExtraType));
+                dto.SpecialFeatureCount = allExtras.Count(i => i.ExtraType.HasValue && BaseItem.DisplayExtraTypes.Contains(i.ExtraType.Value));
             }
 
             if (options.ContainsField(ItemFields.LocalTrailerCount))

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2609,14 +2609,12 @@ namespace Emby.Server.Implementations.Library
                 }).OrderBy(i => i.Path);
         }
 
-        private static readonly string[] ExtrasSubfolderNames = new[] { "extras", "specials", "shorts", "scenes", "featurettes", "behind the scenes", "deleted scenes", "interviews" };
-
         public IEnumerable<Video> FindExtras(BaseItem owner, List<FileSystemMetadata> fileSystemChildren, IDirectoryService directoryService)
         {
             var namingOptions = GetNamingOptions();
 
             var files = owner.IsInMixedFolder ? new List<FileSystemMetadata>() : fileSystemChildren.Where(i => i.IsDirectory)
-                .Where(i => ExtrasSubfolderNames.Contains(i.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                .Where(i => BaseItem.AllExtrasTypesFolderNames.Contains(i.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase))
                 .SelectMany(i => _fileSystem.GetFiles(i.FullName, _videoFileExtensions, false, false))
                 .ToList();
 

--- a/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
+++ b/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
@@ -381,7 +381,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             var dtoOptions = GetDtoOptions(_authContext, request);
 
-            var dtosExtras = item.GetExtras(new ExtraType?[] { ExtraType.Trailer })
+            var dtosExtras = item.GetExtras(new ExtraType[] { ExtraType.Trailer })
                 .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
                 .ToArray();
 

--- a/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
+++ b/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
@@ -381,7 +381,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             var dtoOptions = GetDtoOptions(_authContext, request);
 
-            var dtosExtras = item.GetExtras(new ExtraType[] { ExtraType.Trailer })
+            var dtosExtras = item.GetExtras(new[] { ExtraType.Trailer })
                 .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
                 .ToArray();
 

--- a/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
+++ b/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
@@ -380,7 +380,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             var dtoOptions = GetDtoOptions(_authContext, request);
 
-            var dtosExtras = item.GetExtras(new[] { ExtraType.Trailer })
+            var dtosExtras = item.GetExtras(new[] { ExtraType.Trailer }, false)
                 .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
                 .ToArray();
 

--- a/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
+++ b/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
@@ -361,7 +361,8 @@ namespace MediaBrowser.Api.UserLibrary
 
             var dtoOptions = GetDtoOptions(_authContext, request);
 
-            var dtos = item.GetDisplayExtras()
+            var dtos = item
+                .GetExtras(BaseItem.DisplayExtraTypes)
                 .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item));
 
             return dtos.ToArray();
@@ -380,7 +381,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             var dtoOptions = GetDtoOptions(_authContext, request);
 
-            var dtosExtras = item.GetExtras(new[] { ExtraType.Trailer }, false)
+            var dtosExtras = item.GetExtras(new ExtraType?[] { ExtraType.Trailer })
                 .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
                 .ToArray();
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1327,8 +1327,9 @@ namespace MediaBrowser.Controller.Entities
                         }
 
                         // Use some hackery to get the extra type based on foldername
-                        Enum.TryParse(extraFolderName.Replace(" ", ""), true, out ExtraType extraType);
-                        item.ExtraType = extraType;
+                        item.ExtraType = Enum.TryParse(extraFolderName.Replace(" ", ""), true, out ExtraType extraType)
+                            ? extraType
+                            : (ExtraType?)null;
 
                         return item;
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2878,14 +2878,30 @@ namespace MediaBrowser.Controller.Entities
         /// <value>The remote trailers.</value>
         public IReadOnlyList<MediaUrl> RemoteTrailers { get; set; }
 
+        /// <summary>
+        /// Get all extras associated with this item, sorted by <see cref="SortName"/>.
+        /// </summary>
+        /// <returns>An enumerable containing the items.</returns>
         public IEnumerable<BaseItem> GetExtras()
         {
-            return ExtraIds.Select(LibraryManager.GetItemById).Where(i => i != null).OrderBy(i => i.SortName);
+            return ExtraIds
+                .Select(LibraryManager.GetItemById)
+                .Where(i => i != null)
+                .OrderBy(i => i.SortName);
         }
 
-        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType> extraTypes)
+        /// <summary>
+        /// Get all extras with specific types that are associated with this item.
+        /// </summary>
+        /// <param name="extraTypes">The types of extras to retrieve.</param>
+        /// <param name="includeUnknownTypes">If true, include extras whose type could not be determined.</param>
+        /// <returns>An enumerable containing the extras.</returns>
+        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType> extraTypes, bool includeUnknownTypes)
         {
-            return ExtraIds.Select(LibraryManager.GetItemById).Where(i => i?.ExtraType != null && extraTypes.Contains(i.ExtraType.Value));
+            return ExtraIds
+                .Select(LibraryManager.GetItemById)
+                .Where(i => i != null)
+                .Where(i => i.HasExtraType(extraTypes, includeUnknownTypes));
         }
 
         public IEnumerable<BaseItem> GetTrailers()
@@ -2896,9 +2912,27 @@ namespace MediaBrowser.Controller.Entities
                 return Array.Empty<BaseItem>();
         }
 
+        /// <summary>
+        /// Get all extras associated with this item that should be displayed as "Special Features" in the UI. This is
+        /// all extras with either an unknown type, or a type contained in <see cref="DisplayExtraTypes"/>.
+        /// </summary>
+        /// <returns>An IEnumerable containing the extra items.</returns>
         public IEnumerable<BaseItem> GetDisplayExtras()
         {
-            return GetExtras(DisplayExtraTypes);
+            return GetExtras(DisplayExtraTypes, true);
+        }
+
+        /// <summary>
+        /// Check if this item is an extra with a type that matches a given set.
+        /// </summary>
+        /// <param name="extraTypes">The types of extras to match with.</param>
+        /// <param name="includeUnknownTypes">If true, include extras whose type could not be determined.</param>
+        /// <returns>True if this item matches, otherwise false.</returns>
+        public bool HasExtraType(IReadOnlyCollection<ExtraType> extraTypes, bool includeUnknownTypes)
+        {
+            return
+                (includeUnknownTypes && (ExtraType == null || ExtraType == 0))
+                || (ExtraType.HasValue && extraTypes.Contains(ExtraType.Value));
         }
 
         public virtual bool IsHD => Height >= 720;
@@ -2918,8 +2952,18 @@ namespace MediaBrowser.Controller.Entities
             return RunTimeTicks ?? 0;
         }
 
-        // Possible types of extra videos
-        public static readonly IReadOnlyCollection<ExtraType> DisplayExtraTypes = new[] { Model.Entities.ExtraType.BehindTheScenes, Model.Entities.ExtraType.Clip, Model.Entities.ExtraType.DeletedScene, Model.Entities.ExtraType.Interview, Model.Entities.ExtraType.Sample, Model.Entities.ExtraType.Scene };
+        /// <summary>
+        /// Extra types that should be counted and displayed as "Special Features" in the UI.
+        /// </summary>
+        public static readonly IReadOnlyCollection<ExtraType> DisplayExtraTypes = new HashSet<ExtraType>
+        {
+            Model.Entities.ExtraType.BehindTheScenes,
+            Model.Entities.ExtraType.Clip,
+            Model.Entities.ExtraType.DeletedScene,
+            Model.Entities.ExtraType.Interview,
+            Model.Entities.ExtraType.Sample,
+            Model.Entities.ExtraType.Scene
+        };
 
         public virtual bool SupportsExternalTransfer => false;
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1329,7 +1329,7 @@ namespace MediaBrowser.Controller.Entities
                         // Use some hackery to get the extra type based on foldername
                         item.ExtraType = Enum.TryParse(extraFolderName.Replace(" ", ""), true, out ExtraType extraType)
                             ? extraType
-                            : (ExtraType?)null;
+                            : Model.Entities.ExtraType.Unknown;
 
                         return item;
 
@@ -2896,12 +2896,12 @@ namespace MediaBrowser.Controller.Entities
         /// </summary>
         /// <param name="extraTypes">The types of extras to retrieve.</param>
         /// <returns>An enumerable containing the extras.</returns>
-        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType?> extraTypes)
+        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType> extraTypes)
         {
             return ExtraIds
                 .Select(LibraryManager.GetItemById)
                 .Where(i => i != null)
-                .Where(i => extraTypes.Contains(i.ExtraType));
+                .Where(i => i.ExtraType.HasValue && extraTypes.Contains(i.ExtraType.Value));
         }
 
         public IEnumerable<BaseItem> GetTrailers()
@@ -2932,10 +2932,9 @@ namespace MediaBrowser.Controller.Entities
         /// <summary>
         /// Extra types that should be counted and displayed as "Special Features" in the UI.
         /// </summary>
-        public static readonly IReadOnlyCollection<ExtraType?> DisplayExtraTypes = new HashSet<ExtraType?>
+        public static readonly IReadOnlyCollection<ExtraType> DisplayExtraTypes = new HashSet<ExtraType>
         {
-            null,
-            0,
+            Model.Entities.ExtraType.Unknown,
             Model.Entities.ExtraType.BehindTheScenes,
             Model.Entities.ExtraType.Clip,
             Model.Entities.ExtraType.DeletedScene,

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2895,14 +2895,13 @@ namespace MediaBrowser.Controller.Entities
         /// Get all extras with specific types that are associated with this item.
         /// </summary>
         /// <param name="extraTypes">The types of extras to retrieve.</param>
-        /// <param name="includeUnknownTypes">If true, include extras whose type could not be determined.</param>
         /// <returns>An enumerable containing the extras.</returns>
-        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType> extraTypes, bool includeUnknownTypes)
+        public IEnumerable<BaseItem> GetExtras(IReadOnlyCollection<ExtraType?> extraTypes)
         {
             return ExtraIds
                 .Select(LibraryManager.GetItemById)
                 .Where(i => i != null)
-                .Where(i => i.HasExtraType(extraTypes, includeUnknownTypes));
+                .Where(i => extraTypes.Contains(i.ExtraType));
         }
 
         public IEnumerable<BaseItem> GetTrailers()
@@ -2911,29 +2910,6 @@ namespace MediaBrowser.Controller.Entities
                 return ((IHasTrailers)this).LocalTrailerIds.Select(LibraryManager.GetItemById).Where(i => i != null).OrderBy(i => i.SortName);
             else
                 return Array.Empty<BaseItem>();
-        }
-
-        /// <summary>
-        /// Get all extras associated with this item that should be displayed as "Special Features" in the UI. This is
-        /// all extras with either an unknown type, or a type contained in <see cref="DisplayExtraTypes"/>.
-        /// </summary>
-        /// <returns>An IEnumerable containing the extra items.</returns>
-        public IEnumerable<BaseItem> GetDisplayExtras()
-        {
-            return GetExtras(DisplayExtraTypes, true);
-        }
-
-        /// <summary>
-        /// Check if this item is an extra with a type that matches a given set.
-        /// </summary>
-        /// <param name="extraTypes">The types of extras to match with.</param>
-        /// <param name="includeUnknownTypes">If true, include extras whose type could not be determined.</param>
-        /// <returns>True if this item matches, otherwise false.</returns>
-        public bool HasExtraType(IReadOnlyCollection<ExtraType> extraTypes, bool includeUnknownTypes)
-        {
-            return
-                (includeUnknownTypes && (ExtraType == null || ExtraType == 0))
-                || (ExtraType.HasValue && extraTypes.Contains(ExtraType.Value));
         }
 
         public virtual bool IsHD => Height >= 720;
@@ -2956,8 +2932,10 @@ namespace MediaBrowser.Controller.Entities
         /// <summary>
         /// Extra types that should be counted and displayed as "Special Features" in the UI.
         /// </summary>
-        public static readonly IReadOnlyCollection<ExtraType> DisplayExtraTypes = new HashSet<ExtraType>
+        public static readonly IReadOnlyCollection<ExtraType?> DisplayExtraTypes = new HashSet<ExtraType?>
         {
+            null,
+            0,
             Model.Entities.ExtraType.BehindTheScenes,
             Model.Entities.ExtraType.Clip,
             Model.Entities.ExtraType.DeletedScene,

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1327,7 +1327,7 @@ namespace MediaBrowser.Controller.Entities
                         }
 
                         // Use some hackery to get the extra type based on foldername
-                        item.ExtraType = Enum.TryParse(extraFolderName.Replace(" ", ""), true, out ExtraType extraType)
+                        item.ExtraType = Enum.TryParse(extraFolderName.Replace(" ", string.Empty), true, out ExtraType extraType)
                             ? extraType
                             : Model.Entities.ExtraType.Unknown;
 

--- a/MediaBrowser.Model/Entities/ExtraType.cs
+++ b/MediaBrowser.Model/Entities/ExtraType.cs
@@ -4,6 +4,7 @@ namespace MediaBrowser.Model.Entities
 {
     public enum ExtraType
     {
+        Unknown = 0,
         Clip = 1,
         Trailer = 2,
         BehindTheScenes = 3,


### PR DESCRIPTION
The existing behavior for extras is to not display any extras where the `ExtraType` property could not be determined (i.e. is `null`). This changes that behavior to display those extras with unknown type.

There should likely be additional changes to improve/change how the extra type is parsed, but I think that should be in a separate PR and would be out of scope here.

**Changes**
* Include extras with an unknown type in the `SpecialFeatureCount` DTO property 
* Include extras with an unknown type in response to a `GetSpecialFeatures` request
* Fix an issue where the `ExtraType` is saved as `0` (an invalid enumeration value) instead of `null`

**Issues**
Fixes #2665 
Fixes #2484 