### PR TITLE
Detect circular dependencies during instance creation

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -391,7 +391,7 @@ namespace Emby.Server.Implementations
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>System.Object.</returns>
-        protected object CreateInstanceSafe(Type type)
+        protected object CreateInstanceWithSafeguards(Type type)
         {
             if (_creatingInstances == null)
             {
@@ -445,7 +445,7 @@ namespace Emby.Server.Implementations
         {
             // Convert to list so this isn't executed for each iteration
             var parts = GetExportTypes<T>()
-                .Select(CreateInstanceSafe)
+                .Select(CreateInstanceWithSafeguards)
                 .Where(i => i != null)
                 .Cast<T>()
                 .ToList();


### PR DESCRIPTION
**#4709 Supercedes this PR.**

The 10.6 plugin i checked halted due to a di infinite loop.

This implements a list of DI types that have been asked to be created. If the list already contains one, a DI loop exists, and an exception is thrown, in an attempt to fail the original DI plugin load.

Works with the LDAP 9.0 and JF 10.7 RC 1

https://github.com/jellyfin/jellyfin/issues/4690

This is not a fix - it does not make the plugins work - it just attempts to stop outdated plugins from hanging the system.

It is a stop gap method until a better solution can be implemented.
