### PR TITLE
Bump Version to 10.6.0

### DIFF
--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("10.5.0")]
-[assembly: AssemblyFileVersion("10.5.0")]
+[assembly: AssemblyVersion("10.6.0")]
+[assembly: AssemblyFileVersion("10.6.0")]

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin"
-version: "10.5.0"
+version: "10.6.0"
 packages:
   - debian-package-x64
   - debian-package-armhf

--- a/deployment/debian-package-x64/pkg-src/changelog
+++ b/deployment/debian-package-x64/pkg-src/changelog
@@ -1,3 +1,9 @@
+jellyfin (10.6.0-1) unstable; urgency=medium
+
+  * New upstream version 10.6.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.6.0
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  Sun, 05 Apr 2020 11:29:36 -0400
+
 jellyfin (10.5.0-1) unstable; urgency=medium
 
   * New upstream version 10.5.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.5.0

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -7,7 +7,7 @@
 %endif
 
 Name:           jellyfin
-Version:        10.5.0
+Version:        10.6.0
 Release:        1%{?dist}
 Summary:        The Free Software Media Browser
 License:        GPLv2
@@ -159,6 +159,8 @@ fi
 %systemd_postun_with_restart jellyfin.service
 
 %changelog
+* Sun Apr 05 2020 Jellyfin Packaging Team <packaging@jellyfin.org>
+- New upstream version 10.6.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.6.0
 * Fri Oct 11 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - New upstream version 10.5.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.5.0
 * Sat Aug 31 2019 Jellyfin Packaging Team <packaging@jellyfin.org>


### PR DESCRIPTION
This addresses issues with new plugin builds when running the server on nightly. The plugins are built against the latest NuGet package versions, which is `10.5.2` but the server runs with the outdated version `10.5.0`, so the plugin assemblies fail to load. For example:

```log
System.IO.FileNotFoundException: Could not load file or assembly 'MediaBrowser.Common, Version=10.5.2.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
```

This addresses the issue by updating the server assembly versions to match the latest NuGet versions. I'm not familiar enough with the release process to be 100% sure if this the correct approach to address this, so I'm tagging this for further discussion.

**Changes**
Update server assembly versions from `10.5.0` -> `10.5.2`

**Issues**
* Fixes https://github.com/jellyfin/jellyfin-plugin-autoorganize/issues/35
* Fixes https://github.com/jellyfin/jellyfin/issues/2652
* Fixes https://github.com/jellyfin/jellyfin/issues/2685
* Others?
