### PR TITLE
Make StartupWizardCompleted nullable in PublicSystemInfo

### DIFF
--- a/MediaBrowser.Model/System/PublicSystemInfo.cs
+++ b/MediaBrowser.Model/System/PublicSystemInfo.cs
@@ -43,7 +43,10 @@ namespace MediaBrowser.Model.System
         /// <summary>
         /// Gets or sets a value indicating whether the startup wizard is completed.
         /// </summary>
-        /// <value>The startup completion status.</value>
-        public bool StartupWizardCompleted { get; set; }
+        /// <remarks>
+        /// Nullable for OpenAPI specification only to retain backwards compatibility in apiclients.
+        /// </remarks>
+        /// <value>The startup completion status.</value>]
+        public bool? StartupWizardCompleted { get; set; }
     }
 }


### PR DESCRIPTION
**Changes**
This PR makes the StartupWizardCompleted field that is new in 10.7 nullable. This way apiclients won't fail because they're missing a value in the PublicSystemInfo response.

**Issues**
jellyfin/jellyfin-apiclient-java#124