### PR TITLE
Set mediatype to Audio for playlists in a music library

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
@@ -63,7 +63,8 @@ namespace Emby.Server.Implementations.Library.Resolvers
                     {
                         Path = args.Path,
                         Name = Path.GetFileNameWithoutExtension(args.Path),
-                        IsInMixedFolder = true
+                        IsInMixedFolder = true,
+                        PlaylistMediaType = MediaType.Audio
                     };
                 }
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Added mediatype for playlists in a music collectionfolder. A playlist that is created inside a music collectionfolder falls back the Audio mediatype if nothing is specified.

**Issues**
Fixes #4158 with one caveat. I can't force the mediatype on old playlists, only new ones. May have to set the MediaType manually for existing playlists...
