### PR TITLE
Remove UserManager.AddParts

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -547,9 +547,6 @@ namespace Emby.Server.Implementations
 
             serviceCollection.AddSingleton(ServerConfigurationManager);
 
-            serviceCollection.AddSingleton<Func<IReadOnlyCollection<IPasswordResetProvider>>>(() => GetExports<IPasswordResetProvider>());
-            serviceCollection.AddSingleton<Func<IReadOnlyCollection<IAuthenticationProvider>>>(() => GetExports<IAuthenticationProvider>());
-
             serviceCollection.AddSingleton<ILocalizationManager, LocalizationManager>();
 
             serviceCollection.AddSingleton<IBlurayExaminer, BdInfoExaminer>();

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -547,6 +547,9 @@ namespace Emby.Server.Implementations
 
             serviceCollection.AddSingleton(ServerConfigurationManager);
 
+            serviceCollection.AddSingleton<Func<IReadOnlyCollection<IPasswordResetProvider>>>(() => GetExports<IPasswordResetProvider>());
+            serviceCollection.AddSingleton<Func<IReadOnlyCollection<IAuthenticationProvider>>>(() => GetExports<IAuthenticationProvider>());
+
             serviceCollection.AddSingleton<ILocalizationManager, LocalizationManager>();
 
             serviceCollection.AddSingleton<IBlurayExaminer, BdInfoExaminer>();
@@ -795,7 +798,6 @@ namespace Emby.Server.Implementations
             Resolve<IMediaSourceManager>().AddParts(GetExports<IMediaSourceProvider>());
 
             Resolve<INotificationManager>().AddParts(GetExports<INotificationService>(), GetExports<INotificationTypeFactory>());
-            Resolve<IUserManager>().AddParts(GetExports<IAuthenticationProvider>(), GetExports<IPasswordResetProvider>());
 
             Resolve<IIsoManager>().AddParts(GetExports<IIsoMounter>());
         }

--- a/MediaBrowser.Controller/Library/IUserManager.cs
+++ b/MediaBrowser.Controller/Library/IUserManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
-using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Events;
@@ -165,8 +164,6 @@ namespace MediaBrowser.Controller.Library
         /// <param name="pin">The pin.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
         Task<PinRedeemResult> RedeemPasswordResetPin(string pin);
-
-        void AddParts(IEnumerable<IAuthenticationProvider> authenticationProviders, IEnumerable<IPasswordResetProvider> passwordResetProviders);
 
         NameIdPair[] GetAuthenticationProviders();
 


### PR DESCRIPTION
**Changes**
Remove the (I)UserManager.AddParts method. This method is an anti-pattern, as the class's state should be initialized entirely through Dependency Injection when possible. This also is necessary to allow hot-loading of plugins in the future.
