### PR TITLE
Enable TMDB and OMDB by default

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -49,8 +49,6 @@ namespace MediaBrowser.Model.Configuration
                 new MetadataOptions
                 {
                     ItemType = "Series",
-                    DisabledMetadataFetchers = new[] { "TheMovieDb" },
-                    DisabledImageFetchers = new[] { "TheMovieDb" }
                 },
                 new MetadataOptions
                 {
@@ -69,13 +67,10 @@ namespace MediaBrowser.Model.Configuration
                 new MetadataOptions
                 {
                     ItemType = "Season",
-                    DisabledMetadataFetchers = new[] { "TheMovieDb" },
                 },
                 new MetadataOptions
                 {
                     ItemType = "Episode",
-                    DisabledMetadataFetchers = new[] { "The Open Movie Database", "TheMovieDb" },
-                    DisabledImageFetchers = new[] { "The Open Movie Database", "TheMovieDb" }
                 }
             };
         }


### PR DESCRIPTION
**Changes**

We should enable these by default. With the recent removal of TVDB, we now have 0 metadata provider enabled by default for TV libraries, which will cause an issue for users on release (I'm expecting a bunch of them to not notice and open issues when there's no metadata).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
