### PR TITLE
Don't Send Exception Messages (Old API)

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -230,13 +230,9 @@ namespace Emby.Server.Implementations.HttpServer
 
             httpRes.StatusCode = statusCode;
 
-            if (!_hostEnvironment.IsDevelopment())
-            {
-                await httpRes.WriteAsync("Error processing request.").ConfigureAwait(false);
-                return;
-            }
-
-            var errContent = NormalizeExceptionMessage(ex) ?? string.Empty;
+            var errContent = _hostEnvironment.IsDevelopment()
+                    ? (NormalizeExceptionMessage(ex) ?? string.Empty)
+                    : "Error processing request.";
             httpRes.ContentType = "text/plain";
             httpRes.ContentLength = errContent.Length;
             await httpRes.WriteAsync(errContent).ConfigureAwait(false);

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -230,6 +230,12 @@ namespace Emby.Server.Implementations.HttpServer
 
             httpRes.StatusCode = statusCode;
 
+            if (!_hostEnvironment.IsDevelopment())
+            {
+                await httpRes.WriteAsync("Error processing request.").ConfigureAwait(false);
+                return;
+            }
+
             var errContent = NormalizeExceptionMessage(ex) ?? string.Empty;
             httpRes.ContentType = "text/plain";
             httpRes.ContentLength = errContent.Length;


### PR DESCRIPTION
**Changes**
Because of security reasons, exception messages should no longer get sent to the Clients, unless the server is running in Development mode. This PR adds this change only to the old API endpoint.

**Issues**
Fixes #2965 (in combination with #3186  )
