### PR TITLE
Add trigger for Windows installer build

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -132,18 +132,25 @@ jobs:
 
 - job: TriggerWinInstaller
   displayName: 'Trigger Windows installer build'
-  dependsOn:
-  - BuildPackage
-  condition: succeeded('BuildPackage')
 
   pool:
     vmImage: 'ubuntu-latest'
 
   steps:
-  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
-    displayName: 'Trigger Azure DevOps build'
+  - task: AzureCLI@2
+    displayName: 'Trigger Azure DevOps build (unstable)'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    inputs:
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"
 
-  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
-    displayName: 'Trigger Azure DevOps build'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+  - task: AzureCLI@2
+    displayName: 'Trigger Azure DevOps build (unstable)'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+    inputs:
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -129,3 +129,21 @@ jobs:
       sshEndpoint: repository
       runOptions: 'inline'
       inline: 'sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber)'
+
+- job: TriggerWinInstaller
+  displayName: 'Trigger Windows installer build'
+  dependsOn:
+  - BuildPackage
+  condition: succeeded('BuildPackage')
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
+    displayName: 'Trigger Azure DevOps build'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
+    displayName: 'Trigger Azure DevOps build'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -6,11 +6,11 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
-  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
     displayName: 'Trigger Azure DevOps build'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
 
-  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
     displayName: 'Trigger Azure DevOps build'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
 

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -1,4 +1,19 @@
 jobs:
+- job: TriggerWinInstaller
+  displayName: 'Trigger Windows installer build'
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
+    displayName: 'Trigger Azure DevOps build'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
+
+  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
+    displayName: 'Trigger Azure DevOps build'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+
 - job: BuildPackage
   displayName: 'Build Packages'
 
@@ -129,18 +144,3 @@ jobs:
       sshEndpoint: repository
       runOptions: 'inline'
       inline: 'sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber)'
-
-- job: TriggerWinInstaller
-  displayName: 'Trigger Windows installer build'
-
-  pool:
-    vmImage: 'ubuntu-latest'
-
-  steps:
-  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
-    displayName: 'Trigger Azure DevOps build'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
-
-  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
-    displayName: 'Trigger Azure DevOps build'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -140,10 +140,10 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
-  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
+  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
     displayName: 'Trigger Azure DevOps build'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
 
-  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
+  - script: 'az login --identity && az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
     displayName: 'Trigger Azure DevOps build'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -132,9 +132,6 @@ jobs:
 
 - job: TriggerWinInstaller
   displayName: 'Trigger Windows installer build'
-  dependsOn:
-  - BuildPackage
-  condition: succeeded('BuildPackage')
 
   pool:
     vmImage: 'ubuntu-latest'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -132,25 +132,18 @@ jobs:
 
 - job: TriggerWinInstaller
   displayName: 'Trigger Windows installer build'
+  dependsOn:
+  - BuildPackage
+  condition: succeeded('BuildPackage')
 
   pool:
     vmImage: 'ubuntu-latest'
 
   steps:
-  - task: AzureCLI@2
-    displayName: 'Trigger Azure DevOps build (unstable)'
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"'
+    displayName: 'Trigger Azure DevOps build'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
-    inputs:
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable"
 
-  - task: AzureCLI@2
-    displayName: 'Trigger Azure DevOps build (unstable)'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/azure-ci')
-    inputs:
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"
+  - script: 'az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="$(Build.SourceBranch)"'
+    displayName: 'Trigger Azure DevOps build'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')


### PR DESCRIPTION
**Changes**
Adds a job to the Package CI to trigger a build of the Windows installer at the completion of the other steps. This is a separate set of CI within the https://github.com/jellyfin/jellyfin-windows-installer repository, which has its own pipeline though the `collect-server.azure.sh` script.

**Issues**
N/A
