### PR TITLE
Increase initial scan speed for music libraries

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Emby.Naming.Audio;
 using MediaBrowser.Controller.Entities.Audio;
@@ -132,7 +133,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
             }
 
             var discSubfolderCount = 0;
-            var notMultiDisc = false;
 
             var namingOptions = ((LibraryManager)_libraryManager).GetNamingOptions();
             var parser = new AlbumParser(namingOptions);
@@ -149,18 +149,17 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
                     if (parser.IsMultiPart(path))
                     {
                         logger.LogDebug("Found multi-disc folder: " + path);
-                        discSubfolderCount++;
+                        Interlocked.Increment(ref discSubfolderCount);
                     }
                     else
                     {
                         // If there are folders underneath with music that are not multidisc, then this can't be a multi-disc album
-                        notMultiDisc = true;
                         state.Stop();
                     }
                 }
             });
 
-            if (notMultiDisc)
+            if (!result.IsCompleted)
             {
                 return false;
             }

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -117,10 +117,8 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
             ILibraryManager libraryManager)
         {
             // check for audio files before digging down into directories
-            var firstAudioFile = list
-                .Where(fileSystemInfo => !fileSystemInfo.IsDirectory)
-                .FirstOrDefault(fileSystemInfo => libraryManager.IsAudioFile(fileSystemInfo.FullName));
-            if (firstAudioFile != null)
+            var foundAudioFile = list.Any(fileSystemInfo => !fileSystemInfo.IsDirectory && libraryManager.IsAudioFile(fileSystemInfo.FullName));
+            if (foundAudioFile)
             {
                 // at least one audio file exists
                 return true;


### PR DESCRIPTION
The scan for my 78 thousand track music library on an rclone mount is pretty slow. I looked into the code and found it is partly due to the directory enumeration. 
When scanning, each io operation hits the rclone mount, which does some request to the backend cloud storage. 
The first part of the scan checks to see if something is a music album. If you have 1 folder with 1,000 subfolders, where each one represents an artist, it enumerates each of those subfolders one by one, which is very slow. Changing the scan logic to be more parallel results in a faster scan.

**Changes**
- Rearrange some the logic so it can bail out faster.
- Use `Parallel.ForEach` loops during directory enumeration calls for music scans.

**Issues**
Nothing specific that I saw.

**Future work**
There's additional changes that can be done to further increase the scan speed - this is the simplest one. Other changes would involve parallelizing `Folder.ValidateSubFolders`, `RefreshMetadataRecursive`, and some other refresh metadata methods.