### PR TITLE
Specify a minimum version for jellyfin-ffmpeg dependency in .deb dependencies

### DIFF
--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -23,7 +23,7 @@ Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         jellyfin-ffmpeg,
+         jellyfin-ffmpeg (>= 4.2.1-2),
          libfontconfig1,
          libfreetype6,
          libssl1.1


### PR DESCRIPTION
Lower versions cause #2126 in Jellyfin >= 10.4.3.  This adds in a guardrail against building yourself a broken environment via the .deb installation