### PR TITLE
Fix misformed xml doc comment

### DIFF
--- a/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
@@ -6,7 +6,7 @@ namespace MediaBrowser.Controller.Entities
     {
         /// <summary>
         /// Gets or sets the maximum number of items the query should return.
-        /// <summary>
+        /// </summary>
         public int Limit { get; set; }
 
         public Guid ItemId { get; set; }


### PR DESCRIPTION
Very small change to fix a mis-formed comment. This change is needed to get jellyfin/jellyfin-docs#299 working