### PR TITLE
Open FileStream with FileMode.Create instead of FileMode.OpenOrCreate

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -177,7 +177,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
 
                 lock (_lastExecutionResultSyncLock)
                 {
-                    using FileStream createStream = File.OpenWrite(path);
+                    using FileStream createStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
                     JsonSerializer.SerializeAsync(createStream, value, _jsonOptions);
                 }
             }
@@ -577,9 +577,8 @@ namespace Emby.Server.Implementations.ScheduledTasks
             var path = GetConfigurationFilePath();
 
             Directory.CreateDirectory(Path.GetDirectoryName(path));
-
-            var json = JsonSerializer.Serialize(triggers, _jsonOptions);
-            File.WriteAllText(path, json, Encoding.UTF8);
+            using FileStream createStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+            JsonSerializer.SerializeAsync(createStream, triggers, _jsonOptions);
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
@@ -272,6 +272,10 @@ namespace MediaBrowser.Providers.Plugins.Omdb
                     return path;
                 }
             }
+            else
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+            }
 
             var url = GetOmdbUrl(
                 string.Format(
@@ -280,8 +284,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
                     imdbParam));
 
             var rootObject = await GetDeserializedOmdbResponse<RootObject>(_httpClientFactory.CreateClient(NamedClient.Default), url, cancellationToken).ConfigureAwait(false);
-            Directory.CreateDirectory(Path.GetDirectoryName(path));
-            await using FileStream jsonFileStream = File.OpenWrite(path);
+            await using FileStream jsonFileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
             await JsonSerializer.SerializeAsync(jsonFileStream, rootObject, _jsonOptions, cancellationToken).ConfigureAwait(false);
 
             return path;
@@ -308,6 +311,10 @@ namespace MediaBrowser.Providers.Plugins.Omdb
                     return path;
                 }
             }
+            else
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+            }
 
             var url = GetOmdbUrl(
                 string.Format(
@@ -317,8 +324,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
                     seasonId));
 
             var rootObject = await GetDeserializedOmdbResponse<SeasonRootObject>(_httpClientFactory.CreateClient(NamedClient.Default), url, cancellationToken).ConfigureAwait(false);
-            Directory.CreateDirectory(Path.GetDirectoryName(path));
-            await using FileStream jsonFileStream = File.OpenWrite(path);
+            await using FileStream jsonFileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
             await JsonSerializer.SerializeAsync(jsonFileStream, rootObject, _jsonOptions, cancellationToken).ConfigureAwait(false);
 
             return path;


### PR DESCRIPTION
> The OpenWrite method opens a file if one already exists for the file path,
    or creates a new file if one does not exist. For an existing file,
    it does not append the new text to the existing text. Instead,
    it overwrites the existing characters with the new characters.
    If you overwrite a longer string
    (such as "This is a test of the OpenWrite method") with a shorter string
    (such as "Second run"), the file will contain a mix of the strings
    ("Second runtest of the OpenWrite method").

Ref: https://docs.microsoft.com/en-us/dotnet/api/system.io.file.openwrite?view=net-5.0#remarks

**Issues**
Should fix #5000
Should fix #4965