### PR TITLE
Change stable ci nuget build command

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -195,7 +195,7 @@ jobs:
 
   variables:
   - name: JellyfinVersion
-    value: 0.0.0
+    value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 
   steps:
   - task: UseDotNet@2
@@ -203,10 +203,6 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '5.0.x'
-
-  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
-    displayName: Set release version (stable)
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
   - task: DotNetCoreCLI@2
     displayName: 'Build Stable Nuget packages'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -193,6 +193,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
 
+  variables:
+  - name: JellyfinVersion
+    value: 0.0.0
+
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET 5.0 sdk'
@@ -200,13 +204,23 @@ jobs:
       packageType: 'sdk'
       version: '5.0.x'
 
+  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
+    displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
   - task: DotNetCoreCLI@2
     displayName: 'Build Stable Nuget packages'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
     inputs:
-      command: 'pack'
-      packagesToPack: 'Jellyfin.Data/Jellyfin.Data.csproj;MediaBrowser.Common/MediaBrowser.Common.csproj;MediaBrowser.Controller/MediaBrowser.Controller.csproj;MediaBrowser.Model/MediaBrowser.Model.csproj;Emby.Naming/Emby.Naming.csproj'
-      versioningScheme: 'off'
+      command: 'custom'
+      projects: |
+        Jellyfin.Data/Jellyfin.Data.csproj
+        MediaBrowser.Common/MediaBrowser.Common.csproj
+        MediaBrowser.Controller/MediaBrowser.Controller.csproj
+        MediaBrowser.Model/MediaBrowser.Model.csproj
+        Emby.Naming/Emby.Naming.csproj
+      custom: 'pack'
+      arguments: -o $(Build.ArtifactStagingDirectory) -p:Version=$(JellyfinVersion)
 
   - task: DotNetCoreCLI@2
     displayName: 'Build Unstable Nuget packages'
@@ -233,7 +247,7 @@ jobs:
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
     inputs:
       command: 'push'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
       nuGetFeedType: 'external'
       publishFeedCredentials: 'NugetOrg'
       allowPackageConflicts: true # This ignores an error if the version already exists


### PR DESCRIPTION
**Changes**
Another try at fixing nuget ci. This time I actually tested it.

- Don't specify `.snupkg` files in push because they get pushed automatically (https://github.com/Microsoft/azure-pipelines-tasks/issues/10140)
- Build Nuget packages with version specified in the git tag name (see Docker images) https://github.com/jellyfin/jellyfin/blob/406ae3e43a20216292c554151fa2d0e2a09edfa3/.ci/azure-pipelines-package.yml#L126-L128

Note: I'm tagging #4859 for backport as well since I forgot that at the time of making the PR

This is the sample output from a build for the tag `v10.7.1-rc4` with package names changed to `Example.*`

**Build task:**
```
...
Successfully created package '/home/vsts/work/1/a/Example.Naming.10.7.1-rc4.nupkg'.
Successfully created package '/home/vsts/work/1/a/Example.Naming.10.7.1-rc4.snupkg'.
...
Successfully created package '/home/vsts/work/1/a/Example.Data.10.7.1-rc4.nupkg'.
Successfully created package '/home/vsts/work/1/a/Example.Data.10.7.1-rc4.snupkg'.
...
Successfully created package '/home/vsts/work/1/a/Example.Common.10.7.1-rc4.nupkg'.
Successfully created package '/home/vsts/work/1/a/Example.Common.10.7.1-rc4.snupkg'.
...
Successfully created package '/home/vsts/work/1/a/Example.Controller.10.7.1-rc4.nupkg'.
Successfully created package '/home/vsts/work/1/a/Example.Controller.10.7.1-rc4.snupkg'.
...
Successfully created package '/home/vsts/work/1/a/Example.Model.10.7.1-rc4.nupkg'.
Successfully created package '/home/vsts/work/1/a/Example.Model.10.7.1-rc4.snupkg'.
```
**Push task:**
```
/usr/bin/mono /opt/hostedtoolcache/NuGet/5.4.0/x64/nuget.exe push /home/vsts/work/1/a/Example.Common.10.7.1-rc4.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile /home/vsts/work/1/Nuget/tempNuGet_199.config -Verbosity Detailed
NuGet Version: 5.4.0.6315
Pushing Example.Common.10.7.1-rc4.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 794ms
Your package was pushed.
Pushing Example.Common.10.7.1-rc4.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 435ms
Your package was pushed.
/usr/bin/mono /opt/hostedtoolcache/NuGet/5.4.0/x64/nuget.exe push /home/vsts/work/1/a/Example.Controller.10.7.1-rc4.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile /home/vsts/work/1/Nuget/tempNuGet_199.config -Verbosity Detailed
NuGet Version: 5.4.0.6315
Pushing Example.Controller.10.7.1-rc4.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 1085ms
Your package was pushed.
Pushing Example.Controller.10.7.1-rc4.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 475ms
Your package was pushed.
/usr/bin/mono /opt/hostedtoolcache/NuGet/5.4.0/x64/nuget.exe push /home/vsts/work/1/a/Example.Data.10.7.1-rc4.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile /home/vsts/work/1/Nuget/tempNuGet_199.config -Verbosity Detailed
NuGet Version: 5.4.0.6315
Pushing Example.Data.10.7.1-rc4.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 794ms
Your package was pushed.
Pushing Example.Data.10.7.1-rc4.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 366ms
Your package was pushed.
/usr/bin/mono /opt/hostedtoolcache/NuGet/5.4.0/x64/nuget.exe push /home/vsts/work/1/a/Example.Model.10.7.1-rc4.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile /home/vsts/work/1/Nuget/tempNuGet_199.config -Verbosity Detailed
NuGet Version: 5.4.0.6315
Pushing Example.Model.10.7.1-rc4.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 1021ms
Your package was pushed.
Pushing Example.Model.10.7.1-rc4.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 454ms
Your package was pushed.
/usr/bin/mono /opt/hostedtoolcache/NuGet/5.4.0/x64/nuget.exe push /home/vsts/work/1/a/Example.Naming.10.7.1-rc4.nupkg -NonInteractive -Source https://api.nuget.org/v3/index.json -ApiKey *** -ConfigFile /home/vsts/work/1/Nuget/tempNuGet_199.config -Verbosity Detailed
NuGet Version: 5.4.0.6315
Pushing Example.Naming.10.7.1-rc4.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 841ms
Your package was pushed.
Pushing Example.Naming.10.7.1-rc4.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 414ms
Your package was pushed.
```