### PR TITLE
Fix SessionController.SendMessageCommand Body Binding

### DIFF
--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -323,13 +323,6 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromBody, Required] MessageCommand command)
         {
-
-            // Need to check if message.Text is null, since [Required] can't be applied to properties of a deserialized object.
-            if (string.IsNullOrWhiteSpace(command.Text))
-            {
-                throw new ArgumentNullException("Message Text may not be empty.");
-            }
-
             var nullCorrectedCommand = new MessageCommand
             {
                 Header = string.IsNullOrWhiteSpace(command.Header) ? "Message from Server" : command.Header,

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -323,7 +323,7 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromBody, Required] MessageCommand command)
         {
-            if (string.IsNullOrWhiteSpace(command.Header)) 
+            if (string.IsNullOrWhiteSpace(command.Header))
             {
                 command.Header =  "Message from Server";
             }

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -327,11 +327,13 @@ namespace Jellyfin.Api.Controllers
             {
                 throw new ArgumentException("Request body may not be null");
             }
-            //Need to check if message.Text is null, since [Required] can't be applied to properties of a deserialized object.
+
+            // Need to check if message.Text is null, since [Required] can't be applied to properties of a deserialized object.
             if (string.IsNullOrWhiteSpace(command.Text))
             {
                 throw new ArgumentNullException("Message Text may not be empty.");
             }
+
             var nullCorrectedCommand = new MessageCommand
             {
                 Header = string.IsNullOrWhiteSpace(command.Header) ? "Message from Server" : command.Header,

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -323,12 +323,10 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string sessionId,
             [FromBody, Required] MessageCommand command)
         {
-            var nullCorrectedCommand = new MessageCommand
+            if (string.IsNullOrWhiteSpace(command.Header)) 
             {
-                Header = string.IsNullOrWhiteSpace(command.Header) ? "Message from Server" : command.Header,
-                TimeoutMs = command.TimeoutMs,
-                Text = command.Text
-            };
+                command.Header =  "Message from Server";
+            }
 
             _sessionManager.SendMessageCommand(RequestHelpers.GetSession(_sessionManager, _authContext, Request).Id, sessionId, nullCorrectedCommand, CancellationToken.None);
 

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -321,12 +321,8 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public ActionResult SendMessageCommand(
             [FromRoute, Required] string sessionId,
-            [FromBody] MessageCommand command)
+            [FromBody, Required] MessageCommand command)
         {
-            if (command == null)
-            {
-                throw new ArgumentException("Request body may not be null");
-            }
 
             // Need to check if message.Text is null, since [Required] can't be applied to properties of a deserialized object.
             if (string.IsNullOrWhiteSpace(command.Text))

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -325,10 +325,10 @@ namespace Jellyfin.Api.Controllers
         {
             if (string.IsNullOrWhiteSpace(command.Header))
             {
-                command.Header =  "Message from Server";
+                command.Header = "Message from Server";
             }
 
-            _sessionManager.SendMessageCommand(RequestHelpers.GetSession(_sessionManager, _authContext, Request).Id, sessionId, nullCorrectedCommand, CancellationToken.None);
+            _sessionManager.SendMessageCommand(RequestHelpers.GetSession(_sessionManager, _authContext, Request).Id, sessionId, command, CancellationToken.None);
 
             return NoContent();
         }

--- a/MediaBrowser.Model/Session/MessageCommand.cs
+++ b/MediaBrowser.Model/Session/MessageCommand.cs
@@ -8,6 +8,7 @@ namespace MediaBrowser.Model.Session
     public class MessageCommand
     {
         public string Header { get; set; }
+
         [Required(AllowEmptyStrings = false)]
         public string Text { get; set; }
 

--- a/MediaBrowser.Model/Session/MessageCommand.cs
+++ b/MediaBrowser.Model/Session/MessageCommand.cs
@@ -1,12 +1,14 @@
 #nullable disable
 #pragma warning disable CS1591
 
+using System.ComponentModel.DataAnnotations;
+
 namespace MediaBrowser.Model.Session
 {
     public class MessageCommand
     {
         public string Header { get; set; }
-
+        [Required(AllowEmptyStrings = false)]
         public string Text { get; set; }
 
         public long? TimeoutMs { get; set; }


### PR DESCRIPTION
Changed SessionController.SendMessageCommand to bind information to composite object instead query string parameters.

**Changes**
Changes selected parameter binding of SendMessageCommand to a single composite object bound by [FromBody].

**Issues**
Resolves: #5628
