### PR TITLE
SecurityException should return 403

### DIFF
--- a/Jellyfin.Server/Middleware/ExceptionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/ExceptionMiddleware.cs
@@ -125,8 +125,8 @@ namespace Jellyfin.Server.Middleware
             switch (ex)
             {
                 case ArgumentException _: return StatusCodes.Status400BadRequest;
-                case AuthenticationException _:
-                case SecurityException _: return StatusCodes.Status401Unauthorized;
+                case AuthenticationException _: return StatusCodes.Status401Unauthorized;
+                case SecurityException _: return StatusCodes.Status403Forbidden;
                 case DirectoryNotFoundException _:
                 case FileNotFoundException _:
                 case ResourceNotFoundException _: return StatusCodes.Status404NotFound;


### PR DESCRIPTION
Pre-API migration it was changed in 10.6 to return 403, but this was lost in translation...