### PR TITLE
Load Google Noto on server at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && mv dist /dist
+ && mv dist /dist \
+ && git clone https://github.com/jellyfin/jellyfin-noto \
+ && cp -r jellyfin-noto/subsetted/* /dist/assets/
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 WORKDIR /repo

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -11,8 +11,9 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && mv dist /dist
-
+ && mv dist /dist \
+ && git clone https://github.com/jellyfin/jellyfin-noto \
+ && cp -r jellyfin-noto/subsetted/* /dist/assets/
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,8 +11,9 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \
- && mv dist /dist
-
+ && mv dist /dist \
+ && git clone https://github.com/jellyfin/jellyfin-noto \
+ && cp -r jellyfin-noto/subsetted/* /dist/assets/
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo

--- a/deployment/debian-package-x64/pkg-src/rules
+++ b/deployment/debian-package-x64/pkg-src/rules
@@ -50,6 +50,9 @@ override_dh_auto_build:
 	cd $(CURDIR)/web/ && npm install yarn
 	cd $(CURDIR)/web/ && node_modules/yarn/bin/yarn install
 	mv $(CURDIR)/web/dist/* $(WEB_TARGET)/
+	git clone https://github.com/jellyfin/jellyfin-noto
+	cp -r jellyfin-noto/subsetted/* $(WEB_TARGET)/assets/
+	rm -rf jellyfin-noto
 	# Build the application
 	dotnet publish --configuration $(CONFIG) --output='$(CURDIR)/usr/lib/jellyfin/bin' --self-contained --runtime $(DOTNETRUNTIME) \
 		"-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none" Jellyfin.Server

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -61,6 +61,9 @@ yarn install
 %endif
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 
 %build

--- a/deployment/linux-x64/docker-build.sh
+++ b/deployment/linux-x64/docker-build.sh
@@ -19,6 +19,9 @@ fi
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 rm -rf ${web_build_dir}
 

--- a/deployment/macos/docker-build.sh
+++ b/deployment/macos/docker-build.sh
@@ -19,6 +19,9 @@ fi
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 rm -rf ${web_build_dir}
 

--- a/deployment/portable/docker-build.sh
+++ b/deployment/portable/docker-build.sh
@@ -19,6 +19,9 @@ fi
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 rm -rf ${web_build_dir}
 

--- a/deployment/win-x64/docker-build.sh
+++ b/deployment/win-x64/docker-build.sh
@@ -25,6 +25,9 @@ fi
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 rm -rf ${web_build_dir}
 

--- a/deployment/win-x86/docker-build.sh
+++ b/deployment/win-x86/docker-build.sh
@@ -25,6 +25,9 @@ fi
 yarn install
 mkdir -p ${web_target}
 mv dist/* ${web_target}/
+git clone https://github.com/jellyfin/jellyfin-noto
+cp -r jellyfin-noto/subsetted/* ${web_target}/assets/
+rm -rf jellyfin-noto
 popd
 rm -rf ${web_build_dir}
 


### PR DESCRIPTION
### Overview
Some decisions inevitably will be proven wrong in the future, [like moving fonts from a package in Web](https://github.com/jellyfin/jellyfin-web/pull/735). That means that clients like **Jellyfin Tizen**, where space is a concern, will have really huge sizes. The same thing happened with **Jellyfin Android**. However, in Android there is also another problem: **bandwidth consumption**.

The original Jellyfin Noto package was [subsetted for better performance](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization), so web browsers could fetch only the files that it needed for the characters that were being displayed (instead of the whole font). However, **this doesn't make any sense on clients where there is a webview, as there is no server to fetch the resources (the server is the client itself)**. And this has one problem: Fonts are way bigger subsetted than merged in one file.

This has been solved in making two versions of Jellyfin Noto:

* **subsetted**: Fonts subsetted, just like they've been since we implemented Noto
* **packaged**: Fonts merged as much as possible to reduce space. **We go from 30 MB to 11 MB**

The *subsetted* version will serve fonts from server, while the packaged one will be used locally. Tizen, Web, WebOS, etc... will fetch the subsetted fonts from the user's Jellyfin server, as bandwidth consumption generally is not a problem with this packages.

The *packaged* version is intended for **Android**, iOS and other clients that are bundled and where having the font locally available is required.

[Check my jellyfin-noto repository](https://github.com/ferferga/jellyfin-noto) for a better understanding of the structure

### How is this achieved?

* At build time, fonts are copied to the web client that is built into the server (that's what this PR does)
* By default, Jellyfin Web will include the CSS files for the subsetted package so all the clients that are built around it will always fetch fonts from server. See this PR: 
* This can be overriden by the **packaged** version at build time. See this PR: 

Both Jellyfin Noto versions have exactly the same CSS files: the only difference is the link to the font files. Depending on which version you need for a client, switching is as simple as **cp -r** for overriding those files. That means that builds should be always consistent.

## Requisites

This PR needs that [my Jellyfin Noto repository](https://github.com/ferferga/jellyfin-noto) is forked into the Jellyfin organization and the old one is removed.

## Testing

This branch has the definitive changes. I left my ``font-serve`` branch pointing to my repo so, if you want to test build scripts, just checkout that branch. Build this branch using ``yarn install`` and copy the ``dist`` folder to your build of the server. Copy also the folders from my ``jellyfin-noto`` repository.

## Other considerations

I added ``.woff`` files back for the subsetted versions, as space in server shouldn't be a problem and they improve compatibility with older versions, making the UX consistent 99% of the time (we removed them from the original version [worrying about size in Android clients](https://github.com/jellyfin/jellyfin-web/pull/735#issuecomment-583375330) and this is no longer a problem with this distribution method). ``packaged`` version doesn't include them.