### PR TITLE
Process actor type in nfo files

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -1036,34 +1036,18 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                                 if (!string.IsNullOrWhiteSpace(val))
                                 {
-                                    switch (val)
+                                    type = val switch
                                     {
-                                        case PersonType.Composer:
-                                            type = PersonType.Composer;
-                                            break;
-                                        case PersonType.Conductor:
-                                            type = PersonType.Conductor;
-                                            break;
-                                        case PersonType.Director:
-                                            type = PersonType.Director;
-                                            break;
-                                        case PersonType.Lyricist:
-                                            type = PersonType.Lyricist;
-                                            break;
-                                        case PersonType.Producer:
-                                            type = PersonType.Producer;
-                                            break;
-                                        case PersonType.Writer:
-                                            type = PersonType.Writer;
-                                            break;
-                                        case PersonType.GuestStar:
-                                            type = PersonType.GuestStar;
-                                            break;
+                                        PersonType.Composer => PersonType.Composer,
+                                        PersonType.Conductor => PersonType.Conductor,
+                                        PersonType.Director => PersonType.Director,
+                                        PersonType.Lyricist => PersonType.Lyricist,
+                                        PersonType.Producer => PersonType.Producer,
+                                        PersonType.Writer => PersonType.Writer,
+                                        PersonType.GuestStar => PersonType.GuestStar,
                                         // unknown type --> actor
-                                        default:
-                                            type = PersonType.Actor;
-                                            break;
-                                    }
+                                        _ => PersonType.Actor
+                                    };
                                 }
 
                                 break;

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -1030,6 +1030,45 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                 break;
                             }
 
+                        case "type":
+                            {
+                                var val = reader.ReadElementContentAsString();
+
+                                if (!string.IsNullOrWhiteSpace(val))
+                                {
+                                    switch (val)
+                                    {
+                                        case PersonType.Composer:
+                                            type = PersonType.Composer;
+                                            break;
+                                        case PersonType.Conductor:
+                                            type = PersonType.Conductor;
+                                            break;
+                                        case PersonType.Director:
+                                            type = PersonType.Director;
+                                            break;
+                                        case PersonType.Lyricist:
+                                            type = PersonType.Lyricist;
+                                            break;
+                                        case PersonType.Producer:
+                                            type = PersonType.Producer;
+                                            break;
+                                        case PersonType.Writer:
+                                            type = PersonType.Writer;
+                                            break;
+                                        case PersonType.GuestStar:
+                                            type = PersonType.GuestStar;
+                                            break;
+                                        // unknown type --> actor
+                                        default:
+                                            type = PersonType.Actor;
+                                            break;
+                                    }
+                                }
+
+                                break;
+                            }
+
                         case "order":
                         case "sortorder":
                             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -60,7 +60,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             Assert.Equal(new TimeSpan(0, 0, 6268).Ticks, item.RunTimeTicks);
             Assert.True(item.HasSubtitles);
 
-            Assert.Equal(18, result.People.Count);
+            Assert.Equal(19, result.People.Count);
 
             var writers = result.People.Where(x => x.Type == PersonType.Writer).ToArray();
             Assert.Equal(2, writers.Length);
@@ -81,6 +81,10 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             Assert.Equal("Jason Momoa", aquaman!.Name);
             Assert.Equal(5, aquaman!.SortOrder);
             Assert.Equal("https://m.media-amazon.com/images/M/MV5BMTI5MTU5NjM1MV5BMl5BanBnXkFtZTcwODc4MDk0Mw@@._V1_SX1024_SY1024_.jpg", aquaman!.ImageUrl);
+
+            var lyricist = result.People.FirstOrDefault(x => x.Type == PersonType.Lyricist);
+            Assert.NotNull(lyricist);
+            Assert.Equal("Test Lyricist", lyricist!.Name);
 
             Assert.Equal(new DateTime(2019, 8, 6, 9, 1, 18), item.DateCreated);
         }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
@@ -221,6 +221,11 @@
         <order>14</order>
         <thumb>https://m.media-amazon.com/images/M/MV5BOTFjOTFhNTgtZjk3Ny00MTNjLWE3MWUtMWI3ZWM5NDljZjQwXkEyXkFqcGdeQXVyMjQwMDg0Ng@@._V1_SX1024_SY1024_.jpg</thumb>
     </actor>
+    <actor>
+        <name>Test Lyricist</name>
+        <type>Lyricist</type>
+        <order>15</order>
+    </actor>
     <resume>
         <position>0.000000</position>
         <total>0.000000</total>


### PR DESCRIPTION
**Changes**
Add support for reading `type` tag inside `actor` tag in nfo files. NfoSaver already saves the person type correctly.
Also added it to the movie parser test

**Issues**
Fixes #3686