### PR TITLE
Revert ILoggerFactory usage in BaseItem.cs

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -560,8 +560,6 @@ namespace MediaBrowser.Controller.Entities
         /// <summary>
         /// The logger.
         /// </summary>
-        public static ILoggerFactory LoggerFactory { get; set; }
-
         public static ILogger<BaseItem> Logger { get; set; }
 
         public static ILibraryManager LibraryManager { get; set; }

--- a/MediaBrowser.Controller/Entities/UserView.cs
+++ b/MediaBrowser.Controller/Entities/UserView.cs
@@ -68,7 +68,7 @@ namespace MediaBrowser.Controller.Entities
                 parent = LibraryManager.GetItemById(ParentId) as Folder ?? parent;
             }
 
-            return new UserViewBuilder(UserViewManager, LibraryManager, LoggerFactory.CreateLogger<UserViewBuilder>(), UserDataManager, TVSeriesManager, ConfigurationManager)
+            return new UserViewBuilder(UserViewManager, LibraryManager, Logger, UserDataManager, TVSeriesManager, ConfigurationManager)
                 .GetUserItems(parent, this, CollectionType, query);
         }
 

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.TV;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ namespace MediaBrowser.Controller.Entities
     {
         private readonly IUserViewManager _userViewManager;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger<UserViewBuilder> _logger;
+        private readonly ILogger<BaseItem> _logger;
         private readonly IUserDataManager _userDataManager;
         private readonly ITVSeriesManager _tvSeriesManager;
         private readonly IServerConfigurationManager _config;
@@ -30,7 +31,7 @@ namespace MediaBrowser.Controller.Entities
         public UserViewBuilder(
             IUserViewManager userViewManager,
             ILibraryManager libraryManager,
-            ILogger<UserViewBuilder> logger,
+            ILogger<BaseItem> logger,
             IUserDataManager userDataManager,
             ITVSeriesManager tvSeriesManager,
             IServerConfigurationManager config)


### PR DESCRIPTION
Fixes 

```
[2020-06-20 11:24:30.354 +03:00] [ERR] Error processing request. URL: "http://IP/jellyfin/Users/19049592d87b4ea7a149a747070f233d/Items?Fields=PrimaryImageAspectRatio%2CSortName%2CPath%2CPrimaryImageAspectRatio&ImageTypeLimit=1&ParentId=c00310d49d01f5352278e06b1b96160a&SortBy=IsFolder%2CSortName&SortOrder=Ascending"
System.ArgumentNullException: Value cannot be null. (Parameter 'factory')
   at Microsoft.Extensions.Logging.LoggerFactoryExtensions.CreateLogger[T](ILoggerFactory factory)
   at MediaBrowser.Controller.Entities.UserView.GetItemsInternal(InternalItemsQuery query)
   at MediaBrowser.Controller.Entities.Folder.GetItems(InternalItemsQuery query)
   at MediaBrowser.Api.UserLibrary.ItemsService.GetQueryResult(GetItems request, DtoOptions dtoOptions, User user)
   at MediaBrowser.Api.UserLibrary.ItemsService.GetItems(GetItems request)
   at MediaBrowser.Api.UserLibrary.ItemsService.Get(GetItems request)
   at Emby.Server.Implementations.Services.ServiceExecGeneral.Execute(Type serviceType, IRequest request, Object instance, Object requestDto, String requestName)
   at Emby.Server.Implementations.Services.ServiceController.Execute(HttpListenerHost httpHost, Object requestDto, IRequest req)
   at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost httpHost, IRequest httpReq, HttpResponse httpRes, ILogger logger, CancellationToken cancellationToken)
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken)
```