### PR TITLE
Remove unnecessary library scan during library rename

### DIFF
--- a/MediaBrowser.Api/Library/LibraryStructureService.cs
+++ b/MediaBrowser.Api/Library/LibraryStructureService.cs
@@ -281,24 +281,14 @@ namespace MediaBrowser.Api.Library
             }
             finally
             {
-                CollectionFolder.OnCollectionFolderChange();
-
                 Task.Run(() =>
                 {
-                    // No need to start if scanning the library because it will handle it
-                    if (request.RefreshLibrary)
-                    {
-                        _libraryManager.ValidateMediaLibrary(new SimpleProgress<double>(), CancellationToken.None);
-                    }
-                    else
-                    {
                         // Need to add a delay here or directory watchers may still pick up the changes
                         var task = Task.Delay(1000);
                         // Have to block here to allow exceptions to bubble
                         Task.WaitAll(task);
 
                         _libraryMonitor.Start();
-                    }
                 });
             }
         }

--- a/MediaBrowser.Api/Library/LibraryStructureService.cs
+++ b/MediaBrowser.Api/Library/LibraryStructureService.cs
@@ -283,12 +283,12 @@ namespace MediaBrowser.Api.Library
             {
                 Task.Run(() =>
                 {
-                        // Need to add a delay here or directory watchers may still pick up the changes
-                        var task = Task.Delay(1000);
-                        // Have to block here to allow exceptions to bubble
-                        Task.WaitAll(task);
+                    // Need to add a delay here or directory watchers may still pick up the changes
+                    var task = Task.Delay(1000);
+                    // Have to block here to allow exceptions to bubble
+                    Task.WaitAll(task);
 
-                        _libraryMonitor.Start();
+                    _libraryMonitor.Start();
                 });
             }
         }


### PR DESCRIPTION
**Changes**
Removes code triggering a library re-scan whenever a library was renamed.

**Issues**
Fixes #2451 

**Other Notes**
There should be an accompanying PR for jellyfin-web to remove the `refreshLibrary` param from the request. Once I receive feedback on this ensuring removing that param is necessary I'll go ahead and open one there.