### PR TITLE
Add NullableEnumModelBinder and NullableEnumModelBinderProvider

### DIFF
--- a/Jellyfin.Api/ModelBinders/NullableEnumModelBinder.cs
+++ b/Jellyfin.Api/ModelBinders/NullableEnumModelBinder.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Api.ModelBinders
+{
+    /// <summary>
+    /// Nullable enum model binder.
+    /// </summary>
+    public class NullableEnumModelBinder : IModelBinder
+    {
+        private readonly ILogger<NullableEnumModelBinder> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NullableEnumModelBinder"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of the <see cref="ILogger{NullableEnumModelBinder}"/> interface.</param>
+        public NullableEnumModelBinder(ILogger<NullableEnumModelBinder> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+            var elementType = bindingContext.ModelType.GetElementType() ?? bindingContext.ModelType.GenericTypeArguments[0];
+            var converter = TypeDescriptor.GetConverter(elementType);
+            if (valueProviderResult.Length != 0)
+            {
+                try
+                {
+                    var convertedValue = converter.ConvertFromString(valueProviderResult.FirstValue);
+                    bindingContext.Result = ModelBindingResult.Success(convertedValue);
+                }
+                catch (FormatException e)
+                {
+                    _logger.LogWarning(e, "Error converting value.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Jellyfin.Api/ModelBinders/NullableEnumModelBinderProvider.cs
+++ b/Jellyfin.Api/ModelBinders/NullableEnumModelBinderProvider.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Api.ModelBinders
+{
+    /// <summary>
+    /// Nullable enum model binder provider.
+    /// </summary>
+    public class NullableEnumModelBinderProvider : IModelBinderProvider
+    {
+        /// <inheritdoc />
+        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        {
+            var nullableType = Nullable.GetUnderlyingType(context.Metadata.ModelType);
+            if (nullableType == null || !nullableType.IsEnum)
+            {
+                // Type isn't nullable or isn't an enum.
+                return null;
+            }
+
+            var logger = context.Services.GetRequiredService<ILogger<NullableEnumModelBinder>>();
+            return new NullableEnumModelBinder(logger);
+        }
+    }
+}

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using Jellyfin.Api.Auth.LocalAccessPolicy;
 using Jellyfin.Api.Auth.RequiresElevationPolicy;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Controllers;
+using Jellyfin.Api.ModelBinders;
 using Jellyfin.Server.Configuration;
 using Jellyfin.Server.Filters;
 using Jellyfin.Server.Formatters;
@@ -169,6 +170,8 @@ namespace Jellyfin.Server.Extensions
 
                     opts.OutputFormatters.Add(new CssOutputFormatter());
                     opts.OutputFormatters.Add(new XmlOutputFormatter());
+
+                    opts.ModelBinderProviders.Insert(0, new NullableEnumModelBinderProvider());
                 })
 
                 // Clear app parts to avoid other assemblies being picked up


### PR DESCRIPTION
Enum values that are unknown are now set to `null` if the value doesn't exist and the enum is nullable instead of failing validation.