### PR TITLE
Fixes #3120 - Remove unused string HeaderCameraUploads

### DIFF
--- a/Emby.Server.Implementations/Localization/Core/af.json
+++ b/Emby.Server.Implementations/Localization/Core/af.json
@@ -85,7 +85,6 @@
     "ItemAddedWithName": "{0} is in die versameling",
     "HomeVideos": "Tuis opnames",
     "HeaderRecordingGroups": "Groep Opnames",
-    "HeaderCameraUploads": "Kamera Oplaai",
     "Genres": "Genres",
     "FailedLoginAttemptWithUserName": "Mislukte aansluiting van {0}",
     "ChapterNameValue": "Hoofstuk",

--- a/Emby.Server.Implementations/Localization/Core/ar.json
+++ b/Emby.Server.Implementations/Localization/Core/ar.json
@@ -16,7 +16,6 @@
     "Folders": "المجلدات",
     "Genres": "التضنيفات",
     "HeaderAlbumArtists": "فناني الألبومات",
-    "HeaderCameraUploads": "تحميلات الكاميرا",
     "HeaderContinueWatching": "استئناف",
     "HeaderFavoriteAlbums": "الألبومات المفضلة",
     "HeaderFavoriteArtists": "الفنانون المفضلون",

--- a/Emby.Server.Implementations/Localization/Core/bg-BG.json
+++ b/Emby.Server.Implementations/Localization/Core/bg-BG.json
@@ -16,7 +16,6 @@
     "Folders": "Папки",
     "Genres": "Жанрове",
     "HeaderAlbumArtists": "Изпълнители на албуми",
-    "HeaderCameraUploads": "Качени от камера",
     "HeaderContinueWatching": "Продължаване на гледането",
     "HeaderFavoriteAlbums": "Любими албуми",
     "HeaderFavoriteArtists": "Любими изпълнители",

--- a/Emby.Server.Implementations/Localization/Core/bn.json
+++ b/Emby.Server.Implementations/Localization/Core/bn.json
@@ -14,7 +14,6 @@
     "HeaderFavoriteArtists": "প্রিয় শিল্পীরা",
     "HeaderFavoriteAlbums": "প্রিয় এলবামগুলো",
     "HeaderContinueWatching": "দেখতে থাকুন",
-    "HeaderCameraUploads": "ক্যামেরার আপলোড সমূহ",
     "HeaderAlbumArtists": "এলবাম শিল্পী",
     "Genres": "জেনার",
     "Folders": "ফোল্ডারগুলো",

--- a/Emby.Server.Implementations/Localization/Core/ca.json
+++ b/Emby.Server.Implementations/Localization/Core/ca.json
@@ -16,7 +16,6 @@
     "Folders": "Carpetes",
     "Genres": "Gèneres",
     "HeaderAlbumArtists": "Artistes del Àlbum",
-    "HeaderCameraUploads": "Pujades de Càmera",
     "HeaderContinueWatching": "Continua Veient",
     "HeaderFavoriteAlbums": "Àlbums Preferits",
     "HeaderFavoriteArtists": "Artistes Preferits",

--- a/Emby.Server.Implementations/Localization/Core/cs.json
+++ b/Emby.Server.Implementations/Localization/Core/cs.json
@@ -16,7 +16,6 @@
     "Folders": "Složky",
     "Genres": "Žánry",
     "HeaderAlbumArtists": "Umělci alba",
-    "HeaderCameraUploads": "Nahrané fotografie",
     "HeaderContinueWatching": "Pokračovat ve sledování",
     "HeaderFavoriteAlbums": "Oblíbená alba",
     "HeaderFavoriteArtists": "Oblíbení interpreti",

--- a/Emby.Server.Implementations/Localization/Core/da.json
+++ b/Emby.Server.Implementations/Localization/Core/da.json
@@ -16,7 +16,6 @@
     "Folders": "Mapper",
     "Genres": "Genrer",
     "HeaderAlbumArtists": "Albumkunstnere",
-    "HeaderCameraUploads": "Kamera Uploads",
     "HeaderContinueWatching": "Fortsæt Afspilning",
     "HeaderFavoriteAlbums": "Favoritalbummer",
     "HeaderFavoriteArtists": "Favoritkunstnere",

--- a/Emby.Server.Implementations/Localization/Core/de.json
+++ b/Emby.Server.Implementations/Localization/Core/de.json
@@ -16,7 +16,6 @@
     "Folders": "Verzeichnisse",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Album-Interpreten",
