### PR TITLE
Fix: Streaming crashing due to no deviceProfileId match.

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -333,7 +333,12 @@ namespace Emby.Dlna
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var info = GetProfileInfosInternal().First(i => string.Equals(i.Info.Id, id, StringComparison.OrdinalIgnoreCase));
+            var info = GetProfileInfosInternal().FirstOrDefault(i => string.Equals(i.Info.Id, id, StringComparison.OrdinalIgnoreCase));
+
+            if (info == null)
+            {
+                return null;
+            }
 
             return ParseProfileFile(info.Path, info.Info.Type);
         }


### PR DESCRIPTION
.First crashes the code and returns a `Sequence contains no matching element error.`

Fixes https://github.com/jellyfin/jellyfin/issues/5509

Am still investigating why deviceProfileId isn't being matched, but given the code it looks like it expected ??!?!?!

```
            if (!string.IsNullOrWhiteSpace(deviceProfileId))
            {
                state.DeviceProfile = dlnaManager.GetProfile(deviceProfileId);

                if (state.DeviceProfile == null)
                {
                    var caps = deviceManager.GetCapabilities(deviceProfileId);
                    state.DeviceProfile = caps == null ? dlnaManager.GetProfile(request.Headers) : caps.DeviceProfile;
                }
            }
```