### PR TITLE
Change repeated library names generator

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2936,7 +2936,7 @@ namespace Emby.Server.Implementations.Library
             var virtualFolderPath = Path.Combine(rootFolderPath, name);
             while (Directory.Exists(virtualFolderPath))
             {
-                name += "1";
+                name = char.IsDigit(name[^1]) ? name[0..^1] + (char.GetNumericValue(name[^1]) + 1) : name + 1;
                 virtualFolderPath = Path.Combine(rootFolderPath, name);
             }
 


### PR DESCRIPTION
In the current implementation, if a library with a repeated name is created, a 1 will be add at the end of the string (movies,movies1) but if another one is created another 1 is added (movies, movies1, and movies11).

With my implementation, the last number is incremented each time a new library with a repeated name is created (movies, movies1, and movies2). The counter will work up to 19 which I think is good enough.
