### PR TITLE
Fix eTags DateLastSaved

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -549,8 +549,7 @@ namespace MediaBrowser.Controller.Entities
         /// <value>The date modified.</value>
         [JsonIgnore]
         public DateTime DateModified { get; set; }
-
-        [JsonIgnore]
+    
         public DateTime DateLastSaved { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
**Changes**
Removes `[JsonIgnore]` from above `DateLastSaved` in BaseItem.cs. This allows the property to be properly read and updated whenever media is added, or edited.

**Issues**
Fixes #2881, allowing clients to use the property reliably for detecting content updates.