### PR TITLE
Bump the minimun required jellyfin-ffmpeg version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         jellyfin-ffmpeg (>= 4.3.1-1),
+         jellyfin-ffmpeg (>= 4.2.1-2),
          libfontconfig1,
          libfreetype6,
          libssl1.1

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         jellyfin-ffmpeg (>= 4.2.1-2),
+         jellyfin-ffmpeg (>= 4.3.1-1),
          libfontconfig1,
          libfreetype6,
          libssl1.1

--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -8,8 +8,7 @@ set -o xtrace
 # Version variables
 NSSM_VERSION="nssm-2.24-101-g897c7ad"
 NSSM_URL="http://files.evilt.win/nssm/${NSSM_VERSION}.zip"
-FFMPEG_VERSION="ffmpeg-4.3-win64-static"
-FFMPEG_URL="https://ffmpeg.zeranoe.com/builds/win64/static/${FFMPEG_VERSION}.zip"
+FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg.zip";
 
 # Move to source directory
 pushd ${SOURCE_DIR}
@@ -29,12 +28,11 @@ dotnet publish Jellyfin.Server --configuration Release --self-contained --runtim
 # Prepare addins
 addin_build_dir="$( mktemp -d )"
 wget ${NSSM_URL} -O ${addin_build_dir}/nssm.zip
-wget ${FFMPEG_URL} -O ${addin_build_dir}/ffmpeg.zip
+wget ${FFMPEG_URL} -O ${addin_build_dir}/jellyfin-ffmpeg.zip
 unzip ${addin_build_dir}/nssm.zip -d ${addin_build_dir}
 cp ${addin_build_dir}/${NSSM_VERSION}/win64/nssm.exe ${output_dir}/nssm.exe
-unzip ${addin_build_dir}/ffmpeg.zip -d ${addin_build_dir}
-cp ${addin_build_dir}/${FFMPEG_VERSION}/bin/ffmpeg.exe ${output_dir}/ffmpeg.exe
-cp ${addin_build_dir}/${FFMPEG_VERSION}/bin/ffprobe.exe ${output_dir}/ffprobe.exe
+unzip ${addin_build_dir}/jellyfin-ffmpeg.zip -d ${addin_build_dir}/jellyfin-ffmpeg
+cp ${addin_build_dir}/jellyfin-ffmpeg/* ${output_dir}
 rm -rf ${addin_build_dir}
 
 # Prepare scripts

--- a/windows/build-jellyfin.ps1
+++ b/windows/build-jellyfin.ps1
@@ -47,7 +47,7 @@ function Install-FFMPEG {
     param(
         [string]$ResolvedInstallLocation,
         [string]$Architecture,
-        [string]$FFMPEGVersionX86 = "ffmpeg-4.2.1-win32-shared"
+        [string]$FFMPEGVersionX86 = "ffmpeg-4.3-win32-shared"
     )
     Write-Verbose "Checking Architecture"
     if($Architecture -notin @('x86','x64')){


### PR DESCRIPTION
**Changes**
- ~Bump the minimun required `jellyfin-ffmpeg` version to [4.3.1-1](https://github.com/jellyfin/jellyfin-ffmpeg/pull/46) since the `vpp_qsv` filter in ffmpeg 4.2.x is buggy~
   ~and VP8/VP9 decoders in QSV/NVDEC is avaliable since ffmpeg 4.3.~

- Utilize jellyfin-ffmpeg for portable x64.
