### PR TITLE
Add python to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG DOTNET_VERSION=3.1
 
 FROM node:alpine as web-builder
 ARG JELLYFIN_WEB_VERSION=master
-RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-sdk automake libtool make gcc musl-dev nasm \
+RUN apk add curl python git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-sdk automake libtool make gcc musl-dev nasm \
  && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
  && cd jellyfin-web-* \
  && yarn install \


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

I noticed an error when building the Docker image on my server to test the latest changes. Seems to be a dependency added recently needs a Python version installed. I tried python3 instead of the python package but it does not build.

```
yarn install v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.12: The platform "linux" is incompatible with this module.
info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
error /jellyfin-web-master/node_modules/node-sass: Command failed.
Exit code: 1
Command: node scripts/build.js
Arguments:
Directory: /jellyfin-web-master/node_modules/node-sass
Output:
Building: /usr/local/bin/node /jellyfin-web-master/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [
gyp verb cli   '/usr/local/bin/node',
gyp verb cli   '/jellyfin-web-master/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library='
gyp verb cli ]
gyp info using node-gyp@3.8.0
gyp info using node@14.0.0 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/jellyfin-web-master/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/jellyfin-web-master/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/jellyfin-web-master/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /jellyfin-web-master/node_modules/which/which.js:89:16
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:175:21)
gyp verb `which` failed  python2 Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/jellyfin-web-master/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/jellyfin-web-master/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/jellyfin-web-master/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /jellyfin-web-master/node_modules/which/which.js:89:16
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:175:21) {
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (/jellyfin-web-master/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/jellyfin-web-master/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/jellyfin-web-master/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /jellyfin-web-master/node_modules/which/which.js:89:16
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:175:21)
gyp verb `which` failed  python Error: not found: python
gyp verb `which` failed     at getNotFoundError (/jellyfin-web-master/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/jellyfin-web-master/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/jellyfin-web-master/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /jellyfin-web-master/node_modules/which/which.js:89:16
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /jellyfin-web-master/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:175:21) {
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/jellyfin-web-master/node_modules/node-gyp/lib/configure.js:484:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/jellyfin-web-master/node_modules/node-gyp/lib/configure.js:406:16)
gyp ERR! stack     at F (/jellyfin-web-master/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/jellyfin-web-master/node_modules/which/which.js:80:29)
gyp ERR! stack     at /jellyfin-web-master/node_modules/which/which.js:89:16
gyp ERR! stack     at /jellyfin-web-master/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /jellyfin-web-master/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:175:21)
gyp ERR! System Linux 5.3.0-46-generic
gyp ERR! command "/usr/local/bin/node" "/jellyfin-web-master/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /jellyfin-web-master/node_modules/node-sass
gyp ERR! node -v v14.0.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
Build failed with error code: 1
```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
