### PR TITLE
Adds annotation for content-type of ASP.NET Web API endpoints

### DIFF
--- a/Jellyfin.Api/BaseJellyfinApiController.cs
+++ b/Jellyfin.Api/BaseJellyfinApiController.cs
@@ -7,6 +7,7 @@ namespace Jellyfin.Api
     /// </summary>
     [ApiController]
     [Route("[controller]")]
+    [Produces("application/json")]
     public class BaseJellyfinApiController : ControllerBase
     {
     }

--- a/Jellyfin.Api/BaseJellyfinApiController.cs
+++ b/Jellyfin.Api/BaseJellyfinApiController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Api
@@ -7,7 +8,7 @@ namespace Jellyfin.Api
     /// </summary>
     [ApiController]
     [Route("[controller]")]
-    [Produces("application/json")]
+    [Produces(MediaTypeNames.Application.Json)]
     public class BaseJellyfinApiController : ControllerBase
     {
     }


### PR DESCRIPTION
**Changes**
Adds a `Produces` annotation to the base controller so that all endpoints are marked as returning `application/json`

**Issues**
Part of #2872 
