### PR TITLE
Fix capitalization of Playstate message

### DIFF
--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -826,7 +826,7 @@ namespace Emby.Dlna.PlayTo
                 return SendPlayCommand(data as PlayRequest, cancellationToken);
             }
 
-            if (name == SessionMessageType.PlayState)
+            if (name == SessionMessageType.Playstate)
             {
                 return SendPlaystateCommand(data as PlaystateRequest, cancellationToken);
             }

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1310,7 +1310,7 @@ namespace Emby.Server.Implementations.Session
                 }
             }
 
-            return SendMessageToSession(session, SessionMessageType.PlayState, command, cancellationToken);
+            return SendMessageToSession(session, SessionMessageType.Playstate, command, cancellationToken);
         }
 
         private static void AssertCanControl(SessionInfo session, SessionInfo controllingSession)

--- a/MediaBrowser.Model/Session/SessionMessageType.cs
+++ b/MediaBrowser.Model/Session/SessionMessageType.cs
@@ -15,7 +15,7 @@ namespace MediaBrowser.Model.Session
         Play,
         SyncPlayCommand,
         SyncPlayGroupUpdate,
-        PlayState,
+        Playstate,
         RestartRequired,
         ServerShuttingDown,
         ServerRestarting,


### PR DESCRIPTION
**Changes**
Fixes a change to the capitalization of the "Playstate" command in 10.7 which broke some remote control commands in web

**Issues**
Fixes jellyfin/jellyfin-web#2245
