### PR TITLE
Update Jellyfin.SkiaSharp.NativeAssets.LinuxArm to version 1.68.1

### DIFF
--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.1" />
-    <PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.0" />
+    <PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Arm binaries were outdated leading to crashes on Arm platforms.

Fixes #2471