### PR TITLE
Fix DI memory leak

### DIFF
--- a/Jellyfin.Server.Implementations/JellyfinDbProvider.cs
+++ b/Jellyfin.Server.Implementations/JellyfinDbProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using MediaBrowser.Common.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,15 +12,20 @@ namespace Jellyfin.Server.Implementations
     public class JellyfinDbProvider
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly IApplicationPaths _appPaths;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JellyfinDbProvider"/> class.
         /// </summary>
         /// <param name="serviceProvider">The application's service provider.</param>
-        public JellyfinDbProvider(IServiceProvider serviceProvider)
+        /// <param name="appPaths">The application paths.</param>
+        public JellyfinDbProvider(IServiceProvider serviceProvider, IApplicationPaths appPaths)
         {
             _serviceProvider = serviceProvider;
-            serviceProvider.GetRequiredService<JellyfinDb>().Database.Migrate();
+            _appPaths = appPaths;
+
+            using var jellyfinDb = CreateContext();
+            jellyfinDb.Database.Migrate();
         }
 
         /// <summary>
@@ -27,7 +34,8 @@ namespace Jellyfin.Server.Implementations
         /// <returns>The newly created context.</returns>
         public JellyfinDb CreateContext()
         {
-            return _serviceProvider.GetRequiredService<JellyfinDb>();
+            var contextOptions = new DbContextOptionsBuilder<JellyfinDb>().UseSqlite($"Filename={Path.Combine(_appPaths.DataPath, "jellyfin.db")}");
+            return ActivatorUtilities.CreateInstance<JellyfinDb>(_serviceProvider, contextOptions.Options);
         }
     }
 }

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -64,11 +64,12 @@ namespace Jellyfin.Server
                 Logger.LogWarning($"Skia not available. Will fallback to {nameof(NullImageEncoder)}.");
             }
 
-            // TODO: Set up scoping and use AddDbContextPool
-            serviceCollection.AddDbContext<JellyfinDb>(
-                options => options
-                    .UseSqlite($"Filename={Path.Combine(ApplicationPaths.DataPath, "jellyfin.db")}"),
-                ServiceLifetime.Transient);
+            // TODO: Set up scoping and use AddDbContextPool,
+            // can't register as Transient since tracking transient in GC is funky
+            // serviceCollection.AddDbContext<JellyfinDb>(
+            //     options => options
+            //         .UseSqlite($"Filename={Path.Combine(ApplicationPaths.DataPath, "jellyfin.db")}"),
+            //     ServiceLifetime.Transient);
 
             serviceCollection.AddSingleton<JellyfinDbProvider>();
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Removed `JellyfinDb` from the DI container for now. Registering Transient instances that implement IDisposable and then using them in the root scope is a big no-no. They will never be GC'd until the container or scope is disposed, which will only happen on shutdown.

An alternative solution is to create a Scope whenever we need the context, but the factory pattern is cleaner.

**DISCLAIMER**: I haven't actually been able to reproduce the leak, but based on memory snapshots and research it seems like the most likely scenario.

Sources:
- https://github.com/aspnet/DependencyInjection/issues/456
- https://github.com/dotnet/runtime/issues/36491
- https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-3.1#idisposable-guidance-for-transient-and-shared-instances

**Issues**
Fixes #3680
