### PR TITLE
fix multiversion eligibility check for complex folder names

### DIFF
--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -229,15 +229,14 @@ namespace Emby.Naming.Video
 
                 if (CleanStringParser.TryClean(testFilename, _options.CleanStringRegexes, out var cleanName))
                 {
-                    testFilename = cleanName.ToString();
+                    testFilename = cleanName.Trim().ToString();
                 }
 
-                // The CleanStringParser should have removed common keywords etc., so if it starts with -, _ or [ it's eligible.
+                // The CleanStringParser should have removed common keywords etc.
                 return string.IsNullOrEmpty(testFilename)
                        || testFilename[0] == '-'
                        || testFilename[0] == '_'
-                       || testFilename[0] == '['
-                       || string.IsNullOrWhiteSpace(Regex.Replace(testFilename, @"\[([^]]*)\]", string.Empty));
+                       || Regex.IsMatch(testFilename, @"^\[([^]]*)\]");
             }
 
             return false;

--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -221,20 +221,23 @@ namespace Emby.Naming.Video
             string testFilename = Path.GetFileNameWithoutExtension(testFilePath);
             if (testFilename.StartsWith(folderName, StringComparison.OrdinalIgnoreCase))
             {
-                if (CleanStringParser.TryClean(testFilename, _options.CleanStringRegexes, out var cleanName))
-                {
-                    testFilename = cleanName.ToString();
-                }
-
+                // Remove the folder name before cleaning as we don't care about cleaning that part
                 if (folderName.Length <= testFilename.Length)
                 {
                     testFilename = testFilename.Substring(folderName.Length).Trim();
                 }
 
+                if (CleanStringParser.TryClean(testFilename, _options.CleanStringRegexes, out var cleanName))
+                {
+                    testFilename = cleanName.ToString();
+                }
+
+                // The CleanStringParser should have removed common keywords etc., so if it starts with -, _ or [ it's eligible.
                 return string.IsNullOrEmpty(testFilename)
-                   || testFilename[0] == '-'
-                   || testFilename[0] == '_'
-                   || string.IsNullOrWhiteSpace(Regex.Replace(testFilename, @"\[([^]]*)\]", string.Empty));
+                       || testFilename[0] == '-'
+                       || testFilename[0] == '_'
+                       || testFilename[0] == '['
+                       || string.IsNullOrWhiteSpace(Regex.Replace(testFilename, @"\[([^]]*)\]", string.Empty));
             }
 
             return false;

--- a/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
@@ -389,6 +389,24 @@ namespace Jellyfin.Naming.Tests.Video
         }
 
         [Fact]
+        public void Resolve_GivenUnclosedBrackets_DoesNotGroup()
+        {
+            var files = new[]
+            {
+                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Kapitel 3 (2019) [Version 1].mkv",
+                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Kapitel 3 (2019) [Version 2.mkv"
+            };
+
+            var result = _videoListResolver.Resolve(files.Select(i => new FileSystemMetadata
+            {
+                IsDirectory = false,
+                FullName = i
+            }).ToList()).ToList();
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
         public void TestEmptyList()
         {
             var result = _videoListResolver.Resolve(new List<FileSystemMetadata>()).ToList();

--- a/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
@@ -393,8 +393,8 @@ namespace Jellyfin.Naming.Tests.Video
         {
             var files = new[]
             {
-                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Kapitel 3 (2019) [Version 1].mkv",
-                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Kapitel 3 (2019) [Version 2.mkv"
+                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Chapter 3 (2019) [Version 1].mkv",
+                @"/movies/John Wick - Chapter 3 (2019)/John Wick - Chapter 3 (2019) [Version 2.mkv"
             };
 
             var result = _videoListResolver.Resolve(files.Select(i => new FileSystemMetadata

--- a/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
@@ -369,6 +369,26 @@ namespace Jellyfin.Naming.Tests.Video
         }
 
         [Fact]
+        public void Resolve_GivenFolderNameWithBracketsAndHyphens_GroupsBasedOnFolderName()
+        {
+            var files = new[]
+            {
+                @"/movies/John Wick - Kapitel 3 (2019) [imdbid=tt6146586]/John Wick - Kapitel 3 (2019) [imdbid=tt6146586] - Version 1.mkv",
+                @"/movies/John Wick - Kapitel 3 (2019) [imdbid=tt6146586]/John Wick - Kapitel 3 (2019) [imdbid=tt6146586] - Version 2.mkv"
+            };
+
+            var result = _videoListResolver.Resolve(files.Select(i => new FileSystemMetadata
+            {
+                IsDirectory = false,
+                FullName = i
+            }).ToList()).ToList();
+
+            Assert.Single(result);
+            Assert.Empty(result[0].Extras);
+            Assert.Single(result[0].AlternateVersions);
+        }
+
+        [Fact]
         public void TestEmptyList()
         {
             var result = _videoListResolver.Resolve(new List<FileSystemMetadata>()).ToList();


### PR DESCRIPTION
**Changes**
Moved the cleaning to after removing folder name from the filename. Also added a check for the remainder string starting with `[`.

Reasoning behind this change is that the filenames _must_ start with the folder name, so why not remove the folder name _before_ cleaning the string. And normally a file that starts with `[` is anime or whatever, but this does not apply here.

**Issues**
Fixes #5435