### PR TITLE
revert underscore as a multiversion separator

### DIFF
--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -235,7 +235,6 @@ namespace Emby.Naming.Video
                 // The CleanStringParser should have removed common keywords etc.
                 return string.IsNullOrEmpty(testFilename)
                        || testFilename[0] == '-'
-                       || testFilename[0] == '_'
                        || Regex.IsMatch(testFilename, @"^\[([^]]*)\]");
             }
 

--- a/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/MultiVersionTests.cs
@@ -295,12 +295,9 @@ namespace Jellyfin.Naming.Tests.Video
                 FullName = i
             }).ToList()).ToList();
 
-            Assert.Single(result);
+            Assert.Equal(7, result.Count);
             Assert.Empty(result[0].Extras);
-            Assert.Equal(6, result[0].AlternateVersions.Count);
-            Assert.False(result[0].AlternateVersions[2].Is3D);
-            Assert.True(result[0].AlternateVersions[3].Is3D);
-            Assert.True(result[0].AlternateVersions[4].Is3D);
+            Assert.Empty(result[0].AlternateVersions);
         }
 
         [Fact]


### PR DESCRIPTION
**Changes**
Looking at the history of the multi-version eligibility check and accompanying unit tests, it seems that underscore was broken/unsupported for a long time and also missing in all documentation. It seems only fair to revert this particular change as it causes some false positives and I don't see any reason to reserve three different naming schemes.

**Issues**
Fixes #5528
