### PR TITLE
 Add Azure DevOps package builds

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -35,11 +35,11 @@ jobs:
   steps:
   - script: 'docker build -f deployment/Dockerfile.$(BuildConfiguration) -t jellyfin-server-$(BuildConfiguration) deployment'
     displayName: 'Build Dockerfile'
-    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - script: 'docker image ls -a && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="yes" -e BUILD_ID=$(Build.BuildNumber) jellyfin-server-$(BuildConfiguration)'
     displayName: 'Run Dockerfile (unstable)'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - script: 'docker image ls -a && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="no" -e BUILD_ID=$(Build.BuildNumber) jellyfin-server-$(BuildConfiguration)'
     displayName: 'Run Dockerfile (stable)'
@@ -47,14 +47,14 @@ jobs:
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Release'
-    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       targetPath: '$(Build.SourcesDirectory)/deployment/dist'
       artifactName: 'jellyfin-server-$(BuildConfiguration)'
 
   - task: CopyFilesOverSSH@0
     displayName: 'Upload artifacts to repository server'
-    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       sshEndpoint: repository
       sourceFolder: '$(Build.SourcesDirectory)/deployment/dist'
@@ -79,7 +79,7 @@ jobs:
   steps:
   - task: Docker@2
     displayName: 'Push Unstable Image'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
     inputs:
       repository: 'jellyfin/jellyfin-server'
       command: buildAndPush
@@ -116,7 +116,7 @@ jobs:
   steps:
   - task: SSH@0
     displayName: 'Update Unstable Repository'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
     inputs:
       sshEndpoint: repository
       runOptions: 'inline'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -1,0 +1,122 @@
+jobs:
+- job: BuildPackage
+  displayName: 'Build Packages'
+
+  strategy:
+    matrix:
+      CentOS.amd64:
+        BuildConfiguration: centos.amd64
+      Fedora.amd64:
+        BuildConfiguration: fedora.amd64
+      Debian.amd64:
+        BuildConfiguration: debian.amd64
+      Debian.arm64:
+        BuildConfiguration: debian.arm64
+      Debian.armhf:
+        BuildConfiguration: debian.armhf
+      Ubuntu.amd64:
+        BuildConfiguration: ubuntu.amd64
+      Ubuntu.arm64:
+        BuildConfiguration: ubuntu.arm64
+      Ubuntu.armhf:
+        BuildConfiguration: ubuntu.armhf
+      Linux.amd64:
+        BuildConfiguration: linux.amd64
+      Windows.amd64:
+        BuildConfiguration: windows.amd64
+      MacOS:
+        BuildConfiguration: macos
+      Portable:
+        BuildConfiguration: portable
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - script: 'docker build -f deployment/Dockerfile.$(BuildConfiguration) -t jellyfin-server-$(BuildConfiguration) deployment'
+    displayName: 'Build Dockerfile'
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+
+  - script: 'docker image ls -a && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="yes" -e BUILD_ID=$(Build.BuildNumber) jellyfin-server-$(BuildConfiguration)'
+    displayName: 'Run Dockerfile (unstable)'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+
+  - script: 'docker image ls -a && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="no" -e BUILD_ID=$(Build.BuildNumber) jellyfin-server-$(BuildConfiguration)'
+    displayName: 'Run Dockerfile (stable)'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Release'
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/deployment/dist'
+      artifactName: 'jellyfin-server-$(BuildConfiguration)'
+
+  - task: CopyFilesOverSSH@0
+    displayName: 'Upload artifacts to repository server'
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci'))
+    inputs:
+      sshEndpoint: repository
+      sourceFolder: '$(Build.SourcesDirectory)/deployment/dist'
+      contents: '**'
+      targetFolder: '/srv/repository/incoming/azure/$(Build.BuildNumber)/$(BuildConfiguration)'
+
+- job: BuildDocker
+  displayName: 'Build Docker'
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - task: Docker@2
+    displayName: 'Push Unstable Image'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    inputs:
+      repository: 'jellyfin/jellyfin-server'
+      command: buildAndPush
+      buildContext: '.'
+      Dockerfile: 'deployment/Dockerfile.docker'
+      containerRegistry: Docker Hub
+      tags: |
+        unstable-$(Build.BuildNumber)
+        unstable
+
+  - task: Docker@2
+    displayName: 'Push Stable Image'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    inputs:
+      repository: 'jellyfin/jellyfin-server'
+      command: buildAndPush
+      buildContext: '.'
+      Dockerfile: 'deployment/Dockerfile.docker'
+      containerRegistry: Docker Hub
+      tags: |
+        stable-$(Build.BuildNumber)
+        stable
+
+- job: CollectArtifacts
+  displayName: 'Collect Artifacts'
+  dependsOn:
+  - BuildPackage
+  - BuildDocker
+  condition: and(succeeded('BuildPackage'), succeeded('BuildDocker'))
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - task: SSH@0
+    displayName: 'Update Unstable Repository'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    inputs:
+      sshEndpoint: repository
+      runOptions: 'inline'
+      inline: 'sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber) unstable'
+
+  - task: SSH@0
+    displayName: 'Update Stable Repository'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    inputs:
+      sshEndpoint: repository
+      runOptions: 'inline'
+      inline: 'sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber)'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -66,11 +66,11 @@ jobs:
 
   strategy:
     matrix:
