### PR TITLE
Fix TVDB plugin not handling absolute display order

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@
  - [Larvitar](https://github.com/Larvitar)
  - [LeoVerto](https://github.com/LeoVerto)
  - [Liggy](https://github.com/Liggy)
+ - [lmaonator](https://github.com/lmaonator)
  - [LogicalPhallacy](https://github.com/LogicalPhallacy)
  - [loli10K](https://github.com/loli10K)
  - [lostmypillow](https://github.com/lostmypillow)

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbEpisodeProvider.cs
@@ -154,6 +154,13 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                 item.IndexNumber = Convert.ToInt32(episode.DvdEpisodeNumber ?? episode.AiredEpisodeNumber);
                 item.ParentIndexNumber = episode.DvdSeason ?? episode.AiredSeason;
             }
+            else if (string.Equals(id.SeriesDisplayOrder, "absolute", StringComparison.OrdinalIgnoreCase))
+            {
+                if (episode.AbsoluteNumber.GetValueOrDefault() != 0)
+                {
+                    item.IndexNumber = episode.AbsoluteNumber;
+                }
+            }
             else if (episode.AiredEpisodeNumber.HasValue)
             {
                 item.IndexNumber = episode.AiredEpisodeNumber;


### PR DESCRIPTION
**Changes**
Add check for "absolute" order and set IndexNumber to TVDBs AbsoluteNumber.

From what I've seen AbsoluteNumber can be either null or 0 on TVDB, both should be considered invalid (there are some shows where all episodes have their absolute number set to 0). I think in that case the best action is to leave it at the default id.IndexNumber that Jellyfin presumably got from parsing the filename.

**Issues**
addresses #3062 
