### PR TITLE
Publish OpenAPI spec for master and tagged releases

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -63,7 +63,38 @@ jobs:
       sshEndpoint: repository
       sourceFolder: '$(Build.SourcesDirectory)/deployment/dist'
       contents: '**'
-      targetFolder: '/srv/repository/incoming/azure/$(Build.BuildNumber)/$(BuildConfiguration)'
+
+- job: OpenAPISpec
+  dependsOn: Test
+  condition: or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master'),startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+  displayName: 'Push OpenAPI Spec to repository'
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download OpenAPI Spec'
+    inputs:
+      source: 'current'
+      artifact: "OpenAPI Spec"
+      path: "$(System.ArtifactsDirectory)/openapispec"
+      runVersion: "latest"
+
+  - task: SSH@0
+    displayName: 'Create target directory on repository server'
+    inputs:
+      sshEndpoint: repository
+      runOptions: 'inline'
+      inline: 'mkdir -p /srv/repository/incoming/azure/$(Build.BuildNumber)'
+
+  - task: CopyFilesOverSSH@0
+    displayName: 'Upload artifacts to repository server'
+    inputs:
+      sshEndpoint: repository
+      sourceFolder: '$(System.ArtifactsDirectory)/openapispec'
+      contents: 'openapi.json'
+      targetFolder: '/srv/repository/incoming/azure/$(Build.BuildNumber)'
 
 - job: BuildDocker
   displayName: 'Build Docker'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -34,6 +34,12 @@ jobs:
         Linux: 'ubuntu-latest'
         Windows: 'windows-latest'
         macOS: 'macos-latest'
+        
+- ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master')) }}:
+  - template: azure-pipelines-test.yml
+    parameters:
+      ImageNames:
+        Linux: 'ubuntu-latest'
 
 - ${{ if not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))) }}:
   - template: azure-pipelines-abi.yml


### PR DESCRIPTION
This makes sure to run a limited Test run for master commits and tagged released.

Alright so this publishes the file to the repository server.

This will have the file end up in `/srv/repository/incoming/azure/$(Build.BuildNumber)/openapi.json`