### PR TITLE
Add Authorization handlers

### DIFF
--- a/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Security;
 using MediaBrowser.Model.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 
 namespace Emby.Server.Implementations.HttpServer.Security
@@ -38,6 +39,14 @@ namespace Emby.Server.Implementations.HttpServer.Security
             return GetAuthorization(requestContext);
         }
 
+        public AuthorizationInfo GetAuthorizationInfo(HttpRequest requestContext)
+        {
+            var auth = GetAuthorizationDictionary(requestContext);
+            var (authInfo, _) =
+                GetAuthorizationInfoFromDictionary(auth, requestContext.Headers, requestContext.Query);
+            return authInfo;
+        }
+
         /// <summary>
         /// Gets the authorization.
         /// </summary>
@@ -46,7 +55,23 @@ namespace Emby.Server.Implementations.HttpServer.Security
         private AuthorizationInfo GetAuthorization(IRequest httpReq)
         {
             var auth = GetAuthorizationDictionary(httpReq);
+            var (authInfo, originalAuthInfo) =
+                GetAuthorizationInfoFromDictionary(auth, httpReq.Headers, httpReq.QueryString);
 
+            if (originalAuthInfo != null)
+            {
+                httpReq.Items["OriginalAuthenticationInfo"] = originalAuthInfo;
+            }
+
+            httpReq.Items["AuthorizationInfo"] = authInfo;
+            return authInfo;
+        }
+
+        private (AuthorizationInfo authInfo, AuthenticationInfo originalAuthenticationInfo) GetAuthorizationInfoFromDictionary(
+            in Dictionary<string, string> auth,
+            in IHeaderDictionary headers,
+            in IQueryCollection queryString)
+        {
             string deviceId = null;
             string device = null;
             string client = null;
@@ -64,19 +89,31 @@ namespace Emby.Server.Implementations.HttpServer.Security
 
             if (string.IsNullOrEmpty(token))
             {
-                token = httpReq.Headers["X-Emby-Token"];
+                token = headers["X-Jellyfin-Token"];
             }
 
             if (string.IsNullOrEmpty(token))
             {
-                token = httpReq.Headers["X-MediaBrowser-Token"];
-            }
-            if (string.IsNullOrEmpty(token))
-            {
-                token = httpReq.QueryString["api_key"];
+                token = headers["X-Emby-Token"];
             }
 
-            var info = new AuthorizationInfo
+            if (string.IsNullOrEmpty(token))
+            {
+                token = headers["X-MediaBrowser-Token"];
+            }
+
+            if (string.IsNullOrEmpty(token))
+            {
+                token = queryString["ApiKey"];
+            }
+
+            // TODO depricate this query parameter.
+            if (string.IsNullOrEmpty(token))
+            {
+                token = queryString["api_key"];
+            }
+
+            var authInfo = new AuthorizationInfo
             {
                 Client = client,
                 Device = device,
@@ -85,6 +122,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 Token = token
             };
 
+            AuthenticationInfo originalAuthenticationInfo = null;
             if (!string.IsNullOrWhiteSpace(token))
             {
                 var result = _authRepo.Get(new AuthenticationInfoQuery
@@ -92,81 +130,77 @@ namespace Emby.Server.Implementations.HttpServer.Security
                     AccessToken = token
                 });
 
-                var tokenInfo = result.Items.Count > 0 ? result.Items[0] : null;
+                originalAuthenticationInfo = result.Items.Count > 0 ? result.Items[0] : null;
 
-                if (tokenInfo != null)
+                if (originalAuthenticationInfo != null)
                 {
                     var updateToken = false;
 
                     // TODO: Remove these checks for IsNullOrWhiteSpace
-                    if (string.IsNullOrWhiteSpace(info.Client))
+                    if (string.IsNullOrWhiteSpace(authInfo.Client))
                     {
-                        info.Client = tokenInfo.AppName;
+                        authInfo.Client = originalAuthenticationInfo.AppName;
                     }
 
-                    if (string.IsNullOrWhiteSpace(info.DeviceId))
+                    if (string.IsNullOrWhiteSpace(authInfo.DeviceId))
                     {
-                        info.DeviceId = tokenInfo.DeviceId;
+                        authInfo.DeviceId = originalAuthenticationInfo.DeviceId;
                     }
 
                     // Temporary. TODO - allow clients to specify that the token has been shared with a casting device
-                    var allowTokenInfoUpdate = info.Client == null || info.Client.IndexOf("chromecast", StringComparison.OrdinalIgnoreCase) == -1;
+                    var allowTokenInfoUpdate = authInfo.Client == null || authInfo.Client.IndexOf("chromecast", StringComparison.OrdinalIgnoreCase) == -1;
 
-                    if (string.IsNullOrWhiteSpace(info.Device))
+                    if (string.IsNullOrWhiteSpace(authInfo.Device))
                     {
-                        info.Device = tokenInfo.DeviceName;
+                        authInfo.Device = originalAuthenticationInfo.DeviceName;
                     }
-
-                    else if (!string.Equals(info.Device, tokenInfo.DeviceName, StringComparison.OrdinalIgnoreCase))
+                    else if (!string.Equals(authInfo.Device, originalAuthenticationInfo.DeviceName, StringComparison.OrdinalIgnoreCase))
                     {
                         if (allowTokenInfoUpdate)
                         {
                             updateToken = true;
-                            tokenInfo.DeviceName = info.Device;
+                            originalAuthenticationInfo.DeviceName = authInfo.Device;
                         }
                     }
 
-                    if (string.IsNullOrWhiteSpace(info.Version))
+                    if (string.IsNullOrWhiteSpace(authInfo.Version))
                     {
-                        info.Version = tokenInfo.AppVersion;
+                        authInfo.Version = originalAuthenticationInfo.AppVersion;
                     }
-                    else if (!string.Equals(info.Version, tokenInfo.AppVersion, StringComparison.OrdinalIgnoreCase))
+                    else if (!string.Equals(authInfo.Version, originalAuthenticationInfo.AppVersion, StringComparison.OrdinalIgnoreCase))
                     {
                         if (allowTokenInfoUpdate)
                         {
                             updateToken = true;
-                            tokenInfo.AppVersion = info.Version;
+                            originalAuthenticationInfo.AppVersion = authInfo.Version;
                         }
                     }
 
-                    if ((DateTime.UtcNow - tokenInfo.DateLastActivity).TotalMinutes > 3)
+                    if ((DateTime.UtcNow - originalAuthenticationInfo.DateLastActivity).TotalMinutes > 3)
                     {
-                        tokenInfo.DateLastActivity = DateTime.UtcNow;
+                        originalAuthenticationInfo.DateLastActivity = DateTime.UtcNow;
                         updateToken = true;
                     }
 
-                    if (!tokenInfo.UserId.Equals(Guid.Empty))
+                    if (!originalAuthenticationInfo.UserId.Equals(Guid.Empty))
                     {
-                        info.User = _userManager.GetUserById(tokenInfo.UserId);
+                        authInfo.User = _userManager.GetUserById(originalAuthenticationInfo.UserId);
 
-                        if (info.User != null && !string.Equals(info.User.Username, tokenInfo.UserName, StringComparison.OrdinalIgnoreCase))
+                        if (authInfo.User != null && !string.Equals(authInfo.User.Username, originalAuthenticationInfo.UserName, StringComparison.OrdinalIgnoreCase))
                         {
-                            tokenInfo.UserName = info.User.Username;
+                            originalAuthenticationInfo.UserName = authInfo.User.Username;
                             updateToken = true;
                         }
                     }
 
                     if (updateToken)
                     {
-                        _authRepo.Update(tokenInfo);
+                        _authRepo.Update(originalAuthenticationInfo);
                     }
                 }
-                httpReq.Items["OriginalAuthenticationInfo"] = tokenInfo;
             }
 
-            httpReq.Items["AuthorizationInfo"] = info;
-
-            return info;
+            return (authInfo, originalAuthenticationInfo);
         }
 
         /// <summary>
