### PR TITLE
Improve responses to HEAD /audio/<id>/stream for Samsung DLNA renderers

### DIFF
--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Api.Helpers
         {
             httpContext.Response.ContentType = contentType;
 
-            // if the request is a head request, return a NoContent result with the same headers as it would with a GET request
+            // if the request is a head request, return an OkResult (200) with the same headers as it would with a GET request
             if (isHeadRequest)
             {
                 return new OkResult();

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -46,7 +46,8 @@ namespace Jellyfin.Api.Helpers
 
             if (isHeadRequest)
             {
-                return new FileContentResult(Array.Empty<byte>(), contentType);
+                httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
+                return new OkResult();
             }
 
             return new FileStreamResult(await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false), contentType);
@@ -71,7 +72,7 @@ namespace Jellyfin.Api.Helpers
             // if the request is a head request, return a NoContent result with the same headers as it would with a GET request
             if (isHeadRequest)
             {
-                return new NoContentResult();
+                return new OkResult();
             }
 
             return new PhysicalFileResult(path, contentType) { EnableRangeProcessing = true };


### PR DESCRIPTION
**Changes**
Changed `HEAD /audio/<id>/stream[.format]` responses to:
* return 200 OK instead of 204 No Content
* not return "Content-Length: 0" header

**Issues**
* Fixes Samsung Soundbar (HW-Q80R) returning "Error: Resource not found (716)" to DLNA playback request (`POST /upnp/control/AVTransport1`)

**Details**
Without this fix my Samsung Soundbar (HW-Q80R) fails to play using DLNA
and returns "Error: Resource not found (716)" instead.

I had a look on tcpdump network logs between Jellyfin and the soundbar
and noticed that the device performs a HEAD request for the media before
responding to the DLNA UPNP control request from Jellyfin (or BubbleUPNP
Android App).

Jellyfin retuns 204 No Content response, which is unusual.  Common web
servers generally return 200 OK if the GET would return content, and
this is not-very-clearly suggested [in HTTP
spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1)

The other patch is to ensure that invalid Content-Length: 0 is not
returned with the HEAD response in the streaming case.

I think in both cases we still don't return the same headers with HEAD
as with GET (e.g. Content-Length or Accept-Ranges), but at least we
don't return anything misleading.