### PR TITLE
SSDP: Include any address if LAN subnets aren't specified

### DIFF
--- a/Emby.Server.Implementations/Networking/NetworkManager.cs
+++ b/Emby.Server.Implementations/Networking/NetworkManager.cs
@@ -268,6 +268,12 @@ namespace Emby.Server.Implementations.Networking
             string excludeAddress = "[" + addressString + "]";
             var subnets = LocalSubnetsFn();
 
+            // Include any address if LAN subnets aren't specified
+            if (subnets.Length == 0)
+            {
+                return true;
+            }
+
             // Exclude any addresses if they appear in the LAN list in [ ]
             if (Array.IndexOf(subnets, excludeAddress) != -1)
             {


### PR DESCRIPTION
With https://github.com/jellyfin/jellyfin/pull/3007, the user needs to specify LAN networks (`ServerConfigurationManager.Configuration.LocalNetworkSubnets`) in order for SSDP to work. This breaks the way Jellyfin/Emby has traditionally worked, i.e. SSDP/DLNA worked on all interfaces/addresses by default.

This PR makes it so that when the LAN subnets setting is empty, DLNA binds to all available addresses by default, effectively restoring the old behaviour.