### PR TITLE
Nullability handling for device profile classes

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -976,15 +976,28 @@ namespace Emby.Dlna.Didl
                 return;
             }
 
-            var albumartUrlInfo = GetImageUrl(imageInfo, _profile.MaxAlbumArtWidth, _profile.MaxAlbumArtHeight, "jpg");
+            // TODO: Remove these default values
+            var albumArtUrlInfo = GetImageUrl(
+                imageInfo,
+                _profile.MaxAlbumArtWidth ?? 10000,
+                _profile.MaxAlbumArtHeight ?? 10000,
+                "jpg");
 
             writer.WriteStartElement("upnp", "albumArtURI", NsUpnp);
-            writer.WriteAttributeString("dlna", "profileID", NsDlna, _profile.AlbumArtPn);
-            writer.WriteString(albumartUrlInfo.url);
+            if (!string.IsNullOrEmpty(_profile.AlbumArtPn))
+            {
+                writer.WriteAttributeString("dlna", "profileID", NsDlna, _profile.AlbumArtPn);
+            }
+
+            writer.WriteString(albumArtUrlInfo.url);
             writer.WriteFullEndElement();
 
-            // TOOD: Remove these default values
-            var iconUrlInfo = GetImageUrl(imageInfo, _profile.MaxIconWidth ?? 48, _profile.MaxIconHeight ?? 48, "jpg");
+            // TODO: Remove these default values
+            var iconUrlInfo = GetImageUrl(
+                imageInfo,
+                _profile.MaxIconWidth ?? 48,
+                _profile.MaxIconHeight ?? 48,
+                "jpg");
             writer.WriteElementString("upnp", "icon", NsUpnp, iconUrlInfo.url);
 
             if (!_profile.EnableAlbumArtInDidl)
