### PR TITLE
Add «resize to fill box» alternative for image endpoints

### DIFF
--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Common.Extensions;
@@ -274,7 +275,7 @@ namespace Emby.Drawing
             string backgroundColor,
             string foregroundLayer)
         {
-            var filename = new StringBuilder(128);
+            var filename = new StringBuilder(256);
             filename.Append(originalPath);
 
             filename.Append(",quality=");

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -171,11 +171,26 @@ namespace Emby.Drawing
                 return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
             }
 
-            ImageDimensions newSize = ImageHelper.GetNewImageSize(options, null);
             int quality = options.Quality;
 
             ImageFormat outputFormat = GetOutputFormat(options.SupportedOutputFormats, requiresTransparency);
-            string cacheFilePath = GetCacheFilePath(originalImagePath, newSize, quality, dateModified, outputFormat, options.AddPlayedIndicator, options.PercentPlayed, options.UnplayedCount, options.Blur, options.BackgroundColor, options.ForegroundLayer);
+            string cacheFilePath = GetCacheFilePath(
+                originalImagePath,
+                options.Width,
+                options.Height,
+                options.MaxWidth,
+                options.MaxHeight,
+                options.FillWidth,
+                options.FillHeight,
+                quality,
+                dateModified,
+                outputFormat,
+                options.AddPlayedIndicator,
+                options.PercentPlayed,
+                options.UnplayedCount,
+                options.Blur,
+                options.BackgroundColor,
+                options.ForegroundLayer);
 
             try
             {
@@ -241,48 +256,111 @@ namespace Emby.Drawing
         /// <summary>
         /// Gets the cache file path based on a set of parameters.
         /// </summary>
-        private string GetCacheFilePath(string originalPath, ImageDimensions outputSize, int quality, DateTime dateModified, ImageFormat format, bool addPlayedIndicator, double percentPlayed, int? unwatchedCount, int? blur, string backgroundColor, string foregroundLayer)
+        private string GetCacheFilePath(
+            string originalPath,
+            int? width,
+            int? height,
+            int? maxWidth,
+            int? maxHeight,
+            int? fillWidth,
+            int? fillHeight,
+            int quality,
+            DateTime dateModified,
+            ImageFormat format,
+            bool addPlayedIndicator,
+            double percentPlayed,
+            int? unwatchedCount,
+            int? blur,
+            string backgroundColor,
+            string foregroundLayer)
         {
-            var filename = originalPath
-                + "width=" + outputSize.Width
-                + "height=" + outputSize.Height
-                + "quality=" + quality
-                + "datemodified=" + dateModified.Ticks
-                + "f=" + format;
+            System.Text.StringBuilder filename = new System.Text.StringBuilder(128);
+            filename.Append(originalPath);
+
+            filename.Append(",quality=");
+            filename.Append(quality);
+
+            filename.Append(",datemodified=");
+            filename.Append(dateModified.Ticks);
+
+            filename.Append(",f=");
+            filename.Append(format);
+
+            if (width.HasValue)
+            {
+                filename.Append(",width=");
+                filename.Append(width.Value);
+            }
+
+            if (height.HasValue)
+            {
+                filename.Append(",height=");
+                filename.Append(height.Value);
+            }
+
+            if (maxWidth.HasValue)
+            {
+                filename.Append(",maxwidth=");
+                filename.Append(maxWidth.Value);
+            }
+
+            if (maxHeight.HasValue)
+            {
+                filename.Append(",maxheight=");
+                filename.Append(maxHeight.Value);
+            }
+
+            if (fillWidth.HasValue)
+            {
+                filename.Append(",fillwidth=");
+                filename.Append(fillWidth.Value);
+            }
+
+            if (fillHeight.HasValue)
+            {
+                filename.Append(",fillheight=");
+                filename.Append(fillHeight.Value);
+            }
 
             if (addPlayedIndicator)
             {
-                filename += "pl=true";
+                filename.Append(",pl=true");
             }
 
             if (percentPlayed > 0)
             {
-                filename += "p=" + percentPlayed;
+                filename.Append(",p=");
+                filename.Append(percentPlayed);
             }
 
             if (unwatchedCount.HasValue)
             {
-                filename += "p=" + unwatchedCount.Value;
+                filename.Append(",p=");
+                filename.Append(unwatchedCount.Value);
             }
 
             if (blur.HasValue)
             {
-                filename += "blur=" + blur.Value;
+                filename.Append(",blur=");
+                filename.Append(blur.Value);
             }
 
             if (!string.IsNullOrEmpty(backgroundColor))
             {
-                filename += "b=" + backgroundColor;
+                filename.Append(",b=");
+                filename.Append(backgroundColor);
             }
 
             if (!string.IsNullOrEmpty(foregroundLayer))
             {
-                filename += "fl=" + foregroundLayer;
+                filename.Append(",fl=");
+                filename.Append(foregroundLayer);
             }
 
-            filename += "v=" + Version;
+            filename.Append(",v=");
+            filename.Append(Version);
 
-            return GetCachePath(ResizedImageCachePath, filename, "." + format.ToString().ToLowerInvariant());
+            return GetCachePath(ResizedImageCachePath, filename.ToString(), "." + format.ToString().ToLowerInvariant());
         }
 
         /// <inheritdoc />

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -274,7 +274,7 @@ namespace Emby.Drawing
             string backgroundColor,
             string foregroundLayer)
         {
-            System.Text.StringBuilder filename = new System.Text.StringBuilder(128);
+            var filename = new StringBuilder(128);
             filename.Append(originalPath);
 
             filename.Append(",quality=");

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -521,6 +521,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] string? tag,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] ImageFormat? format,
@@ -530,9 +532,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -553,8 +553,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -607,6 +607,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] string? tag,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] ImageFormat? format,
@@ -615,9 +617,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? unplayedCount,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -638,8 +638,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -691,6 +691,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromRoute, Required] string tag,
             [FromQuery] bool? cropWhitespace,
             [FromRoute, Required] ImageFormat format,
