### PR TITLE
Use larger batch size on mpegts to avoid corrupted thumbnails

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -605,9 +605,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
             // mpegts need larger batch size otherwise the corrupted thumbnail will be created. Larger batch size will lower the processing speed.
             var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparison.OrdinalIgnoreCase);
-            var useLargerBatchSize = string.Equals("mpegts", container, StringComparison.OrdinalIgnoreCase);
             if (enableThumbnail)
             {
+                var useLargerBatchSize = string.Equals("mpegts", container, StringComparison.OrdinalIgnoreCase);
                 var batchSize = useLargerBatchSize ? "50" : "24";
                 if (string.IsNullOrEmpty(vf))
                 {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -603,16 +603,19 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // Use ffmpeg to sample 100 (we can drop this if required using thumbnail=50 for 50 frames) frames and pick the best thumbnail. Have a fall back just in case.
+            // mpegts need larger batch size otherwise the corrupted thumbnail will be created. Larger batch size will lower the processing speed.
             var enableThumbnail = useIFrame && !string.Equals("wtv", container, StringComparison.OrdinalIgnoreCase);
+            var useLargerBatchSize = string.Equals("mpegts", container, StringComparison.OrdinalIgnoreCase);
             if (enableThumbnail)
             {
+                var batchSize = useLargerBatchSize ? "50" : "24";
                 if (string.IsNullOrEmpty(vf))
                 {
-                    vf = "-vf thumbnail=24";
+                    vf = "-vf thumbnail=" + batchSize;
                 }
                 else
                 {
-                    vf += ",thumbnail=24";
+                    vf += ",thumbnail=" + batchSize;
                 }
             }
 


### PR DESCRIPTION
**Changes**
- Use larger batch size on mpegts to avoid corrupted thumbnails

![corrupted](https://user-images.githubusercontent.com/14953024/101593586-2002ef00-3a2b-11eb-8bfe-2df1151c8538.png)
![fine](https://user-images.githubusercontent.com/14953024/101593592-23967600-3a2b-11eb-9b04-7986330223ea.png)
