### PR TITLE
Change split character

### DIFF
--- a/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -387,7 +387,7 @@ namespace Jellyfin.Networking.Manager
             // Get the first LAN interface address that isn't a loopback.
             var interfaces = CreateCollection(_interfaceAddresses
                 .Exclude(_bindExclusions)
-                .Where(IsInLocalNetwork(p))
+                .Where(IsInLocalNetwork)
                 .OrderBy(p => p.Tag));
 
             if (interfaces.Count > 0)

--- a/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -387,7 +387,7 @@ namespace Jellyfin.Networking.Manager
             // Get the first LAN interface address that isn't a loopback.
             var interfaces = CreateCollection(_interfaceAddresses
                 .Exclude(_bindExclusions)
-                .Where(p => IsInLocalNetwork(p))
+                .Where(IsInLocalNetwork(p))
                 .OrderBy(p => p.Tag));
 
             if (interfaces.Count > 0)
@@ -591,7 +591,7 @@ namespace Jellyfin.Networking.Manager
             else // Used in testing only.
             {
                 // Format is <IPAddress>,<Index>,<Name>: <next interface>. Set index to -ve to simulate a gateway.
-                var interfaceList = MockNetworkSettings.Split(':');
+                var interfaceList = MockNetworkSettings.Split('|');
                 foreach (var details in interfaceList)
                 {
                     var parts = details.Split(',');

--- a/tests/Jellyfin.Networking.Tests/NetworkTesting/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkTesting/NetworkParseTests.cs
@@ -54,13 +54,13 @@ namespace Jellyfin.Networking.Tests
         /// <summary>
         /// Checks the ability to ignore interfaces
         /// </summary>
-        /// <param name="interfaces">Mock network setup, in the format (IP address, interface index, interface name) : .... </param>
+        /// <param name="interfaces">Mock network setup, in the format (IP address, interface index, interface name) | .... </param>
         /// <param name="lan">LAN addresses.</param>
         /// <param name="value">Bind addresses that are excluded.</param>
         [Theory]
-        [InlineData("192.168.1.208/24,-16,eth16:200.200.200.200/24,11,eth11", "192.168.1.0/24;200.200.200.0/24", "[192.168.1.208/24,200.200.200.200/24]")]
-        [InlineData("192.168.1.208/24,-16,eth16:200.200.200.200/24,11,eth11", "192.168.1.0/24", "[192.168.1.208/24]")]
-        [InlineData("192.168.1.208/24,-16,vEthernet1:192.168.1.208/24,-16,vEthernet212;200.200.200.200/24,11,eth11", "192.168.1.0/24", "[192.168.1.208/24]")]
+        [InlineData("192.168.1.208/24,-16,eth16|200.200.200.200/24,11,eth11", "192.168.1.0/24;200.200.200.0/24", "[192.168.1.208/24,200.200.200.200/24]")]
+        [InlineData("192.168.1.208/24,-16,eth16|200.200.200.200/24,11,eth11", "192.168.1.0/24", "[192.168.1.208/24]")]
+        [InlineData("192.168.1.208/24,-16,vEthernet1|192.168.1.208/24,-16,vEthernet212|200.200.200.200/24,11,eth11", "192.168.1.0/24", "[192.168.1.208/24]")]
         public void IgnoreVirtualInterfaces(string interfaces, string lan, string value)
         {
             var conf = new NetworkConfiguration()
@@ -434,7 +434,7 @@ namespace Jellyfin.Networking.Tests
                 EnableIPV4 = true
             };
 
-            NetworkManager.MockNetworkSettings = "192.168.1.208/24,-16,eth16:200.200.200.200/24,11,eth11";
+            NetworkManager.MockNetworkSettings = "192.168.1.208/24,-16,eth16|200.200.200.200/24,11,eth11";
             using var nm = new NetworkManager(GetMockConfig(conf), new NullLogger<NetworkManager>());
             NetworkManager.MockNetworkSettings = string.Empty;
 
@@ -501,7 +501,7 @@ namespace Jellyfin.Networking.Tests
                 PublishedServerUriBySubnet = new string[] { publishedServers }
             };
 
-            NetworkManager.MockNetworkSettings = "192.168.1.208/24,-16,eth16:200.200.200.200/24,11,eth11";
+            NetworkManager.MockNetworkSettings = "192.168.1.208/24,-16,eth16|200.200.200.200/24,11,eth11";
             using var nm = new NetworkManager(GetMockConfig(conf), new NullLogger<NetworkManager>());
             NetworkManager.MockNetworkSettings = string.Empty;
 


### PR DESCRIPTION
Changed mock network split character to | from : so that IPv6 addresses can be included in the mock networks.