### PR TITLE
[Fix for 10.7] Missed a config move

### DIFF
--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -104,7 +104,8 @@ namespace Jellyfin.Server
             app.UseBaseUrlRedirection();
 
             // Wrap rest of configuration so everything only listens on BaseUrl.
-            app.Map(_serverConfigurationManager.GetNetworkConfiguration().BaseUrl, mainApp =>
+            var config = _serverConfigurationManager.GetNetworkConfiguration();
+            app.Map(config.BaseUrl, mainApp =>
             {
                 if (env.IsDevelopment())
                 {
@@ -122,8 +123,7 @@ namespace Jellyfin.Server
 
                 mainApp.UseCors();
 
-                if (_serverConfigurationManager.GetNetworkConfiguration().RequireHttps
-                    && _serverApplicationHost.ListenWithHttps)
+                if (config.RequireHttps && _serverApplicationHost.ListenWithHttps)
                 {
                     mainApp.UseHttpsRedirection();
                 }


### PR DESCRIPTION
RequireHttps was moved across to NetworkConfiguration.cs.

Missed this one.