### PR TITLE
ManagedFileSystem: Rewrite GetValidFilename and more improvements

### DIFF
--- a/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
@@ -42,6 +42,16 @@ namespace Jellyfin.Server.Implementations.Tests.IO
             }
         }
 
+        [Theory]
+        [InlineData("ValidFileName", "ValidFileName")]
+        [InlineData("AC/DC", "AC DC")]
+        [InlineData("Invalid\0", "Invalid ")]
+        [InlineData("AC/DC\0KD/A", "AC DC KD A")]
+        public void GetValidFilename_ReturnsValidFilename(string filename, string expectedFileName)
+        {
+            Assert.Equal(expectedFileName, _sut.GetValidFilename(filename));
+        }
+
         [SkippableFact]
         public void GetFileInfo_DanglingSymlink_ExistsFalse()
         {


### PR DESCRIPTION
```
BenchmarkDotNet=v0.12.1, OS=fedora 32
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  DefaultJob : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
```

|                      Method |          Data |        Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |-------------- |------------:|---------:|---------:|-------:|------:|------:|----------:|
|       GetValidFilenameBench |    AC/DCKD/A |    48.94 ns | 0.803 ns | 0.751 ns | 0.0255 |     - |     - |      80 B |
|    GetValidFilenameOldBench |    AC/DCKD/A |    85.70 ns | 1.572 ns | 1.393 ns | 0.0587 |     - |     - |     184 B |
|    GetValidFilenameWinBench |    AC/DCKD/A |   607.00 ns | 4.829 ns | 3.770 ns | 0.0505 |     - |     - |     160 B |
| GetValidFilenameOldWinBench |    AC/DCKD/A |   845.81 ns | 9.330 ns | 8.727 ns | 0.0839 |     - |     - |     264 B |
|       GetValidFilenameBench | ValidFileName |    27.53 ns | 0.151 ns | 0.118 ns | 0.0255 |     - |     - |      80 B |
|    GetValidFilenameOldBench | ValidFileName |    92.01 ns | 1.057 ns | 0.937 ns | 0.0587 |     - |     - |     184 B |
|    GetValidFilenameWinBench | ValidFileName |   344.50 ns | 1.618 ns | 1.514 ns | 0.0505 |     - |     - |     160 B |
| GetValidFilenameOldWinBench | ValidFileName | 1,000.49 ns | 5.477 ns | 4.573 ns | 0.0839 |     - |     - |     264 B |

The `*Win` benchmarks are simulated by replacing `GetInvalidFileNameChars()` with 
```cs
new char[]
        {
            '\"', '<', '>', '|', '\0',
            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
            (char)31, ':', '*', '?', '\\', '/'
        }
```