### PR TITLE
Fix embedded subtitles

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -175,9 +175,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
 
             var protocol = mediaSource.Protocol;
-            if (subtitleStream.IsExternal) {
+            if (subtitleStream.IsExternal)
+            {
                 protocol = _mediaSourceManager.GetPathProtocol(subtitleStream.Path);
             }
+
             var fileInfo = await GetReadableFile(mediaSource.Path, inputFiles, protocol, subtitleStream, cancellationToken).ConfigureAwait(false);
 
             var stream = await GetSubtitleStream(fileInfo.Path, fileInfo.Protocol, fileInfo.IsExternal, cancellationToken).ConfigureAwait(false);

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -174,7 +174,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 inputFiles = new[] { mediaSource.Path };
             }
 
-            var fileInfo = await GetReadableFile(mediaSource.Path, inputFiles, _mediaSourceManager.GetPathProtocol(subtitleStream.Path), subtitleStream, cancellationToken).ConfigureAwait(false);
+            var protocol = mediaSource.Protocol;
+            if (subtitleStream.IsExternal) {
+                protocol = _mediaSourceManager.GetPathProtocol(subtitleStream.Path);
+            }
+            var fileInfo = await GetReadableFile(mediaSource.Path, inputFiles, protocol, subtitleStream, cancellationToken).ConfigureAwait(false);
 
             var stream = await GetSubtitleStream(fileInfo.Path, fileInfo.Protocol, fileInfo.IsExternal, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixes regression introduced by #3521

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

```csharp
[2020-07-25 09:34:12.790 +00:00] [ERR] [71] Emby.Server.Implementations.HttpServer.HttpListenerHost: Error processing request. URL: "http://10.79.0.125:8096/Videos/b886d888-2eac-d1cb-732d-dfde121feb39/b886d8882eacd1cb732ddfde121feb39/Subtitles/2/0/Stream.ass"
System.NullReferenceException: Object reference not set to an instance of an object.
   at Emby.Server.Implementations.Library.MediaSourceManager.GetPathProtocol(String path)
   at MediaBrowser.MediaEncoding.Subtitles.SubtitleEncoder.GetSubtitleStream(MediaSourceInfo mediaSource, MediaStream subtitleStream, CancellationToken cancellationToken)
   at MediaBrowser.MediaEncoding.Subtitles.SubtitleEncoder.MediaBrowser.Controller.MediaEncoding.ISubtitleEncoder.GetSubtitles(BaseItem item, String mediaSourceId, Int32 subtitleStreamIndex, String outputFormat, Int64 startTimeTicks, Int64 endTimeTicks, Boolean preserveOriginalTimestamps, CancellationToken cancellationToken)
   at MediaBrowser.Api.Subtitles.SubtitleService.Get(GetSubtitle request)
   at Emby.Server.Implementations.Services.ServiceExecGeneral.GetTaskResult(Task task)
   at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost httpHost, IRequest httpReq, HttpResponse httpRes, ILogger logger, CancellationToken cancellationToken)
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken)
[2020-07-25 09:34:12.856 +00:00] [DBG] [71] Emby.Server.Implementations.HttpServer.HttpListenerHost: Sending HTTP Response 500 in response to "http://10.79.0.125:8096/Videos/b886d888-2eac-d1cb-732d-dfde121feb39/b886d8882eacd1cb732ddfde121feb39/Subtitles/2/0/Stream.ass"
```