### PR TITLE
Validate the new username when renaming

### DIFF
--- a/Jellyfin.Server.Implementations/Properties/AssemblyInfo.cs
+++ b/Jellyfin.Server.Implementations/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Jellyfin.Server.Implementations")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Jellyfin Project")]
+[assembly: AssemblyProduct("Jellyfin Server")]
+[assembly: AssemblyCopyright("Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+[assembly: InternalsVisibleTo("Jellyfin.Server.Implementations.Tests")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -137,10 +137,7 @@ namespace Jellyfin.Server.Implementations.Users
                 throw new ArgumentNullException(nameof(user));
             }
 
-            if (string.IsNullOrWhiteSpace(newName))
-            {
-                throw new ArgumentException("Invalid username", nameof(newName));
-            }
+            ThrowIfInvalidUsername(newName);
 
             if (user.Username.Equals(newName, StringComparison.Ordinal))
             {
@@ -201,10 +198,7 @@ namespace Jellyfin.Server.Implementations.Users
         /// <inheritdoc/>
         public async Task<User> CreateUserAsync(string name)
         {
-            if (!IsValidUsername(name))
-            {
-                throw new ArgumentException("Usernames can contain unicode symbols, numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)");
-            }
+            ThrowIfInvalidUsername(name);
 
             if (Users.Any(u => u.Username.Equals(name, StringComparison.OrdinalIgnoreCase)))
             {
@@ -733,12 +727,22 @@ namespace Jellyfin.Server.Implementations.Users
             _users[user.Id] = user;
         }
 
+        internal static void ThrowIfInvalidUsername(string name)
+        {
+            if (!string.IsNullOrWhiteSpace(name) && IsValidUsername(name))
+            {
+                return;
+            }
+
+            throw new ArgumentException("Usernames can contain unicode symbols, numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)", nameof(name));
+        }
+
         private static bool IsValidUsername(string name)
         {
             // This is some regex that matches only on unicode "word" characters, as well as -, _ and @
             // In theory this will cut out most if not all 'control' characters which should help minimize any weirdness
             // Usernames can contain letters (a-z + whatever else unicode is cool with), numbers (0-9), at-signs (@), dashes (-), underscores (_), apostrophes ('), periods (.) and spaces ( )
-            return Regex.IsMatch(name, @"^[\w\ \-'._@]*$");
+            return Regex.IsMatch(name, @"^[\w\ \-'._@]+$");
         }
 
         private IAuthenticationProvider GetAuthenticationProvider(User user)

--- a/tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj
+++ b/tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Emby.Server.Implementations\Emby.Server.Implementations.csproj" />
+    <ProjectReference Include="..\..\Jellyfin.Server.Implementations\Jellyfin.Server.Implementations.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Jellyfin.Server.Implementations.Users;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Users
+{
+    public class UserManagerTests
+    {
+        [Theory]
+        [InlineData("this_is_valid", true)]
+        [InlineData("this is also valid", true)]
+        [InlineData(" ", false)]
+        [InlineData("", false)]
+        [InlineData("0@_-' .", true)]
+        public void ThrowIfInvalidUsername_WhenInvalidUsername_ThrowsArgumentException(string username, bool isValid)
+        {
+            var ex = Record.Exception(() => UserManager.ThrowIfInvalidUsername(username));
+
+            var argumentExceptionNotThrown = ex is not ArgumentException;
+            if (ex != null)
+            {
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+            }
+
+            Assert.Equal(isValid, argumentExceptionNotThrown);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerTests.cs
@@ -7,22 +7,22 @@ namespace Jellyfin.Server.Implementations.Tests.Users
     public class UserManagerTests
     {
         [Theory]
-        [InlineData("this_is_valid", true)]
-        [InlineData("this is also valid", true)]
-        [InlineData(" ", false)]
-        [InlineData("", false)]
-        [InlineData("0@_-' .", true)]
-        public void ThrowIfInvalidUsername_WhenInvalidUsername_ThrowsArgumentException(string username, bool isValid)
+        [InlineData("this_is_valid")]
+        [InlineData("this is also valid")]
+        [InlineData("0@_-' .")]
+        public void ThrowIfInvalidUsername_WhenValidUsername_DoesNotThrowArgumentException(string username)
         {
             var ex = Record.Exception(() => UserManager.ThrowIfInvalidUsername(username));
+            Assert.Null(ex);
+        }
 
-            var argumentExceptionNotThrown = ex is not ArgumentException;
-            if (ex != null)
-            {
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-            }
-
-            Assert.Equal(isValid, argumentExceptionNotThrown);
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("")]
+        [InlineData("special characters like & $ ? are not allowed")]
+        public void ThrowIfInvalidUsername_WhenInvalidUsername_ThrowsArgumentException(string username)
+        {
+            Assert.Throws<ArgumentException>(() => UserManager.ThrowIfInvalidUsername(username));
         }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Copied AssemblyInfo.cs from Emby.Server.Implementations in order to use `InternalsVisibleTo`.

Made a new function that throws if the username is invalid. This is used when creating a new user and when renaming an existing user.

I wanted to create an additional test to verify that creation and renaming actually calls the function but it proved to be very annoying to do... so I didn't.

**Issues**
Fixes #5245 
