### PR TITLE
Add HttpClient retry logic

### DIFF
--- a/Jellyfin.Server/Configuration/HttpClientPolicyConfiguration.cs
+++ b/Jellyfin.Server/Configuration/HttpClientPolicyConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Net.Http;
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+using Polly.Extensions.Http;
+
+namespace Jellyfin.Server.Configuration
+{
+    /// <summary>
+    /// HttpClient policy configuration.
+    /// </summary>
+    public static class HttpClientPolicyConfiguration
+    {
+        /// <summary>
+        /// Gets the HttpClient retry policy.
+        /// </summary>
+        /// <returns>The <see cref="IAsyncPolicy"/>.</returns>
+        public static IAsyncPolicy<HttpResponseMessage> GetHttpClientRetryPolicy()
+        {
+            var delay = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromSeconds(1), retryCount: 5);
+            return HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(delay);
+        }
+    }
+}

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -42,6 +42,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using Jellyfin.Networking.Configuration;
+using Jellyfin.Server.Configuration;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Implementations;
 using Jellyfin.Server.Middleware;
@@ -75,7 +76,8 @@ namespace Jellyfin.Server
                     c.DefaultRequestHeaders.Accept.Add(acceptXmlHeader);
                     c.DefaultRequestHeaders.Accept.Add(acceptAnyHeader);
                 })
-                .ConfigurePrimaryHttpMessageHandler(x => new DefaultHttpClientHandler());
+                .ConfigurePrimaryHttpMessageHandler(x => new DefaultHttpClientHandler())
+                .AddPolicyHandler(HttpClientPolicyConfiguration.GetHttpClientRetryPolicy());
 
             services.AddHttpClient(NamedClient.MusicBrainz, c =>
                 {
@@ -84,7 +86,8 @@ namespace Jellyfin.Server
                     c.DefaultRequestHeaders.Accept.Add(acceptXmlHeader);
                     c.DefaultRequestHeaders.Accept.Add(acceptAnyHeader);
                 })
-                .ConfigurePrimaryHttpMessageHandler(x => new DefaultHttpClientHandler());
+                .ConfigurePrimaryHttpMessageHandler(x => new DefaultHttpClientHandler())
+                .AddPolicyHandler(HttpClientPolicyConfiguration.GetHttpClientRetryPolicy());
 
             services.AddHealthChecks()
                 .AddDbContextCheck<JellyfinDb>();


### PR DESCRIPTION
Sourced from: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly

Jitter from: https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#new-jitter-recommendation