### PR TITLE
Repeated class creation due to manual creation of DI classes.

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -407,6 +407,19 @@ namespace Emby.Server.Implementations
             try
             {
                 _creatingInstances.Add(type);
+                
+                // Is this class registered with the DI?
+                var diInterfaceType = type.GetInterfaces().FirstOrDefault(i => string.Equals(i.Name, "I" + type.Name, StringComparison.Ordinal));
+                if (diInterfaceType != null)
+                {
+                    Logger.LogDebug("Requesting instance of {DiType} from DI for {Type}.", diInterfaceType, type);
+                    var instance = ServiceProvider.GetService(diInterfaceType);
+                    if (instance != null)
+                    {
+                        return instance;
+                    }
+                }
+
                 Logger.LogDebug("Creating instance of {Type}", type);
                 return ActivatorUtilities.CreateInstance(ServiceProvider, type);
             }


### PR DESCRIPTION
**Issue:**

1. Register class with DI.
2. Class is manually instantiated via the _GetExports<T>_
3. DI will create another instance of class as the creation is outside of DI, and cannot be injected into it.

**Example:**

1. Plugin registers a class with DI.
_eg. serviceCollection.AddSingleton<IDlnaServerManager, DlnaServerManager>();_

2. Plugin implements the interface _IServerEntryPoint_ so that the class with be instantiated and auto-started.
_eg. public class DlnaServerManager : IDlnaServerManager, IServerEntryPoint_

3. ApplicationHost calls _GetExports<IServerEntryPoint>();_ which creates instances of the classes.
However, this creation is outside of DI, so when a class requiring another IDnlaServerManager parameter is encountered, **another** DlnaServerManager instance is created.

As _DlnaServerManager_ is the parameter passed into _CreateInstanceSafe_ a direct DI Resolve<> won't work, as our style is to use interfaces, not classes (serviceCollection.AddSingleton<IDlnaServerManager, DlnaServerManager> **not**  serviceCollection.AddSingleton<DlnaServerManager>).

This solution - looks for an interface starting with I that matches the name of the class being asked to be created eg. Hello, would cause IHello to be used. DI is then queried to see if this interface / class has been registered, and then is asked to create the instance for us.

This should stop any instance being repeatedly created if it's been registered in DI - as long as it meets this criteria.


**Why is it needed?**
Cannot think of another way which IServerEntryPoint can be used with DI when code isn't triggered.
Concrete values are created using ActivatorUtilities.CreateInstance(ServiceProvider, type) which although permits DI parameters, does not feed the instance back into DI, so multiple calls to the function will result in multiple instances even thought it's registered in the DI as a singleton.

