### PR TITLE
Add missing InstantMix endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/InstantMixController.cs
+++ b/Jellyfin.Api/Controllers/InstantMixController.cs
@@ -86,7 +86,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given album.
         /// </summary>
         /// <param name="id">The item id.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -122,7 +122,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given playlist.
         /// </summary>
         /// <param name="id">The item id.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -158,7 +158,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given genre.
         /// </summary>
         /// <param name="name">The genre name.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -172,7 +172,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the playlist items.</returns>
         [HttpGet("MusicGenres/{name}/InstantMix")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenre(
+        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenreByName(
             [FromRoute, Required] string name,
             [FromQuery] Guid? userId,
             [FromQuery] int? limit,
@@ -193,7 +193,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given artist.
         /// </summary>
         /// <param name="id">The item id.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -229,7 +229,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given genre.
         /// </summary>
         /// <param name="id">The item id.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -243,7 +243,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the playlist items.</returns>
         [HttpGet("MusicGenres/{id}/InstantMix")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenres(
+        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenreById(
             [FromRoute, Required] Guid id,
             [FromQuery] Guid? userId,
             [FromQuery] int? limit,
@@ -265,7 +265,7 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Creates an instant playlist based on a given song.
+        /// Creates an instant playlist based on a given item.
         /// </summary>
         /// <param name="id">The item id.</param>
         /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
@@ -298,6 +298,80 @@ namespace Jellyfin.Api.Controllers
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes!);
             var items = _musicManager.GetInstantMixFromItem(item, user, dtoOptions);
             return GetResult(items, user, limit, dtoOptions);
+        }
+
+        /// <summary>
+        /// Creates an instant playlist based on a given artist.
+        /// </summary>
+        /// <param name="id">The item id.</param>
+        /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
+        /// <param name="limit">Optional. The maximum number of records to return.</param>
+        /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
+        /// <param name="enableImages">Optional. Include image information in output.</param>
+        /// <param name="enableUserData">Optional. Include user data.</param>
+        /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
+        /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
+        /// <response code="200">Instant playlist returned.</response>
+        /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the playlist items.</returns>
+        [HttpGet("Artists/InstantMix")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Obsolete("Use GetInstantMixFromArtists")]
+        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromArtists2(
+            [FromQuery, Required] Guid id,
+            [FromQuery] Guid? userId,
+            [FromQuery] int? limit,
+            [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
+            [FromQuery] bool? enableImages,
+            [FromQuery] bool? enableUserData,
+            [FromQuery] int? imageTypeLimit,
+            [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
+        {
+            return GetInstantMixFromArtists(
+                id,
+                userId,
+                limit,
+                fields,
+                enableImages,
+                enableUserData,
+                imageTypeLimit,
+                enableImageTypes);
+        }
+
+        /// <summary>
+        /// Creates an instant playlist based on a given genre.
+        /// </summary>
+        /// <param name="id">The item id.</param>
+        /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
+        /// <param name="limit">Optional. The maximum number of records to return.</param>
+        /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
+        /// <param name="enableImages">Optional. Include image information in output.</param>
+        /// <param name="enableUserData">Optional. Include user data.</param>
+        /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
+        /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
+        /// <response code="200">Instant playlist returned.</response>
+        /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the playlist items.</returns>
+        [HttpGet("MusicGenres/InstantMix")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Obsolete("Use GetInstantMixFromMusicGenres instead")]
+        public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenreById2(
+            [FromQuery, Required] Guid id,
+            [FromQuery] Guid? userId,
+            [FromQuery] int? limit,
+            [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
+            [FromQuery] bool? enableImages,
+            [FromQuery] bool? enableUserData,
+            [FromQuery] int? imageTypeLimit,
+            [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
+        {
+            return GetInstantMixFromMusicGenreById(
+                id,
+                userId,
+                limit,
+                fields,
+                enableImages,
+                enableUserData,
+                imageTypeLimit,
+                enableImageTypes);
         }
 
         private QueryResult<BaseItemDto> GetResult(List<BaseItem> items, User? user, int? limit, DtoOptions dtoOptions)


### PR DESCRIPTION
Some endpoints were accidentally changed when migrating, so add the old ones back for backwards compatibility. 