### PR TITLE
Fix setting audio stream in PlaybackInfo for jellyfin-web.

### DIFF
--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -283,6 +283,7 @@ namespace Jellyfin.Api.Helpers
                     if (streamInfo != null)
                     {
                         SetDeviceSpecificSubtitleInfo(streamInfo, mediaSource, auth.Token);
+                        mediaSource.DefaultAudioStreamIndex = streamInfo.AudioStreamIndex;
                     }
                 }
             }
@@ -327,6 +328,7 @@ namespace Jellyfin.Api.Helpers
                     if (streamInfo != null)
                     {
                         SetDeviceSpecificSubtitleInfo(streamInfo, mediaSource, auth.Token);
+                        mediaSource.DefaultAudioStreamIndex = streamInfo.AudioStreamIndex;
                     }
                 }
             }
@@ -354,6 +356,7 @@ namespace Jellyfin.Api.Helpers
 
                         // Do this after the above so that StartPositionTicks is set
                         SetDeviceSpecificSubtitleInfo(streamInfo, mediaSource, auth.Token);
+                        mediaSource.DefaultAudioStreamIndex = streamInfo.AudioStreamIndex;
                     }
                 }
                 else
@@ -391,6 +394,7 @@ namespace Jellyfin.Api.Helpers
 
                         // Do this after the above so that StartPositionTicks is set
                         SetDeviceSpecificSubtitleInfo(streamInfo, mediaSource, auth.Token);
+                        mediaSource.DefaultAudioStreamIndex = streamInfo.AudioStreamIndex;
                     }
                 }
             }


### PR DESCRIPTION
**Changes**
Fixes the issue with PlaybackInfo where the audo stream index is not set to the one requested. This does not interfere with playback when no audio stream is specified in PlaybackInfo.

This can be `cherry-pick`'d onto the `release-10.7.z` branch and has been tested.

**Issues**
https://github.com/jellyfin/jellyfin-desktop/issues/203