### PR TITLE
Fix forgot password pin request

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -509,7 +509,7 @@ namespace Jellyfin.Api.Controllers
         /// <summary>
         /// Redeems a forgot password pin.
         /// </summary>
-        /// <param name="forgotPasswordPinRequest">The forgot password pin request containing the endered pin.</param>
+        /// <param name="forgotPasswordPinRequest">The forgot password pin request containing the entered pin.</param>
         /// <response code="200">Pin reset process started.</response>
         /// <returns>A <see cref="Task"/> containing a <see cref="PinRedeemResult"/>.</returns>
         [HttpPost("ForgotPassword/Pin")]

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -509,14 +509,14 @@ namespace Jellyfin.Api.Controllers
         /// <summary>
         /// Redeems a forgot password pin.
         /// </summary>
-        /// <param name="pin">The pin.</param>
+        /// <param name="forgotPasswordPinRequest">The forgot password pin request containing the endered pin.</param>
         /// <response code="200">Pin reset process started.</response>
         /// <returns>A <see cref="Task"/> containing a <see cref="PinRedeemResult"/>.</returns>
         [HttpPost("ForgotPassword/Pin")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult<PinRedeemResult>> ForgotPasswordPin([FromBody, Required] string pin)
+        public async Task<ActionResult<PinRedeemResult>> ForgotPasswordPin([FromBody, Required] ForgotPasswordPinDto forgotPasswordPinRequest)
         {
-            var result = await _userManager.RedeemPasswordResetPin(pin).ConfigureAwait(false);
+            var result = await _userManager.RedeemPasswordResetPin(forgotPasswordPinRequest.Pin).ConfigureAwait(false);
             return result;
         }
 

--- a/Jellyfin.Api/Models/UserDtos/ForgotPasswordPinDto.cs
+++ b/Jellyfin.Api/Models/UserDtos/ForgotPasswordPinDto.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Jellyfin.Api.Models.UserDtos
+{
+    /// <summary>
+    /// Forgot Password Pin enter request body DTO.
+    /// </summary>
+    public class ForgotPasswordPinDto
+    {
+        /// <summary>
+        /// Gets or sets the entered pin to have the password reset.
+        /// </summary>
+        [Required]
+        public string? Pin { get; set; }
+    }
+}


### PR DESCRIPTION
**Changes**
Pre api-migration the data was sent like this:
```
{
  "Pin": "secret-Pin"
}
```

After the api-migration the data was only accepted like this:
```
"secret-Pin"
```

This PR restores the old behavior.