### PR TITLE
Fix - Access Denied on using certificates in windows as user.

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -714,7 +714,7 @@ namespace Emby.Server.Implementations
                 // Don't use an empty string password
                 var password = string.IsNullOrWhiteSpace(info.Password) ? null : info.Password;
 
-                var localCert = new X509Certificate2(certificateLocation, password);
+                var localCert = new X509Certificate2(certificateLocation, password, X509KeyStorageFlags.UserKeySet);
                 // localCert.PrivateKey = PrivateKey.CreateFromFile(pvk_file).RSA;
                 if (!localCert.HasPrivateKey)
                 {


### PR DESCRIPTION
Added X509KeyStorageFlags.UserKeySet option when creating certificate for use by jellyfin. (Needed to test https)

Result under the user account is "Access Denied". It looks like, in order to install/use certs you need to be an admin under windows, so loaded it under the user account.

https://stackoverflow.com/questions/49071730/x509certificate2-access-denied-exception-if-use-ecc-certificate
