### PR TITLE
Add the item path to the ItemLookupInfo class

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2633,6 +2633,7 @@ namespace MediaBrowser.Controller.Entities
         {
             return new T
             {
+                Path = Path,
                 MetadataCountryCode = GetPreferredMetadataCountryCode(),
                 MetadataLanguage = GetPreferredMetadataLanguage(),
                 Name = GetNameForMetadataLookup(),

--- a/MediaBrowser.Controller/Providers/ItemLookupInfo.cs
+++ b/MediaBrowser.Controller/Providers/ItemLookupInfo.cs
@@ -15,6 +15,12 @@ namespace MediaBrowser.Controller.Providers
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the path.
+        /// </summary>
+        /// <value>The path.</value>
+        public string Path { get; set; }
+
+        /// <summary>
         /// Gets or sets the metadata language.
         /// </summary>
         /// <value>The metadata language.</value>


### PR DESCRIPTION
This is important for the Shoko Anime Metadata provider plugin. (Since it's API give metadata based on filename/path).

**Changes**
Adds the Path field from BaseItem to the ItemLookupInfo class.

Helps with this: https://features.jellyfin.org/posts/244/shoko-anime-support 
