### PR TITLE
Add workflows for rebase and automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     interval: weekly
     time: '12:00'
   open-pull-requests-limit: 10
-  
+
+- package-ecosystem: github-actions
+  directory: '/'
+  schedule:
+    interval: weekly
+    time: '12:00'
+  open-pull-requests-limit: 10

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,66 @@
+name: Automation
+
+on:
+  pull_request:
+  issues:
+  issue_comment:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Does PR has the stable backport label?
+        uses: Dreamcodeio/does-pr-has-label@v1.2
+        id: checkLabel
+        with:
+          label: stable backport
+
+      - name: Remove from 'Current Release' project
+        uses: alex-page/github-project-automation-plus@v0.5.1
+        if: (github.event.pull_request || github.event.issue.pull_request) && !steps.checkLabel.outputs.hasLabel
+        continue-on-error: true
+        with:
+          project: Current Release
+          action: delete
+          repo-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Add to 'Release Next' project
+        uses: alex-page/github-project-automation-plus@v0.5.1
+        if: (github.event.pull_request || github.event.issue.pull_request) && github.event.action == 'opened'
+        continue-on-error: true
+        with:
+          project: Release Next
+          column: In progress
+          repo-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Add to 'Current Release' project
+        uses: alex-page/github-project-automation-plus@v0.5.1
+        if: (github.event.pull_request || github.event.issue.pull_request) && steps.checkLabel.outputs.hasLabel
+        continue-on-error: true
+        with:
+          project: Current Release
+          column: In progress
+          repo-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Check number of comments from the team member
+        if: github.event.issue.pull_request == '' && github.event.comment.author_association == 'MEMBER'
+        id: member_comments
+        run: echo "::set-output name=number::$(curl -s ${{ github.event.issue.comments_url }} | jq '.[] | select(.author_association == "MEMBER") | .author_association' | wc -l)"
+
+      - name: Move issue to needs triage
+        uses: alex-page/github-project-automation-plus@v0.5.1
+        if: github.event.issue.pull_request == '' && github.event.comment.author_association == 'MEMBER' && steps.member_comments.outputs.number <= 1
+        continue-on-error: true
+        with:
+          project: Issue Triage for Main Repo
+          column: Needs triage
+          repo-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Add issue to triage project
+        uses: alex-page/github-project-automation-plus@v0.5.1
+        if: github.event.issue.pull_request == '' && github.event.action == 'opened'
+        continue-on-error: true
+        with:
+          project: Issue Triage for Main Repo
+          column: Pending response
+          repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,0 +1,17 @@
+name: 'Merge Conflicts'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    types:
+      - synchronize
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+        with:
+          dirtyLabel: 'merge conflict'
+          repoToken: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,27 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@jellyfin-bot rebase') && github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify as seen
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'
+
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Project automation

* Newly opened PRs will be added to the "Next Release" project.

* If labeled as "stable backport", they will be added to the "Current release" project as well.

* If the "stable backport" is removed, it will be removed from the "Current release" project.

* New issues will be added to "Pending response" in "Issue Triage for Main Repo". As soon as a team member comments on it, the issue will be moved to "Needs triage", so we can manually move it to the low/medium/high priority boards.

## Rebase

Team members can type ``@jellyfin rebase`` on any PR for quickly triggering a rebase on that branch.

⚠️ Only works for members that have their org membership visible.

## Setup

This PR needs the same ``GH_TOKEN`` that is configured in jellyfin-vue to work properly. It also needs to have created a "Current Release" and "Next Release" to work properly. 

I chose those generic names so we don't need to update the action every time a new update appears, but I don't mind if there's a general agreement of doing it manually.