### PR TITLE
Make MaxActiveSessions not nullable

### DIFF
--- a/Jellyfin.Server.Implementations/Migrations/20201004171403_AddMaxActiveSessions.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20201004171403_AddMaxActiveSessions.cs
@@ -13,7 +13,7 @@ namespace Jellyfin.Server.Implementations.Migrations
                 name: "MaxActiveSessions",
                 schema: "jellyfin",
                 table: "Users",
-                nullable: true);
+                nullable: false);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Jellyfin.Server.Implementations/Migrations/20201004171403_AddMaxActiveSessions.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20201004171403_AddMaxActiveSessions.cs
@@ -13,7 +13,8 @@ namespace Jellyfin.Server.Implementations.Migrations
                 name: "MaxActiveSessions",
                 schema: "jellyfin",
                 table: "Users",
-                nullable: false);
+                nullable: false,
+                defaultValue: 0);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Jellyfin.Server.Implementations/Migrations/JellyfinDbModelSnapshot.cs
+++ b/Jellyfin.Server.Implementations/Migrations/JellyfinDbModelSnapshot.cs
@@ -344,7 +344,7 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<int?>("LoginAttemptsBeforeLockout")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("MaxActiveSessions")
+                    b.Property<int>("MaxActiveSessions")
                         .HasColumnType("INTEGER");
 
                     b.Property<int?>("MaxParentalAgeRating")


### PR DESCRIPTION
**Changes**
Fixes a bad assumption with the previous migration.

WARNING: THIS WILL BREAK THE DB FOR ANYONE WHO DEPLOYED THE LAST FEW UNSTABLE RELEASES THAT APPLIED THE MIGRATION, i.e. any since #4269. To fix it, because of sqlite's stupidity, you have to drop the whole table and recreate it. Annoying, I know. Here's how to fix it:

1. Go to wherever `jellyfin.db` is located (e.g. `/var/lib/jellyfin/data`).
2. Stop Jellyfin processes.
3. Open the database in sqlite3 (mind your permissions!): `sudo -u jellyfin sqlite3 jellyfin.db`
4. Run the following to dump the `Users` table:

```
.output jellyfin-users.tmp.sql
.dump Users
.quit
```

5. Edit the line (33 is the line number):

```
 33 , "MaxActiveSessions" INTEGER NULL);
```

to

```
 33 , "MaxActiveSessions" INTEGER NOT NULL);
```

6. Re-enter sqlite3 (`sudo -u jellyfin sqlite3 jellyfin.db`) and drop the Users table (`drop table Users;`).
7. Import the dump: `sudo -u jellyfin sqlite3 < jellyfin-users.tmp.sql`
8. Remove the cruft: `sudo -u jellyfin rm jellyfin-users.tmp.sql`
9. Upgrade to the unstable provided by this PR and/or start Jellyfin if you already did.

Or, in convenient script format:

```
#!/bin/bash

# REPLACE ME WITH YOUR REAL PATH IF DIFFERENT
pushd /var/lib/jellyfin

sudo service jellyfin stop
echo -e ".output jellyfin-users.tmp.sql\n.dump Users" | sudo -u jellyfin sqlite3 jellyfin.db
sed -i 's/"MaxActiveSessions" INTEGER NULL/"MaxActiveSessions" INTEGER NOT NULL/g' jellyfin-users.tmp.sql
echo -e "DROP TABLE Users" | sudo -u jellyfin sqlite3 jellyfin.db
sudo -u jellyfin sqlite3 jellyfin.db < jellyfin-users.tmp.sql
sudo rm jellyfin-users.tmp.sql
sudo service jellyfin start

popd
```

Or in full-SQL, run this with `sudo -u jellyfin sqlite3 jellyfin.db < script.sql`:

```script.sql
UPDATE Users SET MaxActiveSessions = 0 WHERE MaxActiveSessions IS NULL;

CREATE TABLE "Users_new" (
    "Id" TEXT NOT NULL CONSTRAINT "PK_Users" PRIMARY KEY,
    "Username" TEXT NOT NULL,
    "Password" TEXT NULL,
    "EasyPassword" TEXT NULL,
    "MustUpdatePassword" INTEGER NOT NULL,
    "AudioLanguagePreference" TEXT NULL,
    "AuthenticationProviderId" TEXT NOT NULL,
    "PasswordResetProviderId" TEXT NOT NULL,
    "InvalidLoginAttemptCount" INTEGER NOT NULL,
    "LastActivityDate" TEXT NULL,
    "LastLoginDate" TEXT NULL,
    "LoginAttemptsBeforeLockout" INTEGER NULL,
    "SubtitleMode" INTEGER NOT NULL,
    "PlayDefaultAudioTrack" INTEGER NOT NULL,
    "SubtitleLanguagePreference" TEXT NULL,
    "DisplayMissingEpisodes" INTEGER NOT NULL,
    "DisplayCollectionsView" INTEGER NOT NULL,
    "EnableLocalPassword" INTEGER NOT NULL,
    "HidePlayedInLatest" INTEGER NOT NULL,
    "RememberAudioSelections" INTEGER NOT NULL,
    "RememberSubtitleSelections" INTEGER NOT NULL,
    "EnableNextEpisodeAutoPlay" INTEGER NOT NULL,
    "EnableAutoLogin" INTEGER NOT NULL,
    "EnableUserPreferenceAccess" INTEGER NOT NULL,
    "MaxParentalAgeRating" INTEGER NULL,
    "RemoteClientBitrateLimit" INTEGER NULL,
    "InternalId" INTEGER NOT NULL,
    "SyncPlayAccess" INTEGER NOT NULL,
    "RowVersion" INTEGER NOT NULL,
    "MaxActiveSessions" INTEGER NOT NULL DEFAULT 0
);

INSERT INTO Users_new SELECT * FROM Users;

PRAGMA foreign_keys="0";

DROP TABLE Users;

ALTER TABLE Users_new RENAME TO Users;

PRAGMA foreign_keys="1";

```

**Issues**
N/A
