### PR TITLE
Use distinct for AllArtists to avoid double refreshing

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/IHasAlbumArtist.cs
+++ b/MediaBrowser.Controller/Entities/Audio/IHasAlbumArtist.cs
@@ -1,6 +1,8 @@
 #pragma warning disable CS1591
 
 using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Controller.Library;
 
 namespace MediaBrowser.Controller.Entities.Audio
 {
@@ -23,15 +25,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         public static IEnumerable<string> GetAllArtists<T>(this T item)
             where T : IHasArtist, IHasAlbumArtist
         {
-            foreach (var i in item.AlbumArtists)
-            {
-                yield return i;
-            }
-
-            foreach (var i in item.Artists)
-            {
-                yield return i;
-            }
+            return item.AlbumArtists.Concat(item.Artists).DistinctNames();
         }
     }
 }

--- a/MediaBrowser.Controller/Library/NameExtensions.cs
+++ b/MediaBrowser.Controller/Library/NameExtensions.cs
@@ -10,6 +10,10 @@ namespace MediaBrowser.Controller.Library
 {
     public static class NameExtensions
     {
+        public static IEnumerable<string> DistinctNames(this IEnumerable<string> names)
+            => names.GroupBy(RemoveDiacritics, StringComparer.OrdinalIgnoreCase)
+                .Select(x => x.First());
+
         private static string RemoveDiacritics(string? name)
         {
             if (name == null)
@@ -19,9 +23,5 @@ namespace MediaBrowser.Controller.Library
 
             return name.RemoveDiacritics();
         }
-
-        public static IEnumerable<string> DistinctNames(this IEnumerable<string> names)
-            => names.GroupBy(RemoveDiacritics, StringComparer.OrdinalIgnoreCase)
-                    .Select(x => x.First());
     }
 }


### PR DESCRIPTION
It's not uncommon for an artist to be tagged as Artist and AlbumArtist in which case this line https://github.com/jellyfin/jellyfin/blob/ee23d06154133ffc506dda3a8ef0e09d20c03c6c/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs#L202 will refresh the artist twice. This can lead to some weird behaviour.