### PR TITLE
Fix incorrect HLS master playlist fields

### DIFF
--- a/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/DynamicHlsService.cs
@@ -872,9 +872,8 @@ namespace MediaBrowser.Api.Playback.Hls
 
             if (framerate.HasValue)
             {
-                builder.Append(",FRAME-RATE=\"")
-                    .Append(framerate.Value)
-                    .Append('"');
+                builder.Append(",FRAME-RATE=")
+                    .Append(framerate.Value);
             }
         }
 
@@ -888,11 +887,10 @@ namespace MediaBrowser.Api.Playback.Hls
         {
             if (state.OutputWidth.HasValue && state.OutputHeight.HasValue)
             {
-                builder.Append(",RESOLUTION=\"")
+                builder.Append(",RESOLUTION=")
                     .Append(state.OutputWidth.GetValueOrDefault())
                     .Append('x')
-                    .Append(state.OutputHeight.GetValueOrDefault())
-                    .Append('"');
+                    .Append(state.OutputHeight.GetValueOrDefault());
             }
         }
 


### PR DESCRIPTION
For reference: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.4.2

```
 FRAME-RATE

      The value is a decimal-floating-point describing the maximum frame
      rate for all the video in the Variant Stream, rounded to 3 decimal
      places.
```

```
RESOLUTION

      The value is a decimal-resolution describing the optimal pixel
      resolution at which to display all the video in the Variant
      Stream.
```

**Changes**
Change `RESOLUTION` and `FRAME-RATE` field values to be represented as a number rather than a string

**Issues**
#3224 
