### PR TITLE
Logging Performance Increase

### DIFF
--- a/Jellyfin.Server/Resources/Configuration/logging.json
+++ b/Jellyfin.Server/Resources/Configuration/logging.json
@@ -11,7 +11,8 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                    "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}",
+                    "theme": "Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console",
                 }
             },
             {

--- a/Jellyfin.Server/Resources/Configuration/logging.json
+++ b/Jellyfin.Server/Resources/Configuration/logging.json
@@ -13,6 +13,7 @@
                 "Args": {
                     "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}",
                     "theme": "Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console",
+                    "restrictedToMinimumLevel": "Warning"
                 }
             },
             {


### PR DESCRIPTION
Came across this whilst searching for the cause of a logging deadlock.
https://github.com/exceptionless/Exceptionless/pull/830

From what is posted, changing the default theme for the console logging to none would provide some performance benefits.
Likewise I've added limited the level to "_Warning_" on the console, as 99% of the time, debug information is produced too fast on the console to be of use.,

As this is the default logging settings, and is only applied if the log settings don't exist, if would only be of benefit to new installations.
