### PR TITLE
Add optional camelCase formatter

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy;
 using Jellyfin.Api.Auth.RequiresElevationPolicy;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Controllers;
+using Jellyfin.Server.Formatters;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
@@ -66,6 +67,8 @@ namespace Jellyfin.Server.Extensions
             return serviceCollection.AddMvc(opts =>
                 {
                     opts.UseGeneralRoutePrefix(baseUrl);
+                    opts.OutputFormatters.Insert(0, new CamelCaseJsonProfileFormatter());
+                    opts.OutputFormatters.Insert(0, new PascalCaseJsonProfileFormatter());
                 })
 
                 // Clear app parts to avoid other assemblies being picked up

--- a/Jellyfin.Server/Formatters/CamelCaseJsonProfileFormatter.cs
+++ b/Jellyfin.Server/Formatters/CamelCaseJsonProfileFormatter.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Jellyfin.Server.Models;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
 
@@ -12,7 +12,7 @@ namespace Jellyfin.Server.Formatters
         /// <summary>
         /// Initializes a new instance of the <see cref="CamelCaseJsonProfileFormatter"/> class.
         /// </summary>
-        public CamelCaseJsonProfileFormatter() : base(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+        public CamelCaseJsonProfileFormatter() : base(JsonOptions.CamelCase)
         {
             SupportedMediaTypes.Clear();
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json;profile=\"CamelCase\""));

--- a/Jellyfin.Server/Formatters/CamelCaseJsonProfileFormatter.cs
+++ b/Jellyfin.Server/Formatters/CamelCaseJsonProfileFormatter.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Server.Formatters
+{
+    /// <summary>
+    /// Camel Case Json Profile Formatter.
+    /// </summary>
+    public class CamelCaseJsonProfileFormatter : SystemTextJsonOutputFormatter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CamelCaseJsonProfileFormatter"/> class.
+        /// </summary>
+        public CamelCaseJsonProfileFormatter() : base(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+        {
+            SupportedMediaTypes.Clear();
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json;profile=\"CamelCase\""));
+        }
+    }
+}

--- a/Jellyfin.Server/Formatters/PascalCaseJsonProfileFormatter.cs
+++ b/Jellyfin.Server/Formatters/PascalCaseJsonProfileFormatter.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Server.Formatters
+{
+    /// <summary>
+    /// Pascal Case Json Profile Formatter.
+    /// </summary>
+    public class PascalCaseJsonProfileFormatter : SystemTextJsonOutputFormatter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PascalCaseJsonProfileFormatter"/> class.
+        /// </summary>
+        public PascalCaseJsonProfileFormatter() : base(new JsonSerializerOptions { PropertyNamingPolicy = null })
+        {
+            SupportedMediaTypes.Clear();
+            // Add application/json for default formatter
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json;profile=\"PascalCase\""));
+        }
+    }
+}

--- a/Jellyfin.Server/Formatters/PascalCaseJsonProfileFormatter.cs
+++ b/Jellyfin.Server/Formatters/PascalCaseJsonProfileFormatter.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Jellyfin.Server.Models;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
 
@@ -12,7 +12,7 @@ namespace Jellyfin.Server.Formatters
         /// <summary>
         /// Initializes a new instance of the <see cref="PascalCaseJsonProfileFormatter"/> class.
         /// </summary>
-        public PascalCaseJsonProfileFormatter() : base(new JsonSerializerOptions { PropertyNamingPolicy = null })
+        public PascalCaseJsonProfileFormatter() : base(JsonOptions.PascalCase)
         {
             SupportedMediaTypes.Clear();
             // Add application/json for default formatter

--- a/Jellyfin.Server/Models/JsonOptions.cs
+++ b/Jellyfin.Server/Models/JsonOptions.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+
+namespace Jellyfin.Server.Models
+{
+    /// <summary>
+    /// Json Options.
+    /// </summary>
+    public static class JsonOptions
+    {
+        /// <summary>
+        /// Base Json Serializer Options.
+        /// </summary>
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
+
+        /// <summary>
+        /// Gets CamelCase json options.
+        /// </summary>
+        public static JsonSerializerOptions CamelCase
+        {
+            get
+            {
+                var options = _jsonOptions;
+                options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                return options;
+            }
+        }
+
+        /// <summary>
+        /// Gets PascalCase json options.
+        /// </summary>
+        public static JsonSerializerOptions PascalCase
+        {
+            get
+            {
+                var options = _jsonOptions;
+                options.PropertyNamingPolicy = null;
+                return options;
+            }
+        }
+    }
+}

--- a/Jellyfin.Server/Models/JsonOptions.cs
+++ b/Jellyfin.Server/Models/JsonOptions.cs
@@ -8,18 +8,13 @@ namespace Jellyfin.Server.Models
     public static class JsonOptions
     {
         /// <summary>
-        /// Base Json Serializer Options.
-        /// </summary>
-        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
-
-        /// <summary>
         /// Gets CamelCase json options.
         /// </summary>
         public static JsonSerializerOptions CamelCase
         {
             get
             {
-                var options = _jsonOptions;
+                var options = DefaultJsonOptions;
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                 return options;
             }
@@ -32,10 +27,15 @@ namespace Jellyfin.Server.Models
         {
             get
             {
-                var options = _jsonOptions;
+                var options = DefaultJsonOptions;
                 options.PropertyNamingPolicy = null;
                 return options;
             }
         }
+
+        /// <summary>
+        /// Gets base Json Serializer Options.
+        /// </summary>
+        private static JsonSerializerOptions DefaultJsonOptions => new JsonSerializerOptions();
     }
 }


### PR DESCRIPTION
With `Accept: application/json;profile="CamelCase"`
Response:
```
{
  "key1": "Value 1",
  "key2": "vAlUe 2"
}
```

With `Accept: application/json` or `Accept: application/json;profile="PascalCase"`
Response:
```
{
  "Key1": "Value 1",
  "Key2": "vAlUe 2"
}
```

**Issues**
Fixes #2930
