### PR TITLE
Change default value for allow duplicates in playlist option to False

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -18,7 +18,7 @@ namespace Emby.Server.Implementations
             { DefaultRedirectKey, "web/index.html" },
             { FfmpegProbeSizeKey, "1G" },
             { FfmpegAnalyzeDurationKey, "200M" },
-            { PlaylistsAllowDuplicatesKey, bool.TrueString },
+            { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString }
         };
     }


### PR DESCRIPTION
Change the default value for the configuration option PlaylistsAllowDuplicatesKey to False so that playlists do not allow duplicates by default.

**Changes**
Toggled default value in ConfigurationOptions.cs for this setting to False

**Issues**
N/A
