### PR TITLE
Test code to help uncover "access denied" errors on nfo updating.(WIP)

### DIFF
--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -197,7 +197,7 @@ namespace Emby.Server.Implementations.IO
         /// <param name="lst">The LST.</param>
         /// <param name="path">The path.</param>
         /// <returns><c>true</c> if [contains parent folder] [the specified LST]; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">path</exception>
+        /// <exception cref="ArgumentNullException">path.</exception>
         private static bool ContainsParentFolder(IEnumerable<string> lst, string path)
         {
             if (string.IsNullOrEmpty(path))

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -197,7 +197,7 @@ namespace Emby.Server.Implementations.IO
         /// <param name="lst">The LST.</param>
         /// <param name="path">The path.</param>
         /// <returns><c>true</c> if [contains parent folder] [the specified LST]; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">path.</exception>
+        /// <exception cref="ArgumentNullException">path</exception>
         private static bool ContainsParentFolder(IEnumerable<string> lst, string path)
         {
             if (string.IsNullOrEmpty(path))

--- a/MediaBrowser.XbmcMetadata/Savers/AlbumNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/AlbumNfoSaver.cs
@@ -27,14 +27,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
         public AlbumNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<AlbumNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<AlbumNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/ArtistNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/ArtistNfoSaver.cs
@@ -26,14 +26,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor"> The <see cref="ILibraryMonitor"/>.</param>
         public ArtistNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<ArtistNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<ArtistNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -210,7 +210,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
             {
                 if (File.Exists(path))
                 {
-                    Logger.LogDebug("{Path} already exists.");
+                    Logger.LogError("{Path} already exists.");
                     try
                     {
                         File.Delete(path);

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -221,10 +221,9 @@ namespace MediaBrowser.XbmcMetadata.Savers
                     }
                 }
 
-                using (var filestream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read))
-                {
-                    stream.CopyTo(filestream);
-                }
+                using var filestream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+                stream.CopyTo(filestream);
+                filestream.Flush();
             }
             catch (Exception ex)
             {

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -204,7 +204,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private void SaveToFile(Stream stream, string path)
         {
-            LibraryMonitor.ReportFileSystemChangeBeginning(path);
+            // LibraryMonitor.ReportFileSystemChangeBeginning(path);
             try
             {
                 var directory = Path.GetDirectoryName(path) ?? throw new ArgumentException($"Provided path ({path}) is not valid.", nameof(path));
@@ -244,7 +244,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
             finally
             {
-                LibraryMonitor.ReportFileSystemChangeComplete(path, false);
+                // LibraryMonitor.ReportFileSystemChangeComplete(path, false);
             }
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
@@ -28,14 +28,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
         public EpisodeNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<EpisodeNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<EpisodeNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -28,14 +28,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
         public MovieNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<MovieNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<MovieNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
@@ -25,14 +25,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
         public SeasonNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<SeasonNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<SeasonNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
@@ -26,14 +26,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <param name="userManager">The user manager.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
         public SeriesNfoSaver(
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
             IUserDataManager userDataManager,
-            ILogger<SeriesNfoSaver> logger)
-            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger)
+            ILogger<SeriesNfoSaver> logger,
+            ILibraryMonitor libraryMonitor)
+            : base(fileSystem, configurationManager, libraryManager, userManager, userDataManager, logger, libraryMonitor)
         {
         }
 


### PR DESCRIPTION
Extra logging to find out what's happening.
Additional info collector for https://github.com/jellyfin/jellyfin/issues/4826


**From Dotnet Documentation**
Filemode.Create - Specifies that the operating system should create a new file. 

If the file already exists, it will be overwritten. This requires Write permission. 

FileMode.Create is equivalent to requesting that if the file does not exist, use CreateNew; 
otherwise, use Truncate.  **(0 byte file)**
If the file already exists but is a hidden file, an UnauthorizedAccessException exception is thrown.