### PR TITLE
Add label commenter workflow

### DIFF
--- a/.github/workflows/label-commenter-config.yml
+++ b/.github/workflows/label-commenter-config.yml
@@ -36,6 +36,8 @@ labels:
 
               Ensure the `cherry-pick` applies cleanly. If it does not, fix any merge conflicts *preserving as much of the original code as possible*, and make note of the resulting diff.
 
+              Test your changes with a build to ensure they are successful. If not, adjust the diff accordingly.
+
               **Do not** push your merges to either branch. Use `git reset --hard HEAD~1` to revert both branches to their original state.
 
               Reply to this PR with a comment beginning "Cherry-pick test completed." and including the merge-conflict-fixing diff(s) if applicable.

--- a/.github/workflows/label-commenter-config.yml
+++ b/.github/workflows/label-commenter-config.yml
@@ -1,0 +1,41 @@
+comment:
+  header: Hello @{{ issue.user.login }}
+  footer: "\
+    ---\n\n
+    > This is an automated comment created by the [peaceiris/actions-label-commenter]. \
+    Responding to the bot or mentioning it won't have any effect.\n\n
+    [peaceiris/actions-label-commenter]: https://github.com/peaceiris/actions-label-commenter
+    "
+
+labels:
+  - name: stable backport
+    labeled:
+      pr:
+        body: |
+          This pull request has been tagged as a stable backport. It will be cherry-picked into the next stable point release.
+
+          Please observe the following:
+
+            * Any dependent PRs that this PR requires **must** be tagged for stable backporting as well.
+
+            * Any issue(s) this PR fixes or closes **should** target the current stable release or a previous stable release to which a fix has not yet entered the current stable release.
+          
+            * This PR **must** be test cherry-picked against the current release branch (`release-X.Y.z` where X and Y are numbers). It must apply cleanly, or a diff of the expected change must be provided.
+              
+              To do this, run the following commands from your local copy of the Jellyfin repository:
+              
+                1. `git checkout master`
+
+                1. `git merge --no-ff <myPullRequestBranch>`
+
+                1. `git log` -> `commit xxxxxxxxx`, grab hash
+
+                1. `git checkout release-X.Y.z` replacing X and Y with the *current* stable version (e.g. `release-10.7.z`)
+
+                1. `git cherry-pick -sx -m1 <hash>`
+
+              Ensure the `cherry-pick` applies cleanly. If it does not, fix any merge conflicts *preserving as much of the original code as possible*, and make note of the resulting diff.
+
+              **Do not** push your merges to either branch. Use `git reset --hard HEAD~1` to revert both branches to their original state.
+
+              Reply to this PR with a comment beginning "Cherry-pick test completed." and including the merge-conflict-ixing diff(s) if applicable.

--- a/.github/workflows/label-commenter-config.yml
+++ b/.github/workflows/label-commenter-config.yml
@@ -38,4 +38,4 @@ labels:
 
               **Do not** push your merges to either branch. Use `git reset --hard HEAD~1` to revert both branches to their original state.
 
-              Reply to this PR with a comment beginning "Cherry-pick test completed." and including the merge-conflict-ixing diff(s) if applicable.
+              Reply to this PR with a comment beginning "Cherry-pick test completed." and including the merge-conflict-fixing diff(s) if applicable.

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,22 @@
+name: Label Commenter
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  comment:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1


### PR DESCRIPTION
**Changes**
Add label commenter workflow

Right now the main purpose is to handle instructions for stable backports. Can be expanded in the future.

The main thrust of this is to ensure the process for handling stable backports is known to the PR author, and to allow them the opportunity to test the `cherry-pick` before handling by the release manager (i.e. project leader).

This process will help ensure, via a recorded message, that cherry-picks of stable backports have known good fixes before the actual process of cherry-picking begins.

**Issues**
N/A