### PR TITLE
Download jellyfin-web artifact from the correct branch in CI build

### DIFF
--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -29,6 +29,7 @@ jobs:
           source: 'specific'
           project: 'jellyfin'
           pipeline: 'Jellyfin Web'
+          runVersion: 'latestFromBranch'
           runBranch: variables['Build.SourceBranch']
 
       - task: DownloadPipelineArtifact@2
@@ -40,6 +41,7 @@ jobs:
           source: 'specific'
           project: 'jellyfin'
           pipeline: 'Jellyfin Web'
+          runVersion: 'latestFromBranch'
           runBranch: variables['System.PullRequest.TargetBranch']
 
       - task: ExtractFiles@1


### PR DESCRIPTION
Specify `latestFromBranch` when dowloading artifacts so that the `runBranch` specifier is respected
Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact