### PR TITLE
Add interface for MissingEpisodesProvider

### DIFF
--- a/MediaBrowser.Controller/Providers/IRemoteMetadataProvider.cs
+++ b/MediaBrowser.Controller/Providers/IRemoteMetadataProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Providers;
 
 namespace MediaBrowser.Controller.Providers
@@ -23,5 +24,10 @@ namespace MediaBrowser.Controller.Providers
         where TLookupInfoType : ItemLookupInfo
     {
         Task<IEnumerable<RemoteSearchResult>> GetSearchResults(TLookupInfoType searchInfo, CancellationToken cancellationToken);
+    }
+
+    public interface IMissingEpisodesProvider : IRemoteMetadataProvider
+    {
+        Task<IEnumerable<MissingEpisodeInfo>> GetAllEpisodes(Series item, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.Model/Providers/MissingEpisodeInfo.cs
+++ b/MediaBrowser.Model/Providers/MissingEpisodeInfo.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace MediaBrowser.Model.Providers
+{
+    /// <summary>
+    /// Simple episode structure used by MissingEpisodeProvider
+    /// </summary>
+    public class MissingEpisodeInfo
+    {
+        /// <summary>
+        /// Episode's season index number.
+        /// </summary>
+        public int seasonNumber { get; set; }
+
+        /// <summary>
+        /// Episode index number.
+        /// </summary>
+        public int episodeNumber { get; set; }
+
+        /// <summary>
+        /// Episode premiere date.
+        /// </summary>
+        public DateTime airDate { get; set; }
+    }
+}

--- a/MediaBrowser.Model/Providers/MissingEpisodeInfo.cs
+++ b/MediaBrowser.Model/Providers/MissingEpisodeInfo.cs
@@ -8,18 +8,18 @@ namespace MediaBrowser.Model.Providers
     public class MissingEpisodeInfo
     {
         /// <summary>
-        /// Episode's season index number.
+        /// Gets or sets the episode's season index number.
         /// </summary>
-        public int seasonNumber { get; set; }
+        public int SeasonNumber { get; set; }
 
         /// <summary>
-        /// Episode index number.
+        /// Gets or sets the episode index number.
         /// </summary>
-        public int episodeNumber { get; set; }
+        public int EpisodeNumber { get; set; }
 
         /// <summary>
-        /// Episode premiere date.
+        /// Gets or sets the episode premiere date.
         /// </summary>
-        public DateTime airDate { get; set; }
+        public DateTime AirDate { get; set; }
     }
 }

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
@@ -99,7 +99,7 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             var tvdbId = series.GetProviderId(MetadataProvider.Tvdb);
             if (string.IsNullOrEmpty(tvdbId))
             {
-                return new List<MissingEpisodeInfo>();
+                return Enumerable.Empty<MissingEpisodeInfo>();
             }
 
             var episodes = await _tvdbClientManager.GetAllEpisodesAsync(Convert.ToInt32(tvdbId), series.GetPreferredMetadataLanguage(), cancellationToken);
@@ -110,13 +110,13 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                     DateTime.TryParse(i.FirstAired, out var firstAired);
                     return new MissingEpisodeInfo
                     {
-                        seasonNumber = i.AiredSeason.GetValueOrDefault(-1),
-                        episodeNumber = i.AiredEpisodeNumber.GetValueOrDefault(-1),
-                        airDate = firstAired
+                        SeasonNumber = i.AiredSeason.GetValueOrDefault(-1),
+                        EpisodeNumber = i.AiredEpisodeNumber.GetValueOrDefault(-1),
+                        AirDate = firstAired
                     };
                 })
                 // tvdb has a lot of nearly blank episodes
-                .Where(i => i.seasonNumber != -1 && i.episodeNumber != -1)
+                .Where(i => i.SeasonNumber != -1 && i.EpisodeNumber != -1)
                 .ToList();
         }
 

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -21,7 +21,6 @@ namespace MediaBrowser.Providers.TV
     public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
     {
         private readonly ILocalizationManager _localization;
-        private readonly ILogger _logger;
         private readonly IFileSystem _fileSystem;
 
         public SeriesMetadataService(
@@ -34,7 +33,6 @@ namespace MediaBrowser.Providers.TV
             : base(serverConfigurationManager, logger, providerManager, fileSystem, libraryManager)
         {
             _localization = localization;
-            _logger = logger;
             _fileSystem = fileSystem;
         }
 
@@ -67,14 +65,14 @@ namespace MediaBrowser.Providers.TV
                     episodes.AddRange(
                         providerEpisodes
                         .Where(
-                            i => !episodes.Any(p => p.episodeNumber == i.episodeNumber && p.seasonNumber == i.seasonNumber) // Ignore duplicates
+                            i => !episodes.Any(p => p.EpisodeNumber == i.EpisodeNumber && p.SeasonNumber == i.SeasonNumber) // Ignore duplicates
                             )
                         );
                 }
             }
 
-            episodes = episodes.OrderBy(i => i.seasonNumber)
-                               .ThenBy(i => i.episodeNumber)
+            episodes = episodes.OrderBy(i => i.SeasonNumber)
+                               .ThenBy(i => i.EpisodeNumber)
                                .ToList();
 
             try


### PR DESCRIPTION
Right now missing episodes can only be provided by TVDB (hardcoded). Implement and interface that would allow 3rd party plugins to provide missing episodes to series.

**Changes**
1. IMissingEpisodesProvider interface
2. MissingEpisodeInfo class instead of previously used tuple.
3. Changes to TV/SeriesMetadataService.cs that allow it to fetch episodes list from all providers implementing IMissingEpisodesProvider  interface.
4. TV/MissingEpisodeProvider.cs is mostly unchanged.

