### PR TITLE
Revert "Don't return first episodes in next up"

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -143,10 +143,28 @@ namespace Emby.Server.Implementations.TV
             var allNextUp = seriesKeys
                 .Select(i => GetNextUp(i, currentUser, dtoOptions));
 
+            // allNextUp = allNextUp.OrderByDescending(i => i.Item1);
+
+            // If viewing all next up for all series, remove first episodes
+            // But if that returns empty, keep those first episodes (avoid completely empty view)
+            var alwaysEnableFirstEpisode = !string.IsNullOrEmpty(request.SeriesId);
+            var anyFound = false;
+
             return allNextUp
                 .Where(i =>
                 {
-                    return i.Item1 != DateTime.MinValue;
+                    if (alwaysEnableFirstEpisode || i.Item1 != DateTime.MinValue)
+                    {
+                        anyFound = true;
+                        return true;
+                    }
+
+                    if (!anyFound && i.Item1 == DateTime.MinValue)
+                    {
+                        return true;
+                    }
+
+                    return false;
                 })
                 .Select(i => i.Item2())
                 .Where(i => i != null);


### PR DESCRIPTION
Reverts jellyfin/jellyfin#4595

Unfortunately the change caused issues in the Android TV app. The "play next up" button stopped working since it used an endpoint that called this function and relied on it returning first episodes.

A proper fix is to add a new query parameter to the controllers so we can change the behavior from the client. It should default to the old behavior.
