### PR TITLE
Fix some warnings

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2263,7 +2263,6 @@ namespace Emby.Server.Implementations.Data
             return query.IncludeItemTypes.Contains("Trailer", StringComparer.OrdinalIgnoreCase);
         }
 
-
         private static readonly HashSet<string> _artistExcludeParentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Series",
@@ -3290,7 +3289,6 @@ namespace Emby.Server.Implementations.Data
                     commandText += " OFFSET " + offset.ToString(CultureInfo.InvariantCulture);
                 }
             }
-
 
             var isReturningZeroItems = query.Limit.HasValue && query.Limit <= 0;
 
@@ -6005,7 +6003,6 @@ where AncestorIdText not null and ItemValues.Value not null and ItemValues.Type 
                 insertText.Length = _mediaStreamSaveColumnsInsertQuery.Length;
             }
         }
-
 
         /// <summary>
         /// Gets the chapter.

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -468,7 +468,6 @@ namespace Emby.Server.Implementations.Dto
                     IncludeItemTypes = new[] { typeof(MusicAlbum).Name },
                     Name = item.Album,
                     Limit = 1
-
                 });
 
                 if (parentAlbumIds.Count > 0)

--- a/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
@@ -28,7 +28,6 @@ namespace Emby.Server.Implementations.EntryPoints
         private readonly object _syncLock = new object();
         private Timer _updateTimer;
 
-
         public UserDataChangeNotifier(IUserDataManager userDataManager, ISessionManager sessionManager, IUserManager userManager)
         {
             _userDataManager = userDataManager;

--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -874,7 +874,6 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                 public List<Lineup> lineups { get; set; }
             }
 
-
             public class Headends
             {
                 public string headend { get; set; }
@@ -885,8 +884,6 @@ namespace Emby.Server.Implementations.LiveTv.Listings
 
                 public List<Lineup> lineups { get; set; }
             }
-
-
 
             public class Map
             {
@@ -971,9 +968,6 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                 public List<string> date { get; set; }
             }
 
-
-
-
             public class Rating
             {
                 public string body { get; set; }
@@ -1016,8 +1010,6 @@ namespace Emby.Server.Implementations.LiveTv.Listings
 
                 public string isPremiereOrFinale { get; set; }
             }
-
-
 
             public class MetadataSchedule
             {

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -2135,6 +2135,7 @@ namespace Emby.Server.Implementations.LiveTv
         }
 
         private bool _disposed = false;
+
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -393,6 +393,7 @@ namespace Emby.Server.Implementations.Updates
                     // Ignore any exceptions.
                 }
             }
+
             stream.Position = 0;
             _zipClient.ExtractAllFromZip(stream, targetDir, true);
 

--- a/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
+++ b/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
@@ -42,6 +42,7 @@ namespace MediaBrowser.Controller.Channels
         /// Indicates if a sort ascending/descending toggle is supported or not.
         /// </summary>
         public bool SupportsSortOrderToggle { get; set; }
+
         /// <summary>
         /// Gets or sets the automatic refresh levels.
         /// </summary>
@@ -53,6 +54,7 @@ namespace MediaBrowser.Controller.Channels
         /// </summary>
         /// <value>The daily download limit.</value>
         public int? DailyDownloadLimit { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether [supports downloading].
         /// </summary>

--- a/MediaBrowser.Controller/Entities/Audio/Audio.cs
+++ b/MediaBrowser.Controller/Entities/Audio/Audio.cs
@@ -90,7 +90,6 @@ namespace MediaBrowser.Controller.Entities.Audio
 
             var songKey = IndexNumber.HasValue ? IndexNumber.Value.ToString("0000") : string.Empty;
 
-
             if (ParentIndexNumber.HasValue)
             {
                 songKey = ParentIndexNumber.Value.ToString("0000") + "-" + songKey;

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -197,6 +197,7 @@ namespace MediaBrowser.Controller.Entities
         public virtual bool SupportsRemoteImageDownloading => true;
 
         private string _name;
+
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
@@ -661,6 +662,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         private string _forcedSortName;
+
         /// <summary>
         /// Gets or sets the name of the forced sort.
         /// </summary>

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1386,7 +1386,6 @@ namespace MediaBrowser.Controller.Entities
             }
         }
 
