### PR TITLE
fix PGS sub burn-in on vaapi when the resolution is unspecified

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1627,6 +1627,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // format=nv12|vaapi,hwupload,scale_vaapi
                 "format",
 
+                // bwdif,scale=expr
+                "bwdif",
+
                 // yadif,scale=expr
                 "yadif",
 


### PR DESCRIPTION
**Changes**
- drop the resolution check since `outputSizeParam` contains not only Size but also other hardware filters.
- simplify related code.

**Issues**
vaapi and qsv will fail when burning in PGS sub if resolution is unspecified(same as input)
https://github.com/jellyfin/jellyfin/issues/3845
https://github.com/jellyfin/jellyfin/issues/2964
