### PR TITLE
Don't return first episodes in next up

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -146,23 +146,10 @@ namespace Emby.Server.Implementations.TV
             var allNextUp = seriesKeys
                 .Select(i => GetNextUp(i, currentUser, dtoOptions));
 
-            // allNextUp = allNextUp.OrderByDescending(i => i.Item1);
-
-            // If viewing all next up for all series, remove first episodes
-            // But if that returns empty, keep those first episodes (avoid completely empty view)
-            var alwaysEnableFirstEpisode = !string.IsNullOrEmpty(request.SeriesId);
-            var anyFound = false;
-
             return allNextUp
                 .Where(i =>
                 {
-                    if (alwaysEnableFirstEpisode || i.Item1 != DateTime.MinValue)
-                    {
-                        anyFound = true;
-                        return true;
-                    }
-
-                    if (!anyFound && i.Item1 == DateTime.MinValue)
+                    if (i.Item1 != DateTime.MinValue)
                     {
                         return true;
                     }

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -149,12 +149,7 @@ namespace Emby.Server.Implementations.TV
             return allNextUp
                 .Where(i =>
                 {
-                    if (i.Item1 != DateTime.MinValue)
-                    {
-                        return true;
-                    }
-
-                    return false;
+                    return i.Item1 != DateTime.MinValue;
                 })
                 .Select(i => i.Item2())
                 .Where(i => i != null);


### PR DESCRIPTION
**Changes**

This removes the weird behavior where GetNextUp will return first episodes of shows if there is no series in progress.

The rationale is that we shouldn't assume something is next up in queue if it hasn't been started yet.

No changes needed in jellyfin-web, since the section will hide if empty.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
