### PR TITLE
Created PublicUserDto that hides sensitive user info

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -89,18 +89,18 @@ namespace Jellyfin.Api.Controllers
         /// Gets a list of publicly visible users for display on a login screen.
         /// </summary>
         /// <response code="200">Public users returned.</response>
-        /// <returns>An <see cref="IEnumerable{UserDto}"/> containing the public users.</returns>
+        /// <returns>An <see cref="IEnumerable{PublicUserDto}"/> containing the public users.</returns>
         [HttpGet("Public")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<IEnumerable<UserDto>> GetPublicUsers()
+        public ActionResult<IEnumerable<PublicUserDto>> GetPublicUsers()
         {
             // If the startup wizard hasn't been completed then just return all users
             if (!_config.Configuration.IsStartupWizardCompleted)
             {
-                return Ok(Get(false, false, false, false));
+                return Ok(Get(false, false, false, false).Select(user => new PublicUserDto(user)));
             }
 
-            return Ok(Get(false, false, true, true));
+            return Ok(Get(false, false, true, true).Select(user => new PublicUserDto(user)));
         }
 
         /// <summary>

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -20,6 +20,7 @@ namespace MediaBrowser.Model.Dto
         /// <summary>
         /// Initializes a new instance of the <see cref="PublicUserDto"/> class from a <see cref="UserDto"/> object.
         /// </summary>
+        /// <param name="sourceUser">The <see cref="UserDto"/> object from which to construct this <see cref="PublicUserDto"/>.</param>
         public PublicUserDto(UserDto sourceUser)
         {
             this.Name = sourceUser.Name;

--- a/MediaBrowser.Model/Dto/PublicUserDto.cs
+++ b/MediaBrowser.Model/Dto/PublicUserDto.cs
@@ -1,0 +1,83 @@
+#nullable disable
+using System;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Users;
+
+namespace MediaBrowser.Model.Dto
+{
+    /// <summary>
+    /// Class PublicUserDto.
+    /// </summary>
+    public class PublicUserDto : IItemDto, IHasServerId
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicUserDto"/> class.
+        /// </summary>
+        public PublicUserDto()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicUserDto"/> class from a <see cref="UserDto"/> object.
+        /// </summary>
+        public PublicUserDto(UserDto sourceUser)
+        {
+            this.Name = sourceUser.Name;
+            this.ServerId = sourceUser.ServerId;
+            this.ServerName = sourceUser.ServerName;
+            this.Id = sourceUser.Id;
+            this.PrimaryImageTag = sourceUser.PrimaryImageTag;
+            this.HasPassword = sourceUser.HasPassword;
+            this.PrimaryImageAspectRatio = sourceUser.PrimaryImageAspectRatio;
+        }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the server identifier.
+        /// </summary>
+        /// <value>The server identifier.</value>
+        public string ServerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the server.
+        /// This is not used by the server and is for client-side usage only.
+        /// </summary>
+        /// <value>The name of the server.</value>
+        public string ServerName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        /// <value>The id.</value>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary image tag.
+        /// </summary>
+        /// <value>The primary image tag.</value>
+        public string PrimaryImageTag { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has password.
+        /// </summary>
+        /// <value><c>true</c> if this instance has password; otherwise, <c>false</c>.</value>
+        public bool HasPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary image aspect ratio.
+        /// </summary>
+        /// <value>The primary image aspect ratio.</value>
+        public double? PrimaryImageAspectRatio { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Name ?? base.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Created PublicUserDto that hides sensitive user info such as whether they are admins.

This will decrease the likelihood of an attacker targetting an admin account specifically.

**Changes**
Created PublicUserInfo class with parameterless constructor and constructor that accepts UserInfo to allow a UserInfo object to be used to create PublicUserInfo objects.
Modified /Users/Public to return PublicUserInfo object, rather than UserInfo, preventing any sensitive info from being provided.

**Issues**
Resolves #3188
