### PR TITLE
Additional mime types for DLNA (VLC)

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -106,6 +106,7 @@ namespace MediaBrowser.Model.Net
             { ".3g2", "video/3gpp2" },
             { ".mpd", "video/vnd.mpeg.dash.mpd" },
             { ".ts", "video/mp2t" },
+            { ".mpegts", "video/mp2t" },
 
             // Type audio
             { ".mp3", "audio/mpeg" },

--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -123,6 +123,8 @@ namespace MediaBrowser.Model.Net
             { ".xsp", "audio/xsp" },
             { ".dsp", "audio/dsp" },
             { ".flac", "audio/flac" },
+            { ".ape", "audio/x-ape" },
+            { ".wv", "audio/x-wavpack" },
         };
 
         private static readonly Dictionary<string, string> _extensionLookup = CreateExtensionLookup();


### PR DESCRIPTION
**Changes**
Adds mime types for ape, wv and mpegts files so that they can be displayed in VLC Player.

**Issues**
#1181 
