### PR TITLE
If baseurl is not set, redirect relatively on the initial web/index.html redirect

### DIFF
--- a/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
@@ -54,7 +54,8 @@ namespace Jellyfin.Server.Middleware
                 // Always redirect back to the default path if the base prefix is invalid or missing
                 _logger.LogDebug("Normalizing an URL at {LocalPath}", localPath);
 
-                if (string.IsNullOrWhiteSpace(baseUrlPrefix)) {
+                if (string.IsNullOrWhiteSpace(baseUrlPrefix))
+                {
                     baseUrlPrefix = ".";
                 }
 

--- a/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
@@ -53,6 +53,11 @@ namespace Jellyfin.Server.Middleware
             {
                 // Always redirect back to the default path if the base prefix is invalid or missing
                 _logger.LogDebug("Normalizing an URL at {LocalPath}", localPath);
+
+                if (string.IsNullOrWhiteSpace(baseUrlPrefix)) {
+                    baseUrlPrefix = ".";
+                }
+
                 httpContext.Response.Redirect(baseUrlPrefix + "/" + _configuration[ConfigurationExtensions.DefaultRedirectKey]);
                 return;
             }


### PR DESCRIPTION
This fixes the redirect failure when nginx is doing baseurl magic while Jellyfin is unaware.
(regression from then baseurl was first introduced in server)