### PR TITLE
Add test for generic nfo provider id parsing

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -721,20 +721,6 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         break;
                     }
 
-                case "musicBrainzArtistID":
-                    {
-                        if (reader.IsEmptyElement)
-                        {
-                            reader.Read();
-                            break;
-                        }
-
-                        var id = reader.ReadElementContentAsString();
-                        item.SetProviderId(MetadataProvider.MusicBrainzArtist.ToString(), id);
-
-                        break;
-                    }
-
                 default:
                     string readerName = reader.Name;
                     if (_validProviderIds.TryGetValue(readerName, out string? providerIdValue))

--- a/tests/Jellyfin.XbmcMetadata.Tests/Jellyfin.XbmcMetadata.Tests.csproj
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Jellyfin.XbmcMetadata.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../MediaBrowser.XbmcMetadata/MediaBrowser.XbmcMetadata.csproj" />
+    <ProjectReference Include="../../MediaBrowser.Providers/MediaBrowser.Providers.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Movies;
 using MediaBrowser.XbmcMetadata.Parsers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -23,8 +24,13 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         public EpisodeNfoProviderTests()
         {
             var providerManager = new Mock<IProviderManager>();
+
+            var imdbExternalId = new ImdbExternalId();
+            var externalIdInfo = new ExternalIdInfo(imdbExternalId.ProviderName, imdbExternalId.Key, imdbExternalId.Type, imdbExternalId.UrlFormatString);
+
             providerManager.Setup(x => x.GetExternalIdInfos(It.IsAny<IHasProviderIds>()))
-                .Returns(Enumerable.Empty<ExternalIdInfo>());
+                .Returns(new[] { externalIdInfo });
+
             var config = new Mock<IConfigurationManager>();
             config.Setup(x => x.GetConfiguration(It.IsAny<string>()))
                 .Returns(new XbmcMetadataOptions());
@@ -56,6 +62,8 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             Assert.Equal(2017, item.ProductionYear);
             Assert.Single(item.Studios);
             Assert.Contains("Starz", item.Studios);
+            Assert.Equal("tt5017734", item.ProviderIds[MetadataProvider.Imdb.ToString()]);
+            Assert.Equal("1276153", item.ProviderIds[MetadataProvider.Tmdb.ToString()]);
 
             // Credits
             var writers = result.People.Where(x => x.Type == PersonType.Writer).ToArray();

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Plugins.Tmdb.Movies;
 using MediaBrowser.XbmcMetadata.Parsers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -21,8 +22,13 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         public MovieNfoParserTests()
         {
             var providerManager = new Mock<IProviderManager>();
+
+            var tmdbExternalId = new TmdbMovieExternalId();
+            var externalIdInfo = new ExternalIdInfo(tmdbExternalId.ProviderName, tmdbExternalId.Key, tmdbExternalId.Type, tmdbExternalId.UrlFormatString);
+
             providerManager.Setup(x => x.GetExternalIdInfos(It.IsAny<IHasProviderIds>()))
-                .Returns(Enumerable.Empty<ExternalIdInfo>());
+                .Returns(new[] { externalIdInfo });
+
             var config = new Mock<IConfigurationManager>();
             config.Setup(x => x.GetConfiguration(It.IsAny<string>()))
                 .Returns(new XbmcMetadataOptions());
@@ -42,7 +48,8 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
 
             Assert.Equal("Justice League", item.OriginalTitle);
             Assert.Equal("Justice for all.", item.Tagline);
-            Assert.Equal("tt0974015", item.ProviderIds["imdb"]);
+            Assert.Equal("tt0974015", item.ProviderIds[MetadataProvider.Imdb.ToString()]);
+            Assert.Equal("141052", item.ProviderIds[MetadataProvider.Tmdb.ToString()]);
 
             Assert.Equal(4, item.Genres.Length);
             Assert.Contains("Action", item.Genres);

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicAlbumNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicAlbumNfoProviderTests.cs
@@ -9,6 +9,8 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Music;
+using MediaBrowser.Providers.Plugins.MusicBrainz;
 using MediaBrowser.XbmcMetadata.Parsers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -23,8 +25,13 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         public MusicAlbumNfoProviderTests()
         {
             var providerManager = new Mock<IProviderManager>();
+
+            var musicBrainzArtist = new MusicBrainzArtistExternalId();
+            var externalIdInfo = new ExternalIdInfo(musicBrainzArtist.ProviderName, musicBrainzArtist.Key, musicBrainzArtist.Type, "MusicBrainzServer");
+
             providerManager.Setup(x => x.GetExternalIdInfos(It.IsAny<IHasProviderIds>()))
-                .Returns(Enumerable.Empty<ExternalIdInfo>());
+                .Returns(new[] { externalIdInfo });
+
             var config = new Mock<IConfigurationManager>();
             config.Setup(x => x.GetConfiguration(It.IsAny<string>()))
                 .Returns(new XbmcMetadataOptions());

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicArtistNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MusicArtistNfoParserTests.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Music;
 using MediaBrowser.XbmcMetadata.Parsers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -21,8 +22,13 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         public MusicArtistNfoParserTests()
         {
             var providerManager = new Mock<IProviderManager>();
+
+            var musicBrainzArtist = new MusicBrainzArtistExternalId();
+            var externalIdInfo = new ExternalIdInfo(musicBrainzArtist.ProviderName, musicBrainzArtist.Key, musicBrainzArtist.Type, "MusicBrainzServer");
+
             providerManager.Setup(x => x.GetExternalIdInfos(It.IsAny<IHasProviderIds>()))
-                .Returns(Enumerable.Empty<ExternalIdInfo>());
+                .Returns(new[] { externalIdInfo });
+
             var config = new Mock<IConfigurationManager>();
             config.Setup(x => x.GetConfiguration(It.IsAny<string>()))
                 .Returns(new XbmcMetadataOptions());

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeriesNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/SeriesNfoParserTests.cs
@@ -43,8 +43,8 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             Assert.Equal("American Gods", item.OriginalTitle);
             Assert.Equal(string.Empty, item.Tagline);
             Assert.Equal(0, item.RunTimeTicks);
-            Assert.Equal("46639", item.ProviderIds["tmdb"]);
-            Assert.Equal("253573", item.ProviderIds["tvdb"]);
+            Assert.Equal("46639", item.ProviderIds[MetadataProvider.Tmdb.ToString()]);
+            Assert.Equal("253573", item.ProviderIds[MetadataProvider.Tvdb.ToString()]);
 
             Assert.Equal(3, item.Genres.Length);
             Assert.Contains("Drama", item.Genres);

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
@@ -30,6 +30,7 @@
     <plot>Fueled by his restored faith in humanity and inspired by Superman&apos;s selfless act, Bruce Wayne enlists the help of his newfound ally, Diana Prince, to face an even greater enemy. Together, Batman and Wonder Woman work quickly to find and recruit a team of meta-humans to stand against this newly awakened threat. But despite the formation of this unprecedented league of heroes-Batman, Wonder Woman, Aquaman, Cyborg and The Flash-it may already be too late to save the planet from an assault of catastrophic proportions.</plot>
     <tagline>Justice for all.</tagline>
     <runtime>120</runtime>
+    <tmdbId>141052</tmdbId>
     <thumb aspect="set.poster" preview="https://assets.fanart.tv/preview/movies/468551/movieposter/justice-league-collection-5c24ea65591d3.jpg">https://assets.fanart.tv/fanart/movies/468551/movieposter/justice-league-collection-5c24ea65591d3.jpg</thumb>
     <thumb aspect="set.poster" preview="https://assets.fanart.tv/preview/movies/468551/movieposter/justice-league-collection-5c24ea65591d3.jpg">https://assets.fanart.tv/fanart/movies/468551/movieposter/justice-league-collection-5c24ea65591d3.jpg</thumb>
     <thumb aspect="set.clearlogo" preview="https://assets.fanart.tv/preview/movies/468551/hdmovielogo/justice-league-collection-5ba855ed4239a.png">https://assets.fanart.tv/fanart/movies/468551/hdmovielogo/justice-league-collection-5ba855ed4239a.png</thumb>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/The Bone Orchard.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/The Bone Orchard.nfo
@@ -24,6 +24,7 @@
     <lastplayed></lastplayed>
     <id>1276153</id>
     <uniqueid type="tmdb" default="true">1276153</uniqueid>
+    <imdbId>tt5017734</imdbId>
     <genre>Drama</genre>
     <genre>Mystery</genre>
     <genre>Sci-Fi &amp; Fantasy</genre>


### PR DESCRIPTION
**Changes**

- remove `case "musicBrainzArtistID":` from nfo parser because ids are handled dynamically
- add additional id tags for movies and episodes and test parsing for them

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
