### PR TITLE
Reduce Excessive Logging From DeveloperExceptionPageMiddleware

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -508,7 +508,7 @@ namespace Emby.Server.Implementations.HttpServer
                     // Instead, re-throw the exception so it can be handled by the DeveloperExceptionPageMiddleware.
                     // However, do not use the DeveloperExceptionPageMiddleware when the stack trace should be ignored,
                     // because it will log the stack trace when it handles the exception.
-                    if (statusCode == 500 && !ignoreStackTrace && _hostEnvironment.IsDevelopment() )
+                    if (statusCode == 500 && !ignoreStackTrace && _hostEnvironment.IsDevelopment())
                     {
                         throw;
                     }


### PR DESCRIPTION
**Changes**
Do not use the developer exception page to handle server errors when the exception stack trace should be ignored. The `DeveloperExceptionPageMiddleware` logs the stack trace as part of handling the error, filling up the log with junk (i.e. stack traces for task cancelled exceptions).