### PR TITLE
Prevent GetUpNext from returning episodes in progress

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -192,7 +192,7 @@ namespace Emby.Server.Implementations.TV
 
             Func<Episode> getEpisode = () =>
             {
-                var nextEpsiode = _libraryManager.GetItemList(new InternalItemsQuery(user)
+                var nextEpisode = _libraryManager.GetItemList(new InternalItemsQuery(user)
                 {
                     AncestorWithPresentationUniqueKey = null,
                     SeriesPresentationUniqueKey = seriesKey,
@@ -206,14 +206,14 @@ namespace Emby.Server.Implementations.TV
                     DtoOptions = dtoOptions
                 }).Cast<Episode>().FirstOrDefault();
 
-                var userData = _userDataManager.GetUserData(user, nextEpsiode);
+                var userData = _userDataManager.GetUserData(user, nextEpisode);
 
                 if (userData.PlaybackPositionTicks > 0)
                 {
                     return null;
                 }
 
-                return nextEpsiode;
+                return nextEpisode;
             };
 
             if (lastWatchedEpisode != null)

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -206,7 +206,8 @@ namespace Emby.Server.Implementations.TV
                     DtoOptions = dtoOptions
                 }).Cast<Episode>().FirstOrDefault();
 
-                if (!(nextEpisode is null)) {
+                if (nextEpisode != null)
+                {
                     var userData = _userDataManager.GetUserData(user, nextEpisode);
 
                     if (userData.PlaybackPositionTicks > 0)

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -192,7 +192,7 @@ namespace Emby.Server.Implementations.TV
 
             Func<Episode> getEpisode = () =>
             {
-                return _libraryManager.GetItemList(new InternalItemsQuery(user)
+                var nextEpsiode = _libraryManager.GetItemList(new InternalItemsQuery(user)
                 {
                     AncestorWithPresentationUniqueKey = null,
                     SeriesPresentationUniqueKey = seriesKey,
@@ -205,6 +205,15 @@ namespace Emby.Server.Implementations.TV
                     MinSortName = lastWatchedEpisode?.SortName,
                     DtoOptions = dtoOptions
                 }).Cast<Episode>().FirstOrDefault();
+
+                var userData = _userDataManager.GetUserData(user, nextEpsiode);
+
+                if (userData.PlaybackPositionTicks > 0)
+                {
+                    return null;
+                }
+
+                return nextEpsiode;
             };
 
             if (lastWatchedEpisode != null)

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -206,11 +206,13 @@ namespace Emby.Server.Implementations.TV
                     DtoOptions = dtoOptions
                 }).Cast<Episode>().FirstOrDefault();
 
-                var userData = _userDataManager.GetUserData(user, nextEpisode);
+                if (!(nextEpisode is null)) {
+                    var userData = _userDataManager.GetUserData(user, nextEpisode);
 
-                if (userData.PlaybackPositionTicks > 0)
-                {
-                    return null;
+                    if (userData.PlaybackPositionTicks > 0)
+                    {
+                        return null;
+                    }
                 }
 
                 return nextEpisode;


### PR DESCRIPTION
**Changes**

GetUpNext was returning episodes that are in progress, leading to this:

![Screenshot_2020-12-01 Jellyfin](https://user-images.githubusercontent.com/19396809/100743910-40083200-33dd-11eb-8fd8-5d2fd8af8101.png)

Its purpose should be to only return future episodes of a show that is already started, but not in progress episodes.

To achieve this, this gets the user data of the episode to be added to the list, checks if it's in progress and just returns null if it is.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
