### PR TITLE
update dotnet 5.0 buster image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && yarn install \
  && mv dist /dist
 
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-buster as builder
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-buster-slim as builder
 WORKDIR /repo
 COPY . .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Moved fast, broke stuff

Step 5/23 : FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-buster as builder                             
manifest for mcr.microsoft.com/dotnet/sdk:5.0-buster not found: manifest unknown: manifest tagged by "5.0-buster" is not found

arm not tested
