### PR TITLE
Force plugin config location

### DIFF
--- a/MediaBrowser.Providers/Plugins/AudioDb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/AudioDb/Plugin.cs
@@ -19,6 +19,9 @@ namespace MediaBrowser.Providers.Plugins.AudioDb
 
         public override string Description => "Get artist and album metadata or images from AudioDB.";
 
+        // TODO remove when plugin removed from server.
+        public override string ConfigurationFileName => "Jellyfin.Plugin.AudioDb.xml";
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)
         {

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
@@ -23,6 +23,9 @@ namespace MediaBrowser.Providers.Plugins.MusicBrainz
 
         public const long DefaultRateLimit = 2000u;
 
+        // TODO remove when plugin removed from server.
+        public override string ConfigurationFileName => "Jellyfin.Plugin.MusicBrainz.xml";
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)
         {

--- a/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
@@ -19,6 +19,9 @@ namespace MediaBrowser.Providers.Plugins.Omdb
 
         public override string Description => "Get metadata for movies and other video content from OMDb.";
 
+        // TODO remove when plugin removed from server.
+        public override string ConfigurationFileName => "Jellyfin.Plugin.Omdb.xml";
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)
         {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/Plugin.cs
@@ -17,6 +17,9 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
 
         public override string Description => "Get metadata for movies and other video content from TheTVDB.";
 
+        // TODO remove when plugin removed from server.
+        public override string ConfigurationFileName => "Jellyfin.Plugin.TheTvdb.xml";
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)
         {


### PR DESCRIPTION
Fixes #3653

Sets the plugin configuration file to be the future namespace

Note: Plugins won't save correctly until #3634 is merged