### PR TITLE
Reorder requested audio channels checks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,6 +146,7 @@
  - [nielsvanvelzen](https://github.com/nielsvanvelzen)
  - [skyfrk](https://github.com/skyfrk)
  - [ianjazz246](https://github.com/ianjazz246)
+ - [peterspenler](https://github.com/peterspenler)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -274,6 +274,16 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public int? GetRequestedAudioChannels(string codec)
         {
+            if (!string.IsNullOrEmpty(codec))
+            {
+                var value = BaseRequest.GetOption(codec, "audiochannels");
+                if (!string.IsNullOrEmpty(value)
+                    && int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                {
+                    return result;
+                }
+            }
+
             if (BaseRequest.MaxAudioChannels.HasValue)
             {
                 return BaseRequest.MaxAudioChannels;
@@ -287,16 +297,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (BaseRequest.TranscodingMaxAudioChannels.HasValue)
             {
                 return BaseRequest.TranscodingMaxAudioChannels;
-            }
-
-            if (!string.IsNullOrEmpty(codec))
-            {
-                var value = BaseRequest.GetOption(codec, "audiochannels");
-                if (!string.IsNullOrEmpty(value)
-                    && int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
-                {
-                    return result;
-                }
             }
 
             return null;


### PR DESCRIPTION
**Changes**
Reordered the requested audio checks in encoding job info. Some devices have device specific channel limits for certain audio codecs which they request through the `{codecName}-audiochannels` query parameter. For example chromecasts can only handle up to 2 channels when using AAC audio. These request options should override the normal channel limits. 

**Issues**
Fixes #5795 