### PR TITLE
Fix ArgumentOutOfRangeException when getting PostedPlaybackInfo

### DIFF
--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -161,6 +161,11 @@ namespace Jellyfin.Api.Controllers
                     liveStreamId)
                 .ConfigureAwait(false);
 
+            if (info.ErrorCode != null)
+            {
+                return info;
+            }
+
             if (profile != null)
             {
                 // set device specific data


### PR DESCRIPTION
MediaInfoController.GetPostedPlaybackInfo method attempts to access the first item of the mediaInfo Array without checking if MediaInfoHelper.GetPlaybackInfo returned an ErrorCode

**Changes**
Skip Code that accesses mediaInfo MediaSources Array when an ErrorCode is returned
