### PR TITLE
Fix value parsing in Jellyfin.Api

### DIFF
--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Models.ConfigurationDtos;
+using MediaBrowser.Common.Json;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Configuration;
@@ -87,7 +88,7 @@ namespace Jellyfin.Api.Controllers
         public async Task<ActionResult> UpdateNamedConfiguration([FromRoute] string? key)
         {
             var configurationType = _configurationManager.GetConfigurationType(key);
-            var configuration = await JsonSerializer.DeserializeAsync(Request.Body, configurationType).ConfigureAwait(false);
+            var configuration = await JsonSerializer.DeserializeAsync(Request.Body, configurationType, JsonDefaults.GetOptions()).ConfigureAwait(false);
             _configurationManager.SaveConfiguration(key, configuration);
             return NoContent();
         }

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -23,6 +23,8 @@ namespace Jellyfin.Api.Controllers
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IMediaEncoder _mediaEncoder;
 
+        private readonly JsonSerializerOptions _serializerOptions = JsonDefaults.GetOptions();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationController"/> class.
         /// </summary>
@@ -88,7 +90,7 @@ namespace Jellyfin.Api.Controllers
         public async Task<ActionResult> UpdateNamedConfiguration([FromRoute] string? key)
         {
             var configurationType = _configurationManager.GetConfigurationType(key);
-            var configuration = await JsonSerializer.DeserializeAsync(Request.Body, configurationType, JsonDefaults.GetOptions()).ConfigureAwait(false);
+            var configuration = await JsonSerializer.DeserializeAsync(Request.Body, configurationType, _serializerOptions).ConfigureAwait(false);
             _configurationManager.SaveConfiguration(key, configuration);
             return NoContent();
         }

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Models.PluginDtos;
 using MediaBrowser.Common;
+using MediaBrowser.Common.Json;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
 using MediaBrowser.Model.Plugins;
@@ -118,7 +119,7 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
-            var configuration = (BasePluginConfiguration)await JsonSerializer.DeserializeAsync(Request.Body, plugin.ConfigurationType)
+            var configuration = (BasePluginConfiguration)await JsonSerializer.DeserializeAsync(Request.Body, plugin.ConfigurationType, JsonDefaults.GetOptions())
                 .ConfigureAwait(false);
 
             plugin.UpdateConfiguration(configuration);

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -26,6 +25,8 @@ namespace Jellyfin.Api.Controllers
     {
         private readonly IApplicationHost _appHost;
         private readonly IInstallationManager _installationManager;
+
+        private readonly JsonSerializerOptions _serializerOptions = JsonDefaults.GetOptions();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginsController"/> class.
@@ -119,7 +120,7 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
-            var configuration = (BasePluginConfiguration)await JsonSerializer.DeserializeAsync(Request.Body, plugin.ConfigurationType, JsonDefaults.GetOptions())
+            var configuration = (BasePluginConfiguration)await JsonSerializer.DeserializeAsync(Request.Body, plugin.ConfigurationType, _serializerOptions)
                 .ConfigureAwait(false);
 
             plugin.UpdateConfiguration(configuration);

--- a/MediaBrowser.Common/Json/Converters/JsonDoubleConverter.cs
+++ b/MediaBrowser.Common/Json/Converters/JsonDoubleConverter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MediaBrowser.Common.Json.Converters
+{
+    /// <summary>
+    /// Double to String JSON converter.
+    /// Web client send quoted doubles.
+    /// </summary>
+    public class JsonDoubleConverter : JsonConverter<double>
+    {
+        /// <summary>
+        /// Read JSON string as double.
+        /// </summary>
+        /// <param name="reader"><see cref="Utf8JsonReader"/>.</param>
+        /// <param name="typeToConvert">Type.</param>
+        /// <param name="options">Options.</param>
+        /// <returns>Parsed value.</returns>
+        public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                // try to parse number directly from bytes
+                var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+                if (Utf8Parser.TryParse(span, out double number, out var bytesConsumed) && span.Length == bytesConsumed)
+                {
+                    return number;
+                }
+
+                // try to parse from a string if the above failed, this covers cases with other escaped/UTF characters
+                if (double.TryParse(reader.GetString(), out number))
+                {
+                    return number;
+                }
+            }
+
+            // fallback to default handling
+            return reader.GetDouble();
+        }
+
+        /// <summary>
+        /// Write double to JSON string.
+        /// </summary>
+        /// <param name="writer"><see cref="Utf8JsonWriter"/>.</param>
+        /// <param name="value">Value to write.</param>
+        /// <param name="options">Options.</param>
+        public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString(NumberFormatInfo.InvariantInfo));
+        }
+    }
+}

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -9,8 +9,6 @@ namespace MediaBrowser.Common.Json
     /// </summary>
     public static class JsonDefaults
     {
-        private static JsonSerializerOptions _defaultOptions;
-
         /// <summary>
         /// Gets the default <see cref="JsonSerializerOptions" /> options.
         /// </summary>
@@ -23,26 +21,20 @@ namespace MediaBrowser.Common.Json
         /// <returns>The default <see cref="JsonSerializerOptions" /> options.</returns>
         public static JsonSerializerOptions GetOptions()
         {
-            if (_defaultOptions == null)
+            var options = new JsonSerializerOptions
             {
-                var options = new JsonSerializerOptions
-                {
-                    ReadCommentHandling = JsonCommentHandling.Disallow,
-                    WriteIndented = false
-                };
+                ReadCommentHandling = JsonCommentHandling.Disallow,
+                WriteIndented = false
+            };
 
-                options.Converters.Add(new JsonGuidConverter());
-                options.Converters.Add(new JsonInt32Converter());
-                options.Converters.Add(new JsonStringEnumConverter());
-                options.Converters.Add(new JsonNonStringKeyDictionaryConverterFactory());
-                options.Converters.Add(new JsonInt64Converter());
-                options.Converters.Add(new JsonDoubleConverter());
+            options.Converters.Add(new JsonGuidConverter());
+            options.Converters.Add(new JsonInt32Converter());
+            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new JsonNonStringKeyDictionaryConverterFactory());
+            options.Converters.Add(new JsonInt64Converter());
+            options.Converters.Add(new JsonDoubleConverter());
 
-                _defaultOptions = options;
-                return _defaultOptions;
-            }
-
-            return _defaultOptions;
+            return options;
         }
 
         /// <summary>

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -32,6 +32,7 @@ namespace MediaBrowser.Common.Json
             options.Converters.Add(new JsonStringEnumConverter());
             options.Converters.Add(new JsonNonStringKeyDictionaryConverterFactory());
             options.Converters.Add(new JsonInt64Converter());
