### PR TITLE
Fix parameters validation in ImageProcessor.GetCachePath

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -198,3 +198,4 @@
  - [tikuf](https://github.com/tikuf/)
  - [Tim Hobbs](https://github.com/timhobbs)
  - [SvenVandenbrande](https://github.com/SvenVandenbrande)
+ - [olsh](https://github.com/olsh)

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -455,7 +455,7 @@ namespace Emby.Drawing
                 throw new ArgumentException("Path can't be empty.", nameof(path));
             }
 
-            if (path.IsEmpty)
+            if (filename.IsEmpty)
             {
                 throw new ArgumentException("Filename can't be empty.", nameof(filename));
             }


### PR DESCRIPTION
This PR fixes a small copy-paste issue.