### PR TITLE
Use dependency injection to construct migration routines

### DIFF
--- a/Jellyfin.Server/Migrations/IMigrationRoutine.cs
+++ b/Jellyfin.Server/Migrations/IMigrationRoutine.cs
@@ -21,8 +21,6 @@ namespace Jellyfin.Server.Migrations
         /// <summary>
         /// Execute the migration routine.
         /// </summary>
-        /// <param name="host">Host that hosts current version.</param>
-        /// <param name="logger">Host logger.</param>
-        public void Perform(CoreAppHost host, ILogger logger);
+        public void Perform();
     }
 }

--- a/Jellyfin.Server/Migrations/MigrationRunner.cs
+++ b/Jellyfin.Server/Migrations/MigrationRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Server.Migrations
@@ -13,10 +14,10 @@ namespace Jellyfin.Server.Migrations
         /// <summary>
         /// The list of known migrations, in order of applicability.
         /// </summary>
-        internal static readonly IMigrationRoutine[] Migrations =
+        private static readonly Type[] _migrationTypes =
         {
-            new Routines.DisableTranscodingThrottling(),
-            new Routines.CreateUserLoggingConfigFile()
+            typeof(Routines.DisableTranscodingThrottling),
+            typeof(Routines.CreateUserLoggingConfigFile)
         };
 
         /// <summary>
@@ -27,6 +28,10 @@ namespace Jellyfin.Server.Migrations
         public static void Run(CoreAppHost host, ILoggerFactory loggerFactory)
         {
             var logger = loggerFactory.CreateLogger<MigrationRunner>();
+            var migrations = _migrationTypes
+                .Select(m => ActivatorUtilities.CreateInstance(host.ServiceProvider, m))
+                .OfType<IMigrationRoutine>()
+                .ToArray();
             var migrationOptions = ((IConfigurationManager)host.ServerConfigurationManager).GetConfiguration<MigrationOptions>(MigrationsListStore.StoreKey);
 
             if (!host.ServerConfigurationManager.Configuration.IsStartupWizardCompleted && migrationOptions.Applied.Count == 0)
@@ -34,16 +39,16 @@ namespace Jellyfin.Server.Migrations
                 // If startup wizard is not finished, this is a fresh install.
                 // Don't run any migrations, just mark all of them as applied.
                 logger.LogInformation("Marking all known migrations as applied because this is a fresh install");
-                migrationOptions.Applied.AddRange(Migrations.Select(m => (m.Id, m.Name)));
+                migrationOptions.Applied.AddRange(migrations.Select(m => (m.Id, m.Name)));
                 host.ServerConfigurationManager.SaveConfiguration(MigrationsListStore.StoreKey, migrationOptions);
                 return;
             }
 
             var appliedMigrationIds = migrationOptions.Applied.Select(m => m.Id).ToHashSet();
 
-            for (var i = 0; i < Migrations.Length; i++)
+            for (var i = 0; i < migrations.Length; i++)
             {
-                var migrationRoutine = Migrations[i];
+                var migrationRoutine = migrations[i];
                 if (appliedMigrationIds.Contains(migrationRoutine.Id))
                 {
                     logger.LogDebug("Skipping migration '{Name}' since it is already applied", migrationRoutine.Name);
@@ -54,7 +59,7 @@ namespace Jellyfin.Server.Migrations
 
                 try
                 {
-                    migrationRoutine.Perform(host, logger);
+                    migrationRoutine.Perform();
                 }
                 catch (Exception ex)
                 {

--- a/Jellyfin.Server/Migrations/Routines/CreateUserLoggingConfigFile.cs
+++ b/Jellyfin.Server/Migrations/Routines/CreateUserLoggingConfigFile.cs
@@ -36,6 +36,13 @@ namespace Jellyfin.Server.Migrations.Routines
             @"{""Serilog"":{""MinimumLevel"":""Information"",""WriteTo"":[{""Name"":""Console"",""Args"":{""outputTemplate"":""[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}""}},{""Name"":""Async"",""Args"":{""configure"":[{""Name"":""File"",""Args"":{""path"":""%JELLYFIN_LOG_DIR%//log_.log"",""rollingInterval"":""Day"",""retainedFileCountLimit"":3,""rollOnFileSizeLimit"":true,""fileSizeLimitBytes"":100000000,""outputTemplate"":""[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] [{ThreadId}] {SourceContext}:{Message}{NewLine}{Exception}""}}]}}],""Enrich"":[""FromLogContext"",""WithThreadId""]}}",
         };
 
+        private readonly IApplicationPaths _appPaths;
+
+        public CreateUserLoggingConfigFile(IApplicationPaths appPaths)
+        {
+            _appPaths = appPaths;
+        }
+
         /// <inheritdoc/>
         public Guid Id => Guid.Parse("{EF103419-8451-40D8-9F34-D1A8E93A1679}");
 
@@ -43,9 +50,9 @@ namespace Jellyfin.Server.Migrations.Routines
         public string Name => "CreateLoggingConfigHeirarchy";
 
         /// <inheritdoc/>
-        public void Perform(CoreAppHost host, ILogger logger)
+        public void Perform()
         {
-            var logDirectory = host.Resolve<IApplicationPaths>().ConfigurationDirectoryPath;
+            var logDirectory = _appPaths.ConfigurationDirectoryPath;
             var existingConfigPath = Path.Combine(logDirectory, "logging.json");
 
             // If the existing logging.json config file is unmodified, then 'reset' it by moving it to 'logging.old.json'

--- a/Jellyfin.Server/Migrations/Routines/DisableTranscodingThrottling.cs
+++ b/Jellyfin.Server/Migrations/Routines/DisableTranscodingThrottling.cs
@@ -10,6 +10,15 @@ namespace Jellyfin.Server.Migrations.Routines
     /// </summary>
     internal class DisableTranscodingThrottling : IMigrationRoutine
     {
+        private readonly ILogger _logger;
+        private readonly IConfigurationManager _configManager;
+
+        public DisableTranscodingThrottling(ILogger<DisableTranscodingThrottling> logger, IConfigurationManager configManager)
+        {
+            _logger = logger;
+            _configManager = configManager;
+        }
+
         /// <inheritdoc/>
         public Guid Id => Guid.Parse("{4124C2CD-E939-4FFB-9BE9-9B311C413638}");
 
@@ -17,16 +26,16 @@ namespace Jellyfin.Server.Migrations.Routines
         public string Name => "DisableTranscodingThrottling";
 
         /// <inheritdoc/>
-        public void Perform(CoreAppHost host, ILogger logger)
+        public void Perform()
         {
             // Set EnableThrottling to false since it wasn't used before and may introduce issues
-            var encoding = ((IConfigurationManager)host.ServerConfigurationManager).GetConfiguration<EncodingOptions>("encoding");
+            var encoding = _configManager.GetConfiguration<EncodingOptions>("encoding");
             if (encoding.EnableThrottling)
             {
-                logger.LogInformation("Disabling transcoding throttling during migration");
+                _logger.LogInformation("Disabling transcoding throttling during migration");
                 encoding.EnableThrottling = false;
 
-                host.ServerConfigurationManager.SaveConfiguration("encoding", encoding);
+                _configManager.SaveConfiguration("encoding", encoding);
             }
         }
     }


### PR DESCRIPTION
Use dependency injection to construct migration routines. This gives migration routines the flexibility to request whatever dependencies they require to execute without needing to pass the entire application host object. A migration-specific logger can also be used this way instead of re-using the one from the migration runner.

**Issues**
Addresses one issue tracked in #2538