-      Docker.amd64:
+      amd64:
         BuildConfiguration: amd64
-      Docker.arm64:
+      arm64:
         BuildConfiguration: arm64
-      Docker.armhf:
+      armhf:
         BuildConfiguration: armhf
 
   pool:

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -64,6 +64,15 @@ jobs:
 - job: BuildDocker
   displayName: 'Build Docker'
 
+  strategy:
+    matrix:
+      Docker.amd64:
+        BuildConfiguration: amd64
+      Docker.arm64:
+        BuildConfiguration: arm64
+      Docker.armhf:
+        BuildConfiguration: armhf
+
   pool:
     vmImage: 'ubuntu-latest'
 
@@ -75,11 +84,11 @@ jobs:
       repository: 'jellyfin/jellyfin-server'
       command: buildAndPush
       buildContext: '.'
-      Dockerfile: 'deployment/Dockerfile.docker'
+      Dockerfile: 'deployment/Dockerfile.docker.$(BuildConfiguration)'
       containerRegistry: Docker Hub
       tags: |
-        unstable-$(Build.BuildNumber)
-        unstable
+        unstable-$(Build.BuildNumber)-$(BuildConfiguration)
+        unstable-$(BuildConfiguration)
 
   - task: Docker@2
     displayName: 'Push Stable Image'
@@ -88,11 +97,11 @@ jobs:
       repository: 'jellyfin/jellyfin-server'
       command: buildAndPush
       buildContext: '.'
-      Dockerfile: 'deployment/Dockerfile.docker'
+      Dockerfile: 'deployment/Dockerfile.docker.$(BuildConfiguration)'
       containerRegistry: Docker Hub
       tags: |
-        stable-$(Build.BuildNumber)
-        stable
+        stable-$(Build.BuildNumber)-$(BuildConfiguration)
+        stable-$(BuildConfiguration)
 
 - job: CollectArtifacts
   displayName: 'Collect Artifacts'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -43,3 +43,5 @@ jobs:
           NugetPackageName: Jellyfin.Common
           AssemblyFileName: MediaBrowser.Common.dll
       LinuxImage: 'ubuntu-latest'
+
+  - template: azure-pipelines-package.yml

--- a/deployment/Dockerfile.docker.amd64
+++ b/deployment/Dockerfile.docker.amd64
@@ -1,10 +1,9 @@
 ARG DOTNET_VERSION=3.1
-ARG SOURCE_DIR=/src
-ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
-RUN mkdir ${SOURCE_DIR}
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
 
 WORKDIR ${SOURCE_DIR}
 COPY . .

--- a/deployment/Dockerfile.docker.amd64
+++ b/deployment/Dockerfile.docker.amd64
@@ -1,0 +1,14 @@
+ARG DOTNET_VERSION=3.1
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
+
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+
+WORKDIR ${SOURCE_DIR}
+COPY . .
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# because of changes in docker and systemd we need to not build in parallel at the moment
+# see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="${ARTIFACT_DIR}" --self-contained --runtime linux-x64 "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"

--- a/deployment/Dockerfile.docker.amd64
+++ b/deployment/Dockerfile.docker.amd64
@@ -1,6 +1,6 @@
 ARG DOTNET_VERSION=3.1
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster
 
 ARG SOURCE_DIR=/src
 ARG ARTIFACT_DIR=/jellyfin

