### PR TITLE
Include specials in the calculation for the "Next Up" episode

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -104,6 +104,7 @@
  - [shemanaev](https://github.com/shemanaev)
  - [skaro13](https://github.com/skaro13)
  - [sl1288](https://github.com/sl1288)
+ - [Smith00101010](https://github.com/Smith00101010)
  - [sorinyo2004](https://github.com/sorinyo2004)
  - [sparky8251](https://github.com/sparky8251)
  - [spookbits](https://github.com/spookbits)

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -131,11 +131,11 @@ namespace Emby.Server.Implementations.Sorting
             return GetSpecialCompareValue(x).CompareTo(GetSpecialCompareValue(y));
         }
 
-        private static int GetSpecialCompareValue(Episode item)
+        private static long GetSpecialCompareValue(Episode item)
         {
             // First sort by season number
             // Since there are three sort orders, pad with 9 digits (3 for each, figure 1000 episode buffer should be enough)
-            var val = (item.AirsAfterSeasonNumber ?? item.AirsBeforeSeasonNumber ?? 0) * 1000000000;
+            var val = (item.AirsAfterSeasonNumber ?? item.AirsBeforeSeasonNumber ?? 0) * 1000000000L;
 
             // Second sort order is if it airs after the season
             if (item.AirsAfterSeasonNumber.HasValue)

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -232,7 +232,10 @@ namespace Emby.Server.Implementations.TV
                         IsPlayed = false,
                         IsVirtualItem = false,
                         DtoOptions = dtoOptions
-                    }).Cast<Episode>().Where(episode => episode.AirsBeforeSeasonNumber != null || episode.AirsAfterSeasonNumber != null).ToList();
+                    })
+                    .Cast<Episode>()
+                    .Where(episode => episode.AirsBeforeSeasonNumber != null || episode.AirsAfterSeasonNumber != null)
+                    .ToList();
 
                     if (lastWatchedEpisode != null)
                     {
@@ -245,7 +248,8 @@ namespace Emby.Server.Implementations.TV
                         consideredEpisodes.Add(nextEpisode);
                     }
 
-                    var sortedConsideredEpisodes = _libraryManager.Sort(consideredEpisodes, user, new[] { (ItemSortBy.AiredEpisodeOrder, SortOrder.Ascending) }).Cast<Episode>();
+                    var sortedConsideredEpisodes = _libraryManager.Sort(consideredEpisodes, user, new[] { (ItemSortBy.AiredEpisodeOrder, SortOrder.Ascending) })
+                        .Cast<Episode>();
                     if (lastWatchedEpisode != null)
                     {
                         sortedConsideredEpisodes = sortedConsideredEpisodes.SkipWhile(episode => episode.Id != lastWatchedEpisode.Id).Skip(1);

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
@@ -11,7 +10,6 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.TV;
-using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using Series = MediaBrowser.Controller.Entities.TV.Series;
@@ -23,12 +21,14 @@ namespace Emby.Server.Implementations.TV
         private readonly IUserManager _userManager;
         private readonly IUserDataManager _userDataManager;
         private readonly ILibraryManager _libraryManager;
+        private readonly IServerConfigurationManager _configurationManager;
 
-        public TVSeriesManager(IUserManager userManager, IUserDataManager userDataManager, ILibraryManager libraryManager)
+        public TVSeriesManager(IUserManager userManager, IUserDataManager userDataManager, ILibraryManager libraryManager, IServerConfigurationManager configurationManager)
         {
             _userManager = userManager;
             _userDataManager = userDataManager;
             _libraryManager = libraryManager;
+            _configurationManager = configurationManager;
         }
 
         public QueryResult<BaseItem> GetNextUp(NextUpQuery request, DtoOptions dtoOptions)
@@ -200,13 +200,10 @@ namespace Emby.Server.Implementations.TV
                 ParentIndexNumberNotEquals = 0,
                 DtoOptions = new DtoOptions
                 {
-                    Fields = new ItemFields[]
-                    {
-                        ItemFields.SortName
-                    },
+                    Fields = new[] { ItemFields.SortName },
                     EnableImages = false
                 }
-            }).FirstOrDefault();
+            }).Cast<Episode>().FirstOrDefault();
 
             Func<Episode> getEpisode = () =>
             {
@@ -223,6 +220,39 @@ namespace Emby.Server.Implementations.TV
                     MinSortName = lastWatchedEpisode?.SortName,
                     DtoOptions = dtoOptions
                 }).Cast<Episode>().FirstOrDefault();
+
+                if (_configurationManager.Configuration.DisplaySpecialsWithinSeasons)
+                {
+                    var consideredEpisodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
+                    {
+                        AncestorWithPresentationUniqueKey = null,
+                        SeriesPresentationUniqueKey = seriesKey,
+                        ParentIndexNumber = 0,
+                        IncludeItemTypes = new[] { nameof(Episode) },
+                        IsPlayed = false,
+                        IsVirtualItem = false,
+                        DtoOptions = dtoOptions
+                    }).Cast<Episode>().Where(episode => episode.AirsBeforeSeasonNumber != null || episode.AirsAfterSeasonNumber != null).ToList();
+
+                    if (lastWatchedEpisode != null)
+                    {
+                        // Last watched episode is added, because there could be specials that aired before the last watched episode
+                        consideredEpisodes.Add(lastWatchedEpisode);
+                    }
+
+                    if (nextEpisode != null)
+                    {
+                        consideredEpisodes.Add(nextEpisode);
+                    }
+
+                    var sortedConsideredEpisodes = _libraryManager.Sort(consideredEpisodes, user, new[] { (ItemSortBy.AiredEpisodeOrder, SortOrder.Ascending) }).Cast<Episode>();
+                    if (lastWatchedEpisode != null)
+                    {
+                        sortedConsideredEpisodes = sortedConsideredEpisodes.SkipWhile(episode => episode.Id != lastWatchedEpisode.Id).Skip(1);
+                    }
+
+                    nextEpisode = sortedConsideredEpisodes.FirstOrDefault();
+                }
 
                 if (nextEpisode != null)
                 {


### PR DESCRIPTION
**Changes**
I changed the logic that determines the "Up Next" section in the user dashboard to be based on the same logic, that the player uses to determine the next episode to play. This in turn enables it to correctly have a special shown as the next episode, if the corresponding option is enabled by the user, which until now always wer skipped.

**Issues**
Fixes #1479
