### PR TITLE
Respect configured JELLYFIN_USER in Debian's postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -9,6 +9,8 @@ if [[ -f $DEFAULT_FILE ]]; then
   . $DEFAULT_FILE
 fi
 
+JELLYFIN_USER=${JELLYFIN_USER:-jellyfin}
+
 # Data directories for program data (cache, db), configs, and logs
 PROGRAMDATA=${JELLYFIN_DATA_DIRECTORY-/var/lib/$NAME}
 CONFIGDATA=${JELLYFIN_CONFIG_DIRECTORY-/etc/$NAME}
@@ -18,12 +20,12 @@ CACHEDATA=${JELLYFIN_CACHE_DIRECTORY-/var/cache/$NAME}
 case "$1" in
   configure)
     # create jellyfin group if it does not exist
-    if [[ -z "$(getent group jellyfin)" ]]; then
-      addgroup --quiet --system jellyfin > /dev/null 2>&1
+    if [[ -z "$(getent group ${JELLYFIN_USER})" ]]; then
+      addgroup --quiet --system ${JELLYFIN_USER} > /dev/null 2>&1
     fi
     # create jellyfin user if it does not exist
-    if [[ -z "$(getent passwd jellyfin)"  ]]; then
-      adduser --system --ingroup jellyfin --shell /bin/false jellyfin --no-create-home --home ${PROGRAMDATA} \
+    if [[ -z "$(getent passwd ${JELLYFIN_USER})"  ]]; then
+      adduser --system --ingroup ${JELLYFIN_USER} --shell /bin/false ${JELLYFIN_USER} --no-create-home --home ${PROGRAMDATA} \
         --gecos "Jellyfin default user" > /dev/null 2>&1
     fi
     # ensure $PROGRAMDATA exists
@@ -43,7 +45,7 @@ case "$1" in
       mkdir $CACHEDATA
     fi
     # Ensure permissions are correct on all config directories
-    chown -R jellyfin $PROGRAMDATA $CONFIGDATA $LOGDATA $CACHEDATA
+    chown -R ${JELLYFIN_USER} $PROGRAMDATA $CONFIGDATA $LOGDATA $CACHEDATA
     chgrp adm $PROGRAMDATA $CONFIGDATA $LOGDATA $CACHEDATA
     chmod 0750 $PROGRAMDATA $CONFIGDATA $LOGDATA $CACHEDATA
 


### PR DESCRIPTION
In my setup I configured a different user. But updates keep "stealing" file permissions for my `$PROGRAMDATA $CONFIGDATA $LOGDATA $CACHEDATA` directories.