-    "HeaderCameraUploads": "Kamera-Uploads",
     "HeaderContinueWatching": "Fortsetzen",
     "HeaderFavoriteAlbums": "Lieblingsalben",
     "HeaderFavoriteArtists": "Lieblings-Interpreten",

--- a/Emby.Server.Implementations/Localization/Core/el.json
+++ b/Emby.Server.Implementations/Localization/Core/el.json
@@ -16,7 +16,6 @@
     "Folders": "Φάκελοι",
     "Genres": "Είδη",
     "HeaderAlbumArtists": "Καλλιτέχνες του Άλμπουμ",
-    "HeaderCameraUploads": "Μεταφορτώσεις Κάμερας",
     "HeaderContinueWatching": "Συνεχίστε την παρακολούθηση",
     "HeaderFavoriteAlbums": "Αγαπημένα Άλμπουμ",
     "HeaderFavoriteArtists": "Αγαπημένοι Καλλιτέχνες",

--- a/Emby.Server.Implementations/Localization/Core/en-GB.json
+++ b/Emby.Server.Implementations/Localization/Core/en-GB.json
@@ -16,7 +16,6 @@
     "Folders": "Folders",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Album Artists",
-    "HeaderCameraUploads": "Camera Uploads",
     "HeaderContinueWatching": "Continue Watching",
     "HeaderFavoriteAlbums": "Favourite Albums",
     "HeaderFavoriteArtists": "Favourite Artists",

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -16,7 +16,6 @@
     "Folders": "Folders",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Album Artists",
-    "HeaderCameraUploads": "Camera Uploads",
     "HeaderContinueWatching": "Continue Watching",
     "HeaderFavoriteAlbums": "Favorite Albums",
     "HeaderFavoriteArtists": "Favorite Artists",

--- a/Emby.Server.Implementations/Localization/Core/es-AR.json
+++ b/Emby.Server.Implementations/Localization/Core/es-AR.json
@@ -16,7 +16,6 @@
     "Folders": "Carpetas",
     "Genres": "Géneros",
     "HeaderAlbumArtists": "Artistas de álbum",
-    "HeaderCameraUploads": "Subidas de cámara",
     "HeaderContinueWatching": "Seguir viendo",
     "HeaderFavoriteAlbums": "Álbumes favoritos",
     "HeaderFavoriteArtists": "Artistas favoritos",

--- a/Emby.Server.Implementations/Localization/Core/es-MX.json
+++ b/Emby.Server.Implementations/Localization/Core/es-MX.json
@@ -16,7 +16,6 @@
     "Folders": "Carpetas",
     "Genres": "Géneros",
     "HeaderAlbumArtists": "Artistas del álbum",
-    "HeaderCameraUploads": "Subidas desde la cámara",
     "HeaderContinueWatching": "Continuar viendo",
     "HeaderFavoriteAlbums": "Álbumes favoritos",
     "HeaderFavoriteArtists": "Artistas favoritos",

--- a/Emby.Server.Implementations/Localization/Core/es.json
+++ b/Emby.Server.Implementations/Localization/Core/es.json
@@ -16,7 +16,6 @@
     "Folders": "Carpetas",
     "Genres": "Géneros",
     "HeaderAlbumArtists": "Artistas del álbum",
-    "HeaderCameraUploads": "Subidas desde la cámara",
     "HeaderContinueWatching": "Continuar viendo",
     "HeaderFavoriteAlbums": "Álbumes favoritos",
     "HeaderFavoriteArtists": "Artistas favoritos",

--- a/Emby.Server.Implementations/Localization/Core/es_419.json
+++ b/Emby.Server.Implementations/Localization/Core/es_419.json
@@ -105,7 +105,6 @@
     "Inherit": "Heredar",
     "HomeVideos": "Videos caseros",
     "HeaderRecordingGroups": "Grupos de grabación",
-    "HeaderCameraUploads": "Subidas desde la cámara",
     "FailedLoginAttemptWithUserName": "Intento fallido de inicio de sesión desde {0}",
     "DeviceOnlineWithName": "{0} está conectado",
     "DeviceOfflineWithName": "{0} se ha desconectado",

--- a/Emby.Server.Implementations/Localization/Core/es_DO.json
+++ b/Emby.Server.Implementations/Localization/Core/es_DO.json
@@ -12,7 +12,6 @@
     "Application": "Aplicación",
     "AppDeviceValues": "App: {0}, Dispositivo: {1}",
     "HeaderContinueWatching": "Continuar Viendo",