@@ -700,9 +702,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromRoute, Required] int imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromRoute, Required] int imageIndex)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -723,8 +723,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -780,14 +780,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromRoute, Required] int imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromRoute, Required] int imageIndex)
         {
             var item = _libraryManager.GetArtist(name);
             if (item == null)
@@ -808,8 +808,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -865,14 +865,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var item = _libraryManager.GetGenre(name);
             if (item == null)
@@ -893,8 +893,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -951,13 +951,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var item = _libraryManager.GetGenre(name);
             if (item == null)
@@ -978,8 +978,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1035,14 +1035,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var item = _libraryManager.GetMusicGenre(name);
             if (item == null)
@@ -1063,8 +1063,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1121,13 +1121,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var item = _libraryManager.GetMusicGenre(name);
             if (item == null)
@@ -1148,8 +1148,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1205,14 +1205,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var item = _libraryManager.GetPerson(name);
             if (item == null)
@@ -1233,8 +1233,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1291,13 +1291,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var item = _libraryManager.GetPerson(name);
             if (item == null)
@@ -1318,8 +1318,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1375,14 +1375,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var item = _libraryManager.GetStudio(name);
             if (item == null)
@@ -1403,8 +1403,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1461,13 +1461,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var item = _libraryManager.GetStudio(name);
             if (item == null)
@@ -1488,8 +1488,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1545,14 +1545,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] int? imageIndex)
         {
             var user = _userManager.GetUserById(userId);
             if (user?.ProfileImage == null)
@@ -1590,8 +1590,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1649,13 +1649,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? width,
             [FromQuery] int? height,
             [FromQuery] int? quality,
+            [FromQuery] int? fillWidth,
+            [FromQuery] int? fillHeight,
             [FromQuery] bool? cropWhitespace,
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer,
-            [FromQuery] int? fillHeight,
-            [FromQuery] int? fillWidth)
+            [FromQuery] string? foregroundLayer)
         {
             var user = _userManager.GetUserById(userId);
             if (user?.ProfileImage == null)
@@ -1693,8 +1693,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
-                    fillHeight,
                     fillWidth,
+                    fillHeight,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1779,8 +1779,8 @@ namespace Jellyfin.Api.Controllers
             int? width,
             int? height,
             int? quality,
-            int? fillHeight,
             int? fillWidth,
+            int? fillHeight,
             bool? cropWhitespace, // TODO: Remove
             bool? addPlayedIndicator,
             int? blur,
@@ -1844,11 +1844,13 @@ namespace Jellyfin.Api.Controllers
                 item,
                 itemId,
                 imageIndex,
-                height,
-                maxHeight,
-                maxWidth,
-                quality,
                 width,
+                height,
+                maxWidth,
+                maxHeight,
+                fillWidth,
+                fillHeight,
+                quality,
                 addPlayedIndicator,
                 percentPlayed,
                 unplayedCount,
@@ -1859,9 +1861,7 @@ namespace Jellyfin.Api.Controllers
                 outputFormats,
                 cacheDuration,
                 responseHeaders,
-                isHeadRequest,
-                fillHeight,
-                fillWidth).ConfigureAwait(false);
+                isHeadRequest).ConfigureAwait(false);
         }
 
         private ImageFormat[] GetOutputFormats(ImageFormat? format)
