### PR TITLE
Fix InvalidOperationException in TvdbSeriesProvider.MapSeriesToResult

### DIFF
--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
@@ -352,14 +352,9 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                         };
                         var episodesPage = await _tvdbClientManager.GetEpisodesPageAsync(tvdbSeries.Id, episodeQuery, metadataLanguage, CancellationToken.None).ConfigureAwait(false);
 
-                        var episodeDates = episodesPage.Data
+                        result.Item.EndDate = episodesPage.Data
                             .Select(e => DateTime.TryParse(e.FirstAired, out var firstAired) ? firstAired : (DateTime?)null)
-                            .Where(dt => dt.HasValue)
-                            .ToList();
-                        if (episodeDates.Count != 0)
-                        {
-                            result.Item.EndDate = episodeDates.Max();
-                        }
+                            .Max();
                     }
                 }
                 catch (TvDbServerException e)

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
@@ -123,7 +123,7 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                     await _tvdbClientManager
                         .GetSeriesByIdAsync(Convert.ToInt32(tvdbId), metadataLanguage, cancellationToken)
                         .ConfigureAwait(false);
-                MapSeriesToResult(result, seriesResult.Data, metadataLanguage);
+                await MapSeriesToResult(result, seriesResult.Data, metadataLanguage).ConfigureAwait(false);
             }
             catch (TvDbServerException e)
             {
@@ -297,7 +297,7 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             return name.Trim();
         }
 
-        private void MapSeriesToResult(MetadataResult<Series> result, TvDbSharper.Dto.Series tvdbSeries, string metadataLanguage)
+        private async Task MapSeriesToResult(MetadataResult<Series> result, TvDbSharper.Dto.Series tvdbSeries, string metadataLanguage)
         {
             Series series = result.Item;
             series.SetProviderId(MetadataProvider.Tvdb, tvdbSeries.Id.ToString());
@@ -340,20 +340,25 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
             {
                 try
                 {
-                    var episodeSummary = _tvdbClientManager
-                        .GetSeriesEpisodeSummaryAsync(tvdbSeries.Id, metadataLanguage, CancellationToken.None).Result.Data;
-                    var maxSeasonNumber = episodeSummary.AiredSeasons.Select(s => Convert.ToInt32(s)).Max();
-                    var episodeQuery = new EpisodeQuery
+                    var episodeSummary = await _tvdbClientManager.GetSeriesEpisodeSummaryAsync(tvdbSeries.Id, metadataLanguage, CancellationToken.None).ConfigureAwait(false);
+
+                    if (episodeSummary.Data.AiredSeasons.Length > 0)
                     {
-                        AiredSeason = maxSeasonNumber
-                    };
-                    var episodesPage =
-                        _tvdbClientManager.GetEpisodesPageAsync(tvdbSeries.Id, episodeQuery, metadataLanguage, CancellationToken.None).Result.Data;
-                    result.Item.EndDate = episodesPage.Select(e =>
+                        var maxSeasonNumber = episodeSummary.Data.AiredSeasons.Select(s => Convert.ToInt32(s)).Max();
+                        var episodeQuery = new EpisodeQuery
                         {
-                            DateTime.TryParse(e.FirstAired, out var firstAired);
-                            return firstAired;
-                        }).Max();
+                            AiredSeason = maxSeasonNumber
+                        };
+                        var episodesPage = await _tvdbClientManager.GetEpisodesPageAsync(tvdbSeries.Id, episodeQuery, metadataLanguage, CancellationToken.None).ConfigureAwait(false);
+
+                        var episodeDates = episodesPage.Data
+                            .Select(e => DateTime.TryParse(e.FirstAired, out var firstAired) ? firstAired : (DateTime?)null)
+                            .Where(dt => dt.HasValue);
+                        if (episodeDates.Any())
+                        {
+                            result.Item.EndDate = episodeDates.Max().Value;
+                        }
+                    }
                 }
                 catch (TvDbServerException e)
                 {

--- a/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TheTvdb/TvdbSeriesProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -342,9 +343,9 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
                 {
                     var episodeSummary = await _tvdbClientManager.GetSeriesEpisodeSummaryAsync(tvdbSeries.Id, metadataLanguage, CancellationToken.None).ConfigureAwait(false);
 
-                    if (episodeSummary.Data.AiredSeasons.Length > 0)
+                    if (episodeSummary.Data.AiredSeasons.Length != 0)
                     {
-                        var maxSeasonNumber = episodeSummary.Data.AiredSeasons.Select(s => Convert.ToInt32(s)).Max();
+                        var maxSeasonNumber = episodeSummary.Data.AiredSeasons.Max(s => Convert.ToInt32(s, CultureInfo.InvariantCulture));
                         var episodeQuery = new EpisodeQuery
                         {
                             AiredSeason = maxSeasonNumber
@@ -353,10 +354,11 @@ namespace MediaBrowser.Providers.Plugins.TheTvdb
 
                         var episodeDates = episodesPage.Data
                             .Select(e => DateTime.TryParse(e.FirstAired, out var firstAired) ? firstAired : (DateTime?)null)
-                            .Where(dt => dt.HasValue);
-                        if (episodeDates.Any())
+                            .Where(dt => dt.HasValue)
+                            .ToList();
+                        if (episodeDates.Count != 0)
                         {
-                            result.Item.EndDate = episodeDates.Max().Value;
+                            result.Item.EndDate = episodeDates.Max();
                         }
                     }
                 }


### PR DESCRIPTION
Fixes the following error:
```
[2020-09-27 15:27:01.483 -07:00] [ERR] [77] MediaBrowser.Providers.TV.SeriesMetadataService: Error in "TheTVDB"
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.Max(IEnumerable`1 source)
   at MediaBrowser.Providers.Plugins.TheTvdb.TvdbSeriesProvider.MapSeriesToResult(MetadataResult`1 result, Series tvdbSeries, String metadataLanguage) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\TheTvdb\TvdbSeriesProvider.cs:line 345
   at MediaBrowser.Providers.Plugins.TheTvdb.TvdbSeriesProvider.FetchSeriesData(MetadataResult`1 result, String metadataLanguage, Dictionary`2 seriesProviderIds, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\TheTvdb\TvdbSeriesProvider.cs:line 126
   at MediaBrowser.Providers.Plugins.TheTvdb.TvdbSeriesProvider.GetMetadata(SeriesInfo itemId, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\TheTvdb\TvdbSeriesProvider.cs:line 90
   at MediaBrowser.Providers.Manager.MetadataService`2.ExecuteRemoteProviders(MetadataResult`1 temp, String logName, TIdType id, IEnumerable`1 providers, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 853
```
This happens when determining the end date for a series. Specifically, if `episodesPage` or `AiredSeasons` contain no elements (likely due to incomplete / bad data in TVDB).

**Changes**
- Confirm there are values in the arrays before `Max()`ing them.
- Change `MapSeriesToResult` to be async. Since the caller is async and this method was using `.Result` for tasks, it should be an async method.

**Issues**
None that I saw
