### PR TITLE
Fix openapi file schema

### DIFF
--- a/Jellyfin.Server/Filters/FileResponseFilter.cs
+++ b/Jellyfin.Server/Filters/FileResponseFilter.cs
@@ -14,7 +14,8 @@ namespace Jellyfin.Server.Filters
         {
             Schema = new OpenApiSchema
             {
-                Type = "file"
+                Type = "string",
+                Format = "binary"
             }
         };
 


### PR DESCRIPTION
I must have looked at swagger2 docs when making this filter.

Taken from https://swagger.io/docs/specification/describing-responses/
> Response That Returns a File
> An API operation can return a file, such as an image or PDF. OpenAPI 3.0 defines file input/output content as type: string with format: binary or format: base64. This is in contrast with OpenAPI 2.0, which uses type: file to describe file input/output content. If the response returns the file alone, you would typically use a binary string schema and specify the appropriate media type for the response content: 
```yaml
    paths:
      /report:
        get:
          summary: Returns the report in the PDF format
          responses:
            '200':
              description: A PDF file
              content:
                application/pdf:
                  schema:
                    type: string
                    format: binary
```