### PR TITLE
Fix Live TV Recording Scheduling

### DIFF
--- a/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
@@ -45,12 +45,7 @@ namespace Emby.Server.Implementations.HttpServer.Security
 
         public User GetUser(object requestContext)
         {
-            if (requestContext is HttpRequest request)
-            {
-                return GetUser(request.HttpContext);
-            }
-
-            return GetUser((HttpContext)requestContext);
+            return GetUser(((HttpRequest)requestContext).HttpContext);
         }
     }
 }

--- a/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
@@ -45,6 +45,11 @@ namespace Emby.Server.Implementations.HttpServer.Security
 
         public User GetUser(object requestContext)
         {
+            if (requestContext is HttpRequest request)
+            {
+                return GetUser(request.HttpContext);
+            }
+
             return GetUser((HttpContext)requestContext);
         }
     }


### PR DESCRIPTION
Currently (in master) it is impossible to schedule a recording, either for a series or an individual showing, due to an invalid cast.

I'm not sure if this changed with .NET 5.0, however this used to work and there doesn't appear to be a code change that would have caused this to break.

**Changes**
Modify SessionContext.GetUser(object) to cast requestContext to HttpRequest, then use the HttpContext property. This is in lieu of casting directly to an HttpContext.

**Issues**
I was unable to find an issue related to this. This likely exists only in the master branch.
