### PR TITLE
Fixes #5148

### DIFF
--- a/Emby.Dlna/Main/DlnaEntryPoint.cs
+++ b/Emby.Dlna/Main/DlnaEntryPoint.cs
@@ -228,7 +228,10 @@ namespace Emby.Dlna.Main
         {
             try
             {
-                ((DeviceDiscovery)_deviceDiscovery).Start(communicationsServer);
+                if (communicationsServer != null)
+                {
+                    ((DeviceDiscovery)_deviceDiscovery).Start(communicationsServer);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes null exception in https://github.com/jellyfin/jellyfin/issues/5148 caused by uPnP packets being received before the DLNA subsystem is initialised.

