### PR TITLE
Separate Channels permissions from All Libraries

### DIFF
--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -214,6 +214,10 @@ namespace MediaBrowser.Api.UserLibrary
             }
 
             bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id);
+            
+            // Assume all folders inside an EnabledChannel are enabled
+            isInEnabledFolder = isInEnabledFolder || user.Policy.EnabledChannels.Any(i => new Guid(i) == item.Id);
+
             var collectionFolders = _libraryManager.GetCollectionFolders(item);
             foreach (var collectionFolder in collectionFolders)
             {
@@ -225,7 +229,7 @@ namespace MediaBrowser.Api.UserLibrary
                 }
             }
 
-            if (!(item is UserRootFolder) && !user.Policy.EnableAllFolders && !isInEnabledFolder)
+            if (!(item is UserRootFolder) && !user.Policy.EnableAllFolders && !isInEnabledFolder && !user.Policy.EnableAllChannels)
             {
                 Logger.LogWarning("{UserName} is not permitted to access Library {ItemName}.", user.Name, item.Name);
                 return new QueryResult<BaseItem>

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -213,9 +213,9 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id) ||
+            bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id)
                     // Assume all folders inside an EnabledChannel are enabled
-                    user.Policy.EnabledChannels.Any(i => new Guid(i) == item.Id);
+                    || user.Policy.EnabledChannels.Any(i => new Guid(i) == item.Id);
 
             var collectionFolders = _libraryManager.GetCollectionFolders(item);
             foreach (var collectionFolder in collectionFolders)

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -213,10 +213,9 @@ namespace MediaBrowser.Api.UserLibrary
                 request.IncludeItemTypes = "Playlist";
             }
 
-            bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id);
-            
-            // Assume all folders inside an EnabledChannel are enabled
-            isInEnabledFolder = isInEnabledFolder || user.Policy.EnabledChannels.Any(i => new Guid(i) == item.Id);
+            bool isInEnabledFolder = user.Policy.EnabledFolders.Any(i => new Guid(i) == item.Id) ||
+                    // Assume all folders inside an EnabledChannel are enabled
+                    user.Policy.EnabledChannels.Any(i => new Guid(i) == item.Id);
 
             var collectionFolders = _libraryManager.GetCollectionFolders(item);
             foreach (var collectionFolder in collectionFolders)


### PR DESCRIPTION
Currently, permission settings on Channels are not taken into account prior to returning `{UserName} is not permitted to access Library {ItemName}.`.  Whether or not a user can see items within the Channel is solely dependent on `EnableAllFolders`, so you cannot view a plugin's Channels unless you can also see ALL libraries.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR enables does two things for Channel-providing Plugins:
1. Fixes functionality of "EnableAllChannels"
2. Allows users with Channel permissions to access all folders within that Channel

I'm not 100% sure on 2 but I wasn't able to see an obvious way to propagate permissions downward into specific Folders inside a Channel.

I tested on a fairly simple library with two channel-providing plugins (ServerWMC, LazyMan) and it seems to work, but this behavior should also be tested by someone with more content/collections.

**Issues**
Fixes #2719
