### PR TITLE
Enable jellyfin.service unit on Fedora fresh install

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -127,6 +127,9 @@ if [ $1 -gt 1 ] ; then
     if [ "${service_state}" = "active" ]; then
         systemctl start jellyfin.service
     fi
+    if [ "${service_state}" != "active" ]; then
+        systemctl enable jellyfin.service
+    fi
 fi
 %systemd_post jellyfin.service
 

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -129,7 +129,7 @@ if [ $1 -gt 1 ] ; then
     fi
     if [ $1 -eq 1 ]; then
         # On fresh install only, enable the jellyfin.service unit
-        systemctl enable jellyfin.service
+        systemctl enable --now jellyfin.service
     fi
 fi
 %systemd_post jellyfin.service

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -127,7 +127,8 @@ if [ $1 -gt 1 ] ; then
     if [ "${service_state}" = "active" ]; then
         systemctl start jellyfin.service
     fi
-    if [ "${service_state}" != "active" ]; then
+    if [ $1 -eq 1 ]; then
+        # On fresh install only, enable the jellyfin.service unit
         systemctl enable jellyfin.service
     fi
 fi


### PR DESCRIPTION
**Changes**
On a fresh install (`%pre $1` of exactly 1), enable the `jellyfin.service` systemd unit.

Ref: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax

**Issues**
Fixes #4552 