### PR TITLE
Improve restart.sh

### DIFF
--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -43,7 +43,8 @@ fi
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; $sudo_command systemctl start jellyfin" | at now
+        # Without systemd-run here, `jellyfin.service`'s shutdown terminates this process too
+        $sudo_command systemd-run --scope systemctl restart jellyfin
         ;;
     'service')
         echo "sleep 0.5; $sudo_command service jellyfin start" | at now

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -44,7 +44,7 @@ echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
         # Without systemd-run here, `jellyfin.service`'s shutdown terminates this process too
-        $sudo_command systemd-run --scope systemctl restart jellyfin
+        $sudo_command systemd-run systemctl restart jellyfin
         ;;
     'service')
         echo "sleep 0.5; $sudo_command service jellyfin start" | at now

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -11,16 +11,29 @@
 #
 # This script is used by the Debian/Ubuntu/Fedora/CentOS packages.
 
-get_service_command() {
-    for command in systemctl service; do
-        if which $command &>/dev/null; then
-            echo $command && return
+# This is the Right Way(tm) to check if we are booted with
+# systemd, according to sd_booted(3)
+if [ -d /run/systemd/system ]; then
+    cmd=systemctl
+else
+    # Everything else is really hard to figure out, so we just use
+    # service(8) if it's available - that works with most init
+    # systems/distributions I know of, including FreeBSD
+    if type service >/dev/null 2>&1; then
+        cmd=service
+    else
+        # If even service(8) isn't available, we just try /etc/init.d
+        # and hope for the best
+        if [ -d /etc/init.d ]; then
+            cmd=sysv
+        else
+            echo "Unable to detect a way to restart Jellyfin; bailing out" 1>&2
+            echo "Please report this bug to https://github.com/jellyfin/jellyfin/issues" 1>&2
+            exit 1
         fi
-    done
-    echo "sysv"
-}
+    fi
+fi
 
-cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -34,13 +34,19 @@ else
     fi
 fi
 
+if type sudo >/dev/null 2>&1; then
+    sudo_command=sudo
+else
+    sudo_command=
+fi
+
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; /usr/bin/sudo systemctl start jellyfin" | at now 
+        echo "sleep 0.5; $sudo_command systemctl start jellyfin" | at now
         ;;
     'service')
-        echo "sleep 0.5; /usr/bin/sudo service jellyfin start" | at now 
+        echo "sleep 0.5; $sudo_command service jellyfin start" | at now
         ;;
     'sysv')
         echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 

--- a/debian/bin/restart.sh
+++ b/debian/bin/restart.sh
@@ -37,10 +37,10 @@ fi
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
+        echo "sleep 0.5; /usr/bin/sudo systemctl start jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 0.5; /usr/bin/sudo $( which service ) jellyfin start" | at now 
+        echo "sleep 0.5; /usr/bin/sudo service jellyfin start" | at now 
         ;;
     'sysv')
         echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 

--- a/debian/conf/jellyfin-sudoers
+++ b/debian/conf/jellyfin-sudoers
@@ -2,9 +2,9 @@
 Cmnd_Alias RESTARTSERVER_SYSV = /sbin/service jellyfin restart, /usr/sbin/service jellyfin restart
 Cmnd_Alias STARTSERVER_SYSV = /sbin/service jellyfin start, /usr/sbin/service jellyfin start
 Cmnd_Alias STOPSERVER_SYSV = /sbin/service jellyfin stop, /usr/sbin/service jellyfin stop
-Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemctl restart jellyfin, /bin/systemctl restart jellyfin
-Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemctl start jellyfin, /bin/systemctl start jellyfin
-Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemctl stop jellyfin, /bin/systemctl stop jellyfin
+Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl restart jellyfin
+Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl start jellyfin
+Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl stop jellyfin
 Cmnd_Alias RESTARTSERVER_INITD = /etc/init.d/jellyfin restart
 Cmnd_Alias STARTSERVER_INITD = /etc/init.d/jellyfin start
 Cmnd_Alias STOPSERVER_INITD = /etc/init.d/jellyfin stop

--- a/debian/conf/jellyfin-sudoers
+++ b/debian/conf/jellyfin-sudoers
@@ -2,9 +2,9 @@
 Cmnd_Alias RESTARTSERVER_SYSV = /sbin/service jellyfin restart, /usr/sbin/service jellyfin restart
 Cmnd_Alias STARTSERVER_SYSV = /sbin/service jellyfin start, /usr/sbin/service jellyfin start
 Cmnd_Alias STOPSERVER_SYSV = /sbin/service jellyfin stop, /usr/sbin/service jellyfin stop
-Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl restart jellyfin
-Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl start jellyfin
-Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl stop jellyfin
+Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run systemctl restart jellyfin
+Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run systemctl start jellyfin
+Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run systemctl stop jellyfin
 Cmnd_Alias RESTARTSERVER_INITD = /etc/init.d/jellyfin restart
 Cmnd_Alias STARTSERVER_INITD = /etc/init.d/jellyfin start
 Cmnd_Alias STOPSERVER_INITD = /etc/init.d/jellyfin stop

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,6 @@ Depends: at,
          libfontconfig1,
          libfreetype6,
          libssl1.1
-Recommends: jellyfin-web
+Recommends: jellyfin-web, sudo
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin server backend and API.

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -40,7 +40,7 @@ Jellyfin is a free software media system that puts you in control of managing an
 Summary:        The Free Software Media System Server backend
 Requires(pre):  shadow-utils
 Requires:       ffmpeg
