### PR TITLE
Add container to HLS controller URLs

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -164,8 +164,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
         /// <response code="200">Video stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the playlist file.</returns>
-        [HttpGet("Videos/{itemId}/master.m3u8")]
-        [HttpHead("Videos/{itemId}/master.m3u8", Name = "HeadMasterHlsVideoPlaylist")]
+        [HttpGet("Videos/{itemId}/master.{container}")]
+        [HttpHead("Videos/{itemId}/master.{container}", Name = "HeadMasterHlsVideoPlaylist")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesPlaylistFile]
         public async Task<ActionResult> GetMasterHlsVideoPlaylist(
@@ -332,8 +332,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
         /// <response code="200">Audio stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the playlist file.</returns>
-        [HttpGet("Audio/{itemId}/master.m3u8")]
-        [HttpHead("Audio/{itemId}/master.m3u8", Name = "HeadMasterHlsAudioPlaylist")]
+        [HttpGet("Audio/{itemId}/master.{container}")]
+        [HttpHead("Audio/{itemId}/master.{container}", Name = "HeadMasterHlsAudioPlaylist")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesPlaylistFile]
         public async Task<ActionResult> GetMasterHlsAudioPlaylist(
@@ -499,7 +499,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
-        [HttpGet("Videos/{itemId}/main.m3u8")]
+        [HttpGet("Videos/{itemId}/main.{container}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesPlaylistFile]
         public async Task<ActionResult> GetVariantHlsVideoPlaylist(
@@ -665,7 +665,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Audio stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
-        [HttpGet("Audio/{itemId}/main.m3u8")]
+        [HttpGet("Audio/{itemId}/main.{container}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesPlaylistFile]
         public async Task<ActionResult> GetVariantHlsAudioPlaylist(


### PR DESCRIPTION
**Changes**

The URLs for all the HLS controllers require a container field, but none of them provide it.

The documentation for these is also very wrong, but I'm not sure about what containers other than m3u8 are supported, so I didn't touch it.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
