### PR TITLE
change default webdir config from option to env var

### DIFF
--- a/debian/conf/jellyfin
+++ b/debian/conf/jellyfin
@@ -19,7 +19,7 @@ JELLYFIN_LOG_DIR="/var/log/jellyfin"
 JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 
 # web client path, installed by the jellyfin-web package
-JELLYFIN_WEB_OPT="--webdir=/usr/share/jellyfin/web"
+JELLYFIN_WEB_DIR="/usr/share/jellyfin-web"
 
 # Restart script for in-app server control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/lib/jellyfin/restart.sh"

--- a/fedora/jellyfin.env
+++ b/fedora/jellyfin.env
@@ -21,7 +21,7 @@ JELLYFIN_LOG_DIR="/var/log/jellyfin"
 JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 
 # web client path, installed by the jellyfin-web package
-JELLYFIN_WEB_OPT="--webdir=/usr/share/jellyfin-web"
+JELLYFIN_WEB_DIR="/usr/share/jellyfin-web"
 
 # In-App service control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/libexec/jellyfin/restart.sh"


### PR DESCRIPTION
While using systemd to start jellyfin.service on Fedora 33,
the service failed. After inspecting the logs, the following
output seemed relevant:

[INF] [1] Main: Web resources path: /usr/lib64/jellyfin/jellyfin-web
[…]
System.InvalidOperationException: The server is expected to host the web client, but the provided content directory is either invalid or empty: /usr/lib64/jellyfin/jellyfin-web. […]

Apparently the option doesn't get picked up by the unitfile
present if there's been an older version of jellyfin installed
(see fedora/jellyfin.service line 8).

After changing the corresponding environment variable to be
consistent in handling with the rest of the env variables in
/etc/sysconfig/jellyfin, the server starts without a hitch.

Changed the default config file for Debian, too, so both
distributions have the same default values.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
