### PR TITLE
Fix for 4933: Alternative ffmpeg fix

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -209,6 +209,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                     _ffmpegPath = path;
                     EncoderLocation = location;
+                    return true;
                 }
                 else
                 {


### PR DESCRIPTION
This method returns true if any version of ffmpeg if located, on a first come basis.

Alternative to https://github.com/jellyfin/jellyfin/pull/4963