### PR TITLE
Fix support for mixed-protocol subtitles

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -172,7 +172,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 inputFiles = new[] { mediaSource.Path };
             }
 
-            var fileInfo = await GetReadableFile(mediaSource.Path, inputFiles, mediaSource.Protocol, subtitleStream, cancellationToken).ConfigureAwait(false);
+            var fileInfo = await GetReadableFile(mediaSource.Path, inputFiles, _mediaSourceManager.GetPathProtocol(subtitleStream.Path), subtitleStream, cancellationToken).ConfigureAwait(false);
 
             var stream = await GetSubtitleStream(fileInfo.Path, fileInfo.Protocol, fileInfo.IsExternal, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
**Changes**
When determining the protocol of a subtitle track during encoding, determine the subtitle's protocol from its path instead of using the protocol of the main file. This fixes playback of subtitles with a different protocol than the main media file, e.g. locally stored SRT subtitles with the File protocol and STRM main media files with the HTTP protocol.

**Issues**
Fixes #2543 