### PR TITLE
Fix RPM spec again

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -79,15 +79,7 @@ EOF
 
 %files server
 %attr(755,root,root) %{_bindir}/jellyfin
-%{_libdir}/jellyfin/*.json
-%{_libdir}/jellyfin/*.dll
-%{_libdir}/jellyfin/*.so
-%{_libdir}/jellyfin/*.a
-%{_libdir}/jellyfin/createdump
-%{_libdir}/jellyfin/*.xml
-%{_libdir}/jellyfin/wwwroot/api-docs/*
-%{_libdir}/jellyfin/wwwroot/api-docs/redoc/*
-%{_libdir}/jellyfin/wwwroot/api-docs/swagger/*
+%{_libdir}/jellyfin/*
 # Needs 755 else only root can run it since binary build by dotnet is 722
 %attr(755,root,root) %{_libdir}/jellyfin/jellyfin
 %{_libdir}/jellyfin/SOS_README.md


### PR DESCRIPTION
**Changes**
Just make everything under libdir/jf a wildcard. I don't know if this will actually work but maybe it will.

**Issues**
CI failures