### PR TITLE
Add front.jpg to the list of valid album art images.

### DIFF
--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -218,7 +218,8 @@ namespace MediaBrowser.LocalMetadata.Images
             "folder",
             "poster",
             "cover",
-            "default"
+            "front",
+            "default",
         };
 
         private static readonly string[] PersonImageFileNames = new[]


### PR DESCRIPTION
**Changes**
Allows front.jpg to be used as album art when cover/folder image is not available. 
