### PR TITLE
Remove extraneous 'stream' parameter

### DIFF
--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -527,7 +527,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="deviceProfileId">Optional. The dlna device profile id to utilize.</param>
         /// <param name="playSessionId">The play session id.</param>
         /// <param name="segmentContainer">The segment container.</param>
-        /// <param name="segmentLength">The segment lenght.</param>
+        /// <param name="segmentLength">The segment length.</param>
         /// <param name="minSegments">The minimum number of segments.</param>
         /// <param name="mediaSourceId">The media version id, if playing an alternate version.</param>
         /// <param name="deviceId">The device id of the client requesting. Used to stop encoding processes when needed.</param>
@@ -556,7 +556,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="maxVideoBitDepth">Optional. The maximum video bit depth.</param>
         /// <param name="requireAvc">Optional. Whether to require avc.</param>
         /// <param name="deInterlace">Optional. Whether to deinterlace the video.</param>
-        /// <param name="requireNonAnamorphic">Optional. Whether to require a non anamporphic stream.</param>
+        /// <param name="requireNonAnamorphic">Optional. Whether to require a non anamorphic stream.</param>
         /// <param name="transcodingMaxAudioChannels">Optional. The maximum number of audio channels to transcode.</param>
         /// <param name="cpuCoreLimit">Optional. The limit of how many cpu cores to use.</param>
         /// <param name="liveStreamId">The live stream id.</param>
@@ -570,8 +570,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
-        [HttpGet("{itemId}/{stream=stream}.{container}")]
-        [HttpHead("{itemId}/{stream=stream}.{container}", Name = "HeadVideoStreamByContainer")]
+        [HttpGet("{itemId}/stream.{container}")]
+        [HttpHead("{itemId}/stream.{container}", Name = "HeadVideoStreamByContainer")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesVideoFile]
         public Task<ActionResult> GetVideoStreamByContainer(


### PR DESCRIPTION
The argument isn't passed to the method but causes the API generator to include an unnecessary parameter.
Also fixes some typos in the documentation comments.