### PR TITLE
[Permissions] Fix for individual channel plugins #2858

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -266,7 +266,9 @@ namespace Jellyfin.Api.Controllers
 
             bool isInEnabledFolder = user!.GetPreference(PreferenceKind.EnabledFolders).Any(i => new Guid(i) == item.Id)
                                      // Assume all folders inside an EnabledChannel are enabled
-                                     || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.Id);
+                                     || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.Id)
+                                     // Assume all items inside an EnabledChannel are enabled
+                                     || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.ChannelId);
 
             var collectionFolders = _libraryManager.GetCollectionFolders(item);
             foreach (var collectionFolder in collectionFolders)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This change makes it so that items inside an enabled channel plugin (dashboard->user->access) are also enabled and will be visible by the user.

Without this change, the only Channel (plugin, not Live TV) permission that works is "Enable All Channels", so individual channel plugin selections have no effect.

Must be tested at the individual item level, as top-level folders still show but are not populated with any items.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2858