@@ -176,7 +210,32 @@ namespace Emby.Server.Implementations.HttpServer.Security
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
         private Dictionary<string, string> GetAuthorizationDictionary(IRequest httpReq)
         {
-            var auth = httpReq.Headers["X-Emby-Authorization"];
+            var auth = httpReq.Headers["X-Jellyfin-Authorization"];
+            if (string.IsNullOrEmpty(auth))
+            {
+                auth = httpReq.Headers["X-Emby-Authorization"];
+            }
+
+            if (string.IsNullOrEmpty(auth))
+            {
+                auth = httpReq.Headers[HeaderNames.Authorization];
+            }
+
+            return GetAuthorization(auth);
+        }
+
+        /// <summary>
+        /// Gets the auth.
+        /// </summary>
+        /// <param name="httpReq">The HTTP req.</param>
+        /// <returns>Dictionary{System.StringSystem.String}.</returns>
+        private Dictionary<string, string> GetAuthorizationDictionary(HttpRequest httpReq)
+        {
+            var auth = httpReq.Headers["X-Jellyfin-Authorization"];
+            if (string.IsNullOrEmpty(auth))
+            {
+                auth = httpReq.Headers["X-Emby-Authorization"];
+            }
 
             if (string.IsNullOrEmpty(auth))
             {
@@ -206,7 +265,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 return null;
             }
 
-            var acceptedNames = new[] { "MediaBrowser", "Emby" };
+            var acceptedNames = new[] { "MediaBrowser", "Emby", "Jellyfin" };
 
             // It has to be a digest request
             if (!acceptedNames.Contains(parts[0], StringComparer.OrdinalIgnoreCase))
@@ -236,12 +295,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
 
         private static string NormalizeValue(string value)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            return WebUtility.HtmlEncode(value);
+            return string.IsNullOrEmpty(value) ? value : WebUtility.HtmlEncode(value);
         }
     }
 }

--- a/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
@@ -89,11 +89,6 @@ namespace Emby.Server.Implementations.HttpServer.Security
 
             if (string.IsNullOrEmpty(token))
             {
-                token = headers["X-Jellyfin-Token"];
-            }
-
-            if (string.IsNullOrEmpty(token))
-            {
                 token = headers["X-Emby-Token"];
             }
 
