### PR TITLE
Remove jellyfin-ffmpeg dep from server package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Breaks: jellyfin (<<10.6.0)
 Architecture: any
 Depends: at,
          libsqlite3-0,
-         jellyfin-ffmpeg (>= 4.2.1-2),
          libfontconfig1,
          libfreetype6,
          libssl1.1


### PR DESCRIPTION
**Changes**
Remove the jellyfin-ffmpeg dependency from jellyfin-server itself. It is being added to the metapackage instead.

This allows working around the dependency if required, while still preserving the same clean install for normal users.

**Issues**
N/A
