### PR TITLE
Probe result tweaks

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
+++ b/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace MediaBrowser.MediaEncoding.Probing
 {
@@ -90,7 +91,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            if (DateTime.TryParse(val, out var i))
+            if (DateTime.TryParse(val, DateTimeFormatInfo.CurrentInfo, DateTimeStyles.AssumeUniversal, out var i))
             {
                 return i.ToUniversalTime();
             }

--- a/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
+++ b/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
@@ -85,12 +85,14 @@ namespace MediaBrowser.MediaEncoding.Probing
         {
             var val = GetDictionaryValue(tags, key);
 
-            if (!string.IsNullOrEmpty(val))
+            if (string.IsNullOrEmpty(val))
             {
-                if (DateTime.TryParse(val, out var i))
-                {
-                    return i.ToUniversalTime();
-                }
+                return null;
+            }
+
+            if (DateTime.TryParse(val, out var i))
+            {
+                return i.ToUniversalTime();
             }
 
             return null;

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -131,6 +131,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             info.PremiereDate = FFProbeHelpers.GetDictionaryDateTime(tags, "retaildate") ??
                 FFProbeHelpers.GetDictionaryDateTime(tags, "retail date") ??
                 FFProbeHelpers.GetDictionaryDateTime(tags, "retail_date") ??
+                FFProbeHelpers.GetDictionaryDateTime(tags, "date_released") ??
                 FFProbeHelpers.GetDictionaryDateTime(tags, "date");
 
             if (isAudio)


### PR DESCRIPTION
Currently, dates are parsed according to the local time, which results in potentially wrong data being stored in the database after normalizing to UTC - e.g. 2021-04-04 would be stored as '2021-04-03 22:00:00Z' and displayed in the UI as 03.04.2021. This can be fixed by setting the `AssumeUniversal` flag to `TryParse`.

Also, this adds support for the MKV `DATE_RELEASE` tag as a date tag - see the relevant commit for more info.

If necessary, I can split this PR into multiple.