### PR TITLE
Clean the entity name for non-words before searching

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
@@ -140,7 +140,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
                 // ParseName is required here.
                 // Caller provides the filename with extension stripped and NOT the parsed filename
                 var parsedName = _libraryManager.ParseName(info.Name);
-                var searchResults = await _tmdbClientManager.SearchMovieAsync(parsedName.Name,  info.Year ?? parsedName.Year ?? 0, info.MetadataLanguage, cancellationToken).ConfigureAwait(false);
+                var cleanedName = TmdbUtils.CleanName(parsedName.Name);
+                var searchResults = await _tmdbClientManager.SearchMovieAsync(cleanedName,  info.Year ?? parsedName.Year ?? 0, info.MetadataLanguage, cancellationToken).ConfigureAwait(false);
 
                 if (searchResults.Count > 0)
                 {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -189,7 +189,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 // ParseName is required here.
                 // Caller provides the filename with extension stripped and NOT the parsed filename
                 var parsedName = _libraryManager.ParseName(info.Name);
-                var searchResults = await _tmdbClientManager.SearchSeriesAsync(parsedName.Name, info.MetadataLanguage, info.Year ?? parsedName.Year ?? 0, cancellationToken).ConfigureAwait(false);
+                var cleanedName = TmdbUtils.CleanName(parsedName.Name);
+                var searchResults = await _tmdbClientManager.SearchSeriesAsync(cleanedName, info.MetadataLanguage, info.Year ?? parsedName.Year ?? 0, cancellationToken).ConfigureAwait(false);
 
                 if (searchResults.Count > 0)
                 {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using MediaBrowser.Model.Entities;
 using TMDbLib.Objects.General;
 
@@ -12,6 +13,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
     /// </summary>
     public static class TmdbUtils
     {
+        private static readonly Regex _nonWords = new (@"[\W_]+", RegexOptions.Compiled);
+
         /// <summary>
         /// URL of the TMDB instance to use.
         /// </summary>
@@ -41,6 +44,17 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             PersonType.Writer,
             PersonType.Producer
         };
+
+        /// <summary>
+        /// Cleans the name according to TMDb requirements.
+        /// </summary>
+        /// <param name="name">The name of the entity.</param>
+        /// <returns>The cleaned name.</returns>
+        public static string CleanName(string name)
+        {
+            // TMDb expects a space separated list of words make sure that is the case
+            return _nonWords.Replace(name, " ");
+        }
 
         /// <summary>
         /// Maps the TMDB provided roles for crew members to Jellyfin roles.


### PR DESCRIPTION
**Changes**
Added non-word cleaning. It used to do a lot more though https://github.com/jellyfin/jellyfin/blob/907695dec7fda152d0e17c1197637bc0e17c9928/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbSearch.cs#L26-L37, but I it doesn't really belong in tmdb at all, so I'd rather we try without it for now.

I think `ParseName` could use some more work though, but I'm afraid to change it in 10.7 since it's used elsewhere.

**Issues**
Fixes #5224
