### PR TITLE
Fine tune some tone mapping params

### DIFF
--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -88,11 +88,11 @@ namespace MediaBrowser.Model.Configuration
             // The left side of the dot is the platform number, and the right side is the device number on the platform.
             OpenclDevice = "0.0";
             EnableTonemapping = false;
-            TonemappingAlgorithm = "reinhard";
+            TonemappingAlgorithm = "hable";
             TonemappingRange = "auto";
             TonemappingDesat = 0;
             TonemappingThreshold = 0.8;
-            TonemappingPeak = 0;
+            TonemappingPeak = 100;
             TonemappingParam = 0;
             H264Crf = 23;
             H265Crf = 28;


### PR DESCRIPTION
**Changes**
- Set recommand algorithm to Hable. It has better color and contrast.
- Set recommand tone mapping peak to 100. Avoid incorrect brightness information.

Web side changes:
https://github.com/jellyfin/jellyfin-web/pull/2222