@@ -1944,11 +1944,13 @@ namespace Jellyfin.Api.Controllers
             BaseItem? item,
             Guid itemId,
             int? index,
-            int? height,
-            int? maxHeight,
-            int? maxWidth,
-            int? quality,
             int? width,
+            int? height,
+            int? maxWidth,
+            int? maxHeight,
+            int? fillWidth,
+            int? fillHeight,
+            int? quality,
             bool? addPlayedIndicator,
             double? percentPlayed,
             int? unplayedCount,
@@ -1959,9 +1961,7 @@ namespace Jellyfin.Api.Controllers
             IReadOnlyCollection<ImageFormat> supportedFormats,
             TimeSpan? cacheDuration,
             IDictionary<string, string> headers,
-            bool isHeadRequest,
-            int? fillHeight,
-            int? fillWidth)
+            bool isHeadRequest)
         {
             if (!imageInfo.IsLocalFile && item != null)
             {

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -490,6 +490,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="tag">Optional. Supply the cache tag from the item object to receive strong caching headers.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="format">Optional. The <see cref="ImageFormat"/> of the returned image.</param>
@@ -528,7 +530,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -549,6 +553,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -570,6 +576,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="tag">Optional. Supply the cache tag from the item object to receive strong caching headers.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="format">Optional. The <see cref="ImageFormat"/> of the returned image.</param>
@@ -607,7 +615,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? unplayedCount,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -628,6 +638,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -648,6 +660,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="tag">Optional. Supply the cache tag from the item object to receive strong caching headers.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="format">Determines the output format of the image - original,gif,jpg,png.</param>
@@ -686,7 +700,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromRoute, Required] int imageIndex)
+            [FromRoute, Required] int imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item == null)
@@ -707,6 +723,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -731,6 +749,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -765,7 +785,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromRoute, Required] int imageIndex)
+            [FromRoute, Required] int imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetArtist(name);
             if (item == null)
@@ -786,6 +808,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -810,6 +834,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -844,7 +870,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetGenre(name);
             if (item == null)
@@ -865,6 +893,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -890,6 +920,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -923,7 +955,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetGenre(name);
             if (item == null)
@@ -944,6 +978,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -968,6 +1004,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1002,7 +1040,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetMusicGenre(name);
             if (item == null)
@@ -1023,6 +1063,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1048,6 +1090,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1081,7 +1125,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetMusicGenre(name);
             if (item == null)
@@ -1102,6 +1148,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1126,6 +1174,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1160,7 +1210,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetPerson(name);
             if (item == null)
@@ -1181,6 +1233,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1206,6 +1260,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1239,7 +1295,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetPerson(name);
             if (item == null)
@@ -1260,6 +1318,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1284,6 +1344,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1318,7 +1380,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetStudio(name);
             if (item == null)
@@ -1339,6 +1403,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1364,6 +1430,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1397,7 +1465,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var item = _libraryManager.GetStudio(name);
             if (item == null)
@@ -1418,6 +1488,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1442,6 +1514,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1476,7 +1550,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
             [FromQuery] string? foregroundLayer,
-            [FromQuery] int? imageIndex)
+            [FromQuery] int? imageIndex,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var user = _userManager.GetUserById(userId);
             if (user?.ProfileImage == null)
@@ -1514,6 +1590,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1540,6 +1618,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="width">The fixed image width to return.</param>
         /// <param name="height">The fixed image height to return.</param>
         /// <param name="quality">Optional. Quality setting, from 0-100. Defaults to 90 and should suffice in most cases.</param>
