### PR TITLE
Implement LocalOrElevated authorization policy

### DIFF
--- a/Jellyfin.Api/Auth/LocalOrElevatedPolicy/LocalOrElevatedPolicyHandler.cs
+++ b/Jellyfin.Api/Auth/LocalOrElevatedPolicy/LocalOrElevatedPolicyHandler.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Api.Auth.LocalOrElevatedPolicy
+{
+    /// <summary>
+    /// Authorization handler for requiring a request from the local computer or elevated privileges.
+    /// </summary>
+    public class LocalOrElevatedPolicyHandler : AuthorizationHandler<LocalOrElevatedPolicyRequirement>
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalOrElevatedPolicyHandler"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
+        public LocalOrElevatedPolicyHandler(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, LocalOrElevatedPolicyRequirement localOrElevatedPolicyRequirement)
+        {
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext.Connection.LocalIpAddress.Equals(httpContext.Connection.RemoteIpAddress))
+            {
+                context.Succeed(localOrElevatedPolicyRequirement);
+            }
+            else if (context.User.IsInRole(UserRoles.Administrator))
+            {
+                context.Succeed(localOrElevatedPolicyRequirement);
+            }
+            else
+            {
+                context.Fail();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Jellyfin.Api/Auth/LocalOrElevatedPolicy/LocalOrElevatedPolicyRequirement.cs
+++ b/Jellyfin.Api/Auth/LocalOrElevatedPolicy/LocalOrElevatedPolicyRequirement.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Jellyfin.Api.Auth.LocalOrElevatedPolicy
+{
+    /// <summary>
+    /// The authorization requirement, requiring a request from the local computer or elevated privileges, for the authorization handler.
+    /// </summary>
+    public class LocalOrElevatedPolicyRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/Jellyfin.Api/Constants/Policies.cs
+++ b/Jellyfin.Api/Constants/Policies.cs
@@ -14,5 +14,10 @@ namespace Jellyfin.Api.Constants
         /// Policy name for requiring elevated privileges.
         /// </summary>
         public const string RequiresElevation = "RequiresElevation";
+
+        /// <summary>
+        /// Policy name for requiring a local request or elevated privileges.
+        /// </summary>
+        public const string LocalOrElevated = "LocalOrElevated";
     }
 }

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Jellyfin.Api;
 using Jellyfin.Api.Auth;
 using Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy;
+using Jellyfin.Api.Auth.LocalOrElevatedPolicy;
 using Jellyfin.Api.Auth.RequiresElevationPolicy;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Controllers;
@@ -50,6 +51,13 @@ namespace Jellyfin.Server.Extensions
                     {
                         policy.AddAuthenticationSchemes(AuthenticationSchemes.CustomAuthentication);
                         policy.AddRequirements(new FirstTimeSetupOrElevatedRequirement());
+                    });
+                options.AddPolicy(
+                    Policies.LocalOrElevated,
+                    policy =>
+                    {
+                        policy.AddAuthenticationSchemes(AuthenticationSchemes.CustomAuthentication);
+                        policy.AddRequirements(new LocalOrElevatedPolicyRequirement());
                     });
             });
         }


### PR DESCRIPTION
**Changes**
Implement a `LocalOrElevated` authorization policy which replaced `AllowLocal = true` from the old Api endpoint

**Issues**
Part of #2872 
