### PR TITLE
HttpException modification for webservices.

### DIFF
--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -319,15 +319,17 @@ namespace Emby.Server.Implementations.HttpClientManager
             {
                 return;
             }
-
+            
+            string msg = string.Empty;
             if (options.LogErrorResponseBody)
             {
-                string msg = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                msg = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 _logger.LogError("HTTP request failed with message: {Message}", msg);
             }
 
             throw new HttpException(response.ReasonPhrase)
             {
+                ResponseText = msg,
                 StatusCode = response.StatusCode
             };
         }

--- a/MediaBrowser.Model/Net/HttpException.cs
+++ b/MediaBrowser.Model/Net/HttpException.cs
@@ -15,6 +15,11 @@ namespace MediaBrowser.Model.Net
         public HttpStatusCode? StatusCode { get; set; }
 
         /// <summary>
+        /// Gets or sets the webservice response text that accompanied the error code.
+        /// </summary>
+        public string ResponseText { get; set; };
+        
+        /// <summary>
         /// Gets or sets a value indicating whether this instance is timed out.
         /// </summary>
         /// <value><c>true</c> if this instance is timed out; otherwise, <c>false</c>.</value>

--- a/MediaBrowser.Model/Net/HttpException.cs
+++ b/MediaBrowser.Model/Net/HttpException.cs
@@ -17,7 +17,7 @@ namespace MediaBrowser.Model.Net
         /// <summary>
         /// Gets or sets the webservice response text that accompanied the error code.
         /// </summary>
-        public string ResponseText { get; set; }
+        public string? ResponseText { get; set; }
         
         /// <summary>
         /// Gets or sets a value indicating whether this instance is timed out.

--- a/MediaBrowser.Model/Net/HttpException.cs
+++ b/MediaBrowser.Model/Net/HttpException.cs
@@ -17,7 +17,7 @@ namespace MediaBrowser.Model.Net
         /// <summary>
         /// Gets or sets the webservice response text that accompanied the error code.
         /// </summary>
-        public string ResponseText { get; set; };
+        public string ResponseText { get; set; }
         
         /// <summary>
         /// Gets or sets a value indicating whether this instance is timed out.


### PR DESCRIPTION
At present HttpException only logs http response messages to the logger. (If the correct option is set)

When using webservices (such as SSDP), these response strings may contain useful information in the form of XML replies.

This PR stores the response message in a new property of the exception which allows this information be accessed elsewhere.

