### PR TITLE
Remove tests that are upstreamed

### DIFF
--- a/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SsaParserTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SsaParserTests.cs
@@ -13,38 +13,11 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
 {
     public class SsaParserTests
     {
-        // commonly shared invariant value between tests, assumes default format order
-        private const string InvariantDialoguePrefix = "[Events]\nDialogue: ,0:00:00.00,0:00:00.01,,,,,,,";
-
         private readonly SsaParser _parser = new SsaParser(new NullLogger<AssParser>());
 
         [Theory]
-        [InlineData("[EvEnTs]\nDialogue: ,0:00:00.00,0:00:00.01,,,,,,,text", "text")] // label casing insensitivity
-        [InlineData("[Events]\n,0:00:00.00,0:00:00.01,,,,,,,labelless dialogue", "labelless dialogue")] // no "Dialogue:" label, it is optional
-        // TODO: Fix upstream
-        // [InlineData("[Events]\nFormat: Text, Start, End, Layer, Effect, Style\nDialogue: reordered text,0:00:00.00,0:00:00.01", "reordered text")] // reordered formats
-        [InlineData(InvariantDialoguePrefix + "Cased TEXT", "Cased TEXT")] // preserve text casing
-        [InlineData(InvariantDialoguePrefix + "  text  ", "  text  ")] // do not trim text
-        [InlineData(InvariantDialoguePrefix + "text, more text", "text, more text")] // append excess dialogue values (> 10) to text
-        [InlineData(InvariantDialoguePrefix + "start {\\fnFont Name}text{\\fn} end", "start <font face=\"Font Name\">text</font> end")] // font name
-        [InlineData(InvariantDialoguePrefix + "start {\\fs10}text{\\fs} end", "start <font size=\"10\">text</font> end")] // font size
-        [InlineData(InvariantDialoguePrefix + "start {\\c&H112233}text{\\c} end", "start <font color=\"#332211\">text</font> end")] // color
-        // TODO: Fix upstream
-        // [InlineData(InvariantDialoguePrefix + "start {\\1c&H112233}text{\\1c} end", "start <font color=\"#332211\">text</font> end")] // primay color
-        // [InlineData(InvariantDialoguePrefix + "start {\\fnFont Name}text1 {\\fs10}text2{\\fs}{\\fn} {\\1c&H112233}text3{\\1c} end", "start <font face=\"Font Name\">text1 <font size=\"10\">text2</font></font> <font color=\"#332211\">text3</font> end")] // nested formatting
-        public void Parse(string ssa, string expectedText)
-        {
-            using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(ssa)))
-            {
-                SubtitleTrackInfo subtitleTrackInfo = _parser.Parse(stream, CancellationToken.None);
-                SubtitleTrackEvent actual = subtitleTrackInfo.TrackEvents[0];
-                Assert.Equal(expectedText, actual.Text);
-            }
-        }
-
-        [Theory]
         [MemberData(nameof(Parse_MultipleDialogues_TestData))]
-        public void Parse_MultipleDialogues(string ssa, IReadOnlyList<SubtitleTrackEvent> expectedSubtitleTrackEvents)
+        public void Parse_MultipleDialogues_Success(string ssa, IReadOnlyList<SubtitleTrackEvent> expectedSubtitleTrackEvents)
         {
             using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(ssa)))
             {


### PR DESCRIPTION
libse (the SSA parser we use) has these same tests now
