### PR TITLE
Bug Fix : DLNA Server advertising

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -511,8 +511,7 @@ namespace Emby.Dlna
 
         public string GetServerDescriptionXml(IHeaderDictionary headers, string serverUuId, string serverAddress)
         {
-            var profile = GetProfile(headers) ??
-                          GetDefaultProfile();
+            var profile = GetDefaultProfile();
 
             var serverId = _appHost.SystemId;
 


### PR DESCRIPTION
Bug : If you are running under a matching dlna profile and connect to the dlna server - it uses your profile for the device description - changing the dlna's server's name to your profile's friendly one.