### PR TITLE
Remove Microsoft repo from install step

### DIFF
--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -13,9 +13,7 @@ RUN dnf update -y \
  && dnf install -y @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd
 
 # Install DotNET SDK
-RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
- && curl -o /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/$(rpm -E %fedora)/prod.repo \
- && dnf install -y dotnet-sdk-${SDK_VERSION} dotnet-runtime-${SDK_VERSION}
+RUN dnf install -y dotnet-sdk-${SDK_VERSION} dotnet-runtime-${SDK_VERSION}
 
 # Create symlinks and directories
 RUN ln -sf ${SOURCE_DIR}/deployment/build.fedora.amd64 /build.sh \


### PR DESCRIPTION
**Changes**
Remove Microsoft repo from the Fedora install step. This was breaking Fedora builds due to a mismatch. We can use the .NET SDK 5.0 from the Fedora 33 repos instead and this seems to work.

**Issues**

N/A