### PR TITLE
Don't write tagline in <outline> in nfo files

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -450,15 +450,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 writer.WriteElementString("plot", overview);
             }
 
-            if (item is Video)
-            {
-                var outline = (item.Tagline ?? string.Empty)
-                    .StripHtml()
-                    .Replace("&quot;", "'", StringComparison.Ordinal);
-
-                writer.WriteElementString("outline", outline);
-            }
-            else
+            if (!(item is Video))
             {
                 writer.WriteElementString("outline", overview);
             }

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -450,7 +450,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 writer.WriteElementString("plot", overview);
             }
 
-            if (!(item is Video))
+            if (item is not Video)
             {
                 writer.WriteElementString("outline", overview);
             }


### PR DESCRIPTION
**Changes**
Don't write `outline` tag for videos. It should only be scraped from IMDB according to the [Kodi wiki](https://kodi.wiki/view/NFO_files/Movies#nfo_Tags)

**Issues**
Fixes #3142
