### PR TITLE
Fix stream selection having no effect when casting to jellyfin-mpv-shim

### DIFF
--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -153,6 +153,10 @@ namespace Jellyfin.Api.Controllers
         /// <param name="playCommand">The type of play command to issue (PlayNow, PlayNext, PlayLast). Clients who have not yet implemented play next and play last may play now.</param>
         /// <param name="itemIds">The ids of the items to play, comma delimited.</param>
         /// <param name="startPositionTicks">The starting position of the first item.</param>
+        /// <param name="mediaSourceId">Optional. The media source id.</param>
+        /// <param name="audioStreamIndex">Optional. The index of the audio stream to play.</param>
+        /// <param name="subtitleStreamIndex">Optional. The index of the subtitle stream to play.</param>
+        /// <param name="startIndex">Optional. The start index.</param>
         /// <response code="204">Instruction sent to session.</response>
         /// <returns>A <see cref="NoContentResult"/>.</returns>
         [HttpPost("Sessions/{sessionId}/Playing")]
@@ -162,13 +166,21 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromQuery, Required] PlayCommand playCommand,
             [FromQuery, Required, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] itemIds,
-            [FromQuery] long? startPositionTicks)
+            [FromQuery] long? startPositionTicks,
+            [FromQuery] string mediaSourceId,
+            [FromQuery] int? audioStreamIndex,
+            [FromQuery] int? subtitleStreamIndex,
+            [FromQuery] int? startIndex)
         {
             var playRequest = new PlayRequest
             {
                 ItemIds = itemIds,
                 StartPositionTicks = startPositionTicks,
-                PlayCommand = playCommand
+                PlayCommand = playCommand,
+                MediaSourceId = mediaSourceId,
+                AudioStreamIndex = audioStreamIndex,
+                SubtitleStreamIndex = subtitleStreamIndex,
+                StartIndex = startIndex
             };
 
             _sessionManager.SendPlayCommand(

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -167,7 +167,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, Required] PlayCommand playCommand,
             [FromQuery, Required, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] itemIds,
             [FromQuery] long? startPositionTicks,
-            [FromQuery] string mediaSourceId,
+            [FromQuery] string? mediaSourceId,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? subtitleStreamIndex,
             [FromQuery] int? startIndex)


### PR DESCRIPTION
When casting to jellyfin-mpv-shim from jellyfin-web in the browser,
jellyfin-web sends data about which version (for grouped items) and
which streams the user selected in the browser to the
"Sessions/{sessionId}/Playing" API endpoint.

The API endpoint currently doesn't forward them to the cast client
through the Play command, which results in the default streams being
played instead of the streams selected in the browser.

PlayRequest already has the properties and they are already sent to the
cast client by SendPlayCommand when present.
jellyfin-mpv-shim will already use them to select the wanted streams
when it receives the Play command.

**Changes**
All that's needed to make it work is to take the parameters and assign
them to PlayRequest.
