### PR TITLE
Fix for #4161: BaseUrl in DLNA

### DIFF
--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security;a
+using System.Security;
 using System.Text;
 using Emby.Dlna.Common;
 using MediaBrowser.Model.Dlna;

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -4,8 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security;
+using System.Security;a
 using System.Text;
+using Emby.Dlna.Common;
 using MediaBrowser.Model.Dlna;
 
 namespace Emby.Dlna.Server
@@ -19,9 +20,8 @@ namespace Emby.Dlna.Server
         private readonly string _serverAddress;
         private readonly string _serverName;
         private readonly string _serverId;
-        private readonly string _customName;
 
-        public DescriptionXmlBuilder(DeviceProfile profile, string serverUdn, string serverAddress, string serverName, string serverId, string customName)
+        public DescriptionXmlBuilder(DeviceProfile profile, string serverUdn, string serverAddress, string serverName, string serverId)
         {
             if (string.IsNullOrEmpty(serverUdn))
             {
@@ -38,7 +38,6 @@ namespace Emby.Dlna.Server
             _serverAddress = serverAddress;
             _serverName = serverName;
             _serverId = serverId;
-            _customName = customName;
         }
 
         private static bool EnableAbsoluteUrls => false;
@@ -169,12 +168,7 @@ namespace Emby.Dlna.Server
         {
             if (string.IsNullOrEmpty(_profile.FriendlyName))
             {
-                if (string.IsNullOrEmpty(_customName))
-                {
-                    return "Jellyfin - " + _serverName;
-                }
-
-                return _customName;
+                return "Jellyfin - " + _serverName;
             }
 
             var characterList = new List<char>();
@@ -281,7 +275,7 @@ namespace Emby.Dlna.Server
             return SecurityElement.Escape(url);
         }
 
-        private static IEnumerable<DeviceIcon> GetIcons()
+        private IEnumerable<DeviceIcon> GetIcons()
             => new[]
             {
                 new DeviceIcon
@@ -341,26 +335,25 @@ namespace Emby.Dlna.Server
 
         private IEnumerable<DeviceService> GetServices()
         {
-            var list = new List<DeviceService>
-            {
-                new DeviceService
-                {
-                    ServiceType = "urn:schemas-upnp-org:service:ContentDirectory:1",
-                    ServiceId = "urn:upnp-org:serviceId:ContentDirectory",
-                    ScpdUrl = "contentdirectory/contentdirectory.xml",
-                    ControlUrl = "contentdirectory/control",
-                    EventSubUrl = "contentdirectory/events"
-                },
+            var list = new List<DeviceService>();
 
-                new DeviceService
-                {
-                    ServiceType = "urn:schemas-upnp-org:service:ConnectionManager:1",
-                    ServiceId = "urn:upnp-org:serviceId:ConnectionManager",
-                    ScpdUrl = "connectionmanager/connectionmanager.xml",
-                    ControlUrl = "connectionmanager/control",
-                    EventSubUrl = "connectionmanager/events"
-                }
-            };
+            list.Add(new DeviceService
+            {
+                ServiceType = "urn:schemas-upnp-org:service:ContentDirectory:1",
+                ServiceId = "urn:upnp-org:serviceId:ContentDirectory",
+                ScpdUrl = "contentdirectory/contentdirectory.xml",
+                ControlUrl = "contentdirectory/control",
+                EventSubUrl = "contentdirectory/events"
+            });
+
+            list.Add(new DeviceService
+            {
+                ServiceType = "urn:schemas-upnp-org:service:ConnectionManager:1",
+                ServiceId = "urn:upnp-org:serviceId:ConnectionManager",
+                ScpdUrl = "connectionmanager/connectionmanager.xml",
+                ControlUrl = "connectionmanager/control",
+                EventSubUrl = "connectionmanager/events"
+            });
 
             if (_profile.EnableMSMediaReceiverRegistrar)
             {

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -256,6 +256,12 @@ namespace Emby.Dlna.Server
             builder.Append("</serviceList>");
         }
 
+        /// <summary>
+        /// Builds a valid url for inclusion in the xml.
+        /// </summary>
+        /// <param name="url">Url to include.</param>
+        /// <param name="absoluteUrl">Optional. When set to true, the absolute url is always used.</param>
+        /// <returns>The url to use for the element.</returns>
         private string BuildUrl(string url, bool absoluteUrl = false)
         {
             if (string.IsNullOrEmpty(url))


### PR DESCRIPTION
The dlna server used the DLNA base url functionality within its descriptions, enabling shorter url's to be used within it xml description.

However, it looks like this shorting of service urls is not supported (at least in UPnP Tools - which I have to assume is correct).

The result is that services cannot be parsed. eg, **Look at the serviceUrl** - BaseUrl is set to Jellyfin/

Before fix:

![image](https://user-images.githubusercontent.com/22121540/93328586-d633af80-f813-11ea-9910-c79a4f5d9e3a.png)

After fix: (DescriptionXMLBuilder.cs BuildUrl (270))

![image](https://user-images.githubusercontent.com/22121540/93328357-848b2500-f813-11ea-836e-ecd090fb4a01.png)


