### PR TITLE
Add an empty %files section to main package

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -74,6 +74,9 @@ EOF
 %{__install} -D -m 0755 %{SOURCE14} %{buildroot}%{_libexecdir}/jellyfin/restart.sh
 %{__install} -D -m 0644 %{SOURCE16} %{buildroot}%{_prefix}/lib/firewalld/services/jellyfin.xml
 
+%files
+# empty as this is just a meta-package
+
 %files server
 %attr(755,root,root) %{_bindir}/jellyfin
 %{_libdir}/jellyfin/*.json

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -8,7 +8,7 @@
 
 Name:           jellyfin
 Version:        10.6.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Free Software Media System
 License:        GPLv3
 URL:            https://jellyfin.org


### PR DESCRIPTION
**Changes**
In order for the jellyfin meta-package to exist, there has to be an empty
%files section for it.

**Issues**
Fixes: #3701