@@ -210,11 +205,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
         private Dictionary<string, string> GetAuthorizationDictionary(IRequest httpReq)
         {
-            var auth = httpReq.Headers["X-Jellyfin-Authorization"];
-            if (string.IsNullOrEmpty(auth))
-            {
-                auth = httpReq.Headers["X-Emby-Authorization"];
-            }
+            var auth = httpReq.Headers["X-Emby-Authorization"];
 
             if (string.IsNullOrEmpty(auth))
             {
@@ -231,11 +222,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
         private Dictionary<string, string> GetAuthorizationDictionary(HttpRequest httpReq)
         {
-            var auth = httpReq.Headers["X-Jellyfin-Authorization"];
-            if (string.IsNullOrEmpty(auth))
-            {
-                auth = httpReq.Headers["X-Emby-Authorization"];
-            }
+            var auth = httpReq.Headers["X-Emby-Authorization"];
 
             if (string.IsNullOrEmpty(auth))
             {
@@ -265,7 +252,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 return null;
             }
 
-            var acceptedNames = new[] { "MediaBrowser", "Emby", "Jellyfin" };
+            var acceptedNames = new[] { "MediaBrowser", "Emby" };
 
             // It has to be a digest request
             if (!acceptedNames.Contains(parts[0], StringComparer.OrdinalIgnoreCase))

--- a/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
@@ -107,7 +107,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 token = queryString["ApiKey"];
             }
 
-            // TODO depricate this query parameter.
+            // TODO deprecate this query parameter.
             if (string.IsNullOrEmpty(token))
             {
                 token = queryString["api_key"];

--- a/Jellyfin.Api/Auth/BaseAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/BaseAuthorizationHandler.cs
@@ -1,0 +1,102 @@
+﻿#nullable enable
+
+using System.Net;
+using System.Security.Claims;
+using Jellyfin.Api.Helpers;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Api.Auth
+{
+    /// <summary>
+    /// Base authorization handler.
+    /// </summary>
+    /// <typeparam name="T">Type of Authorization Requirement.</typeparam>
+    public abstract class BaseAuthorizationHandler<T> : AuthorizationHandler<T>
+        where T : IAuthorizationRequirement
+    {
+        private readonly IUserManager _userManager;
+        private readonly INetworkManager _networkManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseAuthorizationHandler{T}"/> class.
+        /// </summary>
+        /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+        /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
+        /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
+        protected BaseAuthorizationHandler(
+            IUserManager userManager,
+            INetworkManager networkManager,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _userManager = userManager;
+            _networkManager = networkManager;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <summary>
+        /// Validate authenticated claims.
+        /// </summary>
+        /// <param name="claimsPrincipal">Request claims.</param>
+        /// <param name="ignoreSchedule">Whether to ignore parental control.</param>
+        /// <param name="localAccessOnly">Whether access is to be allowed locally only.</param>
+        /// <returns>Validated claim status.</returns>
+        protected bool ValidateClaims(
+            ClaimsPrincipal claimsPrincipal,
+            bool ignoreSchedule = false,
+            bool localAccessOnly = false)
+        {
+            // Ensure claim has userId.
+            var userId = ClaimHelpers.GetUserId(claimsPrincipal);
+            if (userId == null)
+            {
+                return false;
+            }
+
+            // Ensure userId links to a valid user.
+            var user = _userManager.GetUserById(userId.Value);
+            if (user == null)
+            {
+                return false;
+            }
+
+            // Ensure user is not disabled.
+            if (user.HasPermission(PermissionKind.IsDisabled))
+            {
+                return false;
+            }
+
+            var ip = NormalizeIp(_httpContextAccessor.HttpContext.Connection.RemoteIpAddress).ToString();
+            var isInLocalNetwork = _networkManager.IsInLocalNetwork(ip);
+            // User cannot access remotely and user is remote
+            if (!user.HasPermission(PermissionKind.EnableRemoteAccess) && !isInLocalNetwork)
+            {
+                return false;
+            }
+
+            if (localAccessOnly && !isInLocalNetwork)
+            {
+                return false;
+            }
+
+            // User attempting to access out of parental control hours.
+            if (!ignoreSchedule
+                && !user.HasPermission(PermissionKind.IsAdministrator)
+                && !user.IsParentalScheduleAllowed())
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static IPAddress NormalizeIp(IPAddress ip)
+        {
+            return ip.IsIPv4MappedToIPv6 ? ip.MapToIPv4() : ip;
+        }
+    }
+}

--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace Jellyfin.Api.Auth
                     new Claim(InternalClaimTypes.Device, authorizationInfo.Device),
                     new Claim(InternalClaimTypes.Client, authorizationInfo.Client),
                     new Claim(InternalClaimTypes.Version, authorizationInfo.Version),
-                    new Claim(InternalClaimTypes.Token, authorizationInfo.Token)
+                    new Claim(InternalClaimTypes.Token, authorizationInfo.Token),
                 };
 
                 var identity = new ClaimsIdentity(claims, Scheme.Name);

--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,3 +1,6 @@
+#nullable enable
+
+using System.Globalization;
 using System.Security.Authentication;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
@@ -39,15 +42,10 @@ namespace Jellyfin.Api.Auth
         /// <inheritdoc />
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            var authenticatedAttribute = new AuthenticatedAttribute
-            {
-                IgnoreLegacyAuth = true
-            };
-
             try
             {
-                var user = _authService.Authenticate(Request, authenticatedAttribute);
-                if (user == null)
+                var authorizationInfo = _authService.Authenticate(Request);
+                if (authorizationInfo == null)
                 {
                     return Task.FromResult(AuthenticateResult.NoResult());
                     // TODO return when legacy API is removed.
@@ -57,11 +55,16 @@ namespace Jellyfin.Api.Auth
 
                 var claims = new[]
                 {
-                    new Claim(ClaimTypes.Name, user.Username),
-                    new Claim(
-                        ClaimTypes.Role,
-                        value: user.HasPermission(PermissionKind.IsAdministrator) ? UserRoles.Administrator : UserRoles.User)
+                    new Claim(ClaimTypes.Name, authorizationInfo.User.Username),
+                    new Claim(ClaimTypes.Role, value: authorizationInfo.User.HasPermission(PermissionKind.IsAdministrator) ? UserRoles.Administrator : UserRoles.User),
+                    new Claim(InternalClaimTypes.UserId, authorizationInfo.UserId.ToString("N", CultureInfo.InvariantCulture)),
+                    new Claim(InternalClaimTypes.DeviceId, authorizationInfo.DeviceId),
+                    new Claim(InternalClaimTypes.Device, authorizationInfo.Device),
+                    new Claim(InternalClaimTypes.Client, authorizationInfo.Client),
+                    new Claim(InternalClaimTypes.Version, authorizationInfo.Version),
+                    new Claim(InternalClaimTypes.Token, authorizationInfo.Token)
                 };
+
                 var identity = new ClaimsIdentity(claims, Scheme.Name);
                 var principal = new ClaimsPrincipal(identity);
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);

--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
@@ -1,24 +1,23 @@
-using System.Threading.Tasks;
-using Jellyfin.Api.Constants;
+﻿using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 
-namespace Jellyfin.Api.Auth.RequiresElevationPolicy
+namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
 {
     /// <summary>
-    /// Authorization handler for requiring elevated privileges.
+    /// Default authorization handler.
     /// </summary>
-    public class RequiresElevationHandler : BaseAuthorizationHandler<RequiresElevationRequirement>
+    public class DefaultAuthorizationHandler : BaseAuthorizationHandler<DefaultAuthorizationRequirement>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresElevationHandler"/> class.
+        /// Initializes a new instance of the <see cref="DefaultAuthorizationHandler"/> class.
         /// </summary>
         /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
         /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
         /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
-        public RequiresElevationHandler(
+        public DefaultAuthorizationHandler(
             IUserManager userManager,
             INetworkManager networkManager,
             IHttpContextAccessor httpContextAccessor)
@@ -27,18 +26,16 @@ namespace Jellyfin.Api.Auth.RequiresElevationPolicy
         }
 
         /// <inheritdoc />
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RequiresElevationRequirement requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, DefaultAuthorizationRequirement requirement)
         {
             var validated = ValidateClaims(context.User);
-            if (validated && context.User.IsInRole(UserRoles.Administrator))
-            {
-                context.Succeed(requirement);
-            }
-            else
+            if (!validated)
             {
                 context.Fail();
+                return Task.CompletedTask;
             }
 
+            context.Succeed(requirement);
             return Task.CompletedTask;
         }
     }

--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationRequirement.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationRequirement.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
+{
+    /// <summary>
+    /// The default authorization requirement.
+    /// </summary>
+    public class DefaultAuthorizationRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/Jellyfin.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy
             if (!_configurationManager.CommonConfiguration.IsStartupWizardCompleted)
             {
                 context.Succeed(firstTimeSetupOrElevatedRequirement);
+                return Task.CompletedTask;
             }
 
             var validated = ValidateClaims(context.User);

--- a/Jellyfin.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandler.cs
@@ -1,22 +1,33 @@
 using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 
 namespace Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy
 {
     /// <summary>
     /// Authorization handler for requiring first time setup or elevated privileges.
     /// </summary>
-    public class FirstTimeSetupOrElevatedHandler : AuthorizationHandler<FirstTimeSetupOrElevatedRequirement>
+    public class FirstTimeSetupOrElevatedHandler : BaseAuthorizationHandler<FirstTimeSetupOrElevatedRequirement>
     {
         private readonly IConfigurationManager _configurationManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirstTimeSetupOrElevatedHandler" /> class.
         /// </summary>
-        /// <param name="configurationManager">The jellyfin configuration manager.</param>
-        public FirstTimeSetupOrElevatedHandler(IConfigurationManager configurationManager)
+        /// <param name="configurationManager">Instance of the <see cref="IConfigurationManager"/> interface.</param>
+        /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+        /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
+        /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
+        public FirstTimeSetupOrElevatedHandler(
+            IConfigurationManager configurationManager,
+            IUserManager userManager,
+            INetworkManager networkManager,
+            IHttpContextAccessor httpContextAccessor)
+            : base(userManager, networkManager, httpContextAccessor)
         {
             _configurationManager = configurationManager;
         }
@@ -28,7 +39,9 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy
             {
                 context.Succeed(firstTimeSetupOrElevatedRequirement);
             }
-            else if (context.User.IsInRole(UserRoles.Administrator))
+
+            var validated = ValidateClaims(context.User);
+            if (validated && context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(firstTimeSetupOrElevatedRequirement);
             }

--- a/Jellyfin.Api/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandler.cs
+++ b/Jellyfin.Api/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandler.cs
@@ -1,24 +1,23 @@
-using System.Threading.Tasks;
-using Jellyfin.Api.Constants;
+﻿using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 
-namespace Jellyfin.Api.Auth.RequiresElevationPolicy
+namespace Jellyfin.Api.Auth.IgnoreSchedulePolicy
 {
     /// <summary>
-    /// Authorization handler for requiring elevated privileges.
+    /// Escape schedule controls handler.
     /// </summary>
-    public class RequiresElevationHandler : BaseAuthorizationHandler<RequiresElevationRequirement>
+    public class IgnoreScheduleHandler : BaseAuthorizationHandler<IgnoreScheduleRequirement>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresElevationHandler"/> class.
+        /// Initializes a new instance of the <see cref="IgnoreScheduleHandler"/> class.
         /// </summary>
         /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
         /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
         /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
-        public RequiresElevationHandler(
+        public IgnoreScheduleHandler(
             IUserManager userManager,
             INetworkManager networkManager,
             IHttpContextAccessor httpContextAccessor)
@@ -27,18 +26,16 @@ namespace Jellyfin.Api.Auth.RequiresElevationPolicy
         }
 
         /// <inheritdoc />
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RequiresElevationRequirement requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, IgnoreScheduleRequirement requirement)
         {
-            var validated = ValidateClaims(context.User);
-            if (validated && context.User.IsInRole(UserRoles.Administrator))
-            {
-                context.Succeed(requirement);
-            }
-            else
+            var validated = ValidateClaims(context.User, ignoreSchedule: true);
+            if (!validated)
             {
                 context.Fail();
+                return Task.CompletedTask;
             }
 
+            context.Succeed(requirement);
             return Task.CompletedTask;
         }
     }

--- a/Jellyfin.Api/Auth/IgnoreSchedulePolicy/IgnoreScheduleRequirement.cs
+++ b/Jellyfin.Api/Auth/IgnoreSchedulePolicy/IgnoreScheduleRequirement.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Jellyfin.Api.Auth.IgnoreSchedulePolicy
+{
+    /// <summary>
+    /// Escape schedule controls requirement.
+    /// </summary>
+    public class IgnoreScheduleRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/Jellyfin.Api/Auth/LocalAccessPolicy/LocalAccessHandler.cs
+++ b/Jellyfin.Api/Auth/LocalAccessPolicy/LocalAccessHandler.cs
@@ -1,24 +1,23 @@
-using System.Threading.Tasks;
-using Jellyfin.Api.Constants;
+﻿using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 
-namespace Jellyfin.Api.Auth.RequiresElevationPolicy
+namespace Jellyfin.Api.Auth.LocalAccessPolicy
 {
     /// <summary>
-    /// Authorization handler for requiring elevated privileges.
+    /// Local access handler.
     /// </summary>
-    public class RequiresElevationHandler : BaseAuthorizationHandler<RequiresElevationRequirement>
+    public class LocalAccessHandler : BaseAuthorizationHandler<LocalAccessRequirement>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresElevationHandler"/> class.
+        /// Initializes a new instance of the <see cref="LocalAccessHandler"/> class.
         /// </summary>
         /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
         /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
         /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
-        public RequiresElevationHandler(
+        public LocalAccessHandler(
             IUserManager userManager,
             INetworkManager networkManager,
             IHttpContextAccessor httpContextAccessor)
@@ -27,16 +26,16 @@ namespace Jellyfin.Api.Auth.RequiresElevationPolicy
         }
 
         /// <inheritdoc />
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RequiresElevationRequirement requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, LocalAccessRequirement requirement)
         {
-            var validated = ValidateClaims(context.User);
-            if (validated && context.User.IsInRole(UserRoles.Administrator))
+            var validated = ValidateClaims(context.User, localAccessOnly: true);
+            if (!validated)
             {
-                context.Succeed(requirement);
+                context.Fail();
             }
             else
             {
-                context.Fail();
+                context.Succeed(requirement);
             }
 
             return Task.CompletedTask;

--- a/Jellyfin.Api/Auth/LocalAccessPolicy/LocalAccessRequirement.cs
+++ b/Jellyfin.Api/Auth/LocalAccessPolicy/LocalAccessRequirement.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Jellyfin.Api.Auth.LocalAccessPolicy
+{
+    /// <summary>
+    /// The local access authorization requirement.
+    /// </summary>
+    public class LocalAccessRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/Jellyfin.Api/Constants/InternalClaimTypes.cs
+++ b/Jellyfin.Api/Constants/InternalClaimTypes.cs
@@ -1,0 +1,38 @@
+﻿namespace Jellyfin.Api.Constants
+{
+    /// <summary>
+    /// Internal claim types for authorization.
+    /// </summary>
+    public static class InternalClaimTypes
+    {
+        /// <summary>
+        /// User Id.
+        /// </summary>
+        public const string UserId = "Jellyfin-UserId";
+
+        /// <summary>
+        /// Device Id.
+        /// </summary>
+        public const string DeviceId = "Jellyfin-DeviceId";
+
+        /// <summary>
+        /// Device.
+        /// </summary>
+        public const string Device = "Jellyfin-Device";
+
+        /// <summary>
+        /// Client.
+        /// </summary>
+        public const string Client = "Jellyfin-Client";
+
+        /// <summary>
+        /// Version.
+        /// </summary>
+        public const string Version = "Jellyfin-Version";
+
+        /// <summary>
+        /// Token.
+        /// </summary>
+        public const string Token = "Jellyfin-Token";
+    }
+}

--- a/Jellyfin.Api/Constants/Policies.cs
+++ b/Jellyfin.Api/Constants/Policies.cs
@@ -6,6 +6,11 @@ namespace Jellyfin.Api.Constants
     public static class Policies
     {
         /// <summary>
+        /// Policy name for default authorization.
+        /// </summary>
+        public const string DefaultAuthorization = "DefaultAuthorization";
+
+        /// <summary>
         /// Policy name for requiring first time setup or elevated privileges.
         /// </summary>
         public const string FirstTimeSetupOrElevated = "FirstTimeOrElevated";
@@ -14,5 +19,15 @@ namespace Jellyfin.Api.Constants
         /// Policy name for requiring elevated privileges.
         /// </summary>
         public const string RequiresElevation = "RequiresElevation";
+
+        /// <summary>
+        /// Policy name for allowing local access only.
+        /// </summary>
+        public const string LocalAccessOnly = "LocalAccessOnly";
+
+        /// <summary>
+        /// Policy name for escaping schedule controls.
+        /// </summary>
+        public const string IgnoreSchedule = "IgnoreSchedule";
     }
 }

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Api.Controllers
     /// Configuration Controller.
     /// </summary>
     [Route("System")]
-    [Authorize]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class ConfigurationController : BaseJellyfinApiController
     {
         private readonly IServerConfigurationManager _configurationManager;

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Api.Controllers
     /// <summary>
     /// Devices Controller.
     /// </summary>
-    [Authorize]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class DevicesController : BaseJellyfinApiController
     {
         private readonly IDeviceManager _deviceManager;

--- a/Jellyfin.Api/Controllers/PackageController.cs
+++ b/Jellyfin.Api/Controllers/PackageController.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Api.Controllers
     /// Package Controller.
     /// </summary>
     [Route("Packages")]
-    [Authorize]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class PackageController : BaseJellyfinApiController
     {
         private readonly IInstallationManager _installationManager;

--- a/Jellyfin.Api/Controllers/SearchController.cs
+++ b/Jellyfin.Api/Controllers/SearchController.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using Jellyfin.Api.Constants;
 using Jellyfin.Api.Helpers;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Dto;
@@ -23,7 +24,7 @@ namespace Jellyfin.Api.Controllers
     /// Search controller.
     /// </summary>
     [Route("/Search/Hints")]
-    [Authorize]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class SearchController : BaseJellyfinApiController
     {
         private readonly ISearchEngine _searchEngine;

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -110,7 +110,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">Subtitles retrieved.</response>
         /// <returns>An array of <see cref="RemoteSubtitleInfo"/>.</returns>
         [HttpGet("/Items/{id}/RemoteSearch/Subtitles/{language}")]
-        [Authorize]
+        [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<RemoteSubtitleInfo>>> SearchRemoteSubtitles(
             [FromRoute] Guid id,
@@ -130,7 +130,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="204">Subtitle downloaded.</response>
         /// <returns>A <see cref="NoContentResult"/>.</returns>
         [HttpPost("/Items/{id}/RemoteSearch/Subtitles/{subtitleId}")]
-        [Authorize]
+        [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public async Task<ActionResult> DownloadRemoteSubtitles(
             [FromRoute] Guid id,
@@ -160,7 +160,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">File returned.</response>
         /// <returns>A <see cref="FileStreamResult"/> with the subtitle file.</returns>
         [HttpGet("/Providers/Subtitles/Subtitles/{id}")]
-        [Authorize]
+        [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [Produces(MediaTypeNames.Application.Octet)]
         public async Task<ActionResult> GetRemoteSubtitles([FromRoute] string id)
@@ -250,7 +250,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">Subtitle playlist retrieved.</response>
         /// <returns>A <see cref="FileContentResult"/> with the HLS subtitle playlist.</returns>
         [HttpGet("/Videos/{id}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8")]
-        [Authorize]
+        [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult> GetSubtitlePlaylist(
             [FromRoute] Guid id,

--- a/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
+++ b/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
@@ -4,6 +4,7 @@ using System;
 using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
@@ -17,7 +18,7 @@ namespace Jellyfin.Api.Controllers
     /// Attachments controller.
     /// </summary>
     [Route("Videos")]
-    [Authorize]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class VideoAttachmentsController : BaseJellyfinApiController
     {
         private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Helpers/ClaimHelpers.cs
+++ b/Jellyfin.Api/Helpers/ClaimHelpers.cs
@@ -1,0 +1,77 @@
+﻿﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using Jellyfin.Api.Constants;
+
+namespace Jellyfin.Api.Helpers
+{
+    /// <summary>
+    /// Claim Helpers.
+    /// </summary>
+    public static class ClaimHelpers
+    {
+        /// <summary>
+        /// Get user id from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>User id.</returns>
+        public static Guid? GetUserId(in ClaimsPrincipal user)
+        {
+            var value = GetClaimValue(user, InternalClaimTypes.UserId);
+            return string.IsNullOrEmpty(value)
+                ? null
+                : (Guid?)Guid.Parse(value);
+        }
+
+        /// <summary>
+        /// Get device id from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>Device id.</returns>
+        public static string? GetDeviceId(in ClaimsPrincipal user)
+            => GetClaimValue(user, InternalClaimTypes.DeviceId);
+
+        /// <summary>
+        /// Get device from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>Device.</returns>
+        public static string? GetDevice(in ClaimsPrincipal user)
+            => GetClaimValue(user, InternalClaimTypes.Device);
+
+        /// <summary>
+        /// Get client from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>Client.</returns>
+        public static string? GetClient(in ClaimsPrincipal user)
+            => GetClaimValue(user, InternalClaimTypes.Client);
+
+        /// <summary>
+        /// Get version from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>Version.</returns>
+        public static string? GetVersion(in ClaimsPrincipal user)
+            => GetClaimValue(user, InternalClaimTypes.Version);
+
+        /// <summary>
+        /// Get token from claims.
+        /// </summary>
+        /// <param name="user">Current claims principal.</param>
+        /// <returns>Token.</returns>
+        public static string? GetToken(in ClaimsPrincipal user)
+            => GetClaimValue(user, InternalClaimTypes.Token);
+
+        private static string? GetClaimValue(in ClaimsPrincipal user, string name)
+        {
+            return user?.Identities
+                .SelectMany(c => c.Claims)
+                .Where(claim => claim.Type.Equals(name, StringComparison.OrdinalIgnoreCase))
+                .Select(claim => claim.Value)
+                .FirstOrDefault();
+        }
+    }
+}

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ using MediaBrowser.Common.Json;
 using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -104,6 +106,10 @@ namespace Jellyfin.Server.Extensions
                 .AddCors(options =>
                 {
                     options.AddPolicy(ServerCorsPolicy.DefaultPolicyName, ServerCorsPolicy.DefaultPolicy);
+                })
+                .Configure<ForwardedHeadersOptions>(options =>
+                {
+                    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
                 })
                 .AddMvc(opts =>
                 {

--- a/MediaBrowser.Controller/Net/IAuthService.cs
+++ b/MediaBrowser.Controller/Net/IAuthService.cs
@@ -6,10 +6,31 @@ using Microsoft.AspNetCore.Http;
 
 namespace MediaBrowser.Controller.Net
 {
+    /// <summary>
+    /// IAuthService.
+    /// </summary>
     public interface IAuthService
     {
-        void Authenticate(IRequest request, IAuthenticationAttributes authAttribtues);
+        /// <summary>
+        /// Authenticate and authorize request.
+        /// </summary>
+        /// <param name="request">Request.</param>
+        /// <param name="authAttribtutes">Authorization attributes.</param>
+        void Authenticate(IRequest request, IAuthenticationAttributes authAttribtutes);
 
-        User? Authenticate(HttpRequest request, IAuthenticationAttributes authAttribtues);
+        /// <summary>
+        /// Authenticate and authorize request.
+        /// </summary>
+        /// <param name="request">Request.</param>
+        /// <param name="authAttribtutes">Authorization attributes.</param>
+        /// <returns>Authenticated user.</returns>
+        User? Authenticate(HttpRequest request, IAuthenticationAttributes authAttribtutes);
+
+        /// <summary>
+        /// Authenticate request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>Authorization information. Null if unauthenticated.</returns>
+        AuthorizationInfo Authenticate(HttpRequest request);
     }
 }

--- a/MediaBrowser.Controller/Net/IAuthorizationContext.cs
+++ b/MediaBrowser.Controller/Net/IAuthorizationContext.cs
@@ -1,7 +1,11 @@
 using MediaBrowser.Model.Services;
+using Microsoft.AspNetCore.Http;
 
 namespace MediaBrowser.Controller.Net
 {
+    /// <summary>
+    /// IAuthorization context.
+    /// </summary>
     public interface IAuthorizationContext
     {
         /// <summary>
@@ -17,5 +21,12 @@ namespace MediaBrowser.Controller.Net
         /// <param name="requestContext">The request context.</param>
         /// <returns>AuthorizationInfo.</returns>
         AuthorizationInfo GetAuthorizationInfo(IRequest requestContext);
+
+        /// <summary>
+        /// Gets the authorization information.
+        /// </summary>
+        /// <param name="requestContext">The request context.</param>
+        /// <returns>AuthorizationInfo.</returns>
+        AuthorizationInfo GetAuthorizationInfo(HttpRequest requestContext);
     }
 }

--- a/tests/Jellyfin.Api.Tests/Auth/CustomAuthenticationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/CustomAuthenticationHandlerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Security.Claims;
-using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
@@ -9,7 +8,6 @@ using Jellyfin.Api.Auth;
 using Jellyfin.Api.Constants;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Net;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -26,12 +24,6 @@ namespace Jellyfin.Api.Tests.Auth
         private readonly IFixture _fixture;
 
         private readonly Mock<IAuthService> _jellyfinAuthServiceMock;
-        private readonly Mock<IOptionsMonitor<AuthenticationSchemeOptions>> _optionsMonitorMock;
-        private readonly Mock<ISystemClock> _clockMock;
-        private readonly Mock<IServiceProvider> _serviceProviderMock;
-        private readonly Mock<IAuthenticationService> _authenticationServiceMock;
-        private readonly UrlEncoder _urlEncoder;
-        private readonly HttpContext _context;
 
         private readonly CustomAuthenticationHandler _sut;
         private readonly AuthenticationScheme _scheme;
@@ -47,26 +39,23 @@ namespace Jellyfin.Api.Tests.Auth
             AllowFixtureCircularDependencies();
 
             _jellyfinAuthServiceMock = _fixture.Freeze<Mock<IAuthService>>();
-            _optionsMonitorMock = _fixture.Freeze<Mock<IOptionsMonitor<AuthenticationSchemeOptions>>>();
-            _clockMock = _fixture.Freeze<Mock<ISystemClock>>();
-            _serviceProviderMock = _fixture.Freeze<Mock<IServiceProvider>>();
-            _authenticationServiceMock = _fixture.Freeze<Mock<IAuthenticationService>>();
+            var optionsMonitorMock = _fixture.Freeze<Mock<IOptionsMonitor<AuthenticationSchemeOptions>>>();
+            var serviceProviderMock = _fixture.Freeze<Mock<IServiceProvider>>();
+            var authenticationServiceMock = _fixture.Freeze<Mock<IAuthenticationService>>();
             _fixture.Register<ILoggerFactory>(() => new NullLoggerFactory());
 
-            _urlEncoder = UrlEncoder.Default;
+            serviceProviderMock.Setup(s => s.GetService(typeof(IAuthenticationService)))
+                .Returns(authenticationServiceMock.Object);
 
-            _serviceProviderMock.Setup(s => s.GetService(typeof(IAuthenticationService)))
-                .Returns(_authenticationServiceMock.Object);
-
-            _optionsMonitorMock.Setup(o => o.Get(It.IsAny<string>()))
+            optionsMonitorMock.Setup(o => o.Get(It.IsAny<string>()))
                 .Returns(new AuthenticationSchemeOptions
                 {
                     ForwardAuthenticate = null
                 });
 
-            _context = new DefaultHttpContext
+            HttpContext context = new DefaultHttpContext
             {
-                RequestServices = _serviceProviderMock.Object
+                RequestServices = serviceProviderMock.Object
             };
 
             _scheme = new AuthenticationScheme(
@@ -75,24 +64,7 @@ namespace Jellyfin.Api.Tests.Auth
                 typeof(CustomAuthenticationHandler));
 
             _sut = _fixture.Create<CustomAuthenticationHandler>();
-            _sut.InitializeAsync(_scheme, _context).Wait();
-        }
-
-        [Fact]
-        public async Task HandleAuthenticateAsyncShouldFailWithNullUser()
-        {
-            _jellyfinAuthServiceMock.Setup(
-                    a => a.Authenticate(
-                        It.IsAny<HttpRequest>(),
-                        It.IsAny<AuthenticatedAttribute>()))
-                .Returns((User?)null);
-
-            var authenticateResult = await _sut.AuthenticateAsync();
-
-            Assert.False(authenticateResult.Succeeded);
-            Assert.True(authenticateResult.None);
-            // TODO return when legacy API is removed.
-            // Assert.Equal("Invalid user", authenticateResult.Failure.Message);
+            _sut.InitializeAsync(_scheme, context).Wait();
         }
 
         [Fact]
@@ -102,8 +74,7 @@ namespace Jellyfin.Api.Tests.Auth
 
             _jellyfinAuthServiceMock.Setup(
                     a => a.Authenticate(
-                        It.IsAny<HttpRequest>(),
-                        It.IsAny<AuthenticatedAttribute>()))
+                        It.IsAny<HttpRequest>()))
                 .Throws(new SecurityException(errorMessage));
 
             var authenticateResult = await _sut.AuthenticateAsync();
@@ -125,10 +96,10 @@ namespace Jellyfin.Api.Tests.Auth
         [Fact]
         public async Task HandleAuthenticateAsyncShouldAssignNameClaim()
         {
-            var user = SetupUser();
+            var authorizationInfo = SetupUser();
             var authenticateResult = await _sut.AuthenticateAsync();
 
-            Assert.True(authenticateResult.Principal.HasClaim(ClaimTypes.Name, user.Username));
+            Assert.True(authenticateResult.Principal.HasClaim(ClaimTypes.Name, authorizationInfo.User.Username));
         }
 
         [Theory]
@@ -136,10 +107,10 @@ namespace Jellyfin.Api.Tests.Auth
         [InlineData(false)]
         public async Task HandleAuthenticateAsyncShouldAssignRoleClaim(bool isAdmin)
         {
-            var user = SetupUser(isAdmin);
+            var authorizationInfo = SetupUser(isAdmin);
             var authenticateResult = await _sut.AuthenticateAsync();
 
-            var expectedRole = user.HasPermission(PermissionKind.IsAdministrator) ? UserRoles.Administrator : UserRoles.User;
+            var expectedRole = authorizationInfo.User.HasPermission(PermissionKind.IsAdministrator) ? UserRoles.Administrator : UserRoles.User;
             Assert.True(authenticateResult.Principal.HasClaim(ClaimTypes.Role, expectedRole));
         }
 
@@ -152,18 +123,18 @@ namespace Jellyfin.Api.Tests.Auth
             Assert.Equal(_scheme.Name, authenticatedResult.Ticket.AuthenticationScheme);
         }
 
-        private User SetupUser(bool isAdmin = false)
+        private AuthorizationInfo SetupUser(bool isAdmin = false)
         {
-            var user = _fixture.Create<User>();
-            user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
+            var authorizationInfo = _fixture.Create<AuthorizationInfo>();
+            authorizationInfo.User = _fixture.Create<User>();
+            authorizationInfo.User.SetPermission(PermissionKind.IsAdministrator, isAdmin);
 
             _jellyfinAuthServiceMock.Setup(
                     a => a.Authenticate(
-                        It.IsAny<HttpRequest>(),
-                        It.IsAny<AuthenticatedAttribute>()))
-                .Returns(user);
+                        It.IsAny<HttpRequest>()))
+                .Returns(authorizationInfo);
 
-            return user;
+            return authorizationInfo;
         }
 
         private void AllowFixtureCircularDependencies()

--- a/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
-using Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy;
+using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
@@ -11,51 +11,32 @@ using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
+namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
 {
-    public class FirstTimeSetupOrElevatedHandlerTests
+    public class DefaultAuthorizationHandlerTests
     {
         private readonly Mock<IConfigurationManager> _configurationManagerMock;
         private readonly List<IAuthorizationRequirement> _requirements;
-        private readonly FirstTimeSetupOrElevatedHandler _sut;
+        private readonly DefaultAuthorizationHandler _sut;
         private readonly Mock<IUserManager> _userManagerMock;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
-        public FirstTimeSetupOrElevatedHandlerTests()
+        public DefaultAuthorizationHandlerTests()
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization());
             _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
-            _requirements = new List<IAuthorizationRequirement> { new FirstTimeSetupOrElevatedRequirement() };
+            _requirements = new List<IAuthorizationRequirement> { new DefaultAuthorizationRequirement() };
             _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
             _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
 
-            _sut = fixture.Create<FirstTimeSetupOrElevatedHandler>();
+            _sut = fixture.Create<DefaultAuthorizationHandler>();
         }
 
         [Theory]
         [InlineData(UserRoles.Administrator)]
         [InlineData(UserRoles.Guest)]
         [InlineData(UserRoles.User)]
-        public async Task ShouldSucceedIfStartupWizardIncomplete(string userRole)
-        {
-            TestHelpers.SetupConfigurationManager(_configurationManagerMock, false);
-            var (_, claims) = TestHelpers.SetupUser(
-                _userManagerMock,
-                _httpContextAccessor,
-                userRole,
-                TestHelpers.InternalIp);
-
-            var context = new AuthorizationHandlerContext(_requirements, claims, null);
-
-            await _sut.HandleAsync(context);
-            Assert.True(context.HasSucceeded);
-        }
-
-        [Theory]
-        [InlineData(UserRoles.Administrator, true)]
-        [InlineData(UserRoles.Guest, false)]
-        [InlineData(UserRoles.User, false)]
-        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
+        public async Task ShouldSucceedOnUser(string userRole)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var (_, claims) = TestHelpers.SetupUser(
@@ -67,7 +48,7 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _sut.HandleAsync(context);
-            Assert.Equal(shouldSucceed, context.HasSucceeded);
+            Assert.True(context.HasSucceeded);
         }
     }
 }

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandlerTests.cs
@@ -39,11 +39,10 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
         public async Task ShouldSucceedIfStartupWizardIncomplete(string userRole)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, false);
-            var (_, claims) = TestHelpers.SetupUser(
+            var claims = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
-                userRole,
-                TestHelpers.InternalIp);
+                userRole);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
@@ -58,11 +57,10 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
         public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var (_, claims) = TestHelpers.SetupUser(
+            var claims = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
-                userRole,
-                TestHelpers.InternalIp);
+                userRole);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupOrElevatedPolicy/FirstTimeSetupOrElevatedHandlerTests.cs
@@ -1,13 +1,21 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy;
 using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
+using Jellyfin.Server.Implementations.Users;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Configuration;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 
@@ -15,15 +23,28 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
 {
     public class FirstTimeSetupOrElevatedHandlerTests
     {
+        /// <summary>
+        /// 127.0.0.1.
+        /// </summary>
+        private const long InternalIp = 16777343;
+
+        /// <summary>
+        /// 1.1.1.1.
+        /// </summary>
+        /// private const long ExternalIp = 16843009;
         private readonly Mock<IConfigurationManager> _configurationManagerMock;
         private readonly List<IAuthorizationRequirement> _requirements;
         private readonly FirstTimeSetupOrElevatedHandler _sut;
+        private readonly Mock<IUserManager> _userManagerMock;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
         public FirstTimeSetupOrElevatedHandlerTests()
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization());
             _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
             _requirements = new List<IAuthorizationRequirement> { new FirstTimeSetupOrElevatedRequirement() };
+            _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
+            _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
 
             _sut = fixture.Create<FirstTimeSetupOrElevatedHandler>();
         }
@@ -35,8 +56,15 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
         public async Task ShouldSucceedIfStartupWizardIncomplete(string userRole)
         {
             SetupConfigurationManager(false);
-            var user = SetupUser(userRole);
-            var context = new AuthorizationHandlerContext(_requirements, user, null);
+            var (user, claims) = SetupUser(userRole);
+
+            _userManagerMock.Setup(u => u.GetUserById(It.IsAny<Guid>()))
+                .Returns(user);
+
+            _httpContextAccessor.Setup(h => h.HttpContext.Connection.RemoteIpAddress)
+                .Returns(new IPAddress(InternalIp));
+
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _sut.HandleAsync(context);
             Assert.True(context.HasSucceeded);
@@ -49,18 +77,42 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
         public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
         {
             SetupConfigurationManager(true);
-            var user = SetupUser(userRole);
-            var context = new AuthorizationHandlerContext(_requirements, user, null);
+            var (user, claims) = SetupUser(userRole);
+
+            _userManagerMock.Setup(u => u.GetUserById(It.IsAny<Guid>()))
+                .Returns(user);
+
+            _httpContextAccessor.Setup(h => h.HttpContext.Connection.RemoteIpAddress)
+                .Returns(new IPAddress(InternalIp));
+
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _sut.HandleAsync(context);
             Assert.Equal(shouldSucceed, context.HasSucceeded);
         }
 
-        private static ClaimsPrincipal SetupUser(string role)
+        private static (User, ClaimsPrincipal) SetupUser(string role)
         {
-            var claims = new[] { new Claim(ClaimTypes.Role, role) };
+            var user = new User(
+                "jellyfin",
+                typeof(DefaultAuthenticationProvider).FullName,
+                typeof(DefaultPasswordResetProvider).FullName);
+
+            user.SetPermission(PermissionKind.IsAdministrator, role.Equals(UserRoles.Administrator, StringComparison.OrdinalIgnoreCase));
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Role, role),
+                new Claim(ClaimTypes.Name, "jellyfin"),
+                new Claim(InternalClaimTypes.UserId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.DeviceId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.Device, "test"),
+                new Claim(InternalClaimTypes.Client, "test"),
+                new Claim(InternalClaimTypes.Version, "test"),
+                new Claim(InternalClaimTypes.Token, "test"),
+            };
+
             var identity = new ClaimsIdentity(claims);
-            return new ClaimsPrincipal(identity);
+            return (user, new ClaimsPrincipal(identity));
         }
 
         private void SetupConfigurationManager(bool startupWizardCompleted)

--- a/tests/Jellyfin.Api.Tests/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandlerTests.cs
@@ -24,6 +24,9 @@ namespace Jellyfin.Api.Tests.Auth.IgnoreSchedulePolicy
         private readonly Mock<IUserManager> _userManagerMock;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
+        /// <summary>
+        /// Globally disallow access.
+        /// </summary>
         private readonly AccessSchedule[] _accessSchedules = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };
 
         public IgnoreScheduleHandlerTests()
@@ -44,11 +47,10 @@ namespace Jellyfin.Api.Tests.Auth.IgnoreSchedulePolicy
         public async Task ShouldAllowScheduleCorrectly(string role, bool shouldSucceed)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var (_, claims) = TestHelpers.SetupUser(
+            var claims = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
                 role,
-                TestHelpers.InternalIp,
                 _accessSchedules);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);

--- a/tests/Jellyfin.Api.Tests/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/IgnoreSchedulePolicy/IgnoreScheduleHandlerTests.cs
@@ -1,9 +1,12 @@
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
-using Jellyfin.Api.Auth.FirstTimeSetupOrElevatedPolicy;
+using Jellyfin.Api.Auth.IgnoreSchedulePolicy;
 using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
@@ -11,58 +14,42 @@ using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupOrElevatedPolicy
+namespace Jellyfin.Api.Tests.Auth.IgnoreSchedulePolicy
 {
-    public class FirstTimeSetupOrElevatedHandlerTests
+    public class IgnoreScheduleHandlerTests
     {
         private readonly Mock<IConfigurationManager> _configurationManagerMock;
         private readonly List<IAuthorizationRequirement> _requirements;
-        private readonly FirstTimeSetupOrElevatedHandler _sut;
+        private readonly IgnoreScheduleHandler _sut;
         private readonly Mock<IUserManager> _userManagerMock;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
-        public FirstTimeSetupOrElevatedHandlerTests()
+        private readonly AccessSchedule[] _accessSchedules = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };
+
+        public IgnoreScheduleHandlerTests()
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization());
             _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
-            _requirements = new List<IAuthorizationRequirement> { new FirstTimeSetupOrElevatedRequirement() };
+            _requirements = new List<IAuthorizationRequirement> { new IgnoreScheduleRequirement() };
             _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
             _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
 
-            _sut = fixture.Create<FirstTimeSetupOrElevatedHandler>();
-        }
-
-        [Theory]
-        [InlineData(UserRoles.Administrator)]
-        [InlineData(UserRoles.Guest)]
-        [InlineData(UserRoles.User)]
-        public async Task ShouldSucceedIfStartupWizardIncomplete(string userRole)
-        {
-            TestHelpers.SetupConfigurationManager(_configurationManagerMock, false);
-            var (_, claims) = TestHelpers.SetupUser(
-                _userManagerMock,
-                _httpContextAccessor,
-                userRole,
-                TestHelpers.InternalIp);
-
-            var context = new AuthorizationHandlerContext(_requirements, claims, null);
-
-            await _sut.HandleAsync(context);
-            Assert.True(context.HasSucceeded);
+            _sut = fixture.Create<IgnoreScheduleHandler>();
         }
 
         [Theory]
         [InlineData(UserRoles.Administrator, true)]
-        [InlineData(UserRoles.Guest, false)]
-        [InlineData(UserRoles.User, false)]
-        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
+        [InlineData(UserRoles.User, true)]
+        [InlineData(UserRoles.Guest, true)]
+        public async Task ShouldAllowScheduleCorrectly(string role, bool shouldSucceed)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var (_, claims) = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
-                userRole,
-                TestHelpers.InternalIp);
+                role,
+                TestHelpers.InternalIp,
+                _accessSchedules);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 

--- a/tests/Jellyfin.Api.Tests/Auth/LocalAccessPolicy/LocalAccessHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/LocalAccessPolicy/LocalAccessHandlerTests.cs
@@ -2,52 +2,57 @@
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
-using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
+using Jellyfin.Api.Auth.LocalAccessPolicy;
 using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
+namespace Jellyfin.Api.Tests.Auth.LocalAccessPolicy
 {
-    public class DefaultAuthorizationHandlerTests
+    public class LocalAccessHandlerTests
     {
         private readonly Mock<IConfigurationManager> _configurationManagerMock;
         private readonly List<IAuthorizationRequirement> _requirements;
-        private readonly DefaultAuthorizationHandler _sut;
+        private readonly LocalAccessHandler _sut;
         private readonly Mock<IUserManager> _userManagerMock;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+        private readonly Mock<INetworkManager> _networkManagerMock;
 
-        public DefaultAuthorizationHandlerTests()
+        public LocalAccessHandlerTests()
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization());
             _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
-            _requirements = new List<IAuthorizationRequirement> { new DefaultAuthorizationRequirement() };
+            _requirements = new List<IAuthorizationRequirement> { new LocalAccessRequirement() };
             _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
             _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
+            _networkManagerMock = fixture.Freeze<Mock<INetworkManager>>();
 
-            _sut = fixture.Create<DefaultAuthorizationHandler>();
+            _sut = fixture.Create<LocalAccessHandler>();
         }
 
         [Theory]
-        [InlineData(UserRoles.Administrator)]
-        [InlineData(UserRoles.Guest)]
-        [InlineData(UserRoles.User)]
-        public async Task ShouldSucceedOnUser(string userRole)
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async Task LocalAccessOnly(bool isInLocalNetwork, bool shouldSucceed)
         {
+            _networkManagerMock
+                .Setup(n => n.IsInLocalNetwork(It.IsAny<string>()))
+                .Returns(isInLocalNetwork);
+
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var claims = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
-                userRole);
+                UserRoles.User);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
-
             await _sut.HandleAsync(context);
-            Assert.True(context.HasSucceeded);
+            Assert.Equal(shouldSucceed, context.HasSucceeded);
         }
     }
 }

--- a/tests/Jellyfin.Api.Tests/Auth/RequiresElevationPolicy/RequiresElevationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/RequiresElevationPolicy/RequiresElevationHandlerTests.cs
@@ -39,11 +39,10 @@ namespace Jellyfin.Api.Tests.Auth.RequiresElevationPolicy
         public async Task ShouldHandleRolesCorrectly(string role, bool shouldSucceed)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var (_, claims) = TestHelpers.SetupUser(
+            var claims = TestHelpers.SetupUser(
                 _userManagerMock,
                 _httpContextAccessor,
-                role,
-                TestHelpers.InternalIp);
+                role);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 

--- a/tests/Jellyfin.Api.Tests/Auth/RequiresElevationPolicy/RequiresElevationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/RequiresElevationPolicy/RequiresElevationHandlerTests.cs
@@ -1,20 +1,48 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
 using Jellyfin.Api.Auth.RequiresElevationPolicy;
 using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
+using Jellyfin.Server.Implementations.Users;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Moq;
 using Xunit;
 
 namespace Jellyfin.Api.Tests.Auth.RequiresElevationPolicy
 {
     public class RequiresElevationHandlerTests
     {
+        /// <summary>
+        /// 127.0.0.1.
+        /// </summary>
+        private const long InternalIp = 16777343;
+
+        private readonly Mock<IConfigurationManager> _configurationManagerMock;
+        private readonly List<IAuthorizationRequirement> _requirements;
         private readonly RequiresElevationHandler _sut;
+        private readonly Mock<IUserManager> _userManagerMock;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
         public RequiresElevationHandlerTests()
         {
-            _sut = new RequiresElevationHandler();
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
+            _requirements = new List<IAuthorizationRequirement> { new RequiresElevationRequirement() };
+            _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
+            _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
+
+            _sut = fixture.Create<RequiresElevationHandler>();
         }
 
         [Theory]
@@ -23,16 +51,54 @@ namespace Jellyfin.Api.Tests.Auth.RequiresElevationPolicy
         [InlineData(UserRoles.Guest, false)]
         public async Task ShouldHandleRolesCorrectly(string role, bool shouldSucceed)
         {
-            var requirements = new List<IAuthorizationRequirement> { new RequiresElevationRequirement() };
+            SetupConfigurationManager(true);
+            var (user, claims) = SetupUser(role);
 
-            var claims = new[] { new Claim(ClaimTypes.Role, role) };
-            var identity = new ClaimsIdentity(claims);
-            var user = new ClaimsPrincipal(identity);
+            _userManagerMock.Setup(u => u.GetUserById(It.IsAny<Guid>()))
+                .Returns(user);
 
-            var context = new AuthorizationHandlerContext(requirements, user, null);
+            _httpContextAccessor.Setup(h => h.HttpContext.Connection.RemoteIpAddress)
+                .Returns(new IPAddress(InternalIp));
+
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _sut.HandleAsync(context);
             Assert.Equal(shouldSucceed, context.HasSucceeded);
+        }
+
+        private static (User, ClaimsPrincipal) SetupUser(string role)
+        {
+            var user = new User(
+                "jellyfin",
+                typeof(DefaultAuthenticationProvider).FullName,
+                typeof(DefaultPasswordResetProvider).FullName);
+
+            user.SetPermission(PermissionKind.IsAdministrator, role.Equals(UserRoles.Administrator, StringComparison.OrdinalIgnoreCase));
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Role, role),
+                new Claim(ClaimTypes.Name, "jellyfin"),
+                new Claim(InternalClaimTypes.UserId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.DeviceId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.Device, "test"),
+                new Claim(InternalClaimTypes.Client, "test"),
+                new Claim(InternalClaimTypes.Version, "test"),
+                new Claim(InternalClaimTypes.Token, "test"),
+            };
+
+            var identity = new ClaimsIdentity(claims);
+            return (user, new ClaimsPrincipal(identity));
+        }
+
+        private void SetupConfigurationManager(bool startupWizardCompleted)
+        {
+            var commonConfiguration = new BaseApplicationConfiguration
+            {
+                IsStartupWizardCompleted = startupWizardCompleted
+            };
+
+            _configurationManagerMock.Setup(c => c.CommonConfiguration)
+                .Returns(commonConfiguration);
         }
     }
 }

