### PR TITLE
Fix setting duplicate keys from auth header

### DIFF
--- a/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
@@ -267,7 +267,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 if (param.Length == 2)
                 {
                     var value = NormalizeValue(param[1].Trim(new[] { '"' }));
-                    result.Add(param[0], value);
+                    result[param[0]] = value;
                 }
             }
 


### PR DESCRIPTION
Fixes 

```c#
[2020-10-26 18:31:10.489 -04:00] [ERR] [110] Jellyfin.Server.Middleware.ExceptionMiddleware: Error processing request. URL "GET" "/Users/{userId}".
System.ArgumentException: An item with the same key has already been added. Key: Device
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at Emby.Server.Implementations.HttpServer.Security.AuthorizationContext.GetAuthorization(String authorizationHeader)
   at Emby.Server.Implementations.HttpServer.Security.AuthorizationContext.GetAuthorizationDictionary(HttpRequest httpReq)
   at Emby.Server.Implementations.HttpServer.Security.AuthorizationContext.GetAuthorizationInfo(HttpRequest requestContext)
   at Emby.Server.Implementations.HttpServer.Security.AuthService.Authenticate(HttpRequest request)
   at Jellyfin.Api.Auth.CustomAuthenticationHandler.HandleAuthenticateAsync()
   at Microsoft.AspNetCore.Authentication.AuthenticationHandler`1.AuthenticateAsync()
   at Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync(HttpContext context, String scheme)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
   at Jellyfin.Server.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context)
   at Jellyfin.Server.Middleware.ExceptionMiddleware.Invoke(HttpContext context)
```