### PR TITLE
Revert "Specify a minimum version for jellyfin-ffmpeg dependency in .deb dependencies"

### DIFF
--- a/deployment/debian-package-x64/pkg-src/control
+++ b/deployment/debian-package-x64/pkg-src/control
@@ -23,7 +23,7 @@ Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         jellyfin-ffmpeg (>= 4.2.1-2),
+         jellyfin-ffmpeg,
          libfontconfig1,
          libfreetype6,
          libssl1.1


### PR DESCRIPTION
Reverts jellyfin/jellyfin#2749

We have to revert this because changing this file totally breaks my PR #2656 and I don't know how to fix it (I deleted/renamed the file, but even cherry-picking this commit didn't help).

So revert for now, this change is included in the aforementioned PR now.