### PR TITLE
Convert ClientCapabilities to a Dto with JsonConverters

### DIFF
--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Api.Models.SessionDtos;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Devices;
 using MediaBrowser.Controller.Library;
@@ -412,14 +413,14 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public ActionResult PostFullCapabilities(
             [FromQuery] string? id,
-            [FromBody, Required] ClientCapabilities capabilities)
+            [FromBody, Required] ClientCapabilitiesDto capabilities)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
                 id = RequestHelpers.GetSession(_sessionManager, _authContext, Request).Id;
             }
 
-            _sessionManager.ReportCapabilities(id, capabilities);
+            _sessionManager.ReportCapabilities(id, capabilities.ToClientCapabilities());
 
             return NoContent();
         }

--- a/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
+++ b/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using MediaBrowser.Common.Json.Converters;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Session;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Api.Models.SessionDtos
+{
+    /// <summary>
+    /// Client capabilities dto.
+    /// </summary>
+    public class ClientCapabilitiesDto
+    {
+        /// <summary>
+        /// Gets or sets the list of playable media types.
+        /// </summary>
+        public IReadOnlyList<string> PlayableMediaTypes { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the list of supported commands.
+        /// </summary>
+        [JsonConverter(typeof(JsonCommaDelimitedArrayConverterFactory))]
+        public IReadOnlyList<GeneralCommandType> SupportedCommands { get; set; } = Array.Empty<GeneralCommandType>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether session supports media control.
+        /// </summary>
+        public bool SupportsMediaControl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether session supports content uploading.
+        /// </summary>
+        public bool SupportsContentUploading { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message callback url.
+        /// </summary>
+        public string? MessageCallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether session supports a persistent identifier.
+        /// </summary>
+        public bool SupportsPersistentIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether session supports sync.
+        /// </summary>
+        public bool SupportsSync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the device profile.
+        /// </summary>
+        public DeviceProfile? DeviceProfile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the app store url.
+        /// </summary>
+        public string? AppStoreUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon url.
+        /// </summary>
+        public string? IconUrl { get; set; }
+
+        /// <summary>
+        /// Convert the dto to the full <see cref="ClientCapabilities"/> model.
+        /// </summary>
+        /// <returns>The converted <see cref="ClientCapabilities"/> model.</returns>
+        public ClientCapabilities ToClientCapabilities()
+        {
+            return new ClientCapabilities
+            {
+                PlayableMediaTypes = PlayableMediaTypes,
+                SupportedCommands = SupportedCommands,
+                SupportsMediaControl = SupportsMediaControl,
+                SupportsContentUploading = SupportsContentUploading,
+                MessageCallbackUrl = MessageCallbackUrl,
+                SupportsPersistentIdentifier = SupportsPersistentIdentifier,
+                SupportsSync = SupportsSync,
+                DeviceProfile = DeviceProfile,
+                AppStoreUrl = AppStoreUrl,
+                IconUrl = IconUrl
+            };
+        }
+    }
+}

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -54,7 +55,7 @@ namespace MediaBrowser.Controller.Session
         /// Gets or sets the playable media types.
         /// </summary>
         /// <value>The playable media types.</value>
-        public string[] PlayableMediaTypes
+        public IReadOnlyList<string> PlayableMediaTypes
         {
             get
             {
@@ -230,7 +231,7 @@ namespace MediaBrowser.Controller.Session
         /// Gets or sets the supported commands.
         /// </summary>
         /// <value>The supported commands.</value>
-        public GeneralCommandType[] SupportedCommands
+        public IReadOnlyList<GeneralCommandType> SupportedCommands
             => Capabilities == null ? Array.Empty<GeneralCommandType>() : Capabilities.SupportedCommands;
 
         public Tuple<ISessionController, bool> EnsureController<T>(Func<SessionInfo, ISessionController> factory)

--- a/MediaBrowser.Model/Session/ClientCapabilities.cs
+++ b/MediaBrowser.Model/Session/ClientCapabilities.cs
@@ -2,15 +2,16 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using MediaBrowser.Model.Dlna;
 
 namespace MediaBrowser.Model.Session
 {
     public class ClientCapabilities
     {
-        public string[] PlayableMediaTypes { get; set; }
+        public IReadOnlyList<string> PlayableMediaTypes { get; set; }
 
-        public GeneralCommandType[] SupportedCommands { get; set; }
+        public IReadOnlyList<GeneralCommandType> SupportedCommands { get; set; }
 
         public bool SupportsMediaControl { get; set; }
 


### PR DESCRIPTION
The original `ClientCapabilities` couldn't access the converter so I copied it to a Dto.