### PR TITLE
Fix aac mime-type

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -125,7 +125,7 @@ namespace MediaBrowser.Model.Net
             { ".wmv", "video/x-ms-wmv" },
 
             // Type audio
-            { ".aac", "audio/mp4" },
+            { ".aac", "audio/aac" },
             { ".ac3", "audio/ac3" },
             { ".ape", "audio/x-ape" },
             { ".dsf", "audio/dsf" },


### PR DESCRIPTION
**Changes**
Changes the mime-type for aac to be audio/aac. This seems to fix some transcoding issues on iOS and desktop Safari.
Refs: https://www.iana.org/assignments/media-types/media-types.xhtml#audio

I did notice that while the audio will play now it does seem to randomly skip back to earlier sections of the file during playback. That seems like it is probably a different issue though.

**Issues**
Fixes #3726
