### PR TITLE
Fix for NVDEC decoder and improvements for VAAPI tonemap

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2234,8 +2234,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
             }
             else if ((videoDecoder ?? string.Empty).Contains("cuda", StringComparison.OrdinalIgnoreCase)
-                && width.HasValue
-                && height.HasValue)
+                     && width.HasValue
+                     && height.HasValue)
             {
                 var outputWidth = width.Value;
                 var outputHeight = height.Value;
@@ -2667,14 +2667,14 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // When burning in graphical subtitles using overlay_qsv, upload videostream to the same qsv context.
             else if (isLinux && hasGraphicalSubs && (isQsvH264Encoder || isQsvHevcEncoder)
-                    && !(isTonemappingSupportedOnQsv && isVppTonemappingSupported))
+                     && !(isTonemappingSupportedOnQsv && isVppTonemappingSupported))
             {
                 filters.Add("hwupload=extra_hw_frames=64");
             }
 
             // If we're hardware VAAPI decoding and software encoding, download frames from the decoder first.
             else if ((IsVaapiSupported(state) && isVaapiDecoder) && (isLibX264Encoder || isLibX265Encoder)
-                    && !(isTonemappingSupportedOnQsv && isVppTonemappingSupported))
+                     && !(isTonemappingSupportedOnQsv && isVppTonemappingSupported))
             {
                 var codec = videoStream.Codec;
 

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -51,6 +51,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         bool SupportsHwaccel(string hwaccel);
 
         /// <summary>
+        /// Whether given filter is supported.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="option">The option.</param>
+        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        bool SupportsFilter(string filter, string option);
+
+        /// <summary>
         /// Extracts the audio image.
         /// </summary>
         /// <param name="path">The path.</param>

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -55,7 +55,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// </summary>
         /// <param name="filter">The filter.</param>
         /// <param name="option">The option.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the filter is supported, <c>false</c> otherwise.</returns>
         bool SupportsFilter(string filter, string option);
 
         /// <summary>

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -296,6 +296,38 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return found;
         }
 
+        public bool CheckFilter(string filter, string option)
+        {
+            if (string.IsNullOrEmpty(filter))
+            {
+                return false;
+            }
+
+            string output = null;
+            try
+            {
+                output = GetProcessOutput(_encoderPath, "-h filter=" + filter);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error detecting the given filter");
+            }
+
+            if (output.Contains("Filter " + filter, StringComparison.Ordinal))
+            {
+                if (string.IsNullOrEmpty(option))
+                {
+                    return true;
+                }
+
+                return output.Contains(option, StringComparison.Ordinal);
+            }
+
+            _logger.LogWarning("Filter: {Name} with option {Option} is not available", filter, option);
+
+            return false;
+        }
+
         private IEnumerable<string> GetCodecs(Codec codec)
         {
             string codecstr = codec == Codec.Encoder ? "encoders" : "decoders";

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -295,6 +295,17 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return _hwaccels.Contains(hwaccel, StringComparer.OrdinalIgnoreCase);
         }
 
+        public bool SupportsFilter(string filter, string option)
+        {
+            if (_ffmpegPath != null)
+            {
+                var validator = new EncoderValidator(_logger, _ffmpegPath);
+                return validator.CheckFilter(filter, option);
+            }
+
+            return false;
+        }
+
         public bool CanEncodeToAudioCodec(string codec)
         {
             if (string.Equals(codec, "opus", StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -39,6 +39,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableTonemapping { get; set; }
 
+        public bool EnableVppTonemapping { get; set; }
+
         public string TonemappingAlgorithm { get; set; }
 
         public string TonemappingRange { get; set; }
@@ -90,6 +92,7 @@ namespace MediaBrowser.Model.Configuration
             // The left side of the dot is the platform number, and the right side is the device number on the platform.
             OpenclDevice = "0.0";
             EnableTonemapping = false;
+            EnableVppTonemapping = false;
             TonemappingAlgorithm = "hable";
             TonemappingRange = "auto";
             TonemappingDesat = 0;

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -65,6 +65,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableDecodingColorDepth10Vp9 { get; set; }
 
+        public bool EnableEnhancedNvdecDecoder { get; set; }
+
         public bool EnableHardwareEncoding { get; set; }
 
         public bool AllowHevcEncoding { get; set; }
@@ -100,6 +102,7 @@ namespace MediaBrowser.Model.Configuration
             DeinterlaceMethod = "yadif";
             EnableDecodingColorDepth10Hevc = true;
             EnableDecodingColorDepth10Vp9 = true;
+            EnableEnhancedNvdecDecoder = true;
             EnableHardwareEncoding = true;
             AllowHevcEncoding = true;
             EnableSubtitleExtraction = true;


### PR DESCRIPTION
Web changes:
https://github.com/jellyfin/jellyfin-web/pull/2350

ffmpeg fix:
https://github.com/jellyfin/jellyfin-ffmpeg/pull/59

**Changes**
- Add enhanced NVDEC decoder and format converter
fix green or corrupted frames when decoding some HDR contents. improve transcoding speed.

<img src="https://user-images.githubusercontent.com/14953024/106266394-53137300-6263-11eb-89e7-528aeae883bf.jpg" width = "1080" align=center />

- Add VPP tonemapping for VAAPI  and QuickSync on Linux
 faster tonemapping speed, **70-120fps 1080p and 30-50fps 4k on HD630** when doing 4k H2S.
 Intel opencl runtime is not required by this method. only available on Intel VAAPI and QSV for now.
 as for AMD VAAPI see https://gitlab.freedesktop.org/mesa/mesa/-/issues/3865

|     | Prerequisites  |
|  ----  | ----  |
| 1  | Intel KabyLake/GeminiLake chips or newer, such as i3-7100 and J4105 |
| 2  | Intel media-driver(iHD) 20.1 or newer |
| 3  | libva 2.4 or newer |
| 4  | the ffmpeg fix linked above |
| 5  | HEVC videos with valid HDR10 metadata |

<img src="https://user-images.githubusercontent.com/14953024/106266536-83f3a800-6263-11eb-9a83-818933ee5579.png" width = "1080" align=center />

**Issues**
Fixes #4879
Fixes #4947
Fixes # https://github.com/jellyfin/jellyfin-meta/issues/1#issuecomment-739138464
