### PR TITLE
Do not apply search results on seasons

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -211,9 +211,22 @@ namespace MediaBrowser.Providers.Manager
 
         private void ApplySearchResult(ItemLookupInfo lookupInfo, RemoteSearchResult result)
         {
-            lookupInfo.ProviderIds = result.ProviderIds;
-            lookupInfo.Name = result.Name;
-            lookupInfo.Year = result.ProductionYear;
+            switch (lookupInfo)
+            {
+                case EpisodeInfo episodeInfo:
+                    episodeInfo.SeriesProviderIds = result.ProviderIds;
+                    episodeInfo.ProviderIds.Clear();
+                    break;
+                case SeasonInfo seasonInfo:
+                    seasonInfo.SeriesProviderIds = result.ProviderIds;
+                    seasonInfo.ProviderIds.Clear();
+                    break;
+                default:
+                    lookupInfo.ProviderIds = result.ProviderIds;
+                    lookupInfo.Name = result.Name;
+                    lookupInfo.Year = result.ProductionYear;
+                    break;
+            }
         }
 
         protected async Task SaveItemAsync(MetadataResult<TItemType> result, ItemUpdateType reason, CancellationToken cancellationToken)

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -211,6 +211,7 @@ namespace MediaBrowser.Providers.Manager
 
         private void ApplySearchResult(ItemLookupInfo lookupInfo, RemoteSearchResult result)
         {
+            // Episode and Season do not support Identify, so the search results are the Series'
             switch (lookupInfo)
             {
                 case EpisodeInfo episodeInfo:


### PR DESCRIPTION
This one has already caused several issues with season metadata providers over last few years (!). TLDR: When using "Identify" Jellyfin would set series name and providers into `SeasonInfo` when calling GetMetadata on it.

**Changes**

```c#
if (refreshOptions.SearchResult != null && !(itemOfType is Season))
{
    ApplySearchResult(id, refreshOptions.SearchResult);
}
```
`refreshOptions.SearchResult` contains series info even when refreshing metadata for seasons. I've just added season type check since I did not have any better ideas and we can't use "Identify" for seasons anyways.

**Issues**
#4948 
#4134 
#1843

P.S. I hate myself for spending so much time debugging this.


EDIT: I've noticed that when reidentifying a series, season and episode metadata is not reset. Shouldn't we do it? I mean if a series was identified wrong then all seasons and episodes will have wrong provider IDs. When refreshing metadata for season/episode after "Identify" metadata providers will not care that series ID has changed because episode/season ID is set. I think that when `refreshOptions.SearchResult` for series is set then we should clear all children metadata to make sure that all seasons and episodes are identified correctly after a refresh.

Example: An 'X' metadata provider uses IDs for series, seasons and episodes. It misidentified a series, assigned an ID to it, its seasons and all episodes (each episode has it's own unique ID). User uses "Identify" on said series assigning a correct ID but all seasons and episodes are still using old IDs! In this case user has to manually go through all episodes (there may be hundreds of them), remove IDs from all of them by hand and only then "Identify" the parent series.