### PR TITLE
Nfo id parsing fixes

### DIFF
--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
+using MediaBrowser.Common.Providers;
 
 namespace Emby.Server.Implementations.Library
 {
@@ -43,8 +44,8 @@ namespace Emby.Server.Implementations.Library
             // for imdbid we also accept pattern matching
             if (string.Equals(attribute, "imdbid", StringComparison.OrdinalIgnoreCase))
             {
-                var m = Regex.Match(str, "tt([0-9]{7,8})", RegexOptions.IgnoreCase);
-                return m.Success ? m.Value : null;
+                var match = ProviderIdParsers.TryParseImdbId(str, out var imdbId);
+                return match ? imdbId : null;
             }
 
             return null;

--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -44,8 +44,8 @@ namespace Emby.Server.Implementations.Library
             // for imdbid we also accept pattern matching
             if (string.Equals(attribute, "imdbid", StringComparison.OrdinalIgnoreCase))
             {
-                var match = ProviderIdParsers.TryParseImdbId(str, out var imdbId);
-                return match ? imdbId : null;
+                var match = ProviderIdParsers.TryFindImdbId(str, out var imdbId);
+                return match ? imdbId.ToString() : null;
             }
 
             return null;

--- a/MediaBrowser.Common/Providers/ProviderIdParsers.cs
+++ b/MediaBrowser.Common/Providers/ProviderIdParsers.cs
@@ -19,27 +19,26 @@ namespace MediaBrowser.Common.Providers
         /// <param name="text">The text to parse.</param>
         /// <param name="imdbId">The parsed IMDb id.</param>
         /// <returns>True if parsing was successful, false otherwise.</returns>
-        public static bool TryParseImdbId(string text, [NotNullWhen(true)] out string? imdbId)
+        public static bool TryParseImdbId(ReadOnlySpan<char> text, [NotNullWhen(true)] out string? imdbId)
         {
-            var span = text.AsSpan();
             var tt = "tt".AsSpan();
 
             // imdb id is at least 9 chars (tt + 7 numbers)
-            while (span.Length >= 2 + ImdbMinNumbers)
+            while (text.Length >= 2 + ImdbMinNumbers)
             {
-                var ttPos = span.IndexOf(tt);
+                var ttPos = text.IndexOf(tt);
                 if (ttPos == -1)
                 {
                     imdbId = default;
                     return false;
                 }
 
-                span = span.Slice(ttPos + tt.Length);
+                text = text.Slice(ttPos + tt.Length);
                 var i = 0;
-                for (; i < Math.Min(span.Length, ImdbMaxNumbers); i++)
+                for (; i < Math.Min(text.Length, ImdbMaxNumbers); i++)
                 {
-                    var c = span[i];
-                    if (!IsDigit(c))
+                    var c = text[i];
+                    if (!char.IsDigit(c))
                     {
                         break;
                     }
@@ -48,11 +47,11 @@ namespace MediaBrowser.Common.Providers
                 // skip if more than 8 digits
                 if (i <= ImdbMaxNumbers && i >= ImdbMinNumbers)
                 {
-                    imdbId = string.Concat(tt, span.Slice(0, i));
+                    imdbId = string.Concat(tt, text.Slice(0, i));
                     return true;
                 }
 
-                span = span.Slice(i);
+                text = text.Slice(i);
             }
 
             imdbId = default;
@@ -65,7 +64,7 @@ namespace MediaBrowser.Common.Providers
         /// <param name="text">The text with the url to parse.</param>
         /// <param name="tmdbId">The parsed TMDb id.</param>
         /// <returns>True if parsing was successful, false otherwise.</returns>
-        public static bool TryParseTmdbMovieId(string text, [NotNullWhen(true)] out string? tmdbId)
+        public static bool TryParseTmdbMovieId(ReadOnlySpan<char> text, [NotNullWhen(true)] out string? tmdbId)
             => TryParseProviderId(text, "themoviedb.org/movie/", out tmdbId);
 
         /// <summary>
@@ -74,7 +73,7 @@ namespace MediaBrowser.Common.Providers
         /// <param name="text">The text with the url to parse.</param>
         /// <param name="tmdbId">The parsed TMDb id.</param>
         /// <returns>True if parsing was successful, false otherwise.</returns>
-        public static bool TryParseTmdbSeriesId(string text, [NotNullWhen(true)] out string? tmdbId)
+        public static bool TryParseTmdbSeriesId(ReadOnlySpan<char> text, [NotNullWhen(true)] out string? tmdbId)
             => TryParseProviderId(text, "themoviedb.org/tv/", out tmdbId);
 
         /// <summary>
@@ -83,29 +82,26 @@ namespace MediaBrowser.Common.Providers
         /// <param name="text">The text with the url to parse.</param>
         /// <param name="tvdbId">The parsed TVDb id.</param>
         /// <returns>True if parsing was successful, false otherwise.</returns>
-        public static bool TryParseTvdbId(string text, [NotNullWhen(true)] out string? tvdbId)
+        public static bool TryParseTvdbId(ReadOnlySpan<char> text, [NotNullWhen(true)] out string? tvdbId)
             => TryParseProviderId(text, "thetvdb.com/?tab=series&id=", out tvdbId);
 
-        private static bool TryParseProviderId(string text, string searchString, [NotNullWhen(true)] out string? providerId)
+        private static bool TryParseProviderId(ReadOnlySpan<char> text, ReadOnlySpan<char> searchString, [NotNullWhen(true)] out string? providerId)
         {
-            var span = text.AsSpan();
-            var searchSpan = searchString.AsSpan();
-
-            var searchPos = span.IndexOf(searchSpan);
+            var searchPos = text.IndexOf(searchString);
             if (searchPos == -1)
             {
                 providerId = default;
                 return false;
             }
 
-            span = span.Slice(searchPos + searchSpan.Length);
+            text = text.Slice(searchPos + searchString.Length);
 
             int i = 0;
-            for (; i < span.Length; i++)
+            for (; i < text.Length; i++)
             {
-                var c = span[i];
+                var c = text[i];
 
-                if (!IsDigit(c))
+                if (!char.IsDigit(c))
                 {
                     break;
                 }
@@ -113,17 +109,12 @@ namespace MediaBrowser.Common.Providers
 
             if (i >= 1)
             {
-                providerId = span.Slice(0, i).ToString();
+                providerId = text.Slice(0, i).ToString();
                 return true;
             }
 
             providerId = default;
             return false;
-        }
-
-        private static bool IsDigit(char c)
-        {
-            return c >= '0' && c <= '9';
         }
     }
 }

--- a/MediaBrowser.Common/Providers/ProviderIdParsers.cs
+++ b/MediaBrowser.Common/Providers/ProviderIdParsers.cs
@@ -22,12 +22,10 @@ namespace MediaBrowser.Common.Providers
         /// <returns>True if parsing was successful, false otherwise.</returns>
         public static bool TryFindImdbId(ReadOnlySpan<char> text, [NotNullWhen(true)] out ReadOnlySpan<char> imdbId)
         {
-            var tt = ImdbPrefix.AsSpan();
-
             // imdb id is at least 9 chars (tt + 7 numbers)
             while (text.Length >= 2 + ImdbMinNumbers)
             {
-                var ttPos = text.IndexOf(tt);
+                var ttPos = text.IndexOf(ImdbPrefix);
                 if (ttPos == -1)
                 {
                     imdbId = default;

--- a/MediaBrowser.Common/Providers/ProviderIdParsers.cs
+++ b/MediaBrowser.Common/Providers/ProviderIdParsers.cs
@@ -1,0 +1,119 @@
+﻿#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MediaBrowser.Common.Providers
+{
+    /// <summary>
+    /// Parsers for provider ids.
+    /// </summary>
+    public static class ProviderIdParsers
+    {
+        /// <summary>
+        /// Parses an IMDb id from a string.
+        /// </summary>
+        /// <param name="text">The text to parse.</param>
+        /// <param name="imdbId">The parsed IMDb id.</param>
+        /// <returns>True if parsing was successful, false otherwise.</returns>
+        public static bool TryParseImdbId(string text, [NotNullWhen(true)] out string? imdbId)
+        {
+            var span = text.AsSpan();
+            var tt = "tt".AsSpan();
+
+            while (true)
+            {
+                var ttPos = span.IndexOf(tt);
+                if (ttPos == -1)
+                {
+                    imdbId = default;
+                    return false;
+                }
+
+                span = span.Slice(ttPos + tt.Length);
+
+                int i = 0;
+                // IMDb id has a maximum of 8 digits
+                int max = span.Length > 8 ? 8 : span.Length;
+                for (; i < max; i++)
+                {
+                    var c = span[i];
+
+                    if (c < '0' || c > '9')
+                    {
+                        break;
+                    }
+                }
+
+                // IMDb id has a minimum of 7 digits
+                if (i >= 7)
+                {
+                    imdbId = string.Concat(tt, span.Slice(0, i));
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses an TMDb id from a movie url.
+        /// </summary>
+        /// <param name="text">The text with the url to parse.</param>
+        /// <param name="tmdbId">The parsed TMDb id.</param>
+        /// <returns>True if parsing was successful, false otherwise.</returns>
+        public static bool TryParseTmdbMovieId(string text, [NotNullWhen(true)] out string? tmdbId)
+            => TryParseProviderId(text, "themoviedb.org/movie/", out tmdbId);
+
+        /// <summary>
+        /// Parses an TMDb id from a series url.
+        /// </summary>
+        /// <param name="text">The text with the url to parse.</param>
+        /// <param name="tmdbId">The parsed TMDb id.</param>
+        /// <returns>True if parsing was successful, false otherwise.</returns>
+        public static bool TryParseTmdbSeriesId(string text, [NotNullWhen(true)] out string? tmdbId)
+            => TryParseProviderId(text, "themoviedb.org/tv/", out tmdbId);
+
+        /// <summary>
+        /// Parses an TVDb id from a url.
+        /// </summary>
+        /// <param name="text">The text with the url to parse.</param>
+        /// <param name="tvdbId">The parsed TVDb id.</param>
+        /// <returns>True if parsing was successful, false otherwise.</returns>
+        public static bool TryParseTvdbId(string text, [NotNullWhen(true)] out string? tvdbId)
+            => TryParseProviderId(text, "thetvdb.com/?tab=series&id=", out tvdbId);
+
+        private static bool TryParseProviderId(string text, string searchString, [NotNullWhen(true)] out string? providerId)
+        {
+            var span = text.AsSpan();
+            var searchSpan = searchString.AsSpan();
+
+            while (true)
+            {
+                var searchPos = span.IndexOf(searchSpan);
+                if (searchPos == -1)
+                {
+                    providerId = default;
+                    return false;
+                }
+
+                span = span.Slice(searchPos + searchSpan.Length);
+
+                int i = 0;
+                for (; i < span.Length; i++)
+                {
+                    var c = span[i];
+
+                    if (c < '0' || c > '9')
+                    {
+                        break;
+                    }
+                }
+
+                if (i >= 1)
+                {
+                    providerId = span.Slice(0, i).ToString();
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/MediaBrowser.Common/Providers/ProviderIdParsers.cs
+++ b/MediaBrowser.Common/Providers/ProviderIdParsers.cs
@@ -38,7 +38,7 @@ namespace MediaBrowser.Common.Providers
                 for (; i < Math.Min(text.Length, ImdbMaxNumbers); i++)
                 {
                     var c = text[i];
-                    if (!char.IsDigit(c))
+                    if (!IsDigit(c))
                     {
                         break;
                     }
@@ -101,7 +101,7 @@ namespace MediaBrowser.Common.Providers
             {
                 var c = text[i];
 
-                if (!char.IsDigit(c))
+                if (!IsDigit(c))
                 {
                     break;
                 }
@@ -115,6 +115,11 @@ namespace MediaBrowser.Common.Providers
 
             providerId = default;
             return false;
+        }
+
+        private static bool IsDigit(char c)
+        {
+            return c >= '0' && c <= '9';
         }
     }
 }

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -219,29 +219,29 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
         protected void ParseProviderLinks(T item, string xml)
         {
-            if (ProviderIdParsers.TryParseImdbId(xml, out var imdbId))
+            if (ProviderIdParsers.TryFindImdbId(xml, out var imdbId))
             {
-                item.SetProviderId(MetadataProvider.Imdb, imdbId);
+                item.SetProviderId(MetadataProvider.Imdb, imdbId.ToString());
             }
 
             if (item is Movie)
             {
-                if (ProviderIdParsers.TryParseTmdbMovieId(xml, out var tmdbId))
+                if (ProviderIdParsers.TryFindTmdbMovieId(xml, out var tmdbId))
                 {
-                    item.SetProviderId(MetadataProvider.Tmdb, tmdbId);
+                    item.SetProviderId(MetadataProvider.Tmdb, tmdbId.ToString());
                 }
             }
 
             if (item is Series)
             {
-                if (ProviderIdParsers.TryParseTmdbSeriesId(xml, out var tmdbId))
+                if (ProviderIdParsers.TryFindTmdbSeriesId(xml, out var tmdbId))
                 {
-                    item.SetProviderId(MetadataProvider.Tmdb, tmdbId);
+                    item.SetProviderId(MetadataProvider.Tmdb, tmdbId.ToString());
                 }
 
-                if (ProviderIdParsers.TryParseTvdbId(xml, out var tvdbId))
+                if (ProviderIdParsers.TryFindTvdbId(xml, out var tvdbId))
                 {
-                    item.SetProviderId(MetadataProvider.Tvdb, tvdbId);
+                    item.SetProviderId(MetadataProvider.Tvdb, tvdbId.ToString());
                 }
             }
         }

--- a/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
@@ -47,12 +47,19 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             {
                 case "id":
                     {
+                        // get ids from attributes
                         string? imdbId = reader.GetAttribute("IMDB");
                         string? tmdbId = reader.GetAttribute("TMDB");
 
-                        if (string.IsNullOrWhiteSpace(imdbId))
+                        // read id from content
+                        var contentId = reader.ReadElementContentAsString();
+                        if (contentId.Contains("tt", StringComparison.Ordinal) && string.IsNullOrEmpty(imdbId))
                         {
-                            imdbId = reader.ReadElementContentAsString();
+                            imdbId = contentId;
+                        }
+                        else if (string.IsNullOrEmpty(tmdbId))
+                        {
+                            tmdbId = contentId;
                         }
 
                         if (!string.IsNullOrWhiteSpace(imdbId))

--- a/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
@@ -36,9 +36,6 @@ namespace MediaBrowser.XbmcMetadata.Parsers
         protected override bool SupportsUrlAfterClosingXmlTag => true;
 
         /// <inheritdoc />
-        protected override string TmdbRegex => "themoviedb\\.org\\/tv\\/([0-9]+)";
-
-        /// <inheritdoc />
         protected override void FetchDataFromXmlNode(XmlReader reader, MetadataResult<Series> itemResult)
         {
             var item = itemResult.Item;

--- a/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
@@ -36,7 +36,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
         protected override bool SupportsUrlAfterClosingXmlTag => true;
 
         /// <inheritdoc />
-        protected override string MovieDbParserSearchString => "themoviedb.org/tv/";
+        protected override string TmdbRegex => "themoviedb\\.org\\/tv\\/([0-9]+)";
 
         /// <inheritdoc />
         protected override void FetchDataFromXmlNode(XmlReader reader, MetadataResult<Series> itemResult)

--- a/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
+++ b/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
@@ -1,4 +1,5 @@
-﻿using MediaBrowser.Common.Providers;
+﻿using System;
+using MediaBrowser.Common.Providers;
 using Xunit;
 
 namespace Jellyfin.Common.Tests.Providers
@@ -20,9 +21,9 @@ namespace Jellyfin.Common.Tests.Providers
         [InlineData("tt123456789", true, "tt12345678")]
         public void Parse_Imdb(string text, bool shouldSucceed, string? imdbId)
         {
-            var succeeded = ProviderIdParsers.TryParseImdbId(text, out string? parsedId);
+            var succeeded = ProviderIdParsers.TryFindImdbId(text, out ReadOnlySpan<char> parsedId);
             Assert.Equal(shouldSucceed, succeeded);
-            Assert.Equal(imdbId, parsedId);
+            Assert.Equal(imdbId ?? Span<char>.Empty.ToString(), parsedId.ToString());
         }
 
         [Theory]
@@ -32,9 +33,9 @@ namespace Jellyfin.Common.Tests.Providers
         [InlineData("https://www.themoviedb.org/tv/1668-friends", false, null)]
         public void Parse_TmdbMovie(string text, bool shouldSucceed, string? tmdbId)
         {
-            var succeeded = ProviderIdParsers.TryParseTmdbMovieId(text, out string? parsedId);
+            var succeeded = ProviderIdParsers.TryFindTmdbMovieId(text, out ReadOnlySpan<char> parsedId);
             Assert.Equal(shouldSucceed, succeeded);
-            Assert.Equal(tmdbId, parsedId);
+            Assert.Equal(tmdbId ?? Span<char>.Empty.ToString(), parsedId.ToString());
         }
 
         [Theory]
@@ -44,9 +45,9 @@ namespace Jellyfin.Common.Tests.Providers
         [InlineData("https://www.themoviedb.org/movie/30287-fallo", false, null)]
         public void Parse_TmdbSeries(string text, bool shouldSucceed, string? tmdbId)
         {
-            var succeeded = ProviderIdParsers.TryParseTmdbSeriesId(text, out string? parsedId);
+            var succeeded = ProviderIdParsers.TryFindTmdbSeriesId(text, out ReadOnlySpan<char> parsedId);
             Assert.Equal(shouldSucceed, succeeded);
-            Assert.Equal(tmdbId, parsedId);
+            Assert.Equal(tmdbId ?? Span<char>.Empty.ToString(), parsedId.ToString());
         }
 
         [Theory]
@@ -56,9 +57,9 @@ namespace Jellyfin.Common.Tests.Providers
         [InlineData("https://www.themoviedb.org/tv/1668-friends", false, null)]
         public void Parse_Tvdb(string text, bool shouldSucceed, string? tvdbId)
         {
-            var succeeded = ProviderIdParsers.TryParseTvdbId(text, out string? parsedId);
+            var succeeded = ProviderIdParsers.TryFindTvdbId(text, out ReadOnlySpan<char> parsedId);
             Assert.Equal(shouldSucceed, succeeded);
-            Assert.Equal(tvdbId, parsedId);
+            Assert.Equal(tvdbId ?? Span<char>.Empty.ToString(), parsedId.ToString());
         }
     }
 }

--- a/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
+++ b/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
@@ -17,6 +17,7 @@ namespace Jellyfin.Common.Tests.Providers
         [InlineData("Jellyfin", false, null)]
         [InlineData("tt1234567tt7654321", true, "tt1234567")]
         [InlineData("tt12345678tt7654321", true, "tt12345678")]
+        [InlineData("tt123456789", true, "tt12345678")]
         public void Parse_Imdb(string text, bool shouldSucceed, string? imdbId)
         {
             var succeeded = ProviderIdParsers.TryParseImdbId(text, out string? parsedId);

--- a/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
+++ b/tests/Jellyfin.Common.Tests/Providers/ProviderIdParserTests.cs
@@ -1,0 +1,63 @@
+﻿using MediaBrowser.Common.Providers;
+using Xunit;
+
+namespace Jellyfin.Common.Tests.Providers
+{
+    public class ProviderIdParserTests
+    {
+        [Theory]
+        [InlineData("tt123456", false, null)]
+        [InlineData("tt1234567", true, "tt1234567")]
+        [InlineData("tt12345678", true, "tt12345678")]
+        [InlineData("https://www.imdb.com/title/tt123456", false, null)]
+        [InlineData("https://www.imdb.com/title/tt1234567", true, "tt1234567")]
+        [InlineData("https://www.imdb.com/title/tt12345678", true, "tt12345678")]
+        [InlineData(@"multiline\nhttps://www.imdb.com/title/tt1234567", true, "tt1234567")]
+        [InlineData(@"multiline\nhttps://www.imdb.com/title/tt12345678", true, "tt12345678")]
+        [InlineData("Jellyfin", false, null)]
+        [InlineData("tt1234567tt7654321", true, "tt1234567")]
+        [InlineData("tt12345678tt7654321", true, "tt12345678")]
+        public void Parse_Imdb(string text, bool shouldSucceed, string? imdbId)
+        {
+            var succeeded = ProviderIdParsers.TryParseImdbId(text, out string? parsedId);
+            Assert.Equal(shouldSucceed, succeeded);
+            Assert.Equal(imdbId, parsedId);
+        }
+
+        [Theory]
+        [InlineData("https://www.themoviedb.org/movie/30287-fallo", true, "30287")]
+        [InlineData("themoviedb.org/movie/30287", true, "30287")]
+        [InlineData("https://www.themoviedb.org/movie/fallo-30287", false, null)]
+        [InlineData("https://www.themoviedb.org/tv/1668-friends", false, null)]
+        public void Parse_TmdbMovie(string text, bool shouldSucceed, string? tmdbId)
+        {
+            var succeeded = ProviderIdParsers.TryParseTmdbMovieId(text, out string? parsedId);
+            Assert.Equal(shouldSucceed, succeeded);
+            Assert.Equal(tmdbId, parsedId);
+        }
+
+        [Theory]
+        [InlineData("https://www.themoviedb.org/tv/1668-friends", true, "1668")]
+        [InlineData("themoviedb.org/tv/1668", true, "1668")]
+        [InlineData("https://www.themoviedb.org/tv/friends-1668", false, null)]
+        [InlineData("https://www.themoviedb.org/movie/30287-fallo", false, null)]
+        public void Parse_TmdbSeries(string text, bool shouldSucceed, string? tmdbId)
+        {
+            var succeeded = ProviderIdParsers.TryParseTmdbSeriesId(text, out string? parsedId);
+            Assert.Equal(shouldSucceed, succeeded);
+            Assert.Equal(tmdbId, parsedId);
+        }
+
+        [Theory]
+        [InlineData("https://www.thetvdb.com/?tab=series&id=121361", true, "121361")]
+        [InlineData("thetvdb.com/?tab=series&id=121361", true, "121361")]
+        [InlineData("thetvdb.com/?tab=series&id=Jellyfin121361", false, null)]
+        [InlineData("https://www.themoviedb.org/tv/1668-friends", false, null)]
+        public void Parse_Tvdb(string text, bool shouldSucceed, string? tvdbId)
+        {
+            var succeeded = ProviderIdParsers.TryParseTvdbId(text, out string? parsedId);
+            Assert.Equal(shouldSucceed, succeeded);
+            Assert.Equal(tvdbId, parsedId);
+        }
+    }
+}

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -153,6 +153,21 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
+        public void Parse_RadarrUrlFile_Success()
+        {
+            var result = new MetadataResult<Video>()
+            {
+                Item = new Movie()
+            };
+
+            _parser.Fetch(result, "Test Data/Radarr.nfo", CancellationToken.None);
+            var item = (Movie)result.Item;
+
+            Assert.Equal("583689", item.ProviderIds[MetadataProvider.Tmdb.ToString()]);
+            Assert.Equal("tt4154796", item.ProviderIds[MetadataProvider.Imdb.ToString()]);
+        }
+
+        [Fact]
         public void Fetch_WithNullItem_ThrowsArgumentException()
         {
             var result = new MetadataResult<Video>();

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Justice League.nfo
@@ -91,7 +91,8 @@
     </fanart>
     <mpaa>Australia:M</mpaa>
     <id>tt0974015</id>
-    <uniqueid type="imdb" default="true">tt0974015</uniqueid>
+    <uniqueid type="imdb">tt0974015</uniqueid>
+    <uniqueid type="tmdb">141052</uniqueid>
     <genre>Action</genre>
     <genre>Adventure</genre>
     <genre>Fantasy</genre>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Radarr.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Radarr.nfo
@@ -1,0 +1,2 @@
+﻿https://www.themoviedb.org/movie/583689
+https://www.imdb.com/title/tt4154796


### PR DESCRIPTION
**Changes**

- Check id from `<id>` tag if it contains `tt` for imdb
- Use Helper methods for url files

**Issues**
Fixes #5347 