+        /// <param name="fillWidth">Width of box to fill.</param>
+        /// <param name="fillHeight">Height of box to fill.</param>
         /// <param name="cropWhitespace">Optional. Specify if whitespace should be cropped out of the image. True/False. If unspecified, whitespace will be cropped from logos and clear art.</param>
         /// <param name="addPlayedIndicator">Optional. Add a played indicator.</param>
         /// <param name="blur">Optional. Blur image.</param>
@@ -1573,7 +1653,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? addPlayedIndicator,
             [FromQuery] int? blur,
             [FromQuery] string? backgroundColor,
-            [FromQuery] string? foregroundLayer)
+            [FromQuery] string? foregroundLayer,
+            [FromQuery] int? fillHeight,
+            [FromQuery] int? fillWidth)
         {
             var user = _userManager.GetUserById(userId);
             if (user?.ProfileImage == null)
@@ -1611,6 +1693,8 @@ namespace Jellyfin.Api.Controllers
                     width,
                     height,
                     quality,
+                    fillHeight,
+                    fillWidth,
                     cropWhitespace,
                     addPlayedIndicator,
                     blur,
@@ -1695,6 +1779,8 @@ namespace Jellyfin.Api.Controllers
             int? width,
             int? height,
             int? quality,
+            int? fillHeight,
+            int? fillWidth,
             bool? cropWhitespace, // TODO: Remove
             bool? addPlayedIndicator,
             int? blur,
@@ -1773,7 +1859,9 @@ namespace Jellyfin.Api.Controllers
                 outputFormats,
                 cacheDuration,
                 responseHeaders,
-                isHeadRequest).ConfigureAwait(false);
+                isHeadRequest,
+                fillHeight,
+                fillWidth).ConfigureAwait(false);
         }
 
         private ImageFormat[] GetOutputFormats(ImageFormat? format)
@@ -1871,7 +1959,9 @@ namespace Jellyfin.Api.Controllers
             IReadOnlyCollection<ImageFormat> supportedFormats,
             TimeSpan? cacheDuration,
             IDictionary<string, string> headers,