--- a/deployment/Dockerfile.docker.amd64
+++ b/deployment/Dockerfile.docker.amd64
@@ -4,6 +4,8 @@ ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
+RUN mkdir ${SOURCE_DIR}
+
 WORKDIR ${SOURCE_DIR}
 COPY . .
 

--- a/deployment/Dockerfile.docker.arm64
+++ b/deployment/Dockerfile.docker.arm64
@@ -1,0 +1,14 @@
+ARG DOTNET_VERSION=3.1
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
+
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+
+WORKDIR ${SOURCE_DIR}
+COPY . .
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# because of changes in docker and systemd we need to not build in parallel at the moment
+# see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="${ARTIFACT_DIR}" --self-contained --runtime linux-arm64 "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"

--- a/deployment/Dockerfile.docker.arm64
+++ b/deployment/Dockerfile.docker.arm64
@@ -1,10 +1,9 @@
 ARG DOTNET_VERSION=3.1
-ARG SOURCE_DIR=/src
-ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
-RUN mkdir ${SOURCE_DIR}
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
 
 WORKDIR ${SOURCE_DIR}
 COPY . .

--- a/deployment/Dockerfile.docker.arm64
+++ b/deployment/Dockerfile.docker.arm64
@@ -1,6 +1,6 @@
 ARG DOTNET_VERSION=3.1
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster
 
 ARG SOURCE_DIR=/src
 ARG ARTIFACT_DIR=/jellyfin

--- a/deployment/Dockerfile.docker.arm64
+++ b/deployment/Dockerfile.docker.arm64
@@ -4,6 +4,8 @@ ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
+RUN mkdir ${SOURCE_DIR}
+
 WORKDIR ${SOURCE_DIR}
 COPY . .
 

--- a/deployment/Dockerfile.docker.armhf
+++ b/deployment/Dockerfile.docker.armhf
@@ -1,10 +1,9 @@
 ARG DOTNET_VERSION=3.1
-ARG SOURCE_DIR=/src
-ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
-RUN mkdir ${SOURCE_DIR}
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
 
 WORKDIR ${SOURCE_DIR}
 COPY . .

--- a/deployment/Dockerfile.docker.armhf
+++ b/deployment/Dockerfile.docker.armhf
@@ -1,6 +1,6 @@
 ARG DOTNET_VERSION=3.1
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster
 
 ARG SOURCE_DIR=/src
 ARG ARTIFACT_DIR=/jellyfin

--- a/deployment/Dockerfile.docker.armhf
+++ b/deployment/Dockerfile.docker.armhf
@@ -1,0 +1,14 @@
+ARG DOTNET_VERSION=3.1
+ARG SOURCE_DIR=/src
+ARG ARTIFACT_DIR=/jellyfin
+
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
+
+WORKDIR ${SOURCE_DIR}
+COPY . .
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# because of changes in docker and systemd we need to not build in parallel at the moment
+# see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="${ARTIFACT_DIR}" --self-contained --runtime linux-arm "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none"

--- a/deployment/Dockerfile.docker.armhf
+++ b/deployment/Dockerfile.docker.armhf
@@ -4,6 +4,8 @@ ARG ARTIFACT_DIR=/jellyfin
 
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION}-buster as builder
 
+RUN mkdir ${SOURCE_DIR}
+
 WORKDIR ${SOURCE_DIR}
 COPY . .
 

--- a/deployment/build.centos.amd64
+++ b/deployment/build.centos.amd64
@@ -8,6 +8,22 @@ set -o xtrace
 # Move to source directory
 pushd ${SOURCE_DIR}
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd fedora
+
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    sed -i "s/Version:.*/Version:        ${BUILD_ID}/" jellyfin.spec
+    sed -i "/%changelog/q" jellyfin.spec
+
+    cat <<EOF >>jellyfin.spec
+* $( LANG=C date '+%a %b %d %Y' ) Jellyfin Packaging Team <packaging@jellyfin.org>
+- Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+EOF
+    popd
+fi
+
 # Build RPM
 make -f fedora/Makefile srpm outdir=/root/rpmbuild/SRPMS
 rpmbuild --rebuild -bb /root/rpmbuild/SRPMS/jellyfin-*.src.rpm

