### PR TITLE
Check appropriate profile type

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -514,6 +514,8 @@ namespace MediaBrowser.Model.Dlna
 
         private static List<TranscodeReason> GetTranscodeReasonsFromDirectPlayProfile(MediaSourceInfo item, MediaStream videoStream, MediaStream audioStream, IEnumerable<DirectPlayProfile> directPlayProfiles)
         {
+            var mediaType = videoStream != null ? DlnaProfileType.Video : DlnaProfileType.Audio;
+
             var containerSupported = false;
             var audioSupported = false;
             var videoSupported = false;
@@ -521,7 +523,7 @@ namespace MediaBrowser.Model.Dlna
             foreach (var profile in directPlayProfiles)
             {
                 // Check container type
-                if (profile.SupportsContainer(item.Container))
+                if (profile.Type == mediaType && profile.SupportsContainer(item.Container))
                 {
                     containerSupported = true;
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -514,7 +514,7 @@ namespace MediaBrowser.Model.Dlna
 
         private static List<TranscodeReason> GetTranscodeReasonsFromDirectPlayProfile(MediaSourceInfo item, MediaStream videoStream, MediaStream audioStream, IEnumerable<DirectPlayProfile> directPlayProfiles)
         {
-            var mediaType = videoStream != null ? DlnaProfileType.Video : DlnaProfileType.Audio;
+            var mediaType = videoStream == null ? DlnaProfileType.Audio : DlnaProfileType.Video;
 
             var containerSupported = false;
             var audioSupported = false;


### PR DESCRIPTION
_This is only a cosmetic effect_

MKV is treated as `mkv,webm` and video is tested with `webm` audio profiles - we always have `VideoCodecNotSupported` + `AudioCodecNotSupported`.
It still depends on profile order, so we may still have wrong transcode reasons. But we shouldn't have any problem with order `[webm, mkv]`.

**Changes**
Check appropriate profile type

**Issues**
N/A
