### PR TITLE
Don't throw exception if name is null

### DIFF
--- a/Emby.Naming/Video/CleanDateTimeParser.cs
+++ b/Emby.Naming/Video/CleanDateTimeParser.cs
@@ -15,6 +15,11 @@ namespace Emby.Naming.Video
         public static CleanDateTimeResult Clean(string name, IReadOnlyList<Regex> cleanDateTimeRegexes)
         {
             CleanDateTimeResult result = new CleanDateTimeResult(name);
+            if (string.IsNullOrEmpty(name))
+            {
+                return result;
+            }
+
             var len = cleanDateTimeRegexes.Count;
             for (int i = 0; i < len; i++)
             {


### PR DESCRIPTION
Fixes 
```
[2020-11-09 08:08:26.740 -05:00] [ERR] [63] MediaBrowser.Providers.Manager.ProviderManager: Error refreshing item
System.ArgumentNullException: Value cannot be null. (Parameter 'input')
   at System.Text.RegularExpressions.Regex.Match(String input)
   at Emby.Naming.Video.CleanDateTimeParser.TryClean(String name, Regex expression, CleanDateTimeResult& result)
   at Emby.Naming.Video.CleanDateTimeParser.Clean(String name, IReadOnlyList`1 cleanDateTimeRegexes)
   at Emby.Server.Implementations.Library.LibraryManager.ParseName(String name)
   at MediaBrowser.Controller.Entities.Trailer.BeforeMetadataRefresh(Boolean replaceAllMetdata)
   at MediaBrowser.Providers.Manager.MetadataService`2.RefreshMetadata(BaseItem item, MetadataRefreshOptions refreshOptions, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.BaseItem.RefreshMetadata(MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.ProviderManager.RefreshItem(BaseItem item, MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.ProviderManager.StartProcessingRefreshQueue()
```