--- a/tests/Jellyfin.Api.Tests/Jellyfin.Api.Tests.csproj
+++ b/tests/Jellyfin.Api.Tests/Jellyfin.Api.Tests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="../../MediaBrowser.Api/MediaBrowser.Api.csproj" />
     <ProjectReference Include="../../Jellyfin.Api/Jellyfin.Api.csproj" />
+    <ProjectReference Include="..\..\Jellyfin.Server\Jellyfin.Server.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/tests/Jellyfin.Api.Tests/TestHelpers.cs
+++ b/tests/Jellyfin.Api.Tests/TestHelpers.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Security.Claims;
+using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
+using Jellyfin.Server.Implementations.Users;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using AccessSchedule = Jellyfin.Data.Entities.AccessSchedule;
+
+namespace Jellyfin.Api.Tests
+{
+    public static class TestHelpers
+    {
+        /// <summary>
+        /// 127.0.0.1.
+        /// </summary>
+        public const long InternalIp = 16777343;
+
+        /// <summary>
+        /// 1.1.1.1.
+        /// </summary>
+        public const long ExternalIp = 16843009;
+
+        public static (User, ClaimsPrincipal) SetupUser(
+            Mock<IUserManager> userManagerMock,
+            Mock<IHttpContextAccessor> httpContextAccessorMock,
+            string role,
+            long ip,
+            IEnumerable<AccessSchedule>? accessSchedules = null)
+        {
+            var user = new User(
+                "jellyfin",
+                typeof(DefaultAuthenticationProvider).FullName,
+                typeof(DefaultPasswordResetProvider).FullName);
+
+            // Set administrator flag.
+            user.SetPermission(PermissionKind.IsAdministrator, role.Equals(UserRoles.Administrator, StringComparison.OrdinalIgnoreCase));
+
+            // Add access schedules if set.
+            if (accessSchedules != null)
+            {
+                foreach (var accessSchedule in accessSchedules)
+                {
+                    user.AccessSchedules.Add(accessSchedule);
+                }
+            }
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Role, role),
+                new Claim(ClaimTypes.Name, "jellyfin"),
+                new Claim(InternalClaimTypes.UserId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.DeviceId, Guid.Empty.ToString("N", CultureInfo.InvariantCulture)),
+                new Claim(InternalClaimTypes.Device, "test"),
+                new Claim(InternalClaimTypes.Client, "test"),
+                new Claim(InternalClaimTypes.Version, "test"),
+                new Claim(InternalClaimTypes.Token, "test"),
+            };
+
+            var identity = new ClaimsIdentity(claims);
+
+            userManagerMock
+                .Setup(u => u.GetUserById(It.IsAny<Guid>()))
+                .Returns(user);
+
+            httpContextAccessorMock
+                .Setup(h => h.HttpContext.Connection.RemoteIpAddress)
+                .Returns(new IPAddress(ip));
+
+            return (user, new ClaimsPrincipal(identity));
+        }
+
+        public static void SetupConfigurationManager(in Mock<IConfigurationManager> configurationManagerMock, bool startupWizardCompleted)
+        {
+            var commonConfiguration = new BaseApplicationConfiguration
+            {
+                IsStartupWizardCompleted = startupWizardCompleted
+            };
+
+            configurationManagerMock
+                .Setup(c => c.CommonConfiguration)
+                .Returns(commonConfiguration);
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/TestHelpers.cs
+++ b/tests/Jellyfin.Api.Tests/TestHelpers.cs
@@ -18,21 +18,10 @@ namespace Jellyfin.Api.Tests
 {
     public static class TestHelpers
     {
-        /// <summary>
-        /// 127.0.0.1.
-        /// </summary>
-        public const long InternalIp = 16777343;
-
-        /// <summary>
-        /// 1.1.1.1.
-        /// </summary>
-        public const long ExternalIp = 16843009;
-
-        public static (User, ClaimsPrincipal) SetupUser(
+        public static ClaimsPrincipal SetupUser(
             Mock<IUserManager> userManagerMock,
             Mock<IHttpContextAccessor> httpContextAccessorMock,
             string role,
-            long ip,
             IEnumerable<AccessSchedule>? accessSchedules = null)
         {
             var user = new User(
@@ -72,9 +61,9 @@ namespace Jellyfin.Api.Tests
 
             httpContextAccessorMock
                 .Setup(h => h.HttpContext.Connection.RemoteIpAddress)
-                .Returns(new IPAddress(ip));
+                .Returns(new IPAddress(0));
 
-            return (user, new ClaimsPrincipal(identity));
+            return new ClaimsPrincipal(identity);
         }
 
         public static void SetupConfigurationManager(in Mock<IConfigurationManager> configurationManagerMock, bool startupWizardCompleted)


### PR DESCRIPTION
Adds:

DefaultAuthorizationPolicy
IgnoreSchedulePolicy
LocalAccessPolicy

~~Header:~~
~~`X-Jellyfin-Token` (same as `X-Emby-Token`)~~
~~`X-Jellyfin-Authorization` (same as `X-Emby-Authorization`)~~
~~`Jellyfin` parameter for `X-Jellyfin-Authorization` (allows in place of `Mediabrowser`)~~

Note: all endpoints that require authorization will need the default policy for proper authorization to happen.