### PR TITLE
Make books resumable

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -240,7 +240,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     // Enforce MinResumeDuration
                     var durationSeconds = TimeSpan.FromTicks(runtimeTicks).TotalSeconds;
-                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
+                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds && !(item is Book))
                     {
                         positionTicks = 0;
                         data.Played = playedToCompletion = true;

--- a/MediaBrowser.Controller/Entities/Book.cs
+++ b/MediaBrowser.Controller/Entities/Book.cs
@@ -11,6 +11,10 @@ namespace MediaBrowser.Controller.Entities
         [JsonIgnore]
         public override string MediaType => Model.Entities.MediaType.Book;
 
+        public override bool SupportsPlayedStatus => true;
+
+        public override bool SupportsPositionTicksResume => true;
+
         [JsonIgnore]
         public string SeriesPresentationUniqueKey { get; set; }
 
@@ -19,6 +23,11 @@ namespace MediaBrowser.Controller.Entities
 
         [JsonIgnore]
         public Guid SeriesId { get; set; }
+
+        public Book()
+        {
+            this.RunTimeTicks = TimeSpan.TicksPerSecond;
+        }
 
         public string FindSeriesSortName()
         {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This PR introduces the necessary changes to make jellyfin-web be able to resume books since https://github.com/jellyfin/jellyfin-web/pull/1263 is merged.

* Sets `SupportsPlayedStatus` and `SupportsPositionTicksResume` to true for books. These properties have to be true for an item to be able to store position ticks.
* Sets book's runtime ticks to 1 second. There is no cross-device way to determine the amount of pages a book has as it depends on screen resolution, font etc. Essentially jellyfin-web just reports a percentage progress through the book tied to [CFI](http://idpf.org/epub/linking/cfi/epub-cfi.html) locations.
* Excludes books from minimum resumable duration check as books don't really have a time duration and 1 second is just a mock value.