--- a/deployment/build.debian.amd64
+++ b/deployment/build.debian.amd64
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 dpkg-buildpackage -us -uc --pre-clean --post-clean
 

--- a/deployment/build.debian.arm64
+++ b/deployment/build.debian.arm64
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a arm64 --pre-clean --post-clean

--- a/deployment/build.debian.armhf
+++ b/deployment/build.debian.armhf
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a armhf --pre-clean --post-clean

--- a/deployment/build.fedora.amd64
+++ b/deployment/build.fedora.amd64
@@ -8,6 +8,22 @@ set -o xtrace
 # Move to source directory
 pushd ${SOURCE_DIR}
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd fedora
+
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    sed -i "s/Version:.*/Version:        ${BUILD_ID}/" jellyfin.spec
+    sed -i "/%changelog/q" jellyfin.spec
+
+    cat <<EOF >>jellyfin.spec
+* $( LANG=C date '+%a %b %d %Y' ) Jellyfin Packaging Team <packaging@jellyfin.org>
+- Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+EOF
+    popd
+fi
+
 # Build RPM
 make -f fedora/Makefile srpm outdir=/root/rpmbuild/SRPMS
 rpmbuild -rb /root/rpmbuild/SRPMS/jellyfin-*.src.rpm

--- a/deployment/build.linux.amd64
+++ b/deployment/build.linux.amd64
@@ -9,7 +9,11 @@ set -o xtrace
 pushd ${SOURCE_DIR}
 
 # Get version
-version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    version="${BUILD_ID}"
+else
+    version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+fi
 
 # Build archives
 dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime linux-x64 --output dist/jellyfin-server_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"

--- a/deployment/build.macos
+++ b/deployment/build.macos
@@ -9,7 +9,11 @@ set -o xtrace
 pushd ${SOURCE_DIR}
 
 # Get version
-version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    version="${BUILD_ID}"
+else
+    version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+fi
 
 # Build archives
 dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-x64 --output dist/jellyfin-server_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"

--- a/deployment/build.portable
+++ b/deployment/build.portable
@@ -9,7 +9,11 @@ set -o xtrace
 pushd ${SOURCE_DIR}
 
 # Get version
-version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    version="${BUILD_ID}"
+else
+    version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+fi
 
 # Build archives
 dotnet publish Jellyfin.Server --configuration Release --output dist/jellyfin-server_${version}/ "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none;UseAppHost=true"

--- a/deployment/build.ubuntu.amd64
+++ b/deployment/build.ubuntu.amd64
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 dpkg-buildpackage -us -uc --pre-clean --post-clean
 

--- a/deployment/build.ubuntu.arm64
+++ b/deployment/build.ubuntu.arm64
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a arm64 --pre-clean --post-clean

--- a/deployment/build.ubuntu.armhf
+++ b/deployment/build.ubuntu.armhf
@@ -14,6 +14,21 @@ if [[ ${IS_DOCKER} == YES ]]; then
     sed -i '/dotnet-sdk-3.1,/d' debian/control
 fi
 
+# Modify changelog to unstable configuration if IS_UNSTABLE
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    pushd debian
+    PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
+
+    cat <<EOF >changelog
+jellyfin-server (${BUILD_ID}-unstable) unstable; urgency=medium
+
+  * Jellyfin Server unstable build ${BUILD_ID} for merged PR #${PR_ID}
+
+ -- Jellyfin Packaging Team <packaging@jellyfin.org>  $( date --rfc-2822 )
+EOF
+    popd
+fi
+
 # Build DEB
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a armhf --pre-clean --post-clean

--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -15,7 +15,11 @@ FFMPEG_URL="https://ffmpeg.zeranoe.com/builds/win64/static/${FFMPEG_VERSION}.zip
 pushd ${SOURCE_DIR}
 
 # Get version
-version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    version="${BUILD_ID}"
+else
+    version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+fi
 
 output_dir="dist/jellyfin-server_${version}"
 


### PR DESCRIPTION
**Changes**
Adds configuration to build packages with Azure DevOps. Identical in setup to Web, though with the server-specific tweaks applied.

Right now is configured to build off of this branch; like Web, it will be switched to `refs/heads/master` once tested.

**Issues**
N/A
