### PR TITLE
do not pick a linked item as primary when merging versions

### DIFF
--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -217,9 +217,7 @@ namespace Jellyfin.Api.Controllers
                 return BadRequest("Please supply at least two videos to merge.");
             }
 
-            var videosWithVersions = items.Where(i => i.MediaSourceCount > 1).ToList();
-
-            var primaryVersion = videosWithVersions.FirstOrDefault();
+            var primaryVersion = items.FirstOrDefault(i => i.MediaSourceCount > 1 && string.IsNullOrEmpty(i.PrimaryVersionId));
             if (primaryVersion == null)
             {
                 primaryVersion = items


### PR DESCRIPTION
When merging two versions that are already merged (user error, but can happen), the first one would be picked and if it already has the other version as primary this line will cause a stack overflow as it goes into an infinite loop https://github.com/jellyfin/jellyfin/blob/cd4641dca02bae552cc7ea1942b0efbd4b791bcb/MediaBrowser.Controller/Entities/Video.cs#L174