### PR TITLE
Replace GH_TOKEN with JF_BOT_TOKEN

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           project: Current Release
           action: delete
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Add to 'Release Next' project
         uses: alex-page/github-project-automation-plus@v0.7.1
@@ -29,7 +29,7 @@ jobs:
         with:
           project: Release Next
           column: In progress
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Add to 'Current Release' project
         uses: alex-page/github-project-automation-plus@v0.7.1
@@ -38,7 +38,7 @@ jobs:
         with:
           project: Current Release
           column: In progress
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Check number of comments from the team member
         if: github.event.issue.pull_request == '' && github.event.comment.author_association == 'MEMBER'
@@ -52,7 +52,7 @@ jobs:
         with:
           project: Issue Triage for Main Repo
           column: Needs triage
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Add issue to triage project
         uses: alex-page/github-project-automation-plus@v0.7.1
@@ -61,4 +61,4 @@ jobs:
         with:
           project: Issue Triage for Main Repo
           column: Pending response
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
           dirtyLabel: 'merge conflict'
-          repoToken: ${{ secrets.GH_TOKEN }}
+          repoToken: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,17 +11,17 @@ jobs:
       - name: Notify as seen
         uses: peter-evans/create-or-update-comment@v1.4.5
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.JF_BOT_TOKEN }}
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'
 
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.JF_BOT_TOKEN }}
           fetch-depth: 0
 
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
``GH_TOKEN`` seems to be used internally by GitHub and it's making some actions we're using in some repos fail ([Source](https://github.com/alex-page/github-project-automation-plus/issues/39))

*(PRs made from users of the org are always successful, but PRs that aren't don't work, like Dependabot PRs. This can be checked by looking at the history of server repos and Jellyfin Vue)*

The org-wide secret should be renamed to something else to avoid confusion and further replacements or messes in GH's side. This PR replaces ``GH_TOKEN`` with ``JF_BOT_TOKEN``, which should be pretty generic.