### PR TITLE
[Fix] NotificationType was never set in dlna event manager

### DIFF
--- a/Emby.Dlna/Eventing/DlnaEventManager.cs
+++ b/Emby.Dlna/Eventing/DlnaEventManager.cs
@@ -72,7 +72,8 @@ namespace Emby.Dlna.Eventing
                 Id = id,
                 CallbackUrl = callbackUrl,
                 SubscriptionTime = DateTime.UtcNow,
-                TimeoutSeconds = timeout
+                TimeoutSeconds = timeout,
+                NoticationType = notificationType
             });
 
             return GetEventSubscriptionResponse(id, requestedTimeoutString, timeout);

--- a/Emby.Dlna/Eventing/DlnaEventManager.cs
+++ b/Emby.Dlna/Eventing/DlnaEventManager.cs
@@ -73,7 +73,7 @@ namespace Emby.Dlna.Eventing
                 CallbackUrl = callbackUrl,
                 SubscriptionTime = DateTime.UtcNow,
                 TimeoutSeconds = timeout,
-                NoticationType = notificationType
+                NotificationType = notificationType
             });
 
             return GetEventSubscriptionResponse(id, requestedTimeoutString, timeout);


### PR DESCRIPTION
This is required by the internal DLNA event subscription sub-system.