### PR TITLE
Revert #2146 ordering change

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1401,6 +1401,16 @@ namespace Emby.Server.Implementations.Session
                 user = _userManager.GetUserByName(request.Username);
             }
 
+            if (enforcePassword)
+            {
+                user = await _userManager.AuthenticateUser(
+                    request.Username,
+                    request.Password,
+                    request.PasswordSha1,
+                    request.RemoteEndPoint,
+                    true).ConfigureAwait(false);
+            }
+
             if (user == null)
             {
                 AuthenticationFailed?.Invoke(this, new GenericEventArgs<AuthenticationRequest>(request));
@@ -1411,16 +1421,6 @@ namespace Emby.Server.Implementations.Session
                 && !_deviceManager.CanAccessDevice(user, request.DeviceId))
             {
                 throw new SecurityException("User is not allowed access from this device.");
-            }
-
-            if (enforcePassword)
-            {
-                user = await _userManager.AuthenticateUser(
-                    request.Username,
-                    request.Password,
-                    request.PasswordSha1,
-                    request.RemoteEndPoint,
-                    true).ConfigureAwait(false);
             }
 
             var token = GetAuthorizationToken(user, request.DeviceId, request.App, request.AppVersion, request.DeviceName);


### PR DESCRIPTION
**Changes**
Reverts the ordering change from #2146 which caused user creation in the LDAP plugin to fail.

The underlying CORS issue #1794 ("connection failed" for invalid users) is still present, but that is outside scope right now.

**Issues**
Fixes #2540