+            options.Converters.Add(new JsonDoubleConverter());
 
             return options;
         }

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -9,6 +9,8 @@ namespace MediaBrowser.Common.Json
     /// </summary>
     public static class JsonDefaults
     {
+        private static JsonSerializerOptions _defaultOptions;
+
         /// <summary>
         /// Gets the default <see cref="JsonSerializerOptions" /> options.
         /// </summary>
@@ -21,20 +23,26 @@ namespace MediaBrowser.Common.Json
         /// <returns>The default <see cref="JsonSerializerOptions" /> options.</returns>
         public static JsonSerializerOptions GetOptions()
         {
-            var options = new JsonSerializerOptions
+            if (_defaultOptions == null)
             {
-                ReadCommentHandling = JsonCommentHandling.Disallow,
-                WriteIndented = false
-            };
+                var options = new JsonSerializerOptions
+                {
+                    ReadCommentHandling = JsonCommentHandling.Disallow,
+                    WriteIndented = false
+                };
 
-            options.Converters.Add(new JsonGuidConverter());
-            options.Converters.Add(new JsonInt32Converter());
-            options.Converters.Add(new JsonStringEnumConverter());
-            options.Converters.Add(new JsonNonStringKeyDictionaryConverterFactory());
-            options.Converters.Add(new JsonInt64Converter());
-            options.Converters.Add(new JsonDoubleConverter());
+                options.Converters.Add(new JsonGuidConverter());
+                options.Converters.Add(new JsonInt32Converter());
+                options.Converters.Add(new JsonStringEnumConverter());
+                options.Converters.Add(new JsonNonStringKeyDictionaryConverterFactory());
+                options.Converters.Add(new JsonInt64Converter());
+                options.Converters.Add(new JsonDoubleConverter());
 
-            return options;
+                _defaultOptions = options;
+                return _defaultOptions;
+            }
+
+            return _defaultOptions;
         }
 
         /// <summary>

--- a/MediaBrowser.Model/Configuration/BaseApplicationConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/BaseApplicationConfiguration.cs
@@ -44,7 +44,13 @@ namespace MediaBrowser.Model.Configuration
         public string PreviousVersionStr
         {
             get => PreviousVersion?.ToString();
-            set => PreviousVersion = Version.Parse(value);
+            set
+            {
+                if (Version.TryParse(value, out var version))
+                {
+                    PreviousVersion = version;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
During a shot test of the new Api endpoints, I discovered some minor parsing errors:

- The web client returns doubles quoted as a string (eg. "2.1") which `System.Text.Json` can't parse:
   ▶ This PR adds a custom Json converter for `double` like the ones already existing for `int` and `long`.
- If the web client doesn't return a value for `PreviousVersionStr`, parsing `null` to `Version` would fail:
   ▶ This PR adds handling for null values.
- Some controllers deserialize the request body in the functions. The conversion of quoted numbers would fail because the converters mentioned above are missing:
   ▶ This PR adds the converters as JsonOptions