### PR TITLE
Add MediaBrowser.WebDashboard\jellyfin-web to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ProgramData*/
 CorePlugins*/
 ProgramData-Server*/
 ProgramData-UI*/
+MediaBrowser.WebDashboard/jellyfin-web/**
 
 #################
 ## Visual Studio


### PR DESCRIPTION
This is the correct directory that the `jellyfin-web` content should be copied to before building the server. You can see it is copied to the output directory in the [.csproj configuration](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.WebDashboard/MediaBrowser.WebDashboard.csproj#L14) and is also used in the Docker [build script](https://github.com/jellyfin/jellyfin/blob/master/deployment/portable/docker-build.sh#L13).

I've added it to the .gitignore since it wasn't there before.
