### PR TITLE
Remove used quick connect tokens

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1456,7 +1456,12 @@ namespace Emby.Server.Implementations.Session
                 throw new SecurityException("Unknown quick connect token");
             }
 
-            request.UserId = result.Items[0].UserId;
+            var info = result.Items[0];
+            request.UserId = info.UserId;
+
+            // There's no need to keep the quick connect token in the database, as AuthenticateNewSessionInternal() issues a long lived token.
+            _authRepo.Delete(info);
+
             return AuthenticateNewSessionInternal(request, false);
         }
 


### PR DESCRIPTION
After using quick connect to login, two device entries are created in the Devices page: one with the server's name labeled `QuickConnect`, and another for the connecting device. The first entry is used to associate the user id to the login request and the second entry is created by `AuthenticateNewSessionInternal()`.

**Changes**
After authenticating the incoming quick connect request, delete the initial quick connect token from the authentication repository to avoid adding a second device to the list.