### PR TITLE
Fix bad Debuntu dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-server (10.6.0-2) unstable; urgency=medium
+
+  * Fix upgrade bug
+
+ -- Joshua Boniface <joshua@boniface.me>  Sun, 19 Jul 22:47:27 -0400
+
 jellyfin-server (10.6.0-1) unstable; urgency=medium
 
   * Forthcoming stable release

--- a/debian/control
+++ b/debian/control
@@ -14,9 +14,8 @@ Vcs-Git: https://github.org/jellyfin/jellyfin.git
 Vcs-Browser: https://github.org/jellyfin/jellyfin
 
 Package: jellyfin-server
-Replaces: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server, jellyfin (<<10.6.0)
-Breaks: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server, jellyfin (<<10.6.0)
-Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
+Replaces: jellyfin (<<10.6.0)
+Breaks: jellyfin (<<10.6.0)
 Architecture: any
 Depends: at,
          libsqlite3-0,

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
+                dotnet-sdk-3.1,
                 libc6-dev,
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
-                dotnet-sdk-3.1,
                 libc6-dev,
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,
@@ -15,8 +14,8 @@ Vcs-Git: https://github.org/jellyfin/jellyfin.git
 Vcs-Browser: https://github.org/jellyfin/jellyfin
 
 Package: jellyfin-server
-Replaces: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
-Breaks: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
+Replaces: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server, jellyfin (<<10.6.0)
+Breaks: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server, jellyfin (<<10.6.0)
 Conflicts: mediabrowser, emby, emby-server-beta, jellyfin-dev, emby-server
 Architecture: any
 Depends: at,


### PR DESCRIPTION
**Changes**
Fix the bad dependencies in Debuntu that caused `apt -f install` to be required while upgrading from <10.6.0 to 10.6.0-1. This was used to build the 10.6.0-2 packages which are now live, so the change is moot now, but I've also included a removal of the legacy Emby `Conflicts` entries too since we're well past that now.

**Issues**
N/A
