### PR TITLE
fix: add Palestine to supported countries

### DIFF
--- a/Emby.Server.Implementations/Localization/countries.json
+++ b/Emby.Server.Implementations/Localization/countries.json
@@ -558,6 +558,12 @@
         "TwoLetterISORegionName": "OM"
     },
     {
+        "DisplayName": "Palestine",
+        "Name": "PS",
+        "ThreeLetterISORegionName": "PSE",
+        "TwoLetterISORegionName": "PS"
+    },
+    {
         "DisplayName": "Panama",
         "Name": "PA",
         "ThreeLetterISORegionName": "PAN",


### PR DESCRIPTION
**Changes**

Localization: add *Palestine* to list of countries between *Oman* and *Panama*

The alpha-2 and alpha-3 codes can be verified at: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes

**Screenshots of this change**
![Screenshot from 2020-12-02 21-36-51](https://user-images.githubusercontent.com/536147/100958941-3ff65800-34eb-11eb-8888-129cd53424f1.png)


**Issues**
Fixes #4646