### PR TITLE
Properly handle null structs in json

### DIFF
--- a/MediaBrowser.Common/Json/Converters/JsonNullableStructConverter.cs
+++ b/MediaBrowser.Common/Json/Converters/JsonNullableStructConverter.cs
@@ -8,37 +8,38 @@ namespace MediaBrowser.Common.Json.Converters
     /// Converts a nullable struct or value to/from JSON.
     /// Required - some clients send an empty string.
     /// </summary>
-    /// <typeparam name="T">The struct type.</typeparam>
-    public class JsonNullableStructConverter<T> : JsonConverter<T?>
-        where T : struct
+    /// <typeparam name="TStruct">The struct type.</typeparam>
+    public class JsonNullableStructConverter<TStruct> : JsonConverter<TStruct?>
+        where TStruct : struct
     {
-        private readonly JsonConverter<T?> _baseJsonConverter;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonNullableStructConverter{T}"/> class.
-        /// </summary>
-        /// <param name="baseJsonConverter">The base json converter.</param>
-        public JsonNullableStructConverter(JsonConverter<T?> baseJsonConverter)
-        {
-            _baseJsonConverter = baseJsonConverter;
-        }
-
         /// <inheritdoc />
-        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override TStruct? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            // Handle empty string.
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            // Token is empty string.
             if (reader.TokenType == JsonTokenType.String && ((reader.HasValueSequence && reader.ValueSequence.IsEmpty) || reader.ValueSpan.IsEmpty))
             {
                 return null;
             }
 
-            return _baseJsonConverter.Read(ref reader, typeToConvert, options);
+            return JsonSerializer.Deserialize<TStruct>(ref reader, options);
         }
 
         /// <inheritdoc />
-        public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, TStruct? value, JsonSerializerOptions options)
         {
-            _baseJsonConverter.Write(writer, value, options);
+            if (value.HasValue)
+            {
+                JsonSerializer.Serialize(writer, value.Value, options);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
         }
     }
 }

--- a/MediaBrowser.Common/Json/Converters/JsonNullableStructConverterFactory.cs
+++ b/MediaBrowser.Common/Json/Converters/JsonNullableStructConverterFactory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MediaBrowser.Common.Json.Converters
+{
+    /// <summary>
+    /// Json nullable struct converter factory.
+    /// </summary>
+    public class JsonNullableStructConverterFactory : JsonConverterFactory
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert.IsGenericType
+                   && typeToConvert.GetGenericTypeDefinition() == typeof(Nullable<>)
+                   && typeToConvert.GenericTypeArguments[0].IsValueType;
+        }
+
+        /// <inheritdoc />
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var structType = typeToConvert.GenericTypeArguments[0];
+            return (JsonConverter)Activator.CreateInstance(typeof(JsonNullableStructConverter<>).MakeGenericType(structType));
+        }
+    }
+}

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -39,14 +39,9 @@ namespace MediaBrowser.Common.Json
                 NumberHandling = JsonNumberHandling.AllowReadingFromString
             };
 
-            // Get built-in converters for fallback converting.
-            var baseNullableInt32Converter = (JsonConverter<int?>)options.GetConverter(typeof(int?));
-            var baseNullableInt64Converter = (JsonConverter<long?>)options.GetConverter(typeof(long?));
-
             options.Converters.Add(new JsonGuidConverter());
             options.Converters.Add(new JsonStringEnumConverter());
-            options.Converters.Add(new JsonNullableStructConverter<int>(baseNullableInt32Converter));
-            options.Converters.Add(new JsonNullableStructConverter<long>(baseNullableInt64Converter));
+            options.Converters.Add(new JsonNullableStructConverterFactory());
 
             return options;
         }


### PR DESCRIPTION
Use factory instead of manually adding
Call JsonSerializer instead of passing serializer through constructor