### PR TITLE
Fix rpm package dependencies

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -28,7 +28,7 @@ BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, 
 # COPR @dotnet-sig/dotnet or
 # https://packages.microsoft.com/rhel/7/prod/
 BuildRequires:  dotnet-runtime-5.0, dotnet-sdk-5.0
-Requires: %{name}-server = %{version}-%{release}, %{name}-web >= 10.6, %{name}-web < 10.7
+Requires: %{name}-server = %{version}-%{release}, %{name}-web = %{version}-%{release}
 # Disable Automatic Dependency Processing
 AutoReqProv:    no
 


### PR DESCRIPTION


**Changes**
Fix the version dependencies in the rpm spec. The latest stable rpm for centos is broken because the jellyfin rpm requires `jellyfin-web >= 10.6` and `jellyfin-web < 10.7`. This updates the spec to use the variables for versioning so the dependencies shouldn't need to be maintained going forward (and actually matches the `jellyfin-server` dependency)

**Issues**
https://github.com/jellyfin/jellyfin/issues/4938
