### PR TITLE
Fixed issue with determining if a directory was a directory or file

### DIFF
--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -45,7 +45,7 @@ namespace MediaBrowser.Controller.Playlists
         public static bool IsPlaylistFile(string path)
         {
             // The path will sometimes be a directory and "Path.HasExtension" returns true if the name contains a '.' (dot).
-            return Path.HasExtension(path) && !Directory.Exists(path);
+            return System.IO.Path.HasExtension(path) && !Directory.Exists(path);
         }
 
         [JsonIgnore]

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -43,6 +44,16 @@ namespace MediaBrowser.Controller.Playlists
 
         public static bool IsPlaylistFile(string path)
         {
+            //When a directory contains a `.`, calling "HasExtension" will return true, even if that location is a directory that exists.
+            //This kills the PlaylistXmlSaver, because instead of saving in "config/data/playlists/MyList2.0/playlist.xml",
+            //It saves the information in "config/data/playlists/MyList2.xml". So we just need to see if it's actually a real directory first.
+            //Lucky for us, when a new playlist is created, the directory on the drive is created first, then the Playlist object is created.
+            //And if there's not a directory there, then we can just check if it has an extension.
+            if (new System.IO.DirectoryInfo(path).Exists)
+            { //This is a directory, and therefore definitely not a playlist file.
+                return false;
+            }
+            //Well, there's no directory there, so if it /looks/ like a file path, then it probably is.
             return System.IO.Path.HasExtension(path);
         }
 

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -44,17 +44,8 @@ namespace MediaBrowser.Controller.Playlists
 
         public static bool IsPlaylistFile(string path)
         {
-            //When a directory contains a `.`, calling "HasExtension" will return true, even if that location is a directory that exists.
-            //This kills the PlaylistXmlSaver, because instead of saving in "config/data/playlists/MyList2.0/playlist.xml",
-            //It saves the information in "config/data/playlists/MyList2.xml". So we just need to see if it's actually a real directory first.
-            //Lucky for us, when a new playlist is created, the directory on the drive is created first, then the Playlist object is created.
-            //And if there's not a directory there, then we can just check if it has an extension.
-            if (new System.IO.DirectoryInfo(path).Exists)
-            { //This is a directory, and therefore definitely not a playlist file.
-                return false;
-            }
-            //Well, there's no directory there, so if it /looks/ like a file path, then it probably is.
-            return System.IO.Path.HasExtension(path);
+            // The path will sometimes be a directory and "Path.HasExtension" returns true if the name contains a '.' (dot).
+            return Path.HasExtension(path) && !Directory.Exists(path);
         }
 
         [JsonIgnore]


### PR DESCRIPTION
Fixed issue with determining if a directory was a directory or file when it contained a `.` in the directory name.

**Changes**
Checks to see if a path is an existing directory at all as a initial check to determine if a playlist path is a file path, then if it doesn't, attempts a check using System.IO.Path.HasExtension(string path).

//Let me know if that's too much comment there, it's not initially obvious why the change was made, and it seems like the sort of thing that could be easily reverted by accident if a contributor isn't aware of the reason for the change.

**Issues**
Resolves: #2845