### PR TITLE
Fix: Change to ffmpeg detection.

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -159,7 +159,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             if (version == null)
             {
-                if (MinVersion != null && MinVersion != null) // Version is unknown
+                if (MinVersion != null && MaxVersion != null) // Version is unknown
                 {
                     if (MinVersion == MaxVersion)
                     {
@@ -167,7 +167,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     }
                     else
                     {
-                        _logger.LogWarning("FFmpeg validation: We recommend a minimum of {0} and maximum of {1}", MinVersion, MaxVersion);                        
+                        _logger.LogWarning("FFmpeg validation: We recommend a minimum of {0} and maximum of {1}", MinVersion, MaxVersion);
                     }
                 }
 
@@ -297,7 +297,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             return rc.Length == 0 ? string.Empty : rc.ToString();
         }
-    
+   
         private enum Codec
         {
             Encoder,

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.MediaEncoding.Tests
         [InlineData(EncoderValidatorTestsData.FFmpegV42Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV414Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV404Output, true)]
-        [InlineData(EncoderValidatorTestsData.FFmpegGitUnknownOutput, false)]
+        [InlineData(EncoderValidatorTestsData.FFmpegGitUnknownOutput, true)] // return 4.1.0.1 (custom build based upon 4.1)
         public void ValidateVersionInternalTest(string versionOutput, bool valid)
         {
             var val = new EncoderValidator(new NullLogger<EncoderValidatorTests>());
@@ -36,7 +36,7 @@ namespace Jellyfin.MediaEncoding.Tests
                 yield return new object?[] { EncoderValidatorTestsData.FFmpegV42Output, new Version(4, 2) };
                 yield return new object?[] { EncoderValidatorTestsData.FFmpegV414Output, new Version(4, 1, 4) };
                 yield return new object?[] { EncoderValidatorTestsData.FFmpegV404Output, new Version(4, 0, 4) };
-                yield return new object?[] { EncoderValidatorTestsData.FFmpegGitUnknownOutput, null };
+                yield return new object?[] { EncoderValidatorTestsData.FFmpegGitUnknownOutput, new Version(4, 1, 0, 1) }; // final .1 signifies a custom build.
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
Fix
-------
Dictionary matching wasn't working for me, as my ffmpeg had additional modules installed.

Changes
---------
Added version 4.3 to the dictionary.

The code builds a list of modules found in the dictionary, in the order that they appear in the dictionary for matching.

If no match is found, a further comparison is made, but only using the libavutil. The nearest match is found, and that version number is returned with an revision increment so that the system knows it's a custom build.

eg.

ffmpeg version git-2020-06-28-4cfcfb3 Copyright (c) 2000-2020 the FFmpeg developers
libavutil      56. 55.100 / 56. 55.100
libavcodec     58. 93.100 / 58. 93.100
libavformat    58. 47.100 / 58. 47.100
libavdevice    58. 11.100 / 58. 11.100
libavfilter     7. 86.100 /  7. 86.100
libswscale      5.  8.100 /  5.  8.100
libswresample   3.  8.100 /  3.  8.100
libpostproc    55.  8.100 / 55.  8.100

now identifies as: **Found custom ffmpeg. Approximating version around 4.3**

ffmpeg version N-95234-g35a63a9127 Copyright (c) 2000-2019 the FFmpeg developers
libavutil      56. 35.100 / 56. 35.100
libavcodec     58. 59.101 / 58. 59.101
libavformat    58. 33.100 / 58. 33.100
libavdevice    58.  9.100 / 58.  9.100
libavfilter     7. 62.100 /  7. 62.100
libswscale      5.  6.100 /  5.  6.100
libswresample   3.  6.100 /  3.  6.100
libpostproc    55.  6.100 / 55.  6.100

now identifies as:  **Found custom ffmpeg. Approximating version around 4.2**
