### PR TITLE
Don't run integration tests in parallel

### DIFF
--- a/tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj
+++ b/tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj
@@ -22,6 +22,13 @@
     <PackageReference Include="Moq" Version="4.16.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Don't run tests in parallel -->
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <!-- Code Analyzers -->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />

--- a/tests/Jellyfin.Server.Integration.Tests/xunit.runner.json
+++ b/tests/Jellyfin.Server.Integration.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
* Easier to debug failing tests when the logs aren't scrambled
* Static properties could cause issues
