### PR TITLE
Change 'nowebcontent' flag to 'nowebclient' flag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following sections describe some more advanced scenarios for running the ser
 
 It is not necessary to host the frontend web client as part of the backend server. Hosting these two components separately may be useful for frontend developers who would prefer to host the client in a separate webpack development server for a tighter development loop. See the [jellyfin-web](https://github.com/jellyfin/jellyfin-web#getting-started) repo for instructions on how to do this.
 
-To instruct the server not to host the web content, there is a `nowebcontent` configuration flag that must be set. This can specified using the command line switch `--nowebcontent` or the environment variable `JELLYFIN_NOWEBCONTENT=true`.
+To instruct the server not to host the web content, there is a `nowebclient` configuration flag that must be set. This can specified using the command line
+switch `--nowebclient` or the environment variable `JELLYFIN_NOWEBCONTENT=true`.
 
 Since this is a common scenario, there is also a separate launch profile defined for Visual Studio called `Jellyfin.Server (nowebcontent)` that can be selected from the 'Start Debugging' dropdown in the main toolbar.


### PR DESCRIPTION
Small change to the readme, the `--nowebcontent` flag does not work, the correct flag seems to be `--nowebclient`

![30_07_20_jellyfin](https://user-images.githubusercontent.com/20001253/88975329-4a44e300-d2ba-11ea-9be6-ff67636d3bdb.png)
