### PR TITLE
Remove season name from metadata result

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
@@ -54,7 +54,6 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             result.HasMetadata = true;
             result.Item = new Season
             {
-                Name = info.Name,
                 IndexNumber = seasonNumber,
                 Overview = seasonResult?.Overview
             };


### PR DESCRIPTION
A copy of: https://github.com/jellyfin/jellyfin-plugin-tmdb/pull/1

Apparently TMDB season provider copies `SeasonInfo.Name` to `MetadataResult` which:
1. Does not really make sense. In this case we should not return name at all.
2. Causes an issue where all season names would be replaced with series name. 

Root cause of this issue is in Jellyfin itself which for some reason sets `SeasonInfo.Name` to series name when sending it to `GetMetadata` but anyways I don't think we should copy anything from `SeasonInfo` to `MetadataResult` even if name was correctly set to 'Season X'.

Probably it was originally set to `Name = seasonResult.Name` but someone did not like whatever TMDbLib returned here so it was changed to `info.Name`. Quote from [jellyfin#10.6.z](https://github.com/jellyfin/jellyfin/blob/release-10.6.z/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs):

> // Don't use moviedb season names for now until if/when we have field-level configuration
> // result.Item.Name = seasonInfo.name;

**Changes**
Do not return season name at all.

**Issues**
Should fix:
https://github.com/jellyfin/jellyfin/issues/4948
https://github.com/jellyfin/jellyfin/issues/4134
