### PR TITLE
Dockerfile: support for non-ASCII characters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,15 +45,20 @@ RUN apt-get update \
    ca-certificates \
    vainfo \
    i965-va-driver \
+   locales \
  && apt-get clean autoclean -y\
  && apt-get autoremove -y\
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
  && chmod 777 /cache /config /media \
  && ln -s /opt/ffmpeg/bin/ffmpeg /usr/local/bin \
- && ln -s /opt/ffmpeg/bin/ffprobe /usr/local/bin
+ && ln -s /opt/ffmpeg/bin/ffprobe /usr/local/bin \
+ && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 
 EXPOSE 8096
 VOLUME /cache /config /media

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -52,16 +52,22 @@ RUN apt-get update \
  libraspberrypi0 \
  vainfo \
  libva2 \
+ locales \
  && apt-get remove curl gnupg -y \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
- && chmod 777 /cache /config /media
+ && chmod 777 /cache /config /media \
+ && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 
 EXPOSE 8096
 VOLUME /cache /config /media

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -42,15 +42,21 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
  libfreetype6 \
  libomxil-bellagio0 \
  libomxil-bellagio-bin \
+ locales \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /cache /config /media \
- && chmod 777 /cache /config /media
+ && chmod 777 /cache /config /media \
+ && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 
 EXPOSE 8096
 VOLUME /cache /config /media


### PR DESCRIPTION
Change the default locale from `POSIX` to `make Jellyfin support  non-ASCII characters.

**Issues**

before:

```
'['$'\351\223\266\347\277\274\346\235\200\346\211\213''].Blade.Runner.1982.FiNAL.CUT.720p.HDDVD.x264-SiNNERS.mkv'
'['$'\351\223\266\347\277\274\346\235\200\346\211\213''].Blade.Runner.1982.FiNAL.CUT.720p.HDDVD.x264-SiNNERS.nfo'
```

after apply patch:

```
'[银翼杀手].Blade.Runner.1982.FiNAL.CUT.720p.HDDVD.x264-SiNNERS.mkv'
'[银翼杀手].Blade.Runner.1982.FiNAL.CUT.720p.HDDVD.x264-SiNNERS.nfo'
```


