### PR TITLE
Flip quoting in variable set command

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -85,7 +85,7 @@ jobs:
     value: 0.0.0
 
   steps:
-  - script: echo '##vso[task.setvariable variable=JellyfinVersion]$( awk -F "/" "{ print $NF }" <<<"$(Build.SourceBranch)" | sed "s/^v//" )'
+  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
     displayName: Set release version (stable)
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
 


### PR DESCRIPTION
**Changes**
The quoting as-is was broken and would result in a junk output. This way, the proper value is obtained.

**Issues**
Fixes #3723 