### PR TITLE
Fix Environment authorization policy

### DIFF
--- a/Jellyfin.Api/Controllers/EnvironmentController.cs
+++ b/Jellyfin.Api/Controllers/EnvironmentController.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Api.Controllers
     /// <summary>
     /// Environment Controller.
     /// </summary>
-    [Authorize(Policy = Policies.RequiresElevation)]
+    [Authorize(Policy = Policies.FirstTimeSetupOrElevated)]
     public class EnvironmentController : BaseJellyfinApiController
     {
         private const char UncSeparator = '\\';


### PR DESCRIPTION
In 10.6 policy was `[Authenticated(Roles = "Admin", AllowBeforeStartupWizard = true)]`