### PR TITLE
Order ids to merge to avoid stack overflow

### DIFF
--- a/MediaBrowser.Api/VideosService.cs
+++ b/MediaBrowser.Api/VideosService.cs
@@ -125,10 +125,12 @@ namespace MediaBrowser.Api
 
         public void Post(MergeVersions request)
         {
+
             var items = request.Ids.Split(',')
                 .Select(i => _libraryManager.GetItemById(i))
                 .OfType<Video>()
                 .ToList();
+            items = items.OrderBy(i => i.Id).ToList();
 
             if (items.Count < 2)
             {

--- a/MediaBrowser.Api/VideosService.cs
+++ b/MediaBrowser.Api/VideosService.cs
@@ -125,7 +125,6 @@ namespace MediaBrowser.Api
 
         public void Post(MergeVersions request)
         {
-
             var items = request.Ids.Split(',')
                 .Select(i => _libraryManager.GetItemById(i))
                 .OfType<Video>()

--- a/MediaBrowser.Api/VideosService.cs
+++ b/MediaBrowser.Api/VideosService.cs
@@ -129,8 +129,8 @@ namespace MediaBrowser.Api
             var items = request.Ids.Split(',')
                 .Select(i => _libraryManager.GetItemById(i))
                 .OfType<Video>()
+                .OrderBy(i => i.Id)
                 .ToList();
-            items = items.OrderBy(i => i.Id).ToList();
 
             if (items.Count < 2)
             {


### PR DESCRIPTION
As said in https://github.com/jellyfin/jellyfin/issues/3176, merging 1 with 2 and then 2 with 1 cause a stack overflow. sorting ids first fix the problem


**Changes**
Now the list of ids to merge is sort before merging


