### PR TITLE
tvdb: Log path on lookup errors

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -265,7 +265,7 @@ namespace MediaBrowser.Providers.Manager
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{0} failed in GetImageInfos for type {1}", provider.GetType().Name, item.GetType().Name);
+                _logger.LogError(ex, "{ProviderName} failed in GetImageInfos for type {ItemType} at {ItemPath}", provider.GetType().Name, item.GetType().Name, item.Path);
                 return new List<RemoteImageInfo>();
             }
         }
@@ -430,7 +430,7 @@ namespace MediaBrowser.Providers.Manager
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{0} failed in Supports for type {1}", provider.GetType().Name, item.GetType().Name);
+                _logger.LogError(ex, "{ProviderName} failed in Supports for type {ItemType} at {ItemPath}", provider.GetType().Name, item.GetType().Name, item.Path);
                 return false;
             }
         }

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Providers.TV
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Error in DummySeasonProvider");
+                Logger.LogError(ex, "Error in DummySeasonProvider for {ItemPath}", item.Path);
             }
         }
 


### PR DESCRIPTION
**Changes**

If the (tvdb) lookup fails (due to a bad id in an nfo file for example), then
we have no indication of which directory failed, so the user can not
fix the problem.

Now we include the path in the logger error message such as:

```
MediaBrowser.Providers.TV.SeriesMetadataService: Error in
DummySeasonProvider for /media/x/y/z

```
and

```
MediaBrowser.Providers.Manager.ProviderManager:
TvdbSeriesImageProvider failed in GetImageInfos for type Series for
/media/x/y/z

```
**Issues**

I did not raise an issue (or add to Contributors) since the change is minor.

The problem occurred for me since my nfo file had been written referencing
a series that had later been removed from tvdb.
