### PR TITLE
Fix Activity Log Migrations for Very Old Databases

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateActivityLogDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateActivityLogDb.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Emby.Server.Implementations.Data;
 using Jellyfin.Data.Entities;
 using Jellyfin.Server.Implementations;
@@ -68,7 +67,7 @@ namespace Jellyfin.Server.Migrations.Routines
                 _logger.LogWarning("Migrating the activity database may take a while, do not stop Jellyfin.");
                 using var dbContext = _provider.CreateContext();
 
-                var queryResult = connection.Query("SELECT * FROM ActivityLog ORDER BY Id ASC");
+                var queryResult = connection.Query("SELECT * FROM ActivityLog ORDER BY Id");
 
                 // Make sure that the database is empty in case of failed migration due to power outages, etc.
                 dbContext.ActivityLogs.RemoveRange(dbContext.ActivityLogs);
@@ -86,29 +85,26 @@ namespace Jellyfin.Server.Migrations.Routines
                         severity = LogLevel.Trace;
                     }
 
-                    Guid guid;
-                    if (entry[6].SQLiteType == SQLiteType.Null)
-                    {
-                        guid = Guid.Empty;
-                    }
-                    else if (!Guid.TryParse(entry[6].ToString(), out guid))
+                    var guid = Guid.Empty;
+                    if (entry[6].SQLiteType != SQLiteType.Null && !Guid.TryParse(entry[6].ToString(), out guid))
                     {
                         // This is not a valid Guid, see if it is an internal ID from an old Emby schema
-                        var userEntry = userDbConnection
-                            .Query($"SELECT guid FROM LocalUsersv2 WHERE Id = {entry[6].ToString()}")
-                            .FirstOrDefault();
+                        _logger.LogWarning("Invalid Guid in UserId column: ", entry[6].ToString());
 
-                        if (userEntry.Count == 0 || !Guid.TryParse(userEntry[0].ToString(), out guid))
+                        using var statement = userDbConnection.PrepareStatement("SELECT guid FROM LocalUsersv2 WHERE Id=@Id");
+                        statement.TryBind("@Id", entry[6].ToString());
+
+                        foreach (var row in statement.Query())
                         {
-                            // Give up, just use Guid.Empty
-                            guid = Guid.Empty;
+                            if (row.Count > 0 && Guid.TryParse(row[0].ToString(), out guid))
+                            {
+                                // Successfully parsed a Guid from the user table.
+                                break;
+                            }
                         }
                     }
 
-                    var newEntry = new ActivityLog(
-                        entry[1].ToString(),
-                        entry[4].ToString(),
-                        guid)
+                    var newEntry = new ActivityLog(entry[1].ToString(), entry[4].ToString(), guid)
                     {
                         DateCreated = entry[7].ReadDateTime(),
                         LogSeverity = severity

--- a/Jellyfin.Server/Migrations/Routines/MigrateActivityLogDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateActivityLogDb.cs
@@ -64,6 +64,7 @@ namespace Jellyfin.Server.Migrations.Routines
                 ConnectionFlags.ReadOnly,
                 null))
             {
+                using var userDbConnection = SQLite3.Open(Path.Combine(dataPath, "users.db"), ConnectionFlags.ReadOnly, null);
                 _logger.LogWarning("Migrating the activity database may take a while, do not stop Jellyfin.");
                 using var dbContext = _provider.CreateContext();
 
@@ -76,17 +77,38 @@ namespace Jellyfin.Server.Migrations.Routines
                 dbContext.Database.ExecuteSqlRaw("UPDATE sqlite_sequence SET seq = 0 WHERE name = 'ActivityLog';");
                 dbContext.SaveChanges();
 
-                var newEntries = queryResult.Select(entry =>
+                var newEntries = new List<ActivityLog>();
+
+                foreach (var entry in queryResult)
                 {
                     if (!logLevelDictionary.TryGetValue(entry[8].ToString(), out var severity))
                     {
                         severity = LogLevel.Trace;
                     }
 
+                    Guid guid;
+                    if (entry[6].SQLiteType == SQLiteType.Null)
+                    {
+                        guid = Guid.Empty;
+                    }
+                    else if (!Guid.TryParse(entry[6].ToString(), out guid))
+                    {
+                        // This is not a valid Guid, see if it is an internal ID from an old Emby schema
+                        var userEntry = userDbConnection
+                            .Query($"SELECT guid FROM LocalUsersv2 WHERE Id = {entry[6].ToString()}")
+                            .FirstOrDefault();
+
+                        if (userEntry.Count == 0 || !Guid.TryParse(userEntry[0].ToString(), out guid))
+                        {
+                            // Give up, just use Guid.Empty
+                            guid = Guid.Empty;
+                        }
+                    }
+
                     var newEntry = new ActivityLog(
                         entry[1].ToString(),
                         entry[4].ToString(),
-                        entry[6].SQLiteType == SQLiteType.Null ? Guid.Empty : Guid.Parse(entry[6].ToString()))
+                        guid)
                     {
                         DateCreated = entry[7].ReadDateTime(),
                         LogSeverity = severity
@@ -107,8 +129,8 @@ namespace Jellyfin.Server.Migrations.Routines
                         newEntry.ItemId = entry[5].ToString();
                     }
 
-                    return newEntry;
-                });
+                    newEntries.Add(newEntry);
+                }
 
                 dbContext.ActivityLogs.AddRange(newEntries);
                 dbContext.SaveChanges();


### PR DESCRIPTION
**Changes**
In very old versions of Emby's schema, the `UserId` field is the internal id of a user, and not a guid. This PR fixes the activity log migration for such cases, and any other unforeseen problems migrating the `UserId` field.
