### PR TITLE
Removing some warnings

### DIFF
--- a/MediaBrowser.Model/Channels/ChannelFeatures.cs
+++ b/MediaBrowser.Model/Channels/ChannelFeatures.cs
@@ -2,11 +2,19 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Channels
 {
     public class ChannelFeatures
     {
+        public ChannelFeatures()
+        {
+            MediaTypes = Array.Empty<ChannelMediaType>();
+            ContentTypes = Array.Empty<ChannelMediaContentType>();
+            DefaultSortFields = Array.Empty<ChannelItemSortField>();
+        }
+
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
@@ -29,16 +37,16 @@ namespace MediaBrowser.Model.Channels
         /// Gets or sets the media types.
         /// </summary>
         /// <value>The media types.</value>
-        public ChannelMediaType[] MediaTypes { get; set; }
+        public IReadOnlyCollection<ChannelMediaType> MediaTypes { get; set; }
 
         /// <summary>
         /// Gets or sets the content types.
         /// </summary>
         /// <value>The content types.</value>
-        public ChannelMediaContentType[] ContentTypes { get; set; }
+        public IReadOnlyCollection<ChannelMediaContentType> ContentTypes { get; set; }
 
         /// <summary>
-        /// Represents the maximum number of records the channel allows retrieving at a time.
+        /// Gets or sets the maximum number of records the channel allows retrieving at a time.
         /// </summary>
         public int? MaxPageSize { get; set; }
 
@@ -52,10 +60,10 @@ namespace MediaBrowser.Model.Channels
         /// Gets or sets the default sort orders.
         /// </summary>
         /// <value>The default sort orders.</value>
-        public ChannelItemSortField[] DefaultSortFields { get; set; }
+        public IReadOnlyCollection<ChannelItemSortField> DefaultSortFields { get; set; }
 
         /// <summary>
-        /// Indicates if a sort ascending/descending toggle is supported or not.
+        /// Gets or sets a value indicating whether a sort ascending/descending toggle is supported or not.
         /// </summary>
         public bool SupportsSortOrderToggle { get; set; }
 
@@ -76,12 +84,5 @@ namespace MediaBrowser.Model.Channels
         /// </summary>
         /// <value><c>true</c> if [supports content downloading]; otherwise, <c>false</c>.</value>
         public bool SupportsContentDownloading { get; set; }
-
-        public ChannelFeatures()
-        {
-            MediaTypes = Array.Empty<ChannelMediaType>();
-            ContentTypes = Array.Empty<ChannelMediaContentType>();
-            DefaultSortFields = Array.Empty<ChannelItemSortField>();
-        }
     }
 }

