### PR TITLE
fixed no channel icons when using tvheadend

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -171,7 +171,7 @@ namespace MediaBrowser.Providers.Manager
 
             // Workaround for tvheadend channel icons
             // TODO: Isolate this hack into the tvh plugin
-            if (contentTypeHeader == null || string.IsNullOrEmpty(contentTypeHeader.MediaType))
+            if (string.IsNullOrEmpty(contentType))
             {
                 if (url.IndexOf("/imagecache/", StringComparison.OrdinalIgnoreCase) != -1)
                 {

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -167,16 +167,20 @@ namespace MediaBrowser.Providers.Manager
                 throw new HttpRequestException("Invalid image received.", null, response.StatusCode);
             }
 
-            var contentType = response.Content.Headers.ContentType.MediaType;
+            var contentTypeHeader = response.Content.Headers.ContentType;
+            var contentType = string.Empty;
 
             // Workaround for tvheadend channel icons
             // TODO: Isolate this hack into the tvh plugin
-            if (string.IsNullOrEmpty(contentType))
+            if (contentTypeHeader == null || string.IsNullOrEmpty(contentTypeHeader.MediaType))
             {
                 if (url.IndexOf("/imagecache/", StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     contentType = "image/png";
                 }
+            } else
+            {
+                contentType = contentTypeHeader.MediaType;
             }
 
             // thetvdb will sometimes serve a rubbish 404 html page with a 200 OK code, because reasons...

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -167,7 +167,7 @@ namespace MediaBrowser.Providers.Manager
                 throw new HttpRequestException("Invalid image received.", null, response.StatusCode);
             }
 
-            var contentType = response.Content.Headers?.ContentType;
+            var contentType = response.Content.Headers.ContentType?.MediaType;
 
             // Workaround for tvheadend channel icons
             // TODO: Isolate this hack into the tvh plugin

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -177,9 +177,6 @@ namespace MediaBrowser.Providers.Manager
                 {
                     contentType = "image/png";
                 }
-            } else
-            {
-                contentType = contentTypeHeader.MediaType;
             }
 
             // thetvdb will sometimes serve a rubbish 404 html page with a 200 OK code, because reasons...

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -167,8 +167,7 @@ namespace MediaBrowser.Providers.Manager
                 throw new HttpRequestException("Invalid image received.", null, response.StatusCode);
             }
 
-            var contentTypeHeader = response.Content.Headers.ContentType;
-            var contentType = string.Empty;
+            var contentType = response.Content.Headers?.ContentType;
 
             // Workaround for tvheadend channel icons
             // TODO: Isolate this hack into the tvh plugin


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
When using tvheadend, no channel icons are provided in EPG because of a missing content type in the response header. This results in a lot of internal errors and NullPointerExceptions (see screenshot below). There was already a workaround implemented, but sadly the is-null check was not implemented correctly (maybe the response of tvheadend has changed since the implementation of the workaround?)
![image](https://user-images.githubusercontent.com/27811714/117354438-9b20e200-aeb1-11eb-8ed9-cbbe388dbda3.png)

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
https://github.com/jellyfin/jellyfin-plugin-tvheadend/issues/15
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
