### PR TITLE
Unstable: Null Pointer fix: Api application builder extensions

### DIFF
--- a/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
@@ -24,11 +24,11 @@ namespace Jellyfin.Server.Extensions
             // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
 
-            var baseUrl = serverConfigurationManager.Configuration.BaseUrl.Trim('/');
+            var baseUrl = serverConfigurationManager.Configuration.BaseUrl;
             var apiDocBaseUrl = serverConfigurationManager.Configuration.BaseUrl;
             if (!string.IsNullOrEmpty(baseUrl))
             {
-                baseUrl += '/';
+                baseUrl = baseUrl.Trim('/') + '/';
             }
 
             return applicationBuilder


### PR DESCRIPTION
If BaseUrl is null - the code failed.

I'm also assuming that apiDocBaseUrl will change at some point - so i've left that code as is;

```
var baseUrl = serverConfigurationManager.Configuration.BaseUrl;
var apiDocBaseUrl = serverConfigurationManager.Configuration.BaseUrl;
```        