### PR TITLE
Add NextUpCutoffDate to NextUpQuery

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -156,7 +156,7 @@ namespace Emby.Server.Implementations.TV
                         return i.Item1 != DateTime.MinValue;
                     }
 
-                    if (alwaysEnableFirstEpisode || (i.Item1 != DateTime.MinValue && i.Item1.Date > request.NextUpDateCutoff))
+                    if (alwaysEnableFirstEpisode || (i.Item1 != DateTime.MinValue && (request.NextUpDateCutoff is null ||  i.Item1.Date > request.NextUpDateCutoff)))
                     {
                         anyFound = true;
                         return true;

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -156,7 +156,7 @@ namespace Emby.Server.Implementations.TV
                         return i.Item1 != DateTime.MinValue;
                     }
 
-                    if (alwaysEnableFirstEpisode || i.Item1 != DateTime.MinValue)
+                    if (alwaysEnableFirstEpisode || (i.Item1 != DateTime.MinValue && i.Item1.Date > request.NextUpDateCutoff))
                     {
                         anyFound = true;
                         return true;

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -156,7 +156,7 @@ namespace Emby.Server.Implementations.TV
                         return i.Item1 != DateTime.MinValue;
                     }
 
-                    if (alwaysEnableFirstEpisode || (i.Item1 != DateTime.MinValue && (request.NextUpDateCutoff is null ||  i.Item1.Date > request.NextUpDateCutoff)))
+                    if (alwaysEnableFirstEpisode || (i.Item1 != DateTime.MinValue && i.Item1.Date >= request.NextUpDateCutoff))
                     {
                         anyFound = true;
                         return true;

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -65,6 +65,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
         /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
         /// <param name="enableUserData">Optional. Include user data.</param>
+        /// <param name="nextUpDateCutoff">Starting date of shows to show in Next Up section.</param>
         /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
         /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>
@@ -81,6 +82,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? imageTypeLimit,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes,
             [FromQuery] bool? enableUserData,
+            [FromQuery] DateTime nextUpDateCutoff,
             [FromQuery] bool enableTotalRecordCount = true,
             [FromQuery] bool disableFirstEpisode = false)
         {
@@ -97,7 +99,8 @@ namespace Jellyfin.Api.Controllers
                     StartIndex = startIndex,
                     UserId = userId ?? Guid.Empty,
                     EnableTotalRecordCount = enableTotalRecordCount,
-                    DisableFirstEpisode = disableFirstEpisode
+                    DisableFirstEpisode = disableFirstEpisode,
+                    NextUpDateCutoff = nextUpDateCutoff
                 },
                 options);
 

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -82,7 +82,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? imageTypeLimit,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes,
             [FromQuery] bool? enableUserData,
-            [FromQuery] DateTime nextUpDateCutoff,
+            [FromQuery] DateTime? nextUpDateCutoff,
             [FromQuery] bool enableTotalRecordCount = true,
             [FromQuery] bool disableFirstEpisode = false)
         {

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -65,7 +65,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
         /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
         /// <param name="enableUserData">Optional. Include user data.</param>
-        /// <param name="nextUpDateCutoff">Optional. Starting date of shows to show in Next Up section.</param>
+        /// <param name="nextUpDateCutoff">Starting date of shows to show in Next Up section.</param>
         /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
         /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>
@@ -100,7 +100,7 @@ namespace Jellyfin.Api.Controllers
                     UserId = userId ?? Guid.Empty,
                     EnableTotalRecordCount = enableTotalRecordCount,
                     DisableFirstEpisode = disableFirstEpisode,
-                    NextUpDateCutoff = nextUpDateCutoff
+                    NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue
                 },
                 options);
 

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -65,7 +65,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
         /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
         /// <param name="enableUserData">Optional. Include user data.</param>
-        /// <param name="nextUpDateCutoff">Starting date of shows to show in Next Up section.</param>
+        /// <param name="nextUpDateCutoff">Optional. Starting date of shows to show in Next Up section.</param>
         /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
         /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Model.Querying
             EnableImageTypes = Array.Empty<ImageType>();
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
-            NextUpDateCutoff = null;
+            NextUpDateCutoff = DateTime.MinValue;
         }
 
         /// <summary>
@@ -80,6 +80,6 @@ namespace MediaBrowser.Model.Querying
         /// <summary>
         /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
         /// </summary>
-        public DateTime? NextUpDateCutoff { get; set; }
+        public DateTime NextUpDateCutoff { get; set; }
     }
 }

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Model.Querying
             EnableImageTypes = Array.Empty<ImageType>();
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
-            NextUpDateCutoff = new DateTime(0001, 01, 01);
+            NextUpDateCutoff = null;
         }
 
         /// <summary>
@@ -80,6 +80,6 @@ namespace MediaBrowser.Model.Querying
         /// <summary>
         /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
         /// </summary>
-        public DateTime NextUpDateCutoff { get; set; }
+        public DateTime? NextUpDateCutoff { get; set; }
     }
 }

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -13,6 +13,7 @@ namespace MediaBrowser.Model.Querying
             EnableImageTypes = Array.Empty<ImageType>();
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
+            NextUpDateCutoff = new DateTime(0001, 01, 01);
         }
 
         /// <summary>
@@ -75,5 +76,10 @@ namespace MediaBrowser.Model.Querying
         /// Gets or sets a value indicating whether do disable sending first episode as next up.
         /// </summary>
         public bool DisableFirstEpisode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
+        /// </summary>
+        public DateTime NextUpDateCutoff { get; set; }
     }
 }


### PR DESCRIPTION
**Changes**
Attempt number 2 at adding a way to omit shows that havent been watched in x days from the NextUp section. The original pull request was here https://github.com/jellyfin/jellyfin/pull/5814 but I threw out that work and deleted the branch and that closed the request. Im not sure what the protocol is when something like that needs to be done. My apologies if I did it wrong. I am not super confident this was the correct way to implement this based on what cvium commented on the other one but I was having a lot of trouble understanding exactly what should be done. This has some shortfalls including the client needing to pass a date as a string to get it to work which seems a little flaky but Id love some feedback..

**Issues**
#5814 
