### PR TITLE
Ignore null json values

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -90,6 +90,9 @@ namespace Emby.Server.Implementations.Data
             _typeMapper = new TypeMapper();
             _jsonOptions = JsonDefaults.GetOptions();
 
+            // GetItem throws NotSupportedException with this enabled, so hardcode false.
+            _jsonOptions.IgnoreNullValues = false;
+
             DbFilePath = Path.Combine(_config.ApplicationPaths.DataPath, "library.db");
         }
 

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -168,6 +168,8 @@ namespace Jellyfin.Server.Extensions
                     // From JsonDefaults
                     options.JsonSerializerOptions.ReadCommentHandling = jsonOptions.ReadCommentHandling;
                     options.JsonSerializerOptions.WriteIndented = jsonOptions.WriteIndented;
+                    options.JsonSerializerOptions.IgnoreNullValues = jsonOptions.IgnoreNullValues;
+
                     options.JsonSerializerOptions.Converters.Clear();
                     foreach (var converter in jsonOptions.Converters)
                     {

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -24,7 +24,8 @@ namespace MediaBrowser.Common.Json
             var options = new JsonSerializerOptions
             {
                 ReadCommentHandling = JsonCommentHandling.Disallow,
-                WriteIndented = false
+                WriteIndented = false,
+                IgnoreNullValues = true
             };
 
             options.Converters.Add(new JsonGuidConverter());


### PR DESCRIPTION
SqliteItemRepository.GetItem throws NotSupportedException with this enabled, so hardcode false.

Changes:
```
{
  "Username": "abc123",
  "Pw": null,
  "Password": null
}
```
to 
```
{
  "Username": "abc123"
}
```

Everywhere that `JsonDefaults.GetOptions()` is used:
```
Search target
    MediaBrowser.Common.Json.JsonDefaults.GetOptions():JsonSerializerOptions
Found usages  (7 usages found)
    <Emby.Server.Implementations>  (2 usages found)
        Data  (1 usage found)
            SqliteItemRepository.cs  (1 usage found)
                (91: 41)  _jsonOptions = JsonDefaults.GetOptions();
        HttpServer  (1 usage found)
            WebSocketConnection.cs  (1 usage found)
                (57: 41)  _jsonOptions = JsonDefaults.GetOptions();
    <Jellyfin.Api>  (2 usages found)
        Controllers  (2 usages found)
            ConfigurationController.cs  (1 usage found)
                (26: 82)  private readonly JsonSerializerOptions _serializerOptions = JsonDefaults.GetOptions();
            PluginsController.cs  (1 usage found)
                (29: 82)  private readonly JsonSerializerOptions _serializerOptions = JsonDefaults.GetOptions();
    <Jellyfin.Server>  (1 usage found)
        Migrations  (1 usage found)
            Routines  (1 usage found)
                MigrateUserDb.cs  (1 usage found)
                    (77: 112)  UserMockup mockup = JsonSerializer.Deserialize<UserMockup>(entry[2].ToBlob(), JsonDefaults.GetOptions());
    <MediaBrowser.Common>  (2 usages found)
        Json  (2 usages found)
            JsonDefaults.cs  (2 usages found)
                (49: 27)  var options = GetOptions();
                (60: 27)  var options = GetOptions();
```