### PR TITLE
Set streamState property to what the code expects.

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -101,7 +101,7 @@ namespace Jellyfin.Api.Helpers
             var state = new StreamState(mediaSourceManager, transcodingJobType, transcodingJobHelper)
             {
                 Request = streamingRequest,
-                RequestedUrl = url,
+                RequestedUrl = httpRequest.Path,
                 UserAgent = httpRequest.Headers[HeaderNames.UserAgent],
                 EnableDlnaHeaders = enableDlnaHeaders
             };


### PR DESCRIPTION
Don't know what issue is caused by the current code, but StreamState.RequestedUrl is currently set to the file extension of the Uri. 

The code isn't expecting this, and isn't working as designed later, when it's checked for its url value.

Investigated further.

By url only being set to the file extension part of the request - eg. avi if http://1.1.1.1/web/film.avi (line 91)
the function StreamingHelper.cs / GetOutputFileExtension will always calculate the extension.