### PR TITLE
Fix for 4933: FFMPeg detection.

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -148,13 +148,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 return source == null;
             }
 
-            // If either is recommended, then select that. If both are recommened, select the latest.
-            bool sourceRecommended = IsRecommendedVersion(source);
-            bool destRecommended = IsRecommendedVersion(destination);
-
-            if (sourceRecommended)
+            // If either source or destination is recommended, then select that.
+            if (IsRecommendedVersion(source))
             {
-                if (destRecommended)
+                if (IsRecommendedVersion(destination))
                 {
                     // if both are recommended, select the latest version.
                     return source < destination;

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -121,19 +121,19 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public static Version MaxVersion { get; } = null;
 
         /// <summary>
-        /// Returns a value indicating which version of the encoder more suitable.
+        /// Returns a value indicating which version of the encoder preferred.
         /// </summary>
-        /// <param name="source">Source encoding version.</param>
-        /// <param name="destination">Destination encoding version.</param>
-        /// <returns><c>false</c> if source is better, <c>true</c> if destination is better.</returns>
-        public static bool BestVersion(Version source, Version destination)
+        /// <param name="source">Source version.</param>
+        /// <param name="destination">Destination version.</param>
+        /// <returns><c>false</c> if the source version is preferred, <c>true</c> if destination version is preferred.</returns>
+        public static bool IsPreferredVersion(Version source, Version destination)
         {
             if (source == null || destination == null)
             {
                 return source == null;
             }
 
-            // If either is recommended, then select that.
+            // If either is recommended, then select that. If both are recommened, select the latest.
             bool sourceRecommended = source >= MinVersion && (MaxVersion == null || source <= MaxVersion);
             bool destRecommended = destination >= MinVersion && (MaxVersion == null || destination <= MaxVersion);
 
@@ -142,7 +142,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 if (destRecommended)
                 {
                     // if both are recommended, select the latest version.
-                    return !(source >= destination);
+                    return source < destination;
                 }
                 else
                 {

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -141,7 +141,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 if (destRecommended)
                 {
-                    // if both are recommendend, select the latest version.
+                    // if both are recommended, select the latest version.
                     return !(source >= destination);
                 }
                 else

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -125,7 +125,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         /// <param name="source">Source encoding version.</param>
         /// <param name="destination">Destination encoding version.</param>
-        /// <returns>-1 if source is better, 1 if destination is better.</returns>
+        /// <returns><c>false</c> if source is better, <c>true</c> if destination is better.</returns>
         public static bool BestVersion(Version source, Version destination)
         {
             if (source == null || destination == null)

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -126,24 +126,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <param name="source">Source encoding version.</param>
         /// <param name="destination">Destination encoding version.</param>
         /// <returns>-1 if source is better, 1 if destination is better.</returns>
-        public static int BestVersion(Version source, Version destination)
+        public static bool BestVersion(Version source, Version destination)
         {
-            if (source == null)
+            if (source == null || destination == null)
             {
-                // Always select the none null value.
-                if (destination != null)
-                {
-                    return 1;
-                }
-
-                // doesn't really matter, as both are null.
-                return -1;
-            }
-
-            // Always select the none null value.
-            if (source != null && destination == null)
-            {
-                return -1;
+                return source != null ? false : true;
             }
 
             // If either is recommended, then select that.
@@ -155,18 +142,16 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 if (destRecommended)
                 {
                     // if both are recommendend, select the latest version.
-                    return source >= destination ? -1 : 1;
+                    return !(source >= destination);
                 }
-
-                return -1;
-            }
-            else if (destRecommended)
-            {
-                return 1;
+                else
+                {
+                    return false;
+                }
             }
 
             // select the latest.
-            return source >= destination ? -1 : 1;
+            return !(source >= destination);
         }
 
         public void SetEncoderPath(string path)

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -121,6 +121,21 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public static Version MaxVersion { get; } = null;
 
         /// <summary>
+        /// Checks to see if a version is recommended.
+        /// </summary>
+        /// <param name="version">The <see cref="Version"/> to check.</param>
+        /// <returns><c>True</c> if recommended, <c>false</c> if not.</returns>
+        public static bool IsRecommendedVersion(Version version)
+        {
+            if (version == null)
+            {
+                return false;
+            }
+
+            return version >= MinVersion && (MaxVersion == null || version <= MaxVersion);
+        }
+
+        /// <summary>
         /// Returns a value indicating which version of the encoder preferred.
         /// </summary>
         /// <param name="source">Source version.</param>
@@ -134,8 +149,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // If either is recommended, then select that. If both are recommened, select the latest.
-            bool sourceRecommended = source >= MinVersion && (MaxVersion == null || source <= MaxVersion);
-            bool destRecommended = destination >= MinVersion && (MaxVersion == null || destination <= MaxVersion);
+            bool sourceRecommended = IsRecommendedVersion(source);
+            bool destRecommended = IsRecommendedVersion(destination);
 
             if (sourceRecommended)
             {

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -130,7 +130,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             if (source == null || destination == null)
             {
-                return source != null ? false : true;
+                return source == null;
             }
 
             // If either is recommended, then select that.

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -163,7 +163,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // select the latest.
-            return !(source >= destination);
+            return source < destination;
         }
 
         public void SetEncoderPath(string path)

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -211,7 +211,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     var version = _encoderValidator.ValidateVersion(path);
                     if (version != null)
                     {
-                        if (EncoderValidator.BestVersion(version, _bestVersion) == -1)
+                        if (EncoderValidator.BestVersion(version, _bestVersion))
                         {
                             _bestVersion = version;
                             _bestPath = path;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -219,8 +219,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                             return true;
                         }
 
-                        _logger.LogInformation("FFmpeg: {Location}: version { Version } found: {Path}", location, version, path);
-                        return false;
+                        _logger.LogInformation("FFmpeg: {Location}: version {Version} found: {Path}", location, version, path);
                     }
 
                     _logger.LogWarning("FFmpeg: {Location}: Failed version check: {Path}", location, path);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -120,6 +120,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
+            if (_preferredVersion.version != null && !EncoderValidator.IsRecommendedVersion(_preferredVersion.version))
+            {
+                _logger.LogWarning("Using the best unrecommended version of FFMPeg located.");
+            }
+
             _ffmpegPath = _preferredVersion.path;
             EncoderLocation = _preferredVersion.location;
 

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -18,6 +18,36 @@ namespace Jellyfin.MediaEncoding.Tests
         }
 
         [Theory]
+        [InlineData("2.0.0.0", "1.0.0.0", -1)]
+        [InlineData("4.5.0.0", "5.2.0.0", 1)]
+        [InlineData(null, "3.5.0.0", 1)]
+        [InlineData("2.0.0.0", null, -1)]
+        [InlineData(null, "2.0.0.0", 1)]
+        public void BestVersion(string? source, string? destination, int best)
+        {
+            Assert.Equal(
+                EncoderValidator.BestVersion(
+                    source != null ? Version.Parse(source) : null,
+                    destination != null ? Version.Parse(destination) : null),
+                best);
+        }
+
+        [Theory]
+        [InlineData("2.0.0.0", "1.0.0.0", 1)]
+        [InlineData("4.5.0.0", "5.2.0.0", -1)]
+        [InlineData(null, "3.5.0.0", -1)]
+        [InlineData("2.0.0.0", null, 1)]
+        [InlineData(null, "2.0.0.0", -1)]
+        public void WorstVersion(string? source, string? destination, int worst)
+        {
+            Assert.NotEqual(
+                EncoderValidator.BestVersion(
+                    source != null ? Version.Parse(source) : null,
+                    destination != null ? Version.Parse(destination) : null),
+                worst);
+        }
+
+        [Theory]
         [InlineData(EncoderValidatorTestsData.FFmpegV431Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV43Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV421Output, true)]
@@ -29,7 +59,7 @@ namespace Jellyfin.MediaEncoding.Tests
         public void ValidateVersionInternalTest(string versionOutput, bool valid)
         {
             var val = new EncoderValidator(new NullLogger<EncoderValidatorTests>());
-            Assert.Equal(valid, val.ValidateVersionInternal(versionOutput));
+            Assert.Equal(valid, val.ValidateVersionInternal(versionOutput) != null);
         }
 
         private class GetFFmpegVersionTestData : IEnumerable<object?[]>

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -23,10 +23,10 @@ namespace Jellyfin.MediaEncoding.Tests
         [InlineData(null, "3.5.0.0", true)]
         [InlineData("2.0.0.0", null, false)]
         [InlineData(null, "2.0.0.0", true)]
-        public void BestVersion(string? source, string? destination, bool best)
+        public void PrefferedVersion(string? source, string? destination, bool best)
         {
             Assert.Equal(
-                EncoderValidator.BestVersion(
+                EncoderValidator.IsPreferredVersion(
                     source != null ? Version.Parse(source) : null,
                     destination != null ? Version.Parse(destination) : null),
                 best);

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -33,21 +33,6 @@ namespace Jellyfin.MediaEncoding.Tests
         }
 
         [Theory]
-        [InlineData("2.0.0.0", "1.0.0.0", false)]
-        [InlineData("4.5.0.0", "5.2.0.0", true)]
-        [InlineData(null, "3.5.0.0", true)]
-        [InlineData("2.0.0.0", null, false)]
-        [InlineData(null, "2.0.0.0", true)]
-        public void WorstVersion(string? source, string? destination, bool worst)
-        {
-            Assert.Equal(
-                EncoderValidator.BestVersion(
-                    source != null ? Version.Parse(source) : null,
-                    destination != null ? Version.Parse(destination) : null),
-                worst);
-        }
-
-        [Theory]
         [InlineData(EncoderValidatorTestsData.FFmpegV431Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV43Output, true)]
         [InlineData(EncoderValidatorTestsData.FFmpegV421Output, true)]

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -18,12 +18,12 @@ namespace Jellyfin.MediaEncoding.Tests
         }
 
         [Theory]
-        [InlineData("2.0.0.0", "1.0.0.0", -1)]
-        [InlineData("4.5.0.0", "5.2.0.0", 1)]
-        [InlineData(null, "3.5.0.0", 1)]
-        [InlineData("2.0.0.0", null, -1)]
-        [InlineData(null, "2.0.0.0", 1)]
-        public void BestVersion(string? source, string? destination, int best)
+        [InlineData("2.0.0.0", "1.0.0.0", false)]
+        [InlineData("4.5.0.0", "5.2.0.0", true)]
+        [InlineData(null, "3.5.0.0", true)]
+        [InlineData("2.0.0.0", null, false)]
+        [InlineData(null, "2.0.0.0", true)]
+        public void BestVersion(string? source, string? destination, bool best)
         {
             Assert.Equal(
                 EncoderValidator.BestVersion(
@@ -33,14 +33,14 @@ namespace Jellyfin.MediaEncoding.Tests
         }
 
         [Theory]
-        [InlineData("2.0.0.0", "1.0.0.0", 1)]
-        [InlineData("4.5.0.0", "5.2.0.0", -1)]
-        [InlineData(null, "3.5.0.0", -1)]
-        [InlineData("2.0.0.0", null, 1)]
-        [InlineData(null, "2.0.0.0", -1)]
-        public void WorstVersion(string? source, string? destination, int worst)
+        [InlineData("2.0.0.0", "1.0.0.0", false)]
+        [InlineData("4.5.0.0", "5.2.0.0", true)]
+        [InlineData(null, "3.5.0.0", true)]
+        [InlineData("2.0.0.0", null, false)]
+        [InlineData(null, "2.0.0.0", true)]
+        public void WorstVersion(string? source, string? destination, bool worst)
         {
-            Assert.NotEqual(
+            Assert.Equal(
                 EncoderValidator.BestVersion(
                     source != null ? Version.Parse(source) : null,
                     destination != null ? Version.Parse(destination) : null),


### PR DESCRIPTION
If a version of ffmpeg is discovered that is outside the recommended version - this continues to look for a better one.

Also fixes https://github.com/jellyfin/jellyfin/issues/4933, whereby a version being outside of the recommended results in no version being selected, as function returns false.