### PR TITLE
Fix for #4059

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -92,6 +92,7 @@ namespace Jellyfin.Api.Helpers
             }
 
             var enableDlnaHeaders = !string.IsNullOrWhiteSpace(streamingRequest.Params) ||
+                                    streamingRequest.StreamOptions.ContainsKey("dlnaheaders") ||
                                     string.Equals(httpRequest.Headers["GetContentFeatures.DLNA.ORG"], "1", StringComparison.OrdinalIgnoreCase);
 
             var state = new StreamState(mediaSourceManager, transcodingJobType, transcodingJobHelper)


### PR DESCRIPTION
The Dlna PlayTo device controller includes the flag DlnaHeaders = true.

However, dlna headers are only included if params are passed, or the header GetContentFeatures.DLNA.ORG is included from the device.