### PR TITLE
Fix warnings in Jellyfin.Naming.Tests

### DIFF
--- a/tests/Jellyfin.Naming.Tests/Subtitles/SubtitleParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Subtitles/SubtitleParserTests.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Naming.Tests.Subtitles
             Test("The Skin I Live In (2011).default.foreign.eng.srt", "eng", true, true);
         }
 
-        private void Test(string input, string language, bool isDefault, bool isForced)
+        private void Test(string input, string? language, bool isDefault, bool isForced)
         {
             var parser = GetParser();
 

--- a/tests/Jellyfin.Naming.Tests/TV/AbsoluteEpisodeNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/AbsoluteEpisodeNumberTests.cs
@@ -21,7 +21,8 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(options)
                 .Resolve(path, false, null, null, true);
 
-            Assert.Equal(episodeNumber, result.EpisodeNumber);
+            Assert.NotNull(result);
+            Assert.Equal(episodeNumber, result!.EpisodeNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
@@ -23,12 +23,13 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(options)
                 .Resolve(path, false);
 
-            Assert.Null(result.SeasonNumber);
-            Assert.Null(result.EpisodeNumber);
-            Assert.Equal(year, result.Year);
-            Assert.Equal(month, result.Month);
-            Assert.Equal(day, result.Day);
-            Assert.Equal(seriesName, result.SeriesName, true);
+            Assert.NotNull(result);
+            Assert.Null(result!.SeasonNumber);
+            Assert.Null(result!.EpisodeNumber);
+            Assert.Equal(year, result!.Year);
+            Assert.Equal(month, result!.Month);
+            Assert.Equal(day, result!.Day);
+            Assert.Equal(seriesName, result!.SeriesName, true);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
@@ -30,7 +30,8 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(options)
                 .Resolve(path, false);
 
-            Assert.Equal(episodeNumber, result.EpisodeNumber);
+            Assert.NotNull(result);
+            Assert.Equal(episodeNumber, result!.EpisodeNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeWithoutSeasonTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeWithoutSeasonTests.cs
@@ -19,9 +19,10 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(options)
                 .Resolve(path, false);
 
-            Assert.Equal(seasonNumber, result.SeasonNumber);
-            Assert.Equal(episodeNumber, result.EpisodeNumber);
-            Assert.Equal(seriesName, result.SeriesName, true);
+            Assert.NotNull(result);
+            Assert.Equal(seasonNumber, result!.SeasonNumber);
+            Assert.Equal(episodeNumber, result!.EpisodeNumber);
+            Assert.Equal(seriesName, result!.SeriesName, true);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
@@ -59,7 +59,8 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(_namingOptions)
                 .Resolve(path, false);
 
-            Assert.Equal(expected, result.SeasonNumber);
+            Assert.NotNull(result);
+            Assert.Equal(expected, result!.SeasonNumber);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/SimpleEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SimpleEpisodeTests.cs
@@ -31,9 +31,10 @@ namespace Jellyfin.Naming.Tests.TV
             var result = new EpisodeResolver(options)
                 .Resolve(path, false);
 
-            Assert.Equal(seasonNumber, result.SeasonNumber);
-            Assert.Equal(episodeNumber, result.EpisodeNumber);
-            Assert.Equal(seriesName, result.SeriesName, true);
+            Assert.NotNull(result);
+            Assert.Equal(seasonNumber, result!.SeasonNumber);
+            Assert.Equal(episodeNumber, result!.EpisodeNumber);
+            Assert.Equal(seriesName, result!.SeriesName, true);
         }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/Video/Format3DTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/Format3DTests.cs
@@ -25,8 +25,9 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 GetParser().ResolveFile(@"C:/Users/media/Desktop/Video Test/Movies/Oblivion/Oblivion.3d.hsbs.mkv");
 
-            Assert.Equal("hsbs", result.Format3D);
-            Assert.Equal("Oblivion", result.Name);
+            Assert.NotNull(result);
+            Assert.Equal("hsbs", result!.Format3D);
+            Assert.Equal("Oblivion", result!.Name);
         }
 
         [Fact]
@@ -57,7 +58,7 @@ namespace Jellyfin.Naming.Tests.Video
             Test("Super movie [sbs3d].mp4", true, "sbs3d", options);
         }
 
-        private void Test(string input, bool is3D, string format3D, NamingOptions options)
+        private void Test(string input, bool is3D, string? format3D, NamingOptions options)
         {
             var parser = new Format3DParser(options);
 

--- a/tests/Jellyfin.Naming.Tests/Video/StubTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/StubTests.cs
@@ -29,10 +29,11 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 GetParser().ResolveFile(@"C:/Users/media/Desktop/Video Test/Movies/Oblivion/Oblivion.dvd.disc");
 
-            Assert.Equal("Oblivion", result.Name);
+            Assert.NotNull(result);
+            Assert.Equal("Oblivion", result!.Name);
         }
 
