### PR TITLE
Fixed compilation error on master.

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -200,7 +200,7 @@ namespace MediaBrowser.Model.Entities
                             return result.ToString();
                         }
 
-                        return string.Join(' ', attributes);
+                        return string.Join(" ", attributes);
                     }
 
                     case MediaStreamType.Subtitle:


### PR DESCRIPTION
`string.Join(Char, String[])` was added in .NET Standard 2.1. `MediaBrowser.Model` also targets 2.0 so it can't use this method.