-    "HeaderCameraUploads": "Subidas de Cámara",
     "HeaderAlbumArtists": "Artistas del Álbum",
     "Genres": "Géneros",
     "Folders": "Carpetas",

--- a/Emby.Server.Implementations/Localization/Core/fa.json
+++ b/Emby.Server.Implementations/Localization/Core/fa.json
@@ -16,7 +16,6 @@
     "Folders": "پوشه‌ها",
     "Genres": "ژانرها",
     "HeaderAlbumArtists": "هنرمندان آلبوم",
-    "HeaderCameraUploads": "آپلودهای دوربین",
     "HeaderContinueWatching": "ادامه تماشا",
     "HeaderFavoriteAlbums": "آلبوم‌های مورد علاقه",
     "HeaderFavoriteArtists": "هنرمندان مورد علاقه",

--- a/Emby.Server.Implementations/Localization/Core/fi.json
+++ b/Emby.Server.Implementations/Localization/Core/fi.json
@@ -24,7 +24,6 @@
     "HeaderFavoriteSongs": "Lempikappaleet",
     "HeaderFavoriteShows": "Lempisarjat",
     "HeaderFavoriteEpisodes": "Lempijaksot",
-    "HeaderCameraUploads": "Kamerasta Lähetetyt",
     "HeaderFavoriteArtists": "Lempiartistit",
     "HeaderFavoriteAlbums": "Lempialbumit",
     "HeaderContinueWatching": "Jatka katsomista",

--- a/Emby.Server.Implementations/Localization/Core/fil.json
+++ b/Emby.Server.Implementations/Localization/Core/fil.json
@@ -73,7 +73,6 @@
     "HeaderFavoriteArtists": "Paboritong Artista",
     "HeaderFavoriteAlbums": "Paboritong Albums",
     "HeaderContinueWatching": "Ituloy Manood",
-    "HeaderCameraUploads": "Camera Uploads",
     "HeaderAlbumArtists": "Artista ng Album",
     "Genres": "Kategorya",
     "Folders": "Folders",

--- a/Emby.Server.Implementations/Localization/Core/fr-CA.json
+++ b/Emby.Server.Implementations/Localization/Core/fr-CA.json
@@ -16,7 +16,6 @@
     "Folders": "Dossiers",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Artistes de l'album",
-    "HeaderCameraUploads": "Photos transférées",
     "HeaderContinueWatching": "Continuer à regarder",
     "HeaderFavoriteAlbums": "Albums favoris",
     "HeaderFavoriteArtists": "Artistes favoris",

--- a/Emby.Server.Implementations/Localization/Core/fr.json
+++ b/Emby.Server.Implementations/Localization/Core/fr.json
@@ -16,7 +16,6 @@
     "Folders": "Dossiers",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Artistes",
-    "HeaderCameraUploads": "Photos transférées",
     "HeaderContinueWatching": "Continuer à regarder",
     "HeaderFavoriteAlbums": "Albums favoris",
     "HeaderFavoriteArtists": "Artistes préférés",

--- a/Emby.Server.Implementations/Localization/Core/gsw.json
+++ b/Emby.Server.Implementations/Localization/Core/gsw.json
@@ -16,7 +16,6 @@
     "Folders": "Ordner",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Album-Künstler",
-    "HeaderCameraUploads": "Kamera-Uploads",
     "HeaderContinueWatching": "weiter schauen",
     "HeaderFavoriteAlbums": "Lieblingsalben",
     "HeaderFavoriteArtists": "Lieblings-Künstler",

--- a/Emby.Server.Implementations/Localization/Core/he.json
+++ b/Emby.Server.Implementations/Localization/Core/he.json
@@ -16,7 +16,6 @@
     "Folders": "תיקיות",
     "Genres": "ז'אנרים",
     "HeaderAlbumArtists": "אמני האלבום",
-    "HeaderCameraUploads": "העלאות ממצלמה",
     "HeaderContinueWatching": "המשך לצפות",
     "HeaderFavoriteAlbums": "אלבומים מועדפים",
     "HeaderFavoriteArtists": "אמנים מועדפים",

--- a/Emby.Server.Implementations/Localization/Core/hr.json
+++ b/Emby.Server.Implementations/Localization/Core/hr.json
@@ -16,7 +16,6 @@
     "Folders": "Mape",
     "Genres": "Žanrovi",
     "HeaderAlbumArtists": "Izvođači na albumu",
