### PR TITLE
Disable automation CI on issues

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -2,8 +2,6 @@ name: Automation
 
 on:
   pull_request:
-  issues:
-  issue_comment:
 
 jobs:
   main:


### PR DESCRIPTION
**Changes**

Disabled the automation CI on issues. It's been annoying me for weeks now. Everytime an issue is made or commented on the author will receive a notification because this CI is failing....

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
