### PR TITLE
Fix the I-frame image extraction filter string

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -553,12 +553,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             var mapArg = imageStreamIndex.HasValue ? (" -map 0:v:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
 
-            var enableThumbnail = !new List<string> { "wtv" }.Contains(container ?? string.Empty, StringComparer.OrdinalIgnoreCase);
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
-            var thumbnail = enableThumbnail ? ",thumbnail=24" : string.Empty;
+            var enableThumbnail = useIFrame && !new List<string> { "wtv" }.Contains(container ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(vf))
+            {
+                vf = enableThumbnail ? "-vf thumbnail=24" : string.Empty;
+            }
+            else
+            {
+                vf += enableThumbnail ? ",thumbnail=24" : string.Empty;
+            }
 
-            var args = useIFrame ? string.Format(CultureInfo.InvariantCulture, "-i {0}{3} -threads {5} -v quiet -vframes 1 {2}{4} -f image2 \"{1}\"", inputPath, tempExtractPath, vf, mapArg, thumbnail, threads) :
-                string.Format(CultureInfo.InvariantCulture, "-i {0}{3} -threads {4} -v quiet -vframes 1 {2} -f image2 \"{1}\"", inputPath, tempExtractPath, vf, mapArg, threads);
+            var args = string.Format(CultureInfo.InvariantCulture, "-i {0}{3} -threads {4} -v quiet -vframes 1 {2} -f image2 \"{1}\"", inputPath, tempExtractPath, vf, mapArg, threads);
 
             var probeSizeArgument = EncodingHelper.GetProbeSizeArgument(1);
             var analyzeDurationArgument = EncodingHelper.GetAnalyzeDurationArgument(1);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -554,7 +554,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var mapArg = imageStreamIndex.HasValue ? (" -map 0:v:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
 
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
-            var enableThumbnail = useIFrame && !new List<string> { "wtv" }.Contains(container ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+            var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparer.OrdinalIgnoreCase);
             if (string.IsNullOrEmpty(vf))
             {
                 vf = enableThumbnail ? "-vf thumbnail=24" : string.Empty;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -554,7 +554,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var mapArg = imageStreamIndex.HasValue ? (" -map 0:v:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
 
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
-            var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparer.OrdinalIgnoreCase);
+            var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparison.OrdinalIgnoreCase);
             if (string.IsNullOrEmpty(vf))
             {
                 vf = enableThumbnail ? "-vf thumbnail=24" : string.Empty;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -555,13 +555,16 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
             var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparison.OrdinalIgnoreCase);
-            if (string.IsNullOrEmpty(vf))
+            if (enableThumbnail)
             {
-                vf = enableThumbnail ? "-vf thumbnail=24" : string.Empty;
-            }
-            else
-            {
-                vf += enableThumbnail ? ",thumbnail=24" : string.Empty;
+                if (string.IsNullOrEmpty(vf))
+                {
+                    vf = "-vf thumbnail=24";
+                }
+                else
+                {
+                    vf += ",thumbnail=24";
+                }
             }
 
             var args = string.Format(CultureInfo.InvariantCulture, "-i {0}{3} -threads {4} -v quiet -vframes 1 {2} -f image2 \"{1}\"", inputPath, tempExtractPath, vf, mapArg, threads);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -36,7 +36,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <summary>
         /// The default image extraction timeout in milliseconds.
         /// </summary>
-        internal const int DefaultImageExtractionTimeout = 5000;
+        internal const int DefaultImageExtractionTimeout = 10000;
 
         /// <summary>
         /// The us culture.

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -778,7 +778,11 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
             }
 
-            if (bitrate == 0 && formatInfo != null && !string.IsNullOrEmpty(formatInfo.BitRate) && stream.Type == MediaStreamType.Video)
+            // The bitrate info of FLAC musics and some videos is included in formatInfo.
+            if (bitrate == 0
+                && formatInfo != null
+                && !string.IsNullOrEmpty(formatInfo.BitRate)
+                && (stream.Type == MediaStreamType.Video || stream.Type == MediaStreamType.Audio))
             {
                 // If the stream info doesn't have a bitrate get the value from the media format info
                 if (int.TryParse(formatInfo.BitRate, NumberStyles.Any, _usCulture, out var value))


### PR DESCRIPTION
**Changes**
- Fix the wrong I-frame image extraction filter string introduced in #4501
- Increase `DefaultImageExtractionTimeout` since the default scale width 600 have been removed.
Otherwise the ffmpeg process will be stopped prematurely when extracting image for high resolution videos.
- Allow to extract music bitrate info from formatInfo.


**Issues**
```
-f mov,mp4,m4a,3gp,3g2,mj2 -ss 00:00:30.025 -i file:"h264High10.mp4" -threads 0 -v quiet -vframes 1 ,thumbnail=24 -f image2 "69b6b099-dad0-4e98-b043-9c92a23fe2e8.jpg"
```

Fixes https://github.com/jellyfin/jellyfin/issues/4617