### PR TITLE
Fix BaseItems not being cached in-memory

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -299,7 +299,7 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            _memoryCache.CreateEntry(item.Id).SetValue(item);
+            _memoryCache.Set(item.Id, item);
         }
 
         public void DeleteItem(BaseItem item, DeleteOptions options)


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Changed to MemoryCache.Set since SetValue does not flush automatically. An entry is only added to the MemoryCache when the entry is disposed, which Set does for us. No BaseItems were ever cached 🤣 

I scanned my TV shows with "Refresh all metadata" for 19 minutes and got the following results:

Memory allocations _before_ the change:
![image](https://user-images.githubusercontent.com/675118/89634081-17e04a80-d8a5-11ea-9865-5199341cf4c3.png)

Memory allocations _after_ the change
![image](https://user-images.githubusercontent.com/675118/89634117-23337600-d8a5-11ea-8e5d-138c4a6455e6.png)

