### PR TITLE
Automatically clean activity log database

### DIFF
--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -95,6 +95,8 @@
     "TasksLibraryCategory": "Library",
     "TasksApplicationCategory": "Application",
     "TasksChannelsCategory": "Internet Channels",
+    "TaskCleanActivityLog": "Clean Activity Log",
+    "TaskCleanActivityLogDescription": "Deletes activity log entries older then the configured age.",
     "TaskCleanCache": "Clean Cache Directory",
     "TaskCleanCacheDescription": "Deletes cache files no longer needed by the system.",
     "TaskRefreshChapterImages": "Extract Chapter Images",

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -96,7 +96,7 @@
     "TasksApplicationCategory": "Application",
     "TasksChannelsCategory": "Internet Channels",
     "TaskCleanActivityLog": "Clean Activity Log",
-    "TaskCleanActivityLogDescription": "Deletes activity log entries older then the configured age.",
+    "TaskCleanActivityLogDescription": "Deletes activity log entries older than the configured age.",
     "TaskCleanCache": "Clean Cache Directory",
     "TaskCleanCacheDescription": "Deletes cache files no longer needed by the system.",
     "TaskRefreshChapterImages": "Extract Chapter Images",

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Activity;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Tasks;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks
+{
+    /// <summary>
+    /// Deletes old activity log entries.
+    /// </summary>
+    public class CleanActivityLogTask : IScheduledTask, IConfigurableScheduledTask
+    {
+        private readonly ILocalizationManager _localization;
+        private readonly IActivityManager _activityManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CleanActivityLogTask"/> class.
+        /// </summary>
+        /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+        /// <param name="activityManager">Instance of the <see cref="IActivityManager"/> interface.</param>
+        public CleanActivityLogTask(
+            ILocalizationManager localization,
+            IActivityManager activityManager)
+        {
+            _localization = localization;
+            _activityManager = activityManager;
+        }
+
+        /// <inheritdoc />
+        public string Name => _localization.GetLocalizedString("TaskCleanActivityLog");
+
+        /// <inheritdoc />
+        public string Key => "CleanActivityLog";
+
+        /// <inheritdoc />
+        public string Description => _localization.GetLocalizedString("TaskCleanActivityLogDescription");
+
+        /// <inheritdoc />
+        public string Category => _localization.GetLocalizedString("TasksMaintenanceCategory");
+
+        /// <inheritdoc />
+        public bool IsHidden => false;
+
+        /// <inheritdoc />
+        public bool IsEnabled => true;
+
+        /// <inheritdoc />
+        public bool IsLogged => true;
+
+        /// <inheritdoc />
+        public Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+        {
+            // TODO allow configure
+            var startDate = DateTime.UtcNow.AddDays(-30);
+            return _activityManager.CleanAsync(startDate);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return Enumerable.Empty<TaskTriggerInfo>();
+        }
+    }
+}

--- a/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
+++ b/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
@@ -72,6 +72,18 @@ namespace Jellyfin.Server.Implementations.Activity
             };
         }
 
+        /// <inheritdoc />
+        public async Task CleanAsync(DateTime startDate)
+        {
+            await using var dbContext = _provider.CreateContext();
+            var entries = dbContext.ActivityLogs
+                .AsQueryable()
+                .Where(entry => entry.DateCreated <= startDate);
+
+            dbContext.RemoveRange(entries);
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
         private static ActivityLogEntry ConvertToOldModel(ActivityLog entry)
         {
             return new ActivityLogEntry

--- a/MediaBrowser.Model/Activity/IActivityManager.cs
+++ b/MediaBrowser.Model/Activity/IActivityManager.cs
@@ -16,5 +16,12 @@ namespace MediaBrowser.Model.Activity
         Task CreateAsync(ActivityLog entry);
 
         Task<QueryResult<ActivityLogEntry>> GetPagedResultAsync(ActivityLogQuery query);
+
+        /// <summary>
+        /// Remove all activity logs before the specified date.
+        /// </summary>
+        /// <param name="startDate">Activity log start date.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task CleanAsync(DateTime startDate);
     }
 }

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -272,6 +272,11 @@ namespace MediaBrowser.Model.Configuration
         public string[] KnownProxies { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of days we should retain activity logs.
+        /// </summary>
+        public int? ActivityLogRetentionDays { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServerConfiguration" /> class.
         /// </summary>
         public ServerConfiguration()
@@ -381,6 +386,7 @@ namespace MediaBrowser.Model.Configuration
             SlowResponseThresholdMs = 500;
             CorsHosts = new[] { "*" };
             KnownProxies = Array.Empty<string>();
+            ActivityLogRetentionDays = 30;
         }
     }
 


### PR DESCRIPTION
Fixes #4294 
Note: the scheduled task does not have any triggers by default.

`ActivityLogRetentionDays` is nullable for API compatibility. 