### PR TITLE
Support IsLocal on a unix socket with X-Forwarded-For

### DIFF
--- a/MediaBrowser.Common/Extensions/HttpContextExtensions.cs
+++ b/MediaBrowser.Common/Extensions/HttpContextExtensions.cs
@@ -15,7 +15,8 @@ namespace MediaBrowser.Common.Extensions
         /// <returns><c>true</c> if the request is coming from the same machine, <c>false</c> otherwise.</returns>
         public static bool IsLocal(this HttpContext context)
         {
-            if (context.Connection.RemoteIpAddress == null) {
+            if (context.Connection.RemoteIpAddress == null)
+            {
                 // UNIX Socket request.
                 return true;
             }

--- a/MediaBrowser.Common/Extensions/HttpContextExtensions.cs
+++ b/MediaBrowser.Common/Extensions/HttpContextExtensions.cs
@@ -12,12 +12,18 @@ namespace MediaBrowser.Common.Extensions
         /// Checks the origin of the HTTP context.
         /// </summary>
         /// <param name="context">The incoming HTTP context.</param>
-        /// <returns><c>true</c> if the request is coming from LAN, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the request is coming from the same machine, <c>false</c> otherwise.</returns>
         public static bool IsLocal(this HttpContext context)
         {
-            return (context.Connection.LocalIpAddress == null
-                    && context.Connection.RemoteIpAddress == null)
-                   || Equals(context.Connection.LocalIpAddress, context.Connection.RemoteIpAddress);
+            if (context.Connection.RemoteIpAddress == null) {
+                // UNIX Socket request.
+                return true;
+            }
+
+            // Otherwise it is local if it is from the same IP as us.
+            return Equals(
+                context.Connection.LocalIpAddress,
+                context.Connection.RemoteIpAddress);
         }
 
         /// <summary>


### PR DESCRIPTION
Right now `IsLocal` will work on a unix socket because both local and remote IP addresses are null *unless* you set `X-Forwarded-For`. However `X-Forwarded-For` is necessary for getting the remote header. Furthermore `X-Forwarded-For` is necessary for websocket connections right now.
    
This instead first checks the remote IP, if that is null we assume a UNIX socket and return `true`. Otherwise we fall back to the IP check. This way `IsLocal` will return the results based on the `X-Forwarded-For` header if available.
