### PR TITLE
Fixes for Book Progress

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -220,7 +220,7 @@ namespace Emby.Server.Implementations.Library
             var hasRuntime = runtimeTicks > 0;
 
             // If a position has been reported, and if we know the duration
-            if (positionTicks > 0 && hasRuntime && !(item is AudioBook) && !(item is Book))
+            if (positionTicks > 0 && hasRuntime && item is not AudioBook && item is not Book)
             {
                 var pctIn = decimal.Divide(positionTicks, runtimeTicks) * 100;
 

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -220,7 +220,7 @@ namespace Emby.Server.Implementations.Library
             var hasRuntime = runtimeTicks > 0;
 
             // If a position has been reported, and if we know the duration
-            if (positionTicks > 0 && hasRuntime && !(item is AudioBook))
+            if (positionTicks > 0 && hasRuntime && !(item is AudioBook) && !(item is Book))
             {
                 var pctIn = decimal.Divide(positionTicks, runtimeTicks) * 100;
 
@@ -239,7 +239,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     // Enforce MinResumeDuration
                     var durationSeconds = TimeSpan.FromTicks(runtimeTicks).TotalSeconds;
-                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds && !(item is Book))
+                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
                     {
                         positionTicks = 0;
                         data.Played = playedToCompletion = true;


### PR DESCRIPTION
**Changes**
This PR moves the check for if it's a type `Book` when saving the progress to the database. Currently due to the maths the book progress will be below the default configs `MinResumePct` so this will just ignore books and save the progress without resetting it to 0.

**Issues**
Didn't see an issue for this. But it occurs when you have books on your Jellyfin, read through a few pages and then back out the PDF viewer the progress isn't saved and upon refreshing the page the progress is still 0. 