### PR TITLE
Disable invalid auth provider

### DIFF
--- a/Jellyfin.Server.Implementations/Users/InvalidAuthProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/InvalidAuthProvider.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Server.Implementations.Users
         public string Name => "InvalidOrMissingAuthenticationProvider";
 
         /// <inheritdoc />
-        public bool IsEnabled => true;
+        public bool IsEnabled => false;
 
         /// <inheritdoc />
         public Task<ProviderAuthenticationResult> Authenticate(string username, string password)


### PR DESCRIPTION
The invalid auth provider shouldn't be enabled and judging by this line https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server.Implementations/Users/UserManager.cs#L784, it should be fine to disable it.

**Issues**
- Fixes https://github.com/jellyfin/jellyfin/issues/4099