### PR TITLE
Revert part of #3007 to fix LocalAddress in /system/info/public

### DIFF
--- a/Emby.Server.Implementations/Networking/NetworkManager.cs
+++ b/Emby.Server.Implementations/Networking/NetworkManager.cs
@@ -438,7 +438,13 @@ namespace Emby.Server.Implementations.Networking
             {
                 var ipProperties = network.GetIPProperties();
 
-                // Exclude any addresses if they appear in the LAN list in [ ]
+                // Try to exclude virtual adapters
+                // http://stackoverflow.com/questions/8089685/c-sharp-finding-my-machines-local-ip-address-and-not-the-vms
+                var addr = ipProperties.GatewayAddresses.FirstOrDefault();
+                if (addr == null || (addr.Address.Equals(IPAddress.Any) || addr.Address.Equals(IPAddress.IPv6Any)))
+                {
+                    return Enumerable.Empty<IPAddress>();
+                }
 
                 return ipProperties.UnicastAddresses
                     .Select(i => i.Address)


### PR DESCRIPTION
**Changes**
- Added back a check that was removed in #3007

The /system/info/public endpoint reported "http://172.29.80.1:8096" (which is the address of a virtual ethernet adapter from Hyper-V on my machine)  as my LocalAddress and after adding this bit of code back it was "http://192.168.1.10:8096" again.

I'm not sure if this is a proper fix but I'll let you guys decide that.

This should fix a bunch of chromecast issues that started in 10.6.0 for hyper-v users on Windows. I could only find chromecast issue that seemed relevant.

**Issues**
- Me using my desktop as Jellyfin server
- Maybe #3712