### PR TITLE
Null Pointer fix: BaseControlHandler.cs

### DIFF
--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security;a
+using System.Security;
 using System.Text;
 using Emby.Dlna.Common;
 using MediaBrowser.Model.Dlna;

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -4,8 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security;
+using System.Security;a
 using System.Text;
+using Emby.Dlna.Common;
 using MediaBrowser.Model.Dlna;
 
 namespace Emby.Dlna.Server
@@ -19,9 +20,8 @@ namespace Emby.Dlna.Server
         private readonly string _serverAddress;
         private readonly string _serverName;
         private readonly string _serverId;
-        private readonly string _customName;
 
-        public DescriptionXmlBuilder(DeviceProfile profile, string serverUdn, string serverAddress, string serverName, string serverId, string customName)
+        public DescriptionXmlBuilder(DeviceProfile profile, string serverUdn, string serverAddress, string serverName, string serverId)
         {
             if (string.IsNullOrEmpty(serverUdn))
             {
@@ -38,7 +38,6 @@ namespace Emby.Dlna.Server
             _serverAddress = serverAddress;
             _serverName = serverName;
             _serverId = serverId;
-            _customName = customName;
         }
 
         private static bool EnableAbsoluteUrls => false;
@@ -169,12 +168,7 @@ namespace Emby.Dlna.Server
         {
             if (string.IsNullOrEmpty(_profile.FriendlyName))
             {
-                if (string.IsNullOrEmpty(_customName))
-                {
-                    return "Jellyfin - " + _serverName;
-                }
-
-                return _customName;
+                return "Jellyfin - " + _serverName;
             }
 
             var characterList = new List<char>();
@@ -281,7 +275,7 @@ namespace Emby.Dlna.Server
             return SecurityElement.Escape(url);
         }
 
-        private static IEnumerable<DeviceIcon> GetIcons()
+        private IEnumerable<DeviceIcon> GetIcons()
             => new[]
             {
                 new DeviceIcon
@@ -341,26 +335,25 @@ namespace Emby.Dlna.Server
 
         private IEnumerable<DeviceService> GetServices()
         {
-            var list = new List<DeviceService>
-            {
-                new DeviceService
-                {
-                    ServiceType = "urn:schemas-upnp-org:service:ContentDirectory:1",
-                    ServiceId = "urn:upnp-org:serviceId:ContentDirectory",
-                    ScpdUrl = "contentdirectory/contentdirectory.xml",
-                    ControlUrl = "contentdirectory/control",
-                    EventSubUrl = "contentdirectory/events"
-                },
+            var list = new List<DeviceService>();
 
-                new DeviceService
-                {
-                    ServiceType = "urn:schemas-upnp-org:service:ConnectionManager:1",
-                    ServiceId = "urn:upnp-org:serviceId:ConnectionManager",
-                    ScpdUrl = "connectionmanager/connectionmanager.xml",
-                    ControlUrl = "connectionmanager/control",
-                    EventSubUrl = "connectionmanager/events"
-                }
-            };
+            list.Add(new DeviceService
+            {
+                ServiceType = "urn:schemas-upnp-org:service:ContentDirectory:1",
+                ServiceId = "urn:upnp-org:serviceId:ContentDirectory",
+                ScpdUrl = "contentdirectory/contentdirectory.xml",
+                ControlUrl = "contentdirectory/control",
+                EventSubUrl = "contentdirectory/events"
+            });
+
+            list.Add(new DeviceService
+            {
+                ServiceType = "urn:schemas-upnp-org:service:ConnectionManager:1",
+                ServiceId = "urn:upnp-org:serviceId:ConnectionManager",
+                ScpdUrl = "connectionmanager/connectionmanager.xml",
+                ControlUrl = "connectionmanager/control",
+                EventSubUrl = "connectionmanager/events"
+            });
 
             if (_profile.EnableMSMediaReceiverRegistrar)
             {

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -249,14 +249,8 @@ namespace Emby.Dlna.Server
 
             builder.Append("</serviceList>");
         }
-
-        /// <summary>
-        /// Builds a valid url for inclusion in the xml.
-        /// </summary>
-        /// <param name="url">Url to include.</param>
-        /// <param name="absoluteUrl">Optional. When set to true, the absolute url is always used.</param>
-        /// <returns>The url to use for the element.</returns>
-        private string BuildUrl(string url, bool absoluteUrl = false)
+        
+        private string BuildUrl(string ure)
         {
             if (string.IsNullOrEmpty(url))
             {
@@ -267,7 +261,7 @@ namespace Emby.Dlna.Server
 
             url = "/dlna/" + _serverUdn + "/" + url;
 
-            if (EnableAbsoluteUrls || absoluteUrl)
+            if (EnableAbsoluteUrls)
             {
                 url = _serverAddress.TrimEnd('/') + url;
             }

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -249,8 +249,8 @@ namespace Emby.Dlna.Server
 
             builder.Append("</serviceList>");
         }
-        
-        private string BuildUrl(string ure)
+
+        private string BuildUrl(string url)
         {
             if (string.IsNullOrEmpty(url))
             {

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -235,13 +235,13 @@ namespace Emby.Dlna.Server
                     .Append(SecurityElement.Escape(service.ServiceId ?? string.Empty))
                     .Append("</serviceId>");
                 builder.Append("<SCPDURL>")
-                    .Append(BuildUrl(service.ScpdUrl, true))
+                    .Append(BuildUrl(service.ScpdUrl))
                     .Append("</SCPDURL>");
                 builder.Append("<controlURL>")
-                    .Append(BuildUrl(service.ControlUrl, true))
+                    .Append(BuildUrl(service.ControlUrl))
                     .Append("</controlURL>");
                 builder.Append("<eventSubURL>")
-                    .Append(BuildUrl(service.EventSubUrl, true))
+                    .Append(BuildUrl(service.EventSubUrl))
                     .Append("</eventSubURL>");
 
                 builder.Append("</service>");

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -256,6 +256,12 @@ namespace Emby.Dlna.Server
             builder.Append("</serviceList>");
         }
 
+        /// <summary>
+        /// Builds a valid url for inclusion in the xml.
+        /// </summary>
+        /// <param name="url">Url to include.</param>
+        /// <param name="absoluteUrl">Optional. When set to true, the absolute url is always used.</param>
+        /// <returns>The url to use for the element.</returns>
         private string BuildUrl(string url, bool absoluteUrl = false)
         {
             if (string.IsNullOrEmpty(url))

--- a/Emby.Dlna/Service/BaseControlHandler.cs
+++ b/Emby.Dlna/Service/BaseControlHandler.cs
@@ -150,7 +150,7 @@ namespace Emby.Dlna.Service
                 }
             }
 
-            return new ControlRequestInfo();
+            throw new EndOfStreamException("Stream ended but no body tag found.");
         }
 
         private async Task<ControlRequestInfo> ParseBodyTagAsync(XmlReader reader)

--- a/Emby.Dlna/Service/BaseControlHandler.cs
+++ b/Emby.Dlna/Service/BaseControlHandler.cs
@@ -188,7 +188,7 @@ namespace Emby.Dlna.Service
                 }
             }
 
-           if (localName != null && namespaceURI != null)
+            if (localName != null && namespaceURI != null)
             {
                 return new ControlRequestInfo(localName, namespaceURI);
             }

--- a/Emby.Dlna/Service/BaseControlHandler.cs
+++ b/Emby.Dlna/Service/BaseControlHandler.cs
@@ -155,7 +155,7 @@ namespace Emby.Dlna.Service
 
         private async Task<ControlRequestInfo> ParseBodyTagAsync(XmlReader reader)
         {
-            var result = new ControlRequestInfo();
+            string namespaceURI = null, localName = null;
 
             await reader.MoveToContentAsync().ConfigureAwait(false);
             await reader.ReadAsync().ConfigureAwait(false);
@@ -165,11 +165,12 @@ namespace Emby.Dlna.Service
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
-                    result.LocalName = reader.LocalName;
-                    result.NamespaceURI = reader.NamespaceURI;
+                    localName = reader.LocalName;
+                    namespaceURI = reader.NamespaceURI;
 
                     if (!reader.IsEmptyElement)
                     {
+                        var result = new ControlRequestInfo(localName, namespaceURI);
                         using (var subReader = reader.ReadSubtree())
                         {
                             await ParseFirstBodyChildAsync(subReader, result.Headers).ConfigureAwait(false);
@@ -187,7 +188,12 @@ namespace Emby.Dlna.Service
                 }
             }
 
-            return result;
+           if (localName != null && namespaceURI != null)
+            {
+                return new ControlRequestInfo(localName, namespaceURI);
+            }
+
+            throw new EndOfStreamException("Stream ended but no control found.");
         }
 
         private async Task ParseFirstBodyChildAsync(XmlReader reader, IDictionary<string, string> headers)
@@ -234,11 +240,18 @@ namespace Emby.Dlna.Service
 
         private class ControlRequestInfo
         {
+            public ControlRequestInfo(string localName, string namespaceUri)
+            {
+                LocalName = localName;
+                NamespaceURI = namespaceUri;
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
             public string LocalName { get; set; }
 
             public string NamespaceURI { get; set; }
 
-            public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public Dictionary<string, string> Headers { get; }
         }
     }
 }


### PR DESCRIPTION
The first instance in within a try/catch block in ProcessControlRequestAsync. It calls ProcessControlRequestInternalAsync, which in turn calls ParseRequestAsync.

ParseRequestAsync searches for a body tag - but returns an empty ControlRequestInfo object if none is found.

ProcessControlRequestInternalAsync proceeds to try and output settings from this object that aren't initialised (hence null pointer).

As the code is in an exception block, this won't currently crash, however, putting in the exception is a cleaner solution - and goes towards making the function nullable.

The second instance is in ParseBodyTagAsync where under certain circumstances it is possible to get an empty ControlRequestInfo object.

The final change is creating a constructor for ControlRequestInfo, which makes it nullable.