### PR TITLE
Do not check permissions for Folders collectiontype

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -246,8 +246,13 @@ namespace Jellyfin.Api.Controllers
                 folder = _libraryManager.GetUserRootFolder();
             }
 
-            if (folder is IHasCollectionType hasCollectionType
-                && string.Equals(hasCollectionType.CollectionType, CollectionType.Playlists, StringComparison.OrdinalIgnoreCase))
+            string? collectionType = null;
+            if (folder is IHasCollectionType hasCollectionType)
+            {
+                collectionType = hasCollectionType.CollectionType;
+            }
+
+            if (string.Equals(collectionType, CollectionType.Playlists, StringComparison.OrdinalIgnoreCase))
             {
                 recursive = true;
                 includeItemTypes = new[] { BaseItemKind.Playlist };
@@ -270,10 +275,11 @@ namespace Jellyfin.Api.Controllers
                 }
             }
 
-            if (!(item is UserRootFolder)
+            if (item is not UserRootFolder
                 && !isInEnabledFolder
                 && !user.HasPermission(PermissionKind.EnableAllFolders)
-                && !user.HasPermission(PermissionKind.EnableAllChannels))
+                && !user.HasPermission(PermissionKind.EnableAllChannels)
+                && !string.Equals(collectionType, CollectionType.Folders, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("{UserName} is not permitted to access Library {ItemName}.", user.Username, item.Name);
                 return Unauthorized($"{user.Username} is not permitted to access Library {item.Name}.");


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
CollectionType.Folders seems to be a special type that is only (?) used by the "Folder view" option. Permissions are checked for the individual libraries, so no need to check for "Folders" itself.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/2754
