### PR TITLE
Don't send activity event if notification type is null

### DIFF
--- a/Jellyfin.Server.Implementations/Events/Consumers/Session/PlaybackStopLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Session/PlaybackStopLogger.cs
@@ -59,6 +59,12 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Session
 
             var user = eventArgs.Users[0];
 
+            var notificationType = GetPlaybackStoppedNotificationType(item.MediaType);
+            if (notificationType == null)
+            {
+                return;
+            }
+
             await _activityManager.CreateAsync(new ActivityLog(
                     string.Format(
                         CultureInfo.InvariantCulture,
@@ -66,7 +72,7 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Session
                         user.Username,
                         GetItemName(item),
                         eventArgs.DeviceName),
-                    GetPlaybackStoppedNotificationType(item.MediaType),
+                    notificationType,
                     user.Id))
                 .ConfigureAwait(false);
         }


### PR DESCRIPTION
Fixes 
```
Nov 23 03:41:15 1070L jellyfin[5399]: [03:41:15] [ERR] Jellyfin.Server.Implementations.Events.EventManager: Uncaught exception in EventConsumer Jellyfin.Server.Implementations.Events.Consumers.Session.PlaybackStopLogger:
Nov 23 03:41:15 1070L jellyfin[5399]: System.ArgumentNullException: Value cannot be null. (Parameter 'type')
Nov 23 03:41:15 1070L jellyfin[5399]:    at Jellyfin.Data.Entities.ActivityLog..ctor(String name, String type, Guid userId)
Nov 23 03:41:15 1070L jellyfin[5399]:    at Jellyfin.Server.Implementations.Events.Consumers.Session.PlaybackStopLogger.OnEvent(PlaybackStopEventArgs eventArgs)
Nov 23 03:41:15 1070L jellyfin[5399]:    at Jellyfin.Server.Implementations.Events.EventManager.PublishInternal[T](T eventArgs)
```