### PR TITLE
Correct the License Field for the RPM Package

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -10,7 +10,7 @@ Name:           jellyfin
 Version:        10.8.0
 Release:        1%{?dist}
 Summary:        The Free Software Media System
-License:        GPLv3
+License:        GPLv2+
 URL:            https://jellyfin.org
 # Jellyfin Server tarball created by `make -f .copr/Makefile srpm`, real URL ends with `v%{version}.tar.gz`
 Source0:        jellyfin-server-%{version}.tar.gz


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The patch included in this pull request changes the `License` field in the RPM SPEC file to `GPLv2+`.

The LICENSE file in Jellyfin source tree is for GPLv2, and the Debian package files indicate that Jellyfin's license is GPL-2.0+. 
 However, the RPM SPEC's license field was set to GPLv3, which is inconsistent with the licensing information presented elsewhere.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
N/A
