### PR TITLE
Fix nfo saving during UserDataSaved event

### DIFF
--- a/MediaBrowser.XbmcMetadata/EntryPoint.cs
+++ b/MediaBrowser.XbmcMetadata/EntryPoint.cs
@@ -60,17 +60,7 @@ namespace MediaBrowser.XbmcMetadata
 
         private void SaveMetadataForItem(BaseItem item, ItemUpdateType updateReason)
         {
-            if (!item.IsFileProtocol)
-            {
-                return;
-            }
-
-            if (!item.SupportsLocalMetadata)
-            {
-                return;
-            }
-
-            if (!item.IsSaveLocalMetadataEnabled())
+            if (!item.IsFileProtocol || !item.SupportsLocalMetadata)
             {
                 return;
             }


### PR DESCRIPTION
**Changes**
Remove check for `IsSaveLocalMetadataEnabled` during nfo `OnUserDataSaved`. It doesn't belong there and prevents this event from saving nfo metadata if a user marked an item as watched.

During a normal library scan the method responsible for saving the metadata allows nfo saving if the nfo saver is enabled and `IsSaveLocalMetadataEnabled` is disabled. In my opinion this is the correct way.
During the `OnUserDataSaved` event it only safes the nfo if `IsSaveLocalMetadataEnabled` is enabled. This leads to the confusion why nfo metadata does not get saved if the user data changes but does get saved if a normal library scan is triggered (see issue below). IMO `IsSaveLocalMetadataEnabled` should only be responsible for saving the images in the media folder or not. We don't need 2 checkboxes to enable nfo saving.

With this understanding of the property, the explaining text in the web client is wrong (at least with the german translation). It mentions artwork and metadata. But this seems to be a translation error. The english text is correct and mentions only artwork. Metadata got removed from the english string in this commit https://github.com/jellyfin/jellyfin-web/commit/1c06eed. But I don't feel like going through this huge commit to see why it changed.
So most likely this toggle got a different purpose and nobody bothered to change the German translation

**Issues**
Fixes #3486
