### PR TITLE
TVDB: Fetch image keytypes before querying images

### DIFF
--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbClientManager.cs
@@ -229,6 +229,51 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             return GetEpisodesPageAsync(tvdbId, 1, episodeQuery, language, cancellationToken);
         }
 
+        public async Task<IEnumerable<KeyType>> GetImageKeyTypesForSeriesAsync(int tvdbId, string language, CancellationToken cancellationToken)
+        {
+            var cacheKey = GenerateKey(nameof(TvDbClient.Series.GetImagesSummaryAsync), tvdbId);
+            var imagesSummary = await TryGetValue(cacheKey, language, () => TvDbClient.Series.GetImagesSummaryAsync(tvdbId, cancellationToken)).ConfigureAwait(false);
+            var keyTypes = new List<KeyType>();
+
+            if (imagesSummary.Data.Fanart > 0)
+            {
+                keyTypes.Add(KeyType.Fanart);
+            }
+
+            if (imagesSummary.Data.Series > 0)
+            {
+                keyTypes.Add(KeyType.Series);
+            }
+
+            if (imagesSummary.Data.Poster > 0)
+            {
+                keyTypes.Add(KeyType.Poster);
+            }
+
+            return keyTypes;
+        }
+
+        public async Task<IEnumerable<KeyType>> GetImageKeyTypesForSeasonAsync(int tvdbId, string language, CancellationToken cancellationToken)
+        {
+            var cacheKey = GenerateKey(nameof(TvDbClient.Series.GetImagesSummaryAsync), tvdbId);
+            var imagesSummary = await TryGetValue(cacheKey, language, () => TvDbClient.Series.GetImagesSummaryAsync(tvdbId, cancellationToken)).ConfigureAwait(false);
+            var keyTypes = new List<KeyType>();
+
+            if (imagesSummary.Data.Season > 0)
+            {
+                keyTypes.Add(KeyType.Season);
+            }
+
+            if (imagesSummary.Data.Fanart > 0)
+            {
+                keyTypes.Add(KeyType.Fanart);
+            }
+
+            // TODO seasonwide is not supported in TvDbSharper
+
+            return keyTypes;
+        }
+
         private async Task<T> TryGetValue<T>(string key, string language, Func<Task<T>> resultFactory)
         {
             if (_cache.TryGetValue(key, out T cachedValue))

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbClientManager.cs
@@ -229,49 +229,43 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             return GetEpisodesPageAsync(tvdbId, 1, episodeQuery, language, cancellationToken);
         }
 
-        public async Task<IEnumerable<KeyType>> GetImageKeyTypesForSeriesAsync(int tvdbId, string language, CancellationToken cancellationToken)
+        public async IAsyncEnumerable<KeyType> GetImageKeyTypesForSeriesAsync(int tvdbId, string language, CancellationToken cancellationToken)
         {
             var cacheKey = GenerateKey(nameof(TvDbClient.Series.GetImagesSummaryAsync), tvdbId);
             var imagesSummary = await TryGetValue(cacheKey, language, () => TvDbClient.Series.GetImagesSummaryAsync(tvdbId, cancellationToken)).ConfigureAwait(false);
-            var keyTypes = new List<KeyType>();
 
             if (imagesSummary.Data.Fanart > 0)
             {
-                keyTypes.Add(KeyType.Fanart);
+                yield return KeyType.Fanart;
             }
 
             if (imagesSummary.Data.Series > 0)
             {
-                keyTypes.Add(KeyType.Series);
+                yield return KeyType.Series;
             }
 
             if (imagesSummary.Data.Poster > 0)
             {
-                keyTypes.Add(KeyType.Poster);
+                yield return KeyType.Poster;
             }
-
-            return keyTypes;
         }
 
-        public async Task<IEnumerable<KeyType>> GetImageKeyTypesForSeasonAsync(int tvdbId, string language, CancellationToken cancellationToken)
+        public async IAsyncEnumerable<KeyType> GetImageKeyTypesForSeasonAsync(int tvdbId, string language, CancellationToken cancellationToken)
         {
             var cacheKey = GenerateKey(nameof(TvDbClient.Series.GetImagesSummaryAsync), tvdbId);
             var imagesSummary = await TryGetValue(cacheKey, language, () => TvDbClient.Series.GetImagesSummaryAsync(tvdbId, cancellationToken)).ConfigureAwait(false);
-            var keyTypes = new List<KeyType>();
 
             if (imagesSummary.Data.Season > 0)
             {
-                keyTypes.Add(KeyType.Season);
+                yield return KeyType.Season;
             }
 
             if (imagesSummary.Data.Fanart > 0)
             {
-                keyTypes.Add(KeyType.Fanart);
+                yield return KeyType.Fanart;
             }
 
             // TODO seasonwide is not supported in TvDbSharper
-
-            return keyTypes;
         }
 
         private async Task<T> TryGetValue<T>(string key, string language, Func<Task<T>> resultFactory)

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
@@ -65,7 +65,7 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             var language = item.GetPreferredMetadataLanguage();
             var remoteImages = new List<RemoteImageInfo>();
 
