### PR TITLE
Fix #3624

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -600,17 +600,12 @@ namespace Jellyfin.Server.Implementations.Users
             }
 
             var defaultName = Environment.UserName;
-            if (string.IsNullOrWhiteSpace(defaultName))
+            if (string.IsNullOrWhiteSpace(defaultName) || !IsValidUsername(defaultName))
             {
                 defaultName = "MyJellyfinUser";
             }
 
             _logger.LogWarning("No users, creating one with username {UserName}", defaultName);
-
-            if (!IsValidUsername(defaultName))
-            {
-                throw new ArgumentException("Provided username is not valid!", defaultName);
-            }
 
             var newUser = await CreateUserInternalAsync(defaultName, dbContext).ConfigureAwait(false);
             newUser.SetPermission(PermissionKind.IsAdministrator, true);


### PR DESCRIPTION
**Changes**
It doesn't really make sense to throw an error when creating the default user, because the error is completely non-actionable. Instead, if the autodetected username is not valid, just fall back to a sane default.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #3624