### PR TITLE
Restart Server In-Process

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -125,11 +125,6 @@ namespace Emby.Server.Implementations
         private IHttpServer _httpServer;
         private IHttpClient _httpClient;
 
-        /// <summary>
-        /// Gets a value indicating whether this instance can self restart.
-        /// </summary>
-        public bool CanSelfRestart => _startupOptions.RestartPath != null;
-
         public virtual bool CanLaunchWebBrowser
         {
             get
@@ -981,11 +976,6 @@ namespace Emby.Server.Implementations
         /// </summary>
         public void Restart()
         {
-            if (!CanSelfRestart)
-            {
-                throw new PlatformNotSupportedException("The server is unable to self-restart. Please restart manually.");
-            }
-
             if (IsShuttingDown)
             {
                 return;
@@ -1111,7 +1101,6 @@ namespace Emby.Server.Implementations
                 CachePath = ApplicationPaths.CachePath,
                 OperatingSystem = OperatingSystem.Id.ToString(),
                 OperatingSystemDisplayName = OperatingSystem.Name,
-                CanSelfRestart = CanSelfRestart,
                 CanLaunchWebBrowser = CanLaunchWebBrowser,
                 HasUpdateAvailable = HasUpdateAvailable,
                 TranscodingTempPath = transcodingTempPath,

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -248,6 +248,9 @@ namespace Jellyfin.Server
         /// <summary>
         /// Call static initialization methods for the application.
         /// </summary>
+        /// <remarks>
+        /// This initialization should only performed the first time the application starts, and not on each restart.
+        /// </remarks>
         public static void PerformStaticInitialization()
         {
             // Make sure we have all the code pages we can get

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -186,7 +186,7 @@ namespace Jellyfin.Server
                 ServiceCollection serviceCollection = new ServiceCollection();
                 appHost.Init(serviceCollection);
 
-                var webHost = new WebHostBuilder().ConfigureWebHostBuilder(appHost, serviceCollection, options, startupConfig, appPaths).Build();
+                using var webHost = new WebHostBuilder().ConfigureWebHostBuilder(appHost, serviceCollection, options, startupConfig, appPaths).Build();
 
                 // Re-use the web host service provider in the app host since ASP.NET doesn't allow a custom service collection.
                 appHost.ServiceProvider = webHost.Services;

--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -41,12 +41,6 @@ namespace MediaBrowser.Common
         bool IsShuttingDown { get; }
 
         /// <summary>
-        /// Gets a value indicating whether this instance can self restart.
-        /// </summary>
-        /// <value><c>true</c> if this instance can self restart; otherwise, <c>false</c>.</value>
-        bool CanSelfRestart { get; }
-
-        /// <summary>
         /// Gets the application version.
         /// </summary>
         /// <value>The application version.</value>

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -65,12 +65,6 @@ namespace MediaBrowser.Model.System
         /// <value>The completed installations.</value>
         public InstallationInfo[] CompletedInstallations { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance can self restart.
-        /// </summary>
-        /// <value><c>true</c> if this instance can self restart; otherwise, <c>false</c>.</value>
-        public bool CanSelfRestart { get; set; }
-
         public bool CanLaunchWebBrowser { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
Update the server restart process to restart the server without spawning a new process.

**NOTE: This is a breaking change because the `CanSelfRestart` property has been removed from the `SystemInfo` class. Clients use this to conditionally display the server restart button.**

The breaking change for the web client is handled in https://github.com/jellyfin/jellyfin-web/pull/1293