### PR TITLE
Don't send Exception message in Production Environment

### DIFF
--- a/Jellyfin.Server/Middleware/ExceptionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/ExceptionMiddleware.cs
@@ -93,13 +93,9 @@ namespace Jellyfin.Server.Middleware
                 context.Response.ContentType = MediaTypeNames.Text.Plain;
 
                 // Don't send exception unless the server is in a Development environment
-                if (!_hostEnvironment.IsDevelopment())
-                {
-                    await context.Response.WriteAsync("Error processing request.").ConfigureAwait(false);
-                    return;
-                }
-
-                var errorContent = NormalizeExceptionMessage(ex.Message);
+                var errorContent = _hostEnvironment.IsDevelopment()
+                        ? NormalizeExceptionMessage(ex.Message)
+                        : "Error processing request.";
                 await context.Response.WriteAsync(errorContent).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
**Changes**
Because of security reasons, exception messages should no longer get sent to the Clients, unless the server is running in Development mode. This PR adds this change only to the new ASP API endpoint.

**Issues**
Fixes #2965 (in combination with #3185 )