### PR TITLE
Fix casing of JSON in Jellyfin API

### DIFF
--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -6,6 +6,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace Jellyfin.Api.Controllers
 {

--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -60,18 +60,18 @@ namespace Jellyfin.Api.Controllers
         /// <summary>
         /// Endpoint for updating the initial startup wizard configuration.
         /// </summary>
-        /// <param name="UICulture">The UI language culture.</param>
-        /// <param name="MetadataCountryCode">The metadata country code.</param>
-        /// <param name="PreferredMetadataLanguage">The preferred language for metadata.</param>
+        /// <param name="uiCulture">The UI language culture.</param>
+        /// <param name="metadataCountryCode">The metadata country code.</param>
+        /// <param name="preferredMetadataLanguage">The preferred language for metadata.</param>
         [HttpPost("Configuration")]
         public void UpdateInitialConfiguration(
-            [FromForm] string UICulture,
-            [FromForm] string MetadataCountryCode,
-            [FromForm] string PreferredMetadataLanguage)
+            [FromForm] string uiCulture,
+            [FromForm] string metadataCountryCode,
+            [FromForm] string preferredMetadataLanguage)
         {
-            _config.Configuration.UICulture = UICulture;
-            _config.Configuration.MetadataCountryCode = MetadataCountryCode;
-            _config.Configuration.PreferredMetadataLanguage = PreferredMetadataLanguage;
+            _config.Configuration.UICulture = uiCulture;
+            _config.Configuration.MetadataCountryCode = metadataCountryCode;
+            _config.Configuration.PreferredMetadataLanguage = preferredMetadataLanguage;
             _config.SaveConfiguration();
         }
 

--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -6,7 +6,6 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace Jellyfin.Api.Controllers
 {
@@ -61,18 +60,18 @@ namespace Jellyfin.Api.Controllers
         /// <summary>
         /// Endpoint for updating the initial startup wizard configuration.
         /// </summary>
-        /// <param name="uiCulture">The UI language culture.</param>
-        /// <param name="metadataCountryCode">The metadata country code.</param>
-        /// <param name="preferredMetadataLanguage">The preferred language for metadata.</param>
+        /// <param name="UICulture">The UI language culture.</param>
+        /// <param name="MetadataCountryCode">The metadata country code.</param>
+        /// <param name="PreferredMetadataLanguage">The preferred language for metadata.</param>
         [HttpPost("Configuration")]
         public void UpdateInitialConfiguration(
-            [FromForm] string uiCulture,
-            [FromForm] string metadataCountryCode,
-            [FromForm] string preferredMetadataLanguage)
+            [FromForm] string UICulture,
+            [FromForm] string MetadataCountryCode,
+            [FromForm] string PreferredMetadataLanguage)
         {
-            _config.Configuration.UICulture = uiCulture;
-            _config.Configuration.MetadataCountryCode = metadataCountryCode;
-            _config.Configuration.PreferredMetadataLanguage = preferredMetadataLanguage;
+            _config.Configuration.UICulture = UICulture;
+            _config.Configuration.MetadataCountryCode = MetadataCountryCode;
+            _config.Configuration.PreferredMetadataLanguage = PreferredMetadataLanguage;
             _config.SaveConfiguration();
         }
 

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -71,7 +71,7 @@ namespace Jellyfin.Server.Extensions
                 // Clear app parts to avoid other assemblies being picked up
                 .ConfigureApplicationPartManager(a => a.ApplicationParts.Clear())
                 .AddApplicationPart(typeof(StartupController).Assembly)
-                .AddJsonOptions(options => 
+                .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.PropertyNamingPolicy = null;
                 })

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -71,6 +71,10 @@ namespace Jellyfin.Server.Extensions
                 // Clear app parts to avoid other assemblies being picked up
                 .ConfigureApplicationPartManager(a => a.ApplicationParts.Clear())
                 .AddApplicationPart(typeof(StartupController).Assembly)
+                .AddJsonOptions(options => 
+                {
+                    options.JsonSerializerOptions.PropertyNamingPolicy = null;
+                })
                 .AddControllersAsServices();
         }
 

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ namespace Jellyfin.Server.Extensions
                 .AddApplicationPart(typeof(StartupController).Assembly)
                 .AddJsonOptions(options =>
                 {
+                    // Setting the naming policy to null leaves the property names as-is when serializing objects to JSON.
                     options.JsonSerializerOptions.PropertyNamingPolicy = null;
                 })
                 .AddControllersAsServices();


### PR DESCRIPTION
**Changes**
Fixes responses from the Jellyfin API being automatically camel cased. Currently only affects the startup wizard endpoints.
**Issues**
Fixes #2812 
Replaces jellyfin/jellyfin-web#1050
