### PR TITLE
Normalize application paths

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -527,6 +527,13 @@ namespace Jellyfin.Server
                 }
             }
 
+            // Normalize paths. Only possible with GetFullPath for now - https://github.com/dotnet/runtime/issues/2162
+            dataDir = Path.GetFullPath(dataDir);
+            logDir = Path.GetFullPath(logDir);
+            configDir = Path.GetFullPath(configDir);
+            cacheDir = Path.GetFullPath(cacheDir);
+            webDir = Path.GetFullPath(webDir);
+
             // Ensure the main folders exist before we continue
             try
             {


### PR DESCRIPTION
Users are dumb (read: me dumb) and dotnet is very lenient at times. On Windows `/tmp/test` becomes `C:\tmp\test` and either path is apparently working just fine in `System.IO.Path`, but when you start using `Path.Combine` it becomes a jumbled mess of path formatting.