### PR TITLE
Fixed IndexOutOfRange

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -843,6 +843,7 @@ namespace MediaBrowser.Controller.Entities
         private static BaseItem[] SortItemsByRequest(InternalItemsQuery query, IReadOnlyList<BaseItem> items)
         {
             int size = items.Count;
+
             // ids can potentially contain non-unique guids, but query result cannot,
             // so we include only first occurrence of each guid
             var positions = new Dictionary<Guid, int>(size);
@@ -855,14 +856,15 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
+            if (index > size)
+            {
+                size = index;
+            }
+
             var newItems = new BaseItem[size];
             foreach (var item in items)
             {
-                int x = positions[item.Id];
-                if (x != -1)
-                {
-                    newItems[x] = item;
-                }
+                newItems[positions[item.Id]] = item;
             }
 
             return newItems;

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -842,26 +842,27 @@ namespace MediaBrowser.Controller.Entities
 
         private static BaseItem[] SortItemsByRequest(InternalItemsQuery query, IReadOnlyList<BaseItem> items)
         {
-            var ids = query.ItemIds;
             int size = items.Count;
-
             // ids can potentially contain non-unique guids, but query result cannot,
             // so we include only first occurrence of each guid
             var positions = new Dictionary<Guid, int>(size);
             int index = 0;
-            for (int i = 0; i < ids.Length; i++)
+            foreach (var id in query.ItemIds)
             {
-                if (positions.TryAdd(ids[i], index))
+                if (positions.TryAdd(id, index))
                 {
                     index++;
                 }
             }
 
             var newItems = new BaseItem[size];
-            for (int i = 0; i < size; i++)
+            foreach (var item in items)
             {
-                var item = items[i];
-                newItems[positions[item.Id]] = item;
+                int x = positions[item.Id];
+                if (x != -1)
+                {
+                    newItems[x] = item;
+                }
             }
 
             return newItems;


### PR DESCRIPTION
Partial fix for #5834

Should stop the exception from being created, but not the cause. (# of unique items in Query.ItemIds > items.count)