### PR TITLE
Update to newer Jellyfin.XMLTV

### DIFF
--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="IPNetwork2" Version="2.5.211" />
-    <PackageReference Include="Jellyfin.XmlTv" Version="10.6.0-pre1" />
+    <PackageReference Include="Jellyfin.XmlTv" Version="10.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
**Changes**
Updates to a newer version of Jellyfin.XMLTV. 


**Issues**
To be honest, I'm not sure, but there were reasons here:
https://github.com/jellyfin/Jellyfin.XmlTv/pull/5

Edit: Fixes https://github.com/jellyfin/jellyfin-web/issues/1621