### PR TITLE
Optimize database scheduled task

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -131,9 +131,6 @@ namespace Emby.Server.Implementations.Data
 
             WriteConnection.Execute("PRAGMA temp_store=" + (int)TempStore);
 
-            // Configuration and pragmas can affect VACUUM so it needs to be last.
-            WriteConnection.Execute("VACUUM");
-
             return new ManagedConnection(WriteConnection, WriteLock);
         }
 

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -117,5 +117,7 @@
     "TaskRefreshChannels": "Refresh Channels",
     "TaskRefreshChannelsDescription": "Refreshes internet channel information.",
     "TaskDownloadMissingSubtitles": "Download missing subtitles",
-    "TaskDownloadMissingSubtitlesDescription": "Searches the internet for missing subtitles based on metadata configuration."
+    "TaskDownloadMissingSubtitlesDescription": "Searches the internet for missing subtitles based on metadata configuration.",
+    "TaskOptimizeDatabase": "Optimize database",
+    "TaskOptimizeDatabaseDescription": "Compacts database and truncates free space. Running this task after scanning the library or doing other changes that imply database modifications might improve performance."
 }

--- a/Emby.Server.Implementations/Localization/Core/es.json
+++ b/Emby.Server.Implementations/Localization/Core/es.json
@@ -118,5 +118,7 @@
     "TaskCleanActivityLog": "Limpiar registro de actividad",
     "Undefined": "Indefinido",
     "Forced": "Forzado",
-    "Default": "Predeterminado"
+    "Default": "Predeterminado",
+    "TaskOptimizeDatabase": "Optimizar la base de datos",
+    "TaskOptimizeDatabaseDescription": "Compacta y libera el espacio libre en la base de datos. Ejecutar esta tarea tras escanear la biblioteca o hacer cambios que impliquen modificaciones en la base de datos puede mejorar el rendimiento."
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabase.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabase.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using SQLitePCL.pretty;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks
+{
+    /// <summary>
+    /// Optimizes Jellyfin's database by issuing a VACUUM command.
+    /// </summary>
+    public class OptimizeDatabaseTask : IScheduledTask, IConfigurableScheduledTask
+    {
+        private readonly ILogger<OptimizeDatabaseTask> _logger;
+        private readonly ILocalizationManager _localization;
+        private readonly IServerApplicationPaths _paths;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptimizeDatabaseTask" /> class.
+        /// </summary>
+        public OptimizeDatabaseTask(
+            ILogger<OptimizeDatabaseTask> logger,
+            ILocalizationManager localization,
+            IServerApplicationPaths paths)
+        {
+            _logger = logger;
+            _localization = localization;
+            _paths = paths;
+        }
+
+        /// <inheritdoc />
+        public string Name => _localization.GetLocalizedString("TaskOptimizeDatabase");
+
+        /// <inheritdoc />
+        public string Description => _localization.GetLocalizedString("TaskOptimizeDatabaseDescription");
+
+        /// <inheritdoc />
+        public string Category => _localization.GetLocalizedString("TasksMaintenanceCategory");
+
+        /// <inheritdoc />
+        public string Key => "OptimizeDatabaseTask";
+
+        /// <inheritdoc />
+        public bool IsHidden => false;
+
+        /// <inheritdoc />
+        public bool IsEnabled => true;
+
+        /// <inheritdoc />
+        public bool IsLogged => true;
+
+        /// <summary>
+        /// Creates the triggers that define when the task will run.
+        /// </summary>
+        /// <returns>IEnumerable{BaseTaskTrigger}.</returns>
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return new[]
+            {
+                // Every so often
+                new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks }
+            };
+        }
+
+        /// <summary>
+        /// Returns the task to be executed.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="progress">The progress.</param>
+        /// <returns>Task.</returns>
+        public Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+        {
+            var dataPath = _paths.DataPath;
+            _logger.LogInformation("Issuing VACUUM command to jellyfin.db...");
+
+            try
+            {
+                using var connection = SQLite3.Open(Path.Combine(dataPath, "jellyfin.db"));
+                connection.Execute("VACUUM;");
+                _logger.LogInformation("jellyfin.db vacuumed successfully!");
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error while vacuuming jellyfin.db");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Before, we ran VACUUM at each start (#1455). Although it solved the problem partially, it isn't the best solution for long-running instances. It also freezes the boot process for a while and it can hang it altogether, in case the filesystem is running out of space.

With a scheduled task, this can be ran periodically at user demand, while also keeping server running in case of any error.

**I tested this while running scanning tasks and browsing the library with multiple users and I've never hit any concurrency issue**

### Additional details

* Although this might pose a concurrency problem, our current journaling mode and the fact that library is still in it's own database should not cause any issues **in case we want this for 10.7**.
* In addition to this, I've been testing vacuuming in different connections with my pi-hole instance multiple times this week: 

1. I replicated the pragmas used by Jellyfin.
2. Ran a DNS benchmark (so database got plenty of activity)
3. Connected using ``sqlite3`` cli and issued VACUUM command.

I tried multiple combinations of this and **nver had a single issue**. I read also a lot of the documentation and I got to the conclusion that, as long as there's **one connection that handles transactions** and **one connection that runs vacuum without a transaction**, everything is fine atomic-wise. Anyway, **I'm leaving library.db as it's going to be deprecated sooner than later and it's better to stay in the safe side**.

* I wanted to use EFCore for this but database context is not accesible outside Jellyfin namespace. Anyway, I don't think doing it directly with SQLitePCL is such a bad idea as, once support for other backends is added, we would need to set a check so this trigger only works in SQLite backends. With SQLitePCL we have this done already.