### PR TITLE
Add overloaded constructor for ActivityLog levels

### DIFF
--- a/Jellyfin.Data/Entities/ActivityLog.cs
+++ b/Jellyfin.Data/Entities/ActivityLog.cs
@@ -18,7 +18,8 @@ namespace Jellyfin.Data.Entities
         /// <param name="name">The name.</param>
         /// <param name="type">The type.</param>
         /// <param name="userId">The user id.</param>
-        public ActivityLog(string name, string type, Guid userId)
+        /// <param name="logLevel">The log level.</param>
+        public ActivityLog(string name, string type, Guid userId, LogLevel logLevel = LogLevel.Information)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -34,7 +35,7 @@ namespace Jellyfin.Data.Entities
             Type = type;
             UserId = userId;
             DateCreated = DateTime.UtcNow;
-            LogSeverity = LogLevel.Trace;
+            LogSeverity = logLevel;
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

* Changes the default log level for the existing ActivityLog constructor to "Information" instead of "Trace"
  Trace is basically the nuclear option, yet currently every activity log entry uses it. This switches the default to Information, so the log level is more sane
* Adds an overloaded constructor to allow specifying the log level. This goes hand in hand with the previous change, in order to allow future PRs to specify better log levels for individual entries

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
