### PR TITLE
Make localhost LiveTV restreams always use plain HTTP port

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1458,7 +1458,7 @@ namespace Emby.Server.Implementations
         }
 
         /// <inheritdoc />
-        public string GetLocalApiUrl(IPAddress ipAddress, bool forceHttp=false)
+        public string GetLocalApiUrl(IPAddress ipAddress, bool forceHttp = false)
         {
             if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1475,7 +1475,7 @@ namespace Emby.Server.Implementations
         }
 
         /// <inheritdoc />
-        public string GetLocalApiUrl(ReadOnlySpan<char> host, bool forceHttp=false)
+        public string GetLocalApiUrl(ReadOnlySpan<char> host, bool forceHttp = false)
         {
             var url = new StringBuilder(64);
             bool useHttps = EnableHttps && !forceHttp;

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1419,7 +1419,7 @@ namespace Emby.Server.Implementations
 
         public bool SupportsHttps => Certificate != null || ServerConfigurationManager.Configuration.IsBehindProxy;
 
-        public async Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp=false)
+        public async Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp = false)
         {
             try
             {

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1419,7 +1419,7 @@ namespace Emby.Server.Implementations
 
         public bool SupportsHttps => Certificate != null || ServerConfigurationManager.Configuration.IsBehindProxy;
 
-        public async Task<string> GetLocalApiUrl(CancellationToken cancellationToken)
+        public async Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp=false)
         {
             try
             {
@@ -1428,7 +1428,7 @@ namespace Emby.Server.Implementations
 
                 foreach (var address in addresses)
                 {
-                    return GetLocalApiUrl(address);
+                    return GetLocalApiUrl(address, forceHttp);
                 }
 
                 return null;
@@ -1458,7 +1458,7 @@ namespace Emby.Server.Implementations
         }
 
         /// <inheritdoc />
-        public string GetLocalApiUrl(IPAddress ipAddress)
+        public string GetLocalApiUrl(IPAddress ipAddress, bool forceHttp=false)
         {
             if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
             {
@@ -1468,20 +1468,21 @@ namespace Emby.Server.Implementations
                 str.CopyTo(span.Slice(1));
                 span[^1] = ']';
 
-                return GetLocalApiUrl(span);
+                return GetLocalApiUrl(span, forceHttp);
             }
 
-            return GetLocalApiUrl(ipAddress.ToString());
+            return GetLocalApiUrl(ipAddress.ToString(), forceHttp);
         }
 
         /// <inheritdoc />
-        public string GetLocalApiUrl(ReadOnlySpan<char> host)
+        public string GetLocalApiUrl(ReadOnlySpan<char> host, bool forceHttp=false)
         {
             var url = new StringBuilder(64);
-            url.Append(EnableHttps ? "https://" : "http://")
+            bool useHttps = EnableHttps && !forceHttp;
+            url.Append(useHttps ? "https://" : "http://")
                 .Append(host)
                 .Append(':')
-                .Append(EnableHttps ? HttpsPort : HttpPort);
+                .Append(useHttps ? HttpsPort : HttpPort);
 
             string baseUrl = ServerConfigurationManager.Configuration.BaseUrl;
             if (baseUrl.Length != 0)

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1062,7 +1062,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             var stream = new MediaSourceInfo
             {
-                EncoderPath = _appHost.GetLocalApiUrl("127.0.0.1") + "/LiveTv/LiveRecordings/" + info.Id + "/stream",
+                EncoderPath = _appHost.GetLocalApiUrl("127.0.0.1", true) + "/LiveTv/LiveRecordings/" + info.Id + "/stream",
                 EncoderProtocol = MediaProtocol.Http,
                 Path = info.Path,
                 Protocol = MediaProtocol.File,

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
@@ -121,7 +121,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
             //OpenedMediaSource.Path = tempFile;
             //OpenedMediaSource.ReadAtNativeFramerate = true;
 
-            MediaSource.Path = _appHost.GetLocalApiUrl("127.0.0.1") + "/LiveTv/LiveStreamFiles/" + UniqueId + "/stream.ts";
+            MediaSource.Path = _appHost.GetLocalApiUrl("127.0.0.1", true) + "/LiveTv/LiveStreamFiles/" + UniqueId + "/stream.ts";
             MediaSource.Protocol = MediaProtocol.Http;
             //OpenedMediaSource.SupportsDirectPlay = false;
             //OpenedMediaSource.SupportsDirectStream = true;

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
@@ -106,7 +106,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
             //OpenedMediaSource.Path = tempFile;
             //OpenedMediaSource.ReadAtNativeFramerate = true;
 
-            MediaSource.Path = _appHost.GetLocalApiUrl("127.0.0.1") + "/LiveTv/LiveStreamFiles/" + UniqueId + "/stream.ts";
+            MediaSource.Path = _appHost.GetLocalApiUrl("127.0.0.1", true) + "/LiveTv/LiveStreamFiles/" + UniqueId + "/stream.ts";
             MediaSource.Protocol = MediaProtocol.Http;
 
             //OpenedMediaSource.Path = TempFilePath;

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -267,9 +267,15 @@ namespace Jellyfin.Server
                         .LocalNetworkAddresses
                         .Select(appHost.NormalizeConfiguredLocalAddress)
                         .Where(i => i != null)
-                        .ToList();
-                    if (addresses.Any())
+                        .ToHashSet();
+                    if (addresses.Any() && !addresses.Contains(IPAddress.Any))
                     {
+                        if (!addresses.Contains(IPAddress.Loopback))
+                        {
+                            // we must listen on loopback for LiveTV to function regardless of the settings
+                            addresses.Add(IPAddress.Loopback);
+                        }
+
                         foreach (var address in addresses)
                         {
                             _logger.LogInformation("Kestrel listening on {IpAddress}", address);

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -76,7 +76,7 @@ namespace MediaBrowser.Controller
         /// <param name="hostname">The hostname.</param>
         /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <returns>The local API URL.</returns>
-        string GetLocalApiUrl(ReadOnlySpan<char> hostname, bool forceHttp=false);
+        string GetLocalApiUrl(ReadOnlySpan<char> hostname, bool forceHttp = false);
 
         /// <summary>
         /// Gets the local API URL.

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -68,7 +68,7 @@ namespace MediaBrowser.Controller
         /// <param name="cancellationToken">Token to cancel the request if needed.</param>
         /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <value>The local API URL.</value>
-        Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp=false);
+        Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp = false);
 
         /// <summary>
         /// Gets the local API URL.

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -84,7 +84,7 @@ namespace MediaBrowser.Controller
         /// <param name="address">The IP address.</param>
         /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <returns>The local API URL.</returns>
-        string GetLocalApiUrl(IPAddress address, bool forceHttp=false);
+        string GetLocalApiUrl(IPAddress address, bool forceHttp = false);
 
         /// <summary>
         /// Open a URL in an external browser window.

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -65,22 +65,26 @@ namespace MediaBrowser.Controller
         /// <summary>
         /// Gets the local API URL.
         /// </summary>
+        /// <param name="cancellationToken">Token to cancel the request if needed.</param>
+        /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <value>The local API URL.</value>
-        Task<string> GetLocalApiUrl(CancellationToken cancellationToken);
+        Task<string> GetLocalApiUrl(CancellationToken cancellationToken, bool forceHttp=false);
 
         /// <summary>
         /// Gets the local API URL.
         /// </summary>
         /// <param name="hostname">The hostname.</param>
+        /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <returns>The local API URL.</returns>
-        string GetLocalApiUrl(ReadOnlySpan<char> hostname);
+        string GetLocalApiUrl(ReadOnlySpan<char> hostname, bool forceHttp=false);
 
         /// <summary>
         /// Gets the local API URL.
         /// </summary>
         /// <param name="address">The IP address.</param>
+        /// <param name="forceHttp">Whether to force usage of plain HTTP protocol.</param>
         /// <returns>The local API URL.</returns>
-        string GetLocalApiUrl(IPAddress address);
+        string GetLocalApiUrl(IPAddress address, bool forceHttp=false);
 
         /// <summary>
         /// Open a URL in an external browser window.


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This is a follow up for https://github.com/jellyfin/jellyfin/pull/2740. This change makes LiveTV restream be accessed by ffmpeg via plain HTTP regardless of secure mode settings. Without the change, when secure mode is set to "Handled by reverse proxy" and neither reverse proxy is running on same host where Jellyfin runs nor Jellyfin having a certificate set it would still fail.

Also I've made Jellyfin to always listen on `localhost` so LiveTV which needs this connection works regardless of what addresses Jellyfin is told to listen in settings.

Note that due to changing the API this would probably break plugins, so I'm not sure if it's eligible for backporting to 10.5.z releases. Maybe someone from @jellyfin/backend can tell.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Hopefully fixes https://github.com/jellyfin/jellyfin/issues/2259
Also might help address (now stale) https://github.com/jellyfin/jellyfin/issues/1391, as at least some reports there said LiveTV broke for them when they told Jellyfin to bind selective addresses.