### PR TITLE
Ignore ffmpeg input format for ISO files and fix input path protocol for ISOs

### DIFF
--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -82,11 +82,6 @@ namespace Emby.Server.Implementations.MediaEncoder
                 return false;
             }
 
-            if (video.VideoType == VideoType.Dvd)
-            {
-                return false;
-            }
-
             if (video.IsShortcut)
             {
                 return false;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -313,6 +313,12 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return null;
             }
 
+            // ISO files don't have an ffmpeg format
+            if (string.Equals(container, "iso", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
             return container;
         }
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -370,7 +370,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string GetInputArgument(string inputFile, MediaSourceInfo mediaSource)
         {
             var prefix = "file";
-            if (mediaSource.VideoType == VideoType.BluRay || mediaSource.VideoType == VideoType.Iso)
+            if (mediaSource.VideoType == VideoType.BluRay)
             {
                 prefix = "bluray";
             }


### PR DESCRIPTION
**Changes**

We were sending an invalid input format to ffmpeg for every ISO file (`-f ISO`). This adds an exception to `GetInputFormat` to nullify the format for ISO files.

Another issue arose when trying to play DVD ISOs, as we were treating every ISO as a Blu-ray. This fixes said behavior in `GetInputArgument` by using the proper `file:` protocol for ISOs and using `bluray:` only for BDMV folders (Which is what it's for [according to the ffmpeg documentation](https://ffmpeg.org/ffmpeg-all.html#bluray))

**Issues**

Fixes #5617
