### PR TITLE
Work around symbolic link issue on Linux

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -52,6 +52,11 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
   </ItemGroup>
 
+  <!-- Required for handling symbolic links on Linux -->
+  <ItemGroup>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Emby.Drawing\Emby.Drawing.csproj" />
     <ProjectReference Include="..\Emby.Server.Implementations\Emby.Server.Implementations.csproj" />

--- a/Jellyfin.Server/Middleware/UnixPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Middleware/UnixPhysicalFileResultExecutor.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+using Mono.Unix;
+
+namespace Jellyfin.Server.Middleware
+{
+    /// <summary>
+    /// <see cref="PhysicalFileResultExecutor"/> replacement using <see cref="Mono.Unix.UnixFileInfo"/>.
+    /// </summary>
+    /// This is required until ASP properly handles symbolic links in <see cref="PhysicalFileResultExecutor"/>.
+    /// This most likely depends on proper support in .NET <see cref="System.IO.FileInfo"/>. (Currently reports bugus Length)
+    /// See https://github.com/dotnet/runtime/projects/41
+    public class UnixPhysicalFileResultExecutor : FileResultExecutorBase, IActionResultExecutor<PhysicalFileResult>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnixPhysicalFileResultExecutor"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">The factory used to create loggers.</param>
+        public UnixPhysicalFileResultExecutor(ILoggerFactory loggerFactory)
+            : base(CreateLogger<UnixPhysicalFileResultExecutor>(loggerFactory))
+        {
+        }
+
+        /// <inheritdoc />
+        public virtual Task ExecuteAsync(ActionContext context, PhysicalFileResult result)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            var fileInfo = new UnixFileInfo(result.FileName);
+            if (!fileInfo.Exists)
+            {
+                throw new FileNotFoundException("Invalid path: " + result.FileName, result.FileName);
+            }
+
+            Logger.LogInformation("Sending file {FileName}", fileInfo.Name);
+
+            var lastModified = result.LastModified ?? fileInfo.LastWriteTimeUtc;
+            var (range, rangeLength, serveBody) = SetHeadersAndLog(
+                context,
+                result,
+                fileInfo.Length,
+                result.EnableRangeProcessing,
+                lastModified,
+                result.EntityTag);
+
+            if (serveBody)
+            {
+                return WriteFileAsyncInternal(context, fileInfo, range, rangeLength);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Write file represented by fileInfo to response body.
+        /// </summary>
+        /// <param name="context">The action context.</param>
+        /// <param name="fileInfo">Mono.Unix.UnixFileInfo representing the file to be sent.</param>
+        /// <param name="range">Possibly range header offset.</param>
+        /// <param name="rangeLength">Length of byte range.</param>
+        private async Task WriteFileAsyncInternal(ActionContext context, UnixFileInfo fileInfo, RangeItemHeaderValue? range, long rangeLength)
+        {
+            if (range != null && rangeLength == 0)
+            {
+                return;
+            }
+
+            var response = context.HttpContext.Response;
+            long offset = range?.From ?? 0L;
+            long count = (range == null) ? fileInfo.Length : rangeLength;
+
+            if (offset != 0)
+            {
+                Logger.LogDebug("Writing out response body range {Offset}+{Count}...", offset, count);
+            }
+
+            if (offset < 0 || offset > fileInfo.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(range), range, string.Empty);
+            }
+
+            if (count < 0 || count > fileInfo.Length - offset)
+            {
+                throw new ArgumentOutOfRangeException(nameof(rangeLength), rangeLength, string.Empty);
+            }
+
+            await response.StartAsync().ConfigureAwait(true);
+
+            const int bufferSize = 1024 * 16;
+
+            var fileStream = new FileStream(
+                fileInfo.FullName,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite,
+                bufferSize: bufferSize,
+                options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            fileStream.Seek(offset, SeekOrigin.Begin);
+            await StreamCopyOperation
+                .CopyToAsync(fileStream, response.Body, count, bufferSize, CancellationToken.None)
+                .ConfigureAwait(true);
+        }
+    }
+}

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Net.Mime;
+using System.Runtime.InteropServices;
 using Jellyfin.Networking.Configuration;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Implementations;
@@ -52,6 +53,14 @@ namespace Jellyfin.Server
             {
                 options.HttpsPort = _serverApplicationHost.HttpsPort;
             });
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                services.AddSingleton<
+                    Microsoft.AspNetCore.Mvc.Infrastructure.IActionResultExecutor<Microsoft.AspNetCore.Mvc.PhysicalFileResult>,
+                    UnixPhysicalFileResultExecutor>();
+            }
+
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
 
             services.AddJellyfinApiSwagger();


### PR DESCRIPTION
In 10.7.x the direct file streams were switched to PhysicalFileResult. This has introduced a regression because System.IO.FileInfo (and by extension PhysicalFileResultExecutor) don't handle symbolic links correctly.
More specifically, System.IO.FileInfo will report the symlink size instead of the target size. This means PhysicalFileResultExecutor will only ever try to send a few bytes of a symlinked file.
The fix for the upstream issue has been moved back to .NET 6 so it would be nice to work around the regression in the mean time.

This is a working replacement for PhysicalFileResultExecutor based on Mono.Posix which has proper handling of symbolic links. However, it does introduce an additional dependency. It has been tested on amd64 and aarch64 Linux. I'd expect it to work just as well on macOS, provided the platform check is extended, but I have no means of verifying this claim.

An analogous solution might also be viable on Windows, but I don't know enough about Win32 to take a shot at it.
Alternatively, it may be possible to achieve a similar effect using the open-seek-tell workaround.

Note that this is my first time working with ASP.NET, so I'd welcome suggestions.

**Changes**
Add custom ResultExecutor for PhysicalFileResult based on Mono.Posix

**Issues**
Fixes #5521 on Linux
