### PR TITLE
Allow override of address published by auto discovery

### DIFF
--- a/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Emby.Server.Implementations.Udp;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.EntryPoints
@@ -22,6 +23,7 @@ namespace Emby.Server.Implementations.EntryPoints
         /// </summary>
         private readonly ILogger _logger;
         private readonly IServerApplicationHost _appHost;
+        private readonly IConfiguration _config;
 
         /// <summary>
         /// The UDP server.
@@ -35,18 +37,19 @@ namespace Emby.Server.Implementations.EntryPoints
         /// </summary>
         public UdpServerEntryPoint(
             ILogger<UdpServerEntryPoint> logger,
-            IServerApplicationHost appHost)
+            IServerApplicationHost appHost,
+            IConfiguration configuration)
         {
             _logger = logger;
             _appHost = appHost;
-
+            _config = configuration;
 
         }
 
         /// <inheritdoc />
         public async Task RunAsync()
         {
-            _udpServer = new UdpServer(_logger, _appHost);
+            _udpServer = new UdpServer(_logger, _appHost, _config);
             _udpServer.Start(PortNumber, _cancellationTokenSource.Token);
         }
 

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Emby.Server.Implementations
 {
     public interface IStartupOptions
@@ -40,6 +42,6 @@ namespace Emby.Server.Implementations
         /// <summary>
         /// Gets the value of the --auto-discover-publish-url command line option.
         /// </summary>
-        string AutoDiscoverPublishUrl { get; }
+        Uri PublishedServerUrl { get; }
     }
 }

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -36,5 +36,10 @@ namespace Emby.Server.Implementations
         /// Gets the value of the --plugin-manifest-url command line option.
         /// </summary>
         string PluginManifestUrl { get; }
+
+        /// <summary>
+        /// Gets the value of the --auto-discover-publish-url command line option.
+        /// </summary>
+        string AutoDiscoverPublishUrl { get; }
     }
 }

--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations
         string PluginManifestUrl { get; }
 
         /// <summary>
-        /// Gets the value of the --auto-discover-publish-url command line option.
+        /// Gets the value of the --published-server-url command line option.
         /// </summary>
         Uri PublishedServerUrl { get; }
     }

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller;
 using MediaBrowser.Model.ApiClient;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Udp
@@ -21,6 +22,12 @@ namespace Emby.Server.Implementations.Udp
         /// </summary>
         private readonly ILogger _logger;
         private readonly IServerApplicationHost _appHost;
+        private readonly IConfiguration _config;
+
+        /// <summary>
+        /// Address Override Configuration Key
+        /// </summary>
+        public const string AddressOverrideConfigKey = "AutoDiscoverAddressOverride";
 
         private Socket _udpSocket;
         private IPEndPoint _endpoint;
@@ -31,15 +38,26 @@ namespace Emby.Server.Implementations.Udp
         /// <summary>
         /// Initializes a new instance of the <see cref="UdpServer" /> class.
         /// </summary>
