### PR TITLE
Revert remuxing permission changes from #5859

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -200,11 +200,6 @@ namespace Emby.Server.Implementations.Library
                     {
                         source.SupportsTranscoding = user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding);
                     }
-                    else if (string.Equals(item.MediaType, MediaType.Video, StringComparison.OrdinalIgnoreCase))
-                    {
-                        source.SupportsTranscoding = user.HasPermission(PermissionKind.EnableVideoPlaybackTranscoding);
-                        source.SupportsDirectStream = user.HasPermission(PermissionKind.EnablePlaybackRemuxing);
-                    }
                 }
             }
 


### PR DESCRIPTION
Clients cannot currently handle it properly.

NOTE: This is only a revert for 10.7. The change is still live in 10.8 and clients will need to be fixed.