### PR TITLE
Add series image aspect ratio when ep/season is missing an image

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1139,6 +1139,7 @@ namespace Emby.Server.Implementations.Dto
                     if (episodeSeries != null)
                     {
                         dto.SeriesPrimaryImageTag = GetTagAndFillBlurhash(dto, episodeSeries, ImageType.Primary);
+                        AttachPrimaryImageAspectRatio(dto, episodeSeries);
                     }
                 }
 
@@ -1185,6 +1186,7 @@ namespace Emby.Server.Implementations.Dto
                     if (series != null)
                     {
                         dto.SeriesPrimaryImageTag = GetTagAndFillBlurhash(dto, series, ImageType.Primary);
+                        AttachPrimaryImageAspectRatio(dto, series);
                     }
                 }
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Added the series primary image aspect ratio when using it as a placeholder for episodes and seasons.

**BEFORE**
![image](https://user-images.githubusercontent.com/675118/94196851-3fbb5a00-feb5-11ea-8d64-221d490a056d.png)

**AFTER**
![image](https://user-images.githubusercontent.com/675118/94196881-48139500-feb5-11ea-8444-c142738cc988.png)
