### PR TITLE
Remove coupling to distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && npm ci --no-audit \
  && mv dist /dist
 
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-buster-slim as builder
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo
 COPY . .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Update image tag to make it coherent with rest of Dockerfile.

- The substring `-buster-slim` isn't useful/correct. 
- .NET 6 (from my team) is based exclusively on bullseye.
- If you update just `DOTNET_VERSION` to `6.0`, `docker build` will fail. 
- If the goal is to force using `buster` throughout the Dockerfile, then making `DOTNET_VERSION` configurable isn't correct.
- Context: https://github.com/dotnet/dotnet-docker/blob/main/src/runtime-deps/6.0/bullseye-slim/amd64/Dockerfile#L1

Just saw this as a drive by look at your code. Is intended as helpful context.