-Requires:       libcurl, fontconfig, freetype, openssl, glibc, libicu, at
+Requires:       libcurl, fontconfig, freetype, openssl, glibc, libicu, at, sudo
 
 %description server
 The Jellyfin media server backend.

--- a/fedora/jellyfin.sudoers
+++ b/fedora/jellyfin.sudoers
@@ -1,7 +1,7 @@
 # Allow jellyfin group to start, stop and restart itself
-Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl restart jellyfin
-Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl start jellyfin
-Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl stop jellyfin
+Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run systemctl restart jellyfin
+Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run systemctl start jellyfin
+Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run systemctl stop jellyfin
 
 jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
 jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD

--- a/fedora/jellyfin.sudoers
+++ b/fedora/jellyfin.sudoers
@@ -1,8 +1,7 @@
 # Allow jellyfin group to start, stop and restart itself
-Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemctl restart jellyfin, /bin/systemctl restart jellyfin
-Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemctl start jellyfin, /bin/systemctl start jellyfin
-Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemctl stop jellyfin, /bin/systemctl stop jellyfin
-
+Cmnd_Alias RESTARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl restart jellyfin
+Cmnd_Alias STARTSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl start jellyfin
+Cmnd_Alias STOPSERVER_SYSTEMD = /usr/bin/systemd-run --scope systemctl stop jellyfin
 
 jellyfin ALL=(ALL) NOPASSWD: RESTARTSERVER_SYSTEMD
 jellyfin ALL=(ALL) NOPASSWD: STARTSERVER_SYSTEMD

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -43,7 +43,8 @@ fi
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; $sudo_command systemctl start jellyfin" | at now
+        # Without systemd-run here, `jellyfin.service`'s shutdown terminates this process too
+        $sudo_command systemd-run --scope systemctl restart jellyfin
         ;;
     'service')
         echo "sleep 0.5; $sudo_command service jellyfin start" | at now

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -44,7 +44,7 @@ echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
         # Without systemd-run here, `jellyfin.service`'s shutdown terminates this process too
-        $sudo_command systemd-run --scope systemctl restart jellyfin
+        $sudo_command systemd-run systemctl restart jellyfin
         ;;
     'service')
         echo "sleep 0.5; $sudo_command service jellyfin start" | at now

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -11,16 +11,29 @@
 #
 # This script is used by the Debian/Ubuntu/Fedora/CentOS packages.
 
-get_service_command() {
-    for command in systemctl service; do
-        if which $command &>/dev/null; then
-            echo $command && return
+# This is the Right Way(tm) to check if we are booted with
+# systemd, according to sd_booted(3)
+if [ -d /run/systemd/system ]; then
+    cmd=systemctl
+else
+    # Everything else is really hard to figure out, so we just use
+    # service(8) if it's available - that works with most init
+    # systems/distributions I know of, including FreeBSD
+    if type service >/dev/null 2>&1; then
+        cmd=service
+    else
+        # If even service(8) isn't available, we just try /etc/init.d
+        # and hope for the best
+        if [ -d /etc/init.d ]; then
+            cmd=sysv
+        else
+            echo "Unable to detect a way to restart Jellyfin; bailing out" 1>&2
+            echo "Please report this bug to https://github.com/jellyfin/jellyfin/issues" 1>&2
+            exit 1
         fi
-    done
-    echo "sysv"
-}
+    fi
+fi
 
-cmd="$( get_service_command )"
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -34,13 +34,19 @@ else
     fi
 fi
 
+if type sudo >/dev/null 2>&1; then
+    sudo_command=sudo
+else
+    sudo_command=
+fi
+
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; /usr/bin/sudo systemctl start jellyfin" | at now 
+        echo "sleep 0.5; $sudo_command systemctl start jellyfin" | at now
         ;;
     'service')
-        echo "sleep 0.5; /usr/bin/sudo service jellyfin start" | at now 
+        echo "sleep 0.5; $sudo_command service jellyfin start" | at now
         ;;
     'sysv')
         echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 

--- a/fedora/restart.sh
+++ b/fedora/restart.sh
@@ -37,10 +37,10 @@ fi
 echo "Detected service control platform '$cmd'; using it to restart Jellyfin..."
 case $cmd in
     'systemctl')
-        echo "sleep 0.5; /usr/bin/sudo $( which systemctl ) start jellyfin" | at now 
+        echo "sleep 0.5; /usr/bin/sudo systemctl start jellyfin" | at now 
         ;;
     'service')
-        echo "sleep 0.5; /usr/bin/sudo $( which service ) jellyfin start" | at now 
+        echo "sleep 0.5; /usr/bin/sudo service jellyfin start" | at now 
         ;;
     'sysv')
         echo "sleep 0.5; /usr/bin/sudo /etc/init.d/jellyfin start" | at now 


### PR DESCRIPTION
**Changes**

Fix `restart.sh` to be more robust. In particular:

* Make sure `sudo` is installed (there is also code in there to handle `sudo` not being installed, for obscure running-as-root configurations - I wrote it before I realized I was being dumb and _wasn't_ actually running as root, but it seemed like since it was already written it might as well stay in the PR)
* Fix init system detection to look at what's actually running, not what's installed
* Misc cleanups
* Remove the `| at now` hack for systemd and fix some race conditions

I've split up the changes into individual commits, all of which have an extended description, so I won't repeat what they already say here.

I _did_ test these changes in my production Debian system. I then copied the changes to the Fedora configs, but I did not test those since I didn't want to spin up a Fedora box and deploy Jellyfin from scratch. But they should apply equally well to that platform.

**Issues**

None that I found, but see also #4554; cc @joshuaboniface
