### PR TITLE
POC: Permit plugin testing to be included within the unit tests.

### DIFF
--- a/MediaBrowser.Common/Plugins/BasePlugin.cs
+++ b/MediaBrowser.Common/Plugins/BasePlugin.cs
@@ -88,5 +88,16 @@ namespace MediaBrowser.Common.Plugins
         {
             Id = assemblyId;
         }
+
+        /// <summary>
+        /// Plugin self-test functionality.
+        /// </summary>
+        /// <param name="message">Message to return.</param>
+        /// <returns><c>True</c> if all tests are successful.</returns>
+        public virtual bool SelfTest(out string message)
+        {
+            message = string.Empty;
+            return true;
+        }
     }
 }

--- a/MediaBrowser.Common/Plugins/IPlugin.cs
+++ b/MediaBrowser.Common/Plugins/IPlugin.cs
@@ -53,5 +53,12 @@ namespace MediaBrowser.Common.Plugins
         /// Called when just before the plugin is uninstalled from the server.
         /// </summary>
         void OnUninstalling();
+
+        /// <summary>
+        /// Plugin self-test functionality.
+        /// </summary>
+        /// <param name="message">Message to return.</param>
+        /// <returns><c>True</c> if all tests are successful.</returns>
+        bool SelfTest(out string message);
     }
 }

--- a/tests/Jellyfin.Api.Tests/PluginControllerTest.cs
+++ b/tests/Jellyfin.Api.Tests/PluginControllerTest.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Json;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Api.Tests
+{
+    public sealed class PluginControllerTest : IClassFixture<JellyfinApplicationFactory>
+    {
+        private readonly JellyfinApplicationFactory _factory;
+        private readonly JsonSerializerOptions _jsonOpions = JsonDefaults.GetOptions();
+
+        public PluginControllerTest(JellyfinApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public async Task GetPluginTestResult(Guid pluginId)
+        {
+            var client = _factory.CreateClient();
+
+            var response = await client.GetAsync($"/Plugins/{pluginId}/SelfTest").ConfigureAwait(false);
+
+            Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+
+            var res = await response.Content.ReadAsStreamAsync();
+            var msg = await JsonSerializer.DeserializeAsync<string>(res, _jsonOpions);
+
+            Assert.True(response.StatusCode == HttpStatusCode.OK, msg);
+        }
+
+        [Fact]
+        public async Task RunPluginSelfTests()
+        {
+            var client = _factory.CreateClient();
+
+            var response = await client.GetAsync("/Plugins").ConfigureAwait(false);
+
+            Assert.True(response.IsSuccessStatusCode);
+
+            var res = await response.Content.ReadAsStreamAsync();
+            var plugins = await JsonSerializer.DeserializeAsync<IEnumerable<PluginInfo>>(res, _jsonOpions);
+            if (plugins != null)
+            {
+                foreach (var plugin in plugins)
+                {
+                    await GetPluginTestResult(plugin.Id);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This method does have many flaws, but as a starter, it's minimal and it would at least permit some form of testing.

**Plugins**
The plugin designer uses a new method IPlugin.SelfTest to implement their tests.
Tests return a success state together with an optional string.

**Jellyfin**
A new API function calls the plugin's SelfTest function and returns the success/state.

The test unit controller, retrieves a list of all plugins installed, and enumerates each one, calling the new API.
Any API that fails results in the unit failing.

**Code**
This code does not fully function, but is a concept idea.