### PR TITLE
Fix library with music directly under artist folder

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -141,6 +141,7 @@
  - [Pusta](https://github.com/pusta)
  - [nielsvanvelzen](https://github.com/nielsvanvelzen)
  - [skyfrk](https://github.com/skyfrk)
+ - [ianjazz246](https://github.com/ianjazz246)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -30,7 +30,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// Gets the priority.
         /// </summary>
         /// <value>The priority.</value>
-        public override ResolverPriority Priority => ResolverPriority.Fourth;
+        public override ResolverPriority Priority => ResolverPriority.Fifth;
 
         public MultiItemResolverResult ResolveMultiple(
             Folder parent,

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// Gets the priority.
         /// </summary>
         /// <value>The priority.</value>
-        public override ResolverPriority Priority => ResolverPriority.Second;
+        public override ResolverPriority Priority => ResolverPriority.Third;
 
         /// <summary>
         /// Resolves the specified args.

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -47,7 +47,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
         /// Gets the priority.
         /// </summary>
         /// <value>The priority.</value>
-        public override ResolverPriority Priority => ResolverPriority.Third;
+        public override ResolverPriority Priority => ResolverPriority.Fourth;
 
         /// <inheritdoc />
         public MultiItemResolverResult ResolveMultiple(

--- a/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
+++ b/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
@@ -26,8 +26,13 @@ namespace MediaBrowser.Controller.Resolvers
         Fourth = 4,
 
         /// <summary>
+        /// The Fifth.
+        /// </summary>
+        Fifth = 5,
+
+        /// <summary>
         /// The last.
         /// </summary>
-        Last = 5
+        Last = 6
     }
 }


### PR DESCRIPTION
Fixes #3169 and #2879

Simply changes ResolverPriority of the resolvers so that MusicArtistResolver runs before MusicAlbumResolver. This makes a folder with albums inside a artist folder, regardless of whether there are audio files directly in the folder.

Previously, the MusicAlbumResolver would see an audio file in the artist folder and consider it an album, breaking the real albums.