-            bool isHeadRequest)
+            bool isHeadRequest,
+            int? fillHeight,
+            int? fillWidth)
         {
             if (!imageInfo.IsLocalFile && item != null)
             {
@@ -1887,6 +1977,8 @@ namespace Jellyfin.Api.Controllers
                 ItemId = itemId,
                 MaxHeight = maxHeight,
                 MaxWidth = maxWidth,
+                FillHeight = fillHeight,
+                FillWidth = fillWidth,
                 Quality = quality ?? 100,
                 Width = width,
                 AddPlayedIndicator = addPlayedIndicator ?? false,

--- a/MediaBrowser.Controller/Drawing/ImageHelper.cs
+++ b/MediaBrowser.Controller/Drawing/ImageHelper.cs
@@ -15,7 +15,7 @@ namespace MediaBrowser.Controller.Drawing
             {
                 // Determine the output size based on incoming parameters
                 var newSize = DrawingUtils.Resize(originalImageSize.Value, options.Width ?? 0, options.Height ?? 0, options.MaxWidth ?? 0, options.MaxHeight ?? 0);
-
+                newSize = DrawingUtils.ResizeFill(newSize, options.FillWidth, options.FillHeight);
                 return newSize;
             }
 

--- a/MediaBrowser.Controller/Drawing/ImageHelper.cs
+++ b/MediaBrowser.Controller/Drawing/ImageHelper.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#nullable enable
 
 using System;
 using MediaBrowser.Controller.Entities;
@@ -9,67 +10,12 @@ namespace MediaBrowser.Controller.Drawing
 {
     public static class ImageHelper
     {
-        public static ImageDimensions GetNewImageSize(ImageProcessingOptions options, ImageDimensions? originalImageSize)
+        public static ImageDimensions GetNewImageSize(ImageProcessingOptions options, ImageDimensions originalImageSize)
         {
-            if (originalImageSize.HasValue)
-            {
-                // Determine the output size based on incoming parameters
-                var newSize = DrawingUtils.Resize(originalImageSize.Value, options.Width ?? 0, options.Height ?? 0, options.MaxWidth ?? 0, options.MaxHeight ?? 0);
-                newSize = DrawingUtils.ResizeFill(newSize, options.FillWidth, options.FillHeight);
-                return newSize;
-            }
-
-            return GetSizeEstimate(options);
-        }
-
-        private static ImageDimensions GetSizeEstimate(ImageProcessingOptions options)
-        {
-            if (options.Width.HasValue && options.Height.HasValue)
-            {
-                return new ImageDimensions(options.Width.Value, options.Height.Value);
-            }
-
-            double aspect = GetEstimatedAspectRatio(options.Image.Type, options.Item);
-
-            int? width = options.Width ?? options.MaxWidth;
-
-            if (width.HasValue)
-            {
-                int heightValue = Convert.ToInt32((double)width.Value / aspect);
-                return new ImageDimensions(width.Value, heightValue);
-            }
-
-            var height = options.Height ?? options.MaxHeight ?? 200;
-            int widthValue = Convert.ToInt32(aspect * height);
-            return new ImageDimensions(widthValue, height);
-        }
-
-        private static double GetEstimatedAspectRatio(ImageType type, BaseItem item)
-        {
-            switch (type)
-            {
-                case ImageType.Art:
-                case ImageType.Backdrop:
-                case ImageType.Chapter:
-                case ImageType.Screenshot:
-                case ImageType.Thumb:
-                    return 1.78;
-                case ImageType.Banner:
-                    return 5.4;
-                case ImageType.Box:
-                case ImageType.BoxRear:
-                case ImageType.Disc:
-                case ImageType.Menu:
-                case ImageType.Profile:
-                    return 1;
-                case ImageType.Logo:
-                    return 2.58;
-                case ImageType.Primary:
-                    double defaultPrimaryImageAspectRatio = item.GetDefaultPrimaryImageAspectRatio();
-                    return defaultPrimaryImageAspectRatio > 0 ? defaultPrimaryImageAspectRatio : 2.0 / 3;
-                default:
-                    return 1;
-            }
+            // Determine the output size based on incoming parameters
+            var newSize = DrawingUtils.Resize(originalImageSize, options.Width ?? 0, options.Height ?? 0, options.MaxWidth ?? 0, options.MaxHeight ?? 0);
+            newSize = DrawingUtils.ResizeFill(newSize, options.FillWidth, options.FillHeight);
+            return newSize;
         }
     }
 }

--- a/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
+++ b/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
@@ -32,6 +32,10 @@ namespace MediaBrowser.Controller.Drawing
 
         public int? MaxHeight { get; set; }
 
+        public int? FillWidth { get; set; }
+
+        public int? FillHeight { get; set; }
+
         public int Quality { get; set; }
 
         public IReadOnlyCollection<ImageFormat> SupportedOutputFormats { get; set; }

--- a/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
+++ b/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
@@ -97,6 +97,16 @@ namespace MediaBrowser.Controller.Drawing
                 return false;
             }
 
+            if (FillWidth.HasValue && sizeValue.Width > FillWidth.Value)
+            {
+                return false;
+            }
+
+            if (FillHeight.HasValue && sizeValue.Height > FillHeight.Value)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
+++ b/MediaBrowser.Controller/Drawing/ImageProcessingOptions.cs
@@ -97,12 +97,7 @@ namespace MediaBrowser.Controller.Drawing
                 return false;
             }
 
-            if (FillWidth.HasValue && sizeValue.Width > FillWidth.Value)
-            {
-                return false;
-            }
-
-            if (FillHeight.HasValue && sizeValue.Height > FillHeight.Value)
+            if (sizeValue.Width > FillWidth || sizeValue.Height > FillHeight)
             {
                 return false;
             }

--- a/MediaBrowser.Model/Drawing/DrawingUtils.cs
+++ b/MediaBrowser.Model/Drawing/DrawingUtils.cs
@@ -58,6 +58,54 @@ namespace MediaBrowser.Model.Drawing
         }
 
         /// <summary>
