### PR TITLE
Fix nullref

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -928,7 +928,7 @@ namespace Jellyfin.Api.Controllers
             [FromRoute] int? imageIndex = null)
         {
             var user = _userManager.GetUserById(userId);
-            if (user == null)
+            if (user?.ProfileImage == null)
             {
                 return NotFound();
             }


### PR DESCRIPTION
Should fix this exception:
```
jellyfin-edge_1  | System.NullReferenceException: Object reference not set to an instance of an object.
jellyfin-edge_1  |    at Jellyfin.Api.Controllers.ImageController.GetUserImage(Guid userId, ImageType imageType, String tag, Nullable`1 format, Nullable`1 maxWidth, Nullable`1 maxHeight, Nullable`1 percentPlayed, Nullable`1 unplayedCount, Nullable`1 width, Nullable`1 height, Nullable`1 quality, Nullable`1 cropWhitespace, Nullable`1 addPlayedIndicator, Nullable`1 blur, String backgroundColor, String foregroundLayer, Nullable`1 imageIndex)
jellyfin-edge_1  |    at lambda_method1262(Closure , Object )
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
jellyfin-edge_1  | --- End of stack trace from previous location ---
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
jellyfin-edge_1  | --- End of stack trace from previous location ---
jellyfin-edge_1  |    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.IpBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.LanFilteringMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
jellyfin-edge_1  |    at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
jellyfin-edge_1  |    at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
jellyfin-edge_1  |    at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
jellyfin-edge_1  |    at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
jellyfin-edge_1  |    at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context)
jellyfin-edge_1  |    at Jellyfin.Server.Middleware.ExceptionMiddleware.Invoke(HttpContext context)
```