### PR TITLE
Allow plugins to define their own api endpoints

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1387,15 +1387,17 @@ namespace Emby.Server.Implementations
 
         public IEnumerable<Assembly> GetApiPluginAssemblies()
         {
-            var types = _allConcreteTypes
+            var assemblies = _allConcreteTypes
                 .Where(i => typeof(ControllerBase).IsAssignableFrom(i))
+                .Select(i => i.Assembly)
                 .Distinct();
 
-            foreach (var type in types)
+            foreach (var assembly in assemblies)
             {
-                Logger.LogDebug("Found API endpoints in plugin {name}", type.Assembly.FullName);
-                yield return type.Assembly;
+                Logger.LogDebug("Found API endpoints in plugin {name}", assembly.FullName);
             }
+
+            return assemblies;
         }
 
         public virtual void LaunchUrl(string url)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1395,9 +1395,8 @@ namespace Emby.Server.Implementations
             foreach (var assembly in assemblies)
             {
                 Logger.LogDebug("Found API endpoints in plugin {name}", assembly.FullName);
+                yield return assembly;
             }
-
-            return assemblies;
         }
 
         public virtual void LaunchUrl(string url)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1387,25 +1387,14 @@ namespace Emby.Server.Implementations
 
         public IEnumerable<Assembly> GetApiPluginAssemblies()
         {
-            var assemblies = new List<Assembly>();
-            try
-            {
-                var types = _allConcreteTypes
-                    .Where(i => typeof(ControllerBase).IsAssignableFrom(i))
-                    // .Select(i => ActivatorUtilities.CreateInstance(ServiceProvider, i))
-                    .ToArray();
+            var types = _allConcreteTypes
+                .Where(i => typeof(ControllerBase).IsAssignableFrom(i));
 
-                foreach (var variable in types)
-                {
-                    assemblies.Add(variable.Assembly);
-                }
-            }
-            catch (Exception ex)
+            foreach (var type in types)
             {
-                // ignore
+                Logger.LogDebug("Found API endpoints in plugin " + type.Assembly.FullName);
+                yield return type.Assembly;
             }
-
-            return assemblies;
         }
 
         public virtual void LaunchUrl(string url)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1388,11 +1388,12 @@ namespace Emby.Server.Implementations
         public IEnumerable<Assembly> GetApiPluginAssemblies()
         {
             var types = _allConcreteTypes
-                .Where(i => typeof(ControllerBase).IsAssignableFrom(i));
+                .Where(i => typeof(ControllerBase).IsAssignableFrom(i))
+                .Distinct();
 
             foreach (var type in types)
             {
-                Logger.LogDebug("Found API endpoints in plugin " + type.Assembly.FullName);
+                Logger.LogDebug("Found API endpoints in plugin {name}", type.Assembly.FullName);
                 yield return type.Assembly;
             }
         }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -53,7 +53,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
 using MediaBrowser.Controller;
-using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Collections;
@@ -98,6 +97,7 @@ using MediaBrowser.Providers.Plugins.TheTvdb;
 using MediaBrowser.Providers.Subtitles;
 using MediaBrowser.XbmcMetadata.Providers;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Prometheus.DotNetRuntime;
@@ -1383,6 +1383,29 @@ namespace Emby.Server.Implementations
             var list = _plugins.ToList();
             list.Remove(plugin);
             _plugins = list.ToArray();
+        }
+
+        public IEnumerable<Assembly> GetApiPluginAssemblies()
+        {
+            var assemblies = new List<Assembly>();
+            try
+            {
+                var types = _allConcreteTypes
+                    .Where(i => typeof(ControllerBase).IsAssignableFrom(i))
+                    // .Select(i => ActivatorUtilities.CreateInstance(ServiceProvider, i))
+                    .ToArray();
+
+                foreach (var variable in types)
+                {
+                    assemblies.Add(variable.Assembly);
+                }
+            }
+            catch (Exception ex)
+            {
+                // ignore
+            }
+
+            return assemblies;
         }
 
         public virtual void LaunchUrl(string url)

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -136,9 +136,9 @@ namespace Jellyfin.Server.Extensions
         /// </summary>
         /// <param name="serviceCollection">The service collection.</param>
         /// <param name="baseUrl">The base url for the API.</param>
-        /// <param name="applicationHost">The application host.</param>
+        /// <param name="pluginAssemblies">An IEnumberable containing all plugin assemblies with API controllers.</param>
         /// <returns>The MVC builder.</returns>
-        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, string baseUrl, IApplicationHost applicationHost)
+        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, string baseUrl, IEnumerable<Assembly> pluginAssemblies)
         {
             IMvcBuilder mvcBuilder = serviceCollection
                 .AddCors(options =>
@@ -179,7 +179,7 @@ namespace Jellyfin.Server.Extensions
                     options.JsonSerializerOptions.PropertyNamingPolicy = jsonOptions.PropertyNamingPolicy;
                 });
 
-            foreach (Assembly pluginAssembly in applicationHost.GetApiPluginAssemblies())
+            foreach (Assembly pluginAssembly in pluginAssemblies)
             {
                 mvcBuilder.AddApplicationPart(pluginAssembly);
             }

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -18,7 +18,10 @@ using Jellyfin.Api.Constants;
 using Jellyfin.Api.Controllers;
 using Jellyfin.Server.Formatters;
 using Jellyfin.Server.Models;
