### PR TITLE
Fix network test on dns failure

### DIFF
--- a/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
@@ -382,6 +382,8 @@ namespace Jellyfin.Networking.Tests
         [InlineData("jellyfin.org", "eth16", false, "eth16")]
         // User on external network, no binding - so result is the 1st external.
         [InlineData("jellyfin.org", "", false, "eth11")]
+        // Dns failure - should skip the test.
+        [InlineData("ospoakdposkd.abc", "", false, "eth11")]
         // User assumed to be internal, no binding - so result is the 1st internal.
         [InlineData("", "", false, "eth16")]
         public void TestBindInterfaces(string source, string bindAddresses, bool ipv6enabled, string result)
@@ -414,10 +416,13 @@ namespace Jellyfin.Networking.Tests
 
             _ = nm.TryParseInterface(result, out Collection<IPObject>? resultObj);
 
-            if (resultObj != null)
+            // Check to see if dns resolution is working. If not, skip test.
+            _ = IPHost.TryParse(source, out var host);
+
+            if (resultObj != null && host?.HasAddress == true)
             {
                 result = ((IPNetAddress)resultObj[0]).ToString(true);
-                var intf = nm.GetBindInterface(source, out int? _);
+                var intf = nm.GetBindInterface(source, out _);
 
                 Assert.Equal(intf, result);
             }

--- a/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
@@ -383,7 +383,8 @@ namespace Jellyfin.Networking.Tests
         // User on external network, no binding - so result is the 1st external.
         [InlineData("jellyfin.org", "", false, "eth11")]
         // Dns failure - should skip the test.
-        [InlineData("ospoakdposkd.abc", "", false, "eth11")]
+        // https://en.wikipedia.org/wiki/.test
+        [InlineData("invalid.domain.test", "", false, "eth11")]
         // User assumed to be internal, no binding - so result is the 1st internal.
         [InlineData("", "", false, "eth16")]
         public void TestBindInterfaces(string source, string bindAddresses, bool ipv6enabled, string result)


### PR DESCRIPTION
Test shouldn't now fail in the case of dns resolution failure.