### PR TITLE
Fix blueberry

### DIFF
--- a/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -435,7 +435,7 @@ namespace Jellyfin.Drawing.Skia
                 0f,
                 kernelOffset,
                 SKShaderTileMode.Clamp,
-                false);
+                true);
 
             canvas.DrawBitmap(
                 source,


### PR DESCRIPTION
Should fix https://github.com/jellyfin/jellyfin/issues/4744

cc @anthonylavado as I don't have any way to test this.

--
ImageFilter was added in https://github.com/jellyfin/jellyfin/pull/3772. I'm not sure why it was added but it seems to be the source of the blueberries.