### PR TITLE
Make Plugin Repo URL Configurable

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Emby.Server.Implementations.HttpServer;
+using Emby.Server.Implementations.Updates;
 using MediaBrowser.Providers.Music;
 using static MediaBrowser.Controller.Extensions.ConfigurationExtensions;
 
@@ -17,6 +18,7 @@ namespace Emby.Server.Implementations
         {
             { HostWebClientKey, bool.TrueString },
             { HttpListenerHost.DefaultRedirectKey, "web/index.html" },
+            { InstallationManager.PluginManifestUrlKey, "https://repo.jellyfin.org/releases/plugin/manifest.json" },
             { FfmpegProbeSizeKey, "1G" },
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.TrueString }

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -3,33 +3,38 @@ namespace Emby.Server.Implementations
     public interface IStartupOptions
     {
         /// <summary>
-        /// --ffmpeg
+        /// Gets the value of the --ffmpeg command line option.
         /// </summary>
         string FFmpegPath { get; }
 
         /// <summary>
-        /// --service
+        /// Gets the value of the --service command line option.
         /// </summary>
         bool IsService { get; }
 
         /// <summary>
-        /// --noautorunwebapp
+        /// Gets the value of the --noautorunwebapp command line option.
         /// </summary>
         bool NoAutoRunWebApp { get; }
 
         /// <summary>
-        /// --package-name
+        /// Gets the value of the --package-name command line option.
         /// </summary>
         string PackageName { get; }
 
         /// <summary>
-        /// --restartpath
+        /// Gets the value of the --restartpath command line option.
         /// </summary>
         string RestartPath { get; }
 
         /// <summary>
-        /// --restartargs
+        /// Gets the value of the --restartargs command line option.
         /// </summary>
         string RestartArgs { get; }
+
+        /// <summary>
+        /// Gets the value of the --plugin-manifest-url command line option.
+        /// </summary>
+        string PluginManifestUrl { get; }
     }
 }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Model.Events;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Updates;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Updates
@@ -27,6 +28,11 @@ namespace Emby.Server.Implementations.Updates
     /// </summary>
     public class InstallationManager : IInstallationManager
     {
+        /// <summary>
+        /// The key for a setting that specifies a URL for the plugin repository JSON manifest.
+        /// </summary>
+        public const string PluginManifestUrlKey = "InstallationManager:PluginManifestUrl";
+
         /// <summary>
         /// The _logger.
         /// </summary>
@@ -44,6 +50,7 @@ namespace Emby.Server.Implementations.Updates
         private readonly IApplicationHost _applicationHost;
 
         private readonly IZipClient _zipClient;
+        private readonly IConfiguration _appConfig;
 
         private readonly object _currentInstallationsLock = new object();
 
@@ -65,7 +72,8 @@ namespace Emby.Server.Implementations.Updates
             IJsonSerializer jsonSerializer,
             IServerConfigurationManager config,
             IFileSystem fileSystem,
-            IZipClient zipClient)
+            IZipClient zipClient,
+            IConfiguration appConfig)
         {
             if (logger == null)
             {
@@ -83,6 +91,7 @@ namespace Emby.Server.Implementations.Updates
             _config = config;
             _fileSystem = fileSystem;
             _zipClient = zipClient;
+            _appConfig = appConfig;
         }
 
         /// <inheritdoc />
@@ -115,7 +124,7 @@ namespace Emby.Server.Implementations.Updates
             using (var response = await _httpClient.SendAsync(
                 new HttpRequestOptions
                 {
-                    Url = "https://repo.jellyfin.org/releases/plugin/manifest.json",
+                    Url = _appConfig.GetValue<string>(PluginManifestUrlKey),
                     CancellationToken = cancellationToken,
                     CacheMode = CacheMode.Unconditional,
                     CacheLength = TimeSpan.FromMinutes(3)

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
-using System.Globalization;
 using CommandLine;
 using Emby.Server.Implementations;
+using Emby.Server.Implementations.Updates;
 using MediaBrowser.Controller.Extensions;
 
 namespace Jellyfin.Server
@@ -76,6 +76,10 @@ namespace Jellyfin.Server
         [Option("restartargs", Required = false, HelpText = "Arguments for restart script.")]
         public string? RestartArgs { get; set; }
 
+        /// <inheritdoc />
+        [Option("plugin-manifest-url", Required = false, HelpText = "A custom URL for the plugin repository JSON manifest")]
+        public string? PluginManifestUrl { get; set; }
+
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.
         /// </summary>
@@ -83,6 +87,11 @@ namespace Jellyfin.Server
         public Dictionary<string, string> ConvertToConfig()
         {
             var config = new Dictionary<string, string>();
+
+            if (PluginManifestUrl != null)
+            {
+                config.Add(InstallationManager.PluginManifestUrlKey, PluginManifestUrl);
+            }
 
             if (NoWebClient)
             {


### PR DESCRIPTION
Add a command line switch and configuration setting for the plugin repository.

**Changes**
- Add `--plugin-manifest-url` command line option and `InstallationManager:PluginManifestUrl` configuration option and connect them to the `IConfiguration` framework
- Set `https://repo.jellyfin.org/releases/plugin/manifest.json` as the default value
- Add some extra logging in case the URL specified is not valid