-
         /// <summary>
         /// Gets the linked children.
         /// </summary>

--- a/MediaBrowser.Controller/Entities/IHasMediaSources.cs
+++ b/MediaBrowser.Controller/Entities/IHasMediaSources.cs
@@ -21,7 +21,5 @@ namespace MediaBrowser.Controller.Entities
         List<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution);
 
         List<MediaStream> GetMediaStreams();
-
-
     }
 }

--- a/MediaBrowser.Controller/Entities/Photo.cs
+++ b/MediaBrowser.Controller/Entities/Photo.cs
@@ -16,7 +16,6 @@ namespace MediaBrowser.Controller.Entities
         [JsonIgnore]
         public override Folder LatestItemsIndexContainer => AlbumEntity;
 
-
         [JsonIgnore]
         public PhotoAlbum AlbumEntity
         {

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -450,7 +450,6 @@ namespace MediaBrowser.Controller.Entities.TV
             });
         }
 
-
         protected override bool GetBlockUnratedValue(User user)
         {
             return user.GetPreference(PreferenceKind.BlockUnratedItems).Contains(UnratedItem.Series.ToString());

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -258,7 +258,6 @@ namespace MediaBrowser.Controller.Entities
                 IncludeItemTypes = new[] { typeof(Movie).Name },
                 Recursive = true,
                 EnableTotalRecordCount = false
-
             }).Items
                 .SelectMany(i => i.Genres)
                 .DistinctNames()

--- a/MediaBrowser.Controller/IO/FileData.cs
+++ b/MediaBrowser.Controller/IO/FileData.cs
@@ -111,5 +111,4 @@ namespace MediaBrowser.Controller.IO
             return returnResult;
         }
     }
-
 }

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -77,6 +77,7 @@ namespace MediaBrowser.Controller.Library
         MusicArtist GetArtist(string name);
 
         MusicArtist GetArtist(string name, DtoOptions options);
+
         /// <summary>
         /// Gets a Studio.
         /// </summary>
@@ -234,6 +235,7 @@ namespace MediaBrowser.Controller.Library
         /// Occurs when [item updated].
         /// </summary>
         event EventHandler<ItemChangeEventArgs> ItemUpdated;
+
         /// <summary>
         /// Occurs when [item removed].
         /// </summary>

--- a/MediaBrowser.Controller/Library/IMediaSourceManager.cs
+++ b/MediaBrowser.Controller/Library/IMediaSourceManager.cs
@@ -28,12 +28,14 @@ namespace MediaBrowser.Controller.Library
         /// <param name="itemId">The item identifier.</param>
         /// <returns>IEnumerable&lt;MediaStream&gt;.</returns>
         List<MediaStream> GetMediaStreams(Guid itemId);
+
         /// <summary>
         /// Gets the media streams.
         /// </summary>
         /// <param name="mediaSourceId">The media source identifier.</param>
         /// <returns>IEnumerable&lt;MediaStream&gt;.</returns>
         List<MediaStream> GetMediaStreams(string mediaSourceId);
+
         /// <summary>
         /// Gets the media streams.
         /// </summary>

--- a/MediaBrowser.Controller/Library/ItemResolveArgs.cs
+++ b/MediaBrowser.Controller/Library/ItemResolveArgs.cs
@@ -156,6 +156,7 @@ namespace MediaBrowser.Controller.Library
         }
 
         // REVIEW: @bond
+
         /// <summary>
         /// Gets the physical locations.
         /// </summary>

--- a/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
+++ b/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
@@ -231,6 +231,7 @@ namespace MediaBrowser.Controller.LiveTv
         /// Saves the tuner host.
         /// </summary>
         Task<TunerHostInfo> SaveTunerHost(TunerHostInfo info, bool dataSourceChanged = true);
+
         /// <summary>
         /// Saves the listing provider.
         /// </summary>