--- a/MediaBrowser.Model/Channels/ChannelFolderType.cs
+++ b/MediaBrowser.Model/Channels/ChannelFolderType.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Channels
 {

--- a/MediaBrowser.Model/Channels/ChannelItemSortField.cs
+++ b/MediaBrowser.Model/Channels/ChannelItemSortField.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Channels
 {

--- a/MediaBrowser.Model/Channels/ChannelMediaContentType.cs
+++ b/MediaBrowser.Model/Channels/ChannelMediaContentType.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Channels
 {

--- a/MediaBrowser.Model/Channels/ChannelMediaType.cs
+++ b/MediaBrowser.Model/Channels/ChannelMediaType.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Channels
 {

--- a/MediaBrowser.Model/Channels/ChannelQuery.cs
+++ b/MediaBrowser.Model/Channels/ChannelQuery.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 
@@ -13,13 +14,13 @@ namespace MediaBrowser.Model.Channels
         /// Fields to return within the items, in addition to basic information.
         /// </summary>
         /// <value>The fields.</value>
-        public ItemFields[] Fields { get; set; }
+        public IReadOnlyCollection<ItemFields> Fields { get; set; }
 
         public bool? EnableImages { get; set; }
 
         public int? ImageTypeLimit { get; set; }
 
-        public ImageType[] EnableImageTypes { get; set; }
+        public IReadOnlyCollection<ImageType> EnableImageTypes { get; set; }
 
         /// <summary>
         /// Gets or sets the user identifier.

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 #nullable disable
 #pragma warning disable CS1591
 
@@ -5,6 +7,37 @@ namespace MediaBrowser.Model.Configuration
 {
     public class EncodingOptions
     {
+        public EncodingOptions()
+        {
+            DownMixAudioBoost = 2;
+            MaxMuxingQueueSize = 2048;
+            EnableThrottling = false;
+            ThrottleDelaySeconds = 180;
+            EncodingThreadCount = -1;
+            // This is a DRM device that is almost guaranteed to be there on every intel platform,
+            // plus it's the default one in ffmpeg if you don't specify anything
+            VaapiDevice = "/dev/dri/renderD128";
+            // This is the OpenCL device that is used for tonemapping.
+            // The left side of the dot is the platform number, and the right side is the device number on the platform.
+            OpenclDevice = "0.0";
+            EnableTonemapping = false;
+            TonemappingAlgorithm = "reinhard";
+            TonemappingRange = "auto";
+            TonemappingDesat = 0;
+            TonemappingThreshold = 0.8;
+            TonemappingPeak = 0;
+            TonemappingParam = 0;
+            H264Crf = 23;
+            H265Crf = 28;
+            DeinterlaceDoubleRate = false;
+            DeinterlaceMethod = "yadif";
+            EnableDecodingColorDepth10Hevc = true;
+            EnableDecodingColorDepth10Vp9 = true;
+            EnableHardwareEncoding = true;
+            EnableSubtitleExtraction = true;
+            HardwareDecodingCodecs = new[] { "h264", "vc1" };
+        }
+
         public int EncodingThreadCount { get; set; }
 
         public string TranscodingTempPath { get; set; }
@@ -20,12 +53,12 @@ namespace MediaBrowser.Model.Configuration
         public string HardwareAccelerationType { get; set; }
 
         /// <summary>
-        /// FFmpeg path as set by the user via the UI.
+        ///     Gets or sets the FFmpeg path as set by the user via the UI.
         /// </summary>
         public string EncoderAppPath { get; set; }
 
         /// <summary>
-        /// The current FFmpeg path being used by the system and displayed on the transcode page.
+        ///     Gets or sets the current FFmpeg path being used by the system and displayed on the transcode page.
         /// </summary>
         public string EncoderAppPathDisplay { get; set; }
 
@@ -65,37 +98,6 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableSubtitleExtraction { get; set; }
 
-        public string[] HardwareDecodingCodecs { get; set; }
-
-        public EncodingOptions()
-        {
-            DownMixAudioBoost = 2;
-            MaxMuxingQueueSize = 2048;
-            EnableThrottling = false;
-            ThrottleDelaySeconds = 180;
-            EncodingThreadCount = -1;
-            // This is a DRM device that is almost guaranteed to be there on every intel platform,
-            // plus it's the default one in ffmpeg if you don't specify anything
-            VaapiDevice = "/dev/dri/renderD128";
-            // This is the OpenCL device that is used for tonemapping.
-            // The left side of the dot is the platform number, and the right side is the device number on the platform.
-            OpenclDevice = "0.0";
-            EnableTonemapping = false;
-            TonemappingAlgorithm = "reinhard";
-            TonemappingRange = "auto";
-            TonemappingDesat = 0;
-            TonemappingThreshold = 0.8;
-            TonemappingPeak = 0;
-            TonemappingParam = 0;
-            H264Crf = 23;
-            H265Crf = 28;
-            DeinterlaceDoubleRate = false;
-            DeinterlaceMethod = "yadif";
-            EnableDecodingColorDepth10Hevc = true;
-            EnableDecodingColorDepth10Vp9 = true;
-            EnableHardwareEncoding = true;
-            EnableSubtitleExtraction = true;
-            HardwareDecodingCodecs = new string[] { "h264", "vc1" };
-        }
+        public IReadOnlyCollection<string> HardwareDecodingCodecs { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/ImageOption.cs
+++ b/MediaBrowser.Model/Configuration/ImageOption.cs
@@ -6,6 +6,11 @@ namespace MediaBrowser.Model.Configuration
 {
     public class ImageOption
     {
+        public ImageOption()
+        {
+            Limit = 1;
+        }
+
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
@@ -23,10 +28,5 @@ namespace MediaBrowser.Model.Configuration
         /// </summary>
         /// <value>The minimum width.</value>
         public int MinWidth { get; set; }
-
-        public ImageOption()
-        {
-            Limit = 1;
-        }
     }
 }

--- a/MediaBrowser.Model/Configuration/ImageSavingConvention.cs
+++ b/MediaBrowser.Model/Configuration/ImageSavingConvention.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Configuration
 {

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -3,12 +3,30 @@
 
 using System;
 using System.Collections.Generic;
-using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Model.Configuration
 {
     public class LibraryOptions
     {
+        public LibraryOptions()
+        {
+            TypeOptions = Array.Empty<TypeOptions>();
+            DisabledSubtitleFetchers = Array.Empty<string>();
+            SubtitleFetcherOrder = Array.Empty<string>();
+            DisabledLocalMetadataReaders = Array.Empty<string>();
+
+            SkipSubtitlesIfAudioTrackMatches = true;
+            RequirePerfectSubtitleMatch = true;
+
+            EnablePhotos = true;
+            SaveSubtitlesWithMedia = true;
+            EnableRealtimeMonitor = true;
+            PathInfos = Array.Empty<MediaPathInfo>();
+            EnableInternetProviders = true;
+            EnableAutomaticSeriesGrouping = true;
+            SeasonZeroDisplayName = "Specials";
+        }
+
         public bool EnablePhotos { get; set; }
 
         public bool EnableRealtimeMonitor { get; set; }
@@ -19,7 +37,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool DownloadImagesInAdvance { get; set; }
 
-        public MediaPathInfo[] PathInfos { get; set; }
+        public IReadOnlyCollection<MediaPathInfo> PathInfos { get; set; }
 
         public bool SaveLocalMetadata { get; set; }
 
@@ -34,34 +52,34 @@ namespace MediaBrowser.Model.Configuration
         public int AutomaticRefreshIntervalDays { get; set; }
 
         /// <summary>
-        /// Gets or sets the preferred metadata language.
+        ///     Gets or sets the preferred metadata language.
         /// </summary>
         /// <value>The preferred metadata language.</value>
         public string PreferredMetadataLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the metadata country code.
+        ///     Gets or sets the metadata country code.
         /// </summary>
         /// <value>The metadata country code.</value>
         public string MetadataCountryCode { get; set; }
 
         public string SeasonZeroDisplayName { get; set; }
 
-        public string[] MetadataSavers { get; set; }
+        public IReadOnlyCollection<string> MetadataSavers { get; set; }
 
-        public string[] DisabledLocalMetadataReaders { get; set; }
+        public IReadOnlyCollection<string> DisabledLocalMetadataReaders { get; set; }
 
-        public string[] LocalMetadataReaderOrder { get; set; }
+        public IReadOnlyCollection<string> LocalMetadataReaderOrder { get; set; }
 
-        public string[] DisabledSubtitleFetchers { get; set; }
+        public IReadOnlyCollection<string> DisabledSubtitleFetchers { get; set; }
 
-        public string[] SubtitleFetcherOrder { get; set; }
+        public IReadOnlyCollection<string> SubtitleFetcherOrder { get; set; }
 
         public bool SkipSubtitlesIfEmbeddedSubtitlesPresent { get; set; }
 
         public bool SkipSubtitlesIfAudioTrackMatches { get; set; }
 
-        public string[] SubtitleDownloadLanguages { get; set; }
+        public IReadOnlyCollection<string> SubtitleDownloadLanguages { get; set; }
 
         public bool RequirePerfectSubtitleMatch { get; set; }
 
@@ -81,387 +99,5 @@ namespace MediaBrowser.Model.Configuration
 
             return null;
         }
-
-        public LibraryOptions()
-        {
-            TypeOptions = Array.Empty<TypeOptions>();
-            DisabledSubtitleFetchers = Array.Empty<string>();
-            SubtitleFetcherOrder = Array.Empty<string>();
-            DisabledLocalMetadataReaders = Array.Empty<string>();
-
-            SkipSubtitlesIfAudioTrackMatches = true;
-            RequirePerfectSubtitleMatch = true;
-
-            EnablePhotos = true;
-            SaveSubtitlesWithMedia = true;
-            EnableRealtimeMonitor = true;
-            PathInfos = Array.Empty<MediaPathInfo>();
-            EnableInternetProviders = true;
-            EnableAutomaticSeriesGrouping = true;
-            SeasonZeroDisplayName = "Specials";
-        }
-    }
-
-    public class MediaPathInfo
-    {
-        public string Path { get; set; }
-
-        public string NetworkPath { get; set; }
-    }
-
-    public class TypeOptions
-    {
-        public string Type { get; set; }
-
-        public string[] MetadataFetchers { get; set; }
-
-        public string[] MetadataFetcherOrder { get; set; }
-
-        public string[] ImageFetchers { get; set; }
-
-        public string[] ImageFetcherOrder { get; set; }
-
-        public ImageOption[] ImageOptions { get; set; }
-
-        public ImageOption GetImageOptions(ImageType type)
-        {
-            foreach (var i in ImageOptions)
-            {
-                if (i.Type == type)
-                {
-                    return i;
-                }
-            }
-
-            if (DefaultImageOptions.TryGetValue(Type, out ImageOption[] options))
-            {
-                foreach (var i in options)
-                {
-                    if (i.Type == type)
-                    {
-                        return i;
-                    }
-                }
-            }
-
-            return DefaultInstance;
-        }
-
-        public int GetLimit(ImageType type)
-        {
-            return GetImageOptions(type).Limit;
-        }
-
-        public int GetMinWidth(ImageType type)
-        {
-            return GetImageOptions(type).MinWidth;
-        }
-
-        public bool IsEnabled(ImageType type)
-        {
-            return GetLimit(type) > 0;
-        }
-
-        public TypeOptions()
-        {
-            MetadataFetchers = Array.Empty<string>();
-            MetadataFetcherOrder = Array.Empty<string>();
-            ImageFetchers = Array.Empty<string>();
-            ImageFetcherOrder = Array.Empty<string>();
-            ImageOptions = Array.Empty<ImageOption>();
-        }
-
-        public static Dictionary<string, ImageOption[]> DefaultImageOptions = new Dictionary<string, ImageOption[]>
-        {
-            {
-                "Movie", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Art
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Disc
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Banner
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Thumb
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Logo
-                    }
-                }
-            },
-            {
-                "MusicVideo", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Art
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Disc
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Banner
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Thumb
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Logo
-                    }
-                }
-            },
-            {
-                "Series", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Art
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Banner
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Thumb
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Logo
-                    }
-                }
-            },
-            {
-                "MusicAlbum", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Disc
-                    }
-                }
-            },
-            {
-                "MusicArtist", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    // Don't download this by default
-                    // They do look great, but most artists won't have them, which means a banner view isn't really possible
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Banner
-                    },
-
-                    // Don't download this by default
-                    // Generally not used
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Art
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Logo
-                    }
-                }
-            },
-            {
-                "BoxSet", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Thumb
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Logo
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Art
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Disc
-                    },
-
-                    // Don't download this by default as it's rarely used.
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Banner
-                    }
-                }
-            },
-            {
-                "Season", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Banner
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        Type = ImageType.Thumb
-                    }
-                }
-            },
-            {
-                "Episode", new []
-                {
-                    new ImageOption
-                    {
-                        Limit = 0,
-                        MinWidth = 1280,
-                        Type = ImageType.Backdrop
-                    },
-
-                    new ImageOption
-                    {
-                        Limit = 1,
-                        Type = ImageType.Primary
-                    }
-                }
-            }
-        };
-
-        public static ImageOption DefaultInstance = new ImageOption();
     }
 }

