### PR TITLE
Add full stop at end of comments (SA1629)

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -705,7 +705,7 @@ namespace Emby.Dlna.Didl
         }
 
         /// <summary>
-        /// Adds fields used by both items and folders
+        /// Adds fields used by both items and folders.
         /// </summary>
         private void AddCommonFields(BaseItem item, StubType? itemStubType, BaseItem context, XmlWriter writer, Filter filter)
         {

--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -473,7 +473,7 @@ namespace Emby.Dlna
 
         /// <summary>
         /// Recreates the object using serialization, to ensure it's not a subclass.
-        /// If it's a subclass it may not serlialize properly to xml (different root element tag name)
+        /// If it's a subclass it may not serlialize properly to xml (different root element tag name).
         /// </summary>
         /// <param name="profile"></param>
         /// <returns></returns>

--- a/Emby.Dlna/PlayTo/Device.cs
+++ b/Emby.Dlna/PlayTo/Device.cs
@@ -232,7 +232,7 @@ namespace Emby.Dlna.PlayTo
         }
 
         /// <summary>
-        /// Sets volume on a scale of 0-100
+        /// Sets volume on a scale of 0-100.
         /// </summary>
         public async Task SetVolume(int value, CancellationToken cancellationToken)
         {

--- a/Emby.Naming/Common/MediaType.cs
+++ b/Emby.Naming/Common/MediaType.cs
@@ -5,17 +5,17 @@ namespace Emby.Naming.Common
     public enum MediaType
     {
         /// <summary>
-        /// The audio
+        /// The audio.
         /// </summary>
         Audio = 0,
 
         /// <summary>
-        /// The photo
+        /// The photo.
         /// </summary>
         Photo = 1,
 
         /// <summary>
-        /// The video
+        /// The video.
         /// </summary>
         Video = 2
     }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -956,7 +956,7 @@ namespace Emby.Server.Implementations
         }
 
         /// <summary>
-        /// Notifies that the kernel that a change has been made that requires a restart
+        /// Notifies that the kernel that a change has been made that requires a restart.
         /// </summary>
         public void NotifyPendingRestart()
         {

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -247,12 +247,12 @@ namespace Emby.Server.Implementations.Data
     public enum SynchronousMode
     {
         /// <summary>
-        /// SQLite continues without syncing as soon as it has handed data off to the operating system
+        /// SQLite continues without syncing as soon as it has handed data off to the operating system.
         /// </summary>
         Off = 0,
 
         /// <summary>
-        /// SQLite database engine will still sync at the most critical moments
+        /// SQLite database engine will still sync at the most critical moments.
         /// </summary>
         Normal = 1,
 

--- a/Emby.Server.Implementations/Data/SqliteDisplayPreferencesRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteDisplayPreferencesRepository.cs
@@ -59,7 +59,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Opens the connection to the database
+        /// Opens the connection to the database.
         /// </summary>
         /// <returns>Task.</returns>
         private void InitializeInternal()
@@ -77,7 +77,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Save the display preferences associated with an item in the repo
+        /// Save the display preferences associated with an item in the repo.
         /// </summary>
         /// <param name="displayPreferences">The display preferences.</param>
         /// <param name="userId">The user id.</param>
@@ -122,7 +122,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Save all display preferences associated with a user in the repo
+        /// Save all display preferences associated with a user in the repo.
         /// </summary>
         /// <param name="displayPreferences">The display preferences.</param>
         /// <param name="userId">The user id.</param>

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -102,7 +102,7 @@ namespace Emby.Server.Implementations.Data
         protected override TempStoreMode TempStore => TempStoreMode.Memory;
 
         /// <summary>
-        /// Opens the connection to the database
+        /// Opens the connection to the database.
         /// </summary>
         public void Initialize(SqliteUserDataRepository userDataRepo, IUserManager userManager)
         {
@@ -548,7 +548,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Save a standard item in the repo
+        /// Save a standard item in the repo.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -1204,7 +1204,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Internal retrieve from items or users table
+        /// Internal retrieve from items or users table.
         /// </summary>
         /// <param name="id">The id.</param>
         /// <returns>BaseItem.</returns>
@@ -1918,7 +1918,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Gets chapters for an item
+        /// Gets chapters for an item.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>IEnumerable{ChapterInfo}.</returns>
@@ -1946,7 +1946,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Gets a single chapter for an item
+        /// Gets a single chapter for an item.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="index">The index.</param>

--- a/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
@@ -235,7 +235,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Persist all user data for the specified user
+        /// Persist all user data for the specified user.
         /// </summary>
         private void PersistAllUserData(long internalUserId, UserItemData[] userDataList, CancellationToken cancellationToken)
         {
@@ -309,7 +309,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Return all user-data associated with the given user
+        /// Return all user-data associated with the given user.
         /// </summary>
         /// <param name="internalUserId"></param>
         /// <returns></returns>
@@ -339,7 +339,7 @@ namespace Emby.Server.Implementations.Data
         }
 
         /// <summary>
-        /// Read a row from the specified reader into the provided userData object
+        /// Read a row from the specified reader into the provided userData object.
         /// </summary>
         /// <param name="reader"></param>
         private UserItemData ReadRow(IReadOnlyList<IResultSetValue> reader)

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -74,7 +74,7 @@ namespace Emby.Server.Implementations.Dto
         }
 
         /// <summary>
-        /// Converts a BaseItem to a DTOBaseItem
+        /// Converts a BaseItem to a DTOBaseItem.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="fields">The fields.</param>
@@ -442,7 +442,7 @@ namespace Emby.Server.Implementations.Dto
         }
 
         /// <summary>
-        /// Gets client-side Id of a server-side BaseItem
+        /// Gets client-side Id of a server-side BaseItem.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>System.String.</returns>
@@ -537,7 +537,7 @@ namespace Emby.Server.Implementations.Dto
         }
 
         /// <summary>
-        /// Attaches People DTO's to a DTOBaseItem
+        /// Attaches People DTO's to a DTOBaseItem.
         /// </summary>
         /// <param name="dto">The dto.</param>
         /// <param name="item">The item.</param>
@@ -725,7 +725,7 @@ namespace Emby.Server.Implementations.Dto
         }
 
         /// <summary>
-        /// Sets simple property values on a DTOBaseItem
+        /// Sets simple property values on a DTOBaseItem.
         /// </summary>
         /// <param name="dto">The dto.</param>
         /// <param name="item">The item.</param>

--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -140,7 +140,7 @@ namespace Emby.Server.Implementations.HttpClientManager
             => SendAsync(options, HttpMethod.Get);
 
         /// <summary>
-        /// Performs a GET request and returns the resulting stream
+        /// Performs a GET request and returns the resulting stream.
         /// </summary>
         /// <param name="options">The options.</param>
         /// <returns>Task{Stream}.</returns>

--- a/Emby.Server.Implementations/HttpServer/FileWriter.cs
+++ b/Emby.Server.Implementations/HttpServer/FileWriter.cs
@@ -32,12 +32,12 @@ namespace Emby.Server.Implementations.HttpServer
         private readonly IFileSystem _fileSystem;
 
         /// <summary>
-        /// The _options
+        /// The _options.
         /// </summary>
         private readonly IDictionary<string, string> _options = new Dictionary<string, string>();
 
         /// <summary>
-        /// The _requested ranges
+        /// The _requested ranges.
         /// </summary>
         private List<KeyValuePair<long, long?>> _requestedRanges;
 

--- a/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpListenerHost.cs
@@ -591,7 +591,7 @@ namespace Emby.Server.Implementations.HttpServer
         }
 
         /// <summary>
-        /// Get the default CORS headers
+        /// Get the default CORS headers.
         /// </summary>
         /// <param name="req"></param>
         /// <returns></returns>

--- a/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
@@ -692,7 +692,7 @@ namespace Emby.Server.Implementations.HttpServer
 
 
         /// <summary>
-        /// When the browser sends the IfModifiedDate, it's precision is limited to seconds, so this will account for that
+        /// When the browser sends the IfModifiedDate, it's precision is limited to seconds, so this will account for that.
         /// </summary>
         /// <param name="date">The date.</param>
         /// <returns>DateTime.</returns>

--- a/Emby.Server.Implementations/HttpServer/RangeRequestWriter.cs
+++ b/Emby.Server.Implementations/HttpServer/RangeRequestWriter.cs
@@ -34,17 +34,17 @@ namespace Emby.Server.Implementations.HttpServer
         private const int BufferSize = 81920;
 
         /// <summary>
-        /// The _options
+        /// The _options.
         /// </summary>
         private readonly Dictionary<string, string> _options = new Dictionary<string, string>();
 
         /// <summary>
-        /// The us culture
+        /// The us culture.
         /// </summary>
         private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
 
         /// <summary>
-        /// Additional HTTP Headers
+        /// Additional HTTP Headers.
         /// </summary>
         /// <value>The headers.</value>
         public IDictionary<string, string> Headers => _options;
@@ -110,7 +110,7 @@ namespace Emby.Server.Implementations.HttpServer
         }
 
         /// <summary>
-        /// The _requested ranges
+        /// The _requested ranges.
         /// </summary>
         private List<KeyValuePair<long, long?>> _requestedRanges;
         /// <summary>

