### PR TITLE
Remove JsonIgnore from the DateLastSaved property of BaseItem

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -549,7 +549,6 @@ namespace MediaBrowser.Controller.Entities
         [JsonIgnore]
         public DateTime DateModified { get; set; }
 
-        [JsonIgnore]
         public DateTime DateLastSaved { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
**Changes**
Removes `[JsonIgnore]` from above `DateLastSaved` in BaseItem.cs. This allows the property to be properly read and updated whenever media is added, or edited.

**Issues**
Fixes #2881, allowing clients to use the property reliably for detecting content updates.