### PR TITLE
TMDb: Change Budget and Revenue to long to avoid overflow

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/Models/Movies/MovieResult.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Models/Movies/MovieResult.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Models.Movies
 
         public BelongsToCollection Belongs_To_Collection { get; set; }
 
-        public int Budget { get; set; }
+        public long Budget { get; set; }
 
         public List<Genre> Genres { get; set; }
 
@@ -39,7 +39,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Models.Movies
 
         public string Release_Date { get; set; }
 
-        public int Revenue { get; set; }
+        public long Revenue { get; set; }
 
         public int Runtime { get; set; }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Avengers: Endgame made too much money!!! When deserializing the response, the revenue was too large for an int. Changed it (and Budget) too a long instead.

