### PR TITLE
Disable HEVC encoding by default

### DIFF
--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -35,7 +35,7 @@ namespace MediaBrowser.Model.Configuration
             EnableDecodingColorDepth10Vp9 = true;
             EnableEnhancedNvdecDecoder = true;
             EnableHardwareEncoding = true;
-            AllowHevcEncoding = true;
+            AllowHevcEncoding = false;
             EnableSubtitleExtraction = true;
             HardwareDecodingCodecs = new string[] { "h264", "vc1" };
         }


### PR DESCRIPTION
**Changes**
Based on some discussion in chat, it probably only makes sense to have HEVC encoding enabled if HWA has been setup.

**Issues**
N/A
