### PR TITLE
Build Unstable NuGet packages

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -153,11 +153,11 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     inputs:
       command: 'pack'
-      packagesToPack: Jellyfin.Data/Jellyfin.Data.csproj;MediaBrowser.Common/MediaBrowser.Common.csproj;MediaBrowser.Controller/MediaBrowser.Controller.csproj;MediaBrowser.Model/MediaBrowser.Model.csproj;Emby.Naming/Emby.Naming.csproj
-      packDestination: '$(Build.ArtifactStagingDirectory)'
+      packagesToPack: 'Jellyfin.Data/Jellyfin.Data.csproj;MediaBrowser.Common/MediaBrowser.Common.csproj;MediaBrowser.Controller/MediaBrowser.Controller.csproj;MediaBrowser.Model/MediaBrowser.Model.csproj;Emby.Naming/Emby.Naming.csproj'
+      versioningScheme: 'off'
 
   - task: NuGetCommand@2
     inputs:

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -159,6 +159,11 @@ jobs:
       packagesToPack: 'Jellyfin.Data/Jellyfin.Data.csproj;MediaBrowser.Common/MediaBrowser.Common.csproj;MediaBrowser.Controller/MediaBrowser.Controller.csproj;MediaBrowser.Model/MediaBrowser.Model.csproj;Emby.Naming/Emby.Naming.csproj'
       versioningScheme: 'off'
 
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: Jellyfin Nuget Packages
+
   - task: NuGetCommand@2
     inputs:
       command: 'push'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -147,24 +147,42 @@ jobs:
   displayName: 'Publish NuGet packages'
   dependsOn:
   - BuildPackage
-  condition: and(succeeded('BuildPackage'), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+  condition: succeeded('BuildPackage')
 
   pool:
     vmImage: 'ubuntu-latest'
 
   steps:
   - task: DotNetCoreCLI@2
+    displayName: 'Build Stable Nuget packages'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     inputs:
       command: 'pack'
       packagesToPack: 'Jellyfin.Data/Jellyfin.Data.csproj;MediaBrowser.Common/MediaBrowser.Common.csproj;MediaBrowser.Controller/MediaBrowser.Controller.csproj;MediaBrowser.Model/MediaBrowser.Model.csproj;Emby.Naming/Emby.Naming.csproj'
       versioningScheme: 'off'
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Unstable Nuget packages'
+    inputs:
+      command: 'custom'
+      projects: |
+        Jellyfin.Data/Jellyfin.Data.csproj
+        MediaBrowser.Common/MediaBrowser.Common.csproj
+        MediaBrowser.Controller/MediaBrowser.Controller.csproj
+        MediaBrowser.Model/MediaBrowser.Model.csproj
+        Emby.Naming/Emby.Naming.csproj
+      custom: 'pack'
+      arguments: '--version-suffix $(Build.BuildNumber) -o $(Build.ArtifactStagingDirectory)'
+
   - task: PublishBuildArtifacts@1
+    displayName: 'Publish Nuget packages'
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: Jellyfin Nuget Packages
 
   - task: NuGetCommand@2
+    displayName: 'Push Nuget packages to feed'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     inputs:
       command: 'push'
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/Emby.Naming/Emby.Naming.csproj
+++ b/Emby.Naming/Emby.Naming.csproj
@@ -23,7 +23,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Naming</PackageId>
-    <PackageVersion>10.7.0</PackageVersion>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/Emby.Naming/Emby.Naming.csproj
+++ b/Emby.Naming/Emby.Naming.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Naming</PackageId>
+    <PackageVersion>10.7.0</PackageVersion>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/Jellyfin.Data/Jellyfin.Data.csproj
+++ b/Jellyfin.Data/Jellyfin.Data.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Data</PackageId>
-    <PackageVersion>10.7.0</PackageVersion>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/Jellyfin.Data/Jellyfin.Data.csproj
+++ b/Jellyfin.Data/Jellyfin.Data.csproj
@@ -6,6 +6,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Authors>Jellyfin Contributors</Authors>
+    <PackageId>Jellyfin.Data</PackageId>
+    <PackageVersion>10.7.0</PackageVersion>
+    <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Common</PackageId>
-    <PackageVersion>10.7.0</PackageVersion>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Common</PackageId>
+    <PackageVersion>10.7.0</PackageVersion>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Controller</PackageId>
-    <PackageVersion>10.7.0</PackageVersion>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Controller</PackageId>
+    <PackageVersion>10.7.0</PackageVersion>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Model</PackageId>
-    <PackageVersion>10.7.0</PackageVersion>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <Authors>Jellyfin Contributors</Authors>
     <PackageId>Jellyfin.Model</PackageId>
+    <PackageVersion>10.7.0</PackageVersion>
     <PackageLicenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/jellyfin/jellyfin</RepositoryUrl>
   </PropertyGroup>

--- a/bump_version
+++ b/bump_version
@@ -58,9 +58,9 @@ do
     echo ${f}
     # Parse the version from the *.csproj file
     old_version="$(
-        grep "PackageVersion" ${f} \
+        grep "VersionPrefix" ${f} \
             | awk '{$1=$1};1' \
-            | sed -E 's/<PackageVersion>([0-9\.]+[-a-z0-9]*)<\/PackageVersion>/\1/'
+            | sed -E 's/<VersionPrefix>([0-9\.]+[-a-z0-9]*)<\/VersionPrefix>/\1/'
     )"
     echo old nuget version: $old_version
 

