### PR TITLE
Do not double dispose item repository resources

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
@@ -375,5 +375,15 @@ namespace Emby.Server.Implementations.Data
 
             return userData;
         }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// There is nothing to dispose here since <see cref="BaseSqliteRepository.WriteLock"/> and
+        /// <see cref="BaseSqliteRepository.WriteConnection"/> are managed by <see cref="SqliteItemRepository"/>.
+        /// See <see cref="Initialize(IUserManager, SemaphoreSlim, SQLiteDatabaseConnection)"/>.
+        /// </remarks>
+        protected override void Dispose(bool dispose)
+        {
+        }
     }
 }


### PR DESCRIPTION
The write lock and connection for the item repository are shared with the user data repository since they point to the same database. The item repo has responsibility for disposing these two objects, so the user data repo should not attempt to dispose them as well (which causes an exception in some scenarios). 

This is the correct way to implement the fix proposed in #2989

**Changes**
Overwrite the `Dispose()` method in the `UserDataRepository` so that is does not dispose the `WriteLock` or `WriteConnection`

**Issues**
Fix the integration tests in #2945
