### PR TITLE
Ignore languages with null ids when fetching images from tvdb

### DIFF
--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.4" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
     <PackageReference Include="PlaylistsNET" Version="1.0.4" />
-    <PackageReference Include="TvDbSharper" Version="3.0.1" />
+    <PackageReference Include="TvDbSharper" Version="3.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
@@ -89,9 +89,8 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
         private IEnumerable<RemoteImageInfo> GetImages(Image[] images, string preferredLanguage)
         {
             var list = new List<RemoteImageInfo>();
-            var languages = _tvdbClientManager.GetLanguagesAsync(CancellationToken.None).Result.Data;
             // any languages with null ids are ignored
-            languages = Array.FindAll(languages, language => language.Id != null);
+            var languages = _tvdbClientManager.GetLanguagesAsync(CancellationToken.None).Result.Data.Where(x => x.Id.HasValue);
             foreach (Image image in images)
             {
                 var imageInfo = new RemoteImageInfo

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
@@ -90,6 +90,8 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
         {
             var list = new List<RemoteImageInfo>();
             var languages = _tvdbClientManager.GetLanguagesAsync(CancellationToken.None).Result.Data;
+            // any languages with null ids are ignored
+            languages = Array.FindAll(languages, language => language.Id != null);
             foreach (Image image in images)
             {
                 var imageInfo = new RemoteImageInfo


### PR DESCRIPTION
**Changes**
After https://github.com/HristoKolev/TvDbSharper/issues/20 was fixed in TvDbSharper we can now ignore languages that have a null id, which is currently causing images to **not** be fetched for tvdb show meta data (currently its failing to retrieve all languages regardless if they are valid or not).

I am assuming ignoring _invalid_ languages is the right approach since why consider a language record with no id value. 

I'm unaware if this minor change warrants a test case, please let me know, and I will add one.

**Issues**
https://github.com/jellyfin/jellyfin/issues/3201
