### PR TITLE
Safer startup.

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -478,17 +478,23 @@ namespace Emby.Server.Implementations
 
         private IEnumerable<Task> StartEntryPointsSafe(IEnumerable<IServerEntryPoint> entryPoints, bool isBeforeStartup)
         {
+            IEnumerable<Task> value;
             try
             {
-                yeild StartEntryPoints(entryPoints, isBeforeStartup);
+                value = StartEntryPoints(entryPoints, isBeforeStartup);
             }
             catch (Exception ex)
-            {            
-                Logger.LogError(ex, "Exception in calling SafeEntyPoint.");
-                yeild Task.CompletedTask;
+            {
+                Logger.LogError(ex, "Exception in implementing SafeEntyPoint interface.");
+                value = new List<Task>
+                {
+                    Task.CompletedTask
+                };
             }
+
+            return value;
         }
-        
+
         private IEnumerable<Task> StartEntryPoints(IEnumerable<IServerEntryPoint> entryPoints, bool isBeforeStartup)
         {
             foreach (var entryPoint in entryPoints)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -486,7 +486,7 @@ namespace Emby.Server.Implementations
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Exception in implementing SafeEntyPoint interface.");
-                value = new List<Task>
+                value = new[]
                 {
                     Task.CompletedTask
                 };


### PR DESCRIPTION
It looks like it would be possible for a plugin to crash the system by generating an exception in their IServerEntryPoint implementation.

All methods are executed by a Task.WhenAll. According to the docs, this only reports the last error generated, and if i'm reading the code right, would crash.

This PR introduces another exception catching layer between the two. This should enable failed plugins to log exceptions without a crashing occurring.

