### PR TITLE
Prevent failure to bind to Auto Discover port being a fatal error

### DIFF
--- a/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Emby.Server.Implementations.Udp;
@@ -53,7 +54,7 @@ namespace Emby.Server.Implementations.EntryPoints
                 _udpServer = new UdpServer(_logger, _appHost, _config);
                 _udpServer.Start(PortNumber, _cancellationTokenSource.Token);
             }
-            catch (System.Net.Sockets.SocketException ex)
+            catch (SocketException ex)
             {
                 _logger.LogWarning(ex, "Unable to start AutoDiscovery listener on UDP port {PortNumber}", PortNumber);
             }

--- a/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
@@ -55,7 +55,7 @@ namespace Emby.Server.Implementations.EntryPoints
             }
             catch (System.Net.Sockets.SocketException ex)
             {
-                _logger.LogWarning($"Unable to start AutoDiscovery listener on UDP port {PortNumber} - {ex.Message}");
+                _logger.LogWarning(ex, "Unable to start AutoDiscovery listener on UDP port {PortNumber}", PortNumber);
             }
 
             return Task.CompletedTask;

--- a/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
+++ b/Emby.Server.Implementations/EntryPoints/UdpServerEntryPoint.cs
@@ -48,8 +48,16 @@ namespace Emby.Server.Implementations.EntryPoints
         /// <inheritdoc />
         public Task RunAsync()
         {
-            _udpServer = new UdpServer(_logger, _appHost, _config);
-            _udpServer.Start(PortNumber, _cancellationTokenSource.Token);
+            try
+            {
+                _udpServer = new UdpServer(_logger, _appHost, _config);
+                _udpServer.Start(PortNumber, _cancellationTokenSource.Token);
+            }
+            catch (System.Net.Sockets.SocketException ex)
+            {
+                _logger.LogWarning($"Unable to start AutoDiscovery listener on UDP port {PortNumber} - {ex.Message}");
+            }
+
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Presently if the server cannot bind to the AutoDiscovery port (udp 7359) then the server start up will exit with a fatal error.   Since this port cannot be overridden (which would not make sense) or disabled via config, this would prevent users from running Jellyfin on a server where this port is not available or already in use (e.g. Emby running).

**Changes**
Handle exception trying to bind to udp 7359 and log as warning.