### PR TITLE
Fix get provider id extension

### DIFF
--- a/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
+++ b/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
@@ -49,7 +49,7 @@ namespace MediaBrowser.Model.Entities
             }
 
             instance.ProviderIds.TryGetValue(name, out string? id);
-            return id;
+            return string.IsNullOrEmpty(id) ? null : id;
         }
 
         /// <summary>


### PR DESCRIPTION
Search wasn't happening because this function was returning an empty string instead of null