### PR TITLE
Fix double rate deinterlacing for some TS files

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2530,7 +2530,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var hasGraphicalSubs = state.SubtitleStream != null && !state.SubtitleStream.IsTextSubtitleStream && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode;
 
             // If double rate deinterlacing is enabled and the input framerate is 30fps or below, otherwise the output framerate will be too high for many devices
-            var doubleRateDeinterlace = options.DeinterlaceDoubleRate && (videoStream?.RealFrameRate ?? 60) <= 30;
+            var doubleRateDeinterlace = options.DeinterlaceDoubleRate && (videoStream?.AverageFrameRate ?? 60) <= 30;
 
             var isScalingInAdvance = false;
             var isCudaDeintInAdvance = false;
@@ -3080,7 +3080,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         {
                             inputModifier += " -deint 1";
 
-                            if (!encodingOptions.DeinterlaceDoubleRate || (videoStream?.RealFrameRate ?? 60) > 30)
+                            if (!encodingOptions.DeinterlaceDoubleRate || (videoStream?.AverageFrameRate ?? 60) > 30)
                             {
                                 inputModifier += " -drop_second_field 1";
                             }


### PR DESCRIPTION
This is a small change that uses the average frame rate reported by FFprobe instead of the real frame rate when determining if double rate deinterlacing should be enabled.

Some TS files containing interlaced H.264 video report the the field rate as the real frame rate (e.g. 50) and the average frame rate at the expected frame rate (e.g. 25). As a result double rate deinterlacing is currently disabled for these files, which this change fixes so it works.