### PR TITLE
Fix direct play for DirectPlayProfiles without any codecs set

### DIFF
--- a/MediaBrowser.Model/Dlna/ContainerProfile.cs
+++ b/MediaBrowser.Model/Dlna/ContainerProfile.cs
@@ -55,7 +55,8 @@ namespace MediaBrowser.Model.Dlna
         {
             if (profileContainers == null || profileContainers.Length == 0)
             {
-                return isNegativeList;
+                // Empty profiles always support all containers/codecs
+                return true;
             }
 
             var allInputContainers = SplitValue(inputContainer);


### PR DESCRIPTION
70771fdcd60ec5d8a9f13713662778c7e57d0633 broke direct play by treating empty container/codec strings as unsupported in `ContainerProfile.ContainsContainer()` (which is also used for video and audio codec checks). Instead, they should be treated as supported, for both the positive and negative list option.

**Changes**
- Reverts one of the changes in 70771fdcd60ec5d8a9f13713662778c7e57d0633.

**Issues**
- None filed.