### PR TITLE
Exclude BOM when writing meta.json plugin manifest

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -348,7 +348,7 @@ namespace Emby.Server.Implementations.Plugins
             try
             {
                 var data = JsonSerializer.Serialize(manifest, _jsonOptions);
-                File.WriteAllText(Path.Combine(path, "meta.json"), data, Encoding.UTF8);
+                File.WriteAllText(Path.Combine(path, "meta.json"), data);
                 return true;
             }
 #pragma warning disable CA1031 // Do not catch general exception types


### PR DESCRIPTION
> This method uses UTF-8 encoding without a Byte-Order Mark (BOM), so using the GetPreamble method will return an empty byte array. If it is necessary to include a UTF-8 identifier, such as a byte order mark, at the beginning of a file, use the WriteAllText(String, String, Encoding) method overload with UTF8 encoding.

https://docs.microsoft.com/en-us/dotnet/api/system.io.file.writealltext?view=net-5.0#System_IO_File_WriteAllText_System_String_System_String_

TL;DR: BOM bad. JsonSerializer go boom. https://github.com/dotnet/runtime/issues/29838

Stack trace:
```
[15:10:52] [ERR] [1] Emby.Server.Implementations.Plugins.PluginManager: Error deserializing ?{
  "category": "",
  "changelog": "",
  "description": "",
  "guid": "4b9ed42f-5185-48b5-9803-6ff2989014c4",
  "name": "Open Subtitles",
  "overview": "",
  "owner": "",
  "targetAbi": "10.7.0.0",
  "timestamp": "0001-01-01T00:00:00.0000000Z",
  "version": "10.0.0.0",
  "status": "Active",
  "autoUpdate": false
}.
System.Text.Json.JsonException: '0xEF' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.
 ---> System.Text.Json.JsonReaderException: '0xEF' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0.
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.ConsumeValue(Byte marker)
   at System.Text.Json.Utf8JsonReader.ReadFirstToken(Byte first)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment()
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, JsonReaderException ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadCore[TValue](JsonConverter jsonConverter, Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadCore[TValue](Utf8JsonReader& reader, Type returnType, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](ReadOnlySpan`1 utf8Json, JsonSerializerOptions options)
   at Emby.Server.Implementations.Plugins.PluginManager.LoadManifest(String dir) in C:\Users\claus\RiderProjects\jellyfin\Emby.Server.Implementations\Plugins\PluginManager.cs:line 534
```