### PR TITLE
Don't enable case-insensitivity for json by default

### DIFF
--- a/MediaBrowser.Common/Json/JsonDefaults.cs
+++ b/MediaBrowser.Common/Json/JsonDefaults.cs
@@ -31,7 +31,6 @@ namespace MediaBrowser.Common.Json
             WriteIndented = false,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
-            PropertyNameCaseInsensitive = true,
             Converters =
             {
                 new JsonGuidConverter(),


### PR DESCRIPTION
This should be done by adding `JsonPropertyName` attributes.