### PR TITLE
Networking PR 2: Move AddressOverrideKey into StartupOptions.cs

### DIFF
--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -28,7 +28,7 @@ namespace Emby.Server.Implementations.Udp
         /// Address Override Configuration Key. (Removed later)
         /// </summary>
         private const string AddressOverrideConfigKey = "PublishedServerUrl";
-        
+
         private Socket _udpSocket;
         private IPEndPoint _endpoint;
         private readonly byte[] _receiveBuffer = new byte[8192];

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -24,6 +24,11 @@ namespace Emby.Server.Implementations.Udp
         private readonly IServerApplicationHost _appHost;
         private readonly IConfiguration _config;
 
+        /// <summary>
+        /// Address Override Configuration Key. (Removed later)
+        /// </summary>
+        private const string AddressOverrideConfigKey = "PublishedServerUrl";
+        
         private Socket _udpSocket;
         private IPEndPoint _endpoint;
         private readonly byte[] _receiveBuffer = new byte[8192];

--- a/Emby.Server.Implementations/Udp/UdpServer.cs
+++ b/Emby.Server.Implementations/Udp/UdpServer.cs
@@ -24,11 +24,6 @@ namespace Emby.Server.Implementations.Udp
         private readonly IServerApplicationHost _appHost;
         private readonly IConfiguration _config;
 
-        /// <summary>
-        /// Address Override Configuration Key.
-        /// </summary>
-        public const string AddressOverrideConfigKey = "PublishedServerUrl";
-
         private Socket _udpSocket;
         private IPEndPoint _endpoint;
         private readonly byte[] _receiveBuffer = new byte[8192];

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -94,7 +94,7 @@ namespace Jellyfin.Server
 
             if (PublishedServerUrl != null)
             {
-                config.Add(UdpServer.AddressOverrideConfigKey, PublishedServerUrl.ToString());
+                config.Add(ConfigurationExtensions.AddressOverrideConfigKey, PublishedServerUrl.ToString());
             }
 
             if (FFmpegPath != null)

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using CommandLine;
 using Emby.Server.Implementations;
 using Emby.Server.Implementations.EntryPoints;
-using Emby.Server.Implementations.Udp;
 using Emby.Server.Implementations.Updates;
 using MediaBrowser.Controller.Extensions;
 

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -50,6 +50,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string UnixSocketPathKey = "kestrel:socketPath";
 
         /// <summary>
+        /// The key for a setting that overrides the address used in responses.
+        /// </summary>
+        public const string AddressOverrideConfigKey = "PublishedServerUrl";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>


### PR DESCRIPTION
No functional change and no new functionality. Just tidying up code and making it standard.

Move AddressOverrideKey constant containing the string "PublishedServerUrl" from the Udpserver class, and into the ConfigurationExtensions class where the rest of the startup options are.

UdpServer class is being removed as part of DLNA plugin.