### PR TITLE
Leave SyncPlay group on session disconnect.

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
+++ b/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
@@ -87,7 +87,7 @@ namespace Emby.Server.Implementations.SyncPlay
             _sessionManager = sessionManager;
             _libraryManager = libraryManager;
             _logger = loggerFactory.CreateLogger<SyncPlayManager>();
-            _sessionManager.SessionControllerConnected += OnSessionControllerConnected;
+            _sessionManager.SessionEnded += OnSessionEnded;
         }
 
         /// <inheritdoc />
@@ -352,18 +352,18 @@ namespace Emby.Server.Implementations.SyncPlay
                 return;
             }
 
-            _sessionManager.SessionControllerConnected -= OnSessionControllerConnected;
+            _sessionManager.SessionEnded -= OnSessionEnded;
             _disposed = true;
         }
 
-        private void OnSessionControllerConnected(object sender, SessionEventArgs e)
+        private void OnSessionEnded(object sender, SessionEventArgs e)
         {
             var session = e.SessionInfo;
 
             if (_sessionToGroupMap.TryGetValue(session.Id, out var group))
             {
-                var request = new JoinGroupRequest(group.GroupId);
-                JoinGroup(session, request, CancellationToken.None);
+                var leaveGroupRequest = new LeaveGroupRequest();
+                LeaveGroup(session, leaveGroupRequest, CancellationToken.None);
             }
         }
 


### PR DESCRIPTION
**Changes**
 - This causes sessions to leave the SyncPlay group they are attached to when they disconnect.
 - If the last SyncPlay session disconnects, the group is removed.
 - This prevents the issue where if SyncPlay breaks, users need to delete their Client configuration file to make it usable again.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/4680
Fixes https://github.com/jellyfin/jellyfin-web/issues/2515

**References**
https://www.reddit.com/r/jellyfin/comments/mk3se4/jellyfin_media_player_new_experimental_desktop/gtdtksk/
https://www.reddit.com/r/linux/comments/mv3mx3/introducing_jellyfin_media_player_with_the/gvmcaot/

*This PR can be cherry-picked onto the release-10.7.z branch and has been tested.*