### PR TITLE
Fix Split versions

### DIFF
--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -168,6 +168,11 @@ namespace Jellyfin.Api.Controllers
             if (video == null)
             {
                 return NotFound("The video either does not exist or the id does not belong to a video.");
+            }
+
+            if (video.LinkedAlternateVersions.Length == 0)
+            {
+                video = (Video)_libraryManager.GetItemById(video.PrimaryVersionId);
             }
 
             foreach (var link in video.GetLinkedAlternateVersions())


### PR DESCRIPTION
The split function does only works correctly if the id given is the one of the primary version, this causes that splitting through the web ends with the blue bubble in the top left of the poster showing how many versions are, even if they are not grouped. As can be seen here
![split1](https://user-images.githubusercontent.com/29411250/89721018-c20cbf00-d9d8-11ea-8a21-dc107f126e47.gif)


Forcing to split always the primary version fix the problem
![split2](https://user-images.githubusercontent.com/29411250/89721022-c9cc6380-d9d8-11ea-8329-9fe215e4abf2.gif)


Changes
Force to split always the primary version
@cvium 