### PR TITLE
Fix possible null ref exception

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -208,7 +208,7 @@ namespace Emby.Server.Implementations.Library
         /// Gets or sets the list of entity resolution ignore rules.
         /// </summary>
         /// <value>The entity resolution ignore rules.</value>
-        private IResolverIgnoreRule[] EntityResolutionIgnoreRules { get; set; }
+        private IResolverIgnoreRule[] EntityResolutionIgnoreRules { get; set; } = Array.Empty<IResolverIgnoreRule>();
 
         /// <summary>
         /// Gets or sets the list of currently registered entity resolvers.


### PR DESCRIPTION
Fixes a null ref when `LibraryManager.IgnoreFile` get called before `LibraryManager.AddParts`

```cs
[17:46:50 ERR] Error retrieving children folder
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Emby.Server.Implementations.Library.LibraryManager.IgnoreFile(FileSystemMetadata file, BaseItem parent) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 622
   at Emby.Server.Implementations.Library.LibraryManager.ResolvePath(FileSystemMetadata fileInfo, IDirectoryService directoryService, IItemResolver[] resolvers, Folder parent, String collectionType, LibraryOptions libraryOptions) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 568
   at Emby.Server.Implementations.Library.LibraryManager.ResolvePath(FileSystemMetadata fileInfo, Folder parent) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 536
   at Emby.Server.Implementations.Library.LibraryManager.GetUserRootFolder() in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 812
   at Emby.Server.Implementations.Library.LibraryManager.GetTopFolderContentType(BaseItem item) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 2197
   at Emby.Server.Implementations.Library.LibraryManager.GetInheritedContentType(BaseItem item) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 2138
   at Emby.Server.Implementations.Library.LibraryManager.GetContentType(BaseItem item) in D:\a\1\s\Emby.Server.Implementations\Library\LibraryManager.cs:line 2133
   at MediaBrowser.Controller.Entities.Folder.GetNonCachedChildren(IDirectoryService directoryService) in D:\a\1\s\MediaBrowser.Controller\Entities\Folder.cs:line 600
   at MediaBrowser.Controller.Entities.AggregateFolder.GetNonCachedChildren(IDirectoryService directoryService) in D:\a\1\s\MediaBrowser.Controller\Entities\AggregateFolder.cs:line 153
   at MediaBrowser.Controller.Entities.Folder.ValidateChildrenInternal2(IProgress`1 progress, CancellationToken cancellationToken, Boolean recursive, Boolean refreshChildMetadata, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService) in D:\a\1\s\MediaBrowser.Controller\Entities\Folder.cs:line 320

```
