### PR TITLE
Update BlurHashSharp and set max size to 128x128

### DIFF
--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlurHashSharp" Version="1.0.1" />
-    <PackageReference Include="BlurHashSharp.SkiaSharp" Version="1.0.0" />
+    <PackageReference Include="BlurHashSharp" Version="1.1.0" />
+    <PackageReference Include="BlurHashSharp.SkiaSharp" Version="1.1.0" />
     <PackageReference Include="SkiaSharp" Version="1.68.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.3" />
     <PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.1" />

--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -199,7 +199,8 @@ namespace Jellyfin.Drawing.Skia
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return BlurHashEncoder.Encode(xComp, yComp, path);
+            // Any larger than 128x128 is too slow and there's no visually discernible difference
+            return BlurHashEncoder.Encode(xComp, yComp, path, 128, 128);
         }
 
         private static bool HasDiacritics(string text)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
PERFORMANCE: Updates BlurHashSharp to 1.1.0 and forces a max size of the image pre-hash to be 128x128 (aspect ratio preserved).

With this change encoding a 4K image takes ~0.05s as opposed to the previous 1.6s. See https://github.com/Bond-009/BlurHashSharp/pull/2 for benchmarks.

