### PR TITLE
Remove unnecessary null checks in some places

### DIFF
--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -554,7 +554,7 @@ namespace Jellyfin.Api.Helpers
         private long? GetMaxBitrate(long? clientMaxBitrate, User user, string ipAddress)
         {
             var maxBitrate = clientMaxBitrate;
-            var remoteClientMaxBitrate = user?.RemoteClientBitrateLimit ?? 0;
+            var remoteClientMaxBitrate = user.RemoteClientBitrateLimit ?? 0;
 
             if (remoteClientMaxBitrate <= 0)
             {

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -740,10 +740,7 @@ namespace Jellyfin.Api.Helpers
         /// <param name="state">The state.</param>
         private void OnFfMpegProcessExited(Process process, TranscodingJobDto job, StreamState state)
         {
-            if (job != null)
-            {
-                job.HasExited = true;
-            }
+            job.HasExited = true;
 
             _logger.LogDebug("Disposing stream resources");
             state.Dispose();

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -799,7 +799,7 @@ namespace Jellyfin.Server.Implementations.Users
 
         private IList<IPasswordResetProvider> GetPasswordResetProviders(User user)
         {
-            var passwordResetProviderId = user?.PasswordResetProviderId;
+            var passwordResetProviderId = user.PasswordResetProviderId;
             var providers = _passwordResetProviders.Where(i => i.IsEnabled).ToArray();
 
             if (!string.IsNullOrEmpty(passwordResetProviderId))


### PR DESCRIPTION
Hello!

I made a small PR to understand how that approach fits the project.

Now nullable data types are used widely inside the project, but it leads to warnings, which can be resolved (obviously, we cannot fix it in public methods, because have no guarantees about its usage, but can inspect private methods properly).

**Changes**

1) GetPasswordResetProviders is called from StartForgotPasswordProcess only and that place already check user against null, so conditional access is not required

2) OnFfMpegProcessExited is called only from StartFfMpeg, where it created from OnTranscodeBeginning, which guaranteed that it is not null, so conditional access here is not required

3) GetMaxBitrate is called from two places, but if code passed to it, the user variable cannot be null (if it is not true, NullReferenceException already be thrown)

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Related to https://github.com/jellyfin/jellyfin/issues/2149

Do you think it's a working approach for other areas of the project?
Can it help you with maintaining it?