-    "HeaderCameraUploads": "Uvoz sa kamere",
     "HeaderContinueWatching": "Nastavi gledati",
     "HeaderFavoriteAlbums": "Omiljeni albumi",
     "HeaderFavoriteArtists": "Omiljeni izvođači",

--- a/Emby.Server.Implementations/Localization/Core/hu.json
+++ b/Emby.Server.Implementations/Localization/Core/hu.json
@@ -16,7 +16,6 @@
     "Folders": "Könyvtárak",
     "Genres": "Műfajok",
     "HeaderAlbumArtists": "Album előadók",
-    "HeaderCameraUploads": "Kamera feltöltések",
     "HeaderContinueWatching": "Megtekintés folytatása",
     "HeaderFavoriteAlbums": "Kedvenc albumok",
     "HeaderFavoriteArtists": "Kedvenc előadók",

--- a/Emby.Server.Implementations/Localization/Core/id.json
+++ b/Emby.Server.Implementations/Localization/Core/id.json
@@ -20,7 +20,6 @@
     "HeaderFavoriteArtists": "Artis Favorit",
     "HeaderFavoriteAlbums": "Album Favorit",
     "HeaderContinueWatching": "Lanjut Menonton",
-    "HeaderCameraUploads": "Unggahan Kamera",
     "HeaderAlbumArtists": "Album Artis",
     "Genres": "Aliran",
     "Folders": "Folder",

--- a/Emby.Server.Implementations/Localization/Core/is.json
+++ b/Emby.Server.Implementations/Localization/Core/is.json
@@ -13,7 +13,6 @@
     "HeaderFavoriteArtists": "Uppáhalds Listamenn",
     "HeaderFavoriteAlbums": "Uppáhalds Plötur",
     "HeaderContinueWatching": "Halda áfram að horfa",
-    "HeaderCameraUploads": "Myndavéla upphal",
     "HeaderAlbumArtists": "Höfundur plötu",
     "Genres": "Tegundir",
     "Folders": "Möppur",

--- a/Emby.Server.Implementations/Localization/Core/it.json
+++ b/Emby.Server.Implementations/Localization/Core/it.json
@@ -16,7 +16,6 @@
     "Folders": "Cartelle",
     "Genres": "Generi",
     "HeaderAlbumArtists": "Artisti degli Album",
-    "HeaderCameraUploads": "Caricamenti Fotocamera",
     "HeaderContinueWatching": "Continua a guardare",
     "HeaderFavoriteAlbums": "Album Preferiti",
     "HeaderFavoriteArtists": "Artisti Preferiti",

--- a/Emby.Server.Implementations/Localization/Core/ja.json
+++ b/Emby.Server.Implementations/Localization/Core/ja.json
@@ -16,7 +16,6 @@
     "Folders": "フォルダー",
     "Genres": "ジャンル",
     "HeaderAlbumArtists": "アルバムアーティスト",
-    "HeaderCameraUploads": "カメラアップロード",
     "HeaderContinueWatching": "視聴を続ける",
     "HeaderFavoriteAlbums": "お気に入りのアルバム",
     "HeaderFavoriteArtists": "お気に入りのアーティスト",

--- a/Emby.Server.Implementations/Localization/Core/kk.json
+++ b/Emby.Server.Implementations/Localization/Core/kk.json
@@ -16,7 +16,6 @@
     "Folders": "Qaltalar",
     "Genres": "Janrlar",
     "HeaderAlbumArtists": "Álbom oryndaýshylary",
-    "HeaderCameraUploads": "Kameradan júktelgender",
     "HeaderContinueWatching": "Qaraýdy jalǵastyrý",
     "HeaderFavoriteAlbums": "Tańdaýly álbomdar",
     "HeaderFavoriteArtists": "Tańdaýly oryndaýshylar",

--- a/Emby.Server.Implementations/Localization/Core/ko.json
+++ b/Emby.Server.Implementations/Localization/Core/ko.json
@@ -16,7 +16,6 @@
     "Folders": "폴더",
     "Genres": "장르",
     "HeaderAlbumArtists": "앨범 아티스트",
-    "HeaderCameraUploads": "카메라 업로드",
     "HeaderContinueWatching": "계속 시청하기",
     "HeaderFavoriteAlbums": "즐겨찾는 앨범",
     "HeaderFavoriteArtists": "즐겨찾는 아티스트",

