### PR TITLE
.gitignore: ignore jellyfin-web symlink & .vscode: dotnet telemetry optout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ ProgramData*/
 CorePlugins*/
 ProgramData-Server*/
 ProgramData-UI*/
-MediaBrowser.WebDashboard/jellyfin-web/**
 
 #################
 ## Visual Studio
@@ -276,4 +275,4 @@ BenchmarkDotNet.Artifacts
 # Ignore web artifacts from native builds
 web/
 web-src.*
-MediaBrowser.WebDashboard/jellyfin-web/
+MediaBrowser.WebDashboard/jellyfin-web

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to find out which attributes exist for C# debugging
-    // Use hover for the description of the existing attributes
-    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,9 +1,9 @@
 {
-   // Use IntelliSense to find out which attributes exist for C# debugging
-   // Use hover for the description of the existing attributes
-   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-   "version": "0.2.0",
-   "configurations": [
+    // Use IntelliSense to find out which attributes exist for C# debugging
+    // Use hover for the description of the existing attributes
+    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+    "version": "0.2.0",
+    "configurations": [
         {
             "name": ".NET Core Launch (console)",
             "type": "coreclr",
@@ -24,5 +24,8 @@
             "request": "attach",
             "processId": "${command:pickProcess}"
         }
-    ,]
+    ],
+    "env": {
+        "DOTNET_CLI_TELEMETRY_OPTOUT": "1"
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,5 +21,10 @@
             ],
             "problemMatcher": "$msCompile"
         }
-    ]
+    ],
+    "options": {
+        "env": {
+            "DOTNET_CLI_TELEMETRY_OPTOUT": "1"
+        }
+    }
 }


### PR DESCRIPTION
**Changes**
Captures a symlink for MediaBrowser.WebDashboard/jellyfin-web & removes duplicate entry.
Adds dotnet telemetry optout environment variable for vscode tasks

