### PR TITLE
Remove Content-Length header from DLNA HEAD request

### DIFF
--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -132,7 +132,7 @@ namespace Emby.Dlna.PlayTo
 
         private async void OnDeviceMediaChanged(object sender, MediaChangedEventArgs e)
         {
-            if (_disposed)
+            if (_disposed || string.IsNullOrEmpty(e.OldMediaInfo.Url))
             {
                 return;
             }

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Helpers
             // Headers only
             if (isHeadRequest)
             {
-                httpContext.Response.Headers[HeaderNames.ContentLength] = state.EstimateContentLength ? GetEstimatedContentLength(state) : "0";
+                httpContext.Response.Headers[HeaderNames.ContentLength] = GetEstimatedContentLength(state);
                 httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
                 return new OkResult();
             }

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -85,15 +85,15 @@ namespace Jellyfin.Api.Helpers
         /// <returns>System.Nullable{System.Int64}.</returns>
         private static string GetEstimatedContentLength(StreamState state)
         {
+            long v = 0;
             var totalBitrate = state.TotalOutputBitrate ?? 0;
 
             if (totalBitrate > 0 && state.RunTimeTicks.HasValue)
             {
-                var v = Convert.ToInt64(totalBitrate * TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds / 8);
-                return v.ToString(CultureInfo.InvariantCulture);
+                v = Convert.ToInt64(totalBitrate * TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds / 8);
             }
 
-            return string.Empty;
+            return v.ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Helpers
             // Headers only
             if (isHeadRequest)
             {
-                httpContext.Response.Headers[HeaderNames.ContentLength] = state.EstimateContentLength || isHeadRequest ? GetEstimatedContentLength(state) : string.Empty;
+                httpContext.Response.Headers[HeaderNames.ContentLength] = state.EstimateContentLength ? GetEstimatedContentLength(state) : "0";
                 httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
                 return new OkResult();
             }

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -79,24 +78,6 @@ namespace Jellyfin.Api.Helpers
         }
 
         /// <summary>
-        /// Gets the length of the estimated content.
-        /// </summary>
-        /// <param name="state">The state.</param>
-        /// <returns>System.Nullable{System.Int64}.</returns>
-        private static string GetEstimatedContentLength(StreamState state)
-        {
-            long v = 0;
-            var totalBitrate = state.TotalOutputBitrate ?? 0;
-
-            if (totalBitrate > 0 && state.RunTimeTicks.HasValue)
-            {
-                v = Convert.ToInt64(totalBitrate * TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds / 8);
-            }
-
-            return v.ToString(CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
         /// Returns a transcoded file from the server.
         /// </summary>
         /// <param name="state">The current <see cref="StreamState"/>.</param>
@@ -126,7 +107,6 @@ namespace Jellyfin.Api.Helpers
             // Headers only
             if (isHeadRequest)
             {
-                // httpContext.Response.Headers[HeaderNames.ContentLength] = GetEstimatedContentLength(state);
                 httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
                 return new OkResult();
             }

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -127,7 +127,8 @@ namespace Jellyfin.Api.Helpers
             if (isHeadRequest)
             {
                 httpContext.Response.Headers[HeaderNames.ContentLength] = state.EstimateContentLength || isHeadRequest ? GetEstimatedContentLength(state) : string.Empty;
-                return new FileContentResult(Array.Empty<byte>(), contentType);
+                httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
+                return new OkResult();
             }
 
             var transcodingLock = transcodingJobHelper.GetTranscodingLock(outputPath);

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Helpers
             // Headers only
             if (isHeadRequest)
             {
-                httpContext.Response.Headers[HeaderNames.ContentLength] = GetEstimatedContentLength(state);
+                // httpContext.Response.Headers[HeaderNames.ContentLength] = GetEstimatedContentLength(state);
                 httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
                 return new OkResult();
             }

--- a/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
@@ -131,7 +131,7 @@ namespace Jellyfin.Api.Models.StreamingDtos
         public string? UserAgent { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to estimate the content length in the dlna header, or to return zero.
+        /// Gets or sets a value indicating whether to estimate the content length.
         /// </summary>
         public bool EstimateContentLength { get; set; }
 

--- a/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
@@ -131,7 +131,7 @@ namespace Jellyfin.Api.Models.StreamingDtos
         public string? UserAgent { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to estimate the content length.
+        /// Gets or sets a value indicating whether to estimate the content length in the dlna header, or to return zero.
         /// </summary>
         public bool EstimateContentLength { get; set; }
 


### PR DESCRIPTION
Play function not working on Panasonic TV: https://github.com/jellyfin/jellyfin/issues/4697

Fix1: Stops a null argument exception (caught) being created in the first place.
Fix2: Adds ContentLength value to video HEAD response. (Code from 6.4)