### PR TITLE
Parse color transfer and color primaries from ffprobe, and fix video range

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
+++ b/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
@@ -285,5 +285,12 @@ namespace MediaBrowser.MediaEncoding.Probing
         /// <value>The color transfer.</value>
         [JsonPropertyName("color_transfer")]
         public string ColorTransfer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color transfer.
+        /// </summary>
+        /// <value>The color transfer.</value>
+        [JsonPropertyName("color_primaries")]
+        public string ColorPrimaries { get; set; }
     }
 }

--- a/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
+++ b/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
@@ -287,9 +287,9 @@ namespace MediaBrowser.MediaEncoding.Probing
         public string ColorTransfer { get; set; }
 
         /// <summary>
-        /// Gets or sets the color transfer.
+        /// Gets or sets the color primaries.
         /// </summary>
-        /// <value>The color transfer.</value>
+        /// <value>The color primaries.</value>
         [JsonPropertyName("color_primaries")]
         public string ColorPrimaries { get; set; }
     }

--- a/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
+++ b/MediaBrowser.MediaEncoding/Probing/MediaStreamInfo.cs
@@ -278,5 +278,12 @@ namespace MediaBrowser.MediaEncoding.Probing
         /// <value>The disposition.</value>
         [JsonPropertyName("disposition")]
         public IReadOnlyDictionary<string, int> Disposition { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color transfer.
+        /// </summary>
+        /// <value>The color transfer.</value>
+        [JsonPropertyName("color_transfer")]
+        public string ColorTransfer { get; set; }
     }
 }

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -695,6 +695,11 @@ namespace MediaBrowser.MediaEncoding.Probing
                 {
                     stream.RefFrames = streamInfo.Refs;
                 }
+
+                if (!string.IsNullOrEmpty(streamInfo.ColorTransfer))
+                {
+                    stream.ColorTransfer = streamInfo.ColorTransfer;
+                }
             }
             else
             {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -700,6 +700,11 @@ namespace MediaBrowser.MediaEncoding.Probing
                 {
                     stream.ColorTransfer = streamInfo.ColorTransfer;
                 }
+
+                if (!string.IsNullOrEmpty(streamInfo.ColorPrimaries))
+                {
+                    stream.ColorPrimaries = streamInfo.ColorPrimaries;
+                }
             }
             else
             {

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -34,8 +34,22 @@ namespace MediaBrowser.Model.Entities
         /// <value>The language.</value>
         public string Language { get; set; }
 
+        /// <summary>
+        /// Gets or sets the color transfer.
+        /// </summary>
+        /// <value>The color transfer.</value>
         public string ColorTransfer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color primaries.
+        /// </summary>
+        /// <value>The color primaries.</value>
         public string ColorPrimaries { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color space.
+        /// </summary>
+        /// <value>The color space.</value>
         public string ColorSpace { get; set; }
 
         /// <summary>
@@ -44,11 +58,28 @@ namespace MediaBrowser.Model.Entities
         /// <value>The comment.</value>
         public string Comment { get; set; }
 
+        /// <summary>
+        /// Gets or sets the time base.
+        /// </summary>
+        /// <value>The time base.</value>
         public string TimeBase { get; set; }
+
+        /// <summary>
+        /// Gets or sets the codec time base.
+        /// </summary>
+        /// <value>The codec time base.</value>
         public string CodecTimeBase { get; set; }
 
+        /// <summary>
+        /// Gets or sets the title.
+        /// </summary>
+        /// <value>The title.</value>
         public string Title { get; set; }
 
+        /// <summary>
+        /// Gets or sets the video range.
+        /// </summary>
+        /// <value>The video range.</value>
         public string VideoRange
         {
             get
@@ -60,7 +91,8 @@ namespace MediaBrowser.Model.Entities
 
                 var colorTransfer = ColorTransfer;
 
-                if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
                 {
                     return "HDR";
                 }
@@ -70,7 +102,9 @@ namespace MediaBrowser.Model.Entities
         }
 
         public string localizedUndefined { get; set; }
+
         public string localizedDefault { get; set; }
+
         public string localizedForced { get; set; }
 
         public string DisplayTitle

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -92,7 +92,7 @@ namespace MediaBrowser.Model.Entities
                 var colorTransfer = ColorTransfer;
 
                 if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
+                    || string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
                 {
                     return "HDR";
                 }


### PR DESCRIPTION
**Changes**

* Adds `color_transfer` and `color_primaries` from ffprobe to the stream data.
* Adds the necessary `color_transfer` to detect Hybrid Log-Gamma

This effectively fixes the `video_range` detection.

**Issues**
Fixes #3110
