### PR TITLE
dlna: disable subnet detection

### DIFF
--- a/Emby.Dlna/Main/DlnaEntryPoint.cs
+++ b/Emby.Dlna/Main/DlnaEntryPoint.cs
@@ -269,7 +269,8 @@ namespace Emby.Dlna.Main
                 // Limit to LAN addresses only
                 if (!_networkManager.IsAddressInSubnets(address, true, true))
                 {
-                    continue;
+                    // subnet detection broken?
+                    //continue;
                 }
 
                 var fullService = "urn:schemas-upnp-org:device:MediaServer:1";


### PR DESCRIPTION
This PR disables the whole subnet detection stuff when registering a DLNA endpoint.

Why? It doesn't seem to work right:

**jellyfin/jellyfin**
```
[2020-07-04 14:33:53.002 +02:00] [INF] [94] Dlna: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "10.59.74.6"
[2020-07-04 14:33:53.014 +02:00] [INF] [94] Dlna: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "10.139.157.11"
[2020-07-04 14:33:53.035 +02:00] [INF] [94] Dlna: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "192.168.66.2"
[2020-07-04 14:33:53.051 +02:00] [INF] [94] Dlna: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.17.0.2"
```

**miegl/jellyfin**
```
[2020-07-04 14:48:50.338 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "127.0.0.1"
[2020-07-04 14:48:50.365 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "10.59.74.6"
[2020-07-04 14:48:50.378 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.0.1"
[2020-07-04 14:48:50.391 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.1.1"
[2020-07-04 14:48:50.419 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.2.1"
[2020-07-04 14:48:50.429 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.8.1"
[2020-07-04 14:48:50.450 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.9.1"
[2020-07-04 14:48:50.460 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.16.10.1"
[2020-07-04 14:48:50.494 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "192.168.66.2"
[2020-07-04 14:48:50.505 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.17.100.10"
[2020-07-04 14:48:50.525 +02:00] [INF] [6] Emby.Dlna.Main.DlnaEntryPoint: Registering publisher for "urn:schemas-upnp-org:device:MediaServer:1" on "172.17.0.2"
```

As you can see, jellyfin with LAN subnet detection enabled seems to completely ignore some of my networks.

This PR isn't meant to be accepted right away, I would instead like to know if I'm missing something. I would also be grateful for someone more knowledgeable to suggest a better fix :)