--- a/Emby.Server.Implementations/Localization/Core/lt-LT.json
+++ b/Emby.Server.Implementations/Localization/Core/lt-LT.json
@@ -16,7 +16,6 @@
     "Folders": "Katalogai",
     "Genres": "Žanrai",
     "HeaderAlbumArtists": "Albumo atlikėjai",
-    "HeaderCameraUploads": "Kameros",
     "HeaderContinueWatching": "Žiūrėti toliau",
     "HeaderFavoriteAlbums": "Mėgstami Albumai",
     "HeaderFavoriteArtists": "Mėgstami Atlikėjai",

--- a/Emby.Server.Implementations/Localization/Core/lv.json
+++ b/Emby.Server.Implementations/Localization/Core/lv.json
@@ -72,7 +72,6 @@
     "ItemAddedWithName": "{0} tika pievienots bibliotēkai",
     "HeaderLiveTV": "Tiešraides TV",
     "HeaderContinueWatching": "Turpināt Skatīšanos",
-    "HeaderCameraUploads": "Kameras augšupielādes",
     "HeaderAlbumArtists": "Albumu Izpildītāji",
     "Genres": "Žanri",
     "Folders": "Mapes",

--- a/Emby.Server.Implementations/Localization/Core/mk.json
+++ b/Emby.Server.Implementations/Localization/Core/mk.json
@@ -51,7 +51,6 @@
     "HeaderFavoriteArtists": "Омилени Изведувачи",
     "HeaderFavoriteAlbums": "Омилени Албуми",
     "HeaderContinueWatching": "Продолжи со гледање",
-    "HeaderCameraUploads": "Поставувања од камера",
     "HeaderAlbumArtists": "Изведувачи од Албуми",
     "Genres": "Жанрови",
     "Folders": "Папки",

--- a/Emby.Server.Implementations/Localization/Core/mr.json
+++ b/Emby.Server.Implementations/Localization/Core/mr.json
@@ -54,7 +54,6 @@
     "ItemAddedWithName": "{0} हे संग्रहालयात जोडले गेले",
     "HomeVideos": "घरचे व्हिडीयो",
     "HeaderRecordingGroups": "रेकॉर्डिंग गट",
-    "HeaderCameraUploads": "कॅमेरा अपलोड",
     "CameraImageUploadedFrom": "एक नवीन कॅमेरा चित्र {0} येथून अपलोड केले आहे",
     "Application": "अ‍ॅप्लिकेशन",
     "AppDeviceValues": "अ‍ॅप: {0}, यंत्र: {1}",

--- a/Emby.Server.Implementations/Localization/Core/ms.json
+++ b/Emby.Server.Implementations/Localization/Core/ms.json
@@ -16,7 +16,6 @@
     "Folders": "Fail-fail",
     "Genres": "Genre-genre",
     "HeaderAlbumArtists": "Album Artis-artis",
-    "HeaderCameraUploads": "Muatnaik Kamera",
     "HeaderContinueWatching": "Terus Menonton",
     "HeaderFavoriteAlbums": "Album-album Kegemaran",
     "HeaderFavoriteArtists": "Artis-artis Kegemaran",

--- a/Emby.Server.Implementations/Localization/Core/nb.json
+++ b/Emby.Server.Implementations/Localization/Core/nb.json
@@ -16,7 +16,6 @@
     "Folders": "Mapper",
     "Genres": "Sjangre",
     "HeaderAlbumArtists": "Albumartister",
-    "HeaderCameraUploads": "Kameraopplastinger",
     "HeaderContinueWatching": "Fortsett å se",
     "HeaderFavoriteAlbums": "Favorittalbum",
     "HeaderFavoriteArtists": "Favorittartister",

--- a/Emby.Server.Implementations/Localization/Core/ne.json
+++ b/Emby.Server.Implementations/Localization/Core/ne.json
@@ -41,7 +41,6 @@
     "HeaderFavoriteArtists": "मनपर्ने कलाकारहरू",
     "HeaderFavoriteAlbums": "मनपर्ने एल्बमहरू",
     "HeaderContinueWatching": "हेर्न जारी राख्नुहोस्",
-    "HeaderCameraUploads": "क्यामेरा अपलोडहरू",
     "HeaderAlbumArtists": "एल्बमका कलाकारहरू",
     "Genres": "विधाहरू",
     "Folders": "फोल्डरहरू",

--- a/Emby.Server.Implementations/Localization/Core/nl.json
+++ b/Emby.Server.Implementations/Localization/Core/nl.json
@@ -16,7 +16,6 @@
     "Folders": "Mappen",
     "Genres": "Genres",
     "HeaderAlbumArtists": "Albumartiesten",
