### PR TITLE
Fix frame rate probing for interlaced MKV files

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -666,6 +666,16 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.AverageFrameRate = GetFrameRate(streamInfo.AverageFrameRate);
                 stream.RealFrameRate = GetFrameRate(streamInfo.RFrameRate);
 
+                // Interlaced video streams in Matroska containers return the field rate instead of the frame rate
+                // as both the average and real frame rate, so we half the returned frame rates to get the correct values
+                //
+                // https://gitlab.com/mbunkus/mkvtoolnix/-/wikis/Wrong-frame-rate-displayed
+                if (stream.IsInterlaced && formatInfo.FormatName.Contains("matroska", StringComparison.OrdinalIgnoreCase))
+                {
+                    stream.AverageFrameRate /= 2;
+                    stream.RealFrameRate /= 2;
+                }
+
                 if (isAudio || string.Equals(stream.Codec, "gif", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(stream.Codec, "png", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
**Changes**
Currently Matroska (MKV) files containing interlaced video report the frame rate at the field rate instead of the expected frame rate. As a result the stored and displayed frame rate is double what it should be (e.g. 50 instead of 25). This also has the unintended effect of disabling double rate (bob) deinterlacing for those that have it switched on.

This change halves the average and real frame rate when it is probed for interlaced video streams in an Matroska container, so that the correct frame rate is stored.

**Issues**
Fixes #4314

**Additional Context**
The Matroska container doesn't have a header for the frame rate to be stored in. Instead it stores a display duration for each block containing a frame of video.

As FFprobe (and other apps) don't have a stored framerate in the container to display, they use the block display duration to calculate the frame rate instead.

However this doesn't work properly for interlaced videos, as the blocks store fields instead of frames. The display durations for the blocks are halved so that they represent the duration each field should be displayed, and as a result the frame rate value is calculated as being double what it should be.

For more info see https://gitlab.com/mbunkus/mkvtoolnix/-/wikis/Wrong-frame-rate-displayed.