### PR TITLE
Create Missing Data Folders

### DIFF
--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -67,11 +67,15 @@ namespace Emby.Server.Implementations.Configuration
         /// <summary>
         /// Updates the metadata path.
         /// </summary>
+        /// <exception cref="UnauthorizedAccessException">If the directory does not exist, and the caller does not have the required permission to create it.</exception>
+        /// <exception cref="NotSupportedException">If there is a custom path transcoding path specified, but it is invalid.</exception>
+        /// <exception cref="IOException">If the directory does not exist, and it also could not be created.</exception>
         private void UpdateMetadataPath()
         {
             ((ServerApplicationPaths)ApplicationPaths).InternalMetadataPath = string.IsNullOrWhiteSpace(Configuration.MetadataPath)
-                ? Path.Combine(ApplicationPaths.ProgramDataPath, "metadata")
+                ? ApplicationPaths.DefaultInternalMetadataPath
                 : Configuration.MetadataPath;
+            Directory.CreateDirectory(ApplicationPaths.InternalMetadataPath);
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -9,8 +9,6 @@ namespace Emby.Server.Implementations
     /// </summary>
     public class ServerApplicationPaths : BaseApplicationPaths, IServerApplicationPaths
     {
-        private string _internalMetadataPath;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerApplicationPaths" /> class.
         /// </summary>
@@ -27,6 +25,7 @@ namespace Emby.Server.Implementations
                 cacheDirectoryPath,
                 webDirectoryPath)
         {
+            InternalMetadataPath = DefaultInternalMetadataPath;
         }
 
         /// <summary>
@@ -98,12 +97,11 @@ namespace Emby.Server.Implementations
         /// <value>The user configuration directory path.</value>
         public string UserConfigurationDirectoryPath => Path.Combine(ConfigurationDirectoryPath, "users");
 
+        /// <inheritdoc/>
+        public string DefaultInternalMetadataPath => Path.Combine(ProgramDataPath, "metadata");
+
         /// <inheritdoc />
-        public string InternalMetadataPath
-        {
-            get => _internalMetadataPath ?? (_internalMetadataPath = Path.Combine(DataPath, "metadata"));
-            set => _internalMetadataPath = value;
-        }
+        public string InternalMetadataPath { get; set; }
 
         /// <inheritdoc />
         public string VirtualInternalMetadataPath { get; } = "%MetadataPath%";

--- a/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
+++ b/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using MediaBrowser.Model.Configuration;
 
@@ -17,18 +18,25 @@ namespace MediaBrowser.Common.Configuration
             => configurationManager.GetConfiguration<EncodingOptions>("encoding");
 
         /// <summary>
-        /// Retrieves the transcoding temp path from the encoding configuration.
+        /// Retrieves the transcoding temp path from the encoding configuration, falling back to a default if no path
+        /// is specified in configuration. If the directory does not exist, it will be created.
         /// </summary>
-        /// <param name="configurationManager">The Configuration manager.</param>
+        /// <param name="configurationManager">The configuration manager.</param>
         /// <returns>The transcoding temp path.</returns>
+        /// <exception cref="UnauthorizedAccessException">If the directory does not exist, and the caller does not have the required permission to create it.</exception>
+        /// <exception cref="NotSupportedException">If there is a custom path transcoding path specified, but it is invalid.</exception>
+        /// <exception cref="IOException">If the directory does not exist, and it also could not be created.</exception>
         public static string GetTranscodePath(this IConfigurationManager configurationManager)
         {
+            // Get the configured path and fall back to a default
             var transcodingTempPath = configurationManager.GetEncodingOptions().TranscodingTempPath;
             if (string.IsNullOrEmpty(transcodingTempPath))
             {
-                return Path.Combine(configurationManager.CommonApplicationPaths.ProgramDataPath, "transcodes");
+                transcodingTempPath = Path.Combine(configurationManager.CommonApplicationPaths.ProgramDataPath, "transcodes");
             }
 
+            // Make sure the directory exists
+            Directory.CreateDirectory(transcodingTempPath);
             return transcodingTempPath;
         }
     }

--- a/MediaBrowser.Controller/IServerApplicationPaths.cs
+++ b/MediaBrowser.Controller/IServerApplicationPaths.cs
@@ -71,7 +71,12 @@ namespace MediaBrowser.Controller
         string UserConfigurationDirectoryPath { get; }
 
         /// <summary>
-        /// Gets the internal metadata path.
+        /// Gets the default internal metadata path.
+        /// </summary>
+        string DefaultInternalMetadataPath { get; }
+
+        /// <summary>
+        /// Gets the internal metadata path, either a custom path or the default.
         /// </summary>
         /// <value>The internal metadata path.</value>
         string InternalMetadataPath { get; }


### PR DESCRIPTION
Ensure the 'metadata' and 'transcodes' folders are created before using them.

**Changes**
The metadata folder is created at application startup and also each time the configured path is updated. The 'transcodes' folder is created each time it's value is retrieved. In the future it would be good to consolidate this logic somewhere into a single config management class, but for now this PR aims to be less disruptive by just updating existing behavior.

**Issues**
Fixes #2854