-    "HeaderCameraUploads": "Camera-uploads",
     "HeaderContinueWatching": "Kijken hervatten",
     "HeaderFavoriteAlbums": "Favoriete albums",
     "HeaderFavoriteArtists": "Favoriete artiesten",

--- a/Emby.Server.Implementations/Localization/Core/nn.json
+++ b/Emby.Server.Implementations/Localization/Core/nn.json
@@ -19,7 +19,6 @@
     "HeaderFavoriteArtists": "Favoritt Artistar",
     "HeaderFavoriteAlbums": "Favoritt Album",
     "HeaderContinueWatching": "Fortsett å sjå",
-    "HeaderCameraUploads": "Kamera Opplastingar",
     "HeaderAlbumArtists": "Album Artist",
     "Genres": "Sjangrar",
     "Folders": "Mapper",

--- a/Emby.Server.Implementations/Localization/Core/pl.json
+++ b/Emby.Server.Implementations/Localization/Core/pl.json
@@ -16,7 +16,6 @@
     "Folders": "Foldery",
     "Genres": "Gatunki",
     "HeaderAlbumArtists": "Wykonawcy albumów",
-    "HeaderCameraUploads": "Przekazane obrazy",
     "HeaderContinueWatching": "Kontynuuj odtwarzanie",
     "HeaderFavoriteAlbums": "Ulubione albumy",
     "HeaderFavoriteArtists": "Ulubieni wykonawcy",

--- a/Emby.Server.Implementations/Localization/Core/pt-BR.json
+++ b/Emby.Server.Implementations/Localization/Core/pt-BR.json
@@ -16,7 +16,6 @@
     "Folders": "Pastas",
     "Genres": "Gêneros",
     "HeaderAlbumArtists": "Artistas do Álbum",
-    "HeaderCameraUploads": "Envios da Câmera",
     "HeaderContinueWatching": "Continuar Assistindo",
     "HeaderFavoriteAlbums": "Álbuns Favoritos",
     "HeaderFavoriteArtists": "Artistas favoritos",

--- a/Emby.Server.Implementations/Localization/Core/pt-PT.json
+++ b/Emby.Server.Implementations/Localization/Core/pt-PT.json
@@ -16,7 +16,6 @@
     "Folders": "Pastas",
     "Genres": "Géneros",
     "HeaderAlbumArtists": "Artistas do Álbum",
-    "HeaderCameraUploads": "Envios a partir da câmara",
     "HeaderContinueWatching": "Continuar a Ver",
     "HeaderFavoriteAlbums": "Álbuns Favoritos",
     "HeaderFavoriteArtists": "Artistas Favoritos",

--- a/Emby.Server.Implementations/Localization/Core/pt.json
+++ b/Emby.Server.Implementations/Localization/Core/pt.json
@@ -83,7 +83,6 @@
     "Playlists": "Listas de Reprodução",
     "Photos": "Fotografias",
     "Movies": "Filmes",
-    "HeaderCameraUploads": "Carregamentos a partir da câmara",
     "FailedLoginAttemptWithUserName": "Tentativa de ligação falhada a partir de {0}",
     "DeviceOnlineWithName": "{0} está connectado",
     "DeviceOfflineWithName": "{0} desconectou-se",

--- a/Emby.Server.Implementations/Localization/Core/ro.json
+++ b/Emby.Server.Implementations/Localization/Core/ro.json
@@ -74,7 +74,6 @@
     "HeaderFavoriteArtists": "Artiști Favoriți",
     "HeaderFavoriteAlbums": "Albume Favorite",
     "HeaderContinueWatching": "Vizionează în continuare",
-    "HeaderCameraUploads": "Incărcări Cameră Foto",
     "HeaderAlbumArtists": "Album Artiști",
     "Genres": "Genuri",
     "Folders": "Dosare",

--- a/Emby.Server.Implementations/Localization/Core/ru.json
+++ b/Emby.Server.Implementations/Localization/Core/ru.json
@@ -16,7 +16,6 @@
     "Folders": "Папки",
     "Genres": "Жанры",
     "HeaderAlbumArtists": "Исполнители альбома",
-    "HeaderCameraUploads": "Камеры",
     "HeaderContinueWatching": "Продолжение просмотра",
     "HeaderFavoriteAlbums": "Избранные альбомы",
     "HeaderFavoriteArtists": "Избранные исполнители",

