### PR TITLE
Improve handling of apiclient generator

### DIFF
--- a/.ci/azure-pipelines-api-client.yml
+++ b/.ci/azure-pipelines-api-client.yml
@@ -34,7 +34,7 @@ jobs:
       displayName: 'Build unstable typescript axios client'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
       inputs:
-        script: 'bash ./apiclient/templates/typescript/axios/unstable.sh'
+        script: "bash ./apiclient/templates/typescript/axios/generate.sh $(System.ArtifactsDirectory) $(Build.BuildNumber)"
 
     - task: Npm@1
       displayName: 'Publish unstable typescript axios client'
@@ -50,7 +50,7 @@ jobs:
       displayName: 'Build stable typescript axios client'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
       inputs:
-        script: 'bash ./apiclient/templates/typescript/axios/stable.sh'
+        script: "bash ./apiclient/templates/typescript/axios/generate.sh $(System.ArtifactsDirectory)"
 
     - task: Npm@1
       displayName: 'Publish stable typescript axios client'

--- a/apiclient/templates/typescript/axios/generate.sh
+++ b/apiclient/templates/typescript/axios/generate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+artifactsDirectory="${1}"
+buildNumber="${2}"
+if [[ -n ${buildNumber} ]]; then
+    # Unstable build
+    additionalProperties=",snapshotVersion=\"-SNAPSHOT.${buildNumber}\",npmRepository=\"https://pkgs.dev.azure.com/jellyfin-project/jellyfin/_packaging/unstable/npm/registry/\""
+else
+    # Stable build
+    additionalProperties=""
+fi
+
+java -jar openapi-generator-cli.jar generate \
+    --input-spec ${artifactsDirectory}/openapispec/openapi.json \
+    --generator-name typescript-axios \
+    --output ./apiclient/generated/typescript/axios  \
+    --template-dir ./apiclient/templates/typescript/axios \
+    --ignore-file-override ./apiclient/.openapi-generator-ignore \
+    --additional-properties=useSingleRequestParameter="true",withSeparateModelsAndApi="true",npmName="axios"${additionalProperties}

--- a/apiclient/templates/typescript/axios/stable.sh
+++ b/apiclient/templates/typescript/axios/stable.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-java -jar openapi-generator-cli.jar generate \
-    --input-spec $(System.ArtifactsDirectory)/openapispec/openapi.json \
-    --generator-name typescript-axios \
-    --output ./apiclient/generated/typescript/axios  \
-    --template-dir ./apiclient/templates/typescript/axios \
-    --ignore-file-override ./apiclient/.openapi-generator-ignore \
-    --additional-properties=useSingleRequestParameter="true",withSeparateModelsAndApi="true",npmName="axios"

--- a/apiclient/templates/typescript/axios/unstable.sh
+++ b/apiclient/templates/typescript/axios/unstable.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-java -jar openapi-generator-cli.jar generate \
-    --input-spec $(System.ArtifactsDirectory)/openapispec/openapi.json \
-    --generator-name typescript-axios \
-    --output ./apiclient/generated/typescript/axios  \
-    --template-dir ./apiclient/templates/typescript/axios \
-    --ignore-file-override ./apiclient/.openapi-generator-ignore \
-    --additional-properties=useSingleRequestParameter="true",withSeparateModelsAndApi="true",npmName="axios",snapshotVersion="-SNAPSHOT.$(Build.BuildNumber)",npmRepository="https://pkgs.dev.azure.com/jellyfin-project/jellyfin/_packaging/unstable/npm/registry/"


### PR DESCRIPTION
**Changes**

1. Replace the separate stable/unstable scripts with a single script and
handle the difference with argument parsing.
2. Unify the calls and pass the Azure arguments in on the CLI.

**Issues**
Fixes bug from #4070
