### PR TITLE
Add positionning cues to WebVTT writer

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -7,13 +7,24 @@ using MediaBrowser.Model.MediaInfo;
 
 namespace MediaBrowser.MediaEncoding.Subtitles
 {
+    /// <summary>
+    /// Subtitle writer for the WebVTT format.
+    /// </summary>
     public class VttWriter : ISubtitleWriter
     {
+        /// <inheritdoc />
         public void Write(SubtitleTrackInfo info, Stream stream, CancellationToken cancellationToken)
         {
             using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
             {
                 writer.WriteLine("WEBVTT");
+                writer.WriteLine(string.Empty);
+                writer.WriteLine("REGION");
+                writer.WriteLine("id:subtitle");
+                writer.WriteLine("width:80%");
+                writer.WriteLine("lines:3");
+                writer.WriteLine("regionanchor:50%,100%");
+                writer.WriteLine("viewportanchor:50%,90%");
                 writer.WriteLine(string.Empty);
                 foreach (var trackEvent in info.TrackEvents)
                 {
@@ -22,13 +33,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     var startTime = TimeSpan.FromTicks(trackEvent.StartPositionTicks);
                     var endTime = TimeSpan.FromTicks(trackEvent.EndPositionTicks);
 
-                    // make sure the start and end times are different and seqential
+                    // make sure the start and end times are different and sequential
                     if (endTime.TotalMilliseconds <= startTime.TotalMilliseconds)
                     {
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
                     }
 
-                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff}", startTime, endTime);
+                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} region:subtitle", startTime, endTime);
 
                     var text = trackEvent.Text;
 


### PR DESCRIPTION
**Changes**

Adds a Region to the VttWriter to instruct clients where to render the subtitles.

Based on the W3C specs found here: https://www.w3.org/TR/webvtt1/#region-settings

**Issues**

Goes in tandem with https://github.com/jellyfin/jellyfin-web/pull/1209 to provide a decent display region for clients that support WebVTT.
