### PR TITLE
Respect FFMpeg path passed via Environment Variable

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -568,8 +568,7 @@ namespace Emby.Server.Implementations
             // TODO: Refactor to eliminate the circular dependency here so that Lazy<T> isn't required
             // TODO: Add StartupOptions.FFmpegPath to IConfiguration and remove this custom activation
             serviceCollection.AddTransient(provider => new Lazy<EncodingHelper>(provider.GetRequiredService<EncodingHelper>));
-            serviceCollection.AddSingleton<IMediaEncoder>(provider =>
-                ActivatorUtilities.CreateInstance<MediaBrowser.MediaEncoding.Encoder.MediaEncoder>(provider, _startupOptions.FFmpegPath ?? string.Empty));
+            serviceCollection.AddSingleton<IMediaEncoder, MediaBrowser.MediaEncoding.Encoder.MediaEncoder>();
 
             // TODO: Refactor to eliminate the circular dependencies here so that Lazy<T> isn't required
             serviceCollection.AddTransient(provider => new Lazy<ILibraryMonitor>(provider.GetRequiredService<ILibraryMonitor>));

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -566,7 +566,6 @@ namespace Emby.Server.Implementations
             serviceCollection.AddTransient(provider => new Lazy<IDtoService>(provider.GetRequiredService<IDtoService>));
 
             // TODO: Refactor to eliminate the circular dependency here so that Lazy<T> isn't required
-            // TODO: Add StartupOptions.FFmpegPath to IConfiguration and remove this custom activation
             serviceCollection.AddTransient(provider => new Lazy<EncodingHelper>(provider.GetRequiredService<EncodingHelper>));
             serviceCollection.AddSingleton<IMediaEncoder, MediaBrowser.MediaEncoding.Encoder.MediaEncoder>();
 

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -101,6 +101,11 @@ namespace Jellyfin.Server
                 config.Add(UdpServer.AddressOverrideConfigKey, PublishedServerUrl.ToString());
             }
 
+            if (FFmpegPath != null)
+            {
+                config.Add(ConfigurationExtensions.FfmpegPathKey, FFmpegPath);
+            }
+
             return config;
         }
     }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -24,6 +24,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string FfmpegAnalyzeDurationKey = "FFmpeg:analyzeduration";
 
         /// <summary>
+        /// The key for the FFmpeg path option.
+        /// </summary>
+        public const string FfmpegPathKey = "ffmpeg";
+
+        /// <summary>
         /// The key for a setting that indicates whether playlists should allow duplicate entries.
         /// </summary>
         public const string PlaylistsAllowDuplicatesKey = "playlists:allowDuplicates";

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -21,6 +21,7 @@ using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.System;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 
 namespace MediaBrowser.MediaEncoding.Encoder
 {
@@ -46,7 +47,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private readonly object _runningProcessesLock = new object();
         private readonly List<ProcessWrapper> _runningProcesses = new List<ProcessWrapper>();
 
-        private string _ffmpegPath;
+        private string _ffmpegPath = string.Empty;
         private string _ffprobePath;
 
         public MediaEncoder(
@@ -55,14 +56,14 @@ namespace MediaBrowser.MediaEncoding.Encoder
             IFileSystem fileSystem,
             ILocalizationManager localization,
             Lazy<EncodingHelper> encodingHelperFactory,
-            string startupOptionsFFmpegPath)
+            IConfiguration config)
         {
             _logger = logger;
             _configurationManager = configurationManager;
             _fileSystem = fileSystem;
             _localization = localization;
             _encodingHelperFactory = encodingHelperFactory;
-            _startupOptionFFmpegPath = startupOptionsFFmpegPath;
+            _startupOptionFFmpegPath = config.GetValue<string>(Controller.Extensions.ConfigurationExtensions.FfmpegPathKey) ?? "";
         }
 
         private EncodingHelper EncodingHelper => _encodingHelperFactory.Value;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -63,7 +63,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             _fileSystem = fileSystem;
             _localization = localization;
             _encodingHelperFactory = encodingHelperFactory;
-            _startupOptionFFmpegPath = config.GetValue<string>(Controller.Extensions.ConfigurationExtensions.FfmpegPathKey) ?? "";
+            _startupOptionFFmpegPath = config.GetValue<string>(Controller.Extensions.ConfigurationExtensions.FfmpegPathKey) ?? string.Empty;
         }
 
         private EncodingHelper EncodingHelper => _encodingHelperFactory.Value;


### PR DESCRIPTION
Fix issue whereby `JELLYFIN_FFMPEG`  environment variable was ignored.

**Changes**
- Added ffmpeg commandline param into IConfiguration
- Updated MediaEncoder constructor to take IConfiguration instead ffmpeg path string 
- Removed custom activation for MediaEncoder

