### PR TITLE
Fix Filtering Libraries by First Letter to show all Numbers and Symbols when users click "#"

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -108,7 +108,7 @@ namespace Emby.Server.Implementations.Data
             WriteConnection = SQLiteDatabaseConnectionBuilder.Create(
                 DbFilePath,
                 connectionFlags: DefaultConnectionFlags | ConnectionFlags.Create | ConnectionFlags.ReadWrite)
-                .WithScalarFunc("REGEXP", (ISQLiteValue value, ISQLiteValue pattern) => Regex.IsMatch(Convert.ToString(value), Convert.ToString(pattern)).ToSQLiteValue())
+                .WithScalarFunc("REGEXP", (ISQLiteValue pattern, ISQLiteValue value) => Regex.IsMatch(Convert.ToString(value), Convert.ToString(pattern)).ToSQLiteValue())
                 .Build();
 
             if (CacheSize.HasValue)

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using SQLitePCL.pretty;
@@ -104,10 +105,11 @@ namespace Emby.Server.Implementations.Data
                 return new ManagedConnection(WriteConnection, WriteLock);
             }
 
-            WriteConnection = SQLite3.Open(
+            WriteConnection = SQLiteDatabaseConnectionBuilder.Create(
                 DbFilePath,
-                DefaultConnectionFlags | ConnectionFlags.Create | ConnectionFlags.ReadWrite,
-                null);
+                connectionFlags: DefaultConnectionFlags | ConnectionFlags.Create | ConnectionFlags.ReadWrite)
+                .WithScalarFunc("REGEXP", (ISQLiteValue value, ISQLiteValue pattern) => Regex.IsMatch(Convert.ToString(value), Convert.ToString(pattern)).ToSQLiteValue())
+                .Build();
 
             if (CacheSize.HasValue)
             {

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -3859,8 +3859,16 @@ namespace Emby.Server.Implementations.Data
 
             if (!string.IsNullOrWhiteSpace(query.NameStartsWith))
             {
-                whereClauses.Add("SortName like @NameStartsWith");
-                statement?.TryBind("@NameStartsWith", query.NameStartsWith + "%");
+                if (query.NameStartsWith == "#")
+                {
+                    whereClauses.Add("SortName REGEXP @NameStartsWith");
+                    statement?.TryBind("@NameStartsWith", "^[^A-Za-z]");
+                }
+                else
+                {
+                    whereClauses.Add("SortName like @NameStartsWith");
+                    statement?.TryBind("@NameStartsWith", query.NameStartsWith + "%");
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(query.NameStartsWithOrGreater))


### PR DESCRIPTION
Uses RegEx to properly provide all items in library that start with Number or Symbol.

**Changes**
* Added REGEXP function to SQLite connection constructor
* Modified `StartsWith` Items query to return items where SortName do not start with alpha character.

**Issues**
Resolves: #5660 
