### PR TITLE
Change logging level and message in NetworkManager

### DIFF
--- a/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -1314,9 +1314,7 @@ namespace Jellyfin.Networking.Manager
                 return true;
             }
 
-            // Have to return something, so return an internal address
-
-            _logger.LogWarning("{Source}: External request received, however, no WAN interface found.", source);
+            _logger.LogDebug("{Source}: External request received, but no WAN interface found. Need to route through internal network.", source);
             return false;
         }
     }


### PR DESCRIPTION
Changed logging message and type - as this shouldn't be a warning.

 [2020-12-05 06:40:10.223 +00:00] [WRN] [65] Jellyfin.Networking.Manager.NetworkManager: "meh IP/32": External request received, however, no WAN interface found.