### PR TITLE
Add GitVersion stage to Azure Pipelines CI job for SonarCloud and fix code coverage

### DIFF
--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -14,6 +14,9 @@ jobs:
           BuildConfiguration: Debug
     pool:
       vmImage: "${{ parameters.LinuxImage }}"
+    dependsOn: GitVersion
+    variables:
+      InformationalVersion: $[ dependencies.GitVersion.outputs['Versions.InformationalVersion'] ]
     steps:
       - checkout: self
         clean: true
@@ -41,6 +44,13 @@ jobs:
           project: 'jellyfin'
           pipeline: 'Jellyfin Web'
           runBranch: variables['System.PullRequest.TargetBranch']
+
+      - task: Bash@3
+        displayName: 'Update Informational Version'
+        inputs:
+          targetType: 'filePath'
+          filePath: '.ci/update-informational-version.sh'
+          arguments: "$(InformationalVersion)"
 
       - task: ExtractFiles@1
         displayName: "Extract Web Client"

--- a/.ci/azure-pipelines-test.yml
+++ b/.ci/azure-pipelines-test.yml
@@ -22,6 +22,9 @@ jobs:
             ImageName: ${{ imageName.value }}
     pool:
       vmImage: "$(ImageName)"
+    dependsOn: GitVersion
+    variables:
+      ProductVersion: $[ dependencies.GitVersion.outputs['Versions.ProductVersion'] ]
     steps:
       - checkout: self
         clean: true
@@ -49,6 +52,11 @@ jobs:
           SonarCloud: 'Sonarcloud for Jellyfin'
           organization: 'jellyfin'
           projectKey: 'jellyfin_jellyfin'
+          extraProperties: |
+            sonar.projectVersion=$(ProductVersion)
+            sonar.exclusions=**/obj/**,**/*.dll
+            sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml
+            sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)/*.trx
 
       - task: DotNetCoreCLI@2
         displayName: 'Run CLI Tests'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)
+name: '$(GITVERSION_SemVer)+$(GITVERSION_ShortSha)'
 
 variables:
 - name: TestProjects
@@ -15,6 +15,29 @@ trigger:
   batch: true
 
 jobs:
+  - job: GitVersion
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - task: UseGitVersion@5
+        inputs:
+          versionSpec: '5.x'
+          includePrerelease: true
+          #targetPath: 'wording dir'
+          #useConfigFile: true
+          #configFilePath: 'config_file.yml'
+          #updateAssemblyInfo: true
+          #updateAssemblyInfoFilename: 'SharedVersion.cs'
+          #additionalArguments: '--additional args'
+      - task: Bash@3
+        displayName: "Export GitVersion Variables"
+        name: Versions
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "##vso[task.setvariable variable=ProductVersion;isOutput=true;]$(GitVersion.MajorMinorPatch)"
+            echo "##vso[task.setvariable variable=InformationalVersion;isOutput=true;]$(GitVersion.InformationalVersion)"
+
   - template: azure-pipelines-main.yml
     parameters:
       LinuxImage: "ubuntu-latest"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -23,12 +23,6 @@ jobs:
         inputs:
           versionSpec: '5.x'
           includePrerelease: true
-          #targetPath: 'wording dir'
-          #useConfigFile: true
-          #configFilePath: 'config_file.yml'
-          #updateAssemblyInfo: true
-          #updateAssemblyInfoFilename: 'SharedVersion.cs'
-          #additionalArguments: '--additional args'
       - task: Bash@3
         displayName: "Export GitVersion Variables"
         name: Versions

--- a/.ci/update-informational-version.sh
+++ b/.ci/update-informational-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# update-informational-version - increase the shared informational version
+
+set -o errexit
+set -o pipefail
+
+usage() {
+    echo -e "update-informational-version - increase the shared informational version"
+    echo -e ""
+    echo -e "Usage:"
+    echo -e " $ update-informational-version <new_version>"
+}
+
+if [[ -z $1 ]]; then
+    usage
+    exit 1
+fi
+
+shared_version_file="./SharedVersion.cs"
+
+new_version="$1"
+
+echo "Updating to ${new_version}"
+
+# Set the informational version to the specified new_version
+new_version_sed="$( sed -e 's/[\/&]/\\&/g' <<<"${new_version}" )"
+sed -i "s/AssemblyInformationalVersion(\"[^\"]*\")/AssemblyInformationalVersion(\"${new_version_sed}\")/g" ${shared_version_file}

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -7,9 +7,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedVersion.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />

--- a/Jellyfin.Api/Properties/AssemblyInfo.cs
+++ b/Jellyfin.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Jellyfin.Api")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Jellyfin Project")]
+[assembly: AssemblyProduct("Jellyfin Server")]
+[assembly: AssemblyCopyright("Copyright ©  2020 Jellyfin Contributors. Code released under the GNU General Public License")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -2,3 +2,4 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("10.5.0")]
 [assembly: AssemblyFileVersion("10.5.0")]
+[assembly: AssemblyInformationalVersion("10.5.0-localdev")]

--- a/tests/coverletArgs.runsettings
+++ b/tests/coverletArgs.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
-          <Format>cobertura</Format>          
+          <Format>cobertura,opencover</Format>
           <Exclude>[coverlet.*.tests?]*,[*]Coverlet.Core*,[*]Moq*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
           <SingleHit>false</SingleHit>


### PR DESCRIPTION
Alright now we need to settle on a format.

These are the variables available: https://gitversion.net/docs/more-info/variables

Maybe the hash is not needed for sonarcloud, since it will timestamp them.