### PR TITLE
Enable Person support for Photo items

### DIFF
--- a/MediaBrowser.Controller/Entities/Photo.cs
+++ b/MediaBrowser.Controller/Entities/Photo.cs
@@ -17,6 +17,9 @@ namespace MediaBrowser.Controller.Entities
         public override Folder LatestItemsIndexContainer => AlbumEntity;
 
         [JsonIgnore]
+        public override bool SupportsPeople => true;
+
+        [JsonIgnore]
         public PhotoAlbum AlbumEntity
         {
             get


### PR DESCRIPTION
**Changes**

Sets SupportsPeople for Photo items.

This works when setting the person via the metadata editor on jf-web (The person is saved properly and all), but for some reason trying to get that person via the Items API then fails. I looked a bit into it, but have no real idea of what would be needed to make that part work...

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
