### PR TITLE
[Permissions] Fix for individual channel plugins #2858

### DIFF
--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -215,7 +215,9 @@ namespace MediaBrowser.Api.UserLibrary
 
             bool isInEnabledFolder = user.GetPreference(PreferenceKind.EnabledFolders).Any(i => new Guid(i) == item.Id)
                     // Assume all folders inside an EnabledChannel are enabled
-                    || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.Id);
+                    || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.Id)
+                    // Assume all items inside an EnabledChannel are enabled
+                    || user.GetPreference(PreferenceKind.EnabledChannels).Any(i => new Guid(i) == item.ChannelId);
 
             var collectionFolders = _libraryManager.GetCollectionFolders(item);
             foreach (var collectionFolder in collectionFolders)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Without this change, the only Channel (plugin, not Live TV) permission that works is "Enable All Channels".

This is against the 10.6.z branch as the filename changed for 10.7 and I screwed up the previous backport PR.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2858