--- a/Emby.Server.Implementations/Localization/Core/sk.json
+++ b/Emby.Server.Implementations/Localization/Core/sk.json
@@ -16,7 +16,6 @@
     "Folders": "Priečinky",
     "Genres": "Žánre",
     "HeaderAlbumArtists": "Umelci albumu",
-    "HeaderCameraUploads": "Nahrané fotografie",
     "HeaderContinueWatching": "Pokračovať v pozeraní",
     "HeaderFavoriteAlbums": "Obľúbené albumy",
     "HeaderFavoriteArtists": "Obľúbení umelci",

--- a/Emby.Server.Implementations/Localization/Core/sl-SI.json
+++ b/Emby.Server.Implementations/Localization/Core/sl-SI.json
@@ -16,7 +16,6 @@
     "Folders": "Mape",
     "Genres": "Zvrsti",
     "HeaderAlbumArtists": "Izvajalci albuma",
-    "HeaderCameraUploads": "Posnetki kamere",
     "HeaderContinueWatching": "Nadaljuj gledanje",
     "HeaderFavoriteAlbums": "Priljubljeni albumi",
     "HeaderFavoriteArtists": "Priljubljeni izvajalci",

--- a/Emby.Server.Implementations/Localization/Core/sq.json
+++ b/Emby.Server.Implementations/Localization/Core/sq.json
@@ -96,7 +96,6 @@
     "HeaderFavoriteArtists": "Artistët e preferuar",
     "HeaderFavoriteAlbums": "Albumet e preferuar",
     "HeaderContinueWatching": "Vazhdo të shikosh",
-    "HeaderCameraUploads": "Ngarkimet nga Kamera",
     "HeaderAlbumArtists": "Artistët e albumeve",
     "Genres": "Zhanre",
     "Folders": "Dosje",

--- a/Emby.Server.Implementations/Localization/Core/sr.json
+++ b/Emby.Server.Implementations/Localization/Core/sr.json
@@ -74,7 +74,6 @@
     "HeaderFavoriteArtists": "Омиљени извођачи",
     "HeaderFavoriteAlbums": "Омиљени албуми",
     "HeaderContinueWatching": "Настави гледање",
-    "HeaderCameraUploads": "Слања са камере",
     "HeaderAlbumArtists": "Извођачи албума",
     "Genres": "Жанрови",
     "Folders": "Фасцикле",

--- a/Emby.Server.Implementations/Localization/Core/sv.json
+++ b/Emby.Server.Implementations/Localization/Core/sv.json
@@ -16,7 +16,6 @@
     "Folders": "Mappar",
     "Genres": "Genrer",
     "HeaderAlbumArtists": "Albumartister",
-    "HeaderCameraUploads": "Kamerauppladdningar",
     "HeaderContinueWatching": "Fortsätt kolla",
     "HeaderFavoriteAlbums": "Favoritalbum",
     "HeaderFavoriteArtists": "Favoritartister",

--- a/Emby.Server.Implementations/Localization/Core/ta.json
+++ b/Emby.Server.Implementations/Localization/Core/ta.json
@@ -20,7 +20,6 @@
     "MessageApplicationUpdated": "ஜெல்லிஃபின் சேவையகம் புதுப்பிக்கப்பட்டது",
     "Inherit": "மரபுரிமையாகப் பெறு",
     "HeaderRecordingGroups": "பதிவு குழுக்கள்",
-    "HeaderCameraUploads": "புகைப்பட பதிவேற்றங்கள்",
     "Folders": "கோப்புறைகள்",
     "FailedLoginAttemptWithUserName": "{0} இலிருந்து உள்நுழைவு முயற்சி தோல்வியடைந்தது",
     "DeviceOnlineWithName": "{0} இணைக்கப்பட்டது",

--- a/Emby.Server.Implementations/Localization/Core/th.json
+++ b/Emby.Server.Implementations/Localization/Core/th.json
@@ -50,7 +50,6 @@
     "HeaderFavoriteArtists": "ศิลปินที่ชื่นชอบ",
     "HeaderFavoriteAlbums": "อัมบั้มที่ชื่นชอบ",
     "HeaderContinueWatching": "ดูต่อ",
-    "HeaderCameraUploads": "อัปโหลดรูปถ่าย",
     "HeaderAlbumArtists": "อัลบั้มศิลปิน",
     "Genres": "ประเภท",
     "Folders": "โฟลเดอร์",

