### PR TITLE
Only fetch Next Up for episodes that have been fully matched

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -117,23 +117,19 @@ namespace Emby.Server.Implementations.TV
                 limit = limit.Value + 10;
             }
 
-            var items = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                IncludeItemTypes = new[] { typeof(Episode).Name },
-                OrderBy = new[] { new ValueTuple<string, SortOrder>(ItemSortBy.DatePlayed, SortOrder.Descending) },
-                SeriesPresentationUniqueKey = presentationUniqueKey,
-                Limit = limit,
-                DtoOptions = new DtoOptions
+            var items = _libraryManager
+                .GetItemList(new InternalItemsQuery(user)
                 {
-                    Fields = new ItemFields[]
-                    {
-                        ItemFields.SeriesPresentationUniqueKey
-                    },
-                    EnableImages = false
-                },
-                GroupBySeriesPresentationUniqueKey = true
-
-            }, parentsFolders.ToList()).Cast<Episode>().Select(GetUniqueSeriesKey);
+                    IncludeItemTypes = new[] {typeof(Episode).Name},
+                    OrderBy = new[] {new ValueTuple<string, SortOrder>(ItemSortBy.DatePlayed, SortOrder.Descending)},
+                    SeriesPresentationUniqueKey = presentationUniqueKey,
+                    Limit = limit,
+                    DtoOptions = new DtoOptions {Fields = new ItemFields[] {ItemFields.SeriesPresentationUniqueKey}, EnableImages = false},
+                    GroupBySeriesPresentationUniqueKey = true
+                }, parentsFolders.ToList())
+                .Cast<Episode>()
+                .Where(episode => !string.IsNullOrEmpty(episode.SeriesPresentationUniqueKey))
+                .Select(GetUniqueSeriesKey);
 
             // Avoid implicitly captured closure
             var episodes = GetNextUpEpisodes(request, user, items, dtoOptions);

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -118,15 +118,16 @@ namespace Emby.Server.Implementations.TV
             }
 
             var items = _libraryManager
-                .GetItemList(new InternalItemsQuery(user)
-                {
-                    IncludeItemTypes = new[] {typeof(Episode).Name},
-                    OrderBy = new[] {new ValueTuple<string, SortOrder>(ItemSortBy.DatePlayed, SortOrder.Descending)},
-                    SeriesPresentationUniqueKey = presentationUniqueKey,
-                    Limit = limit,
-                    DtoOptions = new DtoOptions {Fields = new ItemFields[] {ItemFields.SeriesPresentationUniqueKey}, EnableImages = false},
-                    GroupBySeriesPresentationUniqueKey = true
-                }, parentsFolders.ToList())
+                .GetItemList(
+                    new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = new[] { typeof(Episode).Name },
+                        OrderBy = new[] { new ValueTuple<string, SortOrder>(ItemSortBy.DatePlayed, SortOrder.Descending) },
+                        SeriesPresentationUniqueKey = presentationUniqueKey,
+                        Limit = limit,
+                        DtoOptions = new DtoOptions { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = false },
+                        GroupBySeriesPresentationUniqueKey = true
+                    }, parentsFolders.ToList())
                 .Cast<Episode>()
                 .Where(episode => !string.IsNullOrEmpty(episode.SeriesPresentationUniqueKey))
                 .Select(GetUniqueSeriesKey);


### PR DESCRIPTION
For reasons unknown, an episode can be matched to a series but `SeriesPresentationUniqueKey` can still be `null` if it isn't completely finished.

When fetching Next Up episodes it uses the unique key to fetch episodes, but it doesn't filter null values, so it will sometimes fetch something random as shown below...

![image](https://user-images.githubusercontent.com/675118/87538222-29667600-c69c-11ea-9d76-6201454d7dc0.png)
