### PR TITLE
Get episode range end from XBMC compatible nfo

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -51,6 +51,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 // These are not going to be valid xml so no sense in causing the provider to fail and spamming the log with exceptions
                 try
                 {
+                    // Extract episode details from the firs episodedetails block
                     using (var stringReader = new StringReader(xml))
                     using (var reader = XmlReader.Create(stringReader, settings))
                     {
@@ -72,19 +73,14 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             }
                         }
                     }
-                }
-                catch (XmlException)
-                {
-                }
 
-                while ((index = xmlFile.IndexOf(srch, StringComparison.OrdinalIgnoreCase)) != -1)
-                {
-                    xml = xmlFile.Substring(0, index + srch.Length);
-                    xmlFile = xmlFile.Substring(index + srch.Length);
-
-                    // These are not going to be valid xml so no sense in causing the provider to fail and spamming the log with exceptions
-                    try
+                    // Extract the last episode number from nfo
+                    // This is needed because XBMC metadata uses multiple episodedetails blocks instead of episodenumberend tag
+                    while ((index = xmlFile.IndexOf(srch, StringComparison.OrdinalIgnoreCase)) != -1)
                     {
+                        xml = xmlFile.Substring(0, index + srch.Length);
+                        xmlFile = xmlFile.Substring(index + srch.Length);
+
                         using (var stringReader = new StringReader(xml))
                         using (var reader = XmlReader.Create(stringReader, settings))
                         {
@@ -104,9 +100,9 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             }
                         }
                     }
-                    catch (XmlException)
-                    {
-                    }
+                }
+                catch (XmlException)
+                {
                 }
             }
         }

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -51,7 +51,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 // These are not going to be valid xml so no sense in causing the provider to fail and spamming the log with exceptions
                 try
                 {
-                    // Extract episode details from the firs episodedetails block
+                    // Extract episode details from the first episodedetails block
                     using (var stringReader = new StringReader(xml))
                     using (var reader = XmlReader.Create(stringReader, settings))
                     {

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -86,17 +86,9 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         {
                             reader.MoveToContent();
 
-                            if (reader.ReadToDescendant("episode"))
+                            if (reader.ReadToDescendant("episode") && int.TryParse(reader.ReadElementContentAsString(), out var num))
                             {
-                                var number = reader.ReadElementContentAsString();
-
-                                if (!string.IsNullOrWhiteSpace(number))
-                                {
-                                    if (int.TryParse(number, out var num))
-                                    {
-                                        item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
-                                    }
-                                }
+                                item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
                             }
                         }
                     }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -82,6 +82,26 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
+        public void Fetch_Valid_MultiEpisode_Succes()
+        {
+            var result = new MetadataResult<Episode>()
+            {
+                Item = new Episode()
+            };
+
+            _parser.Fetch(result, "Test Data/Rising.nfo", CancellationToken.None);
+
+            var item = result.Item;
+            Assert.Equal("Rising (1)", item.Name);
+            Assert.Equal(1, item.IndexNumber);
+            Assert.Equal(2, item.IndexNumberEnd);
+            Assert.Equal(1, item.ParentIndexNumber);
+            Assert.Equal("A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy.", item.Overview);
+            Assert.Equal(new DateTime(2004, 7, 16), item.PremiereDate);
+            Assert.Equal(2004, item.ProductionYear);
+        }
+
+        [Fact]
         public void Fetch_WithNullItem_ThrowsArgumentException()
         {
             var result = new MetadataResult<Episode>();

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<Episode>()
             {
@@ -82,7 +82,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_MultiEpisode_Succes()
+        public void Fetch_Valid_MultiEpisode_Success()
         {
             var result = new MetadataResult<Episode>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<Video>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicAlbumNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicAlbumNfoProviderTests.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<MusicAlbum>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicArtistNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicArtistNfoParserTests.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<MusicArtist>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeasonNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeasonNfoProviderTests.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<Season>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeriesNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeriesNfoParserTests.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
-        public void Fetch_Valid_Succes()
+        public void Fetch_Valid_Success()
         {
             var result = new MetadataResult<Series>()
             {

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
@@ -1,0 +1,20 @@
+<episodedetails>
+  <title>Rising (1)</title>
+  <season>1</season>
+  <episode>1</episode>
+  <aired>2004-07-16</aired>
+  <plot>A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy.</plot>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25333.jpg</thumb>
+  <watched>false</watched>
+  <rating>8.0</rating>
+</episodedetails>
+<episodedetails>
+  <title>Rising (2)</title>
+  <season>1</season>
+  <episode>2</episode>
+  <aired>2004-07-16</aired>
+  <plot>Sheppard tries to convince Weir to mount a rescue mission to free Colonel Sumner, Teyla, and the others captured by the Wraith.</plot>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25334.jpg</thumb>
+  <watched>false</watched>
+  <rating>7.9</rating>
+</episodedetails>


### PR DESCRIPTION
**Changes**
This PR allows parsing the end of multiepisode file from XBMC compatible nfo. This is required because the nfo contains each episode in a root block.

For example:
Stargate Atlantis - 1x01-02:
```
<episodedetails>
  <title>Rising (1)</title>
  <season>1</season>
  <episode>1</episode>
  ...
</episodedetails>
<episodedetails>
  <title>Rising (2)</title>
  <season>1</season>
  <episode>2</episode>
  ...
</episodedetails>
```

This resulted the file being parsed as episode 1 instead of episode 1-2.