### PR TITLE
Allow server to host SPA web client

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.1" />

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -179,7 +179,21 @@ namespace Jellyfin.Server
                             "The server is expected to host the web client, but the provided content directory is either " +
                             $"invalid or empty: {webContentPath}. If you do not want to host the web client with the " +
                             "server, you may set the '--nowebclient' command line flag, or set" +
-                            $"'{MediaBrowser.Controller.Extensions.ConfigurationExtensions.HostWebClientKey}=false' in your config settings.");
+                            $"'{ConfigurationExtensions.HostWebClientKey}=false' in your config settings.");
+                    }
+                }
+
+                // If hosting the spa client, validate the client content path.
+                if (startupConfig.HostSpaClient())
+                {
+                    string? webContentPath = appHost.ServerConfigurationManager.ApplicationPaths.WebPath;
+                    if (!Directory.Exists(webContentPath) || Directory.GetFiles(webContentPath).Length == 0)
+                    {
+                        throw new InvalidOperationException(
+                            "The server is expected to host the spa web client, but the provided content directory is either " +
+                            $"invalid or empty: {webContentPath}. If you do not want to host the web client with the " +
+                            "server, you may set the '--nowebclient' command line flag, or set" +
+                            $"'{ConfigurationExtensions.HostSpaClientKey}=false' in your config settings.");
                     }
                 }
 
@@ -563,7 +577,7 @@ namespace Jellyfin.Server
         {
             // Use the swagger API page as the default redirect path if not hosting the web client
             var inMemoryDefaultConfig = ConfigurationOptions.DefaultConfiguration;
-            if (startupConfig != null && !startupConfig.HostWebClient())
+            if (startupConfig != null && !startupConfig.HostWebClient() && !startupConfig.HostSpaClient())
             {
                 inMemoryDefaultConfig[ConfigurationExtensions.DefaultRedirectKey] = "api-docs/swagger";
             }

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -170,23 +170,20 @@ namespace Jellyfin.Server
                     extensionProvider.Mappings.Add(".data", MediaTypeNames.Application.Octet);
                     extensionProvider.Mappings.Add(".mem", MediaTypeNames.Application.Octet);
 
+                    var staticFileOptions = new StaticFileOptions
+                    {
+                        FileProvider = new PhysicalFileProvider(_serverConfigurationManager.ApplicationPaths.WebPath),
+                        RequestPath = "/web",
+                        ContentTypeProvider = extensionProvider
+                    };
+
                     if (hostWebClient)
                     {
-                        mainApp.UseStaticFiles(new StaticFileOptions
-                        {
-                            FileProvider = new PhysicalFileProvider(_serverConfigurationManager.ApplicationPaths.WebPath),
-                            RequestPath = "/web",
-                            ContentTypeProvider = extensionProvider
-                        });
+                        mainApp.UseStaticFiles(staticFileOptions);
                     }
                     else if (hostSpaClient)
                     {
-                        mainApp.UseSpaStaticFiles(new StaticFileOptions
-                        {
-                            FileProvider = new PhysicalFileProvider(_serverConfigurationManager.ApplicationPaths.WebPath),
-                            RequestPath = "/web",
-                            ContentTypeProvider = extensionProvider
-                        });
+                        mainApp.UseSpaStaticFiles(staticFileOptions);
                     }
 
                     mainApp.UseRobotsRedirection();

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -35,6 +35,12 @@ namespace Jellyfin.Server
         public string? WebDir { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the server should host a SPA.
+        /// </summary>
+        [Option('s', "spa", Required = false, HelpText = "Indicates that the web server should host a SPA.")]
+        public bool HostSpa { get; set; }
+
+        /// <summary>
         /// Gets or sets the path to the cache directory.
         /// </summary>
         /// <value>The path to the cache directory.</value>
@@ -90,6 +96,13 @@ namespace Jellyfin.Server
             if (NoWebClient)
             {
                 config.Add(ConfigurationExtensions.HostWebClientKey, bool.FalseString);
+                config.Add(ConfigurationExtensions.HostSpaClientKey, bool.FalseString);
+            }
+
+            if (HostSpa)
+            {
+                config.Add(ConfigurationExtensions.HostWebClientKey, bool.FalseString);
+                config.Add(ConfigurationExtensions.HostSpaClientKey, bool.TrueString);
             }
 
             if (PublishedServerUrl != null)

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -20,6 +20,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string HostWebClientKey = "hostwebclient";
 
         /// <summary>
+        /// The key for a setting that indicates whether the application should host spa web client content.
+        /// </summary>
+        public const string HostSpaClientKey = "hostspaclient";
+
+        /// <summary>
         /// The key for the FFmpeg probe size option.
         /// </summary>
         public const string FfmpegProbeSizeKey = "FFmpeg:probesize";
@@ -57,6 +62,15 @@ namespace MediaBrowser.Controller.Extensions
         /// <exception cref="FormatException">The config value is not a valid bool string. See <see cref="bool.Parse(string)"/>.</exception>
         public static bool HostWebClient(this IConfiguration configuration)
             => configuration.GetValue<bool>(HostWebClientKey);
+
+        /// <summary>
+        /// Gets a value indicating whether the application should host a SPA client from the <see cref="IConfiguration"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to retrieve the value from.</param>
+        /// <returns>The parsed config value.</returns>
+        /// <exception cref="FormatException">The config value is not a valid bool string. See <see cref="bool.Parse(string)"/>.</exception>
+        public static bool HostSpaClient(this IConfiguration configuration)
+            => configuration.GetValue<bool>(HostSpaClientKey);
 
         /// <summary>
         /// Gets the FFmpeg probe size from the <see cref="IConfiguration" />.


### PR DESCRIPTION
Adds `-s` // `--spa` config flag to tell server that it's hosting a SPA.
Usage: `--webdir /path/to/web --spa`

Also adds `hostspaclient` config option.

This still allows current web to function normally.

Note: `jellyfin-vue` must currently be generated with the following in `nuxt.config.ts`
```js
  router: {
    base: '/web/'
  },
```