### PR TITLE
Fix: Disable dlna server API responses if dlna is disabled.

### DIFF
--- a/Emby.Dlna/Main/DlnaEntryPoint.cs
+++ b/Emby.Dlna/Main/DlnaEntryPoint.cs
@@ -126,6 +126,11 @@ namespace Emby.Dlna.Main
 
         public static DlnaEntryPoint Current { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the dlna server is enabled.
+        /// </summary>
+        public static bool Enabled { get; private set; }
+
         public IContentDirectory ContentDirectory { get; private set; }
 
         public IConnectionManager ConnectionManager { get; private set; }
@@ -152,6 +157,7 @@ namespace Emby.Dlna.Main
         private void ReloadComponents()
         {
             var options = _config.GetDlnaConfiguration();
+            Enabled = options.EnableServer;
 
             StartSsdpHandler();
 

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -45,14 +45,20 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("{serverId}/description")]
         [HttpGet("{serverId}/description.xml", Name = "GetDescriptionXml_2")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult GetDescriptionXml([FromRoute, Required] string serverId)
         {
-            var url = GetAbsoluteUri();
-            var serverAddress = url.Substring(0, url.IndexOf("/dlna/", StringComparison.OrdinalIgnoreCase));
-            var xml = _dlnaManager.GetServerDescriptionXml(Request.Headers, serverId, serverAddress);
-            return Ok(xml);
+            if (DlnaEntryPoint.Enabled)
+            {
+                var url = GetAbsoluteUri();
+                var serverAddress = url.Substring(0, url.IndexOf("/dlna/", StringComparison.OrdinalIgnoreCase));
+                var xml = _dlnaManager.GetServerDescriptionXml(Request.Headers, serverId, serverAddress);
+                return Ok(xml);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -65,12 +71,18 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory", Name = "GetContentDirectory_2")]
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory.xml", Name = "GetContentDirectory_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         public ActionResult GetContentDirectory([FromRoute, Required] string serverId)
         {
-            return Ok(_contentDirectory.GetServiceXml());
+            if (DlnaEntryPoint.Enabled)
+            {
+                return Ok(_contentDirectory.GetServiceXml());
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -83,12 +95,18 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar", Name = "GetMediaReceiverRegistrar_2")]
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar.xml", Name = "GetMediaReceiverRegistrar_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         public ActionResult GetMediaReceiverRegistrar([FromRoute, Required] string serverId)
         {
-            return Ok(_mediaReceiverRegistrar.GetServiceXml());
+            if (DlnaEntryPoint.Enabled)
+            {
+                return Ok(_mediaReceiverRegistrar.GetServiceXml());
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -101,12 +119,18 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager", Name = "GetConnectionManager_2")]
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager.xml", Name = "GetConnectionManager_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         public ActionResult GetConnectionManager([FromRoute, Required] string serverId)
         {
-            return Ok(_connectionManager.GetServiceXml());
+            if (DlnaEntryPoint.Enabled)
+            {
+                return Ok(_connectionManager.GetServiceXml());
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -147,6 +171,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/MediaReceiverRegistrar/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessMediaReceiverRegistrarControlRequest([FromRoute, Required] string serverId)

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -41,6 +41,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Description xml returned.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>An <see cref="OkResult"/> containing the description xml.</returns>
         [HttpGet("{serverId}/description")]
         [HttpGet("{serverId}/description.xml", Name = "GetDescriptionXml_2")]
@@ -66,6 +67,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna content directory returned.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>An <see cref="OkResult"/> containing the dlna content directory xml.</returns>
         [HttpGet("{serverId}/ContentDirectory")]
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory", Name = "GetContentDirectory_2")]
@@ -90,6 +92,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/MediaReceiverRegistrar")]
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar", Name = "GetMediaReceiverRegistrar_2")]
@@ -114,6 +117,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/ConnectionManager")]
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager", Name = "GetConnectionManager_2")]
@@ -168,6 +172,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/MediaReceiverRegistrar/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -142,6 +142,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ContentDirectory/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -163,6 +164,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ConnectionManager/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -206,6 +208,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/MediaReceiverRegistrar/Events")]
         [HttpUnsubscribe("{serverId}/MediaReceiverRegistrar/Events")]

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -145,11 +145,17 @@ namespace Jellyfin.Api.Controllers
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ContentDirectory/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessContentDirectoryControlRequest([FromRoute, Required] string serverId)
         {
-            return await ProcessControlRequestInternalAsync(serverId, Request.Body, _contentDirectory).ConfigureAwait(false);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return await ProcessControlRequestInternalAsync(serverId, Request.Body, _contentDirectory).ConfigureAwait(false);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -160,11 +166,17 @@ namespace Jellyfin.Api.Controllers
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ConnectionManager/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessConnectionManagerControlRequest([FromRoute, Required] string serverId)
         {
-            return await ProcessControlRequestInternalAsync(serverId, Request.Body, _connectionManager).ConfigureAwait(false);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return await ProcessControlRequestInternalAsync(serverId, Request.Body, _connectionManager).ConfigureAwait(false);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -181,7 +193,12 @@ namespace Jellyfin.Api.Controllers
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessMediaReceiverRegistrarControlRequest([FromRoute, Required] string serverId)
         {
-            return await ProcessControlRequestInternalAsync(serverId, Request.Body, _mediaReceiverRegistrar).ConfigureAwait(false);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return await ProcessControlRequestInternalAsync(serverId, Request.Body, _mediaReceiverRegistrar).ConfigureAwait(false);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -195,11 +212,17 @@ namespace Jellyfin.Api.Controllers
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessMediaReceiverRegistrarEventRequest(string serverId)
         {
-            return ProcessEventRequest(_mediaReceiverRegistrar);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return ProcessEventRequest(_mediaReceiverRegistrar);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -207,17 +230,24 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ContentDirectory/Events")]
         [HttpUnsubscribe("{serverId}/ContentDirectory/Events")]
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessContentDirectoryEventRequest(string serverId)
         {
-            return ProcessEventRequest(_contentDirectory);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return ProcessEventRequest(_contentDirectory);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -225,17 +255,24 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
+        /// <response code="404">Not found.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ConnectionManager/Events")]
         [HttpUnsubscribe("{serverId}/ConnectionManager/Events")]
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessConnectionManagerEventRequest(string serverId)
         {
-            return ProcessEventRequest(_connectionManager);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return ProcessEventRequest(_connectionManager);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -243,14 +280,21 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <param name="fileName">The icon filename.</param>
+        /// <response code="404">Not found.</response>
         /// <returns>Icon stream.</returns>
         [HttpGet("{serverId}/icons/{fileName}")]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesImageFile]
         public ActionResult GetIconId([FromRoute, Required] string serverId, [FromRoute, Required] string fileName)
         {
-            return GetIconInternal(fileName);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return GetIconInternal(fileName);
+            }
+
+            return NotFound();
         }
 
         /// <summary>
@@ -258,11 +302,18 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="fileName">The icon filename.</param>
         /// <returns>Icon stream.</returns>
+        /// <response code="404">Not found.</response>
         [HttpGet("icons/{fileName}")]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesImageFile]
         public ActionResult GetIcon([FromRoute, Required] string fileName)
         {
-            return GetIconInternal(fileName);
+            if (DlnaEntryPoint.Enabled)
+            {
+                return GetIconInternal(fileName);
+            }
+
+            return NotFound();
         }
 
         private ActionResult GetIconInternal(string fileName)

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -41,7 +41,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Description xml returned.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>An <see cref="OkResult"/> containing the description xml.</returns>
         [HttpGet("{serverId}/description")]
         [HttpGet("{serverId}/description.xml", Name = "GetDescriptionXml_2")]
@@ -59,7 +59,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(xml);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna content directory returned.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>An <see cref="OkResult"/> containing the dlna content directory xml.</returns>
         [HttpGet("{serverId}/ContentDirectory")]
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory", Name = "GetContentDirectory_2")]
@@ -84,7 +84,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_contentDirectory.GetServiceXml());
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/MediaReceiverRegistrar")]
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar", Name = "GetMediaReceiverRegistrar_2")]
@@ -109,7 +109,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_mediaReceiverRegistrar.GetServiceXml());
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/ConnectionManager")]
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager", Name = "GetConnectionManager_2")]
@@ -134,7 +134,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_connectionManager.GetServiceXml());
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ContentDirectory/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -156,7 +156,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _contentDirectory).ConfigureAwait(false);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ConnectionManager/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -178,7 +178,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _connectionManager).ConfigureAwait(false);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/MediaReceiverRegistrar/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -200,7 +200,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _mediaReceiverRegistrar).ConfigureAwait(false);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/MediaReceiverRegistrar/Events")]
         [HttpUnsubscribe("{serverId}/MediaReceiverRegistrar/Events")]
@@ -225,7 +225,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_mediaReceiverRegistrar);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ContentDirectory/Events")]
         [HttpUnsubscribe("{serverId}/ContentDirectory/Events")]
@@ -250,7 +250,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_contentDirectory);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ConnectionManager/Events")]
         [HttpUnsubscribe("{serverId}/ConnectionManager/Events")]
@@ -275,7 +275,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_connectionManager);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="fileName">The icon filename.</param>
         /// <response code="200">Request processed.</response>
         /// <response code="404">Not Found.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         /// <returns>Icon stream.</returns>
         [HttpGet("{serverId}/icons/{fileName}")]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
@@ -300,7 +300,7 @@ namespace Jellyfin.Api.Controllers
                 return GetIconInternal(fileName);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         /// <summary>
@@ -310,7 +310,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>Icon stream.</returns>
         /// <response code="200">Request processed.</response>
         /// <response code="404">Not Found.</response>
-        /// <response code="503">Service Unavailable.</response>
+        /// <response code="503">DLNA is disabled.</response>
         [HttpGet("icons/{fileName}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -323,7 +323,7 @@ namespace Jellyfin.Api.Controllers
                 return GetIconInternal(fileName);
             }
 
-            return StatusCode(503);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         private ActionResult GetIconInternal(string fileName)

--- a/Jellyfin.Api/Controllers/DlnaServerController.cs
+++ b/Jellyfin.Api/Controllers/DlnaServerController.cs
@@ -41,12 +41,12 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Description xml returned.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>An <see cref="OkResult"/> containing the description xml.</returns>
         [HttpGet("{serverId}/description")]
         [HttpGet("{serverId}/description.xml", Name = "GetDescriptionXml_2")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult GetDescriptionXml([FromRoute, Required] string serverId)
@@ -59,7 +59,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(xml);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -67,13 +67,13 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna content directory returned.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>An <see cref="OkResult"/> containing the dlna content directory xml.</returns>
         [HttpGet("{serverId}/ContentDirectory")]
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory", Name = "GetContentDirectory_2")]
         [HttpGet("{serverId}/ContentDirectory/ContentDirectory.xml", Name = "GetContentDirectory_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
@@ -84,7 +84,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_contentDirectory.GetServiceXml());
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -92,13 +92,13 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/MediaReceiverRegistrar")]
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar", Name = "GetMediaReceiverRegistrar_2")]
         [HttpGet("{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar.xml", Name = "GetMediaReceiverRegistrar_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
@@ -109,7 +109,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_mediaReceiverRegistrar.GetServiceXml());
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -117,13 +117,13 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Dlna media receiver registrar xml returned.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Dlna media receiver registrar xml.</returns>
         [HttpGet("{serverId}/ConnectionManager")]
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager", Name = "GetConnectionManager_2")]
         [HttpGet("{serverId}/ConnectionManager/ConnectionManager.xml", Name = "GetConnectionManager_3")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
@@ -134,7 +134,7 @@ namespace Jellyfin.Api.Controllers
                 return Ok(_connectionManager.GetServiceXml());
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -142,11 +142,11 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ContentDirectory/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessContentDirectoryControlRequest([FromRoute, Required] string serverId)
@@ -156,7 +156,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _contentDirectory).ConfigureAwait(false);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -164,11 +164,11 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/ConnectionManager/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessConnectionManagerControlRequest([FromRoute, Required] string serverId)
@@ -178,7 +178,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _connectionManager).ConfigureAwait(false);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -186,11 +186,11 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Control response.</returns>
         [HttpPost("{serverId}/MediaReceiverRegistrar/Control")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public async Task<ActionResult<ControlResponse>> ProcessMediaReceiverRegistrarControlRequest([FromRoute, Required] string serverId)
@@ -200,7 +200,7 @@ namespace Jellyfin.Api.Controllers
                 return await ProcessControlRequestInternalAsync(serverId, Request.Body, _mediaReceiverRegistrar).ConfigureAwait(false);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -208,14 +208,14 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/MediaReceiverRegistrar/Events")]
         [HttpUnsubscribe("{serverId}/MediaReceiverRegistrar/Events")]
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessMediaReceiverRegistrarEventRequest(string serverId)
@@ -225,7 +225,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_mediaReceiverRegistrar);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -233,14 +233,14 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ContentDirectory/Events")]
         [HttpUnsubscribe("{serverId}/ContentDirectory/Events")]
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessContentDirectoryEventRequest(string serverId)
@@ -250,7 +250,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_contentDirectory);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -258,14 +258,14 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <response code="200">Request processed.</response>
-        /// <response code="404">Not found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Event subscription response.</returns>
         [HttpSubscribe("{serverId}/ConnectionManager/Events")]
         [HttpUnsubscribe("{serverId}/ConnectionManager/Events")]
         [ApiExplorerSettings(IgnoreApi = true)] // Ignore in openapi docs
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [Produces(MediaTypeNames.Text.Xml)]
         [ProducesFile(MediaTypeNames.Text.Xml)]
         public ActionResult<EventSubscriptionResponse> ProcessConnectionManagerEventRequest(string serverId)
@@ -275,7 +275,7 @@ namespace Jellyfin.Api.Controllers
                 return ProcessEventRequest(_connectionManager);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -283,12 +283,15 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="serverId">Server UUID.</param>
         /// <param name="fileName">The icon filename.</param>
-        /// <response code="404">Not found.</response>
+        /// <response code="200">Request processed.</response>
+        /// <response code="404">Not Found.</response>
+        /// <response code="503">Service Unavailable.</response>
         /// <returns>Icon stream.</returns>
         [HttpGet("{serverId}/icons/{fileName}")]
         [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [ProducesImageFile]
         public ActionResult GetIconId([FromRoute, Required] string serverId, [FromRoute, Required] string fileName)
         {
@@ -297,7 +300,7 @@ namespace Jellyfin.Api.Controllers
                 return GetIconInternal(fileName);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         /// <summary>
@@ -305,9 +308,13 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="fileName">The icon filename.</param>
         /// <returns>Icon stream.</returns>
-        /// <response code="404">Not found.</response>
+        /// <response code="200">Request processed.</response>
+        /// <response code="404">Not Found.</response>
+        /// <response code="503">Service Unavailable.</response>
         [HttpGet("icons/{fileName}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [ProducesImageFile]
         public ActionResult GetIcon([FromRoute, Required] string fileName)
         {
@@ -316,7 +323,7 @@ namespace Jellyfin.Api.Controllers
                 return GetIconInternal(fileName);
             }
 
-            return NotFound();
+            return StatusCode(503);
         }
 
         private ActionResult GetIconInternal(string fileName)


### PR DESCRIPTION
Fix for https://github.com/jellyfin/jellyfin/issues/4431

The Dlna server class is instantiated whether or not the dlna server is enabled or not. (the attribute only controls the comms).

This change caused http not found to be returned if the dlna server is disabled.
