### PR TITLE
Fix #3083: Set the Access-Control-Allow-Origin header to the request …

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -455,7 +455,7 @@ namespace Emby.Server.Implementations.HttpServer
                 if (string.Equals(httpReq.Verb, "OPTIONS", StringComparison.OrdinalIgnoreCase))
                 {
                     httpRes.StatusCode = 200;
-                    foreach(var (key, value) in GetCorsHeaders(httpReq))
+                    foreach(var (key, value) in GetDefaultCorsHeaders(httpReq))
                     {
                         httpRes.Headers.Add(key, value);
                     }
@@ -583,7 +583,7 @@ namespace Emby.Server.Implementations.HttpServer
         /// </summary>
         /// <param name="req"></param>
         /// <returns></returns>
-        public IDictionary<string, string> GetCorsHeaders(IRequest req)
+        public IDictionary<string, string> GetDefaultCorsHeaders(IRequest req)
         {
             var origin = req.Headers["Origin"];
             if (origin == StringValues.Empty)

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -455,9 +455,9 @@ namespace Emby.Server.Implementations.HttpServer
                 if (string.Equals(httpReq.Verb, "OPTIONS", StringComparison.OrdinalIgnoreCase))
                 {
                     httpRes.StatusCode = 200;
-                    foreach(KeyValuePair<string, string> header in GetCorsHeaders(httpReq))
+                    foreach(var (key, value) in GetCorsHeaders(httpReq))
                     {
-                        httpRes.Headers.Add(header.Key, header.Value);
+                        httpRes.Headers.Add(key, value);
                     }
                     httpRes.ContentType = "text/plain";
                     await httpRes.WriteAsync(string.Empty, cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
+++ b/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
@@ -37,7 +37,7 @@ namespace Emby.Server.Implementations.HttpServer
         /// <param name="dto">The dto.</param>
         public void FilterResponse(IRequest req, HttpResponse res, object dto)
         {
-            foreach(var (key, value) in _server.GetCorsHeaders(req))
+            foreach(var (key, value) in _server.GetDefaultCorsHeaders(req))
             {
                 res.Headers.Add(key, value);
             }

--- a/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
+++ b/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
@@ -37,9 +37,9 @@ namespace Emby.Server.Implementations.HttpServer
         /// <param name="dto">The dto.</param>
         public void FilterResponse(IRequest req, HttpResponse res, object dto)
         {
-            foreach(KeyValuePair<string, string> header in _server.GetCorsHeaders(req))
+            foreach(var (key, value) in _server.GetCorsHeaders(req))
             {
-                res.Headers.Add(header.Key, header.Value);
+                res.Headers.Add(key, value);
             }
             // Try to prevent compatibility view
             res.Headers["Access-Control-Allow-Headers"] = ("Accept, Accept-Language, Authorization, Cache-Control, " +

--- a/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
+++ b/Emby.Server.Implementations/HttpServer/ResponseFilter.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -13,14 +15,17 @@ namespace Emby.Server.Implementations.HttpServer
     /// </summary>
     public class ResponseFilter
     {
+        private readonly IHttpServer _server;
         private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResponseFilter"/> class.
         /// </summary>
+        /// <param name="server">The HTTP server.</param>
         /// <param name="logger">The logger.</param>
-        public ResponseFilter(ILogger logger)
+        public ResponseFilter(IHttpServer server, ILogger logger)
         {
+            _server = server;
             _logger = logger;
         }
 
@@ -32,10 +37,16 @@ namespace Emby.Server.Implementations.HttpServer
         /// <param name="dto">The dto.</param>
         public void FilterResponse(IRequest req, HttpResponse res, object dto)
         {
+            foreach(KeyValuePair<string, string> header in _server.GetCorsHeaders(req))
+            {
+                res.Headers.Add(header.Key, header.Value);
+            }
             // Try to prevent compatibility view
-            res.Headers.Add("Access-Control-Allow-Headers", "Accept, Accept-Language, Authorization, Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Content-Length, Content-MD5, Content-Range, Content-Type, Date, Host, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Origin, OriginToken, Pragma, Range, Slug, Transfer-Encoding, Want-Digest, X-MediaBrowser-Token, X-Emby-Authorization");
-            res.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS");
-            res.Headers.Add("Access-Control-Allow-Origin", "*");
+            res.Headers["Access-Control-Allow-Headers"] = ("Accept, Accept-Language, Authorization, Cache-Control, " +
+                "Content-Disposition, Content-Encoding, Content-Language, Content-Length, Content-MD5, Content-Range, " +
+                "Content-Type, Cookie, Date, Host, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, " +
+                "Origin, OriginToken, Pragma, Range, Slug, Transfer-Encoding, Want-Digest, X-MediaBrowser-Token, " +
+                "X-Emby-Authorization");
 
             if (dto is Exception exception)
             {

--- a/MediaBrowser.Controller/Net/IHttpServer.cs
+++ b/MediaBrowser.Controller/Net/IHttpServer.cs
@@ -45,6 +45,6 @@ namespace MediaBrowser.Controller.Net
         /// </summary>
         /// <param name="req"></param>
         /// <returns></returns>
-        IDictionary<string, string> GetCorsHeaders(IRequest req);
+        IDictionary<string, string> GetDefaultCorsHeaders(IRequest req);
     }
 }

--- a/MediaBrowser.Controller/Net/IHttpServer.cs
+++ b/MediaBrowser.Controller/Net/IHttpServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MediaBrowser.Model.Events;
+using MediaBrowser.Model.Services;
 using Microsoft.AspNetCore.Http;
 
 namespace MediaBrowser.Controller.Net
@@ -38,5 +39,12 @@ namespace MediaBrowser.Controller.Net
         /// <param name="context"></param>
         /// <returns></returns>
         Task RequestHandler(HttpContext context);
+
+        /// <summary>
+        /// Get the default CORS headers
+        /// </summary>
+        /// <param name="req"></param>
+        /// <returns></returns>
+        IDictionary<string, string> GetCorsHeaders(IRequest req);
     }
 }


### PR DESCRIPTION
…origin/host header if possible

Note that to fully fix this [requires a couple simple changes in jellyfin-web as well](https://github.com/jellyfin/jellyfin-web/pull/1211).