-        private void Test(string path, bool isStub, string stubType)
+        private void Test(string path, bool isStub, string? stubType)
         {
             var options = new NamingOptions();
 

--- a/tests/Jellyfin.Naming.Tests/Video/VideoResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/VideoResolverTests.cs
@@ -7,8 +7,8 @@ namespace Jellyfin.Naming.Tests.Video
     public class VideoResolverTests : BaseVideoTest
     {
 
-        //Utility method to annotate nullability to avoid more boilerplate to avoid null warnings.
-        //Will be unnecessary once we update to a version of xunit that adds the nullability annotations
+        // Utility method to annotate nullability to avoid more boilerplate to avoid null warnings.
+        // Will be unnecessary once we update to a version of xunit that adds the nullability annotations
         private static void NotNull([NotNull] object? @object)
         {
            Assert.NotNull(@object);

--- a/tests/Jellyfin.Naming.Tests/Video/VideoResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/VideoResolverTests.cs
@@ -1,10 +1,19 @@
 ﻿using MediaBrowser.Model.Entities;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace Jellyfin.Naming.Tests.Video
 {
     public class VideoResolverTests : BaseVideoTest
     {
+
+        //Utility method to annotate nullability to avoid more boilerplate to avoid null warnings.
+        //Will be unnecessary once we update to a version of xunit that adds the nullability annotations
+        private static void NotNull([NotNull] object? @object)
+        {
+           Assert.NotNull(@object);
+        }
+
         // FIXME
         // [Fact]
         public void TestSimpleFile()
@@ -14,6 +23,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/Brave (2007)/Brave (2006).mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -30,6 +40,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/Bad Boys (1995)/Bad Boys (1995).mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(1995, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -46,6 +57,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006).mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -62,6 +74,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/Brave (2007)/Brave (2006)-trailer.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -78,6 +91,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006)-trailer.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -94,6 +108,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006).bluray.disc");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.True(result.IsStub);
             Assert.Equal("bluray", result.StubType);
@@ -111,6 +126,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/Brave (2007)/Brave (2006).bluray.disc");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.True(result.IsStub);
             Assert.Equal("bluray", result.StubType);
@@ -128,6 +144,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006)-trailer.bluray.disc");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.True(result.IsStub);
             Assert.Equal("bluray", result.StubType);
@@ -146,6 +163,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/brave (2007)/brave (2006)-trailer.bluray.disc");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.True(result.IsStub);
             Assert.Equal("bluray", result.StubType);
@@ -163,6 +181,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006).3d.sbs.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.True(result.Is3D);
@@ -180,6 +199,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/300 (2007)/300 (2006).3d1.sbas.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -197,6 +217,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/brave (2007)/brave (2006).3d.sbs.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2006, result.Year);
             Assert.False(result.IsStub);
             Assert.True(result.Is3D);
@@ -213,6 +234,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/American Psycho/American.Psycho.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Null(result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -231,6 +253,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/3.Days.to.Kill/3.Days.to.Kill.2014.720p.BluRay.x264.YIFY.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2014, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -249,6 +272,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/3 days to kill (2005)/3 days to kill (2005).mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Equal(2005, result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);
@@ -265,6 +289,7 @@ namespace Jellyfin.Naming.Tests.Video
             var result =
                 parser.ResolveFile(@"/server/Movies/7 Psychos.mkv/7 Psychos.mkv");
 
+            VideoResolverTests.NotNull(result);
             Assert.Null(result.Year);
             Assert.False(result.IsStub);
             Assert.False(result.Is3D);


### PR DESCRIPTION
This PR removes all the warnings in Jellyfin.Naming.Tests other than the ones related to not marking methods as [Fact] (I tested a couple of those, and they did indeed fail when [Fact] was uncommented, so there are presumably fixes to the naming functionality required to get those warnings to go away).

**Changes**
Most of the issues revolved around potential nulls.  I added Assert.NotNull's in those places to protect against a bare null dereference.  Unfortuantely, while the Xunit has code on master to have anything passed into an Assert.NotNull treated as not nullable afterwards, that version of Xunit has not been released yet, so that doesn't satisfy the compiler.  For cases where there were only a handful of these per test class, I simply tagged the object with ! (e.g.  result!.foo) thereafter, and those can be removed in the long run.  For one test class that had several dozen cases, I created a utility method to wrap the Xunit Assert.NotNull with an annotated method to satisfy the compiler without the need for all the !'s splashed from place to place.

**Issues**
This is related to #2149, although it will not resolve the Jellyfin.Naming.Tests entirely due to the above.