### PR TITLE
Add nuget.config file

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
This file specifies that the official NuGet package source should be used, in an attempt to fix the Azure build