### PR TITLE
Null Pointer Fix : PlayToController.cs

### DIFF
--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -886,7 +886,10 @@ namespace Emby.Dlna.PlayTo
                     return null;
                 }
 
-                mediaSource = await _mediaSourceManager.GetMediaSource(Item, MediaSourceId, LiveStreamId, false, cancellationToken).ConfigureAwait(false);
+                if (_mediaSourceManager != null)
+                {
+                    mediaSource = await _mediaSourceManager.GetMediaSource(Item, MediaSourceId, LiveStreamId, false, cancellationToken).ConfigureAwait(false);
+                }
 
                 return mediaSource;
             }


### PR DESCRIPTION
It is possible for _mediaSourceManager to have a null value. (ParseFromUrl creates new streams and only assigns an ItemId.)

The calling code can handle a null response.