### PR TITLE
Add second endpoint for Startup/User

### DIFF
--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -109,6 +109,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">Initial user retrieved.</response>
         /// <returns>The first user.</returns>
         [HttpGet("User")]
+        [HttpGet("FirstUser")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<StartupUserDto> GetFirstUser()
         {


### PR DESCRIPTION
As requested in https://github.com/jellyfin/jellyfin/pull/3153#discussion_r433910589

Note- This makes Swagger / Redoc always point to `User` instead of `FirstUser` when `FirstUser` is expanded.