### PR TITLE
Prevent system plugins from being uninstalled

### DIFF
--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -402,6 +402,12 @@ namespace Emby.Server.Implementations.Updates
         /// <param name="plugin">The plugin.</param>
         public void UninstallPlugin(IPlugin plugin)
         {
+            if (!plugin.CanUninstall)
+            {
+                _logger.LogInformation("Attempt to delete non removable plugin {0}", plugin.Name);
+                return;
+            }
+
             plugin.OnUninstalling();
 
             // Remove it the quick way for now

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -404,7 +404,7 @@ namespace Emby.Server.Implementations.Updates
         {
             if (!plugin.CanUninstall)
             {
-                _logger.LogInformation("Attempt to delete non removable plugin {0}", plugin.Name);
+                _logger.LogWarning("Attempt to delete non removable plugin {0}, ignoring request", plugin.Name);
                 return;
             }
 

--- a/MediaBrowser.Common/Plugins/BasePlugin.cs
+++ b/MediaBrowser.Common/Plugins/BasePlugin.cs
@@ -53,9 +53,8 @@ namespace MediaBrowser.Common.Plugins
         /// <summary>
         /// Gets a value indicating whether the plugin can be uninstalled.
         /// </summary>
-        public bool CanUninstall => !Path.GetDirectoryName(AssemblyFilePath).Equals(
-            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-            StringComparison.InvariantCulture);
+        public bool CanUninstall => !Path.GetDirectoryName(AssemblyFilePath)
+            .Equals(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), StringComparison.InvariantCulture);
 
         /// <summary>
         /// Gets the plugin info.

--- a/MediaBrowser.Common/Plugins/BasePlugin.cs
+++ b/MediaBrowser.Common/Plugins/BasePlugin.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
@@ -50,6 +51,11 @@ namespace MediaBrowser.Common.Plugins
         public string DataFolderPath { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether the plugin can be uninstalled.
+        /// </summary>
+        public bool CanUninstall => !Path.GetDirectoryName(AssemblyFilePath).Equals(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), StringComparison.InvariantCulture);
+
+        /// <summary>
         /// Gets the plugin info.
         /// </summary>
         /// <returns>PluginInfo.</returns>
@@ -60,7 +66,8 @@ namespace MediaBrowser.Common.Plugins
                 Name = Name,
                 Version = Version.ToString(),
                 Description = Description,
-                Id = Id.ToString()
+                Id = Id.ToString(),
+                CanUninstall = CanUninstall
             };
 
             return info;

--- a/MediaBrowser.Common/Plugins/BasePlugin.cs
+++ b/MediaBrowser.Common/Plugins/BasePlugin.cs
@@ -53,7 +53,9 @@ namespace MediaBrowser.Common.Plugins
         /// <summary>
         /// Gets a value indicating whether the plugin can be uninstalled.
         /// </summary>
-        public bool CanUninstall => !Path.GetDirectoryName(AssemblyFilePath).Equals(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), StringComparison.InvariantCulture);
+        public bool CanUninstall => !Path.GetDirectoryName(AssemblyFilePath).Equals(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            StringComparison.InvariantCulture);
 
         /// <summary>
         /// Gets the plugin info.

--- a/MediaBrowser.Common/Plugins/IPlugin.cs
+++ b/MediaBrowser.Common/Plugins/IPlugin.cs
@@ -41,6 +41,11 @@ namespace MediaBrowser.Common.Plugins
         string AssemblyFilePath { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the plugin can be uninstalled.
+        /// </summary>
+        bool CanUninstall { get; }
+
+        /// <summary>
         /// Gets the full path to the data folder, where the plugin can store any miscellaneous files needed.
         /// </summary>
         /// <value>The data folder path.</value>

--- a/MediaBrowser.Model/Plugins/PluginInfo.cs
+++ b/MediaBrowser.Model/Plugins/PluginInfo.cs
@@ -35,6 +35,12 @@ namespace MediaBrowser.Model.Plugins
         /// </summary>
         /// <value>The unique id.</value>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the plugin can be uninstalled.
+        /// </summary>
+        public bool CanUninstall { get; set; }
+
         /// <summary>
         /// Gets or sets the image URL.
         /// </summary>


### PR DESCRIPTION
**Changes**
Added `CanUninstall` property to Plugin to indicate whether a plugin can be uninstalled.  If an attempt is made to uninstall a plugin with this property set to `False`, it is logged and the uninstallation does not proceed.

Current `CanUninstall` is simply a check if the Plugin Assembly path is the same as the main Jellyfin path.  This could can be changed in the future to add additional/different logic if required.

Related Web PR:   jellyfin/jellyfin-web#1464

**Issues**
Fixes #2555
