### PR TITLE
Enable Workstation GC mode

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>jellyfin</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/debian/conf/jellyfin
+++ b/debian/conf/jellyfin
@@ -33,6 +33,11 @@ JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/lib/jellyfin-ffmpeg/ffmpeg"
 # [OPTIONAL] run Jellyfin without the web app
 #JELLYFIN_NOWEBAPP_OPT="--nowebclient"
 
+# [OPTIONAL] run Jellyfin with ASP.NET Server Garbage Collection (uses more RAM and less CPU than Workstation GC)
+# 0 = Workstation
+# 1 = Server
+#COMPlus_gcServer=1
+
 #
 # SysV init/Upstart options
 #

--- a/fedora/jellyfin.env
+++ b/fedora/jellyfin.env
@@ -35,3 +35,7 @@ JELLYFIN_RESTART_OPT="--restartpath=/usr/libexec/jellyfin/restart.sh"
 # [OPTIONAL] run Jellyfin without the web app
 #JELLYFIN_NOWEBAPP_OPT="--noautorunwebapp"
 
+# [OPTIONAL] run Jellyfin with ASP.NET Server Garbage Collection (uses more RAM and less CPU than Workstation GC)
+# 0 = Workstation
+# 1 = Server
+#COMPlus_gcServer=1


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Default to Workstation GC mode which seems to be what was used in <=10.6. I'm not sure if .NET 5 or the Web API migration is what caused the new default of Server or not, but we've been using ASP.NET for a long time now, so it must be .NET 5.

Workstation uses less RAM than Server and is more suitable for consumer grade hardware. Servers with more RAM might benefit from using Server GC mode, which is run-time overrideable. See https://docs.microsoft.com/en-us/dotnet/core/run-time-config/garbage-collector#workstation-vs-server

Server GC mode reserves _a lot_ of virtual memory, which some devices seem to handle very poorly. Workstation GC reserves much less at the cost of a few more CPU cycles.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/5554