-        public UdpServer(ILogger logger, IServerApplicationHost appHost)
+        public UdpServer(ILogger logger, IServerApplicationHost appHost, IConfiguration configuration)
         {
             _logger = logger;
             _appHost = appHost;
+            _config = configuration;
         }
 
         private async Task RespondToV2Message(string messageText, EndPoint endpoint, CancellationToken cancellationToken)
         {
-            var localUrl = await _appHost.GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
+            string localUrl;
+
+            if (!string.IsNullOrEmpty(_config[AddressOverrideConfigKey]))
+            {
+                localUrl = _config[AddressOverrideConfigKey];
+            }
+            else
+            {
+                localUrl = await _appHost.GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
+            }
+
 
             if (!string.IsNullOrEmpty(localUrl))
             {
@@ -105,7 +123,7 @@ namespace Emby.Server.Implementations.Udp
                 }
                 catch (SocketException ex)
                 {
-                    _logger.LogError(ex, "Failed to receive data drom socket");
+                    _logger.LogError(ex, "Failed to receive data from socket");
                 }
                 catch (OperationCanceledException)
                 {

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -25,7 +25,7 @@ namespace Emby.Server.Implementations.Udp
         private readonly IConfiguration _config;
 
         /// <summary>
-        /// Address Override Configuration Key
+        /// Address Override Configuration Key.
         /// </summary>
         public const string AddressOverrideConfigKey = "PublishedServerUrl";
 

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -27,7 +27,7 @@ namespace Emby.Server.Implementations.Udp
         /// <summary>
         /// Address Override Configuration Key
         /// </summary>
-        public const string AddressOverrideConfigKey = "AutoDiscoverAddressOverride";
+        public const string AddressOverrideConfigKey = "PublishedServerUrl";
 
         private Socket _udpSocket;
         private IPEndPoint _endpoint;
@@ -47,17 +47,9 @@ namespace Emby.Server.Implementations.Udp
 
         private async Task RespondToV2Message(string messageText, EndPoint endpoint, CancellationToken cancellationToken)
         {
-            string localUrl;
-
-            if (!string.IsNullOrEmpty(_config[AddressOverrideConfigKey]))
-            {
-                localUrl = _config[AddressOverrideConfigKey];
-            }
-            else
-            {
-                localUrl = await _appHost.GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
-            }
-
+            string localUrl = !string.IsNullOrEmpty(_config[AddressOverrideConfigKey])
+                ? _config[AddressOverrideConfigKey]
+                : await _appHost.GetLocalApiUrl(cancellationToken).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(localUrl))
             {

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using CommandLine;
 using Emby.Server.Implementations;
+using Emby.Server.Implementations.EntryPoints;
+using Emby.Server.Implementations.Udp;
 using Emby.Server.Implementations.Updates;
 using MediaBrowser.Controller.Extensions;
 
@@ -80,6 +82,10 @@ namespace Jellyfin.Server
         [Option("plugin-manifest-url", Required = false, HelpText = "A custom URL for the plugin repository JSON manifest")]
         public string? PluginManifestUrl { get; set; }
 
+        /// <inheritdoc />
+        [Option("auto-discover-publish-url", Required = false, HelpText = "Jellyfin Server URL to publish via auto discover process")]
+        public string? AutoDiscoverPublishUrl { get; set; }
+
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.
         /// </summary>
@@ -96,6 +102,11 @@ namespace Jellyfin.Server
             if (NoWebClient)
             {
                 config.Add(ConfigurationExtensions.HostWebClientKey, bool.FalseString);
+            }
+
+            if (AutoDiscoverPublishUrl != null)
+            {
+                config.Add(UdpServer.AddressOverrideConfigKey, AutoDiscoverPublishUrl);
             }
 
             return config;

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CommandLine;
 using Emby.Server.Implementations;
@@ -83,8 +84,8 @@ namespace Jellyfin.Server
         public string? PluginManifestUrl { get; set; }
 
         /// <inheritdoc />
-        [Option("auto-discover-publish-url", Required = false, HelpText = "Jellyfin Server URL to publish via auto discover process")]
-        public string? AutoDiscoverPublishUrl { get; set; }
+        [Option("published-server-url", Required = false, HelpText = "Jellyfin Server URL to publish via auto discover process")]
+        public Uri? PublishedServerUrl { get; set; }
 
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.
@@ -104,9 +105,9 @@ namespace Jellyfin.Server
                 config.Add(ConfigurationExtensions.HostWebClientKey, bool.FalseString);
             }
 
-            if (AutoDiscoverPublishUrl != null)
+            if (PublishedServerUrl != null)
             {
-                config.Add(UdpServer.AddressOverrideConfigKey, AutoDiscoverPublishUrl);
+                config.Add(UdpServer.AddressOverrideConfigKey, PublishedServerUrl.ToString());
             }
 
             return config;


### PR DESCRIPTION
Required when using the Docker Container in bridge mode, as currently the internal docker IP is used, which is generally not routable from other LAN devices.

**Changes**
Added configuration value to allow setting of the Address Url (returned in the Auto Discover response) from a command line parameter or environment variable.   If not set, behaviour remains unchanged.