### PR TITLE
Fix left /usr/bin/jellyfin symlink on removal and typo

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -25,7 +25,7 @@ case "$1" in
   purge)
     echo PURGE | debconf-communicate $NAME > /dev/null 2>&1 || true
 
-    if [[ -x "/etc/init.d/jellyfin" ]] || [[ -e "/etc/init/jellyfin.connf" ]]; then
+    if [[ -x "/etc/init.d/jellyfin" ]] || [[ -e "/etc/init/jellyfin.conf" ]]; then
       update-rc.d jellyfin remove >/dev/null 2>&1 || true
     fi
 
@@ -54,7 +54,7 @@ case "$1" in
       rm -rf $PROGRAMDATA
     fi
     # Remove binary symlink
-    [[ -f /usr/bin/jellyfin ]] && rm /usr/bin/jellyfin
+    rm -f /usr/bin/jellyfin
     # Remove sudoers config
     [[ -f /etc/sudoers.d/jellyfin-sudoers ]] && rm /etc/sudoers.d/jellyfin-sudoers
     # Remove anything at the default locations; catches situations where the user moved the defaults


### PR DESCRIPTION
**Changes**
After removal of the symlink target file "/usr/lib/jellyfin/bin/jellyfin", file existence check on the symlink "[[ -f /usr/bin/jellyfin ]]" returns false. As a result the symlink is left in place on package purge. The correct check would be "[[ -L /usr/bin/jellyfin ]]", but since it could be a file in cases, e.g. manual fix on file systems with no symlink support or for any other reason, it is easiest to use "rm -f" to assure that it is removed in both cases and not return false even if it does not exist at all.

Additionally this fixes a typo on upstart script check.