### PR TITLE
Display Audio Track titles

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -107,7 +107,8 @@ namespace MediaBrowser.Model.Entities
                         attributes.Add("Default");
                     }
 
-                    if (!string.IsNullOrEmpty(Title)) {
+                    if (!string.IsNullOrEmpty(Title))
+                    {
                         return attributes
                             // keep Tags that are not already in Title
                             .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -112,6 +112,14 @@ namespace MediaBrowser.Model.Entities
                         attributes.Add("Default");
                     }
 
+                    if (!string.IsNullOrEmpty(Title)) {
+                        return attributes.AsEnumerable()
+                        // keep Tags that are not already in Title
+                        .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1).Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
+                        // attributes concatenation, starting with Title
+                        .ToString();
+                    }
+
                     return string.Join(" ", attributes);
                 }
 

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -176,11 +176,11 @@ namespace MediaBrowser.Model.Entities
                     if (!string.IsNullOrEmpty(Title))
                     {
                         return attributes.AsEnumerable()
-                        // keep Tags that are not already in Title
-                        .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)
-                        // attributes concatenation, starting with Title
-                        .Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
-                        .ToString();
+                            // keep Tags that are not already in Title
+                            .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)
+                            // attributes concatenation, starting with Title
+                            .Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
+                            .ToString();
                     }
 
                     return string.Join(" - ", attributes.ToArray());

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -120,7 +120,7 @@ namespace MediaBrowser.Model.Entities
                         .ToString();
                     }
 
-                    return string.Join(" ", attributes);
+                    return string.Join(" - ", attributes);
                 }
 
                 if (Type == MediaStreamType.Video)

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -83,11 +83,11 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Language))
                     {
-                        // Get full language string i.e. eng -> English
+                        // Get full language string i.e. eng -> English. Will not work for some languages which use ISO 639-2/B instead of /T codes.
                         String fullLanguage = CultureInfo
-                            .GetCultures(CultureTypes.AllCultures)
+                            .GetCultures(CultureTypes.NeutralCultures)
                             .FirstOrDefault(r => r.ThreeLetterISOLanguageName.Equals(Language, StringComparison.OrdinalIgnoreCase))
-                            .DisplayName;
+                            ?.DisplayName;
                         attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                     }
                     if (!string.IsNullOrEmpty(Codec) && !string.Equals(Codec, "dca", StringComparison.OrdinalIgnoreCase))
@@ -151,11 +151,11 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Language))
                     {
-                        // Get full language string i.e. eng -> English
+                        // Get full language string i.e. eng -> English. Will not work for some languages which use ISO 639-2/B instead of /T codes.
                         String fullLanguage = CultureInfo
-                            .GetCultures(CultureTypes.AllCultures)
+                            .GetCultures(CultureTypes.NeutralCultures)
                             .FirstOrDefault(r => r.ThreeLetterISOLanguageName.Equals(Language, StringComparison.OrdinalIgnoreCase))
-                            .DisplayName;
+                            ?.DisplayName;
                         attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                     }
                     else

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -79,11 +79,6 @@ namespace MediaBrowser.Model.Entities
             {
                 if (Type == MediaStreamType.Audio)
                 {
-                    //if (!string.IsNullOrEmpty(Title))
-                    //{
-                    //    return AddLanguageIfNeeded(Title);
-                    //}
-
                     var attributes = new List<string>();
 
                     if (!string.IsNullOrEmpty(Language))
@@ -113,11 +108,12 @@ namespace MediaBrowser.Model.Entities
                     }
 
                     if (!string.IsNullOrEmpty(Title)) {
-                        return attributes.AsEnumerable()
-                        // keep Tags that are not already in Title
-                        .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1).Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
-                        // attributes concatenation, starting with Title
-                        .ToString();
+                        return attributes
+                            // keep Tags that are not already in Title
+                            .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)
+                            // attributes concatenation, starting with Title
+                            .Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
+                            .ToString();
                     }
 
                     return string.Join(" - ", attributes);

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -101,7 +101,7 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(ChannelLayout))
                     {
-                        attributes.Add(ChannelLayout);
+                        attributes.Add(StringHelper.FirstToUpper(ChannelLayout));
                     }
                     else if (Channels.HasValue)
                     {

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -109,9 +109,10 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Title))
                     {
+                        Console.WriteLine(Language);
                         return attributes
-                            // keep Tags that are not already in Title
-                            .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)
+                            // keep Tags that are not the same as the Title
+                            .Where(tag => !Title.Equals(tag))
                             // attributes concatenation, starting with Title
                             .Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
                             .ToString();

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -83,7 +83,12 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Language))
                     {
-                        attributes.Add(StringHelper.FirstToUpper(Language));
+                        // Get full language string i.e. eng -> English
+                        String fullLanguage = CultureInfo
+                            .GetCultures(CultureTypes.AllCultures)
+                            .FirstOrDefault(r => r.ThreeLetterISOLanguageName.Equals(Language, StringComparison.OrdinalIgnoreCase))
+                            .DisplayName;
+                        attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                     }
                     if (!string.IsNullOrEmpty(Codec) && !string.Equals(Codec, "dca", StringComparison.OrdinalIgnoreCase))
                     {
@@ -109,10 +114,9 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Title))
                     {
-                        Console.WriteLine(Language);
                         return attributes
                             // keep Tags that are not the same as the Title
-                            .Where(tag => !Title.Equals(tag))
+                            .Where(tag => Title.IndexOf(tag, StringComparison.OrdinalIgnoreCase) == -1)
                             // attributes concatenation, starting with Title
                             .Aggregate(new StringBuilder(Title), (builder, attr) => builder.Append(" - ").Append(attr))
                             .ToString();
@@ -147,7 +151,12 @@ namespace MediaBrowser.Model.Entities
 
                     if (!string.IsNullOrEmpty(Language))
                     {
-                        attributes.Add(StringHelper.FirstToUpper(Language));
+                        // Get full language string i.e. eng -> English
+                        String fullLanguage = CultureInfo
+                            .GetCultures(CultureTypes.AllCultures)
+                            .FirstOrDefault(r => r.ThreeLetterISOLanguageName.Equals(Language, StringComparison.OrdinalIgnoreCase))
+                            .DisplayName;
+                        attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                     }
                     else
                     {


### PR DESCRIPTION
**Changes**
Allows for named audio tracks to include their name in DisplayTitle. This avoids having multiple tracks with identical names, when some are commentaries. Feature request [here](https://features.jellyfin.org/posts/212/display-audio-track-titles).
Before:
![before](https://user-images.githubusercontent.com/20938000/78509841-4bbc2f80-774e-11ea-95a3-a0a1ada8dd1e.png)
After:
![after](https://user-images.githubusercontent.com/20938000/78509846-570f5b00-774e-11ea-9037-87b8f9cce619.png)
