### PR TITLE
Fix wrong OpenAPI auth header value

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -197,7 +197,7 @@ namespace Jellyfin.Server.Extensions
                 {
                     Type = SecuritySchemeType.ApiKey,
                     In = ParameterLocation.Header,
-                    Name = "X-Emby-Token",
+                    Name = "X-Emby-Authorization",
                     Description = "API key header parameter"
                 });
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changed `X-Emby-Token` header to `X-Emby-Authorization` because the former prevents calling the auth endpoint from generated clients and Swagger UI (due to no token being available)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