--- a/MediaBrowser.Controller/LiveTv/ITunerHost.cs
+++ b/MediaBrowser.Controller/LiveTv/ITunerHost.cs
@@ -56,7 +56,6 @@ namespace MediaBrowser.Controller.LiveTv
         Task<List<MediaSourceInfo>> GetChannelStreamMediaSources(string channelId, CancellationToken cancellationToken);
 
         Task<List<TunerHostInfo>> DiscoverDevices(int discoveryDurationMs, CancellationToken cancellationToken);
-
     }
 
     public interface IConfigurableTunerHost

--- a/MediaBrowser.Controller/LiveTv/LiveTvServiceStatusInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvServiceStatusInfo.cs
@@ -42,6 +42,7 @@ namespace MediaBrowser.Controller.LiveTv
         /// </summary>
         /// <value>The tuners.</value>
         public List<LiveTvTunerInfo> Tuners { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is visible.
         /// </summary>

--- a/MediaBrowser.Controller/LiveTv/ProgramInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/ProgramInfo.cs
@@ -35,6 +35,7 @@ namespace MediaBrowser.Controller.LiveTv
         /// </summary>
         /// <value>The overview.</value>
         public string Overview { get; set; }
+
         /// <summary>
         /// Gets or sets the short overview.
         /// </summary>
@@ -169,31 +170,37 @@ namespace MediaBrowser.Controller.LiveTv
         /// </summary>
         /// <value>The production year.</value>
         public int? ProductionYear { get; set; }
+
         /// <summary>
         /// Gets or sets the home page URL.
         /// </summary>
         /// <value>The home page URL.</value>
         public string HomePageUrl { get; set; }
+
         /// <summary>
         /// Gets or sets the series identifier.
         /// </summary>
         /// <value>The series identifier.</value>
         public string SeriesId { get; set; }
+
         /// <summary>
         /// Gets or sets the show identifier.
         /// </summary>
         /// <value>The show identifier.</value>
         public string ShowId { get; set; }
+
         /// <summary>
         /// Gets or sets the season number.
         /// </summary>
         /// <value>The season number.</value>
         public int? SeasonNumber { get; set; }
+
         /// <summary>
         /// Gets or sets the episode number.
         /// </summary>
         /// <value>The episode number.</value>
         public int? EpisodeNumber { get; set; }
+
         /// <summary>
         /// Gets or sets the etag.
         /// </summary>

--- a/MediaBrowser.Controller/LiveTv/RecordingInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/RecordingInfo.cs
@@ -187,6 +187,7 @@ namespace MediaBrowser.Controller.LiveTv
         /// </summary>
         /// <value><c>null</c> if [has image] contains no value, <c>true</c> if [has image]; otherwise, <c>false</c>.</value>
         public bool? HasImage { get; set; }
+
         /// <summary>
         /// Gets or sets the show identifier.
         /// </summary>

--- a/MediaBrowser.Controller/LiveTv/TimerInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/TimerInfo.cs
@@ -113,6 +113,7 @@ namespace MediaBrowser.Controller.LiveTv
 
         // Program properties
         public int? SeasonNumber { get; set; }
+
         /// <summary>
         /// Gets or sets the episode number.
         /// </summary>

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -109,7 +109,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             return _mediaEncoder.SupportsHwaccel("vaapi");
-
         }
 
         /// <summary>
@@ -508,6 +507,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                                 arg.Append("-hwaccel qsv ");
                             }
                         }
+
                         // While using SW decoder
                         else
                         {
@@ -1440,7 +1440,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             var codec = outputAudioCodec ?? string.Empty;
-
 
             int? transcoderChannelLimit;
             if (codec.IndexOf("wma", StringComparison.OrdinalIgnoreCase) != -1)
@@ -2510,7 +2509,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return inputModifier;
         }
