### PR TITLE
Add .nfo ratings tag

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -624,6 +624,21 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         break;
                     }
 
+                case "ratings":
+                    {
+                        if (!reader.IsEmptyElement)
+                        {
+                            using var subtree = reader.ReadSubtree();
+                            FetchFromRatingsNode(subtree, item);
+                        }
+                        else
+                        {
+                            reader.Read();
+                        }
+
+                        break;
+                    }
+
                 case "aired":
                 case "formed":
                 case "premiered":
@@ -854,6 +869,90 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                 break;
                             }
 
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+                else
+                {
+                    reader.Read();
+                }
+            }
+        }
+
+        private void FetchFromRatingsNode(XmlReader reader, T item)
+        {
+            reader.MoveToContent();
+            reader.Read();
+
+            // Loop through each element
+            while (!reader.EOF && reader.ReadState == ReadState.Interactive)
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    switch (reader.Name)
+                    {
+                        case "rating":
+                        {
+                            if (reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                continue;
+                            }
+
+                            var ratingName = reader.GetAttribute("name");
+
+                            using var subtree = reader.ReadSubtree();
+                            FetchFromRatingNode(subtree, item, ratingName);
+
+                            break;
+                        }
+
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+                else
+                {
+                    reader.Read();
+                }
+            }
+        }
+
+        private void FetchFromRatingNode(XmlReader reader, T item, string? ratingName)
+        {
+            reader.MoveToContent();
+            reader.Read();
+
+            // Loop through each element
+            while (!reader.EOF && reader.ReadState == ReadState.Interactive)
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    switch (reader.Name)
+                    {
+                        case "value":
+                            var val = reader.ReadElementContentAsString();
+
+                            if (!string.IsNullOrWhiteSpace(val))
+                            {
+                                if (float.TryParse(val.Replace(',', '.'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var ratingValue))
+                                {
+                                    // if ratingName contains tomato --> assume critic rating
+                                    if (ratingName != null && ratingName.Contains("tomato", StringComparison.InvariantCultureIgnoreCase))
+                                    {
+                                        item.CriticRating = ratingValue;
+                                    }
+                                    else
+                                    {
+                                        item.CommunityRating = ratingValue;
+                                    }
+                                }
+                            }
+
+                            break;
                         default:
                             reader.Skip();
                             break;

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -941,7 +941,9 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                 if (float.TryParse(val, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var ratingValue))
                                 {
                                     // if ratingName contains tomato --> assume critic rating
-                                    if (ratingName != null && ratingName.Contains("tomato", StringComparison.OrdinalIgnoreCase))
+                                    if (ratingName != null &&
+                                        ratingName.Contains("tomato", StringComparison.OrdinalIgnoreCase) &&
+                                        !ratingName.Contains("audience", StringComparison.OrdinalIgnoreCase))
                                     {
                                         item.CriticRating = ratingValue;
                                     }

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -938,10 +938,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                             if (!string.IsNullOrWhiteSpace(val))
                             {
-                                if (float.TryParse(val.Replace(',', '.'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var ratingValue))
+                                if (float.TryParse(val, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var ratingValue))
                                 {
                                     // if ratingName contains tomato --> assume critic rating
-                                    if (ratingName != null && ratingName.Contains("tomato", StringComparison.InvariantCultureIgnoreCase))
+                                    if (ratingName != null && ratingName.Contains("tomato", StringComparison.OrdinalIgnoreCase))
                                     {
                                         item.CriticRating = ratingValue;
                                     }


### PR DESCRIPTION
**Changes**
Add support for the `<ratings>` tag in .nfo files.
Because of compatibility reasons I didn't remove support for the `<rating>` tag.

Ratings with names containing `tomato` will be treated as `CriticRatings`, every other rating will get imported as `CommunityRating`

**Issues**
Fixes #4887 
