### PR TITLE
return false when providerid is null or empty

### DIFF
--- a/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
+++ b/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
@@ -50,13 +50,15 @@ namespace MediaBrowser.Model.Entities
                 throw new ArgumentNullException(nameof(instance));
             }
 
-            if (instance.ProviderIds == null)
+            var foundProviderId = instance.ProviderIds.TryGetValue(name, out id);
+            // This occurs when searching with Identify (and possibly in other places)
+            if (string.IsNullOrEmpty(id))
             {
                 id = null;
-                return false;
+                foundProviderId = false;
             }
 
-            return instance.ProviderIds.TryGetValue(name, out id);
+            return foundProviderId;
         }
 
         /// <summary>

--- a/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
+++ b/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
@@ -50,6 +50,12 @@ namespace MediaBrowser.Model.Entities
                 throw new ArgumentNullException(nameof(instance));
             }
 
+            if (instance.ProviderIds == null)
+            {
+                id = null;
+                return false;
+            }
+
             var foundProviderId = instance.ProviderIds.TryGetValue(name, out id);
             // This occurs when searching with Identify (and possibly in other places)
             if (string.IsNullOrEmpty(id))

--- a/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
+++ b/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Model.Entities
                 throw new ArgumentNullException(nameof(instance));
             }
 
-            return instance.ProviderIds?.ContainsKey(name) ?? false;
+            return instance.TryGetProviderId(name, out _);
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -869,13 +869,13 @@ namespace MediaBrowser.Providers.Manager
                         }
                     }
                 }
-                catch (Exception)
+#pragma warning disable CA1031 // do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031 // do not catch general exception types
                 {
-                    // Logged at lower levels
+                    _logger.LogError(ex, "Provider {ProviderName} failed to retrieve search results", provider.Name);
                 }
             }
-
-            // _logger.LogDebug("Returning search results {0}", _json.SerializeToString(resultList));
 
             return resultList;
         }

--- a/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
@@ -48,6 +48,15 @@ namespace Jellyfin.Model.Tests.Entities
         }
 
         [Fact]
+        public void HasProviderId_FoundNameEmptyValue_False()
+        {
+            var provider = new ProviderIdsExtensionsTestsObject();
+            provider.ProviderIds[MetadataProvider.Imdb.ToString()] = string.Empty;
+
+            Assert.False(provider.HasProviderId(MetadataProvider.Imdb));
+        }
+
+        [Fact]
         public void GetProviderId_NullInstance_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => ProviderIdsExtensions.GetProviderId(null!, MetadataProvider.Imdb));
@@ -110,6 +119,16 @@ namespace Jellyfin.Model.Tests.Entities
 
             Assert.True(provider.TryGetProviderId(MetadataProvider.Imdb, out var id));
             Assert.Equal(ExampleImdbId, id);
+        }
+
+        [Fact]
+        public void TryGetProviderId_FoundNameEmptyValue_False()
+        {
+            var provider = new ProviderIdsExtensionsTestsObject();
+            provider.ProviderIds[MetadataProvider.Imdb.ToString()] = string.Empty;
+
+            Assert.False(provider.TryGetProviderId(MetadataProvider.Imdb, out var id));
+            Assert.Null(id);
         }
 
         [Fact]

--- a/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Model.Tests.Entities
         [Fact]
         public void HasProviderId_NullProvider_False()
         {
-            var nullProvider = new ProviderIdsExtensionsTestsObject()
+            var nullProvider = new ProviderIdsExtensionsTestsObject
             {
                 ProviderIds = null!
             };
@@ -68,7 +68,7 @@ namespace Jellyfin.Model.Tests.Entities
         [Fact]
         public void GetProviderId_NullProvider_Null()
         {
-            var nullProvider = new ProviderIdsExtensionsTestsObject()
+            var nullProvider = new ProviderIdsExtensionsTestsObject
             {
                 ProviderIds = null!
             };
@@ -85,7 +85,7 @@ namespace Jellyfin.Model.Tests.Entities
         [Fact]
         public void TryGetProviderId_NullProvider_False()
         {
-            var nullProvider = new ProviderIdsExtensionsTestsObject()
+            var nullProvider = new ProviderIdsExtensionsTestsObject
             {
                 ProviderIds = null!
             };
@@ -146,7 +146,7 @@ namespace Jellyfin.Model.Tests.Entities
         [Fact]
         public void SetProviderId_NullProvider_Success()
         {
-            var nullProvider = new ProviderIdsExtensionsTestsObject()
+            var nullProvider = new ProviderIdsExtensionsTestsObject
             {
                 ProviderIds = null!
             };
@@ -158,7 +158,7 @@ namespace Jellyfin.Model.Tests.Entities
         [Fact]
         public void SetProviderId_NullProviderAndEmptyName_Success()
         {
-            var nullProvider = new ProviderIdsExtensionsTestsObject()
+            var nullProvider = new ProviderIdsExtensionsTestsObject
             {
                 ProviderIds = null!
             };


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Sometimes the provider id exists but is null or empty. This usually occurs when searching with Identify. We did previously check for this, but it was lost in the refactor.

**Issues**
Fixes #5348
