### PR TITLE
Check for TypeLoadException and handle accordingly

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -122,6 +122,12 @@ namespace Emby.Server.Implementations.Plugins
                         ChangePluginState(plugin, PluginStatus.Malfunctioned);
                         continue;
                     }
+                    catch (TypeLoadException ex) 
+                    {
+                        _logger.LogError(ex, "Failed to load types for assembly {Path}. Disabling plugin.", file);
+                        ChangePluginState(plugin, PluginStatus.Malfunctioned);
+                        continue;
+                    }
 
                     _logger.LogInformation("Loaded assembly {Assembly} from {Path}", assembly.FullName, file);
                     yield return assembly;


### PR DESCRIPTION
**Changes**
Added a catch block for an unanticipated Exception found during load of an invalid plugin listed on Jellyfin's official repository. Handle the error in the same way as the other by invalidating the plugin, logging the exception, and gracefully continue.

**Issues**
Fixes #5146
