### PR TITLE
Use JsonSerializer.SerializeToUtf8Bytes when doing a round trip

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -515,7 +515,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             // TODO: @bond Fix
-            var json = JsonSerializer.Serialize(mediaSource, _jsonOptions);
+            var json = JsonSerializer.SerializeToUtf8Bytes(mediaSource, _jsonOptions);
             _logger.LogInformation("Live stream opened: " + json);
             var clone = JsonSerializer.Deserialize<MediaSourceInfo>(json, _jsonOptions);
 

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -2239,7 +2239,7 @@ namespace Emby.Server.Implementations.LiveTv
 
         public async Task<TunerHostInfo> SaveTunerHost(TunerHostInfo info, bool dataSourceChanged = true)
         {
-            info = JsonSerializer.Deserialize<TunerHostInfo>(JsonSerializer.Serialize(info));
+            info = JsonSerializer.Deserialize<TunerHostInfo>(JsonSerializer.SerializeToUtf8Bytes(info));
 
             var provider = _tunerHosts.FirstOrDefault(i => string.Equals(info.Type, i.Type, StringComparison.OrdinalIgnoreCase));
 
@@ -2283,7 +2283,7 @@ namespace Emby.Server.Implementations.LiveTv
         {
             // Hack to make the object a pure ListingsProviderInfo instead of an AddListingProvider
             // ServerConfiguration.SaveConfiguration crashes during xml serialization for AddListingProvider
-            info = JsonSerializer.Deserialize<ListingsProviderInfo>(JsonSerializer.Serialize(info));
+            info = JsonSerializer.Deserialize<ListingsProviderInfo>(JsonSerializer.SerializeToUtf8Bytes(info));
 
             var provider = _listingProviders.FirstOrDefault(i => string.Equals(info.Type, i.Type, StringComparison.OrdinalIgnoreCase));
 

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -123,7 +123,7 @@ namespace MediaBrowser.Controller.Entities
             {
                 LibraryOptions[path] = options;
 
-                var clone = JsonSerializer.Deserialize<LibraryOptions>(JsonSerializer.Serialize(options, _jsonOptions), _jsonOptions);
+                var clone = JsonSerializer.Deserialize<LibraryOptions>(JsonSerializer.SerializeToUtf8Bytes(options, _jsonOptions), _jsonOptions);
                 foreach (var mediaPath in clone.PathInfos)
                 {
                     if (!string.IsNullOrEmpty(mediaPath.Path))


### PR DESCRIPTION
This test uses a very small object (CountryInfo), using a bigger object
would increase the difference in allocated memory.

```
BenchmarkDotNet=v0.12.1, OS=fedora 32
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT

|          Method |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|  RoundTripBytes |   932.0 ns |  5.09 ns |  4.25 ns | 0.1173 |     - |     - |     368 B |
| RoundTripString | 1,114.8 ns | 22.19 ns | 23.74 ns | 0.1469 |     - |     - |     464 B |
```
