### PR TITLE
HDHomeRun: Preemptively throw a LiveTvConflictException

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -563,6 +563,19 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
 
         protected override async Task<ILiveStream> GetChannelStream(TunerHostInfo info, ChannelInfo channelInfo, string streamId, List<ILiveStream> currentLiveStreams, CancellationToken cancellationToken)
         {
+            var tunerCount = info.TunerCount;
+
+            if (tunerCount > 0)
+            {
+                var tunerHostId = info.Id;
+                var liveStreams = currentLiveStreams.Where(i => string.Equals(i.TunerHostId, tunerHostId, StringComparison.OrdinalIgnoreCase));
+
+                if (liveStreams.Count() >= tunerCount)
+                {
+                    throw new LiveTvConflictException("HDHomeRun simultaneous stream limit has been reached.");
+                }
+            }
+
             var profile = streamId.Split('_')[0];
 
             Logger.LogInformation("GetChannelStream: channel id: {0}. stream id: {1} profile: {2}", channelInfo.Id, streamId, profile);


### PR DESCRIPTION
When we can determine that the number of live streams will exceed the number of tuners available, prior to attempting to connect to the device, then throw a LiveTvConflictException to expedite the transfer to another host.

**Changes**
Copied logic from M3UTunerHost.GetChannelStream; the same logic applies here.

**Issues**
Unsure if this resolves an outstanding reported issue.