-            var keyTypes = new[] { KeyType.Season, KeyType.Seasonwide, KeyType.Fanart };
+            var keyTypes = await _tvdbClientManager.GetImageKeyTypesForSeasonAsync(tvdbId, language, cancellationToken).ConfigureAwait(false);
             foreach (var keyType in keyTypes)
             {
                 var imageQuery = new ImagesQuery

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeasonImageProvider.cs
@@ -65,8 +65,8 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             var language = item.GetPreferredMetadataLanguage();
             var remoteImages = new List<RemoteImageInfo>();
 
-            var keyTypes = await _tvdbClientManager.GetImageKeyTypesForSeasonAsync(tvdbId, language, cancellationToken).ConfigureAwait(false);
-            foreach (var keyType in keyTypes)
+            var keyTypes = _tvdbClientManager.GetImageKeyTypesForSeasonAsync(tvdbId, language, cancellationToken).ConfigureAwait(false);
+            await foreach (var keyType in keyTypes)
             {
                 var imageQuery = new ImagesQuery
                 {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesImageProvider.cs
@@ -60,9 +60,9 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             var language = item.GetPreferredMetadataLanguage();
             var remoteImages = new List<RemoteImageInfo>();
             var tvdbId = Convert.ToInt32(item.GetProviderId(MetadataProvider.Tvdb));
-            var allowedKeyTypes = await _tvdbClientManager.GetImageKeyTypesForSeriesAsync(tvdbId, language, cancellationToken)
+            var allowedKeyTypes = _tvdbClientManager.GetImageKeyTypesForSeriesAsync(tvdbId, language, cancellationToken)
                 .ConfigureAwait(false);
-            foreach (KeyType keyType in allowedKeyTypes)
+            await foreach (KeyType keyType in allowedKeyTypes)
             {
                 var imageQuery = new ImagesQuery
                 {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesImageProvider.cs
@@ -59,9 +59,10 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
 
             var language = item.GetPreferredMetadataLanguage();
             var remoteImages = new List<RemoteImageInfo>();
-            var keyTypes = new[] { KeyType.Poster, KeyType.Series, KeyType.Fanart };
             var tvdbId = Convert.ToInt32(item.GetProviderId(MetadataProvider.Tvdb));
-            foreach (KeyType keyType in keyTypes)
+            var allowedKeyTypes = await _tvdbClientManager.GetImageKeyTypesForSeriesAsync(tvdbId, language, cancellationToken)
+                .ConfigureAwait(false);
+            foreach (KeyType keyType in allowedKeyTypes)
             {
                 var imageQuery = new ImagesQuery
                 {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
@@ -247,9 +247,14 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                 {
                     Name = tvdbTitles.FirstOrDefault(),
                     ProductionYear = firstAired.Year,
-                    SearchProviderName = Name,
-                    ImageUrl = TvdbUtils.BannerUrl + seriesSearchResult.Banner
+                    SearchProviderName = Name
                 };
+
+                if (!string.IsNullOrEmpty(seriesSearchResult.Banner))
+                {
+                    // Results from their Search endpoints already include the /banners/ part in the url, because reasons...
+                    remoteSearchResult.ImageUrl = TvdbUtils.TvdbImageBaseUrl + seriesSearchResult.Banner;
+                }
 
                 try
                 {
@@ -365,9 +370,13 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                     Type = PersonType.Actor,
                     Name = (actor.Name ?? string.Empty).Trim(),
                     Role = actor.Role,
-                    ImageUrl = TvdbUtils.BannerUrl + actor.Image,
                     SortOrder = actor.SortOrder
                 };
+
+                if (!string.IsNullOrEmpty(actor.Image))
+                {
+                    personInfo.ImageUrl = TvdbUtils.TvdbImageBaseUrl + actor.Image;
+                }
 
                 if (!string.IsNullOrWhiteSpace(personInfo.Name))
                 {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbUtils.cs
@@ -9,7 +9,8 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
     {
         public const string TvdbApiKey = "OG4V3YJ3FAP7FP2K";
         public const string TvdbBaseUrl = "https://www.thetvdb.com/";
-        public const string BannerUrl = TvdbBaseUrl + "banners/";
+        public const string TvdbImageBaseUrl = "https://www.thetvdb.com";
+        public const string BannerUrl = TvdbImageBaseUrl + "/banners/";
 
         public static ImageType GetImageTypeFromKeyType(string keyType)
         {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Use the `/series/{id}/images` endpoint to get the available image types eg. poster, banners to avoid making a lot of unnecessary requests that result in exceptions being thrown.
Also fix the bad banner url in the series provider.
