### PR TITLE
Fix Split movie versions

### DIFF
--- a/MediaBrowser.Api/VideosService.cs
+++ b/MediaBrowser.Api/VideosService.cs
@@ -109,7 +109,11 @@ namespace MediaBrowser.Api
         public void Delete(DeleteAlternateSources request)
         {
             var video = (Video)_libraryManager.GetItemById(request.Id);
-
+            if (video.LinkedAlternateVersions.Length == 0)
+            {
+                video = (Video)_libraryManager.GetItemById(video.PrimaryVersionId);
+            }
+            
             foreach (var link in video.GetLinkedAlternateVersions())
             {
                 link.SetPrimaryVersionId(null);


### PR DESCRIPTION

The split function does only works correctly if the id given is the one of the primary version, this causes that splitting through the web ends with the blue bubble in the top left of the poster showing how many versions are, even if they are not grouped. As can be seen here
![split1](https://user-images.githubusercontent.com/29411250/89716623-c58b5080-d9ae-11ea-8ce7-f0f69ae4792e.gif)

Forcing to split always the primary version fix the problem
![split2](https://user-images.githubusercontent.com/29411250/89716637-f53a5880-d9ae-11ea-95e9-2617ec182cea.gif)



**Changes**
Force to split always the primary version

