### PR TITLE
Fix invalid operation exception in TvdbEpisodeImageProvider.GetImages

### DIFF
--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbEpisodeImageProvider.cs
@@ -57,21 +57,28 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                 // Process images
                 try
                 {
-                    var episodeInfo = new EpisodeInfo
+                    string episodeTvdbId = null;
+
+                    if (episode.IndexNumber.HasValue && episode.ParentIndexNumber.HasValue)
                     {
-                        IndexNumber = episode.IndexNumber.Value,
-                        ParentIndexNumber = episode.ParentIndexNumber.Value,
-                        SeriesProviderIds = series.ProviderIds,
-                        SeriesDisplayOrder = series.DisplayOrder
-                    };
-                    string episodeTvdbId = await _tvdbClientManager
-                        .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
+                        var episodeInfo = new EpisodeInfo
+                        {
+                            IndexNumber = episode.IndexNumber.Value,
+                            ParentIndexNumber = episode.ParentIndexNumber.Value,
+                            SeriesProviderIds = series.ProviderIds,
+                            SeriesDisplayOrder = series.DisplayOrder
+                        };
+
+                        episodeTvdbId = await _tvdbClientManager
+                            .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
+                    }
+
                     if (string.IsNullOrEmpty(episodeTvdbId))
                     {
                         _logger.LogError(
                             "Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}",
-                            episodeInfo.ParentIndexNumber,
-                            episodeInfo.IndexNumber,
+                            episode.ParentIndexNumber,
+                            episode.IndexNumber,
                             series.GetProviderId(MetadataProvider.Tvdb));
                         return imageResult;
                     }


### PR DESCRIPTION
Depending on the TVDB data for a series / episode, this fixes the following error during library scans:

```
[2020-09-27 15:54:47.517 -07:00] [ERR] [10] MediaBrowser.Providers.Manager.ProviderManager: "TvdbEpisodeImageProvider" failed in GetImageInfos for type "Episode" at "%xyz%"
System.InvalidOperationException: Nullable object must have a value.
   at System.Nullable`1.get_Value()
   at MediaBrowser.Providers.Plugins.TheTvdb.TvdbEpisodeImageProvider.GetImages(BaseItem item, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\TheTvdb\TvdbEpisodeImageProvider.cs:line 60
   at MediaBrowser.Providers.Manager.ProviderManager.GetImages(BaseItem item, IRemoteImageProvider provider, IReadOnlyCollection`1 preferredLanguages, CancellationToken cancellationToken, Nullable`1 type) in C:\Programming\jellyfin\MediaBrowser.Providers\Manager\ProviderManager.cs:line 263
```

**Changes**
- Confirm `IndexNumber` & `ParentIndexNumber` have a value before using them
- You'll now see a log line showing that one of those numbers was null instead of the exception:
```[2020-09-27 16:05:50.015 -07:00] [ERR] [101] MediaBrowser.Providers.Plugins.TheTvdb.TvdbEpisodeImageProvider: Episode 1xnull not found for series "%xyz%"```

**Issues**
- The same error was mentioned in a comment for #2355, but this change is unrelated to the main issue.
