### PR TITLE
Remove #nullable enable in Jellyfin.Api

### DIFF
--- a/Jellyfin.Api/Auth/BaseAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/BaseAuthorizationHandler.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Net;
+﻿using System.Net;
 using System.Security.Claims;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Data.Enums;

--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Globalization;
 using System.Security.Authentication;
 using System.Security.Claims;

--- a/Jellyfin.Api/Helpers/ClaimHelpers.cs
+++ b/Jellyfin.Api/Helpers/ClaimHelpers.cs
@@ -1,6 +1,4 @@
-﻿﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Security.Claims;
 using Jellyfin.Api.Constants;


### PR DESCRIPTION
`#nullable enable` is not needed in every file in Jellyfin.Api as it is enabled on project level.