### PR TITLE
Default to English metadata during the setup wizard.

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -254,7 +254,7 @@ namespace MediaBrowser.Model.Configuration
         /// Gets or sets the preferred metadata language.
         /// </summary>
         /// <value>The preferred metadata language.</value>
-        public string PreferredMetadataLanguage { get; set; } = string.Empty;
+        public string PreferredMetadataLanguage { get; set; } = "en";
 
         /// <summary>
         /// Gets or sets the metadata country code.


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
When on the Preferred Metadata Language page in the setup wizard, the country selection defaults to the United States, but the language option has no default, which is annoying. I'd assume most Jellyfin users are primarily English speakers, so I think that justifies defaulting to English.