### PR TITLE
Revert "Enable jellyfin.service unit on Fedora fresh install"

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -127,10 +127,6 @@ if [ $1 -gt 1 ] ; then
     if [ "${service_state}" = "active" ]; then
         systemctl start jellyfin.service
     fi
-    if [ $1 -eq 1 ]; then
-        # On fresh install only, enable the jellyfin.service unit
-        systemctl enable --now jellyfin.service
-    fi
 fi
 %systemd_post jellyfin.service
 


### PR DESCRIPTION
Reverts jellyfin/jellyfin#4553

Apparently this is bad form in the Fedora ecosystem.