### PR TITLE
Fix docs endpoint order

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -195,7 +195,7 @@ namespace Jellyfin.Server.Extensions
 
                 // Order actions by route path, then by http method.
                 c.OrderActionsBy(description =>
-                    $"{description.ActionDescriptor.RouteValues["controller"]}_{description.HttpMethod}");
+                    $"{description.ActionDescriptor.RouteValues["controller"]}_{description.RelativePath}");
 
                 // Use method name as operationId
                 c.CustomOperationIds(description =>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/24963659/85806198-9923b980-b70b-11ea-9c21-202cabb4031c.png)

After:
![image](https://user-images.githubusercontent.com/24963659/85806204-9f199a80-b70b-11ea-8f3c-47e2c4192c17.png)

Not sure why the docs say to have ordering as the former, but the new order makes more sense to me.