### PR TITLE
Set openapi version to server version

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -260,7 +260,7 @@ namespace Jellyfin.Server.Extensions
         {
             return serviceCollection.AddSwaggerGen(c =>
             {
-                var version = typeof(ApplicationHost).Assembly.GetName().Version?.ToString();
+                var version = typeof(ApplicationHost).Assembly.GetName().Version?.ToString() ?? "0.0.0.1";
                 c.SwaggerDoc("api-docs", new OpenApiInfo
                 {
                     Title = "Jellyfin API",

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -260,15 +260,16 @@ namespace Jellyfin.Server.Extensions
         {
             return serviceCollection.AddSwaggerGen(c =>
             {
+                var version = typeof(ApplicationHost).Assembly.GetName().Version?.ToString();
                 c.SwaggerDoc("api-docs", new OpenApiInfo
                 {
                     Title = "Jellyfin API",
-                    Version = "v1",
+                    Version = version,
                     Extensions = new Dictionary<string, IOpenApiExtension>
                     {
                         {
                             "x-jellyfin-version",
-                            new OpenApiString(typeof(ApplicationHost).Assembly.GetName().Version?.ToString())
+                            new OpenApiString(version)
                         }
                     }
                 });


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/5488

I left `x-jellyfin-version` for backwards compat.