### PR TITLE
Make MusicBrainzAlbumProvider thread safe and fix retry logic

### DIFF
--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -757,7 +757,7 @@ namespace MediaBrowser.Providers.Music
 
                     if (_stopWatchMusicBrainz.ElapsedMilliseconds < _musicBrainzQueryIntervalMs)
                     {
-                        // MusicBrainz is extremely adamant about limiting to one request per second
+                        // MusicBrainz is extremely adamant about limiting to one request per second.
                         var delayMs = _musicBrainzQueryIntervalMs - _stopWatchMusicBrainz.ElapsedMilliseconds;
                         await Task.Delay((int)delayMs, cancellationToken).ConfigureAwait(false);
                     }
@@ -770,7 +770,7 @@ namespace MediaBrowser.Providers.Music
                     using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
                     // MusicBrainz request a contact email address is supplied, as comment, in user agent field:
-                    // https://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#User-Agent
+                    // https://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#User-Agent .
                     request.Headers.UserAgent.ParseAdd(string.Format(
                         CultureInfo.InvariantCulture,
                         "{0} ( {1} )",
@@ -779,11 +779,11 @@ namespace MediaBrowser.Providers.Music
 
                     response = await _httpClientFactory.CreateClient(NamedClient.Default).SendAsync(request).ConfigureAwait(false);
 
-                    // We retry a finite number of times, and only whilst MB is indicating 503 (throttling)
+                    // We retry a finite number of times, and only whilst MB is indicating 503 (throttling).
                 }
                 while (attempts < MusicBrainzQueryAttempts && response.StatusCode == HttpStatusCode.ServiceUnavailable);
 
-                // Log error if unable to query MB database due to throttling
+                // Log error if unable to query MB database due to throttling.
                 if (attempts == MusicBrainzQueryAttempts && response.StatusCode == HttpStatusCode.ServiceUnavailable)
                 {
                     _logger.LogError("GetMusicBrainzResponse: 503 Service Unavailable (throttled) response received {0} times whilst requesting {1}", attempts, requestUrl);

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -743,14 +743,14 @@ namespace MediaBrowser.Providers.Music
         /// </summary>
         internal async Task<HttpResponseMessage> GetMusicBrainzResponse(string url, CancellationToken cancellationToken)
         {
-            HttpResponseMessage response;
-            var attempts = 0u;
-            var requestUrl = _musicBrainzBaseUrl.TrimEnd('/') + url;
-
             await _apiRequestLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
+                HttpResponseMessage response;
+                var attempts = 0u;
+                var requestUrl = _musicBrainzBaseUrl.TrimEnd('/') + url;
+
                 do
                 {
                     attempts++;
@@ -767,7 +767,7 @@ namespace MediaBrowser.Providers.Music
                     _logger.LogDebug("GetMusicBrainzResponse: Time since previous request: {0} ms", _stopWatchMusicBrainz.ElapsedMilliseconds);
                     _stopWatchMusicBrainz.Restart();
 
-                    using var request = new HttpRequestMessage(HttpMethod.Get, _musicBrainzBaseUrl.TrimEnd('/') + url);
+                    using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
                     // MusicBrainz request a contact email address is supplied, as comment, in user agent field:
                     // https://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#User-Agent
@@ -788,13 +788,13 @@ namespace MediaBrowser.Providers.Music
                 {
                     _logger.LogError("GetMusicBrainzResponse: 503 Service Unavailable (throttled) response received {0} times whilst requesting {1}", attempts, requestUrl);
                 }
+
+                return response;
             }
             finally
             {
                 _apiRequestLock.Release();
             }
-
-            return response;
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -782,16 +782,16 @@ namespace MediaBrowser.Providers.Music
                     // We retry a finite number of times, and only whilst MB is indicating 503 (throttling)
                 }
                 while (attempts < MusicBrainzQueryAttempts && response.StatusCode == HttpStatusCode.ServiceUnavailable);
+
+                // Log error if unable to query MB database due to throttling
+                if (attempts == MusicBrainzQueryAttempts && response.StatusCode == HttpStatusCode.ServiceUnavailable)
+                {
+                    _logger.LogError("GetMusicBrainzResponse: 503 Service Unavailable (throttled) response received {0} times whilst requesting {1}", attempts, requestUrl);
+                }
             }
             finally
             {
                 _apiRequestLock.Release();
-            }
-
-            // Log error if unable to query MB database due to throttling
-            if (attempts == MusicBrainzQueryAttempts && response.StatusCode == HttpStatusCode.ServiceUnavailable)
-            {
-                _logger.LogError("GetMusicBrainzResponse: 503 Service Unavailable (throttled) response received {0} times whilst requesting {1}", attempts, requestUrl);
             }
 
             return response;


### PR DESCRIPTION
Related to #4242, and similar to #4223. 
Fixes issues when refreshing multiple items at the same time for musicbrainz. Unfortunately due to musicbrainz api limits, it seems like we need to keep this running sequentially.

Also fixes the retry logic - it's currently broken and throws this error whenever it tries the same request again:

```
System.InvalidOperationException: The request message was already sent. Cannot send the same request message multiple times.
   at System.Net.Http.HttpClient.CheckRequestMessage(HttpRequestMessage request)
   at System.Net.Http.HttpClient.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.SendAsync(HttpRequestMessage request)
   at MediaBrowser.Providers.Music.MusicBrainzAlbumProvider.GetMusicBrainzResponse(String url, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\MusicBrainz\MusicBrainzAlbumProvider.cs:line 774
   at MediaBrowser.Providers.Music.MusicBrainzAlbumProvider.GetReleaseResult(String albumName, String artistId, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\MusicBrainz\MusicBrainzAlbumProvider.cs:line 285
   at MediaBrowser.Providers.Music.MusicBrainzAlbumProvider.GetMetadata(AlbumInfo id, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Plugins\MusicBrainz\MusicBrainzAlbumProvider.cs:line 213
   at MediaBrowser.Providers.Manager.MetadataService`2.ExecuteRemoteProviders(MetadataResult`1 temp, String logName, TIdType id, IEnumerable`1 providers, CancellationToken cancellationToken) in C:\Programming\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 853
```

**Changes**
- Add a semaphore to only allow a single request at a time.
- Fix music brainz retry logic.

**Issues**
None