### PR TITLE
Bump dependencies to Fedora 33

### DIFF
--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:33
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -10,7 +10,7 @@ ENV IS_DOCKER=YES
 
 # Prepare Fedora environment
 RUN dnf update -y \
- && dnf install -y @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel
+ && dnf install -y @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd
 
 # Install DotNET SDK
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \


### PR DESCRIPTION
Fedora 33 is out so Fedora 31 is unmaintened so its time to migrate the build to Fedora 33 !

