### PR TITLE
Fixes zero byte nfo files.

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -203,10 +203,10 @@ namespace MediaBrowser.XbmcMetadata.Savers
             var directory = Path.GetDirectoryName(path) ?? throw new ArgumentException($"Provided path ({path}) is not valid.", nameof(path));
             Directory.CreateDirectory(directory);
 
-            // On Windows, savint the file will fail if the file is hidden or readonly
+            // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 
-            using (var filestream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (var filestream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 stream.CopyTo(filestream);
             }

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -206,6 +206,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
             // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 
+            // use FileShare.None as this bypasses dotnet bug dotnet/runtime#42790 .
             using (var filestream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 stream.CopyTo(filestream);


### PR DESCRIPTION
Fixes #4826 and bypasses dotnet bug. (https://github.com/dotnet/runtime/issues/42790)

May be other occurrences of this bug in JF.

From Dotnet Documentation
Filemode.Create - Specifies that the operating system should create a new file.

If the file already exists, it will be overwritten. This requires Write permission. 

FileMode.Create is equivalent to requesting that if the file does not exist, use CreateNew;
otherwise, use Truncate. (0 byte file)
If the file already exists but is a hidden file, an UnauthorizedAccessException exception is thrown.