### PR TITLE
Fix possible ArgumentNullException

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
@@ -54,7 +54,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             if (string.IsNullOrEmpty(tmdbId))
             {
-                return null;
+                return Enumerable.Empty<RemoteImageInfo>();
             }
 
             var language = item.GetPreferredMetadataLanguage();


### PR DESCRIPTION
```
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
   at MediaBrowser.Providers.Manager.ProviderManager.GetImages(BaseItem
           item, IRemoteImageProvider provider, IReadOnlyCollection`1
           preferredLanguages, CancellationToken cancellationToken,
           Nullable`1 type) in
   /home/bond/dev/jellyfin/MediaBrowser.Providers/Manager/ProviderManager.cs:line
   280
```