@@ -1207,8 +1220,7 @@ namespace Emby.Dlna.Didl
 
             if (width.HasValue && height.HasValue)
             {
-                var newSize = DrawingUtils.Resize(
-                        new ImageDimensions(width.Value, height.Value), 0, 0, maxWidth, maxHeight);
+                var newSize = DrawingUtils.Resize(new ImageDimensions(width.Value, height.Value), 0, 0, maxWidth, maxHeight);
 
                 width = newSize.Width;
                 height = newSize.Height;

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -298,9 +298,9 @@ namespace Jellyfin.Api.Controllers
                 {
                     Type = DlnaProfileType.Audio,
                     Context = EncodingContext.Streaming,
-                    Container = transcodingContainer,
-                    AudioCodec = audioCodec,
-                    Protocol = transcodingProtocol,
+                    Container = transcodingContainer ?? "mp3",
+                    AudioCodec = audioCodec ?? "mp3",
+                    Protocol = transcodingProtocol ?? "http",
                     BreakOnNonKeyFrames = breakOnNonKeyFrames ?? false,
                     MaxAudioChannels = transcodingAudioChannels?.ToString(CultureInfo.InvariantCulture)
                 }

--- a/MediaBrowser.Model/Dlna/DeviceProfile.cs
+++ b/MediaBrowser.Model/Dlna/DeviceProfile.cs
@@ -1,6 +1,6 @@
-#nullable disable
 #pragma warning disable CA1819 // Properties should not return arrays
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Xml.Serialization;
 using MediaBrowser.Model.MediaInfo;
@@ -14,120 +14,103 @@ namespace MediaBrowser.Model.Dlna
     public class DeviceProfile
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceProfile"/> class.
-        /// </summary>
-        public DeviceProfile()
-        {
-            DirectPlayProfiles = Array.Empty<DirectPlayProfile>();
-            TranscodingProfiles = Array.Empty<TranscodingProfile>();
-            ResponseProfiles = Array.Empty<ResponseProfile>();
-            CodecProfiles = Array.Empty<CodecProfile>();
-            ContainerProfiles = Array.Empty<ContainerProfile>();
-            SubtitleProfiles = Array.Empty<SubtitleProfile>();
-
-            XmlRootAttributes = Array.Empty<XmlAttribute>();
-
-            SupportedMediaTypes = "Audio,Photo,Video";
-            MaxStreamingBitrate = 8000000;
-            MaxStaticBitrate = 8000000;
-            MusicStreamingTranscodingBitrate = 128000;
-        }
-
-        /// <summary>
         /// Gets or sets the Name.
         /// </summary>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the Id.
         /// </summary>
         [XmlIgnore]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the Identification.
         /// </summary>
-        public DeviceIdentification Identification { get; set; }
+        public DeviceIdentification? Identification { get; set; }
 
         /// <summary>
         /// Gets or sets the FriendlyName.
         /// </summary>
-        public string FriendlyName { get; set; }
+        public string? FriendlyName { get; set; }
 
         /// <summary>
         /// Gets or sets the Manufacturer.
         /// </summary>
-        public string Manufacturer { get; set; }
+        public string? Manufacturer { get; set; }
 
         /// <summary>
         /// Gets or sets the ManufacturerUrl.
         /// </summary>
-        public string ManufacturerUrl { get; set; }
+        public string? ManufacturerUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the ModelName.
         /// </summary>
-        public string ModelName { get; set; }
+        public string? ModelName { get; set; }
 
         /// <summary>
         /// Gets or sets the ModelDescription.
         /// </summary>
-        public string ModelDescription { get; set; }
+        public string? ModelDescription { get; set; }
 
         /// <summary>
         /// Gets or sets the ModelNumber.
         /// </summary>
-        public string ModelNumber { get; set; }
+        public string? ModelNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the ModelUrl.
         /// </summary>
-        public string ModelUrl { get; set; }
+        public string? ModelUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the SerialNumber.
         /// </summary>
-        public string SerialNumber { get; set; }
+        public string? SerialNumber { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether EnableAlbumArtInDidl.
         /// </summary>
+        [DefaultValue(false)]
         public bool EnableAlbumArtInDidl { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether EnableSingleAlbumArtLimit.
         /// </summary>
+        [DefaultValue(false)]
         public bool EnableSingleAlbumArtLimit { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether EnableSingleSubtitleLimit.
         /// </summary>
+        [DefaultValue(false)]
         public bool EnableSingleSubtitleLimit { get; set; }
 
         /// <summary>
         /// Gets or sets the SupportedMediaTypes.
         /// </summary>
-        public string SupportedMediaTypes { get; set; }
+        public string SupportedMediaTypes { get; set; } = "Audio,Photo,Video";
 
         /// <summary>
         /// Gets or sets the UserId.
         /// </summary>
-        public string UserId { get; set; }
+        public string? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the AlbumArtPn.
         /// </summary>
-        public string AlbumArtPn { get; set; }
+        public string? AlbumArtPn { get; set; }
 
         /// <summary>
         /// Gets or sets the MaxAlbumArtWidth.
         /// </summary>
-        public int MaxAlbumArtWidth { get; set; }
+        public int? MaxAlbumArtWidth { get; set; }
 
         /// <summary>
         /// Gets or sets the MaxAlbumArtHeight.
         /// </summary>
-        public int MaxAlbumArtHeight { get; set; }
+        public int? MaxAlbumArtHeight { get; set; }
 
         /// <summary>
         /// Gets or sets the MaxIconWidth.
@@ -142,92 +125,97 @@ namespace MediaBrowser.Model.Dlna
         /// <summary>
         /// Gets or sets the MaxStreamingBitrate.
         /// </summary>
-        public int? MaxStreamingBitrate { get; set; }
+        public int? MaxStreamingBitrate { get; set; } = 8000000;
 
         /// <summary>
         /// Gets or sets the MaxStaticBitrate.
         /// </summary>
-        public int? MaxStaticBitrate { get; set; }
+        public int? MaxStaticBitrate { get; set; } = 8000000;
 
         /// <summary>
         /// Gets or sets the MusicStreamingTranscodingBitrate.
         /// </summary>
-        public int? MusicStreamingTranscodingBitrate { get; set; }
+        public int? MusicStreamingTranscodingBitrate { get; set; } = 128000;
 
         /// <summary>
         /// Gets or sets the MaxStaticMusicBitrate.
         /// </summary>
-        public int? MaxStaticMusicBitrate { get; set; }
+        public int? MaxStaticMusicBitrate { get; set; } = 8000000;
 
         /// <summary>
         /// Gets or sets the content of the aggregationFlags element in the urn:schemas-sonycom:av namespace.
         /// </summary>
-        public string SonyAggregationFlags { get; set; }
+        public string? SonyAggregationFlags { get; set; }
 
         /// <summary>
         /// Gets or sets the ProtocolInfo.
         /// </summary>
-        public string ProtocolInfo { get; set; }
+        public string? ProtocolInfo { get; set; }
 
         /// <summary>
         /// Gets or sets the TimelineOffsetSeconds.
         /// </summary>
+        [DefaultValue(0)]
         public int TimelineOffsetSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether RequiresPlainVideoItems.
         /// </summary>
+        [DefaultValue(false)]
         public bool RequiresPlainVideoItems { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether RequiresPlainFolders.
         /// </summary>
+        [DefaultValue(false)]
         public bool RequiresPlainFolders { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether EnableMSMediaReceiverRegistrar.
         /// </summary>
+        [DefaultValue(false)]
         public bool EnableMSMediaReceiverRegistrar { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether IgnoreTranscodeByteRangeRequests.
         /// </summary>
+        [DefaultValue(false)]
         public bool IgnoreTranscodeByteRangeRequests { get; set; }
 
         /// <summary>
         /// Gets or sets the XmlRootAttributes.
         /// </summary>
-        public XmlAttribute[] XmlRootAttributes { get; set; }
+        public XmlAttribute[] XmlRootAttributes { get; set; } = Array.Empty<XmlAttribute>();
 
         /// <summary>
         /// Gets or sets the direct play profiles.
         /// </summary>
-        public DirectPlayProfile[] DirectPlayProfiles { get; set; }
+        public DirectPlayProfile[] DirectPlayProfiles { get; set; } = Array.Empty<DirectPlayProfile>();
 
         /// <summary>
         /// Gets or sets the transcoding profiles.
         /// </summary>
-        public TranscodingProfile[] TranscodingProfiles { get; set; }
+        public TranscodingProfile[] TranscodingProfiles { get; set; } = Array.Empty<TranscodingProfile>();
 
         /// <summary>
         /// Gets or sets the ContainerProfiles.
         /// </summary>
-        public ContainerProfile[] ContainerProfiles { get; set; }
+        public ContainerProfile[] ContainerProfiles { get; set; } = Array.Empty<ContainerProfile>();
 
         /// <summary>
         /// Gets or sets the CodecProfiles.
         /// </summary>
-        public CodecProfile[] CodecProfiles { get; set; }
+        public CodecProfile[] CodecProfiles { get; set; } = Array.Empty<CodecProfile>();
 
         /// <summary>
         /// Gets or sets the ResponseProfiles.
         /// </summary>
-        public ResponseProfile[] ResponseProfiles { get; set; }
+        public ResponseProfile[] ResponseProfiles { get; set; } = Array.Empty<ResponseProfile>();
 
         /// <summary>
         /// Gets or sets the SubtitleProfiles.
         /// </summary>
-        public SubtitleProfile[] SubtitleProfiles { get; set; }
+        public SubtitleProfile[] SubtitleProfiles { get; set; } = Array.Empty<SubtitleProfile>();
 
         /// <summary>
         /// The GetSupportedMediaTypes.
@@ -244,13 +232,13 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="container">The container.</param>
         /// <param name="audioCodec">The audio Codec.</param>
         /// <returns>A <see cref="TranscodingProfile"/>.</returns>
-        public TranscodingProfile GetAudioTranscodingProfile(string container, string audioCodec)
+        public TranscodingProfile? GetAudioTranscodingProfile(string? container, string? audioCodec)
         {
             container = (container ?? string.Empty).TrimStart('.');
 
             foreach (var i in TranscodingProfiles)
             {
-                if (i.Type != MediaBrowser.Model.Dlna.DlnaProfileType.Audio)
+                if (i.Type != DlnaProfileType.Audio)
                 {
                     continue;
                 }
@@ -278,13 +266,13 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="audioCodec">The audio Codec.</param>
         /// <param name="videoCodec">The video Codec.</param>
         /// <returns>The <see cref="TranscodingProfile"/>.</returns>
-        public TranscodingProfile GetVideoTranscodingProfile(string container, string audioCodec, string videoCodec)
+        public TranscodingProfile? GetVideoTranscodingProfile(string? container, string? audioCodec, string? videoCodec)
         {
             container = (container ?? string.Empty).TrimStart('.');
 
             foreach (var i in TranscodingProfiles)
             {
-                if (i.Type != MediaBrowser.Model.Dlna.DlnaProfileType.Video)
+                if (i.Type != DlnaProfileType.Video)
                 {
                     continue;
                 }
@@ -299,7 +287,7 @@ namespace MediaBrowser.Model.Dlna
                     continue;
                 }
 
-                if (!string.Equals(videoCodec, i.VideoCodec ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(videoCodec, i.VideoCodec, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -320,7 +308,7 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="audioSampleRate">The audio sample rate.</param>
         /// <param name="audioBitDepth">The audio bit depth.</param>
         /// <returns>The <see cref="ResponseProfile"/>.</returns>
-        public ResponseProfile GetAudioMediaProfile(string container, string audioCodec, int? audioChannels, int? audioBitrate, int? audioSampleRate, int? audioBitDepth)
+        public ResponseProfile? GetAudioMediaProfile(string container, string? audioCodec, int? audioChannels, int? audioBitrate, int? audioSampleRate, int? audioBitDepth)
         {
             foreach (var i in ResponseProfiles)
             {
@@ -384,7 +372,7 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         /// <returns>The <see cref="ResponseProfile"/>.</returns>
-        public ResponseProfile GetImageMediaProfile(string container, int? width, int? height)
+        public ResponseProfile? GetImageMediaProfile(string container, int? width, int? height)
         {
             foreach (var i in ResponseProfiles)
             {
@@ -442,7 +430,7 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="videoCodecTag">The video Codec tag.</param>
         /// <param name="isAvc">True if Avc.</param>
         /// <returns>The <see cref="ResponseProfile"/>.</returns>
-        public ResponseProfile GetVideoMediaProfile(
+        public ResponseProfile? GetVideoMediaProfile(
             string container,
             string audioCodec,
             string videoCodec,

--- a/MediaBrowser.Model/Dlna/DeviceProfile.cs
+++ b/MediaBrowser.Model/Dlna/DeviceProfile.cs
@@ -432,8 +432,8 @@ namespace MediaBrowser.Model.Dlna
         /// <returns>The <see cref="ResponseProfile"/>.</returns>
         public ResponseProfile? GetVideoMediaProfile(
             string container,
-            string audioCodec,
-            string videoCodec,
+            string? audioCodec,
+            string? videoCodec,
             int? width,
             int? height,
             int? bitDepth,

--- a/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
+++ b/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
@@ -1,6 +1,6 @@
-#nullable disable
 #pragma warning disable CS1591
 
+using System.ComponentModel.DataAnnotations;
 using System.Xml.Serialization;
 
 namespace MediaBrowser.Model.Dlna
@@ -8,14 +8,15 @@ namespace MediaBrowser.Model.Dlna
     public class DirectPlayProfile
     {
         [XmlAttribute("container")]
-        public string Container { get; set; }
+        public string? Container { get; set; }
 
         [XmlAttribute("audioCodec")]
-        public string AudioCodec { get; set; }
+        public string? AudioCodec { get; set; }
 
         [XmlAttribute("videoCodec")]
-        public string VideoCodec { get; set; }
+        public string? VideoCodec { get; set; }
 
+        [Required]
         [XmlAttribute("type")]
         public DlnaProfileType Type { get; set; }
 
@@ -31,7 +32,7 @@ namespace MediaBrowser.Model.Dlna
 
         public bool SupportsAudioCodec(string codec)
         {
-            return (Type == DlnaProfileType.Audio || Type == DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
+            return (Type is DlnaProfileType.Audio or DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
+++ b/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
@@ -32,7 +32,7 @@ namespace MediaBrowser.Model.Dlna
 
         public bool SupportsAudioCodec(string codec)
         {
-            return (Type is DlnaProfileType.Audio or DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
+            return (Type == DlnaProfileType.Audio || Type == DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -1,54 +1,69 @@
-#nullable disable
 #pragma warning disable CS1591
 
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Xml.Serialization;
 
 namespace MediaBrowser.Model.Dlna
 {
     public class TranscodingProfile
     {
+        [Required]
         [XmlAttribute("container")]
-        public string Container { get; set; }
+        public string Container { get; set; } = string.Empty;
 
+        [Required]
         [XmlAttribute("type")]
         public DlnaProfileType Type { get; set; }
 
+        [Required]
         [XmlAttribute("videoCodec")]
-        public string VideoCodec { get; set; }
+        public string VideoCodec { get; set; } = string.Empty;
 
+        [Required]
         [XmlAttribute("audioCodec")]
-        public string AudioCodec { get; set; }
+        public string AudioCodec { get; set; } = string.Empty;
 
+        [Required]
         [XmlAttribute("protocol")]
-        public string Protocol { get; set; }
+        public string Protocol { get; set; } = string.Empty;
 
+        [DefaultValue(false)]
         [XmlAttribute("estimateContentLength")]
         public bool EstimateContentLength { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("enableMpegtsM2TsMode")]
         public bool EnableMpegtsM2TsMode { get; set; }
 
+        [DefaultValue(TranscodeSeekInfo.Auto)]
         [XmlAttribute("transcodeSeekInfo")]
         public TranscodeSeekInfo TranscodeSeekInfo { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("copyTimestamps")]
         public bool CopyTimestamps { get; set; }
 
+        [DefaultValue(EncodingContext.Streaming)]
         [XmlAttribute("context")]
         public EncodingContext Context { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("enableSubtitlesInManifest")]
         public bool EnableSubtitlesInManifest { get; set; }
 
         [XmlAttribute("maxAudioChannels")]
-        public string MaxAudioChannels { get; set; }
+        public string? MaxAudioChannels { get; set; }
 
+        [DefaultValue(0)]
         [XmlAttribute("minSegments")]
         public int MinSegments { get; set; }
 
+        [DefaultValue(0)]
         [XmlAttribute("segmentLength")]
         public int SegmentLength { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("breakOnNonKeyFrames")]
         public bool BreakOnNonKeyFrames { get; set; }
 


### PR DESCRIPTION
Refactored some classes in the device profile model to handle nullability and added `DefaultValue` and `Required` attributes for the generated API.
Some properties (like `MinSegments` in `TranscodingProfile`) couldn't be made nullable as that would break parsing device profile XMLs.
I also moved some initializers directly to the variables, if constructor assignment is preferred I can also move them back.

Also fixed a bug in the `ContainsContainer` method, passing a null/empty `profileContainers` would have caused the method to always return true, which seems to be wrong. Now it properly returns the correct value according to `isNegativeList`.