### PR TITLE
Check response status code before saving images

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -158,6 +158,14 @@ namespace MediaBrowser.Providers.Manager
             var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
             using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
 
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new HttpException($"Invalid image received ({response.StatusCode}).")
+                {
+                    StatusCode = response.StatusCode
+                };
+            }
+
             var contentType = response.Content.Headers.ContentType.MediaType;
 
             // Workaround for tvheadend channel icons

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -157,7 +157,14 @@ namespace MediaBrowser.Providers.Manager
         {
             var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
             using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new HttpException("Invalid image received.")
+                {
+                    StatusCode = response.StatusCode
+                };
+            }
 
             var contentType = response.Content.Headers.ContentType.MediaType;
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -157,14 +157,7 @@ namespace MediaBrowser.Providers.Manager
         {
             var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
             using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
-
-            if (response.StatusCode != HttpStatusCode.OK)
-            {
-                throw new HttpException("Invalid image received.")
-                {
-                    StatusCode = response.StatusCode
-                };
-            }
+            response.EnsureSuccessStatusCode();
 
             var contentType = response.Content.Headers.ContentType.MediaType;
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -160,7 +160,7 @@ namespace MediaBrowser.Providers.Manager
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                throw new HttpException($"Invalid image received ({response.StatusCode}).")
+                throw new HttpException("Invalid image received.")
                 {
                     StatusCode = response.StatusCode
                 };


### PR DESCRIPTION
At some point jellyfin downloaded a "poster" that is actually an xml file and ran into trouble getting the image dimensions:
```
[2020-09-27 14:40:58.006 -07:00] [ERR] [47] Emby.Server.Implementations.Library.LibraryManager: Cannot get image dimensions for "C:\Users\Gary\AppData\Local\jellyfin\metadata\library\ba\ba96d5eae180f07a89aee79d69c228f0\poster.xml"
Non-success codec result: Unimplemented
Jellyfin.Drawing.Skia.SkiaCodecException: Exception of type 'Jellyfin.Drawing.Skia.SkiaCodecException' was thrown.
   at Jellyfin.Drawing.Skia.SkiaHelper.EnsureSuccess(SKCodecResult result) in C:\Programming\jellyfin\Jellyfin.Drawing.Skia\SkiaHelper.cs:line 21
   at Jellyfin.Drawing.Skia.SkiaEncoder.GetImageSize(String path) in C:\Programming\jellyfin\Jellyfin.Drawing.Skia\SkiaEncoder.cs:line 184
   at Emby.Drawing.ImageProcessor.GetImageDimensions(String path) in C:\Programming\jellyfin\Emby.Drawing\ImageProcessor.cs:line 316
   at Emby.Drawing.ImageProcessor.GetImageDimensions(BaseItem item, ItemImageInfo info) in C:\Programming\jellyfin\Emby.Drawing\ImageProcessor.cs:line 307
   at Emby.Server.Implementations.Library.LibraryManager.UpdateImagesAsync(BaseItem item, Boolean forceUpdate) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 1906
```

The contents of `poster.xml` is:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>CAC0C74554096849</RequestId><HostId>OyoYC1pxFTjsgsAxxQS1ofhXCLHxSTwWN//TlTwP6IMaD/C8v3Rm5/ihwSTCgDa1V9pQO0iVrag=</HostId></Error>
```

It downloaded an invalid season poster. That response is the default tvdb response for invalid images. For example going to https://www.thetvdb.com/banners/seasons/abc123-1.jpg returns the same thing.

The root cause might be related to how `TvdbSeasonImageProvider` works because maybe it shouldn't be telling jellyfin to get an image for that url. Anyway I think this status code check should still be added.

The result makes it print this nice warning instead of an error:
```
[2020-09-27 21:45:51.978 -07:00] [WRN] [85] Emby.Server.Implementations.Library.LibraryManager: Cannot fetch image from "https://www.thetvdb.com/banners/seasons/abc123-1.jpg"
```
**Changes**
- Check that the status code is 200 OK before saving images

**Issues**
None that I saw
