### PR TITLE
Add more ignorepatterns and tests

### DIFF
--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -11,7 +11,7 @@ namespace Emby.Server.Implementations.Library
         /// <summary>
         /// Files matching these glob patterns will be ignored.
         /// </summary>
-        public static readonly string[] Patterns = new string[]
+        private static readonly string[] _patterns =
         {
             "**/small.jpg",
             "**/albumart.jpg",
@@ -19,32 +19,51 @@ namespace Emby.Server.Implementations.Library
 
             // Directories
             "**/metadata/**",
+            "**/metadata",
             "**/ps3_update/**",
+            "**/ps3_update",
             "**/ps3_vprm/**",
+            "**/ps3_vprm",
             "**/extrafanart/**",
+            "**/extrafanart",
             "**/extrathumbs/**",
+            "**/extrathumbs",
             "**/.actors/**",
+            "**/.actors",
             "**/.wd_tv/**",
+            "**/.wd_tv",
             "**/lost+found/**",
+            "**/lost+found",
 
             // WMC temp recording directories that will constantly be written to
             "**/TempRec/**",
+            "**/TempRec",
             "**/TempSBE/**",
+            "**/TempSBE",
 
             // Synology
             "**/eaDir/**",
+            "**/eaDir",
             "**/@eaDir/**",
+            "**/@eaDir",
             "**/#recycle/**",
+            "**/#recycle",
 
             // Qnap
             "**/@Recycle/**",
+            "**/@Recycle",
             "**/.@__thumb/**",
+            "**/.@__thumb",
             "**/$RECYCLE.BIN/**",
+            "**/$RECYCLE.BIN",
             "**/System Volume Information/**",
+            "**/System Volume Information",
             "**/.grab/**",
+            "**/.grab",
 
             // Unix hidden files and directories
             "**/.*/**",
+            "**/.*",
 
             // thumbs.db
             "**/thumbs.db",
@@ -56,16 +75,19 @@ namespace Emby.Server.Implementations.Library
 
         private static readonly GlobOptions _globOptions = new GlobOptions
         {
-            Evaluation = {
+            Evaluation =
+            {
                 CaseInsensitive = true
             }
         };
 
-        private static readonly Glob[] _globs = Patterns.Select(p => Glob.Parse(p, _globOptions)).ToArray();
+        private static readonly Glob[] _globs = _patterns.Select(p => Glob.Parse(p, _globOptions)).ToArray();
 
         /// <summary>
         /// Returns true if the supplied path should be ignored.
         /// </summary>
+        /// <param name="path">The path to test.</param>
+        /// <returns>Whether to ignore the path.</returns>
         public static bool ShouldIgnore(string path)
         {
             return _globs.Any(g => g.IsMatch(path));

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
@@ -7,12 +7,19 @@ namespace Jellyfin.Server.Implementations.Tests.Library
     {
         [Theory]
         [InlineData("/media/small.jpg", true)]
+        [InlineData("/media/albumart.jpg", true)]
+        [InlineData("/media/movie.sample.mp4", true)]
         [InlineData("/media/movies/#Recycle/test.txt", true)]
         [InlineData("/media/movies/#recycle/", true)]
+        [InlineData("/media/movies/#recycle", true)]
         [InlineData("thumbs.db", true)]
         [InlineData(@"C:\media\movies\movie.avi", false)]
         [InlineData("/media/.hiddendir/file.mp4", true)]
         [InlineData("/media/dir/.hiddenfile.mp4", true)]
+        [InlineData("/volume1/video/Series/@eaDir", true)]
+        [InlineData("/volume1/video/Series/@eaDir/file.txt", true)]
+        [InlineData("/directory/@Recycle", true)]
+        [InlineData("/directory/@Recycle/file.mp3", true)]
         public void PathIgnored(string path, bool expected)
         {
             Assert.Equal(expected, IgnorePatterns.ShouldIgnore(path));


### PR DESCRIPTION
Fixes #3391

Dotnet.Glob doesn't ignore if there is a trailing path in the pattern but not the test string.