### PR TITLE
Fix inverted SkipWhile

### DIFF
--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -267,7 +267,7 @@ namespace Jellyfin.Api.Controllers
             if (startItemId.HasValue)
             {
                 episodes = episodes
-                    .SkipWhile(i => startItemId.Value.Equals(i.Id))
+                    .SkipWhile(i => !startItemId.Value.Equals(i.Id))
                     .ToList();
             }
 


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/4932

Confirmed this was the original functionality from 10.6
https://github.com/jellyfin/jellyfin/blob/907695dec7fda152d0e17c1197637bc0e17c9928/MediaBrowser.Api/TvShowsService.cs#L467