### PR TITLE
Provide NoResult instead of Fail in CustomAuthenticationHandler

### DIFF
--- a/Emby.Server.Implementations/HttpServer/Security/AuthService.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthService.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Net;
@@ -20,9 +21,15 @@ namespace Emby.Server.Implementations.HttpServer.Security
         public AuthorizationInfo Authenticate(HttpRequest request)
         {
             var auth = _authorizationContext.GetAuthorizationInfo(request);
+
+            if (!auth.HasToken)
+            {
+                throw new AuthenticationException("Request does not contain a token.");
+            }
+
             if (!auth.IsAuthenticated)
             {
-                throw new AuthenticationException("Invalid token.");
+                throw new SecurityException("Invalid token.");
             }
 
             if (auth.User?.HasPermission(PermissionKind.IsDisabled) ?? false)

--- a/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/AuthorizationContext.cs
@@ -102,7 +102,8 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 DeviceId = deviceId,
                 Version = version,
                 Token = token,
-                IsAuthenticated = false
+                IsAuthenticated = false,
+                HasToken = false
             };
 
             if (string.IsNullOrWhiteSpace(token))
@@ -111,6 +112,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
                 return authInfo;
             }
 
+            authInfo.HasToken = true;
             var result = _authRepo.Get(new AuthenticationInfoQuery
             {
                 AccessToken = token

--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Net;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -18,6 +20,7 @@ namespace Jellyfin.Api.Auth
     public class CustomAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
     {
         private readonly IAuthService _authService;
+        private readonly ILogger<CustomAuthenticationHandler> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomAuthenticationHandler" /> class.
@@ -35,6 +38,7 @@ namespace Jellyfin.Api.Auth
             ISystemClock clock) : base(options, logger, encoder, clock)
         {
             _authService = authService;
+            _logger = logger.CreateLogger<CustomAuthenticationHandler>();
         }
 
         /// <inheritdoc />
@@ -70,11 +74,13 @@ namespace Jellyfin.Api.Auth
             }
             catch (AuthenticationException ex)
             {
-                return Task.FromResult(AuthenticateResult.Fail(ex));
+                _logger.LogDebug(ex, "Error authenticating with {Handler}", nameof(CustomAuthenticationHandler));
+                return Task.FromResult(AuthenticateResult.NoResult());
             }
             catch (SecurityException ex)
             {
-                return Task.FromResult(AuthenticateResult.Fail(ex));
+                _logger.LogDebug(ex, "Error authenticating with {Handler}", nameof(CustomAuthenticationHandler));
+                return Task.FromResult(AuthenticateResult.NoResult());
             }
         }
     }

--- a/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -8,7 +7,6 @@ using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Net;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -79,8 +77,7 @@ namespace Jellyfin.Api.Auth
             }
             catch (SecurityException ex)
             {
-                _logger.LogDebug(ex, "Error authenticating with {Handler}", nameof(CustomAuthenticationHandler));
-                return Task.FromResult(AuthenticateResult.NoResult());
+                return Task.FromResult(AuthenticateResult.Fail(ex));
             }
         }
     }

--- a/MediaBrowser.Controller/Net/AuthorizationInfo.cs
+++ b/MediaBrowser.Controller/Net/AuthorizationInfo.cs
@@ -58,5 +58,10 @@ namespace MediaBrowser.Controller.Net
         /// Gets or sets a value indicating whether the token is authenticated.
         /// </summary>
         public bool IsAuthenticated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the request has a token.
+        /// </summary>
+        public bool HasToken { get; set; }
     }
 }

--- a/tests/Jellyfin.Api.Tests/Auth/CustomAuthenticationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/CustomAuthenticationHandlerTests.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Api.Tests.Auth
         }
 
         [Fact]
-        public async Task HandleAuthenticateAsyncShouldFailOnAuthenticationException()
+        public async Task HandleAuthenticateAsyncShouldProvideNoResultOnAuthenticationException()
         {
             var errorMessage = _fixture.Create<string>();
 
@@ -81,7 +81,7 @@ namespace Jellyfin.Api.Tests.Auth
             var authenticateResult = await _sut.AuthenticateAsync();
 
             Assert.False(authenticateResult.Succeeded);
-            Assert.Equal(errorMessage, authenticateResult.Failure?.Message);
+            Assert.True(authenticateResult.None);
         }
 
         [Fact]


### PR DESCRIPTION
The ASP.NET framework automatically logs when an AuthenticationHandler fails, so return `AuthenticateResult.NoResult()` instead. Authorization is still failed by the AuthorizationHandler(s)

Fixes https://github.com/jellyfin/jellyfin/issues/4627