### PR TITLE
Fix 500 error causing first-time setup wizard to hang

### DIFF
--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,3 +1,4 @@
+using System.Security.Authentication;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -58,6 +59,10 @@ namespace Jellyfin.Api.Auth
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
                 return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+            catch (AuthenticationException ex)
+            {
+                return Task.FromResult(AuthenticateResult.Fail(ex));
             }
             catch (SecurityException ex)
             {


### PR DESCRIPTION
On a fresh setup of Jellyfin & Jellyfin Web, the setup wizard hangs and it's impossible to continue. This is caused by the request to `/Startup/User` returning an HTTP 500.

This was introduced in 53380689a. Changing the exceptions throw changed how `CustomAuthenticationHandler` processed failures.

**Changes**
Catch `AuthenticationException`s in `CustomAuthenticationHandler`.

**Issues**
~~I think this resolves #3132~~ I don't think there's an open issue for this
