### PR TITLE
Avoid including stray commas in HLS codecs field

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1496,9 +1496,14 @@ namespace Jellyfin.Api.Controllers
 
             StringBuilder codecs = new StringBuilder();
 
-            codecs.Append(videoCodecs)
-                .Append(',')
-                .Append(audioCodecs);
+            codecs.Append(videoCodecs);
+
+            if (!string.IsNullOrEmpty(videoCodecs) && !string.IsNullOrEmpty(audioCodecs))
+            {
+                codecs.Append(',');
+            }
+
+            codecs.Append(audioCodecs);
 
             if (codecs.Length > 1)
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Avoid including stray comma when only audio is streamed. Previously Chromecast and possibly other strict HLS clients treat audio only streams as video. 
