### PR TITLE
Use TMDb parental rating building from movies for shows

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
@@ -206,12 +206,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
 
                 if (ourRelease != null)
                 {
-                    var ratingPrefix = string.Equals(info.MetadataCountryCode, "us", StringComparison.OrdinalIgnoreCase) ? string.Empty : info.MetadataCountryCode + "-";
-                    var newRating = ratingPrefix + ourRelease.Certification;
-
-                    newRating = newRating.Replace("de-", "FSK-", StringComparison.OrdinalIgnoreCase);
-
-                    movie.OfficialRating = newRating;
+                    movie.OfficialRating = TmdbUtils.BuildParentalRating(ourRelease.Iso_3166_1, ourRelease.Certification);
                 }
                 else if (usRelease != null)
                 {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -300,7 +300,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             if (ourRelease != null)
             {
-                series.OfficialRating = ourRelease.Rating;
+                series.OfficialRating = TmdbUtils.BuildParentalRating(ourRelease.Iso_3166_1, ourRelease.Rating);
             }
             else if (usRelease != null)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -173,5 +173,20 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
 
             return imageLanguage;
         }
+
+        /// <summary>
+        /// Combines the metadata country code and the parental rating from the Api into the value we store in our database.
+        /// </summary>
+        /// <param name="countryCode">The Iso 3166-1 country code of the rating country.</param>
+        /// <param name="ratingValue">The rating value returned by the Tmdb Api.</param>
+        /// <returns>The combined parental rating of country code+rating value.</returns>
+        public static string BuildParentalRating(string countryCode, string ratingValue)
+        {
+            // exclude US because we store us values as TV-14 without the country code.
+            var ratingPrefix = string.Equals(countryCode, "US", StringComparison.OrdinalIgnoreCase) ? string.Empty : countryCode + "-";
+            var newRating = ratingPrefix + ratingValue;
+
+            return newRating.Replace("DE-", "FSK-", StringComparison.OrdinalIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
**Changes**
TV show provider used to set OfficialRating to the value the TMDb Api returned, which is already the correct value (like TV-MA) for the US. Every other country requires the country code as a prefix (or FSK for Germany).
The movie provider already did this, so I made a helper method for building the correct rating string.

**Issues**
Fixes #5966
