### PR TITLE
Ignore inaccessible files & folders during library scans

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
@@ -41,7 +41,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
                 }
 
                 // It's a directory-based playlist if the directory contains a playlist file
-                var filePaths = Directory.EnumerateFiles(args.Path);
+                var filePaths = Directory.EnumerateFiles(args.Path, "*", new EnumerationOptions { IgnoreInaccessible = true });
                 if (filePaths.Any(f => f.EndsWith(PlaylistXmlSaver.DefaultPlaylistFilename, StringComparison.OrdinalIgnoreCase)))
                 {
                     return new Playlist


### PR DESCRIPTION
Ignore inaccessible files & folders during library scans.

**Changes**
Library scans enumerate many files and folders. If a single file or folder is inaccessible due to permission issues during one of those enumeration calls, the whole enumeration call would fail. For example if you have a single TV show or movie folder that is inaccessible, the library scan would fail to enumerate any other shows / movies within that same parent folder.

Examples of those errors:
```
[2020-12-31 17:40:25.260 -08:00] [ERR] [13] Emby.Server.Implementations.Library.LibraryManager: Error resolving path "M:\Anime\A_Secret_Folder"
System.UnauthorizedAccessException: Access to the path 'M:\Anime\A_Secret_Folder' is denied.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.DirectoryInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.EnumerateDirectories(String searchPattern, SearchOption searchOption)
   at Emby.Server.Implementations.IO.ManagedFileSystem.GetFileSystemEntries(String path, Boolean recursive) in C:\Programming\jellyfin\Emby.Server.Implementations\IO\ManagedFileSystem.cs:line 630
   at MediaBrowser.Controller.Providers.DirectoryService.<GetFileSystemEntries>b__5_0(String p) in C:\Programming\jellyfin\MediaBrowser.Controller\Providers\DirectoryService.cs:line 28
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at MediaBrowser.Controller.Providers.DirectoryService.GetFileSystemEntries(String path) in C:\Programming\jellyfin\MediaBrowser.Controller\Providers\DirectoryService.cs:line 28
   at MediaBrowser.Controller.IO.FileData.GetFilteredFileSystemEntries(IDirectoryService directoryService, String path, IFileSystem fileSystem, IServerApplicationHost appHost, ILogger logger, ItemResolveArgs args, Int32 flattenFolderDepth, Boolean resolveShortcuts) in C:\Programming\jellyfin\MediaBrowser.Controller\IO\FileData.cs:line 48
   at Emby.Server.Implementations.Library.LibraryManager.ResolvePath(FileSystemMetadata fileInfo, IDirectoryService directoryService, IItemResolver[] resolvers, Folder parent, String collectionType, LibraryOptions libraryOptions) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 586
   at Emby.Server.Implementations.Library.LibraryManager.<>c__DisplayClass88_0.<ResolveFileList>b__0(FileSystemMetadata f) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 711
```

```
[2020-12-31 17:55:06.117 -08:00] [ERR] [8] Emby.Server.Implementations.Library.LibraryManager: Error in "PlaylistResolver" resolving "M:\Anime\A_Secret_Folder"
   System.UnauthorizedAccessException: Access to the path 'M:\Anime\A_Secret_Folder' is denied.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.UserFiles(String directory, String expression, EnumerationOptions options)
   at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.Directory.EnumerateFiles(String path)
   at Emby.Server.Implementations.Library.Resolvers.PlaylistResolver.Resolve(ItemResolveArgs args) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\Resolvers\PlaylistResolver.cs:line 44
   at Emby.Server.Implementations.Library.Resolvers.ItemResolver`1.MediaBrowser.Controller.Resolvers.IItemResolver.ResolvePath(ItemResolveArgs args) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\Resolvers\ItemResolver.cs:line 46
   at Emby.Server.Implementations.Library.LibraryManager.Resolve(ItemResolveArgs args, IItemResolver resolver) in C:\Programming\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 490
```

.NET 5 introduces a new [EnumerationOptions class](https://docs.microsoft.com/en-us/dotnet/api/system.io.enumerationoptions?view=net-5.0) with an `IgnoreInaccessible` property that allows us to choose how an enumeration should handle files & folders that are inaccessible.  Now the library scan will ignore them.

Note: `IgnoreInaccessible` defaults to `true` so we don't really need to specify it. But I think including it in the code is good practice to ensure future contributors know this behavior is occurring.

**Issues**
- Fixes #4882 & #2402