--- a/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/CoreResolutionIgnoreRule.cs
@@ -8,7 +8,7 @@ using MediaBrowser.Model.IO;
 namespace Emby.Server.Implementations.Library
 {
     /// <summary>
-    /// Provides the core resolver ignore rules
+    /// Provides the core resolver ignore rules.
     /// </summary>
     public class CoreResolutionIgnoreRule : IResolverIgnoreRule
     {

--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -4,12 +4,12 @@ using DotNet.Globbing;
 namespace Emby.Server.Implementations.Library
 {
     /// <summary>
-    /// Glob patterns for files to ignore
+    /// Glob patterns for files to ignore.
     /// </summary>
     public static class IgnorePatterns
     {
         /// <summary>
-        /// Files matching these glob patterns will be ignored
+        /// Files matching these glob patterns will be ignored.
         /// </summary>
         public static readonly string[] Patterns = new string[]
         {
@@ -64,7 +64,7 @@ namespace Emby.Server.Implementations.Library
         private static readonly Glob[] _globs = Patterns.Select(p => Glob.Parse(p, _globOptions)).ToArray();
 
         /// <summary>
-        /// Returns true if the supplied path should be ignored
+        /// Returns true if the supplied path should be ignored.
         /// </summary>
         public static bool ShouldIgnore(string path)
         {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -97,13 +97,13 @@ namespace Emby.Server.Implementations.Library
         private IIntroProvider[] IntroProviders { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of entity resolution ignore rules
+        /// Gets or sets the list of entity resolution ignore rules.
         /// </summary>
         /// <value>The entity resolution ignore rules.</value>
         private IResolverIgnoreRule[] EntityResolutionIgnoreRules { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of currently registered entity resolvers
+        /// Gets or sets the list of currently registered entity resolvers.
         /// </summary>
         /// <value>The entity resolvers enumerable.</value>
         private IItemResolver[] EntityResolvers { get; set; }
@@ -209,12 +209,12 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// The _root folder
+        /// The _root folder.
         /// </summary>
         private volatile AggregateFolder _rootFolder;
 
         /// <summary>
-        /// The _root folder sync lock
+        /// The _root folder sync lock.
         /// </summary>
         private readonly object _rootFolderSyncLock = new object();
 
@@ -627,7 +627,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Determines whether a path should be ignored based on its contents - called after the contents have been read
+        /// Determines whether a path should be ignored based on its contents - called after the contents have been read.
         /// </summary>
         /// <param name="args">The args.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise</returns>
@@ -909,7 +909,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Gets a Genre
+        /// Gets a Genre.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>Task{Genre}.</returns>
@@ -990,7 +990,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Reloads the root media folder
+        /// Reloads the root media folder.
         /// </summary>
         /// <param name="progress">The progress.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/Emby.Server.Implementations/Library/ResolverHelper.cs
+++ b/Emby.Server.Implementations/Library/ResolverHelper.cs
@@ -107,7 +107,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Ensures DateCreated and DateModified have values
+        /// Ensures DateCreated and DateModified have values.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="item">The item.</param>

--- a/Emby.Server.Implementations/Library/Resolvers/ItemResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/ItemResolver.cs
@@ -28,7 +28,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
         public virtual ResolverPriority Priority => ResolverPriority.First;
 
         /// <summary>
-        /// Sets initial values on the newly resolved item
+        /// Sets initial values on the newly resolved item.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="args">The args.</param>

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -103,7 +103,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Retrieve all user data for the given user
+        /// Retrieve all user data for the given user.
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>
@@ -188,7 +188,7 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Converts a UserItemData to a DTOUserItemData
+        /// Converts a UserItemData to a DTOUserItemData.
         /// </summary>
         /// <param name="data">The data.</param>
         /// <returns>DtoUserItemData.</returns>

--- a/Emby.Server.Implementations/LiveTv/RefreshChannelsScheduledTask.cs
+++ b/Emby.Server.Implementations/LiveTv/RefreshChannelsScheduledTask.cs
@@ -35,7 +35,7 @@ namespace Emby.Server.Implementations.LiveTv
         }
 
         /// <summary>
-        /// Creates the triggers that define when the task will run
+        /// Creates the triggers that define when the task will run.
         /// </summary>
         /// <returns>IEnumerable{BaseTaskTrigger}.</returns>
         public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()

--- a/Emby.Server.Implementations/Networking/NetworkManager.cs
+++ b/Emby.Server.Implementations/Networking/NetworkManager.cs
@@ -411,7 +411,7 @@ namespace Emby.Server.Implementations.Networking
         }
 
         /// <summary>
-        /// Gets a random port number that is currently available
+        /// Gets a random port number that is currently available.
         /// </summary>
         /// <returns>System.Int32.</returns>
         public int GetRandomUnusedTcpPort()

--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.ScheduledTasks
 {
     /// <summary>
-    /// Class ScheduledTaskWorker
+    /// Class ScheduledTaskWorker.
     /// </summary>
     public class ScheduledTaskWorker : IScheduledTaskWorker
     {
@@ -111,11 +111,11 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
         private bool _readFromFile = false;
         /// <summary>
-        /// The _last execution result
+        /// The _last execution result.
         /// </summary>
         private TaskResult _lastExecutionResult;
         /// <summary>
-        /// The _last execution result sync lock
+        /// The _last execution result sync lock.
         /// </summary>
         private readonly object _lastExecutionResultSyncLock = new object();
         /// <summary>
@@ -182,7 +182,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         public string Category => ScheduledTask.Category;
 
         /// <summary>
-        /// Gets the current cancellation token
+        /// Gets the current cancellation token.
         /// </summary>
         /// <value>The current cancellation token source.</value>
         private CancellationTokenSource CurrentCancellationTokenSource { get; set; }
@@ -278,7 +278,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// The _id
+        /// The _id.
         /// </summary>
         private string _id;
 
@@ -358,7 +358,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         private Task _currentTask;
 
         /// <summary>
-        /// Executes the task
+        /// Executes the task.
         /// </summary>
         /// <param name="options">Task options.</param>
         /// <returns>Task.</returns>
@@ -453,7 +453,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stops the task if it is currently executing
+        /// Stops the task if it is currently executing.
         /// </summary>
         /// <exception cref="InvalidOperationException">Cannot cancel a Task unless it is in the Running state.</exception>
         public void Cancel()
@@ -683,7 +683,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Converts a TaskTriggerInfo into a concrete BaseTaskTrigger
+        /// Converts a TaskTriggerInfo into a concrete BaseTaskTrigger.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <returns>BaseTaskTrigger.</returns>
@@ -753,7 +753,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Disposes each trigger
+        /// Disposes each trigger.
         /// </summary>
         private void DisposeTriggers()
         {

--- a/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/TaskManager.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.ScheduledTasks
 {
     /// <summary>
-    /// Class TaskManager
+    /// Class TaskManager.
     /// </summary>
     public class TaskManager : ITaskManager
     {
@@ -23,13 +23,13 @@ namespace Emby.Server.Implementations.ScheduledTasks
         public event EventHandler<TaskCompletionEventArgs> TaskCompleted;
 
         /// <summary>
-        /// Gets the list of Scheduled Tasks
+        /// Gets the list of Scheduled Tasks.
         /// </summary>
         /// <value>The scheduled tasks.</value>
         public IScheduledTaskWorker[] ScheduledTasks { get; private set; }
 
         /// <summary>
-        /// The _task queue
+        /// The _task queue.
         /// </summary>
         private readonly ConcurrentQueue<Tuple<Type, TaskOptions>> _taskQueue =
             new ConcurrentQueue<Tuple<Type, TaskOptions>>();
@@ -81,7 +81,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Cancels if running
+        /// Cancels if running.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         public void CancelIfRunning<T>()

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Model.Globalization;
 namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 {
     /// <summary>
-    /// Deletes old cache files
+    /// Deletes old cache files.
     /// </summary>
     public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
     {
@@ -44,7 +44,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         }
 
         /// <summary>
-        /// Creates the triggers that define when the task will run
+        /// Creates the triggers that define when the task will run.
         /// </summary>
         /// <returns>IEnumerable{BaseTaskTrigger}.</returns>
         public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
@@ -57,7 +57,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         }
 
         /// <summary>
-        /// Returns the task to be executed
+        /// Returns the task to be executed.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="progress">The progress.</param>
@@ -93,7 +93,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 
 
         /// <summary>
-        /// Deletes the cache files from directory with a last write time less than a given date
+        /// Deletes the cache files from directory with a last write time less than a given date.
         /// </summary>
         /// <param name="cancellationToken">The task cancellation token.</param>
         /// <param name="directory">The directory.</param>

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Model.Globalization;
 namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 {
     /// <summary>
-    /// Deletes all transcoding temp files
+    /// Deletes all transcoding temp files.
     /// </summary>
     public class DeleteTranscodeFileTask : IScheduledTask, IConfigurableScheduledTask
     {

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/DailyTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/DailyTrigger.cs
@@ -28,7 +28,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         private Timer Timer { get; set; }
 
         /// <summary>
-        /// Stars waiting for the trigger action
+        /// Stars waiting for the trigger action.
         /// </summary>
         /// <param name="lastResult">The last result.</param>
         /// <param name="logger">The logger.</param>
@@ -51,7 +51,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stops waiting for the trigger action
+        /// Stops waiting for the trigger action.
         /// </summary>
         public void Stop()
         {

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/IntervalTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/IntervalTrigger.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.ScheduledTasks
 {
     /// <summary>
-    /// Represents a task trigger that runs repeatedly on an interval
+    /// Represents a task trigger that runs repeatedly on an interval.
     /// </summary>
     public class IntervalTrigger : ITaskTrigger
     {
@@ -31,7 +31,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         private DateTime _lastStartDate;
 
         /// <summary>
-        /// Stars waiting for the trigger action
+        /// Stars waiting for the trigger action.
         /// </summary>
         /// <param name="lastResult">The last result.</param>
         /// <param name="logger">The logger.</param>
@@ -70,7 +70,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stops waiting for the trigger action
+        /// Stops waiting for the trigger action.
         /// </summary>
         public void Stop()
         {

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/StartupTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/StartupTrigger.cs
@@ -25,7 +25,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stars waiting for the trigger action
+        /// Stars waiting for the trigger action.
         /// </summary>
         /// <param name="lastResult">The last result.</param>
         /// <param name="logger">The logger.</param>
@@ -42,7 +42,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stops waiting for the trigger action
+        /// Stops waiting for the trigger action.
         /// </summary>
         public void Stop()
         {

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
@@ -6,12 +6,12 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.ScheduledTasks
 {
     /// <summary>
-    /// Represents a task trigger that fires on a weekly basis
+    /// Represents a task trigger that fires on a weekly basis.
     /// </summary>
     public class WeeklyTrigger : ITaskTrigger
     {
         /// <summary>
-        /// Get the time of day to trigger the task to run
+        /// Get the time of day to trigger the task to run.
         /// </summary>
         /// <value>The time of day.</value>
         public TimeSpan TimeOfDay { get; set; }
@@ -34,7 +34,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         private Timer Timer { get; set; }
 
         /// <summary>
-        /// Stars waiting for the trigger action
+        /// Stars waiting for the trigger action.
         /// </summary>
         /// <param name="lastResult">The last result.</param>
         /// <param name="logger">The logger.</param>
@@ -77,7 +77,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
         }
 
         /// <summary>
-        /// Stops waiting for the trigger action
+        /// Stops waiting for the trigger action.
         /// </summary>
         public void Stop()
         {

--- a/Emby.Server.Implementations/Services/ServiceHandler.cs
+++ b/Emby.Server.Implementations/Services/ServiceHandler.cs
@@ -180,7 +180,7 @@ namespace Emby.Server.Implementations.Services
             => string.Equals(method, expected, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Duplicate params have their values joined together in a comma-delimited string
+        /// Duplicate params have their values joined together in a comma-delimited string.
         /// </summary>
         private static Dictionary<string, string> GetFlattenedRequestParams(HttpRequest request)
         {

--- a/Emby.Server.Implementations/Services/UrlExtensions.cs
+++ b/Emby.Server.Implementations/Services/UrlExtensions.cs
@@ -9,7 +9,7 @@ namespace Emby.Server.Implementations.Services
     /// Donated by Ivan Korneliuk from his post:
     /// http://korneliuk.blogspot.com/2012/08/servicestack-reusing-dtos.html
     ///
-    /// Modified to only allow using routes matching the supplied HTTP Verb
+    /// Modified to only allow using routes matching the supplied HTTP Verb.
     /// </summary>
     public static class UrlExtensions
     {

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -843,7 +843,7 @@ namespace Emby.Server.Implementations.Session
         }
 
         /// <summary>
-        /// Used to report that playback has ended for an item
+        /// Used to report that playback has ended for an item.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <returns>Task.</returns>

--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.Session
 {
     /// <summary>
-    /// Class SessionWebSocketListener
+    /// Class SessionWebSocketListener.
     /// </summary>
     public sealed class SessionWebSocketListener : IWebSocketListener, IDisposable
     {
@@ -34,12 +34,12 @@ namespace Emby.Server.Implementations.Session
         public const float ForceKeepAliveFactor = 0.75f;
 
         /// <summary>
-        /// The _session manager
+        /// The _session manager.
         /// </summary>
         private readonly ISessionManager _sessionManager;
 
         /// <summary>
-        /// The _logger
+        /// The _logger.
         /// </summary>
         private readonly ILogger<SessionWebSocketListener> _logger;
         private readonly ILoggerFactory _loggerFactory;

--- a/Emby.Server.Implementations/Sorting/AlbumArtistComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AlbumArtistComparer.cs
@@ -8,7 +8,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class AlbumArtistComparer
+    /// Class AlbumArtistComparer.
     /// </summary>
     public class AlbumArtistComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/AlbumComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AlbumComparer.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class AlbumComparer
+    /// Class AlbumComparer.
     /// </summary>
     public class AlbumComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/CriticRatingComparer.cs
+++ b/Emby.Server.Implementations/Sorting/CriticRatingComparer.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class CriticRatingComparer
+    /// Class CriticRatingComparer.
     /// </summary>
     public class CriticRatingComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/DateCreatedComparer.cs
+++ b/Emby.Server.Implementations/Sorting/DateCreatedComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class DateCreatedComparer
+    /// Class DateCreatedComparer.
     /// </summary>
     public class DateCreatedComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/DatePlayedComparer.cs
+++ b/Emby.Server.Implementations/Sorting/DatePlayedComparer.cs
@@ -8,7 +8,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class DatePlayedComparer
+    /// Class DatePlayedComparer.
     /// </summary>
     public class DatePlayedComparer : IUserBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/NameComparer.cs
+++ b/Emby.Server.Implementations/Sorting/NameComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class NameComparer
+    /// Class NameComparer.
     /// </summary>
     public class NameComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/PlayCountComparer.cs
+++ b/Emby.Server.Implementations/Sorting/PlayCountComparer.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class PlayCountComparer
+    /// Class PlayCountComparer.
     /// </summary>
     public class PlayCountComparer : IUserBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/PremiereDateComparer.cs
+++ b/Emby.Server.Implementations/Sorting/PremiereDateComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class PremiereDateComparer
+    /// Class PremiereDateComparer.
     /// </summary>
     public class PremiereDateComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/ProductionYearComparer.cs
+++ b/Emby.Server.Implementations/Sorting/ProductionYearComparer.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class ProductionYearComparer
+    /// Class ProductionYearComparer.
     /// </summary>
     public class ProductionYearComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/RandomComparer.cs
+++ b/Emby.Server.Implementations/Sorting/RandomComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class RandomComparer
+    /// Class RandomComparer.
     /// </summary>
     public class RandomComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/RuntimeComparer.cs
+++ b/Emby.Server.Implementations/Sorting/RuntimeComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class RuntimeComparer
+    /// Class RuntimeComparer.
     /// </summary>
     public class RuntimeComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Sorting/SortNameComparer.cs
+++ b/Emby.Server.Implementations/Sorting/SortNameComparer.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.Sorting
 {
     /// <summary>
-    /// Class SortNameComparer
+    /// Class SortNameComparer.
     /// </summary>
     public class SortNameComparer : IBaseItemComparer
     {

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -18,7 +18,7 @@ namespace Emby.Server.Implementations.Udp
     public sealed class UdpServer : IDisposable
     {
         /// <summary>
-        /// The _logger
+        /// The _logger.
         /// </summary>
         private readonly ILogger _logger;
         private readonly IServerApplicationHost _appHost;

--- a/Jellyfin.Data/Entities/Artwork.cs
+++ b/Jellyfin.Data/Entities/Artwork.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="kind"></param>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -77,7 +77,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -101,7 +101,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Path
+        /// Backing field for Path.
         /// </summary>
         protected string _Path;
         /// <summary>
@@ -139,7 +139,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Kind
+        /// Backing field for Kind.
         /// </summary>
         internal Enums.ArtKind _Kind;
         /// <summary>
@@ -152,7 +152,7 @@ namespace Jellyfin.Data.Entities
         partial void GetKind(ref Enums.ArtKind result);
 
         /// <summary>
-        /// Indexed, Required
+        /// Indexed, Required.
         /// </summary>
         [Required]
         public Enums.ArtKind Kind
@@ -175,7 +175,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Book.cs
+++ b/Jellyfin.Data/Entities/Book.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public Book(Guid urlid, DateTime dateadded)

--- a/Jellyfin.Data/Entities/BookMetadata.cs
+++ b/Jellyfin.Data/Entities/BookMetadata.cs
@@ -27,7 +27,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for ISBN
+        /// Backing field for ISBN.
         /// </summary>
         protected long? _ISBN;
         /// <summary>

--- a/Jellyfin.Data/Entities/Chapter.cs
+++ b/Jellyfin.Data/Entities/Chapter.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="language">ISO-639-3 3-character language codes</param>
         /// <param name="timestart"></param>
@@ -60,7 +60,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -73,7 +73,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -98,7 +98,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -135,7 +135,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Language
+        /// Backing field for Language.
         /// </summary>
         protected string _Language;
         /// <summary>
@@ -149,7 +149,7 @@ namespace Jellyfin.Data.Entities
 
         /// <summary>
         /// Required, Min length = 3, Max length = 3
-        /// ISO-639-3 3-character language codes
+        /// ISO-639-3 3-character language codes.
         /// </summary>
         [Required]
         [MinLength(3)]
@@ -175,7 +175,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for TimeStart
+        /// Backing field for TimeStart.
         /// </summary>
         protected long _TimeStart;
         /// <summary>
@@ -188,7 +188,7 @@ namespace Jellyfin.Data.Entities
         partial void GetTimeStart(ref long result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public long TimeStart
@@ -211,7 +211,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for TimeEnd
+        /// Backing field for TimeEnd.
         /// </summary>
         protected long? _TimeEnd;
         /// <summary>
@@ -243,7 +243,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Collection.cs
+++ b/Jellyfin.Data/Entities/Collection.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Data.Entities
         partial void Init();
 
         /// <summary>
-        /// Default constructor
+        /// Default constructor.
         /// </summary>
         public Collection()
         {
@@ -23,7 +23,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -36,7 +36,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -61,7 +61,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -98,7 +98,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/CollectionItem.cs
+++ b/Jellyfin.Data/Entities/CollectionItem.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="_collection0"></param>
         /// <param name="_collectionitem1"></param>
@@ -67,7 +67,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -80,7 +80,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -105,7 +105,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]
@@ -121,7 +121,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [ForeignKey("LibraryItem_Id")]
         public virtual LibraryItem LibraryItem { get; set; }

--- a/Jellyfin.Data/Entities/Company.cs
+++ b/Jellyfin.Data/Entities/Company.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="_moviemetadata0"></param>
         /// <param name="_seriesmetadata1"></param>
@@ -75,7 +75,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -88,7 +88,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -113,7 +113,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/CompanyMetadata.cs
+++ b/Jellyfin.Data/Entities/CompanyMetadata.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -60,7 +60,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Description
+        /// Backing field for Description.
         /// </summary>
         protected string _Description;
         /// <summary>
@@ -97,7 +97,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Headquarters
+        /// Backing field for Headquarters.
         /// </summary>
         protected string _Headquarters;
         /// <summary>
@@ -134,7 +134,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Country
+        /// Backing field for Country.
         /// </summary>
         protected string _Country;
         /// <summary>
@@ -171,7 +171,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Homepage
+        /// Backing field for Homepage.
         /// </summary>
         protected string _Homepage;
         /// <summary>

--- a/Jellyfin.Data/Entities/CustomItem.cs
+++ b/Jellyfin.Data/Entities/CustomItem.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public CustomItem(Guid urlid, DateTime dateadded)

--- a/Jellyfin.Data/Entities/CustomItemMetadata.cs
+++ b/Jellyfin.Data/Entities/CustomItemMetadata.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>

--- a/Jellyfin.Data/Entities/Episode.cs
+++ b/Jellyfin.Data/Entities/Episode.cs
@@ -31,7 +31,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         /// <param name="_season0"></param>
@@ -66,7 +66,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for EpisodeNumber
+        /// Backing field for EpisodeNumber.
         /// </summary>
         protected int? _EpisodeNumber;
         /// <summary>

--- a/Jellyfin.Data/Entities/EpisodeMetadata.cs
+++ b/Jellyfin.Data/Entities/EpisodeMetadata.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -60,7 +60,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Outline
+        /// Backing field for Outline.
         /// </summary>
         protected string _Outline;
         /// <summary>
@@ -97,7 +97,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Plot
+        /// Backing field for Plot.
         /// </summary>
         protected string _Plot;
         /// <summary>
@@ -134,7 +134,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Tagline
+        /// Backing field for Tagline.
         /// </summary>
         protected string _Tagline;
         /// <summary>

--- a/Jellyfin.Data/Entities/Genre.cs
+++ b/Jellyfin.Data/Entities/Genre.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="_metadata0"></param>
@@ -56,7 +56,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -69,7 +69,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -94,7 +94,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         internal string _Name;
         /// <summary>
@@ -132,7 +132,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Library.cs
+++ b/Jellyfin.Data/Entities/Library.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="name"></param>
         public Library(string name)
@@ -51,7 +51,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -89,7 +89,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -127,7 +127,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/LibraryItem.cs
+++ b/Jellyfin.Data/Entities/LibraryItem.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         protected LibraryItem(Guid urlid, DateTime dateadded)
@@ -33,7 +33,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -46,7 +46,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -71,7 +71,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for UrlId
+        /// Backing field for UrlId.
         /// </summary>
         internal Guid _UrlId;
         /// <summary>
@@ -108,7 +108,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for DateAdded
+        /// Backing field for DateAdded.
         /// </summary>
         protected DateTime _DateAdded;
         /// <summary>
@@ -121,7 +121,7 @@ namespace Jellyfin.Data.Entities
         partial void GetDateAdded(ref DateTime result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public DateTime DateAdded
@@ -144,7 +144,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]
@@ -160,7 +160,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [ForeignKey("LibraryRoot_Id")]
         public virtual LibraryRoot LibraryRoot { get; set; }

--- a/Jellyfin.Data/Entities/LibraryRoot.cs
+++ b/Jellyfin.Data/Entities/LibraryRoot.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="path">Absolute Path</param>
         public LibraryRoot(string path)
@@ -51,7 +51,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -89,7 +89,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Path
+        /// Backing field for Path.
         /// </summary>
         protected string _Path;
         /// <summary>
@@ -103,7 +103,7 @@ namespace Jellyfin.Data.Entities
 
         /// <summary>
         /// Required, Max length = 65535
-        /// Absolute Path
+        /// Absolute Path.
         /// </summary>
         [Required]
         [MaxLength(65535)]
@@ -128,7 +128,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for NetworkPath
+        /// Backing field for NetworkPath.
         /// </summary>
         protected string _NetworkPath;
         /// <summary>
@@ -166,7 +166,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]
@@ -182,7 +182,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [ForeignKey("Library_Id")]
         public virtual Library Library { get; set; }

--- a/Jellyfin.Data/Entities/MediaFile.cs
+++ b/Jellyfin.Data/Entities/MediaFile.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="path">Relative to the LibraryRoot</param>
         /// <param name="kind"></param>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -77,7 +77,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -102,7 +102,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Path
+        /// Backing field for Path.
         /// </summary>
         protected string _Path;
         /// <summary>
@@ -116,7 +116,7 @@ namespace Jellyfin.Data.Entities
 
         /// <summary>
         /// Required, Max length = 65535
-        /// Relative to the LibraryRoot
+        /// Relative to the LibraryRoot.
         /// </summary>
         [Required]
         [MaxLength(65535)]
@@ -141,7 +141,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Kind
+        /// Backing field for Kind.
         /// </summary>
         protected Enums.MediaFileKind _Kind;
         /// <summary>
@@ -154,7 +154,7 @@ namespace Jellyfin.Data.Entities
         partial void GetKind(ref Enums.MediaFileKind result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public Enums.MediaFileKind Kind
@@ -177,7 +177,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/MediaFileStream.cs
+++ b/Jellyfin.Data/Entities/MediaFileStream.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="streamnumber"></param>
         /// <param name="_mediafile0"></param>
@@ -55,7 +55,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -68,7 +68,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -93,7 +93,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for StreamNumber
+        /// Backing field for StreamNumber.
         /// </summary>
         protected int _StreamNumber;
         /// <summary>
@@ -106,7 +106,7 @@ namespace Jellyfin.Data.Entities
         partial void GetStreamNumber(ref int result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public int StreamNumber
@@ -129,7 +129,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Metadata.cs
+++ b/Jellyfin.Data/Entities/Metadata.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -50,7 +50,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -63,7 +63,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -88,7 +88,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Title
+        /// Backing field for Title.
         /// </summary>
         protected string _Title;
         /// <summary>
@@ -102,7 +102,7 @@ namespace Jellyfin.Data.Entities
 
         /// <summary>
         /// Required, Max length = 1024
-        /// The title or name of the object
+        /// The title or name of the object.
         /// </summary>
         [Required]
         [MaxLength(1024)]
@@ -127,7 +127,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for OriginalTitle
+        /// Backing field for OriginalTitle.
         /// </summary>
         protected string _OriginalTitle;
         /// <summary>
@@ -164,7 +164,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for SortTitle
+        /// Backing field for SortTitle.
         /// </summary>
         protected string _SortTitle;
         /// <summary>
@@ -201,7 +201,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Language
+        /// Backing field for Language.
         /// </summary>
         protected string _Language;
         /// <summary>
@@ -215,7 +215,7 @@ namespace Jellyfin.Data.Entities
 
         /// <summary>
         /// Required, Min length = 3, Max length = 3
-        /// ISO-639-3 3-character language codes
+        /// ISO-639-3 3-character language codes.
         /// </summary>
         [Required]
         [MinLength(3)]
@@ -241,7 +241,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for ReleaseDate
+        /// Backing field for ReleaseDate.
         /// </summary>
         protected DateTimeOffset? _ReleaseDate;
         /// <summary>
@@ -273,7 +273,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for DateAdded
+        /// Backing field for DateAdded.
         /// </summary>
         protected DateTime _DateAdded;
         /// <summary>
@@ -286,7 +286,7 @@ namespace Jellyfin.Data.Entities
         partial void GetDateAdded(ref DateTime result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public DateTime DateAdded
@@ -309,7 +309,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for DateModified
+        /// Backing field for DateModified.
         /// </summary>
         protected DateTime _DateModified;
         /// <summary>
@@ -322,7 +322,7 @@ namespace Jellyfin.Data.Entities
         partial void GetDateModified(ref DateTime result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public DateTime DateModified
@@ -345,7 +345,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/MetadataProvider.cs
+++ b/Jellyfin.Data/Entities/MetadataProvider.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="name"></param>
         public MetadataProvider(string name)
@@ -51,7 +51,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -64,7 +64,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -89,7 +89,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -127,7 +127,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/MetadataProviderId.cs
+++ b/Jellyfin.Data/Entities/MetadataProviderId.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="providerid"></param>
         /// <param name="_metadata0"></param>
@@ -77,7 +77,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -90,7 +90,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -115,7 +115,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for ProviderId
+        /// Backing field for ProviderId.
         /// </summary>
         protected string _ProviderId;
         /// <summary>
@@ -153,7 +153,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]
@@ -169,7 +169,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [ForeignKey("MetadataProvider_Id")]
         public virtual MetadataProvider MetadataProvider { get; set; }

--- a/Jellyfin.Data/Entities/Movie.cs
+++ b/Jellyfin.Data/Entities/Movie.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public Movie(Guid urlid, DateTime dateadded)

--- a/Jellyfin.Data/Entities/MovieMetadata.cs
+++ b/Jellyfin.Data/Entities/MovieMetadata.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -65,7 +65,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Outline
+        /// Backing field for Outline.
         /// </summary>
         protected string _Outline;
         /// <summary>
@@ -102,7 +102,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Plot
+        /// Backing field for Plot.
         /// </summary>
         protected string _Plot;
         /// <summary>
@@ -139,7 +139,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Tagline
+        /// Backing field for Tagline.
         /// </summary>
         protected string _Tagline;
         /// <summary>
@@ -176,7 +176,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Country
+        /// Backing field for Country.
         /// </summary>
         protected string _Country;
         /// <summary>

--- a/Jellyfin.Data/Entities/MusicAlbum.cs
+++ b/Jellyfin.Data/Entities/MusicAlbum.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public MusicAlbum(Guid urlid, DateTime dateadded)

--- a/Jellyfin.Data/Entities/MusicAlbumMetadata.cs
+++ b/Jellyfin.Data/Entities/MusicAlbumMetadata.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -65,7 +65,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Barcode
+        /// Backing field for Barcode.
         /// </summary>
         protected string _Barcode;
         /// <summary>
@@ -102,7 +102,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for LabelNumber
+        /// Backing field for LabelNumber.
         /// </summary>
         protected string _LabelNumber;
         /// <summary>
@@ -139,7 +139,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Country
+        /// Backing field for Country.
         /// </summary>
         protected string _Country;
         /// <summary>

--- a/Jellyfin.Data/Entities/Person.cs
+++ b/Jellyfin.Data/Entities/Person.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid"></param>
         /// <param name="name"></param>
@@ -59,7 +59,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -72,7 +72,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -97,7 +97,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for UrlId
+        /// Backing field for UrlId.
         /// </summary>
         protected Guid _UrlId;
         /// <summary>
@@ -110,7 +110,7 @@ namespace Jellyfin.Data.Entities
         partial void GetUrlId(ref Guid result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public Guid UrlId
@@ -133,7 +133,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -171,7 +171,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for SourceId
+        /// Backing field for SourceId.
         /// </summary>
         protected string _SourceId;
         /// <summary>
@@ -208,7 +208,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for DateAdded
+        /// Backing field for DateAdded.
         /// </summary>
         protected DateTime _DateAdded;
         /// <summary>
@@ -221,7 +221,7 @@ namespace Jellyfin.Data.Entities
         partial void GetDateAdded(ref DateTime result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public DateTime DateAdded
@@ -244,7 +244,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for DateModified
+        /// Backing field for DateModified.
         /// </summary>
         protected DateTime _DateModified;
         /// <summary>
@@ -257,7 +257,7 @@ namespace Jellyfin.Data.Entities
         partial void GetDateModified(ref DateTime result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public DateTime DateModified
@@ -280,7 +280,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/PersonRole.cs
+++ b/Jellyfin.Data/Entities/PersonRole.cs
@@ -31,7 +31,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="type"></param>
         /// <param name="_metadata0"></param>
@@ -65,7 +65,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -78,7 +78,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -103,7 +103,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Role
+        /// Backing field for Role.
         /// </summary>
         protected string _Role;
         /// <summary>
@@ -140,7 +140,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Type
+        /// Backing field for Type.
         /// </summary>
         protected Enums.PersonRoleType _Type;
         /// <summary>
@@ -153,7 +153,7 @@ namespace Jellyfin.Data.Entities
         partial void GetType(ref Enums.PersonRoleType result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public Enums.PersonRoleType Type
@@ -176,7 +176,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]
@@ -192,7 +192,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [ForeignKey("Person_Id")]
 

--- a/Jellyfin.Data/Entities/Photo.cs
+++ b/Jellyfin.Data/Entities/Photo.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public Photo(Guid urlid, DateTime dateadded)

--- a/Jellyfin.Data/Entities/PhotoMetadata.cs
+++ b/Jellyfin.Data/Entities/PhotoMetadata.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>

--- a/Jellyfin.Data/Entities/ProviderMapping.cs
+++ b/Jellyfin.Data/Entities/ProviderMapping.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="providername"></param>
         /// <param name="providersecrets"></param>
@@ -65,7 +65,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -97,7 +97,7 @@ namespace Jellyfin.Data.Entities
         public string ProviderData { get; set; }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Rating.cs
+++ b/Jellyfin.Data/Entities/Rating.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="value"></param>
         /// <param name="_metadata0"></param>
@@ -55,7 +55,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -68,7 +68,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -93,7 +93,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Value
+        /// Backing field for Value.
         /// </summary>
         protected double _Value;
         /// <summary>
@@ -106,7 +106,7 @@ namespace Jellyfin.Data.Entities
         partial void GetValue(ref double result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public double Value
@@ -129,7 +129,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Votes
+        /// Backing field for Votes.
         /// </summary>
         protected int? _Votes;
         /// <summary>
@@ -161,7 +161,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/RatingSource.cs
+++ b/Jellyfin.Data/Entities/RatingSource.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace Jellyfin.Data.Entities
 {
     /// <summary>
-    /// This is the entity to store review ratings, not age ratings
+    /// This is the entity to store review ratings, not age ratings.
     /// </summary>
     public partial class RatingSource
     {
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="maximumvalue"></param>
         /// <param name="minimumvalue"></param>
@@ -62,7 +62,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -75,7 +75,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -100,7 +100,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -137,7 +137,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for MaximumValue
+        /// Backing field for MaximumValue.
         /// </summary>
         protected double _MaximumValue;
         /// <summary>
@@ -150,7 +150,7 @@ namespace Jellyfin.Data.Entities
         partial void GetMaximumValue(ref double result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public double MaximumValue
@@ -173,7 +173,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for MinimumValue
+        /// Backing field for MinimumValue.
         /// </summary>
         protected double _MinimumValue;
         /// <summary>
@@ -186,7 +186,7 @@ namespace Jellyfin.Data.Entities
         partial void GetMinimumValue(ref double result);
 
         /// <summary>
-        /// Required
+        /// Required.
         /// </summary>
         [Required]
         public double MinimumValue
@@ -209,7 +209,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Release.cs
+++ b/Jellyfin.Data/Entities/Release.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="_movie0"></param>
@@ -87,7 +87,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Id
+        /// Backing field for Id.
         /// </summary>
         internal int _Id;
         /// <summary>
@@ -100,7 +100,7 @@ namespace Jellyfin.Data.Entities
         partial void GetId(ref int result);
 
         /// <summary>
-        /// Identity, Indexed, Required
+        /// Identity, Indexed, Required.
         /// </summary>
         [Key]
         [Required]
@@ -125,7 +125,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Name
+        /// Backing field for Name.
         /// </summary>
         protected string _Name;
         /// <summary>
@@ -163,7 +163,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Required, ConcurrenyToken
+        /// Required, ConcurrenyToken.
         /// </summary>
         [ConcurrencyCheck]
         [Required]

--- a/Jellyfin.Data/Entities/Season.cs
+++ b/Jellyfin.Data/Entities/Season.cs
@@ -31,7 +31,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         /// <param name="_series0"></param>
@@ -66,7 +66,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for SeasonNumber
+        /// Backing field for SeasonNumber.
         /// </summary>
         protected int? _SeasonNumber;
         /// <summary>

--- a/Jellyfin.Data/Entities/SeasonMetadata.cs
+++ b/Jellyfin.Data/Entities/SeasonMetadata.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -61,7 +61,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Outline
+        /// Backing field for Outline.
         /// </summary>
         protected string _Outline;
         /// <summary>

--- a/Jellyfin.Data/Entities/Series.cs
+++ b/Jellyfin.Data/Entities/Series.cs
@@ -20,7 +20,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         public Series(Guid urlid, DateTime dateadded)
@@ -47,7 +47,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for AirsDayOfWeek
+        /// Backing field for AirsDayOfWeek.
         /// </summary>
         protected DayOfWeek? _AirsDayOfWeek;
         /// <summary>
@@ -79,7 +79,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for AirsTime
+        /// Backing field for AirsTime.
         /// </summary>
         protected DateTimeOffset? _AirsTime;
         /// <summary>
@@ -92,7 +92,7 @@ namespace Jellyfin.Data.Entities
         partial void GetAirsTime(ref DateTimeOffset? result);
 
         /// <summary>
-        /// The time the show airs, ignore the date portion
+        /// The time the show airs, ignore the date portion.
         /// </summary>
         public DateTimeOffset? AirsTime
         {
@@ -114,7 +114,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for FirstAired
+        /// Backing field for FirstAired.
         /// </summary>
         protected DateTimeOffset? _FirstAired;
         /// <summary>

--- a/Jellyfin.Data/Entities/SeriesMetadata.cs
+++ b/Jellyfin.Data/Entities/SeriesMetadata.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>
@@ -65,7 +65,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for Outline
+        /// Backing field for Outline.
         /// </summary>
         protected string _Outline;
         /// <summary>
@@ -102,7 +102,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Plot
+        /// Backing field for Plot.
         /// </summary>
         protected string _Plot;
         /// <summary>
@@ -139,7 +139,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Tagline
+        /// Backing field for Tagline.
         /// </summary>
         protected string _Tagline;
         /// <summary>
@@ -176,7 +176,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Backing field for Country
+        /// Backing field for Country.
         /// </summary>
         protected string _Country;
         /// <summary>

--- a/Jellyfin.Data/Entities/Track.cs
+++ b/Jellyfin.Data/Entities/Track.cs
@@ -31,7 +31,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="urlid">This is whats gets displayed in the Urls and API requests. This could also be a string.</param>
         /// <param name="_musicalbum0"></param>
@@ -66,7 +66,7 @@ namespace Jellyfin.Data.Entities
          *************************************************************************/
 
         /// <summary>
-        /// Backing field for TrackNumber
+        /// Backing field for TrackNumber.
         /// </summary>
         protected int? _TrackNumber;
         /// <summary>

--- a/Jellyfin.Data/Entities/TrackMetadata.cs
+++ b/Jellyfin.Data/Entities/TrackMetadata.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Data.Entities
         }
 
         /// <summary>
-        /// Public constructor with required data
+        /// Public constructor with required data.
         /// </summary>
         /// <param name="title">The title or name of the object</param>
         /// <param name="language">ISO-639-3 3-character language codes</param>

--- a/Jellyfin.Data/Enums/PreferenceKind.cs
+++ b/Jellyfin.Data/Enums/PreferenceKind.cs
@@ -26,7 +26,7 @@ namespace Jellyfin.Data.Enums
         EnabledDevices = 3,
 
         /// <summary>
-        /// A list of enabled channels
+        /// A list of enabled channels.
         /// </summary>
         EnabledChannels = 4,
 

--- a/Jellyfin.Server.Implementations/JellyfinDb.cs
+++ b/Jellyfin.Server.Implementations/JellyfinDb.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Server.Implementations
 
         /// <summary>
         /// Repository for global::Jellyfin.Data.Entities.RatingSource - This is the entity to
-        /// store review ratings, not age ratings
+        /// store review ratings, not age ratings.
         /// </summary>
         public virtual DbSet<RatingSource> RatingSources { get; set; }
         public virtual DbSet<Release> Releases { get; set; }

--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -43,7 +43,7 @@ namespace MediaBrowser.Api
         private readonly IMediaSourceManager _mediaSourceManager;
 
         /// <summary>
-        /// The active transcoding jobs
+        /// The active transcoding jobs.
         /// </summary>
         private readonly List<TranscodingJob> _activeTranscodingJobs = new List<TranscodingJob>();
 
@@ -293,7 +293,7 @@ namespace MediaBrowser.Api
 
         /// <summary>
         /// <summary>
-        /// The progressive
+        /// The progressive.
         /// </summary>
         /// Called when [transcode failed to start].
         /// </summary>

--- a/MediaBrowser.Api/BaseApiService.cs
+++ b/MediaBrowser.Api/BaseApiService.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class BaseApiService
+    /// Class BaseApiService.
     /// </summary>
     public abstract class BaseApiService : IService, IRequiresRequest
     {

--- a/MediaBrowser.Api/ChannelService.cs
+++ b/MediaBrowser.Api/ChannelService.cs
@@ -36,7 +36,7 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -90,7 +90,7 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -149,7 +149,7 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]

--- a/MediaBrowser.Api/ConfigurationService.cs
+++ b/MediaBrowser.Api/ConfigurationService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetConfiguration
+    /// Class GetConfiguration.
     /// </summary>
     [Route("/System/Configuration", "GET", Summary = "Gets application configuration")]
     [Authenticated]
@@ -28,7 +28,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateConfiguration
+    /// Class UpdateConfiguration.
     /// </summary>
     [Route("/System/Configuration", "POST", Summary = "Updates application configuration")]
     [Authenticated(Roles = "Admin")]
@@ -65,12 +65,12 @@ namespace MediaBrowser.Api
     public class ConfigurationService : BaseApiService
     {
         /// <summary>
-        /// The _json serializer
+        /// The _json serializer.
         /// </summary>
         private readonly IJsonSerializer _jsonSerializer;
 
         /// <summary>
-        /// The _configuration manager
+        /// The _configuration manager.
         /// </summary>
         private readonly IServerConfigurationManager _configurationManager;
 

--- a/MediaBrowser.Api/DisplayPreferencesService.cs
+++ b/MediaBrowser.Api/DisplayPreferencesService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class UpdateDisplayPreferences
+    /// Class UpdateDisplayPreferences.
     /// </summary>
     [Route("/DisplayPreferences/{DisplayPreferencesId}", "POST", Summary = "Updates a user's display preferences for an item")]
     public class UpdateDisplayPreferences : DisplayPreferences, IReturnVoid
@@ -44,17 +44,17 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class DisplayPreferencesService
+    /// Class DisplayPreferencesService.
     /// </summary>
     [Authenticated]
     public class DisplayPreferencesService : BaseApiService
     {
         /// <summary>
-        /// The _display preferences manager
+        /// The _display preferences manager.
         /// </summary>
         private readonly IDisplayPreferencesRepository _displayPreferencesManager;
         /// <summary>
-        /// The _json serializer
+        /// The _json serializer.
         /// </summary>
         private readonly IJsonSerializer _jsonSerializer;
 

--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetDirectoryContents
+    /// Class GetDirectoryContents.
     /// </summary>
     [Route("/Environment/DirectoryContents", "GET", Summary = "Gets the contents of a given directory in the file system")]
     public class GetDirectoryContents : IReturn<List<FileSystemEntryInfo>>
@@ -66,7 +66,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetDrives
+    /// Class GetDrives.
     /// </summary>
     [Route("/Environment/Drives", "GET", Summary = "Gets available drives from the server's file system")]
     public class GetDrives : IReturn<List<FileSystemEntryInfo>>
@@ -74,7 +74,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetNetworkComputers
+    /// Class GetNetworkComputers.
     /// </summary>
     [Route("/Environment/NetworkDevices", "GET", Summary = "Gets a list of devices on the network")]
     public class GetNetworkDevices : IReturn<List<FileSystemEntryInfo>>
@@ -103,7 +103,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class EnvironmentService
+    /// Class EnvironmentService.
     /// </summary>
     [Authenticated(Roles = "Admin", AllowBeforeStartupWizard = true)]
     public class EnvironmentService : BaseApiService
@@ -112,7 +112,7 @@ namespace MediaBrowser.Api
         private const string UncSeparatorString = "\\";
 
         /// <summary>
-        /// The _network manager
+        /// The _network manager.
         /// </summary>
         private readonly INetworkManager _networkManager;
         private readonly IFileSystem _fileSystem;
@@ -220,7 +220,7 @@ namespace MediaBrowser.Api
         }
 
         /// <summary>
-        /// Gets the list that is returned when an empty path is supplied
+        /// Gets the list that is returned when an empty path is supplied.
         /// </summary>
         /// <returns>IEnumerable{FileSystemEntryInfo}.</returns>
         private IEnumerable<FileSystemEntryInfo> GetDrives()

--- a/MediaBrowser.Api/IHasItemFields.cs
+++ b/MediaBrowser.Api/IHasItemFields.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Interface IHasItemFields
+    /// Interface IHasItemFields.
     /// </summary>
     public interface IHasItemFields
     {

--- a/MediaBrowser.Api/Images/ImageByNameService.cs
+++ b/MediaBrowser.Api/Images/ImageByNameService.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Images
 {
     /// <summary>
-    /// Class GetGeneralImage
+    /// Class GetGeneralImage.
     /// </summary>
     [Route("/Images/General/{Name}/{Type}", "GET", Summary = "Gets a general image by name")]
     public class GetGeneralImage
@@ -33,7 +33,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class GetRatingImage
+    /// Class GetRatingImage.
     /// </summary>
     [Route("/Images/Ratings/{Theme}/{Name}", "GET", Summary = "Gets a rating image by name")]
     public class GetRatingImage
@@ -54,7 +54,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class GetMediaInfoImage
+    /// Class GetMediaInfoImage.
     /// </summary>
     [Route("/Images/MediaInfo/{Theme}/{Name}", "GET", Summary = "Gets a media info image by name")]
     public class GetMediaInfoImage
@@ -93,12 +93,12 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class ImageByNameService
+    /// Class ImageByNameService.
     /// </summary>
     public class ImageByNameService : BaseApiService
     {
         /// <summary>
-        /// The _app paths
+        /// The _app paths.
         /// </summary>
         private readonly IServerApplicationPaths _appPaths;
 

--- a/MediaBrowser.Api/Images/ImageRequest.cs
+++ b/MediaBrowser.Api/Images/ImageRequest.cs
@@ -4,30 +4,30 @@ using MediaBrowser.Model.Services;
 namespace MediaBrowser.Api.Images
 {
     /// <summary>
-    /// Class ImageRequest
+    /// Class ImageRequest.
     /// </summary>
     public class ImageRequest : DeleteImageRequest
     {
         /// <summary>
-        /// The max width
+        /// The max width.
         /// </summary>
         [ApiMember(Name = "MaxWidth", Description = "The maximum image width to return.", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? MaxWidth { get; set; }
 
         /// <summary>
-        /// The max height
+        /// The max height.
         /// </summary>
         [ApiMember(Name = "MaxHeight", Description = "The maximum image height to return.", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? MaxHeight { get; set; }
 
         /// <summary>
-        /// The width
+        /// The width.
         /// </summary>
         [ApiMember(Name = "Width", Description = "The fixed image width to return.", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Width { get; set; }
 
         /// <summary>
-        /// The height
+        /// The height.
         /// </summary>
         [ApiMember(Name = "Height", Description = "The fixed image height to return.", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Height { get; set; }
@@ -79,7 +79,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class DeleteImageRequest
+    /// Class DeleteImageRequest.
     /// </summary>
     public class DeleteImageRequest
     {

--- a/MediaBrowser.Api/Images/ImageService.cs
+++ b/MediaBrowser.Api/Images/ImageService.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class UpdateItemImageIndex
+    /// Class UpdateItemImageIndex.
     /// </summary>
     [Route("/Items/{Id}/Images/{Type}/{Index}/Index", "POST", Summary = "Updates the index for an item image")]
     [Authenticated(Roles = "admin")]
@@ -94,7 +94,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class GetPersonImage
+    /// Class GetPersonImage.
     /// </summary>
     [Route("/Artists/{Name}/Images/{Type}", "GET")]
     [Route("/Artists/{Name}/Images/{Type}/{Index}", "GET")]
@@ -131,7 +131,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class GetUserImage
+    /// Class GetUserImage.
     /// </summary>
     [Route("/Users/{Id}/Images/{Type}", "GET")]
     [Route("/Users/{Id}/Images/{Type}/{Index}", "GET")]
@@ -148,7 +148,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class DeleteItemImage
+    /// Class DeleteItemImage.
     /// </summary>
     [Route("/Items/{Id}/Images/{Type}", "DELETE")]
     [Route("/Items/{Id}/Images/{Type}/{Index}", "DELETE")]
@@ -164,7 +164,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class DeleteUserImage
+    /// Class DeleteUserImage.
     /// </summary>
     [Route("/Users/{Id}/Images/{Type}", "DELETE")]
     [Route("/Users/{Id}/Images/{Type}/{Index}", "DELETE")]
@@ -180,7 +180,7 @@ namespace MediaBrowser.Api.Images
     }
 
     /// <summary>
-    /// Class PostUserImage
+    /// Class PostUserImage.
     /// </summary>
     [Route("/Users/{Id}/Images/{Type}", "POST")]
     [Route("/Users/{Id}/Images/{Type}/{Index}", "POST")]
@@ -195,14 +195,14 @@ namespace MediaBrowser.Api.Images
         public string Id { get; set; }
 
         /// <summary>
-        /// The raw Http Request Input Stream
+        /// The raw Http Request Input Stream.
         /// </summary>
         /// <value>The request stream.</value>
         public Stream RequestStream { get; set; }
     }
 
     /// <summary>
-    /// Class PostItemImage
+    /// Class PostItemImage.
     /// </summary>
     [Route("/Items/{Id}/Images/{Type}", "POST")]
     [Route("/Items/{Id}/Images/{Type}/{Index}", "POST")]
@@ -217,14 +217,14 @@ namespace MediaBrowser.Api.Images
         public string Id { get; set; }
 
         /// <summary>
-        /// The raw Http Request Input Stream
+        /// The raw Http Request Input Stream.
         /// </summary>
         /// <value>The request stream.</value>
         public Stream RequestStream { get; set; }
     }
 
     /// <summary>
-    /// Class ImageService
+    /// Class ImageService.
     /// </summary>
     public class ImageService : BaseApiService
     {

--- a/MediaBrowser.Api/Images/RemoteImageService.cs
+++ b/MediaBrowser.Api/Images/RemoteImageService.cs
@@ -33,7 +33,7 @@ namespace MediaBrowser.Api.Images
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]

--- a/MediaBrowser.Api/Library/LibraryService.cs
+++ b/MediaBrowser.Api/Library/LibraryService.cs
@@ -49,7 +49,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class GetCriticReviews
+    /// Class GetCriticReviews.
     /// </summary>
     [Route("/Items/{Id}/CriticReviews", "GET", Summary = "Gets critic reviews for an item")]
     [Authenticated]
@@ -70,7 +70,7 @@ namespace MediaBrowser.Api.Library
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -78,7 +78,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class GetThemeSongs
+    /// Class GetThemeSongs.
     /// </summary>
     [Route("/Items/{Id}/ThemeSongs", "GET", Summary = "Gets theme songs for an item")]
     [Authenticated]
@@ -103,7 +103,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class GetThemeVideos
+    /// Class GetThemeVideos.
     /// </summary>
     [Route("/Items/{Id}/ThemeVideos", "GET", Summary = "Gets theme videos for an item")]
     [Authenticated]
@@ -128,7 +128,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class GetThemeVideos
+    /// Class GetThemeVideos.
     /// </summary>
     [Route("/Items/{Id}/ThemeMedia", "GET", Summary = "Gets theme videos and songs for an item")]
     [Authenticated]
@@ -205,7 +205,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class GetPhyscialPaths
+    /// Class GetPhyscialPaths.
     /// </summary>
     [Route("/Library/PhysicalPaths", "GET", Summary = "Gets a list of physical paths from virtual folders")]
     [Authenticated(Roles = "Admin")]
@@ -312,7 +312,7 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class LibraryService
+    /// Class LibraryService.
     /// </summary>
     public class LibraryService : BaseApiService
     {

--- a/MediaBrowser.Api/Library/LibraryStructureService.cs
+++ b/MediaBrowser.Api/Library/LibraryStructureService.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Library
 {
     /// <summary>
-    /// Class GetDefaultVirtualFolders
+    /// Class GetDefaultVirtualFolders.
     /// </summary>
     [Route("/Library/VirtualFolders", "GET")]
     public class GetVirtualFolders : IReturn<List<VirtualFolderInfo>>
@@ -166,18 +166,18 @@ namespace MediaBrowser.Api.Library
     }
 
     /// <summary>
-    /// Class LibraryStructureService
+    /// Class LibraryStructureService.
     /// </summary>
     [Authenticated(Roles = "Admin", AllowBeforeStartupWizard = true)]
     public class LibraryStructureService : BaseApiService
     {
         /// <summary>
-        /// The _app paths
+        /// The _app paths.
         /// </summary>
         private readonly IServerApplicationPaths _appPaths;
 
         /// <summary>
-        /// The _library manager
+        /// The _library manager.
         /// </summary>
         private readonly ILibraryManager _libraryManager;
         private readonly ILibraryMonitor _libraryMonitor;

--- a/MediaBrowser.Api/LiveTv/LiveTvService.cs
+++ b/MediaBrowser.Api/LiveTv/LiveTvService.cs
@@ -31,7 +31,7 @@ using Microsoft.Net.Http.Headers;
 namespace MediaBrowser.Api.LiveTv
 {
     /// <summary>
-    /// This is insecure right now to avoid windows phone refactoring
+    /// This is insecure right now to avoid windows phone refactoring.
     /// </summary>
     [Route("/LiveTv/Info", "GET", Summary = "Gets available live tv services.")]
     [Authenticated]
@@ -72,7 +72,7 @@ namespace MediaBrowser.Api.LiveTv
         public bool? IsSports { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -100,7 +100,7 @@ namespace MediaBrowser.Api.LiveTv
         public string EnableImageTypes { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -188,7 +188,7 @@ namespace MediaBrowser.Api.LiveTv
         public string EnableImageTypes { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -250,7 +250,7 @@ namespace MediaBrowser.Api.LiveTv
         public string EnableImageTypes { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -410,7 +410,7 @@ namespace MediaBrowser.Api.LiveTv
         public Guid LibrarySeriesId { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -473,7 +473,7 @@ namespace MediaBrowser.Api.LiveTv
         public string GenreIds { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]

--- a/MediaBrowser.Api/LocalizationService.cs
+++ b/MediaBrowser.Api/LocalizationService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetCultures
+    /// Class GetCultures.
     /// </summary>
     [Route("/Localization/Cultures", "GET", Summary = "Gets known cultures")]
     public class GetCultures : IReturn<CultureDto[]>
@@ -16,7 +16,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetCountries
+    /// Class GetCountries.
     /// </summary>
     [Route("/Localization/Countries", "GET", Summary = "Gets known countries")]
     public class GetCountries : IReturn<CountryInfo[]>
@@ -24,7 +24,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class ParentalRatings
+    /// Class ParentalRatings.
     /// </summary>
     [Route("/Localization/ParentalRatings", "GET", Summary = "Gets known parental ratings")]
     public class GetParentalRatings : IReturn<ParentalRating[]>
@@ -32,7 +32,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class ParentalRatings
+    /// Class ParentalRatings.
     /// </summary>
     [Route("/Localization/Options", "GET", Summary = "Gets localization options")]
     public class GetLocalizationOptions : IReturn<LocalizationOption[]>
@@ -40,13 +40,13 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class CulturesService
+    /// Class CulturesService.
     /// </summary>
     [Authenticated(AllowBeforeStartupWizard = true)]
     public class LocalizationService : BaseApiService
     {
         /// <summary>
-        /// The _localization
+        /// The _localization.
         /// </summary>
         private readonly ILocalizationManager _localization;
 

--- a/MediaBrowser.Api/Movies/MoviesService.cs
+++ b/MediaBrowser.Api/Movies/MoviesService.cs
@@ -65,13 +65,13 @@ namespace MediaBrowser.Api.Movies
     }
 
     /// <summary>
-    /// Class MoviesService
+    /// Class MoviesService.
     /// </summary>
     [Authenticated]
     public class MoviesService : BaseApiService
     {
         /// <summary>
-        /// The _user manager
+        /// The _user manager.
         /// </summary>
         private readonly IUserManager _userManager;
 

--- a/MediaBrowser.Api/Movies/TrailersService.cs
+++ b/MediaBrowser.Api/Movies/TrailersService.cs
@@ -18,18 +18,18 @@ namespace MediaBrowser.Api.Movies
     }
 
     /// <summary>
-    /// Class TrailersService
+    /// Class TrailersService.
     /// </summary>
     [Authenticated]
     public class TrailersService : BaseApiService
     {
         /// <summary>
-        /// The _user manager
+        /// The _user manager.
         /// </summary>
         private readonly IUserManager _userManager;
 
         /// <summary>
-        /// The _library manager
+        /// The _library manager.
         /// </summary>
         private readonly ILibraryManager _libraryManager;
 

--- a/MediaBrowser.Api/Music/AlbumsService.cs
+++ b/MediaBrowser.Api/Music/AlbumsService.cs
@@ -27,16 +27,16 @@ namespace MediaBrowser.Api.Music
     public class AlbumsService : BaseApiService
     {
         /// <summary>
-        /// The _user manager
+        /// The _user manager.
         /// </summary>
         private readonly IUserManager _userManager;
 
         /// <summary>
-        /// The _user data repository
+        /// The _user data repository.
         /// </summary>
         private readonly IUserDataManager _userDataRepository;
         /// <summary>
-        /// The _library manager
+        /// The _library manager.
         /// </summary>
         private readonly ILibraryManager _libraryManager;
         private readonly IItemRepository _itemRepo;

--- a/MediaBrowser.Api/PackageService.cs
+++ b/MediaBrowser.Api/PackageService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetPackage
+    /// Class GetPackage.
     /// </summary>
     [Route("/Packages/{Name}", "GET", Summary = "Gets a package, by name or assembly guid")]
     [Authenticated]
@@ -36,7 +36,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetPackages
+    /// Class GetPackages.
     /// </summary>
     [Route("/Packages", "GET", Summary = "Gets available packages")]
     [Authenticated]
@@ -45,7 +45,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class InstallPackage
+    /// Class InstallPackage.
     /// </summary>
     [Route("/Packages/Installed/{Name}", "POST", Summary = "Installs a package")]
     [Authenticated(Roles = "Admin")]
@@ -74,7 +74,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class CancelPackageInstallation
+    /// Class CancelPackageInstallation.
     /// </summary>
     [Route("/Packages/Installing/{Id}", "DELETE", Summary = "Cancels a package installation")]
     [Authenticated(Roles = "Admin")]
@@ -89,7 +89,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class PackageService
+    /// Class PackageService.
     /// </summary>
     public class PackageService : BaseApiService
     {

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -28,7 +28,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Playback
 {
     /// <summary>
-    /// Class BaseStreamingService
+    /// Class BaseStreamingService.
     /// </summary>
     public abstract class BaseStreamingService : BaseApiService
     {

--- a/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/BaseHlsService.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Playback.Hls
 {
     /// <summary>
-    /// Class BaseHlsService
+    /// Class BaseHlsService.
     /// </summary>
     public abstract class BaseHlsService : BaseStreamingService
     {

--- a/MediaBrowser.Api/Playback/Hls/HlsSegmentService.cs
+++ b/MediaBrowser.Api/Playback/Hls/HlsSegmentService.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Playback.Hls
 {
     /// <summary>
-    /// Class GetHlsAudioSegment
+    /// Class GetHlsAudioSegment.
     /// </summary>
     // Can't require authentication just yet due to seeing some requests come from Chrome without full query string
     //[Authenticated]
@@ -37,7 +37,7 @@ namespace MediaBrowser.Api.Playback.Hls
     }
 
     /// <summary>
-    /// Class GetHlsVideoSegment
+    /// Class GetHlsVideoSegment.
     /// </summary>
     [Route("/Videos/{Id}/hls/{PlaylistId}/stream.m3u8", "GET")]
     [Authenticated]
@@ -66,7 +66,7 @@ namespace MediaBrowser.Api.Playback.Hls
     }
 
     /// <summary>
-    /// Class GetHlsVideoSegment
+    /// Class GetHlsVideoSegment.
     /// </summary>
     // Can't require authentication just yet due to seeing some requests come from Chrome without full query string
     //[Authenticated]

--- a/MediaBrowser.Api/Playback/Hls/VideoHlsService.cs
+++ b/MediaBrowser.Api/Playback/Hls/VideoHlsService.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Api.Playback.Hls
     }
 
     /// <summary>
-    /// Class VideoHlsService
+    /// Class VideoHlsService.
     /// </summary>
     [Authenticated]
     public class VideoHlsService : BaseHlsService

--- a/MediaBrowser.Api/Playback/Progressive/AudioService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/AudioService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Playback.Progressive
 {
     /// <summary>
-    /// Class GetAudioStream
+    /// Class GetAudioStream.
     /// </summary>
     [Route("/Audio/{Id}/stream.{Container}", "GET", Summary = "Gets an audio stream")]
     [Route("/Audio/{Id}/stream", "GET", Summary = "Gets an audio stream")]
@@ -26,7 +26,7 @@ namespace MediaBrowser.Api.Playback.Progressive
     }
 
     /// <summary>
-    /// Class AudioService
+    /// Class AudioService.
     /// </summary>
     // TODO: In order to autheneticate this in the future, Dlna playback will require updating
     //[Authenticated]

--- a/MediaBrowser.Api/Playback/Progressive/BaseProgressiveStreamingService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/BaseProgressiveStreamingService.cs
@@ -21,7 +21,7 @@ using Microsoft.Net.Http.Headers;
 namespace MediaBrowser.Api.Playback.Progressive
 {
     /// <summary>
-    /// Class BaseProgressiveStreamingService
+    /// Class BaseProgressiveStreamingService.
     /// </summary>
     public abstract class BaseProgressiveStreamingService : BaseStreamingService
     {

--- a/MediaBrowser.Api/Playback/Progressive/VideoService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/VideoService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Playback.Progressive
 {
     /// <summary>
-    /// Class GetVideoStream
+    /// Class GetVideoStream.
     /// </summary>
     [Route("/Videos/{Id}/stream.mpegts", "GET")]
     [Route("/Videos/{Id}/stream.ts", "GET")]
@@ -62,7 +62,7 @@ namespace MediaBrowser.Api.Playback.Progressive
     }
 
     /// <summary>
-    /// Class VideoService
+    /// Class VideoService.
     /// </summary>
     // TODO: In order to autheneticate this in the future, Dlna playback will require updating
     //[Authenticated]

--- a/MediaBrowser.Api/Playback/StaticRemoteStreamWriter.cs
+++ b/MediaBrowser.Api/Playback/StaticRemoteStreamWriter.cs
@@ -8,17 +8,17 @@ using MediaBrowser.Model.Services;
 namespace MediaBrowser.Api.Playback
 {
     /// <summary>
-    /// Class StaticRemoteStreamWriter
+    /// Class StaticRemoteStreamWriter.
     /// </summary>
     public class StaticRemoteStreamWriter : IAsyncStreamWriter, IHasHeaders
     {
         /// <summary>
-        /// The _input stream
+        /// The _input stream.
         /// </summary>
         private readonly HttpResponseInfo _response;
 
         /// <summary>
-        /// The _options
+        /// The _options.
         /// </summary>
         private readonly IDictionary<string, string> _options = new Dictionary<string, string>();
 

--- a/MediaBrowser.Api/Playback/StreamRequest.cs
+++ b/MediaBrowser.Api/Playback/StreamRequest.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Model.Services;
 namespace MediaBrowser.Api.Playback
 {
     /// <summary>
-    /// Class StreamRequest
+    /// Class StreamRequest.
     /// </summary>
     public class StreamRequest : BaseEncodingJobOptions
     {

--- a/MediaBrowser.Api/PlaylistService.cs
+++ b/MediaBrowser.Api/PlaylistService.cs
@@ -95,14 +95,14 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]

--- a/MediaBrowser.Api/PluginService.cs
+++ b/MediaBrowser.Api/PluginService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class Plugins
+    /// Class Plugins.
     /// </summary>
     [Route("/Plugins", "GET", Summary = "Gets a list of currently installed plugins")]
     [Authenticated]
@@ -25,7 +25,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UninstallPlugin
+    /// Class UninstallPlugin.
     /// </summary>
     [Route("/Plugins/{Id}", "DELETE", Summary = "Uninstalls a plugin")]
     [Authenticated(Roles = "Admin")]
@@ -40,7 +40,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetPluginConfiguration
+    /// Class GetPluginConfiguration.
     /// </summary>
     [Route("/Plugins/{Id}/Configuration", "GET", Summary = "Gets a plugin's configuration")]
     [Authenticated]
@@ -55,7 +55,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdatePluginConfiguration
+    /// Class UpdatePluginConfiguration.
     /// </summary>
     [Route("/Plugins/{Id}/Configuration", "POST", Summary = "Updates a plugin's configuration")]
     [Authenticated]
@@ -69,7 +69,7 @@ namespace MediaBrowser.Api
         public string Id { get; set; }
 
         /// <summary>
-        /// The raw Http Request Input Stream
+        /// The raw Http Request Input Stream.
         /// </summary>
         /// <value>The request stream.</value>
         public Stream RequestStream { get; set; }
@@ -86,7 +86,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetPluginSecurityInfo
+    /// Class GetPluginSecurityInfo.
     /// </summary>
     [Route("/Plugins/SecurityInfo", "GET", Summary = "Gets plugin registration information", IsHidden = true)]
     [Authenticated]
@@ -95,7 +95,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdatePluginSecurityInfo
+    /// Class UpdatePluginSecurityInfo.
     /// </summary>
     [Route("/Plugins/SecurityInfo", "POST", Summary = "Updates plugin registration information", IsHidden = true)]
     [Authenticated(Roles = "Admin")]
@@ -136,17 +136,17 @@ namespace MediaBrowser.Api
         public bool IsMBSupporter { get; set; }
     }
     /// <summary>
-    /// Class PluginsService
+    /// Class PluginsService.
     /// </summary>
     public class PluginService : BaseApiService
     {
         /// <summary>
-        /// The _json serializer
+        /// The _json serializer.
         /// </summary>
         private readonly IJsonSerializer _jsonSerializer;
 
         /// <summary>
-        /// The _app host
+        /// The _app host.
         /// </summary>
         private readonly IApplicationHost _appHost;
         private readonly IInstallationManager _installationManager;

--- a/MediaBrowser.Api/ScheduledTasks/ScheduledTaskService.cs
+++ b/MediaBrowser.Api/ScheduledTasks/ScheduledTaskService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.ScheduledTasks
 {
     /// <summary>
-    /// Class GetScheduledTask
+    /// Class GetScheduledTask.
     /// </summary>
     [Route("/ScheduledTasks/{Id}", "GET", Summary = "Gets a scheduled task, by Id")]
     public class GetScheduledTask : IReturn<TaskInfo>
@@ -25,7 +25,7 @@ namespace MediaBrowser.Api.ScheduledTasks
     }
 
     /// <summary>
-    /// Class GetScheduledTasks
+    /// Class GetScheduledTasks.
     /// </summary>
     [Route("/ScheduledTasks", "GET", Summary = "Gets scheduled tasks")]
     public class GetScheduledTasks : IReturn<TaskInfo[]>
@@ -38,7 +38,7 @@ namespace MediaBrowser.Api.ScheduledTasks
     }
 
     /// <summary>
-    /// Class StartScheduledTask
+    /// Class StartScheduledTask.
     /// </summary>
     [Route("/ScheduledTasks/Running/{Id}", "POST", Summary = "Starts a scheduled task")]
     public class StartScheduledTask : IReturnVoid
@@ -52,7 +52,7 @@ namespace MediaBrowser.Api.ScheduledTasks
     }
 
     /// <summary>
-    /// Class StopScheduledTask
+    /// Class StopScheduledTask.
     /// </summary>
     [Route("/ScheduledTasks/Running/{Id}", "DELETE", Summary = "Stops a scheduled task")]
     public class StopScheduledTask : IReturnVoid
@@ -66,7 +66,7 @@ namespace MediaBrowser.Api.ScheduledTasks
     }
 
     /// <summary>
-    /// Class UpdateScheduledTaskTriggers
+    /// Class UpdateScheduledTaskTriggers.
     /// </summary>
     [Route("/ScheduledTasks/{Id}/Triggers", "POST", Summary = "Updates the triggers for a scheduled task")]
     public class UpdateScheduledTaskTriggers : List<TaskTriggerInfo>, IReturnVoid
@@ -80,7 +80,7 @@ namespace MediaBrowser.Api.ScheduledTasks
     }
 
     /// <summary>
-    /// Class ScheduledTasksService
+    /// Class ScheduledTasksService.
     /// </summary>
     [Authenticated(Roles = "Admin")]
     public class ScheduledTaskService : BaseApiService

--- a/MediaBrowser.Api/ScheduledTasks/ScheduledTasksWebSocketListener.cs
+++ b/MediaBrowser.Api/ScheduledTasks/ScheduledTasksWebSocketListener.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.ScheduledTasks
 {
     /// <summary>
-    /// Class ScheduledTasksWebSocketListener
+    /// Class ScheduledTasksWebSocketListener.
     /// </summary>
     public class ScheduledTasksWebSocketListener : BasePeriodicWebSocketListener<IEnumerable<TaskInfo>, WebSocketListenerState>
     {

--- a/MediaBrowser.Api/SearchService.cs
+++ b/MediaBrowser.Api/SearchService.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetSearchHints
+    /// Class GetSearchHints.
     /// </summary>
     [Route("/Search/Hints", "GET", Summary = "Gets search hints based on a search term")]
     public class GetSearchHints : IReturn<SearchHintResult>
@@ -31,7 +31,7 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -45,7 +45,7 @@ namespace MediaBrowser.Api
         public Guid UserId { get; set; }
 
         /// <summary>
-        /// Search characters used to find items
+        /// Search characters used to find items.
         /// </summary>
         /// <value>The index by.</value>
         [ApiMember(Name = "SearchTerm", Description = "The search term to filter on", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "GET")]
@@ -104,13 +104,13 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class SearchService
+    /// Class SearchService.
     /// </summary>
     [Authenticated]
     public class SearchService : BaseApiService
     {
         /// <summary>
-        /// The _search engine
+        /// The _search engine.
         /// </summary>
         private readonly ISearchEngine _searchEngine;
         private readonly ILibraryManager _libraryManager;

--- a/MediaBrowser.Api/Sessions/SessionInfoWebSocketListener.cs
+++ b/MediaBrowser.Api/Sessions/SessionInfoWebSocketListener.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.Sessions
 {
     /// <summary>
-    /// Class SessionInfoWebSocketListener
+    /// Class SessionInfoWebSocketListener.
     /// </summary>
     public class SessionInfoWebSocketListener : BasePeriodicWebSocketListener<IEnumerable<SessionInfo>, WebSocketListenerState>
     {
@@ -19,7 +19,7 @@ namespace MediaBrowser.Api.Sessions
         protected override string Name => "Sessions";
 
         /// <summary>
-        /// The _kernel
+        /// The _kernel.
         /// </summary>
         private readonly ISessionManager _sessionManager;
 

--- a/MediaBrowser.Api/Sessions/SessionService.cs
+++ b/MediaBrowser.Api/Sessions/SessionService.cs
@@ -46,14 +46,14 @@ namespace MediaBrowser.Api.Sessions
         public string Id { get; set; }
 
         /// <summary>
-        /// Artist, Genre, Studio, Person, or any kind of BaseItem
+        /// Artist, Genre, Studio, Person, or any kind of BaseItem.
         /// </summary>
         /// <value>The type of the item.</value>
         [ApiMember(Name = "ItemType", Description = "The type of item to browse to.", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string ItemType { get; set; }
 
         /// <summary>
-        /// Artist name, genre name, item Id, etc
+        /// Artist name, genre name, item Id, etc.
         /// </summary>
         /// <value>The item identifier.</value>
         [ApiMember(Name = "ItemId", Description = "The Id of the item.", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]

--- a/MediaBrowser.Api/SimilarItemsHelper.cs
+++ b/MediaBrowser.Api/SimilarItemsHelper.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class BaseGetSimilarItemsFromItem
+    /// Class BaseGetSimilarItemsFromItem.
     /// </summary>
     public class BaseGetSimilarItemsFromItem : BaseGetSimilarItems
     {
@@ -50,14 +50,14 @@ namespace MediaBrowser.Api
         public Guid UserId { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -65,7 +65,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class SimilarItemsHelper
+    /// Class SimilarItemsHelper.
     /// </summary>
     public static class SimilarItemsHelper
     {

--- a/MediaBrowser.Api/System/ActivityLogService.cs
+++ b/MediaBrowser.Api/System/ActivityLogService.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Api.System
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]

--- a/MediaBrowser.Api/System/ActivityLogWebSocketListener.cs
+++ b/MediaBrowser.Api/System/ActivityLogWebSocketListener.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.System
 {
     /// <summary>
-    /// Class SessionInfoWebSocketListener
+    /// Class SessionInfoWebSocketListener.
     /// </summary>
     public class ActivityLogWebSocketListener : BasePeriodicWebSocketListener<ActivityLogEntry[], WebSocketListenerState>
     {
@@ -19,7 +19,7 @@ namespace MediaBrowser.Api.System
         protected override string Name => "ActivityLogEntry";
 
         /// <summary>
-        /// The _kernel
+        /// The _kernel.
         /// </summary>
         private readonly IActivityManager _activityManager;
 

--- a/MediaBrowser.Api/System/SystemService.cs
+++ b/MediaBrowser.Api/System/SystemService.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.System
 {
     /// <summary>
-    /// Class GetSystemInfo
+    /// Class GetSystemInfo.
     /// </summary>
     [Route("/System/Info", "GET", Summary = "Gets information about the server")]
     [Authenticated(EscapeParentalControl = true, AllowBeforeStartupWizard = true)]
@@ -38,7 +38,7 @@ namespace MediaBrowser.Api.System
     }
 
     /// <summary>
-    /// Class RestartApplication
+    /// Class RestartApplication.
     /// </summary>
     [Route("/System/Restart", "POST", Summary = "Restarts the application, if needed")]
     [Authenticated(Roles = "Admin", AllowLocal = true)]
@@ -83,12 +83,12 @@ namespace MediaBrowser.Api.System
     }
 
     /// <summary>
-    /// Class SystemInfoService
+    /// Class SystemInfoService.
     /// </summary>
     public class SystemService : BaseApiService
     {
         /// <summary>
-        /// The _app host
+        /// The _app host.
         /// </summary>
         private readonly IServerApplicationHost _appHost;
         private readonly IApplicationPaths _appPaths;

--- a/MediaBrowser.Api/TvShowsService.cs
+++ b/MediaBrowser.Api/TvShowsService.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetNextUpEpisodes
+    /// Class GetNextUpEpisodes.
     /// </summary>
     [Route("/Shows/NextUp", "GET", Summary = "Gets a list of next up episodes")]
     public class GetNextUpEpisodes : IReturn<QueryResult<BaseItemDto>>, IHasDtoOptions
@@ -39,14 +39,14 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -99,14 +99,14 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -143,7 +143,7 @@ namespace MediaBrowser.Api
         public Guid UserId { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -175,7 +175,7 @@ namespace MediaBrowser.Api
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
@@ -211,7 +211,7 @@ namespace MediaBrowser.Api
         public Guid UserId { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -243,18 +243,18 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class TvShowsService
+    /// Class TvShowsService.
     /// </summary>
     [Authenticated]
     public class TvShowsService : BaseApiService
     {
         /// <summary>
-        /// The _user manager
+        /// The _user manager.
         /// </summary>
         private readonly IUserManager _userManager;
 
         /// <summary>
-        /// The _library manager
+        /// The _library manager.
         /// </summary>
         private readonly ILibraryManager _libraryManager;
 

--- a/MediaBrowser.Api/UserLibrary/ArtistsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ArtistsService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetArtists
+    /// Class GetArtists.
     /// </summary>
     [Route("/Artists", "GET", Summary = "Gets all artists from a given item, folder, or the entire library")]
     public class GetArtists : GetItemsByName
@@ -45,7 +45,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class ArtistsService
+    /// Class ArtistsService.
     /// </summary>
     [Authenticated]
     public class ArtistsService : BaseItemsByNameService<MusicArtist>

--- a/MediaBrowser.Api/UserLibrary/BaseItemsByNameService.cs
+++ b/MediaBrowser.Api/UserLibrary/BaseItemsByNameService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class BaseItemsByNameService
+    /// Class BaseItemsByNameService.
     /// </summary>
     /// <typeparam name="TItemType">The type of the T item type.</typeparam>
     public abstract class BaseItemsByNameService<TItemType> : BaseApiService
@@ -52,7 +52,7 @@ namespace MediaBrowser.Api.UserLibrary
         protected IUserManager UserManager { get; }
 
         /// <summary>
-        /// Gets the library manager
+        /// Gets the library manager.
         /// </summary>
         protected ILibraryManager LibraryManager { get; }
 
@@ -375,7 +375,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetItemsByName
+    /// Class GetItemsByName.
     /// </summary>
     public class GetItemsByName : BaseItemsRequest, IReturn<QueryResult<BaseItemDto>>
     {

--- a/MediaBrowser.Api/UserLibrary/BaseItemsRequest.cs
+++ b/MediaBrowser.Api/UserLibrary/BaseItemsRequest.cs
@@ -111,14 +111,14 @@ namespace MediaBrowser.Api.UserLibrary
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         [ApiMember(Name = "Limit", Description = "Optional. The maximum number of records to return", IsRequired = false, DataType = "int", ParameterType = "query", Verb = "GET")]
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Whether or not to perform the query recursively
+        /// Whether or not to perform the query recursively.
         /// </summary>
         /// <value><c>true</c> if recursive; otherwise, <c>false</c>.</value>
         [ApiMember(Name = "Recursive", Description = "When searching within folders, this determines whether or not the search will be recursive. true/false", IsRequired = false, DataType = "boolean", ParameterType = "query", Verb = "GET")]
@@ -141,7 +141,7 @@ namespace MediaBrowser.Api.UserLibrary
         public string ParentId { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         [ApiMember(Name = "Fields", Description = "Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimeted. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -162,14 +162,14 @@ namespace MediaBrowser.Api.UserLibrary
         public string IncludeItemTypes { get; set; }
 
         /// <summary>
-        /// Filters to apply to the results
+        /// Filters to apply to the results.
         /// </summary>
         /// <value>The filters.</value>
         [ApiMember(Name = "Filters", Description = "Optional. Specify additional filters to apply. This allows multiple, comma delimeted. Options: IsFolder, IsNotFolder, IsUnplayed, IsPlayed, IsFavorite, IsResumable, Likes, Dislikes", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
         public string Filters { get; set; }
 
         /// <summary>
-        /// Gets or sets the Isfavorite option
+        /// Gets or sets the Isfavorite option.
         /// </summary>
         /// <value>IsFavorite</value>
         [ApiMember(Name = "IsFavorite", Description = "Optional filter by items that are marked as favorite, or not.", IsRequired = false, DataType = "bool", ParameterType = "query", Verb = "GET")]
@@ -190,7 +190,7 @@ namespace MediaBrowser.Api.UserLibrary
         public string ImageTypes { get; set; }
 
         /// <summary>
-        /// What to sort the results by
+        /// What to sort the results by.
         /// </summary>
         /// <value>The sort by.</value>
         [ApiMember(Name = "SortBy", Description = "Optional. Specify one or more sort orders, comma delimeted. Options: Album, AlbumArtist, Artist, Budget, CommunityRating, CriticRating, DateCreated, DatePlayed, PlayCount, PremiereDate, ProductionYear, SortName, Random, Revenue, Runtime", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -200,7 +200,7 @@ namespace MediaBrowser.Api.UserLibrary
         public bool? IsPlayed { get; set; }
 
         /// <summary>
-        /// Limit results to items containing specific genres
+        /// Limit results to items containing specific genres.
         /// </summary>
         /// <value>The genres.</value>
         [ApiMember(Name = "Genres", Description = "Optional. If specified, results will be filtered based on genre. This allows multiple, pipe delimeted.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -215,7 +215,7 @@ namespace MediaBrowser.Api.UserLibrary
         public string Tags { get; set; }
 
         /// <summary>
-        /// Limit results to items containing specific years
+        /// Limit results to items containing specific years.
         /// </summary>
         /// <value>The years.</value>
         [ApiMember(Name = "Years", Description = "Optional. If specified, results will be filtered based on production year. This allows multiple, comma delimeted.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]
@@ -234,7 +234,7 @@ namespace MediaBrowser.Api.UserLibrary
         public string EnableImageTypes { get; set; }
 
         /// <summary>
-        /// Limit results to items containing a specific person
+        /// Limit results to items containing a specific person.
         /// </summary>
         /// <value>The person.</value>
         [ApiMember(Name = "Person", Description = "Optional. If specified, results will be filtered to include only those containing the specified person.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
@@ -244,14 +244,14 @@ namespace MediaBrowser.Api.UserLibrary
         public string PersonIds { get; set; }
 
         /// <summary>
-        /// If the Person filter is used, this can also be used to restrict to a specific person type
+        /// If the Person filter is used, this can also be used to restrict to a specific person type.
         /// </summary>
         /// <value>The type of the person.</value>
         [ApiMember(Name = "PersonTypes", Description = "Optional. If specified, along with Person, results will be filtered to include only those containing the specified person and PersonType. Allows multiple, comma-delimited", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET")]
         public string PersonTypes { get; set; }
 
         /// <summary>
-        /// Limit results to items containing specific studios
+        /// Limit results to items containing specific studios.
         /// </summary>
         /// <value>The studios.</value>
         [ApiMember(Name = "Studios", Description = "Optional. If specified, results will be filtered based on studio. This allows multiple, pipe delimeted.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "GET", AllowMultiple = true)]

--- a/MediaBrowser.Api/UserLibrary/GenresService.cs
+++ b/MediaBrowser.Api/UserLibrary/GenresService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetGenres
+    /// Class GetGenres.
     /// </summary>
     [Route("/Genres", "GET", Summary = "Gets all genres from a given item, folder, or the entire library")]
     public class GetGenres : GetItemsByName
@@ -22,7 +22,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetGenre
+    /// Class GetGenre.
     /// </summary>
     [Route("/Genres/{Name}", "GET", Summary = "Gets a genre, by name")]
     public class GetGenre : IReturn<BaseItemDto>
@@ -43,7 +43,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GenresService
+    /// Class GenresService.
     /// </summary>
     [Authenticated]
     public class GenresService : BaseItemsByNameService<Genre>

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -20,7 +20,7 @@ using MusicAlbum = MediaBrowser.Controller.Entities.Audio.MusicAlbum;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetItems
+    /// Class GetItems.
     /// </summary>
     [Route("/Items", "GET", Summary = "Gets items based on a query.")]
     [Route("/Users/{UserId}/Items", "GET", Summary = "Gets items based on a query.")]
@@ -34,18 +34,18 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class ItemsService
+    /// Class ItemsService.
     /// </summary>
     [Authenticated]
     public class ItemsService : BaseApiService
     {
         /// <summary>
-        /// The _user manager
+        /// The _user manager.
         /// </summary>
         private readonly IUserManager _userManager;
 
         /// <summary>
-        /// The _library manager
+        /// The _library manager.
         /// </summary>
         private readonly ILibraryManager _libraryManager;
         private readonly ILocalizationManager _localization;
@@ -496,7 +496,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class DateCreatedComparer
+    /// Class DateCreatedComparer.
     /// </summary>
     public class DateCreatedComparer : IComparer<BaseItem>
     {

--- a/MediaBrowser.Api/UserLibrary/PersonsService.cs
+++ b/MediaBrowser.Api/UserLibrary/PersonsService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetPersons
+    /// Class GetPersons.
     /// </summary>
     [Route("/Persons", "GET", Summary = "Gets all persons from a given item, folder, or the entire library")]
     public class GetPersons : GetItemsByName
@@ -22,7 +22,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetPerson
+    /// Class GetPerson.
     /// </summary>
     [Route("/Persons/{Name}", "GET", Summary = "Gets a person, by name")]
     public class GetPerson : IReturn<BaseItemDto>
@@ -43,7 +43,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class PersonsService
+    /// Class PersonsService.
     /// </summary>
     [Authenticated]
     public class PersonsService : BaseItemsByNameService<Person>

--- a/MediaBrowser.Api/UserLibrary/PlaystateService.cs
+++ b/MediaBrowser.Api/UserLibrary/PlaystateService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class MarkPlayedItem
+    /// Class MarkPlayedItem.
     /// </summary>
     [Route("/Users/{UserId}/PlayedItems/{Id}", "POST", Summary = "Marks an item as played")]
     public class MarkPlayedItem : IReturn<UserItemDataDto>
@@ -38,7 +38,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class MarkUnplayedItem
+    /// Class MarkUnplayedItem.
     /// </summary>
     [Route("/Users/{UserId}/PlayedItems/{Id}", "DELETE", Summary = "Marks an item as unplayed")]
     public class MarkUnplayedItem : IReturn<UserItemDataDto>
@@ -81,7 +81,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class OnPlaybackStart
+    /// Class OnPlaybackStart.
     /// </summary>
     [Route("/Users/{UserId}/PlayingItems/{Id}", "POST", Summary = "Reports that a user has begun playing an item")]
     public class OnPlaybackStart : IReturnVoid
@@ -123,7 +123,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class OnPlaybackProgress
+    /// Class OnPlaybackProgress.
     /// </summary>
     [Route("/Users/{UserId}/PlayingItems/{Id}/Progress", "POST", Summary = "Reports a user's playback progress")]
     public class OnPlaybackProgress : IReturnVoid
@@ -181,7 +181,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class OnPlaybackStopped
+    /// Class OnPlaybackStopped.
     /// </summary>
     [Route("/Users/{UserId}/PlayingItems/{Id}", "DELETE", Summary = "Reports that a user has stopped playing an item")]
     public class OnPlaybackStopped : IReturnVoid

--- a/MediaBrowser.Api/UserLibrary/StudiosService.cs
+++ b/MediaBrowser.Api/UserLibrary/StudiosService.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetStudios
+    /// Class GetStudios.
     /// </summary>
     [Route("/Studios", "GET", Summary = "Gets all studios from a given item, folder, or the entire library")]
     public class GetStudios : GetItemsByName
@@ -21,7 +21,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetStudio
+    /// Class GetStudio.
     /// </summary>
     [Route("/Studios/{Name}", "GET", Summary = "Gets a studio, by name")]
     public class GetStudio : IReturn<BaseItemDto>
@@ -42,7 +42,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class StudiosService
+    /// Class StudiosService.
     /// </summary>
     [Authenticated]
     public class StudiosService : BaseItemsByNameService<Studio>

--- a/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
+++ b/MediaBrowser.Api/UserLibrary/UserLibraryService.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetItem
+    /// Class GetItem.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}", "GET", Summary = "Gets an item from a user's library")]
     public class GetItem : IReturn<BaseItemDto>
@@ -41,7 +41,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetItem
+    /// Class GetItem.
     /// </summary>
     [Route("/Users/{UserId}/Items/Root", "GET", Summary = "Gets the root folder from a user's library")]
     public class GetRootFolder : IReturn<BaseItemDto>
@@ -55,7 +55,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetIntros
+    /// Class GetIntros.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}/Intros", "GET", Summary = "Gets intros to play before the main media item plays")]
     public class GetIntros : IReturn<QueryResult<BaseItemDto>>
@@ -76,7 +76,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class MarkFavoriteItem
+    /// Class MarkFavoriteItem.
     /// </summary>
     [Route("/Users/{UserId}/FavoriteItems/{Id}", "POST", Summary = "Marks an item as a favorite")]
     public class MarkFavoriteItem : IReturn<UserItemDataDto>
@@ -97,7 +97,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class UnmarkFavoriteItem
+    /// Class UnmarkFavoriteItem.
     /// </summary>
     [Route("/Users/{UserId}/FavoriteItems/{Id}", "DELETE", Summary = "Unmarks an item as a favorite")]
     public class UnmarkFavoriteItem : IReturn<UserItemDataDto>
@@ -118,7 +118,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class ClearUserItemRating
+    /// Class ClearUserItemRating.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}/Rating", "DELETE", Summary = "Deletes a user's saved personal rating for an item")]
     public class DeleteUserItemRating : IReturn<UserItemDataDto>
@@ -139,7 +139,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class UpdateUserItemRating
+    /// Class UpdateUserItemRating.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}/Rating", "POST", Summary = "Updates a user's rating for an item")]
     public class UpdateUserItemRating : IReturn<UserItemDataDto>
@@ -167,7 +167,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetLocalTrailers
+    /// Class GetLocalTrailers.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}/LocalTrailers", "GET", Summary = "Gets local trailers for an item")]
     public class GetLocalTrailers : IReturn<BaseItemDto[]>
@@ -188,7 +188,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetSpecialFeatures
+    /// Class GetSpecialFeatures.
     /// </summary>
     [Route("/Users/{UserId}/Items/{Id}/SpecialFeatures", "GET", Summary = "Gets special features for an item")]
     public class GetSpecialFeatures : IReturn<BaseItemDto[]>
@@ -259,7 +259,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class UserLibraryService
+    /// Class UserLibraryService.
     /// </summary>
     [Authenticated]
     public class UserLibraryService : BaseApiService

--- a/MediaBrowser.Api/UserLibrary/YearsService.cs
+++ b/MediaBrowser.Api/UserLibrary/YearsService.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api.UserLibrary
 {
     /// <summary>
-    /// Class GetYears
+    /// Class GetYears.
     /// </summary>
     [Route("/Years", "GET", Summary = "Gets all years from a given item, folder, or the entire library")]
     public class GetYears : GetItemsByName
@@ -21,7 +21,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class GetYear
+    /// Class GetYear.
     /// </summary>
     [Route("/Years/{Year}", "GET", Summary = "Gets a year")]
     public class GetYear : IReturn<BaseItemDto>
@@ -42,7 +42,7 @@ namespace MediaBrowser.Api.UserLibrary
     }
 
     /// <summary>
-    /// Class YearsService
+    /// Class YearsService.
     /// </summary>
     [Authenticated]
     public class YearsService : BaseItemsByNameService<Year>

--- a/MediaBrowser.Api/UserService.cs
+++ b/MediaBrowser.Api/UserService.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Api
 {
     /// <summary>
-    /// Class GetUsers
+    /// Class GetUsers.
     /// </summary>
     [Route("/Users", "GET", Summary = "Gets a list of users")]
     [Authenticated]
@@ -41,7 +41,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class GetUser
+    /// Class GetUser.
     /// </summary>
     [Route("/Users/{Id}", "GET", Summary = "Gets a user by Id")]
     [Authenticated(EscapeParentalControl = true)]
@@ -56,7 +56,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class DeleteUser
+    /// Class DeleteUser.
     /// </summary>
     [Route("/Users/{Id}", "DELETE", Summary = "Deletes a user")]
     [Authenticated(Roles = "Admin")]
@@ -71,7 +71,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class AuthenticateUser
+    /// Class AuthenticateUser.
     /// </summary>
     [Route("/Users/{Id}/Authenticate", "POST", Summary = "Authenticates a user")]
     public class AuthenticateUser : IReturn<AuthenticationResult>
@@ -95,7 +95,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class AuthenticateUser
+    /// Class AuthenticateUser.
     /// </summary>
     [Route("/Users/AuthenticateByName", "POST", Summary = "Authenticates a user")]
     public class AuthenticateUserByName : IReturn<AuthenticationResult>
@@ -119,7 +119,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateUserPassword
+    /// Class UpdateUserPassword.
     /// </summary>
     [Route("/Users/{Id}/Password", "POST", Summary = "Updates a user's password")]
     [Authenticated]
@@ -149,7 +149,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateUserEasyPassword
+    /// Class UpdateUserEasyPassword.
     /// </summary>
     [Route("/Users/{Id}/EasyPassword", "POST", Summary = "Updates a user's easy password")]
     [Authenticated]
@@ -177,7 +177,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateUser
+    /// Class UpdateUser.
     /// </summary>
     [Route("/Users/{Id}", "POST", Summary = "Updates a user")]
     [Authenticated]
@@ -186,7 +186,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateUser
+    /// Class UpdateUser.
     /// </summary>
     [Route("/Users/{Id}/Policy", "POST", Summary = "Updates a user policy")]
     [Authenticated(Roles = "admin")]
@@ -197,7 +197,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UpdateUser
+    /// Class UpdateUser.
     /// </summary>
     [Route("/Users/{Id}/Configuration", "POST", Summary = "Updates a user configuration")]
     [Authenticated]
@@ -208,7 +208,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class CreateUser
+    /// Class CreateUser.
     /// </summary>
     [Route("/Users/New", "POST", Summary = "Creates a user")]
     [Authenticated(Roles = "Admin")]
@@ -236,7 +236,7 @@ namespace MediaBrowser.Api
     }
 
     /// <summary>
-    /// Class UsersService
+    /// Class UsersService.
     /// </summary>
     public class UserService : BaseApiService
     {

--- a/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
+++ b/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
@@ -18,7 +18,7 @@ namespace MediaBrowser.Controller.Channels
         public List<ChannelMediaContentType> ContentTypes { get; set; }
 
         /// <summary>
-        /// Represents the maximum number of records the channel allows retrieving at a time
+        /// Represents the maximum number of records the channel allows retrieving at a time.
         /// </summary>
         public int? MaxPageSize { get; set; }
 

--- a/MediaBrowser.Controller/Configuration/IServerConfigurationManager.cs
+++ b/MediaBrowser.Controller/Configuration/IServerConfigurationManager.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Model.Configuration;
 namespace MediaBrowser.Controller.Configuration
 {
     /// <summary>
-    /// Interface IServerConfigurationManager
+    /// Interface IServerConfigurationManager.
     /// </summary>
     public interface IServerConfigurationManager : IConfigurationManager
     {

--- a/MediaBrowser.Controller/Drawing/IImageProcessor.cs
+++ b/MediaBrowser.Controller/Drawing/IImageProcessor.cs
@@ -10,7 +10,7 @@ using MediaBrowser.Model.Entities;
 namespace MediaBrowser.Controller.Drawing
 {
     /// <summary>
-    /// Interface IImageProcessor
+    /// Interface IImageProcessor.
     /// </summary>
     public interface IImageProcessor
     {

--- a/MediaBrowser.Controller/Dto/IDtoService.cs
+++ b/MediaBrowser.Controller/Dto/IDtoService.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Controller.Dto
 {
     /// <summary>
-    /// Interface IDtoService
+    /// Interface IDtoService.
     /// </summary>
     public interface IDtoService
     {

--- a/MediaBrowser.Controller/Entities/AggregateFolder.cs
+++ b/MediaBrowser.Controller/Entities/AggregateFolder.cs
@@ -35,7 +35,7 @@ namespace MediaBrowser.Controller.Entities
         public override bool SupportsPlayedStatus => false;
 
         /// <summary>
-        /// The _virtual children
+        /// The _virtual children.
         /// </summary>
         private readonly ConcurrentBag<BaseItem> _virtualChildren = new ConcurrentBag<BaseItem>();
 

--- a/MediaBrowser.Controller/Entities/Audio/Audio.cs
+++ b/MediaBrowser.Controller/Entities/Audio/Audio.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Entities;
 namespace MediaBrowser.Controller.Entities.Audio
 {
     /// <summary>
-    /// Class Audio
+    /// Class Audio.
     /// </summary>
     public class Audio : BaseItem,
         IHasAlbumArtist,

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -15,7 +15,7 @@ using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
 namespace MediaBrowser.Controller.Entities.Audio
 {
     /// <summary>
-    /// Class MusicAlbum
+    /// Class MusicAlbum.
     /// </summary>
     public class MusicAlbum : Folder, IHasAlbumArtist, IHasArtist, IHasMusicGenres, IHasLookupInfo<AlbumInfo>, IMetadataContainer
     {

--- a/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
@@ -15,7 +15,7 @@ using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
 namespace MediaBrowser.Controller.Entities.Audio
 {
     /// <summary>
-    /// Class MusicArtist
+    /// Class MusicArtist.
     /// </summary>
     public class MusicArtist : Folder, IItemByName, IHasMusicGenres, IHasDualAccess, IHasLookupInfo<ArtistInfo>
     {
@@ -111,7 +111,7 @@ namespace MediaBrowser.Controller.Entities.Audio
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -201,7 +201,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Entities/Audio/MusicGenre.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicGenre.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities.Audio
 {
     /// <summary>
-    /// Class MusicGenre
+    /// Class MusicGenre.
     /// </summary>
     public class MusicGenre : BaseItem, IItemByName
     {
@@ -34,7 +34,7 @@ namespace MediaBrowser.Controller.Entities.Audio
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -98,7 +98,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -31,12 +31,12 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class BaseItem
+    /// Class BaseItem.
     /// </summary>
     public abstract class BaseItem : IHasProviderIds, IHasLookupInfo<ItemLookupInfo>, IEquatable<BaseItem>
     {
         /// <summary>
-        /// The supported image extensions
+        /// The supported image extensions.
         /// </summary>
         public static readonly string[] SupportedImageExtensions
             = new[] { ".png", ".jpg", ".jpeg", ".tbn", ".gif" };
@@ -75,7 +75,7 @@ namespace MediaBrowser.Controller.Entities
         public static char SlugChar = '-';
 
         /// <summary>
-        /// The trailer folder name
+        /// The trailer folder name.
         /// </summary>
         public const string TrailerFolderName = "trailers";
         public const string ThemeSongsFolderName = "theme-music";
@@ -243,7 +243,7 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         [JsonIgnore]
         public virtual string ContainingFolderPath
@@ -267,7 +267,7 @@ namespace MediaBrowser.Controller.Entities
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// If this content came from an external service, the id of the content on that service
+        /// If this content came from an external service, the id of the content on that service.
         /// </summary>
         [JsonIgnore]
         public string ExternalId { get; set; }
@@ -411,7 +411,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// This is just a helper for convenience
+        /// This is just a helper for convenience.
         /// </summary>
         /// <value>The primary image path.</value>
         [JsonIgnore]
@@ -556,7 +556,7 @@ namespace MediaBrowser.Controller.Entities
         public DateTime DateLastRefreshed { get; set; }
 
         /// <summary>
-        /// The logger
+        /// The logger.
         /// </summary>
         public static ILoggerFactory LoggerFactory { get; set; }
         public static ILogger<BaseItem> Logger { get; set; }
@@ -799,7 +799,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Finds a parent of a given type
+        /// Finds a parent of a given type.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>``0.</returns>
@@ -1351,7 +1351,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Overrides the base implementation to refresh metadata for local trailers
+        /// Overrides the base implementation to refresh metadata for local trailers.
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -1753,7 +1753,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Determines if a given user has access to this item
+        /// Determines if a given user has access to this item.
         /// </summary>
         /// <param name="user">The user.</param>
         /// <returns><c>true</c> if [is parental allowed] [the specified user]; otherwise, <c>false</c>.</returns>
@@ -2059,7 +2059,7 @@ namespace MediaBrowser.Controller.Entities
         public virtual bool EnableRememberingTrackSelections => true;
 
         /// <summary>
-        /// Adds a studio to the item
+        /// Adds a studio to the item.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <exception cref="ArgumentNullException"></exception>
@@ -2095,7 +2095,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Adds a genre to the item
+        /// Adds a genre to the item.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <exception cref="ArgumentNullException"></exception>
@@ -2190,7 +2190,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Gets an image
+        /// Gets an image.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="imageIndex">Index of the image.</param>
@@ -2506,7 +2506,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Gets the file system path to delete when the item is to be deleted
+        /// Gets the file system path to delete when the item is to be deleted.
         /// </summary>
         /// <returns></returns>
         public virtual IEnumerable<FileSystemMetadata> GetDeletePaths()

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -18,7 +18,7 @@ namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
     /// Specialized Folder class that points to a subset of the physical folders in the system.
-    /// It is created from the user-specific folders within the system root
+    /// It is created from the user-specific folders within the system root.
     /// </summary>
     public class CollectionFolder : Folder, ICollectionFolder
     {
@@ -140,7 +140,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Allow different display preferences for each collection folder
+        /// Allow different display preferences for each collection folder.
         /// </summary>
         /// <value>The display prefs id.</value>
         [JsonIgnore]

--- a/MediaBrowser.Controller/Entities/Extensions.cs
+++ b/MediaBrowser.Controller/Entities/Extensions.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Entities;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Extensions
+    /// Class Extensions.
     /// </summary>
     public static class Extensions
     {

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -31,7 +31,7 @@ using Series = MediaBrowser.Controller.Entities.TV.Series;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Folder
+    /// Class Folder.
     /// </summary>
     public class Folder : BaseItem
     {
@@ -172,7 +172,7 @@ namespace MediaBrowser.Controller.Entities
         public virtual IEnumerable<BaseItem> Children => LoadChildren();
 
         /// <summary>
-        /// thread-safe access to all recursive children of this folder - without regard to user
+        /// thread-safe access to all recursive children of this folder - without regard to user.
         /// </summary>
         /// <value>The recursive children.</value>
         [JsonIgnore]
@@ -229,7 +229,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Validates that the children of the folder still exist
+        /// Validates that the children of the folder still exist.
         /// </summary>
         /// <param name="progress">The progress.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -570,7 +570,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Get the children of this folder from the actual file system
+        /// Get the children of this folder from the actual file system.
         /// </summary>
         /// <returns>IEnumerable{BaseItem}.</returns>
         protected virtual IEnumerable<BaseItem> GetNonCachedChildren(IDirectoryService directoryService)
@@ -582,7 +582,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Get our children from the repo - stubbed for now
+        /// Get our children from the repo - stubbed for now.
         /// </summary>
         /// <returns>IEnumerable{BaseItem}.</returns>
         protected List<BaseItem> GetCachedChildren()
@@ -1286,7 +1286,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Gets allowed recursive children of an item
+        /// Gets allowed recursive children of an item.
         /// </summary>
         /// <param name="user">The user.</param>
         /// <param name="includeLinkedChildren">if set to <c>true</c> [include linked children].</param>

--- a/MediaBrowser.Controller/Entities/Genre.cs
+++ b/MediaBrowser.Controller/Entities/Genre.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Genre
+    /// Class Genre.
     /// </summary>
     public class Genre : BaseItem, IItemByName
     {
@@ -31,7 +31,7 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -96,7 +96,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Entities/ICollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/ICollectionFolder.cs
@@ -3,7 +3,7 @@ using System;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// This is just a marker interface to denote top level folders
+    /// This is just a marker interface to denote top level folders.
     /// </summary>
     public interface ICollectionFolder : IHasCollectionType
     {

--- a/MediaBrowser.Controller/Entities/IHasAspectRatio.cs
+++ b/MediaBrowser.Controller/Entities/IHasAspectRatio.cs
@@ -1,7 +1,7 @@
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Interface IHasAspectRatio
+    /// Interface IHasAspectRatio.
     /// </summary>
     public interface IHasAspectRatio
     {

--- a/MediaBrowser.Controller/Entities/IHasDisplayOrder.cs
+++ b/MediaBrowser.Controller/Entities/IHasDisplayOrder.cs
@@ -1,7 +1,7 @@
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Interface IHasDisplayOrder
+    /// Interface IHasDisplayOrder.
     /// </summary>
     public interface IHasDisplayOrder
     {

--- a/MediaBrowser.Controller/Entities/IHasScreenshots.cs
+++ b/MediaBrowser.Controller/Entities/IHasScreenshots.cs
@@ -1,7 +1,7 @@
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Interface IHasScreenshots
+    /// Interface IHasScreenshots.
     /// </summary>
     public interface IHasScreenshots
     {

--- a/MediaBrowser.Controller/Entities/LinkedChild.cs
+++ b/MediaBrowser.Controller/Entities/LinkedChild.cs
@@ -16,7 +16,7 @@ namespace MediaBrowser.Controller.Entities
         public string Id { get; set; }
 
         /// <summary>
-        /// Serves as a cache
+        /// Serves as a cache.
         /// </summary>
         public Guid? ItemId { get; set; }
 

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Controller.Entities.Movies
 {
     /// <summary>
-    /// Class BoxSet
+    /// Class BoxSet.
     /// </summary>
     public class BoxSet : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<BoxSetInfo>
     {

--- a/MediaBrowser.Controller/Entities/Movies/Movie.cs
+++ b/MediaBrowser.Controller/Entities/Movies/Movie.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Model.Providers;
 namespace MediaBrowser.Controller.Entities.Movies
 {
     /// <summary>
-    /// Class Movie
+    /// Class Movie.
     /// </summary>
     public class Movie : Video, IHasSpecialFeatures, IHasTrailers, IHasLookupInfo<MovieInfo>, ISupportsBoxSetGrouping
     {

--- a/MediaBrowser.Controller/Entities/Person.cs
+++ b/MediaBrowser.Controller/Entities/Person.cs
@@ -46,7 +46,7 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -118,7 +118,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Entities/Studio.cs
+++ b/MediaBrowser.Controller/Entities/Studio.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Studio
+    /// Class Studio.
     /// </summary>
     public class Studio : BaseItem, IItemByName
     {
@@ -25,7 +25,7 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -97,7 +97,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities.TV
 {
     /// <summary>
-    /// Class Episode
+    /// Class Episode.
     /// </summary>
     public class Episode : Video, IHasTrailers, IHasLookupInfo<EpisodeInfo>, IHasSeries
     {
@@ -101,7 +101,7 @@ namespace MediaBrowser.Controller.Entities.TV
         }
 
         /// <summary>
-        /// This Episode's Series Instance
+        /// This Episode's Series Instance.
         /// </summary>
         /// <value>The series.</value>
         [JsonIgnore]

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Controller.Entities.TV
 {
     /// <summary>
-    /// Class Season
+    /// Class Season.
     /// </summary>
     public class Season : Folder, IHasSeries, IHasLookupInfo<SeasonInfo>
     {
@@ -68,7 +68,7 @@ namespace MediaBrowser.Controller.Entities.TV
         }
 
         /// <summary>
-        /// This Episode's Series Instance
+        /// This Episode's Series Instance.
         /// </summary>
         /// <value>The series.</value>
         [JsonIgnore]
@@ -225,7 +225,7 @@ namespace MediaBrowser.Controller.Entities.TV
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -17,7 +17,7 @@ using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
 namespace MediaBrowser.Controller.Entities.TV
 {
     /// <summary>
-    /// Class Series
+    /// Class Series.
     /// </summary>
     public class Series : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<SeriesInfo>, IMetadataContainer
     {
@@ -54,7 +54,7 @@ namespace MediaBrowser.Controller.Entities.TV
         public IReadOnlyList<Guid> RemoteTrailerIds { get; set; }
 
         /// <summary>
-        /// airdate, dvd or absolute
+        /// airdate, dvd or absolute.
         /// </summary>
         public string DisplayOrder { get; set; }
 

--- a/MediaBrowser.Controller/Entities/Trailer.cs
+++ b/MediaBrowser.Controller/Entities/Trailer.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.Providers;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Trailer
+    /// Class Trailer.
     /// </summary>
     public class Trailer : Video, IHasLookupInfo<TrailerInfo>
     {

--- a/MediaBrowser.Controller/Entities/UserItemData.cs
+++ b/MediaBrowser.Controller/Entities/UserItemData.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class UserItemData
+    /// Class UserItemData.
     /// </summary>
     public class UserItemData
     {
@@ -21,11 +21,11 @@ namespace MediaBrowser.Controller.Entities
         public string Key { get; set; }
 
         /// <summary>
-        /// The _rating
+        /// The _rating.
         /// </summary>
         private double? _rating;
         /// <summary>
-        /// Gets or sets the users 0-10 rating
+        /// Gets or sets the users 0-10 rating.
         /// </summary>
         /// <value>The rating.</value>
         /// <exception cref="ArgumentOutOfRangeException">Rating;A 0 to 10 rating is required for UserItemData.</exception>

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -17,7 +17,7 @@ using MediaBrowser.Model.MediaInfo;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Video
+    /// Class Video.
     /// </summary>
     public class Video : BaseItem,
         IHasAspectRatio,

--- a/MediaBrowser.Controller/Entities/Year.cs
+++ b/MediaBrowser.Controller/Entities/Year.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Class Year
+    /// Class Year.
     /// </summary>
     public class Year : BaseItem, IItemByName
     {
@@ -21,7 +21,7 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]
@@ -107,7 +107,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// This is called before any metadata refresh and returns true or false indicating if changes were made
+        /// This is called before any metadata refresh and returns true or false indicating if changes were made.
         /// </summary>
         public override bool BeforeMetadataRefresh(bool replaceAllMetdata)
         {

--- a/MediaBrowser.Controller/Extensions/StringExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/StringExtensions.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace MediaBrowser.Controller.Extensions
 {
     /// <summary>
-    /// Class BaseExtensions
+    /// Class BaseExtensions.
     /// </summary>
     public static class StringExtensions
     {

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Http;
 namespace MediaBrowser.Controller
 {
     /// <summary>
-    /// Interface IServerApplicationHost
+    /// Interface IServerApplicationHost.
     /// </summary>
     public interface IServerApplicationHost : IApplicationHost
     {

--- a/MediaBrowser.Controller/IServerApplicationPaths.cs
+++ b/MediaBrowser.Controller/IServerApplicationPaths.cs
@@ -5,7 +5,7 @@ namespace MediaBrowser.Controller
     public interface IServerApplicationPaths : IApplicationPaths
     {
         /// <summary>
-        /// Gets the path to the base root media directory
+        /// Gets the path to the base root media directory.
         /// </summary>
         /// <value>The root folder path.</value>
         string RootFolderPath { get; }
@@ -17,13 +17,13 @@ namespace MediaBrowser.Controller
         string DefaultUserViewsPath { get; }
 
         /// <summary>
-        /// Gets the path to the People directory
+        /// Gets the path to the People directory.
         /// </summary>
         /// <value>The people path.</value>
         string PeoplePath { get; }
 
         /// <summary>
-        /// Gets the path to the Genre directory
+        /// Gets the path to the Genre directory.
         /// </summary>
         /// <value>The genre path.</value>
         string GenrePath { get; }
@@ -35,25 +35,25 @@ namespace MediaBrowser.Controller
         string MusicGenrePath { get; }
 
         /// <summary>
-        /// Gets the path to the Studio directory
+        /// Gets the path to the Studio directory.
         /// </summary>
         /// <value>The studio path.</value>
         string StudioPath { get; }
 
         /// <summary>
-        /// Gets the path to the Year directory
+        /// Gets the path to the Year directory.
         /// </summary>
         /// <value>The year path.</value>
         string YearPath { get; }
 
         /// <summary>
-        /// Gets the path to the General IBN directory
+        /// Gets the path to the General IBN directory.
         /// </summary>
         /// <value>The general path.</value>
         string GeneralPath { get; }
 
         /// <summary>
-        /// Gets the path to the Ratings IBN directory
+        /// Gets the path to the Ratings IBN directory.
         /// </summary>
         /// <value>The ratings path.</value>
         string RatingsPath { get; }
@@ -65,7 +65,7 @@ namespace MediaBrowser.Controller
         string MediaInfoImagesPath { get; }
 
         /// <summary>
-        /// Gets the path to the user configuration directory
+        /// Gets the path to the user configuration directory.
         /// </summary>
         /// <value>The user configuration directory path.</value>
         string UserConfigurationDirectoryPath { get; }

--- a/MediaBrowser.Controller/Library/IIntroProvider.cs
+++ b/MediaBrowser.Controller/Library/IIntroProvider.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class BaseIntroProvider
+    /// Class BaseIntroProvider.
     /// </summary>
     public interface IIntroProvider
     {

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -21,7 +21,7 @@ using Person = MediaBrowser.Controller.Entities.Person;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Interface ILibraryManager
+    /// Interface ILibraryManager.
     /// </summary>
     public interface ILibraryManager
     {
@@ -38,7 +38,7 @@ namespace MediaBrowser.Controller.Library
             bool allowIgnorePath = true);
 
         /// <summary>
-        /// Resolves a set of files into a list of BaseItem
+        /// Resolves a set of files into a list of BaseItem.
         /// </summary>
         IEnumerable<BaseItem> ResolvePaths(
             IEnumerable<FileSystemMetadata> files,
@@ -54,7 +54,7 @@ namespace MediaBrowser.Controller.Library
         AggregateFolder RootFolder { get; }
 
         /// <summary>
-        /// Gets a Person
+        /// Gets a Person.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>Task{Person}.</returns>
@@ -75,14 +75,14 @@ namespace MediaBrowser.Controller.Library
         MusicArtist GetArtist(string name);
         MusicArtist GetArtist(string name, DtoOptions options);
         /// <summary>
-        /// Gets a Studio
+        /// Gets a Studio.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>Task{Studio}.</returns>
         Studio GetStudio(string name);
 
         /// <summary>
-        /// Gets a Genre
+        /// Gets a Genre.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>Task{Genre}.</returns>
@@ -96,7 +96,7 @@ namespace MediaBrowser.Controller.Library
         MusicGenre GetMusicGenre(string name);
 
         /// <summary>
-        /// Gets a Year
+        /// Gets a Year.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>Task{Year}.</returns>
@@ -113,7 +113,7 @@ namespace MediaBrowser.Controller.Library
         Task ValidatePeople(CancellationToken cancellationToken, IProgress<double> progress);
 
         /// <summary>
-        /// Reloads the root media folder
+        /// Reloads the root media folder.
         /// </summary>
         /// <param name="progress">The progress.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/MediaBrowser.Controller/Library/ILibraryPostScanTask.cs
+++ b/MediaBrowser.Controller/Library/ILibraryPostScanTask.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// An interface for tasks that run after the media library scan
+    /// An interface for tasks that run after the media library scan.
     /// </summary>
     public interface ILibraryPostScanTask
     {

--- a/MediaBrowser.Controller/Library/IMetadataSaver.cs
+++ b/MediaBrowser.Controller/Library/IMetadataSaver.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Interface IMetadataSaver
+    /// Interface IMetadataSaver.
     /// </summary>
     public interface IMetadataSaver
     {

--- a/MediaBrowser.Controller/Library/ISearchEngine.cs
+++ b/MediaBrowser.Controller/Library/ISearchEngine.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Model.Search;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Interface ILibrarySearchEngine
+    /// Interface ILibrarySearchEngine.
     /// </summary>
     public interface ISearchEngine
     {

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -42,14 +42,14 @@ namespace MediaBrowser.Controller.Library
         UserItemDataDto GetUserDataDto(BaseItem item, BaseItemDto itemDto, User user, DtoOptions dto_options);
 
         /// <summary>
-        /// Get all user data for the given user
+        /// Get all user data for the given user.
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>
         List<UserItemData> GetAllUserData(Guid userId);
 
         /// <summary>
-        /// Save the all provided user data for the given user
+        /// Save the all provided user data for the given user.
         /// </summary>
         /// <param name="userId"></param>
         /// <param name="userData"></param>
@@ -58,7 +58,7 @@ namespace MediaBrowser.Controller.Library
         void SaveAllUserData(Guid userId, UserItemData[] userData, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Updates playstate for an item and returns true or false indicating if it was played to completion
+        /// Updates playstate for an item and returns true or false indicating if it was played to completion.
         /// </summary>
         bool UpdatePlayState(BaseItem item, UserItemData data, long? positionTicks);
     }

--- a/MediaBrowser.Controller/Library/IUserManager.cs
+++ b/MediaBrowser.Controller/Library/IUserManager.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Users;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Interface IUserManager
+    /// Interface IUserManager.
     /// </summary>
     public interface IUserManager
     {

--- a/MediaBrowser.Controller/Library/ItemChangeEventArgs.cs
+++ b/MediaBrowser.Controller/Library/ItemChangeEventArgs.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class ItemChangeEventArgs
+    /// Class ItemChangeEventArgs.
     /// </summary>
     public class ItemChangeEventArgs
     {

--- a/MediaBrowser.Controller/Library/ItemResolveArgs.cs
+++ b/MediaBrowser.Controller/Library/ItemResolveArgs.cs
@@ -15,7 +15,7 @@ namespace MediaBrowser.Controller.Library
     public class ItemResolveArgs : EventArgs
     {
         /// <summary>
-        /// The _app paths
+        /// The _app paths.
         /// </summary>
         private readonly IServerApplicationPaths _appPaths;
 

--- a/MediaBrowser.Controller/Library/PlaybackProgressEventArgs.cs
+++ b/MediaBrowser.Controller/Library/PlaybackProgressEventArgs.cs
@@ -8,7 +8,7 @@ using MediaBrowser.Model.Dto;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Holds information about a playback progress event
+    /// Holds information about a playback progress event.
     /// </summary>
     public class PlaybackProgressEventArgs : EventArgs
     {

--- a/MediaBrowser.Controller/Library/Profiler.cs
+++ b/MediaBrowser.Controller/Library/Profiler.cs
@@ -5,21 +5,21 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class Profiler
+    /// Class Profiler.
     /// </summary>
     public class Profiler : IDisposable
     {
         /// <summary>
-        /// The name
+        /// The name.
         /// </summary>
         readonly string _name;
         /// <summary>
-        /// The stopwatch
+        /// The stopwatch.
         /// </summary>
         readonly Stopwatch _stopwatch;
 
         /// <summary>
-        /// The _logger
+        /// The _logger.
         /// </summary>
         private readonly ILogger<Profiler> _logger;
 

--- a/MediaBrowser.Controller/Library/SearchHintInfo.cs
+++ b/MediaBrowser.Controller/Library/SearchHintInfo.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class SearchHintInfo
+    /// Class SearchHintInfo.
     /// </summary>
     public class SearchHintInfo
     {

--- a/MediaBrowser.Controller/Library/TVUtils.cs
+++ b/MediaBrowser.Controller/Library/TVUtils.cs
@@ -3,7 +3,7 @@ using System;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class TVUtils
+    /// Class TVUtils.
     /// </summary>
     public static class TVUtils
     {

--- a/MediaBrowser.Controller/Library/UserDataSaveEventArgs.cs
+++ b/MediaBrowser.Controller/Library/UserDataSaveEventArgs.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Entities;
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
-    /// Class UserDataSaveEventArgs
+    /// Class UserDataSaveEventArgs.
     /// </summary>
     public class UserDataSaveEventArgs : EventArgs
     {

--- a/MediaBrowser.Controller/LiveTv/ChannelInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/ChannelInfo.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Model.LiveTv;
 namespace MediaBrowser.Controller.LiveTv
 {
     /// <summary>
-    /// Class ChannelInfo
+    /// Class ChannelInfo.
     /// </summary>
     public class ChannelInfo
     {
@@ -44,13 +44,13 @@ namespace MediaBrowser.Controller.LiveTv
         public ChannelType ChannelType { get; set; }
 
         /// <summary>
-        /// Supply the image path if it can be accessed directly from the file system
+        /// Supply the image path if it can be accessed directly from the file system.
         /// </summary>
         /// <value>The image path.</value>
         public string ImagePath { get; set; }
 
         /// <summary>
-        /// Supply the image url if it can be downloaded
+        /// Supply the image url if it can be downloaded.
         /// </summary>
         /// <value>The image URL.</value>
         public string ImageUrl { get; set; }

--- a/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
+++ b/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
@@ -14,7 +14,7 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Controller.LiveTv
 {
     /// <summary>
-    /// Manages all live tv services installed on the server
+    /// Manages all live tv services installed on the server.
     /// </summary>
     public interface ILiveTvManager
     {

--- a/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
@@ -140,7 +140,7 @@ namespace MediaBrowser.Controller.LiveTv
 
         /// <summary>
         /// Returns the folder containing the item.
-        /// If the item is a folder, it returns the folder itself
+        /// If the item is a folder, it returns the folder itself.
         /// </summary>
         /// <value>The containing folder path.</value>
         [JsonIgnore]

--- a/MediaBrowser.Controller/LiveTv/ProgramInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/ProgramInfo.cs
@@ -18,7 +18,7 @@ namespace MediaBrowser.Controller.LiveTv
         public string ChannelId { get; set; }
 
         /// <summary>
-        /// Name of the program
+        /// Name of the program.
         /// </summary>
         public string Name { get; set; }
 
@@ -95,13 +95,13 @@ namespace MediaBrowser.Controller.LiveTv
         public string EpisodeTitle { get; set; }
 
         /// <summary>
-        /// Supply the image path if it can be accessed directly from the file system
+        /// Supply the image path if it can be accessed directly from the file system.
         /// </summary>
         /// <value>The image path.</value>
         public string ImagePath { get; set; }
 
         /// <summary>
-        /// Supply the image url if it can be downloaded
+        /// Supply the image url if it can be downloaded.
         /// </summary>
         /// <value>The image URL.</value>
         public string ImageUrl { get; set; }

--- a/MediaBrowser.Controller/LiveTv/RecordingInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/RecordingInfo.cs
@@ -169,13 +169,13 @@ namespace MediaBrowser.Controller.LiveTv
         public float? CommunityRating { get; set; }
 
         /// <summary>
-        /// Supply the image path if it can be accessed directly from the file system
+        /// Supply the image path if it can be accessed directly from the file system.
         /// </summary>
         /// <value>The image path.</value>
         public string ImagePath { get; set; }
 
         /// <summary>
-        /// Supply the image url if it can be downloaded
+        /// Supply the image url if it can be downloaded.
         /// </summary>
         /// <value>The image URL.</value>
         public string ImageUrl { get; set; }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -108,7 +108,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Gets the name of the output video codec
+        /// Gets the name of the output video codec.
         /// </summary>
         public string GetVideoEncoder(EncodingJobInfo state, EncodingOptions encodingOptions)
         {
@@ -285,7 +285,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Infers the audio codec based on the url
+        /// Infers the audio codec based on the url.
         /// </summary>
         public string InferAudioCodec(string container)
         {
@@ -703,7 +703,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Gets the video bitrate to specify on the command line
+        /// Gets the video bitrate to specify on the command line.
         /// </summary>
         public string GetVideoQualityParam(EncodingJobInfo state, string videoEncoder, EncodingOptions encodingOptions, string defaultPreset)
         {
@@ -1300,7 +1300,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Gets the number of audio channels to specify on the command line
+        /// Gets the number of audio channels to specify on the command line.
         /// </summary>
         /// <param name="state">The state.</param>
         /// <param name="audioStream">The audio stream.</param>
@@ -1486,7 +1486,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Determines which stream will be used for playback
+        /// Determines which stream will be used for playback.
         /// </summary>
         /// <param name="allStream">All stream.</param>
         /// <param name="desiredIndex">Index of the desired.</param>
@@ -1961,7 +1961,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// If we're going to put a fixed size on the command line, this will calculate it
+        /// If we're going to put a fixed size on the command line, this will calculate it.
         /// </summary>
         public string GetOutputSizeParam(
             EncodingJobInfo state,
@@ -2505,7 +2505,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Gets the name of the output video codec
+        /// Gets the name of the output video codec.
         /// </summary>
         protected string GetHardwareAcceleratedVideoDecoder(EncodingJobInfo state, EncodingOptions encodingOptions)
         {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -418,7 +418,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public double? TargetVideoLevel
         {
@@ -441,7 +441,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetVideoBitDepth
         {
@@ -476,7 +476,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public float? TargetFramerate
         {
@@ -508,7 +508,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetPacketLength
         {
@@ -524,7 +524,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public string TargetVideoProfile
         {
@@ -679,20 +679,20 @@ namespace MediaBrowser.Controller.MediaEncoding
     }
 
     /// <summary>
-    /// Enum TranscodingJobType
+    /// Enum TranscodingJobType.
     /// </summary>
     public enum TranscodingJobType
     {
         /// <summary>
-        /// The progressive
+        /// The progressive.
         /// </summary>
         Progressive,
         /// <summary>
-        /// The HLS
+        /// The HLS.
         /// </summary>
         Hls,
         /// <summary>
-        /// The dash
+        /// The dash.
         /// </summary>
         Dash
     }

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.System;
 namespace MediaBrowser.Controller.MediaEncoding
 {
     /// <summary>
-    /// Interface IMediaEncoder
+    /// Interface IMediaEncoder.
     /// </summary>
     public interface IMediaEncoder : ITranscoderSupport
     {

--- a/MediaBrowser.Controller/MediaEncoding/MediaEncoderHelpers.cs
+++ b/MediaBrowser.Controller/MediaEncoding/MediaEncoderHelpers.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.IO;
 namespace MediaBrowser.Controller.MediaEncoding
 {
     /// <summary>
-    /// Class MediaEncoderHelpers
+    /// Class MediaEncoderHelpers.
     /// </summary>
     public static class MediaEncoderHelpers
     {

--- a/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
+++ b/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Controller.Net
 {
     /// <summary>
-    /// Starts sending data over a web socket periodically when a message is received, and then stops when a corresponding stop message is received
+    /// Starts sending data over a web socket periodically when a message is received, and then stops when a corresponding stop message is received.
     /// </summary>
     /// <typeparam name="TReturnDataType">The type of the T return data type.</typeparam>
     /// <typeparam name="TStateType">The type of the T state type.</typeparam>
@@ -20,7 +20,7 @@ namespace MediaBrowser.Controller.Net
         where TReturnDataType : class
     {
         /// <summary>
-        /// The _active connections
+        /// The _active connections.
         /// </summary>
         private readonly List<Tuple<IWebSocketConnection, CancellationTokenSource, TStateType>> _activeConnections =
             new List<Tuple<IWebSocketConnection, CancellationTokenSource, TStateType>>();
@@ -38,7 +38,7 @@ namespace MediaBrowser.Controller.Net
         protected abstract Task<TReturnDataType> GetDataToSend();
 
         /// <summary>
-        /// The logger
+        /// The logger.
         /// </summary>
         protected ILogger<BasePeriodicWebSocketListener<TReturnDataType, TStateType>> Logger;
 
@@ -78,7 +78,7 @@ namespace MediaBrowser.Controller.Net
         }
 
         /// <summary>
-        /// Starts sending messages over a web socket
+        /// Starts sending messages over a web socket.
         /// </summary>
         /// <param name="message">The message.</param>
         private void Start(WebSocketMessageInfo message)
@@ -180,7 +180,7 @@ namespace MediaBrowser.Controller.Net
         }
 
         /// <summary>
-        /// Stops sending messages over a web socket
+        /// Stops sending messages over a web socket.
         /// </summary>
         /// <param name="message">The message.</param>
         private void Stop(WebSocketMessageInfo message)

--- a/MediaBrowser.Controller/Net/IHttpResultFactory.cs
+++ b/MediaBrowser.Controller/Net/IHttpResultFactory.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Services;
 namespace MediaBrowser.Controller.Net
 {
     /// <summary>
-    /// Interface IHttpResultFactory
+    /// Interface IHttpResultFactory.
     /// </summary>
     public interface IHttpResultFactory
     {

--- a/MediaBrowser.Controller/Net/IHttpServer.cs
+++ b/MediaBrowser.Controller/Net/IHttpServer.cs
@@ -29,19 +29,19 @@ namespace MediaBrowser.Controller.Net
         void Init(IEnumerable<Type> serviceTypes, IEnumerable<IWebSocketListener> listener, IEnumerable<string> urlPrefixes);
 
         /// <summary>
-        /// If set, all requests will respond with this message
+        /// If set, all requests will respond with this message.
         /// </summary>
         string GlobalResponse { get; set; }
 
         /// <summary>
-        /// The HTTP request handler
+        /// The HTTP request handler.
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
         Task RequestHandler(HttpContext context);
 
         /// <summary>
-        /// Get the default CORS headers
+        /// Get the default CORS headers.
         /// </summary>
         /// <param name="req"></param>
         /// <returns></returns>

--- a/MediaBrowser.Controller/Net/IWebSocketListener.cs
+++ b/MediaBrowser.Controller/Net/IWebSocketListener.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 namespace MediaBrowser.Controller.Net
 {
     /// <summary>
-    ///This is an interface for listening to messages coming through a web socket connection
+    ///This is an interface for listening to messages coming through a web socket connection.
     /// </summary>
     public interface IWebSocketListener
     {

--- a/MediaBrowser.Controller/Net/WebSocketMessageInfo.cs
+++ b/MediaBrowser.Controller/Net/WebSocketMessageInfo.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Model.Net;
 namespace MediaBrowser.Controller.Net
 {
     /// <summary>
-    /// Class WebSocketMessageInfo
+    /// Class WebSocketMessageInfo.
     /// </summary>
     public class WebSocketMessageInfo : WebSocketMessage<string>
     {

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -9,12 +9,12 @@ using MediaBrowser.Model.Querying;
 namespace MediaBrowser.Controller.Persistence
 {
     /// <summary>
-    /// Provides an interface to implement an Item repository
+    /// Provides an interface to implement an Item repository.
     /// </summary>
     public interface IItemRepository : IRepository
     {
         /// <summary>
-        /// Saves an item
+        /// Saves an item.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -43,14 +43,14 @@ namespace MediaBrowser.Controller.Persistence
         BaseItem RetrieveItem(Guid id);
 
         /// <summary>
-        /// Gets chapters for an item
+        /// Gets chapters for an item.
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
         List<ChapterInfo> GetChapters(BaseItem id);
 
         /// <summary>
-        /// Gets a single chapter for an item
+        /// Gets a single chapter for an item.
         /// </summary>
         /// <param name="id"></param>
         /// <param name="index"></param>

--- a/MediaBrowser.Controller/Persistence/IRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IRepository.cs
@@ -3,12 +3,12 @@ using System;
 namespace MediaBrowser.Controller.Persistence
 {
     /// <summary>
-    /// Provides a base interface for all the repository interfaces
+    /// Provides a base interface for all the repository interfaces.
     /// </summary>
     public interface IRepository : IDisposable
     {
         /// <summary>
-        /// Gets the name of the repository
+        /// Gets the name of the repository.
         /// </summary>
         /// <value>The name.</value>
         string Name { get; }

--- a/MediaBrowser.Controller/Persistence/IUserDataRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IUserDataRepository.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Persistence
 {
     /// <summary>
-    /// Provides an interface to implement a UserData repository
+    /// Provides an interface to implement a UserData repository.
     /// </summary>
     public interface IUserDataRepository : IRepository
     {
@@ -30,14 +30,14 @@ namespace MediaBrowser.Controller.Persistence
         UserItemData GetUserData(long userId, List<string> keys);
 
         /// <summary>
-        /// Return all user data associated with the given user
+        /// Return all user data associated with the given user.
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>
         List<UserItemData> GetAllUserData(long userId);
 
         /// <summary>
-        /// Save all user data associated with the given user
+        /// Save all user data associated with the given user.
         /// </summary>
         /// <param name="userId"></param>
         /// <param name="userData"></param>

--- a/MediaBrowser.Controller/Plugins/IPluginConfigurationPage.cs
+++ b/MediaBrowser.Controller/Plugins/IPluginConfigurationPage.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Common.Plugins;
 namespace MediaBrowser.Controller.Plugins
 {
     /// <summary>
-    /// Interface IConfigurationPage
+    /// Interface IConfigurationPage.
     /// </summary>
     public interface IPluginConfigurationPage
     {
@@ -34,16 +34,16 @@ namespace MediaBrowser.Controller.Plugins
     }
 
     /// <summary>
-    /// Enum ConfigurationPageType
+    /// Enum ConfigurationPageType.
     /// </summary>
     public enum ConfigurationPageType
     {
         /// <summary>
-        /// The plugin configuration
+        /// The plugin configuration.
         /// </summary>
         PluginConfiguration,
         /// <summary>
-        /// The none
+        /// The none.
         /// </summary>
         None
     }

--- a/MediaBrowser.Controller/Providers/IMetadataProvider.cs
+++ b/MediaBrowser.Controller/Providers/IMetadataProvider.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Providers
 {
     /// <summary>
-    /// Marker interface
+    /// Marker interface.
     /// </summary>
     public interface IMetadataProvider
     {

--- a/MediaBrowser.Controller/Providers/MetadataRefreshMode.cs
+++ b/MediaBrowser.Controller/Providers/MetadataRefreshMode.cs
@@ -3,22 +3,22 @@ namespace MediaBrowser.Controller.Providers
     public enum MetadataRefreshMode
     {
         /// <summary>
-        /// The none
+        /// The none.
         /// </summary>
         None = 0,
 
         /// <summary>
-        /// The validation only
+        /// The validation only.
         /// </summary>
         ValidationOnly = 1,
 
         /// <summary>
-        /// Providers will be executed based on default rules
+        /// Providers will be executed based on default rules.
         /// </summary>
         Default = 2,
 
         /// <summary>
-        /// All providers will be executed to search for new metadata
+        /// All providers will be executed to search for new metadata.
         /// </summary>
         FullRefresh = 3
     }

--- a/MediaBrowser.Controller/Providers/MetadataResult.cs
+++ b/MediaBrowser.Controller/Providers/MetadataResult.cs
@@ -40,7 +40,7 @@ namespace MediaBrowser.Controller.Providers
         }
 
         /// <summary>
-        /// Not only does this clear, but initializes the list so that services can differentiate between a null list and zero people
+        /// Not only does this clear, but initializes the list so that services can differentiate between a null list and zero people.
         /// </summary>
         public void ResetPeople()
         {

--- a/MediaBrowser.Controller/Providers/VideoContentType.cs
+++ b/MediaBrowser.Controller/Providers/VideoContentType.cs
@@ -1,17 +1,17 @@
 namespace MediaBrowser.Controller.Providers
 {
     /// <summary>
-    /// Enum VideoContentType
+    /// Enum VideoContentType.
     /// </summary>
     public enum VideoContentType
     {
         /// <summary>
-        /// The episode
+        /// The episode.
         /// </summary>
         Episode = 0,
 
         /// <summary>
-        /// The movie
+        /// The movie.
         /// </summary>
         Movie = 1
     }

--- a/MediaBrowser.Controller/Resolvers/BaseItemResolver.cs
+++ b/MediaBrowser.Controller/Resolvers/BaseItemResolver.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Controller.Library;
 namespace MediaBrowser.Controller.Resolvers
 {
     /// <summary>
-    /// Class ItemResolver
+    /// Class ItemResolver.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public abstract class ItemResolver<T> : IItemResolver
@@ -27,7 +27,7 @@ namespace MediaBrowser.Controller.Resolvers
         public virtual ResolverPriority Priority => ResolverPriority.First;
 
         /// <summary>
-        /// Sets initial values on the newly resolved item
+        /// Sets initial values on the newly resolved item.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="args">The args.</param>

--- a/MediaBrowser.Controller/Resolvers/IItemResolver.cs
+++ b/MediaBrowser.Controller/Resolvers/IItemResolver.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.IO;
 namespace MediaBrowser.Controller.Resolvers
 {
     /// <summary>
-    /// Interface IItemResolver
+    /// Interface IItemResolver.
     /// </summary>
     public interface IItemResolver
     {

--- a/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
+++ b/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
@@ -1,25 +1,25 @@
 namespace MediaBrowser.Controller.Resolvers
 {
     /// <summary>
-    /// Enum ResolverPriority
+    /// Enum ResolverPriority.
     /// </summary>
     public enum ResolverPriority
     {
         /// <summary>
-        /// The first
+        /// The first.
         /// </summary>
         First = 1,
         /// <summary>
-        /// The second
+        /// The second.
         /// </summary>
         Second = 2,
         /// <summary>
-        /// The third
+        /// The third.
         /// </summary>
         Third = 3,
         Fourth = 4,
         /// <summary>
-        /// The last
+        /// The last.
         /// </summary>
         Last = 5
     }

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Model.SyncPlay;
 namespace MediaBrowser.Controller.Session
 {
     /// <summary>
-    /// Interface ISessionManager
+    /// Interface ISessionManager.
     /// </summary>
     public interface ISessionManager
     {
@@ -79,14 +79,14 @@ namespace MediaBrowser.Controller.Session
         void UpdateDeviceName(string sessionId, string reportedDeviceName);
 
         /// <summary>
-        /// Used to report that playback has started for an item
+        /// Used to report that playback has started for an item.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <returns>Task.</returns>
         Task OnPlaybackStart(PlaybackStartInfo info);
 
         /// <summary>
-        /// Used to report playback progress for an item
+        /// Used to report playback progress for an item.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <returns>Task.</returns>
@@ -96,7 +96,7 @@ namespace MediaBrowser.Controller.Session
         Task OnPlaybackProgress(PlaybackProgressInfo info, bool isAutomated);
 
         /// <summary>
-        /// Used to report that playback has ended for an item
+        /// Used to report that playback has ended for an item.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <returns>Task.</returns>

--- a/MediaBrowser.Controller/Sorting/IBaseItemComparer.cs
+++ b/MediaBrowser.Controller/Sorting/IBaseItemComparer.cs
@@ -4,7 +4,7 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Sorting
 {
     /// <summary>
-    /// Interface IBaseItemComparer
+    /// Interface IBaseItemComparer.
     /// </summary>
     public interface IBaseItemComparer : IComparer<BaseItem>
     {

--- a/MediaBrowser.Controller/Sorting/IUserBaseItemComparer.cs
+++ b/MediaBrowser.Controller/Sorting/IUserBaseItemComparer.cs
@@ -3,7 +3,7 @@ using MediaBrowser.Controller.Library;
 namespace MediaBrowser.Controller.Sorting
 {
     /// <summary>
-    /// Represents a BaseItem comparer that requires a User to perform it's comparison
+    /// Represents a BaseItem comparer that requires a User to perform it's comparison.
     /// </summary>
     public interface IUserBaseItemComparer : IBaseItemComparer
     {

--- a/MediaBrowser.Controller/Sync/IRemoteSyncProvider.cs
+++ b/MediaBrowser.Controller/Sync/IRemoteSyncProvider.cs
@@ -1,7 +1,7 @@
 namespace MediaBrowser.Controller.Sync
 {
     /// <summary>
-    /// A marker interface
+    /// A marker interface.
     /// </summary>
     public interface IRemoteSyncProvider
     {

--- a/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
+++ b/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
@@ -14,14 +14,14 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.LocalMetadata.Parsers
 {
     /// <summary>
-    /// Provides a base class for parsing metadata xml
+    /// Provides a base class for parsing metadata xml.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public class BaseItemXmlParser<T>
         where T : BaseItem
     {
         /// <summary>
-        /// The logger
+        /// The logger.
         /// </summary>
         protected ILogger<BaseItemXmlParser<T>> Logger { get; private set; }
         protected IProviderManager ProviderManager { get; private set; }
@@ -39,7 +39,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
         }
 
         /// <summary>
-        /// Fetches metadata for an item from one xml file
+        /// Fetches metadata for an item from one xml file.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="metadataFile">The metadata file.</param>
@@ -124,7 +124,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
 
         /// <summary>
-        /// Fetches metadata from one Xml Element
+        /// Fetches metadata from one Xml Element.
         /// </summary>
         /// <param name="reader">The reader.</param>
         /// <param name="itemResult">The item result.</param>
@@ -1230,7 +1230,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
 
 
         /// <summary>
-        /// Used to split names of comma or pipe delimeted genres and people
+        /// Used to split names of comma or pipe delimeted genres and people.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>IEnumerable{System.String}.</returns>

--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.MediaInfo;
 namespace MediaBrowser.MediaEncoding.BdInfo
 {
     /// <summary>
-    /// Class BdInfoExaminer
+    /// Class BdInfoExaminer.
     /// </summary>
     public class BdInfoExaminer : IBlurayExaminer
     {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -25,7 +25,7 @@ using System.Diagnostics;
 namespace MediaBrowser.MediaEncoding.Encoder
 {
     /// <summary>
-    /// Class MediaEncoder
+    /// Class MediaEncoder.
     /// </summary>
     public class MediaEncoder : IMediaEncoder, IDisposable
     {
@@ -425,7 +425,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         /// <summary>
-        /// The us culture
+        /// The us culture.
         /// </summary>
         protected readonly CultureInfo UsCulture = new CultureInfo("en-US");
 

--- a/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
+++ b/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
@@ -35,7 +35,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets a string from an FFProbeResult tags dictionary
+        /// Gets a string from an FFProbeResult tags dictionary.
         /// </summary>
         /// <param name="tags">The tags.</param>
         /// <param name="key">The key.</param>
@@ -52,7 +52,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets an int from an FFProbeResult tags dictionary
+        /// Gets an int from an FFProbeResult tags dictionary.
         /// </summary>
         /// <param name="tags">The tags.</param>
         /// <param name="key">The key.</param>
@@ -73,7 +73,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets a DateTime from an FFProbeResult tags dictionary
+        /// Gets a DateTime from an FFProbeResult tags dictionary.
         /// </summary>
         /// <param name="tags">The tags.</param>
         /// <param name="key">The key.</param>
@@ -94,7 +94,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Converts a dictionary to case insensitive
+        /// Converts a dictionary to case insensitive.
         /// </summary>
         /// <param name="dict">The dict.</param>
         /// <returns>Dictionary{System.StringSystem.String}.</returns>

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -515,7 +515,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Converts ffprobe stream info to our MediaAttachment class
+        /// Converts ffprobe stream info to our MediaAttachment class.
         /// </summary>
         /// <param name="streamInfo">The stream info.</param>
         /// <returns>MediaAttachments.</returns>
@@ -548,7 +548,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Converts ffprobe stream info to our MediaStream class
+        /// Converts ffprobe stream info to our MediaStream class.
         /// </summary>
         /// <param name="isAudio">if set to <c>true</c> [is info].</param>
         /// <param name="streamInfo">The stream info.</param>
@@ -767,7 +767,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets a string from an FFProbeResult tags dictionary
+        /// Gets a string from an FFProbeResult tags dictionary.
         /// </summary>
         /// <param name="tags">The tags.</param>
         /// <param name="key">The key.</param>
@@ -1154,7 +1154,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets the studios from the tags collection
+        /// Gets the studios from the tags collection.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <param name="tags">The tags.</param>
@@ -1191,7 +1191,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
-        /// Gets the genres from the tags collection
+        /// Gets the genres from the tags collection.
         /// </summary>
         /// <param name="info">The information.</param>
         /// <param name="tags">The tags.</param>

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -344,7 +344,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         }
 
         /// <summary>
-        /// The _semaphoreLocks
+        /// The _semaphoreLocks.
         /// </summary>
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphoreLocks =
             new ConcurrentDictionary<string, SemaphoreSlim>();

--- a/MediaBrowser.Model/Channels/ChannelFeatures.cs
+++ b/MediaBrowser.Model/Channels/ChannelFeatures.cs
@@ -38,7 +38,7 @@ namespace MediaBrowser.Model.Channels
         public ChannelMediaContentType[] ContentTypes { get; set; }
 
         /// <summary>
-        /// Represents the maximum number of records the channel allows retrieving at a time
+        /// Represents the maximum number of records the channel allows retrieving at a time.
         /// </summary>
         public int? MaxPageSize { get; set; }
 

--- a/MediaBrowser.Model/Channels/ChannelQuery.cs
+++ b/MediaBrowser.Model/Channels/ChannelQuery.cs
@@ -10,7 +10,7 @@ namespace MediaBrowser.Model.Channels
     public class ChannelQuery
     {
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         public ItemFields[] Fields { get; set; }
@@ -34,7 +34,7 @@ namespace MediaBrowser.Model.Channels
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }

--- a/MediaBrowser.Model/Configuration/BaseApplicationConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/BaseApplicationConfiguration.cs
@@ -12,7 +12,7 @@ namespace MediaBrowser.Model.Configuration
     public class BaseApplicationConfiguration
     {
         /// <summary>
-        /// The number of days we should retain log files
+        /// The number of days we should retain log files.
         /// </summary>
         /// <value>The log file retention days.</value>
         public int LogFileRetentionDays { get; set; }

--- a/MediaBrowser.Model/Configuration/MetadataPluginType.cs
+++ b/MediaBrowser.Model/Configuration/MetadataPluginType.cs
@@ -3,7 +3,7 @@
 namespace MediaBrowser.Model.Configuration
 {
     /// <summary>
-    /// Enum MetadataPluginType
+    /// Enum MetadataPluginType.
     /// </summary>
     public enum MetadataPluginType
     {

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -111,19 +111,19 @@ namespace MediaBrowser.Model.Configuration
         public string MetadataCountryCode { get; set; }
 
         /// <summary>
-        /// Characters to be replaced with a ' ' in strings to create a sort name
+        /// Characters to be replaced with a ' ' in strings to create a sort name.
         /// </summary>
         /// <value>The sort replace characters.</value>
         public string[] SortReplaceCharacters { get; set; }
 
         /// <summary>
-        /// Characters to be removed from strings to create a sort name
+        /// Characters to be removed from strings to create a sort name.
         /// </summary>
         /// <value>The sort remove characters.</value>
         public string[] SortRemoveCharacters { get; set; }
 
         /// <summary>
-        /// Words to be removed from strings to create a sort name
+        /// Words to be removed from strings to create a sort name.
         /// </summary>
         /// <value>The sort remove words.</value>
         public string[] SortRemoveWords { get; set; }

--- a/MediaBrowser.Model/Configuration/UserConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/UserConfiguration.cs
@@ -7,7 +7,7 @@ using Jellyfin.Data.Enums;
 namespace MediaBrowser.Model.Configuration
 {
     /// <summary>
-    /// Class UserConfiguration
+    /// Class UserConfiguration.
     /// </summary>
     public class UserConfiguration
     {

--- a/MediaBrowser.Model/Dlna/AudioOptions.cs
+++ b/MediaBrowser.Model/Dlna/AudioOptions.cs
@@ -47,7 +47,7 @@ namespace MediaBrowser.Model.Dlna
         public int? MaxAudioChannels { get; set; }
 
         /// <summary>
-        /// The application's configured quality setting
+        /// The application's configured quality setting.
         /// </summary>
         public long? MaxBitrate { get; set; }
 

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -465,7 +465,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Returns the audio stream that will be used
+        /// Returns the audio stream that will be used.
         /// </summary>
         public MediaStream TargetAudioStream
         {
@@ -481,7 +481,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Returns the video stream that will be used
+        /// Returns the video stream that will be used.
         /// </summary>
         public MediaStream TargetVideoStream
         {
@@ -497,7 +497,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetAudioSampleRate
         {
@@ -509,7 +509,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetAudioBitDepth
         {
@@ -532,7 +532,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetVideoBitDepth
         {
@@ -579,7 +579,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public float? TargetFramerate
         {
@@ -593,7 +593,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public double? TargetVideoLevel
         {
@@ -680,7 +680,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public int? TargetPacketLength
         {
@@ -694,7 +694,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio sample rate that will be in the output stream
+        /// Predicts the audio sample rate that will be in the output stream.
         /// </summary>
         public string TargetVideoProfile
         {
@@ -732,7 +732,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio bitrate that will be in the output stream
+        /// Predicts the audio bitrate that will be in the output stream.
         /// </summary>
         public int? TargetAudioBitrate
         {
@@ -746,7 +746,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio channels that will be in the output stream
+        /// Predicts the audio channels that will be in the output stream.
         /// </summary>
         public int? TargetAudioChannels
         {
@@ -787,7 +787,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio codec that will be in the output stream
+        /// Predicts the audio codec that will be in the output stream.
         /// </summary>
         public string[] TargetAudioCodec
         {
@@ -840,7 +840,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Predicts the audio channels that will be in the output stream
+        /// Predicts the audio channels that will be in the output stream.
         /// </summary>
         public long? TargetSize
         {

--- a/MediaBrowser.Model/Dlna/SubtitleDeliveryMethod.cs
+++ b/MediaBrowser.Model/Dlna/SubtitleDeliveryMethod.cs
@@ -5,22 +5,22 @@ namespace MediaBrowser.Model.Dlna
     public enum SubtitleDeliveryMethod
     {
         /// <summary>
-        /// The encode
+        /// The encode.
         /// </summary>
         Encode = 0,
 
         /// <summary>
-        /// The embed
+        /// The embed.
         /// </summary>
         Embed = 1,
 
         /// <summary>
-        /// The external
+        /// The external.
         /// </summary>
         External = 2,
 
         /// <summary>
-        /// The HLS
+        /// The HLS.
         /// </summary>
         Hls = 3
     }

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -308,7 +308,7 @@ namespace MediaBrowser.Model.Dto
         public int? LocalTrailerCount { get; set; }
 
         /// <summary>
-        /// User data for this item based on the user it's being requested for
+        /// User data for this item based on the user it's being requested for.
         /// </summary>
         /// <value>The user data.</value>
         public UserItemDataDto UserData { get; set; }

--- a/MediaBrowser.Model/Dto/ImageOptions.cs
+++ b/MediaBrowser.Model/Dto/ImageOptions.cs
@@ -61,7 +61,7 @@ namespace MediaBrowser.Model.Dto
 
         /// <summary>
         /// Gets or sets the image tag.
-        /// If set this will result in strong, unconditional response caching
+        /// If set this will result in strong, unconditional response caching.
         /// </summary>
         /// <value>The hash.</value>
         public string Tag { get; set; }

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -28,7 +28,7 @@ namespace MediaBrowser.Model.Dto
         public string Name { get; set; }
 
         /// <summary>
-        /// Differentiate internet url vs local network
+        /// Differentiate internet url vs local network.
         /// </summary>
         public bool IsRemote { get; set; }
 

--- a/MediaBrowser.Model/Entities/DisplayPreferences.cs
+++ b/MediaBrowser.Model/Entities/DisplayPreferences.cs
@@ -104,7 +104,7 @@ namespace MediaBrowser.Model.Entities
         public bool ShowSidebar { get; set; }
 
         /// <summary>
-        /// Gets or sets the client
+        /// Gets or sets the client.
         /// </summary>
         public string Client { get; set; }
     }

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Model.MediaInfo;
 namespace MediaBrowser.Model.Entities
 {
     /// <summary>
-    /// Class MediaStream
+    /// Class MediaStream.
     /// </summary>
     public class MediaStream
     {

--- a/MediaBrowser.Model/Entities/MetadataProvider.cs
+++ b/MediaBrowser.Model/Entities/MetadataProvider.cs
@@ -3,28 +3,28 @@
 namespace MediaBrowser.Model.Entities
 {
     /// <summary>
-    /// Enum MetadataProviders
+    /// Enum MetadataProviders.
     /// </summary>
     public enum MetadataProvider
     {
         /// <summary>
-        /// The imdb
+        /// The imdb.
         /// </summary>
         Imdb = 2,
         /// <summary>
-        /// The TMDB
+        /// The TMDB.
         /// </summary>
         Tmdb = 3,
         /// <summary>
-        /// The TVDB
+        /// The TVDB.
         /// </summary>
         Tvdb = 4,
         /// <summary>
-        /// The tvcom
+        /// The tvcom.
         /// </summary>
         Tvcom = 5,
         /// <summary>
-        /// Tmdb Collection Id
+        /// Tmdb Collection Id.
         /// </summary>
         TmdbCollection = 7,
         MusicBrainzAlbum = 8,

--- a/MediaBrowser.Model/Entities/VirtualFolderInfo.cs
+++ b/MediaBrowser.Model/Entities/VirtualFolderInfo.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Configuration;
 namespace MediaBrowser.Model.Entities
 {
     /// <summary>
-    /// Used to hold information about a user's list of configured virtual folders
+    /// Used to hold information about a user's list of configured virtual folders.
     /// </summary>
     public class VirtualFolderInfo
     {

--- a/MediaBrowser.Model/IO/IZipClient.cs
+++ b/MediaBrowser.Model/IO/IZipClient.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace MediaBrowser.Model.IO
 {
     /// <summary>
-    /// Interface IZipClient
+    /// Interface IZipClient.
     /// </summary>
     public interface IZipClient
     {

--- a/MediaBrowser.Model/LiveTv/ChannelType.cs
+++ b/MediaBrowser.Model/LiveTv/ChannelType.cs
@@ -6,7 +6,7 @@ namespace MediaBrowser.Model.LiveTv
     public enum ChannelType
     {
         /// <summary>
-        /// The TV
+        /// The TV.
         /// </summary>
         TV,
 

--- a/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
@@ -54,7 +54,7 @@ namespace MediaBrowser.Model.LiveTv
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }
@@ -67,13 +67,13 @@ namespace MediaBrowser.Model.LiveTv
         public bool EnableUserData { get; set; }
 
         /// <summary>
-        /// Used to specific whether to return news or not
+        /// Used to specific whether to return news or not.
         /// </summary>
         /// <remarks>If set to null, all programs will be returned</remarks>
         public bool? IsNews { get; set; }
 
         /// <summary>
-        /// Used to specific whether to return movies or not
+        /// Used to specific whether to return movies or not.
         /// </summary>
         /// <remarks>If set to null, all programs will be returned</remarks>
         public bool? IsMovie { get; set; }
@@ -93,7 +93,7 @@ namespace MediaBrowser.Model.LiveTv
         public string[] SortBy { get; set; }
 
         /// <summary>
-        /// The sort order to return results with
+        /// The sort order to return results with.
         /// </summary>
         /// <value>The sort order.</value>
         public SortOrder? SortOrder { get; set; }

--- a/MediaBrowser.Model/LiveTv/RecordingQuery.cs
+++ b/MediaBrowser.Model/LiveTv/RecordingQuery.cs
@@ -37,7 +37,7 @@ namespace MediaBrowser.Model.LiveTv
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }
@@ -61,7 +61,7 @@ namespace MediaBrowser.Model.LiveTv
         public string SeriesTimerId { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         public ItemFields[] Fields { get; set; }

--- a/MediaBrowser.Model/LiveTv/SeriesTimerQuery.cs
+++ b/MediaBrowser.Model/LiveTv/SeriesTimerQuery.cs
@@ -7,7 +7,7 @@ namespace MediaBrowser.Model.LiveTv
     public class SeriesTimerQuery
     {
         /// <summary>
-        /// Gets or sets the sort by - SortName, Priority
+        /// Gets or sets the sort by - SortName, Priority.
         /// </summary>
         /// <value>The sort by.</value>
         public string? SortBy { get; set; }

--- a/MediaBrowser.Model/Net/NetworkShare.cs
+++ b/MediaBrowser.Model/Net/NetworkShare.cs
@@ -6,27 +6,27 @@ namespace MediaBrowser.Model.Net
     public class NetworkShare
     {
         /// <summary>
-        /// The name of the computer that this share belongs to
+        /// The name of the computer that this share belongs to.
         /// </summary>
         public string Server { get; set; }
 
         /// <summary>
-        /// Share name
+        /// Share name.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Local path
+        /// Local path.
         /// </summary>
         public string Path { get; set; }
 
         /// <summary>
-        /// Share type
+        /// Share type.
         /// </summary>
         public NetworkShareType ShareType { get; set; }
 
         /// <summary>
-        /// Comment
+        /// Comment.
         /// </summary>
         public string Remark { get; set; }
     }

--- a/MediaBrowser.Model/Notifications/NotificationOption.cs
+++ b/MediaBrowser.Model/Notifications/NotificationOption.cs
@@ -18,7 +18,7 @@ namespace MediaBrowser.Model.Notifications
         public string Type { get; set; }
 
         /// <summary>
-        /// User Ids to not monitor (it's opt out)
+        /// User Ids to not monitor (it's opt out).
         /// </summary>
         public string[] DisabledMonitorUsers { get; set; }
 

--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -8,198 +8,198 @@ namespace MediaBrowser.Model.Querying
     public enum ItemFields
     {
         /// <summary>
-        /// The air time
+        /// The air time.
         /// </summary>
         AirTime,
 
         /// <summary>
-        /// The can delete
+        /// The can delete.
         /// </summary>
         CanDelete,
 
         /// <summary>
-        /// The can download
+        /// The can download.
         /// </summary>
         CanDownload,
 
         /// <summary>
-        /// The channel information
+        /// The channel information.
         /// </summary>
         ChannelInfo,
 
         /// <summary>
-        /// The chapters
+        /// The chapters.
         /// </summary>
         Chapters,
 
         ChildCount,
 
         /// <summary>
-        /// The cumulative run time ticks
+        /// The cumulative run time ticks.
         /// </summary>
         CumulativeRunTimeTicks,
 
         /// <summary>
-        /// The custom rating
+        /// The custom rating.
         /// </summary>
         CustomRating,
 
         /// <summary>
-        /// The date created of the item
+        /// The date created of the item.
         /// </summary>
         DateCreated,
 
         /// <summary>
-        /// The date last media added
+        /// The date last media added.
         /// </summary>
         DateLastMediaAdded,
 
         /// <summary>
-        /// Item display preferences
+        /// Item display preferences.
         /// </summary>
         DisplayPreferencesId,
 
         /// <summary>
-        /// The etag
+        /// The etag.
         /// </summary>
         Etag,
 
         /// <summary>
-        /// The external urls
+        /// The external urls.
         /// </summary>
         ExternalUrls,
 
         /// <summary>
-        /// Genres
+        /// Genres.
         /// </summary>
         Genres,
 
         /// <summary>
-        /// The home page URL
+        /// The home page URL.
         /// </summary>
         HomePageUrl,
 
         /// <summary>
-        /// The item counts
+        /// The item counts.
         /// </summary>
         ItemCounts,
 
         /// <summary>
-        /// The media source count
+        /// The media source count.
         /// </summary>
         MediaSourceCount,
 
         /// <summary>
-        /// The media versions
+        /// The media versions.
         /// </summary>
         MediaSources,
 
         OriginalTitle,
 
         /// <summary>
-        /// The item overview
+        /// The item overview.
         /// </summary>
         Overview,
 
         /// <summary>
-        /// The id of the item's parent
+        /// The id of the item's parent.
         /// </summary>
         ParentId,
 
         /// <summary>
-        /// The physical path of the item
+        /// The physical path of the item.
         /// </summary>
         Path,
 
         /// <summary>
-        /// The list of people for the item
+        /// The list of people for the item.
         /// </summary>
         People,
 
         PlayAccess,
 
         /// <summary>
-        /// The production locations
+        /// The production locations.
         /// </summary>
         ProductionLocations,
 
         /// <summary>
-        /// Imdb, tmdb, etc
+        /// Imdb, tmdb, etc.
         /// </summary>
         ProviderIds,
 
         /// <summary>
-        /// The aspect ratio of the primary image
+        /// The aspect ratio of the primary image.
         /// </summary>
         PrimaryImageAspectRatio,
 
         RecursiveItemCount,
 
         /// <summary>
-        /// The settings
+        /// The settings.
         /// </summary>
         Settings,
 
         /// <summary>
-        /// The screenshot image tags
+        /// The screenshot image tags.
         /// </summary>
         ScreenshotImageTags,
 
         SeriesPrimaryImage,
 
         /// <summary>
-        /// The series studio
+        /// The series studio.
         /// </summary>
         SeriesStudio,
 
         /// <summary>
-        /// The sort name of the item
+        /// The sort name of the item.
         /// </summary>
         SortName,
 
         /// <summary>
-        /// The special episode numbers
+        /// The special episode numbers.
         /// </summary>
         SpecialEpisodeNumbers,
 
         /// <summary>
-        /// The studios of the item
+        /// The studios of the item.
         /// </summary>
         Studios,
 
         BasicSyncInfo,
         /// <summary>
-        /// The synchronize information
+        /// The synchronize information.
         /// </summary>
         SyncInfo,
 
         /// <summary>
-        /// The taglines of the item
+        /// The taglines of the item.
         /// </summary>
         Taglines,
 
         /// <summary>
-        /// The tags
+        /// The tags.
         /// </summary>
         Tags,
 
         /// <summary>
-        /// The trailer url of the item
+        /// The trailer url of the item.
         /// </summary>
         RemoteTrailers,
 
         /// <summary>
-        /// The media streams
+        /// The media streams.
         /// </summary>
         MediaStreams,
 
         /// <summary>
-        /// The season user data
+        /// The season user data.
         /// </summary>
         SeasonUserData,
 
         /// <summary>
-        /// The service name
+        /// The service name.
         /// </summary>
         ServiceName,
         ThemeSongIds,

--- a/MediaBrowser.Model/Querying/ItemSortBy.cs
+++ b/MediaBrowser.Model/Querying/ItemSortBy.cs
@@ -3,7 +3,7 @@
 namespace MediaBrowser.Model.Querying
 {
     /// <summary>
-    /// These represent sort orders that are known by the core
+    /// These represent sort orders that are known by the core.
     /// </summary>
     public static class ItemSortBy
     {

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -33,13 +33,13 @@ namespace MediaBrowser.Model.Querying
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         public ItemFields[] Fields { get; set; }

--- a/MediaBrowser.Model/Querying/QueryResult.cs
+++ b/MediaBrowser.Model/Querying/QueryResult.cs
@@ -15,7 +15,7 @@ namespace MediaBrowser.Model.Querying
         public IReadOnlyList<T> Items { get; set; }
 
         /// <summary>
-        /// The total number of records available
+        /// The total number of records available.
         /// </summary>
         /// <value>The total record count.</value>
         public int TotalRecordCount { get; set; }

--- a/MediaBrowser.Model/Querying/UpcomingEpisodesQuery.cs
+++ b/MediaBrowser.Model/Querying/UpcomingEpisodesQuery.cs
@@ -26,13 +26,13 @@ namespace MediaBrowser.Model.Querying
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Fields to return within the items, in addition to basic information
+        /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
         public ItemFields[] Fields { get; set; }

--- a/MediaBrowser.Model/Search/SearchQuery.cs
+++ b/MediaBrowser.Model/Search/SearchQuery.cs
@@ -8,7 +8,7 @@ namespace MediaBrowser.Model.Search
     public class SearchQuery
     {
         /// <summary>
-        /// The user to localize search results for
+        /// The user to localize search results for.
         /// </summary>
         /// <value>The user id.</value>
         public Guid UserId { get; set; }
@@ -26,7 +26,7 @@ namespace MediaBrowser.Model.Search
         public int? StartIndex { get; set; }
 
         /// <summary>
-        /// The maximum number of items to return
+        /// The maximum number of items to return.
         /// </summary>
         /// <value>The limit.</value>
         public int? Limit { get; set; }

--- a/MediaBrowser.Model/Services/ApiMemberAttribute.cs
+++ b/MediaBrowser.Model/Services/ApiMemberAttribute.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Model.Services
         public string Route { get; set; }
 
         /// <summary>
-        /// Whether to exclude this property from being included in the ModelSchema
+        /// Whether to exclude this property from being included in the ModelSchema.
         /// </summary>
         public bool ExcludeInSchema { get; set; }
     }

--- a/MediaBrowser.Model/Services/IRequest.cs
+++ b/MediaBrowser.Model/Services/IRequest.cs
@@ -23,7 +23,7 @@ namespace MediaBrowser.Model.Services
         string Verb { get; }
 
         /// <summary>
-        /// The request ContentType
+        /// The request ContentType.
         /// </summary>
         string ContentType { get; }
 
@@ -32,7 +32,7 @@ namespace MediaBrowser.Model.Services
         string UserAgent { get; }
 
         /// <summary>
-        /// The expected Response ContentType for this request
+        /// The expected Response ContentType for this request.
         /// </summary>
         string ResponseContentType { get; set; }
 
@@ -55,7 +55,7 @@ namespace MediaBrowser.Model.Services
         string RemoteIp { get; }
 
         /// <summary>
-        /// The value of the Authorization Header used to send the Api Key, null if not available
+        /// The value of the Authorization Header used to send the Api Key, null if not available.
         /// </summary>
         string Authorization { get; }
 
@@ -68,7 +68,7 @@ namespace MediaBrowser.Model.Services
         long ContentLength { get; }
 
         /// <summary>
-        /// The value of the Referrer, null if not available
+        /// The value of the Referrer, null if not available.
         /// </summary>
         Uri UrlReferrer { get; }
     }

--- a/MediaBrowser.Model/Services/IRequiresRequestStream.cs
+++ b/MediaBrowser.Model/Services/IRequiresRequestStream.cs
@@ -7,7 +7,7 @@ namespace MediaBrowser.Model.Services
     public interface IRequiresRequestStream
     {
         /// <summary>
-        /// The raw Http Request Input Stream
+        /// The raw Http Request Input Stream.
         /// </summary>
         Stream RequestStream { get; set; }
     }

--- a/MediaBrowser.Model/Session/PlayRequest.cs
+++ b/MediaBrowser.Model/Session/PlayRequest.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Model.Services;
 namespace MediaBrowser.Model.Session
 {
     /// <summary>
-    /// Class PlayRequest
+    /// Class PlayRequest.
     /// </summary>
     public class PlayRequest
     {
@@ -19,7 +19,7 @@ namespace MediaBrowser.Model.Session
         public Guid[] ItemIds { get; set; }
 
         /// <summary>
-        /// Gets or sets the start position ticks that the first item should be played at
+        /// Gets or sets the start position ticks that the first item should be played at.
         /// </summary>
         /// <value>The start position ticks.</value>
         [ApiMember(Name = "StartPositionTicks", Description = "The starting position of the first item.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]

--- a/MediaBrowser.Model/Sync/SyncCategory.cs
+++ b/MediaBrowser.Model/Sync/SyncCategory.cs
@@ -5,15 +5,15 @@ namespace MediaBrowser.Model.Sync
     public enum SyncCategory
     {
         /// <summary>
-        /// The latest
+        /// The latest.
         /// </summary>
         Latest = 0,
         /// <summary>
-        /// The next up
+        /// The next up.
         /// </summary>
         NextUp = 1,
         /// <summary>
-        /// The resume
+        /// The resume.
         /// </summary>
         Resume = 2
     }

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -23,7 +23,7 @@ namespace MediaBrowser.Model.System
     };
 
     /// <summary>
-    /// Class SystemInfo
+    /// Class SystemInfo.
     /// </summary>
     public class SystemInfo : PublicSystemInfo
     {

--- a/MediaBrowser.Model/Tasks/IScheduledTaskWorker.cs
+++ b/MediaBrowser.Model/Tasks/IScheduledTaskWorker.cs
@@ -57,7 +57,7 @@ namespace MediaBrowser.Model.Tasks
         double? CurrentProgress { get; }
 
         /// <summary>
-        /// Gets the triggers that define when the task will run
+        /// Gets the triggers that define when the task will run.
         /// </summary>
         /// <value>The triggers.</value>
         /// <exception cref="ArgumentNullException">value</exception>

--- a/MediaBrowser.Model/Tasks/ITaskManager.cs
+++ b/MediaBrowser.Model/Tasks/ITaskManager.cs
@@ -10,7 +10,7 @@ namespace MediaBrowser.Model.Tasks
     public interface ITaskManager : IDisposable
     {
         /// <summary>
-        /// Gets the list of Scheduled Tasks
+        /// Gets the list of Scheduled Tasks.
         /// </summary>
         /// <value>The scheduled tasks.</value>
         IScheduledTaskWorker[] ScheduledTasks { get; }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -24,19 +24,19 @@ using Season = MediaBrowser.Controller.Entities.TV.Season;
 namespace MediaBrowser.Providers.Manager
 {
     /// <summary>
-    /// Class ImageSaver
+    /// Class ImageSaver.
     /// </summary>
     public class ImageSaver
     {
         private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
 
         /// <summary>
-        /// The _config
+        /// The _config.
         /// </summary>
         private readonly IServerConfigurationManager _config;
 
         /// <summary>
-        /// The _directory watchers
+        /// The _directory watchers.
         /// </summary>
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly IFileSystem _fileSystem;

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -168,7 +168,7 @@ namespace MediaBrowser.Providers.Manager
         }
 
         /// <summary>
-        /// Image types that are only one per item
+        /// Image types that are only one per item.
         /// </summary>
         private readonly ImageType[] _singularImages =
         {
@@ -189,7 +189,7 @@ namespace MediaBrowser.Providers.Manager
         }
 
         /// <summary>
-        /// Determines if an item already contains the given images
+        /// Determines if an item already contains the given images.
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="images">The images.</param>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -38,7 +38,7 @@ using Series = MediaBrowser.Controller.Entities.TV.Series;
 namespace MediaBrowser.Providers.Manager
 {
     /// <summary>
-    /// Class ProviderManager
+    /// Class ProviderManager.
     /// </summary>
     public class ProviderManager : IProviderManager, IDisposable
     {

--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -17,7 +17,7 @@ using MediaBrowser.Model.IO;
 namespace MediaBrowser.Providers.MediaInfo
 {
     /// <summary>
-    /// Uses ffmpeg to create video images
+    /// Uses ffmpeg to create video images.
     /// </summary>
     public class AudioImageProvider : IDynamicImageProvider
     {

--- a/MediaBrowser.Providers/MediaInfo/FFProbeAudioInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeAudioInfo.cs
@@ -99,7 +99,7 @@ namespace MediaBrowser.Providers.MediaInfo
         }
 
         /// <summary>
-        /// Fetches data from the tags dictionary
+        /// Fetches data from the tags dictionary.
         /// </summary>
         /// <param name="audio">The audio.</param>
         /// <param name="data">The data.</param>

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -342,7 +342,7 @@ namespace MediaBrowser.Providers.MediaInfo
         }
 
         /// <summary>
-        /// Gets information about the longest playlist on a bdrom
+        /// Gets information about the longest playlist on a bdrom.
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>VideoStream.</returns>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Models/Search/MovieResult.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Models/Search/MovieResult.cs
@@ -53,7 +53,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Models.Search
         /// <value>The vote_average.</value>
         public double Vote_Average { get; set; }
         /// <summary>
-        /// For collection search results
+        /// For collection search results.
         /// </summary>
         public string Name { get; set; }
         /// <summary>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Logging;
 namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
 {
     /// <summary>
-    /// Class MovieDbProvider
+    /// Class MovieDbProvider.
     /// </summary>
     public class TmdbMovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>, IHasOrder
     {
@@ -129,7 +129,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
         public string Name => TmdbUtils.ProviderName;
 
         /// <summary>
-        /// The _TMDB settings task
+        /// The _TMDB settings task.
         /// </summary>
         private TmdbSettingsResult _tmdbSettings;
 

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -108,7 +108,7 @@ namespace MediaBrowser.Providers.TV
 
         /// <summary>
         /// Returns true if a series has any seasons or episodes without season or episode numbers
-        /// If this data is missing no virtual items will be added in order to prevent possible duplicates
+        /// If this data is missing no virtual items will be added in order to prevent possible duplicates.
         /// </summary>
         private bool HasInvalidContent(IList<BaseItem> allItems)
         {
@@ -171,7 +171,7 @@ namespace MediaBrowser.Providers.TV
         }
 
         /// <summary>
-        /// Removes the virtual entry after a corresponding physical version has been added
+        /// Removes the virtual entry after a corresponding physical version has been added.
         /// </summary>
         private bool RemoveObsoleteOrMissingEpisodes(
             IEnumerable<BaseItem> allRecursiveChildren,

--- a/RSSDP/DiscoveredSsdpDevice.cs
+++ b/RSSDP/DiscoveredSsdpDevice.cs
@@ -55,7 +55,7 @@ namespace Rssdp
         }
 
         /// <summary>
-        /// Returns the headers from the SSDP device response message
+        /// Returns the headers from the SSDP device response message.
         /// </summary>
         public HttpHeaders ResponseHeaders { get; set; }
 


### PR DESCRIPTION
**Changes**
Adds full stops at the end of '///' comments to fix SA1629

- -771 warnings

Match:
`(\s+\/\/\/[\w ,'\(\)\[\]\-]+)(\s+)*(?=\/\/\/ <\/summary>)`

Replace:
`$1.$2`

**Issues**
#2149 
