### PR TITLE
[Fix] DLNA BROWSE issues.

### DIFF
--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -408,7 +408,7 @@ namespace Emby.Dlna.ContentDirectory
 
                             if (childItem.IsDisplayedAsFolder || displayStubType.HasValue)
                             {
-                                var childCount = GetUserItems(childItem, displayStubType, _user, sortCriteria, null, 0)
+                                var childCount = GetUserItems(childItem, displayStubType, _user, sortCriteria, null, requestedCount)
                                     .TotalRecordCount;
 
                                 _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCount, filter);
@@ -907,6 +907,16 @@ namespace Emby.Dlna.ContentDirectory
                     StubType = StubType.Genres
                 }
             };
+
+            // If Limit is < 6 then we return too many items, so we must remove some.
+            if (limit != null && limit < array.Length)
+            {
+                return new QueryResult<ServerItem>
+                {
+                    Items = array.ToArray().Take((int)limit).ToList(),
+                    TotalRecordCount = (int)limit
+                };
+            }
 
             return new QueryResult<ServerItem>
             {

--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -913,8 +913,8 @@ namespace Emby.Dlna.ContentDirectory
             {
                 return new QueryResult<ServerItem>
                 {
-                    Items = array.ToArray().Take((int)limit).ToList(),
-                    TotalRecordCount = (int)limit
+                    Items = array.Take(limit.Value).ToList(),
+                    TotalRecordCount = limit.Value
                 };
             }
 

--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -908,7 +908,7 @@ namespace Emby.Dlna.ContentDirectory
                 }
             };
 
-            // If Limit is < 6 then we return too many items, so we must remove some.
+            // At this point, array contains six items. If Limit is < 6 then we return too many items, so the extra must be removed.
             if (limit != null && limit < array.Length)
             {
                 return new QueryResult<ServerItem>

--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -909,7 +909,7 @@ namespace Emby.Dlna.ContentDirectory
             };
 
             // At this point, array contains six items. If Limit is < 6 then we return too many items, so the extra must be removed.
