### PR TITLE
Run explicit service start if restart failed

### DIFF
--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
+        sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start" | at now 
+        sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start
         ;;
     'sysv')
-        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
+        sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start
         ;;
 esac
 exit 0

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart" | at now 
+        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start" | at now 
         ;;
     'sysv')
-        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now 
+        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
         ;;
 esac
 exit 0

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin
+        echo "sleep 0.5; /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
         ;;
     'service')
-        sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start
+        echo "sleep 0.5; /usr/bin/sudo $( which service ) jellyfin start" | at now 
         ;;
     'sysv')
-        sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start
+        echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
         ;;
 esac
 exit 0

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -40,7 +40,7 @@ Jellyfin is a free software media system that puts you in control of managing an
 Summary:        The Free Software Media System Server backend
 Requires(pre):  shadow-utils
 Requires:       ffmpeg
-Requires:       libcurl, fontconfig, freetype, openssl, glibc libicu
+Requires:       libcurl, fontconfig, freetype, openssl, glibc, libicu, at
 
 %description server
 The Jellyfin media server backend.

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
+        sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start" | at now 
+        sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start
         ;;
     'sysv')
-        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
+        sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start
         ;;
 esac
 exit 0

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin
+        echo "sleep 0.5; /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
         ;;
     'service')
-        sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start
+        echo "sleep 0.5; /usr/bin/sudo $( which service ) jellyfin start" | at now 
         ;;
     'sysv')
-        sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start
+        echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
         ;;
 esac
 exit 0

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -24,13 +24,13 @@ cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin" | at now
+        echo "sleep 2; /usr/bin/sudo $( which systemctl ) restart jellyfin || /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart" | at now
+        echo "sleep 2; /usr/bin/sudo $( which service ) jellyfin restart || /usr/bin/sudo $( which service ) jellyfin start" | at now 
         ;;
     'sysv')
-        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart" | at now
+        echo "sleep 2; /usr/bin/sudo /etc/init.d/jellyfin restart || /usr/bin/sudo /etc/init.d/jellyfin start" | at now 
         ;;
 esac
 exit 0


### PR DESCRIPTION
**Changes**
Should solve the occasional bugs with the restart in the WebUI.
Sometimes the service stops and then doesn't start again; this will run
an explicit start action afterwards. If this doesn't fix it I'm certain
there would be more tweaking that can be done.

Also remove the `at now` hackery; whether this works or not I'm
not certain, but is worth a test. I shall do so.

**Issues**
Fixes #4016 
