### PR TITLE
Fix ArgumentOutOfRangeException scanning AudioBooks

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -201,6 +201,11 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
                     continue;
                 }
 
+                if (resolvedItem.Files.Count == 0)
+                {
+                    continue;
+                }
+
                 var firstMedia = resolvedItem.Files[0];
 
                 var libraryItem = new T


### PR DESCRIPTION
AudioResolver.ResolveMultipleAudio method can attempt to access the first item in a List without checking if the list is empty which throws an ArgumentOutOfRangeException and stops the 'Scan Library' process.


**Changes**
Ignores items where the List of files is empty.

