### PR TITLE
Avoid transcoding to 3ch audio for HLS streaming

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1725,6 +1725,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Avoid transcoding to audio channels other than 1ch, 2ch, 6ch (5.1 layout) and 8ch (7.1 layout).
             // https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices
             if (isTranscodingAudio
+                && state.TranscodingType != TranscodingJobType.Progressive
                 && resultChannels.HasValue
                 && (resultChannels.Value > 2 && resultChannels.Value < 6 || resultChannels.Value == 7))
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1722,6 +1722,16 @@ namespace MediaBrowser.Controller.MediaEncoding
                     : transcoderChannelLimit.Value;
             }
 
+            // Avoid transcoding to audio channels other than 1ch, 2ch, 6ch (5.1 layout) and 8ch (7.1 layout).
+            // https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices
+            if (isTranscodingAudio
+                && resultChannels.HasValue
+                && resultChannels.Value > 2
+                && resultChannels.Value < 6)
+            {
+                resultChannels = 2;
+            }
+
             return resultChannels;
         }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1726,8 +1726,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices
             if (isTranscodingAudio
                 && resultChannels.HasValue
-                && resultChannels.Value > 2
-                && resultChannels.Value < 6)
+                && (resultChannels.Value > 2 && resultChannels.Value < 6 || resultChannels.Value == 7))
             {
                 resultChannels = 2;
             }


### PR DESCRIPTION
**Changes**
- Avoid transcoding to 3ch audio for HLS streaming

**Issues**
Transcoding to 3ch will break the playback.
Fixes https://github.com/jellyfin/jellyfin-web/issues/2249
