### PR TITLE
Fix live tv hls playback

### DIFF
--- a/Jellyfin.Api/Controllers/HlsSegmentController.cs
+++ b/Jellyfin.Api/Controllers/HlsSegmentController.cs
@@ -112,11 +112,13 @@ namespace Jellyfin.Api.Controllers
         /// <param name="segmentId">The segment id.</param>
         /// <param name="segmentContainer">The segment container.</param>
         /// <response code="200">Hls video segment returned.</response>
+        /// <response code="404">Hls segment not found.</response>
         /// <returns>A <see cref="FileStreamResult"/> containing the video segment.</returns>
         // Can't require authentication just yet due to seeing some requests come from Chrome without full query string
         // [Authenticated]
         [HttpGet("Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesVideoFile]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "itemId", Justification = "Required for ServiceStack")]
         public ActionResult GetHlsVideoSegmentLegacy(


### PR DESCRIPTION
LiveTV was being transcoded with a `.ts` extension instead of the hardcoded `.m3u8`.