### PR TITLE
Fix API forbidden response

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -98,7 +98,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to update the image.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the image.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -144,7 +144,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to update the image.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the image.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -190,7 +190,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to delete the image.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to delete the image.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -229,7 +229,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to delete the image.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to delete the image.");
             }
 
             var user = _userManager.GetUserById(userId);

--- a/Jellyfin.Api/Controllers/QuickConnectController.cs
+++ b/Jellyfin.Api/Controllers/QuickConnectController.cs
@@ -88,7 +88,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (_quickConnect.State == QuickConnectState.Unavailable)
             {
-                return Forbid("Quick connect is unavailable");
+                return StatusCode(StatusCodes.Status403Forbidden, "Quick connect is unavailable");
             }
 
             _quickConnect.Activate();
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Controllers
             var userId = ClaimHelpers.GetUserId(Request.HttpContext.User);
             if (!userId.HasValue)
             {
-                return Forbid("Unknown user id");
+                return StatusCode(StatusCodes.Status403Forbidden, "Unknown user id");
             }
 
             return _quickConnect.AuthorizeRequest(userId.Value, code);

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -169,7 +169,7 @@ namespace Jellyfin.Api.Controllers
 
             if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(pw))
             {
-                return Forbid("Only sha1 password is not allowed.");
+                return StatusCode(StatusCodes.Status403Forbidden, "Only sha1 password is not allowed.");
             }
 
             // Password should always be null
@@ -271,7 +271,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to update the password.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the password.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -296,7 +296,7 @@ namespace Jellyfin.Api.Controllers
 
                 if (success == null)
                 {
-                    return Forbid("Invalid user or password entered.");
+                    return StatusCode(StatusCodes.Status403Forbidden, "Invalid user or password entered.");
                 }
 
                 await _userManager.ChangePassword(user, request.NewPw).ConfigureAwait(false);
@@ -329,7 +329,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, true))
             {
-                return Forbid("User is not allowed to update the easy password.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the easy password.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -376,7 +376,7 @@ namespace Jellyfin.Api.Controllers
 
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, false))
             {
-                return Forbid("User update not allowed.");
+                return StatusCode(StatusCodes.Status403Forbidden, "User update not allowed.");
             }
 
             var user = _userManager.GetUserById(userId);
@@ -421,14 +421,14 @@ namespace Jellyfin.Api.Controllers
             {
                 if (_userManager.Users.Count(i => i.HasPermission(PermissionKind.IsAdministrator)) == 1)
                 {
-                    return Forbid("There must be at least one user in the system with administrative access.");
+                    return StatusCode(StatusCodes.Status403Forbidden, "There must be at least one user in the system with administrative access.");
                 }
             }
 
             // If disabling
             if (newPolicy.IsDisabled && user.HasPermission(PermissionKind.IsAdministrator))
             {
-                return Forbid("Administrators cannot be disabled.");
+                return StatusCode(StatusCodes.Status403Forbidden, "Administrators cannot be disabled.");
             }
 
             // If disabling
@@ -436,7 +436,7 @@ namespace Jellyfin.Api.Controllers
             {
                 if (_userManager.Users.Count(i => !i.HasPermission(PermissionKind.IsDisabled)) == 1)
                 {
-                    return Forbid("There must be at least one enabled user in the system.");
+                    return StatusCode(StatusCodes.Status403Forbidden, "There must be at least one enabled user in the system.");
                 }
 
                 var currentToken = _authContext.GetAuthorizationInfo(Request).Token;
@@ -466,7 +466,7 @@ namespace Jellyfin.Api.Controllers
         {
             if (!RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, userId, false))
             {
-                return Forbid("User configuration update not allowed");
+                return StatusCode(StatusCodes.Status403Forbidden, "User configuration update not allowed");
             }
 
             await _userManager.UpdateConfigurationAsync(userId, userConfig).ConfigureAwait(false);


### PR DESCRIPTION
The `Forbid()` constructor is used to pass authentication schemes, so it would return a `500` error stating there is no authentication scheme with the name [...]