### PR TITLE
Fix HLS music playback on iOS

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -155,7 +155,7 @@ namespace Jellyfin.Api.Helpers
                 return new FileContentResult(Array.Empty<byte>(), MimeTypes.GetMimeType("playlist.m3u8"));
             }
 
-            var totalBitrate = state.OutputAudioBitrate ?? 0 + state.OutputVideoBitrate ?? 0;
+            var totalBitrate = (state.OutputAudioBitrate ?? 0) + (state.OutputVideoBitrate ?? 0);
 
             var builder = new StringBuilder();
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1380,24 +1380,40 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public int? GetAudioBitrateParam(BaseEncodingJobOptions request, MediaStream audioStream)
         {
+            if (audioStream == null)
+            {
+                return null;
+            }
+
             if (request.AudioBitRate.HasValue)
             {
                 // Don't encode any higher than this
                 return Math.Min(384000, request.AudioBitRate.Value);
             }
 
-            return null;
+            // Empty bitrate area is not allow on iOS
+            // Default audio bitrate to 128K if it is not being requested
+            // https://ffmpeg.org/ffmpeg-codecs.html#toc-Codec-Options
+            return 128000;
         }
 
         public int? GetAudioBitrateParam(int? audioBitRate, MediaStream audioStream)
         {
+            if (audioStream == null)
+            {
+                return null;
+            }
+
             if (audioBitRate.HasValue)
             {
                 // Don't encode any higher than this
                 return Math.Min(384000, audioBitRate.Value);
             }
 
-            return null;
+            // Empty bitrate area is not allow on iOS
+            // Default audio bitrate to 128K if it is not being requested
+            // https://ffmpeg.org/ffmpeg-codecs.html#toc-Codec-Options
+            return 128000;
         }
 
         public string GetAudioFilterParam(EncodingJobInfo state, EncodingOptions encodingOptions, bool isHls)


### PR DESCRIPTION
**Changes**
- Default the output audio bitrate to 128000 as per ffmpeg docs if it is not being requested.

**Issues**
- `BANDWIDTH` area in master playlist is not allow to be empty on iOS, otherwise the playback won't begin.
Only happens when transcoding music and streaming in HLS to iOS devices.

Fixes: https://github.com/jellyfin/jellyfin/issues/3957