### PR TITLE
Write DateTimes in ISO8601 format for backwards compatibility.

### DIFF
--- a/MediaBrowser.Common/Json/Converters/JsonDateTimeIso8601Converter.cs
+++ b/MediaBrowser.Common/Json/Converters/JsonDateTimeIso8601Converter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MediaBrowser.Common.Json.Converters
+{
+    /// <summary>
+    /// Returns an ISO8601 formatted datetime.
+    /// </summary>
+    /// <remarks>
+    /// Used for legacy compatibility.
+    /// </remarks>
+    public class JsonDateTimeIso8601Converter : JsonConverter<DateTime>
+    {
+        /// <inheritdoc />
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => reader.GetDateTime();
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+}

--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -42,6 +42,7 @@ namespace MediaBrowser.Common.Json
             options.Converters.Add(new JsonGuidConverter());
             options.Converters.Add(new JsonStringEnumConverter());
             options.Converters.Add(new JsonNullableStructConverterFactory());
+            options.Converters.Add(new JsonDateTimeIso8601Converter());
 
             return options;
         }


### PR DESCRIPTION
Python doesn't like the default format 😢 