+        /// Resizes to fill box.
+        /// Returns original size if both width and height are null or zero.
+        /// </summary>
+        /// <param name="size">The original size object.</param>
+        /// <param name="fillWidth">A new fixed width, if desired.</param>
+        /// <param name="fillHeight">A new fixed height, if desired.</param>
+        /// <returns>A new size object or size.</returns>
+        public static ImageDimensions ResizeFill(
+            ImageDimensions size,
+            int? fillWidth,
+            int? fillHeight)
+        {
+            // Return original size if input is invalid.
+            if (
+                (fillWidth == null && fillHeight == null)
+                || (fillWidth == 0 || fillHeight == 0))
+            {
+                return size;
+            }
+
+            if (fillWidth == null || fillWidth == 0)
+            {
+                fillWidth = 1;
+            }
+
+            if (fillHeight == null || fillHeight == 0)
+            {
+                fillHeight = 1;
+            }
+
+            double widthRatio = (double)size.Width / (double)fillWidth;
+            double heightRatio = (double)size.Height / (double)fillHeight!;
+            // min()
+            double scaleRatio = widthRatio > heightRatio ? heightRatio : widthRatio;
+
+            // Clamp to current size.
+            if (scaleRatio < 1)
+            {
+                return size;
+            }
+
+            int newWidth = Convert.ToInt32(Math.Ceiling((double)size.Width / scaleRatio));
+            int newHeight = Convert.ToInt32(Math.Ceiling((double)size.Height / scaleRatio));
+
+            return new ImageDimensions(newWidth, newHeight);
+        }
+
+        /// <summary>
         /// Gets the new width.
         /// </summary>
         /// <param name="currentHeight">Height of the current.</param>

--- a/MediaBrowser.Model/Drawing/DrawingUtils.cs
+++ b/MediaBrowser.Model/Drawing/DrawingUtils.cs
@@ -58,7 +58,7 @@ namespace MediaBrowser.Model.Drawing
         }
 
         /// <summary>
-        /// Resizes to fill box.
+        /// Scale down to fill box.
         /// Returns original size if both width and height are null or zero.
         /// </summary>
         /// <param name="size">The original size object.</param>
@@ -71,9 +71,8 @@ namespace MediaBrowser.Model.Drawing
             int? fillHeight)
         {
             // Return original size if input is invalid.
-            if (
-                (fillWidth == null && fillHeight == null)
-                || (fillWidth == 0 || fillHeight == 0))
+            if ((fillWidth == null || fillWidth == 0)
+                && (fillHeight == null || fillHeight == 0))
             {
                 return size;
             }
@@ -89,9 +88,8 @@ namespace MediaBrowser.Model.Drawing
             }
 
             double widthRatio = (double)size.Width / (double)fillWidth;
-            double heightRatio = (double)size.Height / (double)fillHeight!;
-            // min()
-            double scaleRatio = widthRatio > heightRatio ? heightRatio : widthRatio;
+            double heightRatio = (double)size.Height / (double)fillHeight;
+            double scaleRatio = Math.Min(widthRatio, heightRatio);
 
             // Clamp to current size.
             if (scaleRatio < 1)

--- a/MediaBrowser.Model/Drawing/DrawingUtils.cs
+++ b/MediaBrowser.Model/Drawing/DrawingUtils.cs
@@ -87,8 +87,8 @@ namespace MediaBrowser.Model.Drawing
                 fillHeight = 1;
             }
 
-            double widthRatio = (double)size.Width / (double)fillWidth;
-            double heightRatio = (double)size.Height / (double)fillHeight;
+            double widthRatio = size.Width / (double)fillWidth;
+            double heightRatio = size.Height / (double)fillHeight;
             double scaleRatio = Math.Min(widthRatio, heightRatio);
 
             // Clamp to current size.
@@ -97,8 +97,8 @@ namespace MediaBrowser.Model.Drawing
                 return size;
             }
 
-            int newWidth = Convert.ToInt32(Math.Ceiling((double)size.Width / scaleRatio));
-            int newHeight = Convert.ToInt32(Math.Ceiling((double)size.Height / scaleRatio));
+            int newWidth = Convert.ToInt32(Math.Ceiling(size.Width / scaleRatio));
+            int newHeight = Convert.ToInt32(Math.Ceiling(size.Height / scaleRatio));
 
             return new ImageDimensions(newWidth, newHeight);
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Adds fillHeight and fillWidth optional parameters to all(?) image endpoints.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Server portion for resolving jellyfin/jellyfin-web#2191

Web PR: jellyfin/jellyfin-web#2514
apiClient PR: jellyfin/jellyfin-apiclient-javascript#167