### PR TITLE
Respect AutoRunWebApp and NoAutoRunWebApp settings when HostWebClient is false

### DIFF
--- a/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
+++ b/Emby.Server.Implementations/EntryPoints/StartupWizard.cs
@@ -32,30 +32,40 @@ namespace Emby.Server.Implementations.EntryPoints
         /// <inheritdoc />
         public Task RunAsync()
         {
+            Run();
+            return Task.CompletedTask;
+        }
+
+        private void Run()
+        {
             if (!_appHost.CanLaunchWebBrowser)
             {
-                return Task.CompletedTask;
+                return;
             }
 
-            if (!_appConfig.HostWebClient())
+            // Always launch the startup wizard if possible when it has not been completed
+            if (!_config.Configuration.IsStartupWizardCompleted && _appConfig.HostWebClient())
             {
-                BrowserLauncher.OpenSwaggerPage(_appHost);
+                BrowserLauncher.OpenWebApp(_appHost);
+                return;
             }
-            else if (!_config.Configuration.IsStartupWizardCompleted)
+
+            // Do nothing if the web app is configured to not run automatically
+            var options = ((ApplicationHost)_appHost).StartupOptions;
+            if (!_config.Configuration.AutoRunWebApp || options.NoAutoRunWebApp)
+            {
+                return;
+            }
+
+            // Launch the swagger page if the web client is not hosted, otherwise open the web client
+            if (_appConfig.HostWebClient())
             {
                 BrowserLauncher.OpenWebApp(_appHost);
             }
-            else if (_config.Configuration.AutoRunWebApp)
+            else
             {
-                var options = ((ApplicationHost)_appHost).StartupOptions;
-
-                if (!options.NoAutoRunWebApp)
-                {
-                    BrowserLauncher.OpenWebApp(_appHost);
-                }
+                BrowserLauncher.OpenSwaggerPage(_appHost);
             }
-
-            return Task.CompletedTask;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes an issue where the web browser is automatically launched even if `AutoRunWebApp = false` or `NoAutoRunWebApp = true` when the server is not hosting web content.

The existing behavior was to always launch the swagger API page when `HostWebClient` was false, ignoring `AutoRunWebApp` and `NoAutoRunWebApp`