--- a/Emby.Server.Implementations/Localization/Core/tr.json
+++ b/Emby.Server.Implementations/Localization/Core/tr.json
@@ -16,7 +16,6 @@
     "Folders": "Klasörler",
     "Genres": "Türler",
     "HeaderAlbumArtists": "Albüm Sanatçıları",
-    "HeaderCameraUploads": "Kamera Yüklemeleri",
     "HeaderContinueWatching": "İzlemeye Devam Et",
     "HeaderFavoriteAlbums": "Favori Albümler",
     "HeaderFavoriteArtists": "Favori Sanatçılar",

--- a/Emby.Server.Implementations/Localization/Core/uk.json
+++ b/Emby.Server.Implementations/Localization/Core/uk.json
@@ -16,7 +16,6 @@
     "HeaderFavoriteArtists": "Улюблені виконавці",
     "HeaderFavoriteAlbums": "Улюблені альбоми",
     "HeaderContinueWatching": "Продовжити перегляд",
-    "HeaderCameraUploads": "Завантажено з камери",
     "HeaderAlbumArtists": "Виконавці альбому",
     "Genres": "Жанри",
     "Folders": "Каталоги",

--- a/Emby.Server.Implementations/Localization/Core/ur_PK.json
+++ b/Emby.Server.Implementations/Localization/Core/ur_PK.json
@@ -105,7 +105,6 @@
     "Inherit": "وراثت میں",
     "HomeVideos": "ہوم ویڈیو",
     "HeaderRecordingGroups": "ریکارڈنگ گروپس",
-    "HeaderCameraUploads": "کیمرہ اپلوڈز",
     "FailedLoginAttemptWithUserName": "لاگن کئ کوشش ناکام {0}",
     "DeviceOnlineWithName": "{0} متصل ھو چکا ھے",
     "DeviceOfflineWithName": "{0} منقطع ھو چکا ھے",

--- a/Emby.Server.Implementations/Localization/Core/vi.json
+++ b/Emby.Server.Implementations/Localization/Core/vi.json
@@ -103,7 +103,6 @@
     "HeaderFavoriteEpisodes": "Tập Phim Yêu Thích",
     "HeaderFavoriteArtists": "Nghệ Sĩ Yêu Thích",
     "HeaderFavoriteAlbums": "Album Ưa Thích",
-    "HeaderCameraUploads": "Máy Ảnh Tải Lên",
     "FailedLoginAttemptWithUserName": "Nỗ lực đăng nhập thất bại từ {0}",
     "DeviceOnlineWithName": "{0} đã kết nối",
     "DeviceOfflineWithName": "{0} đã ngắt kết nối",

--- a/Emby.Server.Implementations/Localization/Core/zh-CN.json
+++ b/Emby.Server.Implementations/Localization/Core/zh-CN.json
@@ -16,7 +16,6 @@
     "Folders": "文件夹",
     "Genres": "风格",
     "HeaderAlbumArtists": "专辑作家",
-    "HeaderCameraUploads": "相机上传",
     "HeaderContinueWatching": "继续观影",
     "HeaderFavoriteAlbums": "收藏的专辑",
     "HeaderFavoriteArtists": "最爱的艺术家",

--- a/Emby.Server.Implementations/Localization/Core/zh-HK.json
+++ b/Emby.Server.Implementations/Localization/Core/zh-HK.json
@@ -16,7 +16,6 @@
     "Folders": "檔案夾",
     "Genres": "風格",
     "HeaderAlbumArtists": "專輯藝人",
-    "HeaderCameraUploads": "相機上載",
     "HeaderContinueWatching": "繼續觀看",
     "HeaderFavoriteAlbums": "最愛專輯",
     "HeaderFavoriteArtists": "最愛的藝人",

--- a/Emby.Server.Implementations/Localization/Core/zh-TW.json
+++ b/Emby.Server.Implementations/Localization/Core/zh-TW.json
@@ -16,7 +16,6 @@
     "Folders": "資料夾",
     "Genres": "風格",
     "HeaderAlbumArtists": "專輯演出者",
-    "HeaderCameraUploads": "相機上傳",
     "HeaderContinueWatching": "繼續觀賞",
     "HeaderFavoriteAlbums": "最愛專輯",
     "HeaderFavoriteArtists": "最愛演出者",


### PR DESCRIPTION
Looked for all appearances of HeaderCameraUploads and removed them.

This fixes issue #3120 . Pending to be done (probably in another PR) look for all entries in localization files to see if there are others unused strings.