### PR TITLE
Fix DLNA PlayTo encoding issue

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -113,6 +113,8 @@ namespace Emby.Dlna.Didl
 
                     writer.WriteFullEndElement();
                     // writer.WriteEndDocument();
+
+                    writer.Flush();
                 }
 
                 return builder.ToString();

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -96,6 +96,7 @@ namespace Emby.Dlna.Didl
 
             using (StringWriter builder = new StringWriterWithEncoding(Encoding.UTF8))
             {
+                // If this using are changed to single lines, then write.Flush needs to be appended before the return.
                 using (var writer = XmlWriter.Create(builder, settings))
                 {
                     // writer.WriteStartDocument();
@@ -113,8 +114,6 @@ namespace Emby.Dlna.Didl
 
                     writer.WriteFullEndElement();
                     // writer.WriteEndDocument();
-
-                    writer.Flush();
                 }
 
                 return builder.ToString();

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -896,16 +896,16 @@ namespace Emby.Dlna.PlayTo
 
                 var parts = url.Split('/');
 
-                for (var i = 0; i < parts.Length; i++)
+                for (var i = 0; i < parts.Length - 1; i++)
                 {
                     var part = parts[i];
 
                     if (string.Equals(part, "audio", StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(part, "videos", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (parts.Length > i + 1)
+                        if (Guid.TryParse(parts[i + 1], out var result))
                         {
-                            return Guid.Parse(parts[i + 1]);
+                            return result;
                         }
                     }
                 }

--- a/Emby.Dlna/PlayTo/TransportCommands.cs
+++ b/Emby.Dlna/PlayTo/TransportCommands.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security;
 using System.Xml.Linq;
 using Emby.Dlna.Common;
 using Emby.Dlna.Ssdp;
@@ -175,12 +176,12 @@ namespace Emby.Dlna.PlayTo
             if (state != null)
             {
                 var sendValue = state.AllowedValues.FirstOrDefault(a => string.Equals(a, commandParameter, StringComparison.OrdinalIgnoreCase)) ??
-                    (state.AllowedValues.Count > 0 ? state.AllowedValues[0] : value);
+                    (state.AllowedValues.Count > 0 ? state.AllowedValues[0] : SecurityElement.Escape(value));
 
                 return string.Format(CultureInfo.InvariantCulture, "<{0} xmlns:dt=\"urn:schemas-microsoft-com:datatypes\" dt:dt=\"{1}\">{2}</{0}>", argument.Name, state.DataType ?? "string", sendValue);
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "<{0}>{1}</{0}>", argument.Name, value);
+            return string.Format(CultureInfo.InvariantCulture, "<{0}>{1}</{0}>", argument.Name, SecurityElement.Escape(value));
         }
     }
 }

--- a/Emby.Dlna/PlayTo/TransportCommands.cs
+++ b/Emby.Dlna/PlayTo/TransportCommands.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security;
 using System.Xml.Linq;
 using Emby.Dlna.Common;
 using Emby.Dlna.Ssdp;

--- a/Emby.Dlna/PlayTo/TransportCommands.cs
+++ b/Emby.Dlna/PlayTo/TransportCommands.cs
@@ -176,12 +176,12 @@ namespace Emby.Dlna.PlayTo
             if (state != null)
             {
                 var sendValue = state.AllowedValues.FirstOrDefault(a => string.Equals(a, commandParameter, StringComparison.OrdinalIgnoreCase)) ??
-                    (state.AllowedValues.Count > 0 ? state.AllowedValues[0] : SecurityElement.Escape(value));
+                    (state.AllowedValues.Count > 0 ? state.AllowedValues[0] : value);
 
                 return string.Format(CultureInfo.InvariantCulture, "<{0} xmlns:dt=\"urn:schemas-microsoft-com:datatypes\" dt:dt=\"{1}\">{2}</{0}>", argument.Name, state.DataType ?? "string", sendValue);
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "<{0}>{1}</{0}>", argument.Name, SecurityElement.Escape(value));
+            return string.Format(CultureInfo.InvariantCulture, "<{0}>{1}</{0}>", argument.Name, value);
         }
     }
 }


### PR DESCRIPTION
**Fix 1:** Didl metadata wasn't being populated (all the time???) as flush was absent.

**Fix 2:** Exception caused by non-string GUID being parsed. 
(Raised by the DLNA eventing when the TV was already playing alternative content that contained the word "audios" in the url)

Additional errors still exist in metadata parsing around url encoding, which results in xml parsing errors. This is addressed in the plugin.