### PR TITLE
Handle null outputFileExtension in GetOutputFilePath

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -131,12 +131,10 @@ namespace MediaBrowser.Api.Playback
         /// </summary>
         private string GetOutputFilePath(StreamState state, EncodingOptions encodingOptions, string outputFileExtension)
         {
-            if (outputFileExtension == null) outputFileExtension = "";
-            
             var data = $"{state.MediaPath}-{state.UserAgent}-{state.Request.DeviceId}-{state.Request.PlaySessionId}";
 
             var filename = data.GetMD5().ToString("N", CultureInfo.InvariantCulture);
-            var ext = outputFileExtension.ToLowerInvariant();
+            var ext = outputFileExtension?.ToLowerInvariant();
             var folder = ServerConfigurationManager.GetTranscodePath();
 
             return EnableOutputInSubFolder

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -131,6 +131,8 @@ namespace MediaBrowser.Api.Playback
         /// </summary>
         private string GetOutputFilePath(StreamState state, EncodingOptions encodingOptions, string outputFileExtension)
         {
+            if (outputFileExtension == null) outputFileExtension = "";
+            
             var data = $"{state.MediaPath}-{state.UserAgent}-{state.Request.DeviceId}-{state.Request.PlaySessionId}";
 
             var filename = data.GetMD5().ToString("N", CultureInfo.InvariantCulture);


### PR DESCRIPTION
**Changes**
Handle outputFileExtension  == null in GetOutputFilePath by setting it to "".

**Issues**
Fixes #2737 
