### PR TITLE
Use ConcurrentDictionary's in DirectoryService

### DIFF
--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -47,7 +47,7 @@ namespace MediaBrowser.Controller.Providers
         {
             var result = _fileCache.GetOrAdd(path, p =>
             {
-                var file = _fileSystem.GetFileInfo(path);
+                var file = _fileSystem.GetFileInfo(p);
                 return file != null && file.Exists ? file : null;
             });
 
@@ -70,7 +70,7 @@ namespace MediaBrowser.Controller.Providers
                 _filePathCache.TryRemove(path, out _);
             }
 
-            return _filePathCache.GetOrAdd(path, p => _fileSystem.GetFilePaths(path).ToList());
+            return _filePathCache.GetOrAdd(path, p => _fileSystem.GetFilePaths(p).ToList());
         }
     }
 }

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Model.IO;
@@ -11,11 +12,11 @@ namespace MediaBrowser.Controller.Providers
     {
         private readonly IFileSystem _fileSystem;
 
-        private readonly Dictionary<string, FileSystemMetadata[]> _cache = new Dictionary<string, FileSystemMetadata[]>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, FileSystemMetadata[]> _cache = new ConcurrentDictionary<string, FileSystemMetadata[]>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly Dictionary<string, FileSystemMetadata> _fileCache = new Dictionary<string, FileSystemMetadata>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, FileSystemMetadata> _fileCache = new ConcurrentDictionary<string, FileSystemMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly Dictionary<string, List<string>> _filePathCache = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, List<string>> _filePathCache = new ConcurrentDictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         public DirectoryService(IFileSystem fileSystem)
         {
@@ -24,14 +25,7 @@ namespace MediaBrowser.Controller.Providers
 
         public FileSystemMetadata[] GetFileSystemEntries(string path)
         {
-            if (!_cache.TryGetValue(path, out FileSystemMetadata[] entries))
-            {
-                entries = _fileSystem.GetFileSystemEntries(path).ToArray();
-
-                _cache[path] = entries;
-            }
-
-            return entries;
+            return _cache.GetOrAdd(path, (p) => _fileSystem.GetFileSystemEntries(p).ToArray());
         }
 
         public List<FileSystemMetadata> GetFiles(string path)
@@ -51,21 +45,19 @@ namespace MediaBrowser.Controller.Providers
 
         public FileSystemMetadata GetFile(string path)
         {
-            if (!_fileCache.TryGetValue(path, out FileSystemMetadata file))
+            var result = _fileCache.GetOrAdd(path, (p) =>
             {
-                file = _fileSystem.GetFileInfo(path);
+                var file = _fileSystem.GetFileInfo(path);
+                return (file != null && file.Exists) ? file : null;
+            });
 
-                if (file != null && file.Exists)
-                {
-                    _fileCache[path] = file;
-                }
-                else
-                {
-                    return null;
-                }
+            if (result == null)
+            {
+                // lets not store null results in the cache
+                _fileCache.TryRemove(path, out FileSystemMetadata removed);
             }
 
-            return file;
+            return result;
         }
 
         public IReadOnlyList<string> GetFilePaths(string path)
@@ -73,14 +65,12 @@ namespace MediaBrowser.Controller.Providers
 
         public IReadOnlyList<string> GetFilePaths(string path, bool clearCache)
         {
-            if (clearCache || !_filePathCache.TryGetValue(path, out List<string> result))
+            if (clearCache)
             {
-                result = _fileSystem.GetFilePaths(path).ToList();
-
-                _filePathCache[path] = result;
+                _filePathCache.TryRemove(path, out List<string> removed);
             }
 
-            return result;
+            return _filePathCache.GetOrAdd(path, (p) => _fileSystem.GetFilePaths(path).ToList());
         }
     }
 }

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -48,7 +48,7 @@ namespace MediaBrowser.Controller.Providers
             var result = _fileCache.GetOrAdd(path, p =>
             {
                 var file = _fileSystem.GetFileInfo(path);
-                return (file != null && file.Exists) ? file : null;
+                return file != null && file.Exists ? file : null;
             });
 
             if (result == null)

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -25,7 +25,7 @@ namespace MediaBrowser.Controller.Providers
 
         public FileSystemMetadata[] GetFileSystemEntries(string path)
         {
-            return _cache.GetOrAdd(path, (p) => _fileSystem.GetFileSystemEntries(p).ToArray());
+            return _cache.GetOrAdd(path, p => _fileSystem.GetFileSystemEntries(p).ToArray());
         }
 
         public List<FileSystemMetadata> GetFiles(string path)
@@ -45,7 +45,7 @@ namespace MediaBrowser.Controller.Providers
 
         public FileSystemMetadata GetFile(string path)
         {
-            var result = _fileCache.GetOrAdd(path, (p) =>
+            var result = _fileCache.GetOrAdd(path, p =>
             {
                 var file = _fileSystem.GetFileInfo(path);
                 return (file != null && file.Exists) ? file : null;
@@ -54,7 +54,7 @@ namespace MediaBrowser.Controller.Providers
             if (result == null)
             {
                 // lets not store null results in the cache
-                _fileCache.TryRemove(path, out FileSystemMetadata removed);
+                _fileCache.TryRemove(path, out _);
             }
 
             return result;
@@ -67,10 +67,10 @@ namespace MediaBrowser.Controller.Providers
         {
             if (clearCache)
             {
-                _filePathCache.TryRemove(path, out List<string> removed);
+                _filePathCache.TryRemove(path, out _);
             }
 
-            return _filePathCache.GetOrAdd(path, (p) => _fileSystem.GetFilePaths(path).ToList());
+            return _filePathCache.GetOrAdd(path, p => _fileSystem.GetFilePaths(path).ToList());
         }
     }
 }


### PR DESCRIPTION
I'm working on making the scanner / metadata refresh run multiple at once. One issue I ran into is `DirectoryService`'s cache dictionaries. Errors like this would show up since it's not thread safe:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)
   at MediaBrowser.Controller.Providers.DirectoryService.GetFile(String path) in C:\Programming\jellyfin\MediaBrowser.Controller\Providers\DirectoryService.cs:line 60
   at MediaBrowser.Providers.MediaInfo.FFProbeProvider.HasChanged(BaseItem item, IDirectoryService directoryService) in C:\Programming\jellyfin\MediaBrowser.Providers\MediaInfo\FFProbeProvider.cs:line 95
   at MediaBrowser.Providers.Manager.MetadataService`2.HasChanged(BaseItem item, IHasItemChangeMonitor changeMonitor, IDirectoryService directoryService) in C:\Programming\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 910
```
Switching to use `ConcurrentDictionary` solves this.

**Changes**
- Use `ConcurrentDictionary`'s in `DirectoryService`

**Issues**
None