+using MediaBrowser.Common;
 using MediaBrowser.Common.Json;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller;
 using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -135,10 +138,11 @@ namespace Jellyfin.Server.Extensions
         /// </summary>
         /// <param name="serviceCollection">The service collection.</param>
         /// <param name="baseUrl">The base url for the API.</param>
+        /// <param name="applicationHost">The application host.</param>
         /// <returns>The MVC builder.</returns>
-        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, string baseUrl)
+        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, string baseUrl, IApplicationHost applicationHost)
         {
-            return serviceCollection
+            IMvcBuilder mvcBuilder = serviceCollection
                 .AddCors(options =>
                 {
                     options.AddPolicy(ServerCorsPolicy.DefaultPolicyName, ServerCorsPolicy.DefaultPolicy);
@@ -177,6 +181,16 @@ namespace Jellyfin.Server.Extensions
                     options.JsonSerializerOptions.PropertyNamingPolicy = jsonOptions.PropertyNamingPolicy;
                 })
                 .AddControllersAsServices();
+
+            if (applicationHost.Plugins != null)
+            {
+                foreach (IPlugin plugin in applicationHost.Plugins)
+                {
+                    mvcBuilder.AddApplicationPart(plugin.GetType().Assembly);
+                }
+            }
+
+            return mvcBuilder;
         }
 
         /// <summary>

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -20,8 +20,6 @@ using Jellyfin.Server.Formatters;
 using Jellyfin.Server.Models;
 using MediaBrowser.Common;
 using MediaBrowser.Common.Json;
-using MediaBrowser.Common.Plugins;
-using MediaBrowser.Controller;
 using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -179,18 +177,14 @@ namespace Jellyfin.Server.Extensions
 
                     // From JsonDefaults.PascalCase
                     options.JsonSerializerOptions.PropertyNamingPolicy = jsonOptions.PropertyNamingPolicy;
-                })
-                .AddControllersAsServices();
+                });
 
-            if (applicationHost.Plugins != null)
+            foreach (Assembly pluginAssembly in applicationHost.GetApiPluginAssemblies())
             {
-                foreach (IPlugin plugin in applicationHost.Plugins)
-                {
-                    mvcBuilder.AddApplicationPart(plugin.GetType().Assembly);
-                }
+                mvcBuilder.AddApplicationPart(pluginAssembly);
             }
 
-            return mvcBuilder;
+            return mvcBuilder.AddControllersAsServices();
         }
 
         /// <summary>

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -41,7 +41,7 @@ namespace Jellyfin.Server
         {
             services.AddResponseCompression();
             services.AddHttpContextAccessor();
-            services.AddJellyfinApi(_serverConfigurationManager.Configuration.BaseUrl.TrimStart('/'), _applicationHost);
+            services.AddJellyfinApi(_serverConfigurationManager.Configuration.BaseUrl.TrimStart('/'), _applicationHost.GetApiPluginAssemblies());
 
             services.AddJellyfinApiSwagger();
 

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -2,8 +2,10 @@ using System.Net.Http;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Middleware;
 using Jellyfin.Server.Models;
+using MediaBrowser.Common;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,14 +20,17 @@ namespace Jellyfin.Server
     public class Startup
     {
         private readonly IServerConfigurationManager _serverConfigurationManager;
+        private readonly IApplicationHost _applicationHost;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup" /> class.
         /// </summary>
         /// <param name="serverConfigurationManager">The server configuration manager.</param>
-        public Startup(IServerConfigurationManager serverConfigurationManager)
+        /// <param name="applicationHost">The application host.</param>
+        public Startup(IServerConfigurationManager serverConfigurationManager, IApplicationHost applicationHost)
         {
             _serverConfigurationManager = serverConfigurationManager;
+            _applicationHost = applicationHost;
         }
 
         /// <summary>
@@ -36,7 +41,7 @@ namespace Jellyfin.Server
         {
             services.AddResponseCompression();
             services.AddHttpContextAccessor();
-            services.AddJellyfinApi(_serverConfigurationManager.Configuration.BaseUrl.TrimStart('/'));
+            services.AddJellyfinApi(_serverConfigurationManager.Configuration.BaseUrl.TrimStart('/'), _applicationHost);
 
             services.AddJellyfinApiSwagger();
 

--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -75,6 +76,12 @@ namespace MediaBrowser.Common
         /// </summary>
         /// <value>The plugins.</value>
         IReadOnlyList<IPlugin> Plugins { get; }
+
+        /// <summary>
+        /// Gets all plugin assemblies which implement a custom rest api.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{Assembly}"/> containing the plugin assemblies.</returns>
+        IEnumerable<Assembly> GetApiPluginAssemblies();
 
         /// <summary>
         /// Notifies the pending restart.


### PR DESCRIPTION
**Changes**
To allow plugins to register their own ASP.NET Web Api endpoints, we need to register each assembly in the `MvcBuilder`.
~~However, this is currently not possible, as `applicationHost.Plugins` doesn't contain the plugins. They get loaded after `Startup.ConfigureServices` ran.
Can we load the plugins earlier? I tried to move some things around (calling [this line](https://github.com/Ullmie02/jellyfin/blob/98d1d2325d515ef0e6bd0a59c961967e9b5224be/Jellyfin.Server/Program.cs#L188) before calling [this line](https://github.com/Ullmie02/jellyfin/blob/98d1d2325d515ef0e6bd0a59c961967e9b5224be/Jellyfin.Server/Program.cs#L184)) but `InitializeServices` needs the `appHost.ServiceProvider` which we get from the WebHostBuilder.~~