### PR TITLE
Allow JsonGuidConverter to read null

### DIFF
--- a/MediaBrowser.Common/Json/Converters/JsonGuidConverter.cs
+++ b/MediaBrowser.Common/Json/Converters/JsonGuidConverter.cs
@@ -11,7 +11,11 @@ namespace MediaBrowser.Common.Json.Converters
     {
         /// <inheritdoc />
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => new Guid(reader.GetString());
+        {
+            var guidStr = reader.GetString();
+
+            return guidStr == null ? Guid.Empty : new Guid(guidStr);
+        }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options)


### PR DESCRIPTION
Apparently, the JsonGuidSerializer now writes nulls instead of 0000-0000 style Guids. Only it still can't read them.
See c4925ad70bd84477bd1e8df59de3db1196432fc2. Merged in https://github.com/jellyfin/jellyfin/pull/4568

**Changes**
I like the idea, so I made the reader able to read them as well.

**Issues**
Fixes #4602