-
 
         public void AttachMediaSourceInfo(
             EncodingJobInfo state,

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -697,10 +697,12 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// The progressive.
         /// </summary>
         Progressive,
+
         /// <summary>
         /// The HLS.
         /// </summary>
         Hls,
+
         /// <summary>
         /// The dash.
         /// </summary>

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -100,6 +100,7 @@ namespace MediaBrowser.Controller.Persistence
         /// <param name="query">The query.</param>
         /// <returns>IEnumerable&lt;Guid&gt;.</returns>
         QueryResult<Guid> GetItemIds(InternalItemsQuery query);
+
         /// <summary>
         /// Gets the items.
         /// </summary>

--- a/MediaBrowser.Controller/Resolvers/IItemResolver.cs
+++ b/MediaBrowser.Controller/Resolvers/IItemResolver.cs
@@ -19,6 +19,7 @@ namespace MediaBrowser.Controller.Resolvers
         /// <param name="args">The args.</param>
         /// <returns>BaseItem.</returns>
         BaseItem ResolvePath(ItemResolveArgs args);
+
         /// <summary>
         /// Gets the priority.
         /// </summary>

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -22,7 +22,6 @@ namespace MediaBrowser.Controller.Session
         private readonly ISessionManager _sessionManager;
         private readonly ILogger _logger;
 
-
         private readonly object _progressLock = new object();
         private Timer _progressTimer;
         private PlaybackProgressInfo _lastProgressInfo;

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -498,7 +498,6 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
-
             if (playMethods.Count > 0)
             {
                 transcodeReasons.Clear();
@@ -1431,6 +1430,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.AudioChannels:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1466,6 +1466,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.IsAvc:
                         {
                             if (!enableNonQualifiedConditions)
@@ -1487,6 +1488,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.IsAnamorphic:
                         {
                             if (!enableNonQualifiedConditions)
@@ -1508,6 +1510,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.IsInterlaced:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1539,6 +1542,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.AudioProfile:
                     case ProfileConditionValue.Has64BitOffsets:
                     case ProfileConditionValue.PacketLength:
@@ -1550,6 +1554,7 @@ namespace MediaBrowser.Model.Dlna
                             // Not supported yet
                             break;
                         }
+
                     case ProfileConditionValue.RefFrames:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1585,6 +1590,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.VideoBitDepth:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1620,6 +1626,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.VideoProfile:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1643,6 +1650,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.Height:
                         {
                             if (!enableNonQualifiedConditions)
@@ -1668,6 +1676,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.VideoBitrate:
                         {
                             if (!enableNonQualifiedConditions)
@@ -1693,6 +1702,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.VideoFramerate:
                         {
                             if (!enableNonQualifiedConditions)
@@ -1718,6 +1728,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.VideoLevel:
                         {
                             if (string.IsNullOrEmpty(qualifier))
@@ -1743,6 +1754,7 @@ namespace MediaBrowser.Model.Dlna
 
                             break;
                         }
+
                     case ProfileConditionValue.Width:
                         {
                             if (!enableNonQualifiedConditions)

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -276,7 +276,6 @@ namespace MediaBrowser.Model.Dlna
 
             list.Add(new NameValuePair("SubtitleMethod", item.SubtitleStreamIndex.HasValue && item.SubtitleDeliveryMethod != SubtitleDeliveryMethod.External ? item.SubtitleDeliveryMethod.ToString() : string.Empty));
 
-
             if (!item.IsDirectStream)
             {
                 if (item.RequireNonAnamorphic)

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -429,6 +429,7 @@ namespace MediaBrowser.Model.Dto
         /// </summary>
         /// <value>The album id.</value>
         public Guid AlbumId { get; set; }
+
         /// <summary>
         /// Gets or sets the album image tag.
         /// </summary>
@@ -599,11 +600,13 @@ namespace MediaBrowser.Model.Dto
         /// </summary>
         /// <value>The trailer count.</value>
         public int? TrailerCount { get; set; }
+
         /// <summary>
         /// Gets or sets the movie count.
         /// </summary>
         /// <value>The movie count.</value>
         public int? MovieCount { get; set; }
+
         /// <summary>
         /// Gets or sets the series count.
         /// </summary>
@@ -611,16 +614,19 @@ namespace MediaBrowser.Model.Dto
         public int? SeriesCount { get; set; }
 
         public int? ProgramCount { get; set; }
+
         /// <summary>
         /// Gets or sets the episode count.
         /// </summary>
         /// <value>The episode count.</value>
         public int? EpisodeCount { get; set; }
+
         /// <summary>
         /// Gets or sets the song count.
         /// </summary>
         /// <value>The song count.</value>
         public int? SongCount { get; set; }
+
         /// <summary>
         /// Gets or sets the album count.
         /// </summary>
@@ -628,6 +634,7 @@ namespace MediaBrowser.Model.Dto
         public int? AlbumCount { get; set; }
 
         public int? ArtistCount { get; set; }
+
         /// <summary>
         /// Gets or sets the music video count.
         /// </summary>
@@ -768,6 +775,7 @@ namespace MediaBrowser.Model.Dto
         /// </summary>
         /// <value>The timer identifier.</value>
         public string TimerId { get; set; }
+
         /// <summary>
         /// Gets or sets the current program.
         /// </summary>

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -451,11 +451,13 @@ namespace MediaBrowser.Model.Entities
         /// </summary>
         /// <value>The method.</value>
         public SubtitleDeliveryMethod? DeliveryMethod { get; set; }
+
         /// <summary>
         /// Gets or sets the delivery URL.
         /// </summary>
         /// <value>The delivery URL.</value>
         public string DeliveryUrl { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is external URL.
         /// </summary>

--- a/MediaBrowser.Model/Entities/MetadataProvider.cs
+++ b/MediaBrowser.Model/Entities/MetadataProvider.cs
@@ -11,18 +11,22 @@ namespace MediaBrowser.Model.Entities
         /// The imdb.
         /// </summary>
         Imdb = 2,
+
         /// <summary>
         /// The TMDB.
         /// </summary>
         Tmdb = 3,
+
         /// <summary>
         /// The TVDB.
         /// </summary>
         Tvdb = 4,
+
         /// <summary>
         /// The tvcom.
         /// </summary>
         Tvcom = 5,
+
         /// <summary>
         /// Tmdb Collection Id.
         /// </summary>

--- a/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
@@ -84,6 +84,7 @@ namespace MediaBrowser.Model.LiveTv
         /// </summary>
         /// <value><c>null</c> if [is kids] contains no value, <c>true</c> if [is kids]; otherwise, <c>false</c>.</value>
         public bool? IsKids { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is sports.
         /// </summary>

--- a/MediaBrowser.Model/Providers/RemoteImageInfo.cs
+++ b/MediaBrowser.Model/Providers/RemoteImageInfo.cs
@@ -68,5 +68,4 @@ namespace MediaBrowser.Model.Providers
         /// <value>The type of the rating.</value>
         public RatingType RatingType { get; set; }
     }
-
 }

--- a/MediaBrowser.Model/Providers/RemoteSearchResult.cs
+++ b/MediaBrowser.Model/Providers/RemoteSearchResult.cs
@@ -50,6 +50,5 @@ namespace MediaBrowser.Model.Providers
         public RemoteSearchResult AlbumArtist { get; set; }
 
         public RemoteSearchResult[] Artists { get; set; }
-
     }
 }

--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -168,6 +168,7 @@ namespace MediaBrowser.Model.Querying
         Studios,
 
         BasicSyncInfo,
+
         /// <summary>
         /// The synchronize information.
         /// </summary>

--- a/MediaBrowser.Model/Querying/UpcomingEpisodesQuery.cs
+++ b/MediaBrowser.Model/Querying/UpcomingEpisodesQuery.cs
@@ -37,16 +37,19 @@ namespace MediaBrowser.Model.Querying
         /// </summary>
         /// <value>The fields.</value>
         public ItemFields[] Fields { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether [enable images].
         /// </summary>
         /// <value><c>null</c> if [enable images] contains no value, <c>true</c> if [enable images]; otherwise, <c>false</c>.</value>
         public bool? EnableImages { get; set; }
+
         /// <summary>
         /// Gets or sets the image type limit.
         /// </summary>
         /// <value>The image type limit.</value>
         public int? ImageTypeLimit { get; set; }
+
         /// <summary>
         /// Gets or sets the enable image types.
         /// </summary>

--- a/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
+++ b/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
@@ -88,16 +88,19 @@ namespace MediaBrowser.Model.Session
         /// </summary>
         /// <value>The play method.</value>
         public PlayMethod PlayMethod { get; set; }
+
         /// <summary>
         /// Gets or sets the live stream identifier.
         /// </summary>
         /// <value>The live stream identifier.</value>
         public string LiveStreamId { get; set; }
+
         /// <summary>
         /// Gets or sets the play session identifier.
         /// </summary>
         /// <value>The play session identifier.</value>
         public string PlaySessionId { get; set; }
+
         /// <summary>
         /// Gets or sets the repeat mode.
         /// </summary>

--- a/MediaBrowser.Model/Sync/SyncCategory.cs
+++ b/MediaBrowser.Model/Sync/SyncCategory.cs
@@ -8,10 +8,12 @@ namespace MediaBrowser.Model.Sync
         /// The latest.
         /// </summary>
         Latest = 0,
+
         /// <summary>
         /// The next up.
         /// </summary>
         NextUp = 1,
+
         /// <summary>
         /// The resume.
         /// </summary>

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -14,13 +14,16 @@ namespace MediaBrowser.Model.System
     {
         /// <summary>No path to FFmpeg found.</summary>
         NotFound,
+
         /// <summary>Path supplied via command line using switch --ffmpeg.</summary>
         SetByArgument,
+
         /// <summary>User has supplied path via Transcoding UI page.</summary>
         Custom,
+
         /// <summary>FFmpeg tool found on system $PATH.</summary>
         System
-    };
+    }
 
     /// <summary>
     /// Class SystemInfo.

--- a/MediaBrowser.Model/Tasks/IConfigurableScheduledTask.cs
+++ b/MediaBrowser.Model/Tasks/IConfigurableScheduledTask.cs
@@ -9,6 +9,7 @@ namespace MediaBrowser.Model.Tasks
         /// </summary>
         /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
         bool IsHidden { get; }
+
         /// <summary>
         /// Gets a value indicating whether this instance is enabled.
         /// </summary>

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/ArtistProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/ArtistProvider.cs
@@ -198,6 +198,7 @@ namespace MediaBrowser.Providers.Music
                                 result.Name = reader.ReadElementContentAsString();
                                 break;
                             }
+
                         case "annotation":
                             {
                                 result.Overview = reader.ReadElementContentAsString();

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -444,6 +444,7 @@ namespace MediaBrowser.Providers.Music
                                     result.Title = reader.ReadElementContentAsString();
                                     break;
                                 }
+
                             case "date":
                                 {
                                     var val = reader.ReadElementContentAsString();
@@ -454,17 +455,20 @@ namespace MediaBrowser.Providers.Music
 
                                     break;
                                 }
+
                             case "annotation":
                                 {
                                     result.Overview = reader.ReadElementContentAsString();
                                     break;
                                 }
+
                             case "release-group":
                                 {
                                     result.ReleaseGroupId = reader.GetAttribute("id");
                                     reader.Skip();
                                     break;
                                 }
+
                             case "artist-credit":
                                 {
                                     using (var subReader = reader.ReadSubtree())

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/GenericTmdbMovieInfo.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/GenericTmdbMovieInfo.cs
@@ -302,7 +302,6 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
                 {
                     Url = string.Format(CultureInfo.InvariantCulture, "https://www.youtube.com/watch?v={0}", i.Source),
                     Name = i.Name
-
                 }).ToArray();
             }
         }

--- a/MediaBrowser.Providers/TV/DummySeasonProvider.cs
+++ b/MediaBrowser.Providers/TV/DummySeasonProvider.cs
@@ -217,7 +217,6 @@ namespace MediaBrowser.Providers.TV
                     new DeleteOptions
                     {
                         DeleteFileLocation = true
-
                     },
                     false);
 


### PR DESCRIPTION
As part of #2149, removes all occurrences of:
* SA1514: Element documentation header should be preceded by blank line (53 warnings)
* SA1513: Closing brace should be followed by blank line (21 warnings)
* SA1507: Code should not contain multiple blank lines in a row (18 warnings)
* SA1508: A closing brace should not be preceded by a blank line (8 warnings)