--- a/MediaBrowser.Model/Configuration/MediaPathInfo.cs
+++ b/MediaBrowser.Model/Configuration/MediaPathInfo.cs
@@ -1,0 +1,9 @@
+namespace MediaBrowser.Model.Configuration
+{
+    public class MediaPathInfo
+    {
+        public string Path { get; set; }
+
+        public string NetworkPath { get; set; }
+    }
+}

--- a/MediaBrowser.Model/Configuration/MetadataConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/MetadataConfiguration.cs
@@ -4,11 +4,11 @@ namespace MediaBrowser.Model.Configuration
 {
     public class MetadataConfiguration
     {
-        public bool UseFileCreationTimeForDateAdded { get; set; }
-
         public MetadataConfiguration()
         {
             UseFileCreationTimeForDateAdded = true;
         }
+
+        public bool UseFileCreationTimeForDateAdded { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/MetadataOptions.cs
+++ b/MediaBrowser.Model/Configuration/MetadataOptions.cs
@@ -2,28 +2,15 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Configuration
 {
     /// <summary>
-    /// Class MetadataOptions.
+    ///     Class MetadataOptions.
     /// </summary>
     public class MetadataOptions
     {
-        public string ItemType { get; set; }
-
-        public string[] DisabledMetadataSavers { get; set; }
-
-        public string[] LocalMetadataReaderOrder { get; set; }
-
-        public string[] DisabledMetadataFetchers { get; set; }
-
-        public string[] MetadataFetcherOrder { get; set; }
-
-        public string[] DisabledImageFetchers { get; set; }
-
-        public string[] ImageFetcherOrder { get; set; }
-
         public MetadataOptions()
         {
             DisabledMetadataSavers = Array.Empty<string>();
@@ -33,5 +20,19 @@ namespace MediaBrowser.Model.Configuration
             DisabledImageFetchers = Array.Empty<string>();
             ImageFetcherOrder = Array.Empty<string>();
         }
+
+        public string ItemType { get; set; }
+
+        public IReadOnlyCollection<string> DisabledMetadataSavers { get; set; }
+
+        public IReadOnlyCollection<string> LocalMetadataReaderOrder { get; set; }
+
+        public IReadOnlyCollection<string> DisabledMetadataFetchers { get; set; }
+
+        public IReadOnlyCollection<string> MetadataFetcherOrder { get; set; }
+
+        public IReadOnlyCollection<string> DisabledImageFetchers { get; set; }
+
+        public IReadOnlyCollection<string> ImageFetcherOrder { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/MetadataPluginSummary.cs
+++ b/MediaBrowser.Model/Configuration/MetadataPluginSummary.cs
@@ -2,34 +2,35 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Model.Configuration
 {
     public class MetadataPluginSummary
     {
-        /// <summary>
-        /// Gets or sets the type of the item.
-        /// </summary>
-        /// <value>The type of the item.</value>
-        public string ItemType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the plugins.
-        /// </summary>
-        /// <value>The plugins.</value>
-        public MetadataPlugin[] Plugins { get; set; }
-
-        /// <summary>
-        /// Gets or sets the supported image types.
-        /// </summary>
-        /// <value>The supported image types.</value>
-        public ImageType[] SupportedImageTypes { get; set; }
-
         public MetadataPluginSummary()
         {
             SupportedImageTypes = Array.Empty<ImageType>();
             Plugins = Array.Empty<MetadataPlugin>();
         }
+
+        /// <summary>
+        ///     Gets or sets the type of the item.
+        /// </summary>
+        /// <value>The type of the item.</value>
+        public string ItemType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the plugins.
+        /// </summary>
+        /// <value>The plugins.</value>
+        public IReadOnlyCollection<MetadataPlugin> Plugins { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the supported image types.
+        /// </summary>
+        /// <value>The supported image types.</value>
+        public IReadOnlyCollection<ImageType> SupportedImageTypes { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/MetadataPluginType.cs
+++ b/MediaBrowser.Model/Configuration/MetadataPluginType.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Configuration
 {

--- a/MediaBrowser.Model/Configuration/PathSubstitution.cs
+++ b/MediaBrowser.Model/Configuration/PathSubstitution.cs
@@ -1,0 +1,9 @@
+namespace MediaBrowser.Model.Configuration
+{
+    public class PathSubstitution
+    {
+        public string From { get; set; }
+
+        public string To { get; set; }
+    }
+}

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -117,19 +117,19 @@ namespace MediaBrowser.Model.Configuration
         /// Characters to be replaced with a ' ' in strings to create a sort name.
         /// </summary>
         /// <value>The sort replace characters.</value>
-        public string[] SortReplaceCharacters { get; set; }
+        public IReadOnlyCollection<string> SortReplaceCharacters { get; set; }
 
         /// <summary>
         /// Characters to be removed from strings to create a sort name.
         /// </summary>
         /// <value>The sort remove characters.</value>
-        public string[] SortRemoveCharacters { get; set; }
+        public IReadOnlyCollection<string> SortRemoveCharacters { get; set; }
 
         /// <summary>
         /// Words to be removed from strings to create a sort name.
         /// </summary>
         /// <value>The sort remove words.</value>
-        public string[] SortRemoveWords { get; set; }
+        public IReadOnlyCollection<string> SortRemoveWords { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum percentage of an item that must be played in order for playstate to be updated.
@@ -170,7 +170,7 @@ namespace MediaBrowser.Model.Configuration
         /// <value>The image saving convention.</value>
         public ImageSavingConvention ImageSavingConvention { get; set; }
 
-        public MetadataOptions[] MetadataOptions { get; set; }
+        public IReadOnlyCollection<MetadataOptions> MetadataOptions { get; set; }
 
         public bool SkipDeserializationForBasicTypes { get; set; }
 
@@ -210,7 +210,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool SaveMetadataHidden { get; set; }
 
-        public NameValuePair[] ContentTypes { get; set; }
+        public IReadOnlyCollection<NameValuePair> ContentTypes { get; set; }
 
         public int RemoteClientBitrateLimit { get; set; }
 
@@ -220,11 +220,11 @@ namespace MediaBrowser.Model.Configuration
 
         public bool DisplaySpecialsWithinSeasons { get; set; }
 
-        public string[] LocalNetworkSubnets { get; set; }
+        public IReadOnlyCollection<string> LocalNetworkSubnets { get; set; }
 
-        public string[] LocalNetworkAddresses { get; set; }
+        public IReadOnlyCollection<string> LocalNetworkAddresses { get; set; }
 
-        public string[] CodecsUsed { get; set; }
+        public IReadOnlyCollection<string> CodecsUsed { get; set; }
 
         public List<RepositoryInfo> PluginRepositories { get; set; }
 
@@ -239,7 +239,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableNewOmdbSupport { get; set; }
 
-        public string[] RemoteIPFilter { get; set; }
+        public IReadOnlyCollection<string> RemoteIPFilter { get; set; }
 
         public bool IsRemoteIPFilterBlacklist { get; set; }
 
@@ -249,7 +249,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableSimpleArtistDetection { get; set; }
 
-        public string[] UninstalledPlugins { get; set; }
+        public IReadOnlyCollection<string> UninstalledPlugins { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether slow server responses should be logged as a warning.
@@ -264,12 +264,12 @@ namespace MediaBrowser.Model.Configuration
         /// <summary>
         /// Gets or sets the cors hosts.
         /// </summary>
-        public string[] CorsHosts { get; set; }
+        public IReadOnlyCollection<string> CorsHosts { get; set; }
 
         /// <summary>
         /// Gets or sets the known proxies.
         /// </summary>
-        public string[] KnownProxies { get; set; }
+        public IReadOnlyCollection<string> KnownProxies { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerConfiguration" /> class.
@@ -382,12 +382,5 @@ namespace MediaBrowser.Model.Configuration
             CorsHosts = new[] { "*" };
             KnownProxies = Array.Empty<string>();
         }
-    }
-
-    public class PathSubstitution
-    {
-        public string From { get; set; }
-
-        public string To { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/TypeOptions.cs
+++ b/MediaBrowser.Model/Configuration/TypeOptions.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Model.Entities;
+
+namespace MediaBrowser.Model.Configuration
+{
+    /// <summary>
+    /// Represents a type option object.
+    /// </summary>
+    public class TypeOptions
+    {
+        private static readonly Dictionary<string, ImageOption[]> DefaultImageOptions = new Dictionary<string, ImageOption[]>
+        {
+            {
+                "Movie", new[]
+                {
+                    new ImageOption { Limit = 1, MinWidth = 1280, Type = ImageType.Backdrop },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Art },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Disc }, new ImageOption { Limit = 1, Type = ImageType.Primary }, new ImageOption { Limit = 0, Type = ImageType.Banner }, new ImageOption { Limit = 1, Type = ImageType.Thumb }, new ImageOption { Limit = 1, Type = ImageType.Logo }
+                }
+            },
+            {
+                "MusicVideo", new[]
+                {
+                    new ImageOption { Limit = 1, MinWidth = 1280, Type = ImageType.Backdrop },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Art },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Disc }, new ImageOption { Limit = 1, Type = ImageType.Primary }, new ImageOption { Limit = 0, Type = ImageType.Banner }, new ImageOption { Limit = 1, Type = ImageType.Thumb }, new ImageOption { Limit = 1, Type = ImageType.Logo }
+                }
+            },
+            {
+                "Series", new[]
+                {
+                    new ImageOption { Limit = 1, MinWidth = 1280, Type = ImageType.Backdrop },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Art }, new ImageOption { Limit = 1, Type = ImageType.Primary }, new ImageOption { Limit = 1, Type = ImageType.Banner }, new ImageOption { Limit = 1, Type = ImageType.Thumb }, new ImageOption { Limit = 1, Type = ImageType.Logo }
+                }
+            },
+            {
+                "MusicAlbum", new[]
+                {
+                    new ImageOption { Limit = 0, MinWidth = 1280, Type = ImageType.Backdrop },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Disc }
+                }
+            },
+            {
+                "MusicArtist", new[]
+                {
+                    new ImageOption { Limit = 1, MinWidth = 1280, Type = ImageType.Backdrop },
+
+                    // Don't download this by default
+                    // They do look great, but most artists won't have them, which means a banner view isn't really possible
+                    new ImageOption { Limit = 0, Type = ImageType.Banner },
+
+                    // Don't download this by default
+                    // Generally not used
+                    new ImageOption { Limit = 0, Type = ImageType.Art }, new ImageOption { Limit = 1, Type = ImageType.Logo }
+                }
+            },
+            {
+                "BoxSet", new[]
+                {
+                    new ImageOption { Limit = 1, MinWidth = 1280, Type = ImageType.Backdrop }, new ImageOption { Limit = 1, Type = ImageType.Primary }, new ImageOption { Limit = 1, Type = ImageType.Thumb }, new ImageOption { Limit = 1, Type = ImageType.Logo },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Art },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Disc },
+
+                    // Don't download this by default as it's rarely used.
+                    new ImageOption { Limit = 0, Type = ImageType.Banner }
+                }
+            },
+            { "Season", new[] { new ImageOption { Limit = 0, MinWidth = 1280, Type = ImageType.Backdrop }, new ImageOption { Limit = 1, Type = ImageType.Primary }, new ImageOption { Limit = 0, Type = ImageType.Banner }, new ImageOption { Limit = 0, Type = ImageType.Thumb } } },
+            { "Episode", new[] { new ImageOption { Limit = 0, MinWidth = 1280, Type = ImageType.Backdrop }, new ImageOption { Limit = 1, Type = ImageType.Primary } } }
+        };
+
+        private static readonly ImageOption DefaultInstance = new ImageOption();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeOptions"/> class.
+        /// </summary>
+        public TypeOptions()
+        {
+            MetadataFetchers = Array.Empty<string>();
+            MetadataFetcherOrder = Array.Empty<string>();
+            ImageFetchers = Array.Empty<string>();
+            ImageFetcherOrder = Array.Empty<string>();
+            ImageOptions = Array.Empty<ImageOption>();
+        }
+
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata fetchers.
+        /// </summary>
+        /// <value>
+        /// The metadata fetchers.
+        /// </value>
+        public IReadOnlyCollection<string> MetadataFetchers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata fetcher order.
+        /// </summary>
+        /// <value>
+        /// The metadata fetcher order.
+        /// </value>
+        public IReadOnlyCollection<string> MetadataFetcherOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the image fetchers.
+        /// </summary>
+        /// <value>
+        /// The image fetchers.
+        /// </value>
+        public IReadOnlyCollection<string> ImageFetchers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the image fetcher order.
+        /// </summary>
+        /// <value>
+        /// The image fetcher order.
+        /// </value>
+        public IReadOnlyCollection<string> ImageFetcherOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the image options.
+        /// </summary>
+        /// <value>
+        /// The image options.
+        /// </value>
+        public IReadOnlyCollection<ImageOption> ImageOptions { get; set; }
+
+        /// <summary>
+        /// Gets the image opiton that applies for the given type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The first ImageOption that matches the given type.</returns>
+        public ImageOption GetImageOptionByType(ImageType type)
+        {
+            foreach (var i in ImageOptions)
+            {
+                if (i.Type == type)
+                {
+                    return i;
+                }
+            }
+
+            if (DefaultImageOptions.TryGetValue(Type, out ImageOption[] options))
+            {
+                foreach (var i in options)
+                {
+                    if (i.Type == type)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return DefaultInstance;
+        }
+
+        /// <summary>
+        /// Gets the limit.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>Fisrt matching image option.</returns>
+        public int GetLimit(ImageType type)
+        {
+            return GetImageOptionByType(type).Limit;
+        }
+
+        /// <summary>
+        /// Gets the minimum width.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The MinWidth property of the first matching image option.</returns>
+        public int GetMinWidth(ImageType type)
+        {
+            return GetImageOptionByType(type).MinWidth;
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is enabled.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified type is enabled; otherwise, <c>false</c>.
+        /// </returns>
+        public bool IsEnabled(ImageType type)
+        {
+            return GetLimit(type) > 0;
+        }
+    }
+}

--- a/MediaBrowser.Model/Dlna/AudioOptions.cs
+++ b/MediaBrowser.Model/Dlna/AudioOptions.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using MediaBrowser.Model.Dto;
 
 namespace MediaBrowser.Model.Dlna
@@ -29,11 +30,12 @@ namespace MediaBrowser.Model.Dlna
 
         public Guid ItemId { get; set; }
 
-        public MediaSourceInfo[] MediaSources { get; set; }
+        public IReadOnlyCollection<MediaSourceInfo> MediaSources { get; set; }
 
         public DeviceProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or sets the media source Id.
         /// Optional. Only needed if a specific AudioStreamIndex or SubtitleStreamIndex are requested.
         /// </summary>
         public string MediaSourceId { get; set; }
@@ -41,13 +43,13 @@ namespace MediaBrowser.Model.Dlna
         public string DeviceId { get; set; }
 
         /// <summary>
-        /// Allows an override of supported number of audio channels
-        /// Example: DeviceProfile supports five channel, but user only has stereo speakers
+        /// Gets or sets allowing an override of supported number of audio channels
+        /// Example: DeviceProfile supports five channel, but user only has stereo speakers.
         /// </summary>
         public int? MaxAudioChannels { get; set; }
 
         /// <summary>
-        /// The application's configured quality setting.
+        /// Gets or sets the application's configured quality setting.
         /// </summary>
         public long? MaxBitrate { get; set; }
 
@@ -66,6 +68,7 @@ namespace MediaBrowser.Model.Dlna
         /// <summary>
         /// Gets the maximum bitrate.
         /// </summary>
+        /// <param name="isAudio">Specifies whether the max bit rate is being ser for audio or not.</param>
         /// <returns>System.Nullable&lt;System.Int32&gt;.</returns>
         public long? GetMaxBitrate(bool isAudio)
         {

--- a/MediaBrowser.Model/Dlna/ContainerProfile.cs
+++ b/MediaBrowser.Model/Dlna/ContainerProfile.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Serialization;
 
@@ -9,18 +10,18 @@ namespace MediaBrowser.Model.Dlna
 {
     public class ContainerProfile
     {
-        [XmlAttribute("type")]
-        public DlnaProfileType Type { get; set; }
-
-        public ProfileCondition[] Conditions { get; set; }
-
-        [XmlAttribute("container")]
-        public string Container { get; set; }
-
         public ContainerProfile()
         {
             Conditions = Array.Empty<ProfileCondition>();
         }
+
+        [XmlAttribute("type")]
+        public DlnaProfileType Type { get; set; }
+
+        public IReadOnlyCollection<ProfileCondition> Conditions { get; set; }
+
+        [XmlAttribute("container")]
+        public string Container { get; set; }
 
         public string[] GetContainers()
         {

--- a/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
+++ b/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
@@ -38,7 +38,8 @@ namespace MediaBrowser.Model.Dlna
                 ";DLNA.ORG_FLAGS={0}",
                 DlnaMaps.FlagsToString(flagValue));
 
-            ResponseProfile mediaProfile = _profile.GetImageMediaProfile(container,
+            ResponseProfile mediaProfile = _profile.GetImageMediaProfile(
+                container,
                 width,
                 height);
 
@@ -78,15 +79,6 @@ namespace MediaBrowser.Model.Dlna
                             DlnaFlags.BackgroundTransferMode |
                             DlnaFlags.InteractiveTransferMode |
                             DlnaFlags.DlnaV15;
-
-            // if (isDirectStream)
-            //{
-            //    flagValue = flagValue | DlnaFlags.ByteBasedSeek;
-            //}
-            // else if (runtimeTicks.HasValue)
-            //{
-            //    flagValue = flagValue | DlnaFlags.TimeBasedSeek;
-            //}
 
             string dlnaflags = string.Format(
                 CultureInfo.InvariantCulture,
@@ -148,19 +140,10 @@ namespace MediaBrowser.Model.Dlna
                             DlnaFlags.InteractiveTransferMode |
                             DlnaFlags.DlnaV15;
 
-            // if (isDirectStream)
-            //{
-            //    flagValue = flagValue | DlnaFlags.ByteBasedSeek;
-            //}
-            // else if (runtimeTicks.HasValue)
-            //{
-            //    flagValue = flagValue | DlnaFlags.TimeBasedSeek;
-            //}
+            string dlnaflags = string.Format(CultureInfo.InvariantCulture, ";DLNA.ORG_FLAGS={0}", DlnaMaps.FlagsToString(flagValue));
 
-            string dlnaflags = string.Format(CultureInfo.InvariantCulture, ";DLNA.ORG_FLAGS={0}",
-             DlnaMaps.FlagsToString(flagValue));
-
-            ResponseProfile mediaProfile = _profile.GetVideoMediaProfile(container,
+            ResponseProfile mediaProfile = _profile.GetVideoMediaProfile(
+                container,
                 audioCodec,
                 videoCodec,
                 width,
@@ -221,9 +204,7 @@ namespace MediaBrowser.Model.Dlna
         private static string GetImageOrgPnValue(string container, int? width, int? height)
         {
             MediaFormatProfile? format = new MediaFormatProfileResolver()
-                .ResolveImageFormat(container,
-                width,
-                height);
+                .ResolveImageFormat(container, width, height);
 
             return format.HasValue ? format.Value.ToString() : null;
         }
@@ -231,10 +212,7 @@ namespace MediaBrowser.Model.Dlna
         private static string GetAudioOrgPnValue(string container, int? audioBitrate, int? audioSampleRate, int? audioChannels)
         {
             MediaFormatProfile? format = new MediaFormatProfileResolver()
-                .ResolveAudioFormat(container,
-                audioBitrate,
-                audioSampleRate,
-                audioChannels);
+                .ResolveAudioFormat(container, audioBitrate, audioSampleRate, audioChannels);
 
             return format.HasValue ? format.Value.ToString() : null;
         }

--- a/MediaBrowser.Model/Dlna/MediaFormatProfile.cs
+++ b/MediaBrowser.Model/Dlna/MediaFormatProfile.cs
@@ -1,4 +1,6 @@
 #pragma warning disable CS1591
+#pragma warning disable CA1707
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Dlna
 {

--- a/MediaBrowser.Model/Users/UserActionType.cs
+++ b/MediaBrowser.Model/Users/UserActionType.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable SA1602
 
 namespace MediaBrowser.Model.Users
 {

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 using Jellyfin.Data.Enums;
 using AccessSchedule = Jellyfin.Data.Entities.AccessSchedule;
@@ -10,109 +11,6 @@ namespace MediaBrowser.Model.Users
 {
     public class UserPolicy
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is administrator.
-        /// </summary>
-        /// <value><c>true</c> if this instance is administrator; otherwise, <c>false</c>.</value>
-        public bool IsAdministrator { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is hidden.
-        /// </summary>
-        /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
-        public bool IsHidden { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is disabled.
-        /// </summary>
-        /// <value><c>true</c> if this instance is disabled; otherwise, <c>false</c>.</value>
-        public bool IsDisabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the max parental rating.
-        /// </summary>
-        /// <value>The max parental rating.</value>
-        public int? MaxParentalRating { get; set; }
-
-        public string[] BlockedTags { get; set; }
-
-        public bool EnableUserPreferenceAccess { get; set; }
-
-        public AccessSchedule[] AccessSchedules { get; set; }
-
-        public UnratedItem[] BlockUnratedItems { get; set; }
-
-        public bool EnableRemoteControlOfOtherUsers { get; set; }
-
-        public bool EnableSharedDeviceControl { get; set; }
-
-        public bool EnableRemoteAccess { get; set; }
-
-        public bool EnableLiveTvManagement { get; set; }
-
-        public bool EnableLiveTvAccess { get; set; }
-
-        public bool EnableMediaPlayback { get; set; }
-
-        public bool EnableAudioPlaybackTranscoding { get; set; }
-
-        public bool EnableVideoPlaybackTranscoding { get; set; }
-
-        public bool EnablePlaybackRemuxing { get; set; }
-
-        public bool ForceRemoteSourceTranscoding { get; set; }
-
-        public bool EnableContentDeletion { get; set; }
-
-        public string[] EnableContentDeletionFromFolders { get; set; }
-
-        public bool EnableContentDownloading { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [enable synchronize].
-        /// </summary>
-        /// <value><c>true</c> if [enable synchronize]; otherwise, <c>false</c>.</value>
-        public bool EnableSyncTranscoding { get; set; }
-
-        public bool EnableMediaConversion { get; set; }
-
-        public string[] EnabledDevices { get; set; }
-
-        public bool EnableAllDevices { get; set; }
-
-        public Guid[] EnabledChannels { get; set; }
-
-        public bool EnableAllChannels { get; set; }
-
-        public Guid[] EnabledFolders { get; set; }
-
-        public bool EnableAllFolders { get; set; }
-
-        public int InvalidLoginAttemptCount { get; set; }
-
-        public int LoginAttemptsBeforeLockout { get; set; }
-
-        public int MaxActiveSessions { get; set; }
-
-        public bool EnablePublicSharing { get; set; }
-
-        public Guid[] BlockedMediaFolders { get; set; }
-
-        public Guid[] BlockedChannels { get; set; }
-
-        public int RemoteClientBitrateLimit { get; set; }
-
-        [XmlElement(ElementName = "AuthenticationProviderId")]
-        public string AuthenticationProviderId { get; set; }
-
-        public string PasswordResetProviderId { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating what SyncPlay features the user can access.
-        /// </summary>
-        /// <value>Access level to SyncPlay features.</value>
-        public SyncPlayAccess SyncPlayAccess { get; set; }
-
         public UserPolicy()
         {
             IsHidden = true;
@@ -162,5 +60,108 @@ namespace MediaBrowser.Model.Users
             EnableRemoteAccess = true;
             SyncPlayAccess = SyncPlayAccess.CreateAndJoinGroups;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is administrator.
+        /// </summary>
+        /// <value><c>true</c> if this instance is administrator; otherwise, <c>false</c>.</value>
+        public bool IsAdministrator { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is hidden.
+        /// </summary>
+        /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
+        public bool IsHidden { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is disabled.
+        /// </summary>
+        /// <value><c>true</c> if this instance is disabled; otherwise, <c>false</c>.</value>
+        public bool IsDisabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max parental rating.
+        /// </summary>
+        /// <value>The max parental rating.</value>
+        public int? MaxParentalRating { get; set; }
+
+        public IReadOnlyCollection<string> BlockedTags { get; set; }
+
+        public bool EnableUserPreferenceAccess { get; set; }
+
+        public IReadOnlyCollection<AccessSchedule> AccessSchedules { get; set; }
+
+        public IReadOnlyCollection<UnratedItem> BlockUnratedItems { get; set; }
+
+        public bool EnableRemoteControlOfOtherUsers { get; set; }
+
+        public bool EnableSharedDeviceControl { get; set; }
+
+        public bool EnableRemoteAccess { get; set; }
+
+        public bool EnableLiveTvManagement { get; set; }
+
+        public bool EnableLiveTvAccess { get; set; }
+
+        public bool EnableMediaPlayback { get; set; }
+
+        public bool EnableAudioPlaybackTranscoding { get; set; }
+
+        public bool EnableVideoPlaybackTranscoding { get; set; }
+
+        public bool EnablePlaybackRemuxing { get; set; }
+
+        public bool ForceRemoteSourceTranscoding { get; set; }
+
+        public bool EnableContentDeletion { get; set; }
+
+        public IReadOnlyCollection<string> EnableContentDeletionFromFolders { get; set; }
+
+        public bool EnableContentDownloading { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable synchronize].
+        /// </summary>
+        /// <value><c>true</c> if [enable synchronize]; otherwise, <c>false</c>.</value>
+        public bool EnableSyncTranscoding { get; set; }
+
+        public bool EnableMediaConversion { get; set; }
+
+        public IReadOnlyCollection<string> EnabledDevices { get; set; }
+
+        public bool EnableAllDevices { get; set; }
+
+        public IReadOnlyCollection<Guid> EnabledChannels { get; set; }
+
+        public bool EnableAllChannels { get; set; }
+
+        public IReadOnlyCollection<Guid> EnabledFolders { get; set; }
+
+        public bool EnableAllFolders { get; set; }
+
+        public int InvalidLoginAttemptCount { get; set; }
+
+        public int LoginAttemptsBeforeLockout { get; set; }
+
+        public int MaxActiveSessions { get; set; }
+
+        public bool EnablePublicSharing { get; set; }
+
+        public IReadOnlyCollection<Guid> BlockedMediaFolders { get; set; }
+
+        public IReadOnlyCollection<Guid> BlockedChannels { get; set; }
+
+        public int RemoteClientBitrateLimit { get; set; }
+
+        [XmlElement(ElementName = "AuthenticationProviderId")]
+        public string AuthenticationProviderId { get; set; }
+
+        public string PasswordResetProviderId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating what SyncPlay features the user can access.
+        /// </summary>
+        /// <value>Access level to SyncPlay features.</value>
+        public SyncPlayAccess SyncPlayAccess { get; set; }
     }
 }


### PR DESCRIPTION
Some warnings being removed for issue #2149 

I'm just wondering if the warning about "Property's description should start with Get or sets" shouldn't be disabled in the config file instead of changing descriptions/disabling warning file by file.
