### PR TITLE
Make codec check in profile examine profile type first

### DIFF
--- a/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
+++ b/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
@@ -25,12 +25,12 @@ namespace MediaBrowser.Model.Dlna
 
         public bool SupportsVideoCodec(string codec)
         {
-            return ContainerProfile.ContainsContainer(VideoCodec, codec);
+            return Type == DlnaProfileType.Video && ContainerProfile.ContainsContainer(VideoCodec, codec);
         }
 
         public bool SupportsAudioCodec(string codec)
         {
-            return ContainerProfile.ContainsContainer(AudioCodec, codec);
+            return (Type == DlnaProfileType.Audio || Type == DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
         }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fix check for profile supporting a codec - it should first check profile media type

For example, audio-only profiles have "VideoCodec" set to "null" which translates to "any codec", which breaks some logic later on.

Before this change in some conditions a stream being transcoded because video codec was unsupported had `ContainerExceedsLimit` as a transcode reason (example: `h265` video + `aac` 5.1 audio packed in `.mkv` and played back in mobile browser).

After the fix the reason is proper `audio codec not supported` and `video codec not supported`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Don't know if we have some open.