### PR TITLE
Increase the max muxing queue size for ffmpeg

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1356,7 +1356,7 @@ namespace Jellyfin.Api.Controllers
 
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -f hls -max_delay 5000000 -hls_time {6} -individual_header_trailer 0 -hls_segment_type {7} -start_number {8} -hls_segment_filename \"{9}\" -hls_playlist_type vod -hls_list_size 0 -y \"{10}\"",
+                "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size 2048 -f hls -max_delay 5000000 -hls_time {6} -individual_header_trailer 0 -hls_segment_type {7} -start_number {8} -hls_segment_filename \"{9}\" -hls_playlist_type vod -hls_list_size 0 -y \"{10}\"",
                 inputModifier,
                 _encodingHelper.GetInputArgument(state, encodingOptions),
                 threads,


### PR DESCRIPTION
**Changes**
- Increase the max muxing queue size to 2048 for ffmpeg.
This can alleviate the situation that the default value of 128 is not enough.


**Issues**
https://github.com/jellyfin/jellyfin/issues/3960
https://github.com/jellyfin/jellyfin/issues/3780
https://github.com/jellyfin/jellyfin/issues/3640
https://github.com/jellyfin/jellyfin/issues/3335
https://github.com/jellyfin/jellyfin/issues/3090
