### PR TITLE
SchedulesDirect no longer refreshes channels properly

### DIFF
--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -784,18 +784,17 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             var allStations = root.stations ?? new List<ScheduleDirect.Station>();
 
             var map = root.map;
-            int len = map.Count;
-            var array = new List<ChannelInfo>(len);
-            for (int i = 0; i < len; i++)
+            var list = new List<ChannelInfo>(map.Count);
+            foreach (var channel in map)
             {
-                var channelNumber = GetChannelNumber(map[i]);
+                var channelNumber = GetChannelNumber(channel);
 
-                var station = allStations.Find(item => string.Equals(item.stationID, map[i].stationID, StringComparison.OrdinalIgnoreCase));
+                var station = allStations.Find(item => string.Equals(item.stationID, channel.stationID, StringComparison.OrdinalIgnoreCase));
                 if (station == null)
                 {
                     station = new ScheduleDirect.Station
                     {
-                        stationID = map[i].stationID
+                        stationID = channel.stationID
                     };
                 }
 
@@ -812,10 +811,10 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                     channelInfo.ImageUrl = station.logo.URL;
                 }
 
-                array[i] = channelInfo;
+                list.Add(channelInfo);
             }
 
-            return array;
+            return list;
         }
 
         private static string NormalizeName(string value)


### PR DESCRIPTION
SchedulesDirect no longer refreshes channels properly and was introduced in changeset 81ca6cb47cb1df49196f9a961de4698fbc406ec1.

*NOTE:* Please also merge into the 10.7 branch after this is approved as it's broken in that branch too.

**Changes**
new List(int) sets the capacity of the list, however it does not pre-allocate those entries, and thus treating it like a pre-allocated array results in an index out of range exception. .Add() or .AddRange() must be used to add items.

Therefore, this was modified to use a foreach loop to properly utilize an array. The intent of the original change still exists however as the list capacity is still set on creation.

**Issues**
I couldn't find an open issue. This was introduced in the 10.7 branch and master.

**Stack Trace**
```
Dec 22 19:59:42 jenny dotnet[27417]: [19:59:42] [INF] [92] Emby.Server.Implementations.LiveTv.Listings.SchedulesDirect: Mapping Stations to Channel
Dec 22 19:59:42 jenny dotnet[27417]: [19:59:42] [ERR] [92] Emby.Server.Implementations.LiveTv.EmbyTV.EmbyTV: Error adding metadata
Dec 22 19:59:42 jenny dotnet[27417]: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
Dec 22 19:59:42 jenny dotnet[27417]:    at Emby.Server.Implementations.LiveTv.Listings.SchedulesDirect.GetChannels(ListingsProviderInfo info, CancellationToken cancellationToken) in /home/petris/jellyfin-git/src/jellyfin/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs:line 815
Dec 22 19:59:42 jenny dotnet[27417]:    at Emby.Server.Implementations.LiveTv.Listings.SchedulesDirect.GetChannels(ListingsProviderInfo info, CancellationToken cancellationToken) in /home/petris/jellyfin-git/src/jellyfin/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs:line 818
Dec 22 19:59:42 jenny dotnet[27417]:    at Emby.Server.Implementations.LiveTv.EmbyTV.EmbyTV.GetEpgChannels(IListingsProvider provider, ListingsProviderInfo info, Boolean enableCache, CancellationToken cancellationToken) in /home/petris/jellyfin-git/src/jellyfin/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs:line 397
Dec 22 19:59:42 jenny dotnet[27417]:    at Emby.Server.Implementations.LiveTv.EmbyTV.EmbyTV.AddMetadata(IListingsProvider provider, ListingsProviderInfo info, IEnumerable`1 tunerChannels, Boolean enableCache, CancellationToken cancellationToken) in /home/petris/jellyfin-git/src/jellyfin/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs:line 368
Dec 22 19:59:42 jenny dotnet[27417]:    at Emby.Server.Implementations.LiveTv.EmbyTV.EmbyTV.GetChannelsAsync(Boolean enableCache, CancellationToken cancellationToken) in /home/petris/jellyfin-git/src/jellyfin/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs:line 346
```