### PR TITLE
adjust episode path expression to allow digits in series names

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -282,7 +282,13 @@ namespace Emby.Naming.Common
                     SupportsAbsoluteEpisodeNumbers = true
                 },
 
-                // Case Closed (1996-2007)/Case Closed - 317.mkv
+                // Not a Kodi rule as well, but below rule also causes false positives for triple-digit episode names
+                // [bar] Foo - 1 [baz] special case of below expression to prevent false positives with digits in the series name
+                new EpisodeExpression(@".*?(\[.*?\])+.*?(?<seriesname>[\w\s]+?)[\s_]*-[\s_]*(?<epnumber>\d+).*$")
+                {
+                    IsNamed = true
+                },
+
                 // /server/anything_102.mp4
                 // /server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv
                 // /server/anything_1996.11.14.mp4
@@ -299,11 +305,6 @@ namespace Emby.Naming.Common
 
                 // *** End Kodi Standard Naming
 
-                // [bar] Foo - 1 [baz]
-                new EpisodeExpression(@".*?(\[.*?\])+.*?(?<seriesname>[\w\s]+?)[-\s_]+(?<epnumber>[0-9]+).*$")
-                {
-                    IsNamed = true
-                },
                 new EpisodeExpression(@".*(\\|\/)[sS]?(?<seasonnumber>[0-9]+)[xX](?<epnumber>[0-9]+)[^\\\/]*$")
                 {
                     IsNamed = true

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
@@ -66,12 +66,16 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("Season 2/2. Infestation.avi", 2)]
         [InlineData("The Wonder Years/The.Wonder.Years.S04.PDTV.x264-JCH/The Wonder Years s04e07 Christmas Party NTSC PDTV.avi", 7)]
         [InlineData("Running Man/Running Man S2017E368.mkv", 368)]
+        [InlineData("Season 2/[HorribleSubs] Hunter X Hunter - 136 [720p].mkv", 136)] // triple digit episode number
+        [InlineData("Log Horizon 2/[HorribleSubs] Log Horizon 2 - 03 [720p].mkv", 3)] // digit in series name
+        [InlineData("Season 1/seriesname 05.mkv", 5)] // no hyphen between series name and episode number
+        [InlineData("[BBT-RMX] Ranma ½ - 154 [50AC421A].mkv", 154)] // hyphens in the pre-name info, triple digit episode number
+        // TODO: [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", 317)] // triple digit episode number
         // TODO: [InlineData("Season 2/16 12 Some Title.avi", 16)]
         // TODO: [InlineData("/The.Legend.of.Condor.Heroes.2017.V2.web-dl.1080p.h264.aac-hdctv/The.Legend.of.Condor.Heroes.2017.E07.V2.web-dl.1080p.h264.aac-hdctv.mkv", 7)]
         // TODO: [InlineData("Season 4/Uchuu.Senkan.Yamato.2199.E03.avi", 3)]
         // TODO: [InlineData("Season 2/7 12 Angry Men.avi", 7)]
         // TODO: [InlineData("Season 02/02x03x04x15 - Ep Name.mp4", 2)]
-        // TODO: [InlineData("Season 2/[HorribleSubs] Hunter X Hunter - 136 [720p].mkv", 136)]
         public void GetEpisodeNumberFromFileTest(string path, int? expected)
         {
             var result = new EpisodePathParser(_namingOptions)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
The previous expression was too greedy to consume digits, because the hyphen was optional. This lead to incorrect episode numbers for certain series with digits in their names, in those cases each episode was recognized as the same episode number (the digit from the series name).

The rule, which matches most standard  anime filenames, also had a lower priority than one of the Kodi rules, leading to incorrect recognition for absolute numbered episodes with triple digits and higher (first digit was used as season number, rest of digits as episode number). This also resolves one of the TODO test cases.

Additional test cases were added to ensure that both hyphens in different parts of the filename, as well as names without hyphens, still work correctly. All previous test cases still pass.

Unfortunately another TODO ([EpisodeNumberTests.cs@L76](https://github.com/senritsu/jellyfin/blob/4e21b49994ba031e0716568c38681c3c5b83bbc0/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs#L76), Uchuu Senkan Yamato 2199) with the same issue (digits in the series name) could not be trivially fixed in the same change, due to the significantly different formatting. Attempts to resolve this case did not work out for now.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
