### PR TITLE
Fix the problem that hardware decoding cannot be used on macOS.

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -457,7 +457,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             var isMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            
             if (!IsCopyCodec(outputVideoCodec))
             {
                 if (state.IsVideoRequest

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -456,7 +456,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             var isQsvEncoder = outputVideoCodec.IndexOf("qsv", StringComparison.OrdinalIgnoreCase) != -1;
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-
+            var isMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            
             if (!IsCopyCodec(outputVideoCodec))
             {
                 if (state.IsVideoRequest
@@ -510,6 +511,12 @@ namespace MediaBrowser.Controller.MediaEncoding
                             arg.Append("-init_hw_device qsv=hw -filter_hw_device hw ");
                         }
                     }
+                }
+                
+                if (state.IsVideoRequest
+                    && string.Equals(encodingOptions.HardwareAccelerationType, "videotoolbox", StringComparison.OrdinalIgnoreCase))
+                {
+                    arg.Append("-hwaccel videotoolbox ");
                 }
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -457,6 +457,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             var isMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
             if (!IsCopyCodec(outputVideoCodec))
             {
                 if (state.IsVideoRequest
@@ -511,7 +512,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         }
                     }
                 }
-                
+
                 if (state.IsVideoRequest
                     && string.Equals(encodingOptions.HardwareAccelerationType, "videotoolbox", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
I am a macOS user and I am glad that **Jellyfin** supports **videotoolbox** in version 10.6.
But I found that **Jellyfin** cannot use **videotoolbox** for hardware decoding.
This is caused by a missing parameter **-hwaccel**  in **ffmpeg**.
I tried to fix this problem and tested it. 
It works now.