### PR TITLE
Added SeriesInfo to ItemFields enum

### DIFF
--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -220,6 +220,7 @@ namespace MediaBrowser.Model.Querying
         ExtraIds,
         LocalTrailerCount,
         IsHD,
-        SpecialFeatureCount
+        SpecialFeatureCount,
+        SeriesInfo
     }
 }


### PR DESCRIPTION
**Blocked as obsolete. Will submit pr post 10.7RC to remove from web. Details in this PR - which is why it's not closed.**

Added SeriesInfo to the itemField.cs enum.

Don't know what this does, if anything, apart from getting rid of the exception!

Was causing the following.

```
[2020-11-21 15:46:13.634 +00:00] [WRN] [18] Jellyfin.Api.ModelBinders.CommaDelimitedArrayModelBinder: Error converting value.
System.FormatException: SeriesInfo is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'SeriesInfo' was not found.
   at System.Enum.TryParseByName(RuntimeType enumType, String originalValueString, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, UInt64& result)
   at System.Enum.TryParseInt32Enum(RuntimeType enumType, String originalValueString, ReadOnlySpan`1 value, Int32 minInclusive, Int32 maxInclusive, Boolean ignoreCase, Boolean throwOnFailure, TypeCode type, Int32& result)
   at System.Enum.TryParse(Type enumType, String value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.Enum.Parse(Type enumType, String value, Boolean ignoreCase)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromString(String text)
   at Jellyfin.Api.ModelBinders.CommaDelimitedArrayModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in C:\Code\jellyfin\Jellyfin.Api\ModelBinders\CommaDelimitedArrayModelBinder.cs:line 67
```

and exists in 4 places in the web.