--- a/bump_version
+++ b/bump_version
@@ -20,6 +20,12 @@ fi
 
 shared_version_file="./SharedVersion.cs"
 build_file="./build.yaml"
+# csproj files for nuget packages
+mediabrowser_common="MediaBrowser.Common/MediaBrowser.Common.csproj"
+jellyfin_data="Jellyfin.Data/Jellyfin.Data.csproj"
+mediabrowser_controller="MediaBrowser.Controller/MediaBrowser.Controller.csproj"
+mediabrowser_model="MediaBrowser.Model/MediaBrowser.Model.csproj"
+emby_naming="Emby.Naming/Emby.Naming.csproj"
 
 new_version="$1"
 
@@ -44,6 +50,23 @@ echo $old_version
 # Set the build.yaml version to the specified new_version
 old_version_sed="$( sed 's/\./\\./g' <<<"${old_version}" )" # Escape the '.' chars
 sed -i "s/${old_version_sed}/${new_version}/g" ${build_file}
+
+# update nuget package version
+for f in ${mediabrowser_common} ${jellyfin_data} ${mediabrowser_controller} ${mediabrowser_model} ${emby_naming}
+do
+    code ${f}
+    echo ${f}
+    # Parse the version from the *.csproj file
+    old_version="$(
+        grep "PackageVersion" ${f} \
+            | awk '{$1=$1};1' \
+            | sed -E 's/<PackageVersion>([0-9\.]+[-a-z0-9]*)<\/PackageVersion>/\1/'
+    )"
+    echo old nuget version: $old_version
+
+    # Set the nuget version to the specified new_version
+    sed -i "s|${old_version}|${new_version}|g" ${f}
+done
 
 if [[ ${new_version} == *"-"* ]]; then
     new_version_deb="$( sed 's/-/~/g' <<<"${new_version}" )"

--- a/bump_version
+++ b/bump_version
@@ -21,11 +21,7 @@ fi
 shared_version_file="./SharedVersion.cs"
 build_file="./build.yaml"
 # csproj files for nuget packages
-mediabrowser_common="MediaBrowser.Common/MediaBrowser.Common.csproj"
-jellyfin_data="Jellyfin.Data/Jellyfin.Data.csproj"
-mediabrowser_controller="MediaBrowser.Controller/MediaBrowser.Controller.csproj"
-mediabrowser_model="MediaBrowser.Model/MediaBrowser.Model.csproj"
-emby_naming="Emby.Naming/Emby.Naming.csproj"
+jellyfin_subprojects=( MediaBrowser.Common/MediaBrowser.Common.csproj Jellyfin.Data/Jellyfin.Data.csproj MediaBrowser.Controller/MediaBrowser.Controller.csproj MediaBrowser.Model/MediaBrowser.Model.csproj Emby.Naming/Emby.Naming.csproj )
 
 new_version="$1"
 
@@ -52,20 +48,19 @@ old_version_sed="$( sed 's/\./\\./g' <<<"${old_version}" )" # Escape the '.' cha
 sed -i "s/${old_version_sed}/${new_version}/g" ${build_file}
 
 # update nuget package version
-for f in ${mediabrowser_common} ${jellyfin_data} ${mediabrowser_controller} ${mediabrowser_model} ${emby_naming}
+for subproject in ${jellyfin_subprojects[@]}; do
 do
-    code ${f}
-    echo ${f}
+    echo ${subproject}
     # Parse the version from the *.csproj file
     old_version="$(
-        grep "VersionPrefix" ${f} \
+        grep "VersionPrefix" ${subproject} \
             | awk '{$1=$1};1' \
             | sed -E 's/<VersionPrefix>([0-9\.]+[-a-z0-9]*)<\/VersionPrefix>/\1/'
     )"
     echo old nuget version: $old_version
 
     # Set the nuget version to the specified new_version
-    sed -i "s|${old_version}|${new_version}|g" ${f}
+    sed -i "s|${old_version}|${new_version}|g" ${subproject}
 done
 
 if [[ ${new_version} == *"-"* ]]; then


### PR DESCRIPTION
**Changes**
With this PR merged, every commit to master builds unstable nuget packages. They don't get pushed to any Nuget feeds. To achive this, I added the `VersionPrefix` property to every .csproj file which outputs Nuget packages and integrated the version number into the bump_version script.

I changed the Nuget pack CI task to the .Net Core pack Task because of this note in the [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/nuget?view=azure-devops&tabs=yaml#package-versioning)
> Please note that DotNetCore and DotNetStandard packages should be packaged with the DotNetCoreCLI@2 task to avoid System.InvalidCastExceptions. See the .NET Core CLI task for more details.

**Issues**
This allows for easier plugin development before we publish the stable version because we can make changes to the plugins during the release cycle.