### PR TITLE
Fix duplicated movies when group movies into collections is enabled

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -348,11 +348,13 @@ namespace Emby.Server.Implementations.Collections
                         foreach (var child in item.GetMediaSources(true))
                         {
 
-                            if (results.ContainsKey(Guid.Parse(child.Id)))
+                            if (Guid.TryParse(child.Id, out var id) && results.ContainsKey(id))
                             {
                                 alreadyInResults = true;
+                                break;
                             }
                         }
+
                         if (!alreadyInResults)
                         {
 

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -344,7 +344,20 @@ namespace Emby.Server.Implementations.Collections
                     }
                     else
                     {
-                        results[item.Id] = item;
+                        var alreadyInResults = false;
+                        foreach (var child in item.GetMediaSources(true))
+                        {
+
+                            if (results.ContainsKey(Guid.Parse(child.Id)))
+                            {
+                                alreadyInResults = true;
+                            }
+                        }
+                        if (!alreadyInResults)
+                        {
+
+                            results[item.Id] = item;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If "Group movies into collections" is enabled the server returns every version of a movie instead of returning just the default one causing the web to show duplicated movies.


With my changes, the server checks if the version of the movie is already in the results and skips it if it is

This should fix this issue https://github.com/jellyfin/jellyfin/issues/3361

