### PR TITLE
fix refresh endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -303,7 +303,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <response code="204">Library scan started.</response>
         /// <returns>A <see cref="NoContentResult"/>.</returns>
-        [HttpGet("Library/Refresh")]
+        [HttpPost("Library/Refresh")]
         [Authorize(Policy = Policies.RequiresElevation)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public async Task<ActionResult> RefreshLibrary()


### PR DESCRIPTION
The endpoint was called with `curl -v -d "" -H "X-MediaBrowser-Token: TOKEN" https://jellyfin.tld/library/refresh` in the past and I have mistakenly been thinking it was ASP.NET being less lenient than ServiceStack when it's actually because it was changed from POST to GET 🙃 