### PR TITLE
Prefer to use libfdk_aac encoder for better audio quality when it is available

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -424,7 +424,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(codec, "aac", StringComparison.OrdinalIgnoreCase))
             {
-                // Prefer to use libfdk_aac for better audio quality while using the custom build FFmpeg
+                // Use libfdk_aac for better audio quality if using custom build of FFmpeg which has fdk_aac support
                 if (_mediaEncoder.SupportsEncoder("libfdk_aac"))
                 {
                     return "libfdk_aac";

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -424,6 +424,11 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(codec, "aac", StringComparison.OrdinalIgnoreCase))
             {
+                // Prefer to use libfdk_aac for better audio quality while using the custom build FFmpeg
+                if (_mediaEncoder.SupportsEncoder("libfdk_aac"))
+                {
+                    return "libfdk_aac";
+                }
                 return "aac -strict experimental";
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -429,7 +429,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     return "libfdk_aac";
                 }
-                return "aac -strict experimental";
+                return "aac";
             }
 
             if (string.Equals(codec, "mp3", StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -429,6 +429,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     return "libfdk_aac";
                 }
+
                 return "aac";
             }
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -42,6 +42,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "libvpx",
             "libvpx-vp9",
             "aac",
+            "libfdk_aac",
             "libmp3lame",
             "libopus",
             "libvorbis",


### PR DESCRIPTION
**Changes**

This PR was proposed by @PeterCxy.

> Currently, Jellyfin always tries to use the default aac encoder in ffmpeg when transcoding audio (for both video files and standalone music files). This encoder is fine for most purposes, but sometimes it produces some really jarring distortion at higher frequencies. It would be nice to be able to use a better aac encoder, however even if ffmpeg is built with libfdk_aac enabled, Jellyfin still uses the default aac encoder.

The library is also incompatible with GPL. Users would still need to supply their own build of FFmpeg to make this work, as libfdk_aac could not be redistributed.

https://ffmpeg.org/ffmpeg-all.html#libfdk_005faac


**Issues**
Fixes: https://github.com/jellyfin/jellyfin/issues/2705