-            if (limit != null && limit < array.Length)
+            if (limit < array.Length)
             {
                 return new QueryResult<ServerItem>
                 {

--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -714,121 +714,64 @@ namespace Emby.Dlna.ContentDirectory
         /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
         private QueryResult<ServerItem> GetMusicFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
         {
-            var query = new InternalItemsQuery(user)
+            if (stubType.HasValue)
             {
-                StartIndex = startIndex,
-                Limit = limit
-            };
-            SetSorting(query, sort, false);
-
-            if (stubType.HasValue && stubType.Value == StubType.Latest)
-            {
-                return GetMusicLatest(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Playlists)
-            {
-                return GetMusicPlaylists(user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Albums)
-            {
-                return GetMusicAlbums(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Artists)
-            {
-                return GetMusicArtists(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.AlbumArtists)
-            {
-                return GetMusicAlbumArtists(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.FavoriteAlbums)
-            {
-                return GetFavoriteAlbums(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.FavoriteArtists)
-            {
-                return GetFavoriteArtists(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.FavoriteSongs)
-            {
-                return GetFavoriteSongs(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Songs)
-            {
-                return GetMusicSongs(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Genres)
-            {
-                return GetMusicGenres(item, user, query);
-            }
-
-            var list = new List<ServerItem>
-            {
-                new ServerItem(item)
+                var query = new InternalItemsQuery(user)
                 {
-                    StubType = StubType.Latest
-                },
+                    StartIndex = startIndex,
+                    Limit = limit
+                };
 
-                new ServerItem(item)
-                {
-                    StubType = StubType.Playlists
-                },
+                SetSorting(query, sort, false);
 
-                new ServerItem(item)
+                switch (stubType.Value)
                 {
-                    StubType = StubType.Albums
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.AlbumArtists
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.Artists
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.Songs
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.Genres
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.FavoriteArtists
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.FavoriteAlbums
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.FavoriteSongs
+                    case StubType.Latest:
+                        return GetMusicLatest(item, user, query);
+                    case StubType.Playlists:
+                        return GetMusicPlaylists(user, query);
+                    case StubType.Albums:
+                        return GetMusicAlbums(item, user, query);
+                    case StubType.Artists:
+                        return GetMusicArtists(item, user, query);
+                    case StubType.AlbumArtists:
+                        return GetMusicAlbumArtists(item, user, query);
+                    case StubType.FavoriteAlbums:
+                        return GetFavoriteAlbums(item, user, query);
+                    case StubType.FavoriteArtists:
+                        return GetFavoriteArtists(item, user, query);
+                    case StubType.FavoriteSongs:
+                        return GetFavoriteSongs(item, user, query);
+                    case StubType.Songs:
+                        return GetMusicSongs(item, user, query);
+                    case StubType.Genres:
+                        return GetMusicGenres(item, user, query);
+                    default:
+                        Logger.LogError("GetMusicFolder received request for content type {StubType}:", stubType.Value);
+                        break;
                 }
-            };
+            }
 
-            return new QueryResult<ServerItem>
+            var items = new[]
+                {
+                    new ServerItem(item, StubType.Latest),
+                    new ServerItem(item, StubType.Playlists),
+                    new ServerItem(item, StubType.Albums),
+                    new ServerItem(item, StubType.AlbumArtists),
+                    new ServerItem(item, StubType.Artists),
+                    new ServerItem(item, StubType.Songs),
+                    new ServerItem(item, StubType.Genres),
+                    new ServerItem(item, StubType.FavoriteArtists),
+                    new ServerItem(item, StubType.FavoriteAlbums),
+                    new ServerItem(item, StubType.FavoriteSongs)
+                };
+
+            if (limit.HasValue)
             {
-                Items = list,
-                TotalRecordCount = list.Count
-            };
+                return new QueryResult<ServerItem>(items.Take(limit.Value).ToArray());
+            }
+
+            return new QueryResult<ServerItem>(items);
         }
 
         /// <summary>
@@ -843,86 +786,52 @@ namespace Emby.Dlna.ContentDirectory
         /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
         private QueryResult<ServerItem> GetMovieFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
         {
-            var query = new InternalItemsQuery(user)
+            if (stubType.HasValue)
             {
-                StartIndex = startIndex,
-                Limit = limit
-            };
-            SetSorting(query, sort, false);
-
-            if (stubType.HasValue && stubType.Value == StubType.ContinueWatching)
-            {
-                return GetMovieContinueWatching(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Latest)
-            {
-                return GetMovieLatest(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Movies)
-            {
-                return GetMovieMovies(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Collections)
-            {
-                return GetMovieCollections(user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Favorites)
-            {
-                return GetMovieFavorites(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Genres)
-            {
-                return GetGenres(item, user, query);
-            }
-
-            var array = new[]
-            {
-                new ServerItem(item)
+                var query = new InternalItemsQuery(user)
                 {
-                    StubType = StubType.ContinueWatching
-                },
-                new ServerItem(item)
-                {
-                    StubType = StubType.Latest
-                },
-                new ServerItem(item)
-                {
-                    StubType = StubType.Movies
-                },
-                new ServerItem(item)
-                {
-                    StubType = StubType.Collections
-                },
-                new ServerItem(item)
-                {
-                    StubType = StubType.Favorites
-                },
-                new ServerItem(item)
-                {
-                    StubType = StubType.Genres
-                }
-            };
-
-            // At this point, array contains six items. If Limit is < 6 then we return too many items, so the extra must be removed.
-            if (limit < array.Length)
-            {
-                return new QueryResult<ServerItem>
-                {
-                    Items = array.Take(limit.Value).ToList(),
-                    TotalRecordCount = limit.Value
+                    StartIndex = startIndex,
+                    Limit = limit
                 };
+
+                SetSorting(query, sort, false);
+
+                switch (stubType.Value)
+                {
+                    case StubType.ContinueWatching:
+                        return GetMovieContinueWatching(item, user, query);
+                    case StubType.Latest:
+                        return GetMovieLatest(item, user, query);
+                    case StubType.Movies:
+                        return GetMovieMovies(item, user, query);
+                    case StubType.Collections:
+                        return GetMovieCollections(user, query);
+                    case StubType.Favorites:
+                        return GetMovieFavorites(item, user, query);
+                    case StubType.Genres:
+                        return GetGenres(item, user, query);
+                    default:
+                        Logger.LogError("GetMovieFolders received request for content type {StubType}:", stubType.Value);
+                        break;
+                }
             }
 
-            return new QueryResult<ServerItem>
+            var items = new[]
+                {
+                    new ServerItem(item, StubType.ContinueWatching),
+                    new ServerItem(item, StubType.Latest),
+                    new ServerItem(item, StubType.Movies),
+                    new ServerItem(item, StubType.Collections),
+                    new ServerItem(item, StubType.Favorites),
+                    new ServerItem(item, StubType.Genres)
+                };
+
+            if (limit.HasValue)
             {
-                Items = array,
-                TotalRecordCount = array.Length
-            };
+                return new QueryResult<ServerItem>(items.Take(limit.Value).ToArray());
+            }
+
+            return new QueryResult<ServerItem>(items);
         }
 
         /// <summary>
@@ -936,10 +845,7 @@ namespace Emby.Dlna.ContentDirectory
         {
             var folders = _libraryManager.GetUserRootFolder().GetChildren(user, true)
                 .OrderBy(i => i.SortName)
-                .Select(i => new ServerItem(i)
-                {
-                    StubType = StubType.Folder
-                })
+                .Select(i => new ServerItem(i, StubType.Folder))
                 .ToArray();
 
             return ApplyPaging(
@@ -964,91 +870,55 @@ namespace Emby.Dlna.ContentDirectory
         /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
         private QueryResult<ServerItem> GetTvFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
         {
-            var query = new InternalItemsQuery(user)
+            if (stubType.HasValue)
             {
-                StartIndex = startIndex,
-                Limit = limit
-            };
-            SetSorting(query, sort, false);
-
-            if (stubType.HasValue && stubType.Value == StubType.ContinueWatching)
-            {
-                return GetMovieContinueWatching(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.NextUp)
-            {
-                return GetNextUp(item, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Latest)
-            {
-                return GetTvLatest(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Series)
-            {
-                return GetSeries(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.FavoriteSeries)
-            {
-                return GetFavoriteSeries(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.FavoriteEpisodes)
-            {
-                return GetFavoriteEpisodes(item, user, query);
-            }
-
-            if (stubType.HasValue && stubType.Value == StubType.Genres)
-            {
-                return GetGenres(item, user, query);
-            }
-
-            var list = new List<ServerItem>
-            {
-                new ServerItem(item)
+                var query = new InternalItemsQuery(user)
                 {
-                    StubType = StubType.ContinueWatching
-                },
+                    StartIndex = startIndex,
+                    Limit = limit
+                };
 
-                new ServerItem(item)
-                {
-                    StubType = StubType.NextUp
-                },
+                SetSorting(query, sort, false);
 
-                new ServerItem(item)
+                switch (stubType.Value)
                 {
-                    StubType = StubType.Latest
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.Series
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.FavoriteSeries
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.FavoriteEpisodes
-                },
-
-                new ServerItem(item)
-                {
-                    StubType = StubType.Genres
+                    case StubType.ContinueWatching:
+                        return GetMovieContinueWatching(item, user, query);
+                    case StubType.NextUp:
+                        return GetNextUp(item, query);
+                    case StubType.Latest:
+                        return GetTvLatest(item, user, query);
+                    case StubType.Series:
+                        return GetSeries(item, user, query);
+                    case StubType.FavoriteSeries:
+                        return GetFavoriteSeries(item, user, query);
+                    case StubType.FavoriteEpisodes:
+                        return GetFavoriteEpisodes(item, user, query);
+                    case StubType.Genres:
+                        return GetGenres(item, user, query);
+                    default:
+                        Logger.LogError("GetTvFolder received request for content type {StubType}:", stubType.Value);
+                        break;
                 }
-            };
+            }
 
-            return new QueryResult<ServerItem>
+            var items = new[]
+                {
+                    new ServerItem(item, StubType.ContinueWatching),
+                    new ServerItem(item, StubType.NextUp),
+                    new ServerItem(item, StubType.Latest),
+                    new ServerItem(item, StubType.Series),
+                    new ServerItem(item, StubType.FavoriteSeries),
+                    new ServerItem(item, StubType.FavoriteEpisodes),
+                    new ServerItem(item, StubType.Genres)
+                };
+
+            if (limit.HasValue)
             {
-                Items = list,
-                TotalRecordCount = list.Count
-            };
+                return new QueryResult<ServerItem>(items.Take(limit.Value).ToArray());
+            }
+
+            return new QueryResult<ServerItem>(items);
         }
 
         /// <summary>
@@ -1121,8 +991,8 @@ namespace Emby.Dlna.ContentDirectory
         /// <summary>
         /// Returns the Movie collections meeting the criteria.
         /// </summary>
-        /// <param name="user">The see cref="User"/>.</param>
-        /// <param name="query">The see cref="InternalItemsQuery"/>.</param>
+        /// <param name="user">The <see cref="User"/>.</param>
+        /// <param name="query">The <see cref="InternalItemsQuery"/>.</param>
         /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
         private QueryResult<ServerItem> GetMovieCollections(User user, InternalItemsQuery query)
         {
@@ -1716,15 +1586,13 @@ namespace Emby.Dlna.ContentDirectory
                 id = parts[23];
             }
 
-            var enumNames = Enum.GetNames(typeof(StubType));
-            foreach (var name in enumNames)
+            var special = id.Split('_', 2);
+            if (special.Length == 2)
             {
-                if (id.StartsWith(name + "_", StringComparison.OrdinalIgnoreCase))
+                if (Enum.TryParse(typeof(StubType), special[0], true, out object result))
                 {
-                    stubType = Enum.Parse<StubType>(name, true);
-                    id = id.Split('_', 2)[1];
-
-                    break;
+                    id = special[1];
+                    stubType = (StubType)result;
                 }
             }
 
@@ -1732,10 +1600,7 @@ namespace Emby.Dlna.ContentDirectory
             {
                 var item = _libraryManager.GetItemById(itemId);
 
-                return new ServerItem(item)
-                {
-                    StubType = stubType
-                };
+                return new ServerItem(item, stubType);
             }
 
             Logger.LogError("Error parsing item Id: {Id}. Returning user root folder.", id);

--- a/Emby.Dlna/ContentDirectory/ServerItem.cs
+++ b/Emby.Dlna/ContentDirectory/ServerItem.cs
@@ -24,6 +24,17 @@ namespace Emby.Dlna.ContentDirectory
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ServerItem"/> class.
+        /// </summary>
+        /// <param name="item">The <see cref="BaseItem"/>.</param>
+        /// <param name="stubType">The <see cref="StubType"/>.</param>
+        public ServerItem(BaseItem item, StubType stubType)
+        {
+            Item = item;
+            StubType = stubType;
+        }
+
+        /// <summary>
         /// Gets or sets the underlying base item.
         /// </summary>
         public BaseItem Item { get; set; }

--- a/Emby.Dlna/ContentDirectory/ServerItem.cs
+++ b/Emby.Dlna/ContentDirectory/ServerItem.cs
@@ -28,7 +28,7 @@ namespace Emby.Dlna.ContentDirectory
         /// </summary>
         /// <param name="item">The <see cref="BaseItem"/>.</param>
         /// <param name="stubType">The <see cref="StubType"/>.</param>
-        public ServerItem(BaseItem item, StubType stubType)
+        public ServerItem(BaseItem item, StubType? stubType)
         {
             Item = item;
             StubType = stubType;

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -653,10 +653,10 @@ namespace Emby.Dlna.Didl
                 writer.WriteAttributeString("id", clientId);
 
                 var parent = folder.DisplayParentId;
-                if (stubType != StubType.ContinueWatching)
+                if (stubType == StubType.ContinueWatching)
                 {
                     // Continue watching, parent is it's normal self.
-                    writer.WriteAttributeString("parentID", folder.Id.ToString());
+                    writer.WriteAttributeString("parentID", folder.Id.ToString("N", CultureInfo.InvariantCulture));
                 }
                 else if (parent.Equals(Guid.Empty)
                     || folder.Parent.IsRoot

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -1151,7 +1151,7 @@ namespace Emby.Dlna.Didl
             int? width = imageInfo.Width;
             int? height = imageInfo.Height;
 
-            if (width <= 1 || height <= 1)
+            if (width <= 0 || height <= 0)
             {
                 width = null;
                 height = null;

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -653,10 +653,16 @@ namespace Emby.Dlna.Didl
                 writer.WriteAttributeString("id", clientId);
 
                 var parent = folder.DisplayParentId;
-                if (parent.Equals(Guid.Empty)
+                if (stubType != StubType.ContinueWatching)
+                {
+                    // Continue watching, parent is it's normal self.
+                    writer.WriteAttributeString("parentID", folder.Id.ToString());
+                }
+                else if (parent.Equals(Guid.Empty)
                     || folder.Parent.IsRoot
                     || folder.Parent.DisplayParentId.Equals(Guid.Empty))
                 {
+                    // Override user roots that have parent values. We can't go any higher.
                     writer.WriteAttributeString("parentID", "0");
                 }
                 else if (context != null)

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -622,6 +622,11 @@ namespace Emby.Dlna.Didl
             writer.WriteFullEndElement();
         }
 
+        /// <summary>
+        /// Return true if the <paramref name="id">id</paramref> is a root item.
+        /// </summary>
+        /// <param name="id">The id to search for.</param>
+        /// <returns>Result of the operation.</returns>
         public static bool IsIdRoot(string id)
             => string.IsNullOrWhiteSpace(id)
                 || string.Equals(id, "0", StringComparison.OrdinalIgnoreCase)
@@ -647,21 +652,20 @@ namespace Emby.Dlna.Didl
             {
                 writer.WriteAttributeString("id", clientId);
 
-                if (context != null)
+                var parent = folder.DisplayParentId;
+                if (parent.Equals(Guid.Empty)
+                    || folder.Parent.IsRoot
+                    || folder.Parent.DisplayParentId.Equals(Guid.Empty))
+                {
+                    writer.WriteAttributeString("parentID", "0");
+                }
+                else if (context != null)
                 {
                     writer.WriteAttributeString("parentID", GetClientId(context, null));
                 }
                 else
                 {
-                    var parent = folder.DisplayParentId;
-                    if (parent.Equals(Guid.Empty))
-                    {
-                        writer.WriteAttributeString("parentID", "0");
-                    }
-                    else
-                    {
-                        writer.WriteAttributeString("parentID", GetClientId(parent, null));
-                    }
+                    writer.WriteAttributeString("parentID", GetClientId(parent, null));
                 }
             }
 

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -442,7 +442,7 @@ namespace Emby.Dlna.Didl
         /// </summary>
         /// <remarks>
         /// If context is a season, this will return a string containing just episode number and name.
-        /// Otherwise the result will include series nams and season number.
+        /// Otherwise the result will include series names and season number.
         /// </remarks>
         /// <param name="episode">The episode.</param>
         /// <param name="context">Current context.</param>
@@ -1151,12 +1151,7 @@ namespace Emby.Dlna.Didl
             int? width = imageInfo.Width;
             int? height = imageInfo.Height;
 
-            if (width == 0 || height == 0)
-            {
-                width = null;
-                height = null;
-            }
-            else if (width == -1 || height == -1)
+            if (width <= 1 || height <= 1)
             {
                 width = null;
                 height = null;

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -479,7 +479,6 @@ namespace MediaBrowser.Controller.Entities
             }
 
             var itemsArray = totalRecordLimit.HasValue ? items.Take(totalRecordLimit.Value).ToArray() : items.ToArray();
-            var totalCount = itemsArray.Length;
 
             if (query.Limit.HasValue)
             {
@@ -489,6 +488,8 @@ namespace MediaBrowser.Controller.Entities
             {
                 itemsArray = itemsArray.Skip(query.StartIndex.Value).ToArray();
             }
+
+            var totalCount = itemsArray.Length;
 
             return new QueryResult<BaseItem>
             {


### PR DESCRIPTION
The Developer Tools for UPnP™ Technology's Device Validator reports up various errors when asked to the DLNA server. 
This PR contains the fixes to resolve these errors.

**Issue 1:**
Issuing a BROWSE browsemeta request against the DLNA server, when the item is the media folder of a user profile, returns a parent item and not 0 (it should be treated as a root item). I assume this code was written before user profiles.
**Fixed** This PR fixes this issue returning the correct value of 0.

**Issue 2:**
"Browse All": Browse("f137a2dd21bbc1b99aa5c0f6bf02a805", BROWSEDIRECTCHILDREN, "*", 0, 1, "") did not yield exactly one CDS-compliant media object in its result. Instantiated a total of 6 media objects.
**Fixed** The correct number of items are returned.

**Issue 3:**
"Browse All": Browse("continuewatching_f137a2dd21bbc1b99aa5c0f6bf02a805", BROWSEMETADATA, "*", 0, 0, "") returned a DIDL-Lite media object with parentID="0" when it should be "f137a2dd21bbc1b99aa5c0f6bf02a805".
**Fixed** Continue Watching's parent is now the top level folder.