### PR TITLE
Null exception fix

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -210,6 +210,7 @@ namespace Jellyfin.Api.Helpers
                         && !state.VideoRequest.MaxHeight.HasValue;
 
                     if (isVideoResolutionNotRequested
+                        && state.VideoStream != null
                         && state.VideoRequest.VideoBitRate.HasValue
                         && state.VideoStream.BitRate.HasValue
                         && state.VideoRequest.VideoBitRate.Value >= state.VideoStream.BitRate.Value)


### PR DESCRIPTION
Came across it during dlna server debugging last night. Not that clued up with what this code actually does (yet) - but it's something to do with playback.

state.VideoStream is a variable that can be null (definition not nullable yet), but there isn't a null check before the _state.VideoStream.BitRate.HasValue_ check, causing an exception. Checks on state.VideoStream's nullable state seem to appear everywhere else.

```
                        && state.VideoStream != null
                        && state.VideoRequest.VideoBitRate.HasValue
                        && state.VideoStream.BitRate.HasValue
```

adding this check, permits the playback to start.

Admittedly, i am using a codebase which is somewhat modified from 10.7's, but this looks to be possible in the current code base.