### PR TITLE
Revert "Fix frame rate probing for interlaced MKV files"

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -666,16 +666,6 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.AverageFrameRate = GetFrameRate(streamInfo.AverageFrameRate);
                 stream.RealFrameRate = GetFrameRate(streamInfo.RFrameRate);
 
-                // Interlaced video streams in Matroska containers return the field rate instead of the frame rate
-                // as both the average and real frame rate, so we half the returned frame rates to get the correct values
-                //
-                // https://gitlab.com/mbunkus/mkvtoolnix/-/wikis/Wrong-frame-rate-displayed
-                if (stream.IsInterlaced && formatInfo.FormatName.Contains("matroska", StringComparison.OrdinalIgnoreCase))
-                {
-                    stream.AverageFrameRate /= 2;
-                    stream.RealFrameRate /= 2;
-                }
-
                 if (isAudio || string.Equals(stream.Codec, "gif", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(stream.Codec, "png", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
**Changes**
This reverts the change I made in #4369.

On further testing I've descovered that while the fix corrected the displayed frame rate for some interlaced MKV files (mainly recorded from broadcast TV), it also incorrectly halfed the displayed frame rate for some others (mainly encoded by FFmpeg/x264).

I also discovered that for the "fixed" files, with double rate deinterlacing enabled FFmpeg is really dumb and will double the rate based on the it's incorrectly reported frame rate. So for example a 50i file is deinterlaced to 100fps, not 50fps as intended. Reverting this fix prevents that and results in a deinterlaced file at a sensible/correct frame rate, just with double rate disabled.

As the first fix creates more bugs than it fixes, I feel it's best to revert it for now until there's a better fix (which may have to be in FFmpeg, not Jellyfin). #4314 should also be reopened.