### PR TITLE
Use GeneralCommandType enum in GeneralCommand

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -135,6 +135,7 @@
  - [YouKnowBlom](https://github.com/YouKnowBlom)
  - [KristupasSavickas](https://github.com/KristupasSavickas)
  - [Pusta](https://github.com/pusta)
+ - [nielsvanvelzen](https://github.com/nielsvanvelzen)
 
 # Emby Contributors
 

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -669,62 +669,57 @@ namespace Emby.Dlna.PlayTo
 
         private Task SendGeneralCommand(GeneralCommand command, CancellationToken cancellationToken)
         {
-            if (Enum.TryParse(command.Name, true, out GeneralCommandType commandType))
+            switch (command.Name)
             {
-                switch (commandType)
-                {
-                    case GeneralCommandType.VolumeDown:
-                        return _device.VolumeDown(cancellationToken);
-                    case GeneralCommandType.VolumeUp:
-                        return _device.VolumeUp(cancellationToken);
-                    case GeneralCommandType.Mute:
-                        return _device.Mute(cancellationToken);
-                    case GeneralCommandType.Unmute:
-                        return _device.Unmute(cancellationToken);
-                    case GeneralCommandType.ToggleMute:
-                        return _device.ToggleMute(cancellationToken);
-                    case GeneralCommandType.SetAudioStreamIndex:
-                        if (command.Arguments.TryGetValue("Index", out string index))
+                case GeneralCommandType.VolumeDown:
+                    return _device.VolumeDown(cancellationToken);
+                case GeneralCommandType.VolumeUp:
+                    return _device.VolumeUp(cancellationToken);
+                case GeneralCommandType.Mute:
+                    return _device.Mute(cancellationToken);
+                case GeneralCommandType.Unmute:
+                    return _device.Unmute(cancellationToken);
+                case GeneralCommandType.ToggleMute:
+                    return _device.ToggleMute(cancellationToken);
+                case GeneralCommandType.SetAudioStreamIndex:
+                    if (command.Arguments.TryGetValue("Index", out string index))
+                    {
+                        if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
                         {
-                            if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
-                            {
-                                return SetAudioStreamIndex(val);
-                            }
-
-                            throw new ArgumentException("Unsupported SetAudioStreamIndex value supplied.");
+                            return SetAudioStreamIndex(val);
                         }
 
-                        throw new ArgumentException("SetAudioStreamIndex argument cannot be null");
-                    case GeneralCommandType.SetSubtitleStreamIndex:
-                        if (command.Arguments.TryGetValue("Index", out index))
-                        {
-                            if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
-                            {
-                                return SetSubtitleStreamIndex(val);
-                            }
+                        throw new ArgumentException("Unsupported SetAudioStreamIndex value supplied.");
+                    }
 
-                            throw new ArgumentException("Unsupported SetSubtitleStreamIndex value supplied.");
+                    throw new ArgumentException("SetAudioStreamIndex argument cannot be null");
+                case GeneralCommandType.SetSubtitleStreamIndex:
+                    if (command.Arguments.TryGetValue("Index", out index))
+                    {
+                        if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
+                        {
+                            return SetSubtitleStreamIndex(val);
                         }
 
-                        throw new ArgumentException("SetSubtitleStreamIndex argument cannot be null");
-                    case GeneralCommandType.SetVolume:
-                        if (command.Arguments.TryGetValue("Volume", out string vol))
-                        {
-                            if (int.TryParse(vol, NumberStyles.Integer, _usCulture, out var volume))
-                            {
-                                return _device.SetVolume(volume, cancellationToken);
-                            }
+                        throw new ArgumentException("Unsupported SetSubtitleStreamIndex value supplied.");
+                    }
 
-                            throw new ArgumentException("Unsupported volume value supplied.");
+                    throw new ArgumentException("SetSubtitleStreamIndex argument cannot be null");
+                case GeneralCommandType.SetVolume:
+                    if (command.Arguments.TryGetValue("Volume", out string vol))
+                    {
+                        if (int.TryParse(vol, NumberStyles.Integer, _usCulture, out var volume))
+                        {
+                            return _device.SetVolume(volume, cancellationToken);
                         }
 
-                        throw new ArgumentException("Volume argument cannot be null");
-                    default:
-                        return Task.CompletedTask;
-                }
+                        throw new ArgumentException("Unsupported volume value supplied.");
+                    }
+
+                    throw new ArgumentException("Volume argument cannot be null");
+                default:
+                    return Task.CompletedTask;
             }
-
-            return Task.CompletedTask;
         }
 
         private async Task SetAudioStreamIndex(int? newIndex)

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1037,7 +1037,7 @@ namespace Emby.Server.Implementations.Session
 
             var generalCommand = new GeneralCommand
             {
-                Name = GeneralCommandType.DisplayMessage.ToString()
+                Name = GeneralCommandType.DisplayMessage
             };
 
             generalCommand.Arguments["Header"] = command.Header;
@@ -1268,7 +1268,7 @@ namespace Emby.Server.Implementations.Session
         {
             var generalCommand = new GeneralCommand
             {
-                Name = GeneralCommandType.DisplayContent.ToString(),
+                Name = GeneralCommandType.DisplayContent,
                 Arguments =
                 {
                     ["ItemId"] = command.ItemId,

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -217,16 +217,15 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromRoute, Required] string command)
         {
-            var name = command;
-            if (Enum.TryParse(name, true, out GeneralCommandType commandType))
+            if (!Enum.TryParse(command, true, out GeneralCommandType commandType))
             {
-                name = commandType.ToString();
+                return BadRequest();
             }
 
             var currentSession = RequestHelpers.GetSession(_sessionManager, _authContext, Request);
             var generalCommand = new GeneralCommand
             {
-                Name = name,
+                Name = commandType,
                 ControllingUserId = currentSession.UserId
             };
 
@@ -249,11 +248,16 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromRoute, Required] string command)
         {
+            if (!Enum.TryParse(command, true, out GeneralCommandType commandType))
+            {
+                return BadRequest();
+            }
+
             var currentSession = RequestHelpers.GetSession(_sessionManager, _authContext, Request);
 
             var generalCommand = new GeneralCommand
             {
-                Name = command,
+                Name = commandType,
                 ControllingUserId = currentSession.UserId
             };
 

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -215,17 +215,12 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public ActionResult SendSystemCommand(
             [FromRoute, Required] string sessionId,
-            [FromRoute, Required] string command)
+            [FromRoute, Required] GeneralCommandType command)
         {
-            if (!Enum.TryParse(command, true, out GeneralCommandType commandType))
-            {
-                return BadRequest();
-            }
-
             var currentSession = RequestHelpers.GetSession(_sessionManager, _authContext, Request);
             var generalCommand = new GeneralCommand
             {
-                Name = commandType,
+                Name = command,
                 ControllingUserId = currentSession.UserId
             };
 
@@ -246,18 +241,13 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public ActionResult SendGeneralCommand(
             [FromRoute, Required] string sessionId,
-            [FromRoute, Required] string command)
+            [FromRoute, Required] GeneralCommandType command)
         {
-            if (!Enum.TryParse(command, true, out GeneralCommandType commandType))
-            {
-                return BadRequest();
-            }
-
             var currentSession = RequestHelpers.GetSession(_sessionManager, _authContext, Request);
 
             var generalCommand = new GeneralCommand
             {
-                Name = commandType,
+                Name = command,
                 ControllingUserId = currentSession.UserId
             };
 

--- a/MediaBrowser.Model/Session/GeneralCommand.cs
+++ b/MediaBrowser.Model/Session/GeneralCommand.cs
@@ -8,7 +8,7 @@ namespace MediaBrowser.Model.Session
 {
     public class GeneralCommand
     {
-        public string Name { get; set; }
+        public GeneralCommandType Name { get; set; }
 
         public Guid ControllingUserId { get; set; }
 


### PR DESCRIPTION
**Changes**
The GeneralCommand adds the type of the send command in the "Name" field. This PR changes that field to use the GeneralCommandType instead of a string. This will result in the GeneralCommandType being included in the OpenAPI JSON so the apiclients can use that information.

**Issues**
- Mentioned in #4029 
