### PR TITLE
Various DLNA Device Profile fixes

### DIFF
--- a/Emby.Dlna/Profiles/DefaultProfile.cs
+++ b/Emby.Dlna/Profiles/DefaultProfile.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CS1591
 
+using System;
+using System.Globalization;
 using System.Linq;
 using MediaBrowser.Model.Dlna;
 
@@ -10,6 +12,7 @@ namespace Emby.Dlna.Profiles
     {
         public DefaultProfile()
         {
+            Id = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
             Name = "Generic Device";
 
             ProtocolInfo = "http-get:*:video/mpeg:*,http-get:*:video/mp4:*,http-get:*:video/vnd.dlna.mpeg-tts:*,http-get:*:video/avi:*,http-get:*:video/x-matroska:*,http-get:*:video/x-ms-wmv:*,http-get:*:video/wtv:*,http-get:*:audio/mpeg:*,http-get:*:audio/mp3:*,http-get:*:audio/mp4:*,http-get:*:audio/x-ms-wma:*,http-get:*:audio/wav:*,http-get:*:audio/L16:*,http-get:*:image/jpeg:*,http-get:*:image/png:*,http-get:*:image/gif:*,http-get:*:image/tiff:*";

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -508,17 +508,18 @@ namespace Jellyfin.Api.Helpers
 
         private static void ApplyDeviceProfileSettings(StreamState state, IDlnaManager dlnaManager, IDeviceManager deviceManager, HttpRequest request, string? deviceProfileId, bool? @static)
         {
-            var headers = request.Headers;
-
             if (!string.IsNullOrWhiteSpace(deviceProfileId))
             {
-                state.DeviceProfile = dlnaManager.GetProfile(deviceProfileId);
-            }
-            else if (!string.IsNullOrWhiteSpace(deviceProfileId))
-            {
-                var caps = deviceManager.GetCapabilities(deviceProfileId);
+                if (state.DeviceProfile == null)
+                {
+                    state.DeviceProfile = dlnaManager.GetProfile(deviceProfileId);
+                }
 
-                state.DeviceProfile = caps == null ? dlnaManager.GetProfile(headers) : caps.DeviceProfile;
+                if (state.DeviceProfile == null)
+                {
+                    var caps = deviceManager.GetCapabilities(deviceProfileId);
+                    state.DeviceProfile = caps == null ? dlnaManager.GetProfile(request.Headers) : caps.DeviceProfile;
+                }
             }
 
             var profile = state.DeviceProfile;

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -510,10 +510,7 @@ namespace Jellyfin.Api.Helpers
         {
             if (!string.IsNullOrWhiteSpace(deviceProfileId))
             {
-                if (state.DeviceProfile == null)
-                {
-                    state.DeviceProfile = dlnaManager.GetProfile(deviceProfileId);
-                }
+                state.DeviceProfile = dlnaManager.GetProfile(deviceProfileId);
 
                 if (state.DeviceProfile == null)
                 {


### PR DESCRIPTION
Fix: Assigns dynamic profiles a deviceId so that properties retreived via dlna can be used in streaming calcs. #https://github.com/jellyfin/jellyfin/issues/5394

Fix: Implements the redundant code that was part of the profile detection in the stream helper.