### PR TITLE
Don't logout if deviceId is null

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1540,23 +1540,26 @@ namespace Emby.Server.Implementations.Session
                     Limit = 1
                 }).Items.FirstOrDefault();
 
-            var allExistingForDevice = _authRepo.Get(
-                new AuthenticationInfoQuery
-                {
-                    DeviceId = deviceId
-                }).Items;
-
-            foreach (var auth in allExistingForDevice)
+            if (!string.IsNullOrEmpty(deviceId))
             {
-                if (existing == null || !string.Equals(auth.AccessToken, existing.AccessToken, StringComparison.Ordinal))
+                var allExistingForDevice = _authRepo.Get(
+                    new AuthenticationInfoQuery
+                    {
+                        DeviceId = deviceId
+                    }).Items;
+
+                foreach (var auth in allExistingForDevice)
                 {
-                    try
+                    if (existing == null || !string.Equals(auth.AccessToken, existing.AccessToken, StringComparison.Ordinal))
                     {
-                        Logout(auth);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error while logging out.");
+                        try
+                        {
+                            Logout(auth);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error while logging out.");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
As reported by @nielsvanvelzen 
This fixes an issue that occurs if a client sends an authorization request without a DeviceId set- all tokens are removed. The proper fix would be to set the `[Required]` attribute but I don't want to potentially break existing clients.

```
[2021-05-10 19:55:07.083 +02:00] [INF] [21] Jellyfin.Server.Implementations.Users.UserManager: Authentication request for "Demo" has succeeded.
[2021-05-10 19:55:07.084 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Current/Max sessions for user "Demo": 3/0
[2021-05-10 19:55:07.086 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.092 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.097 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.102 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.107 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.111 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.116 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.121 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.126 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.132 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.144 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.155 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.160 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.165 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.169 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.177 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.182 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.186 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.191 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.196 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.201 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.206 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.213 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.218 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.223 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.229 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.234 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.239 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.244 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.249 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.254 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.259 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.264 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.269 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.274 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.279 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Logging out access token "[...]"
[2021-05-10 19:55:07.284 +02:00] [INF] [21] Emby.Server.Implementations.Session.SessionManager: Reissuing access token: "[...]"
```