### PR TITLE
Add FullNowPlayingQueue property to sessions endpoint

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -424,16 +424,15 @@ namespace Emby.Server.Implementations.Session
 
             var nowPlayingQueue = info.NowPlayingQueue;
 
-            if (nowPlayingQueue != null)
+            if (nowPlayingQueue?.Length > 0)
             {
                 session.NowPlayingQueue = nowPlayingQueue;
+
+                var itemIds = nowPlayingQueue.Select(queue => queue.Id).ToArray();
+                session.NowPlayingQueueFullItems = _dtoService.GetBaseItemDtos(
+                    _libraryManager.GetItemList(new InternalItemsQuery { ItemIds = itemIds }),
+                    new DtoOptions(true));
             }
-
-            var itemIds = session.NowPlayingQueue.Select(queue => queue.Id).ToArray();
-
-            session.NowPlayingQueueFullItems = _dtoService.GetBaseItemDtos(_libraryManager.GetItemList(new InternalItemsQuery {
-                ItemIds = itemIds,
-            }), new DtoOptions(true)).ToArray();
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -428,6 +428,12 @@ namespace Emby.Server.Implementations.Session
             {
                 session.NowPlayingQueue = nowPlayingQueue;
             }
+
+            var itemIds = session.NowPlayingQueue.Select(queue => queue.Id).ToArray();
+
+            session.NowPlayingQueueFullItems = _dtoService.GetBaseItemDtos(_libraryManager.GetItemList(new InternalItemsQuery {
+                ItemIds = itemIds,
+            }), new DtoOptions(true)).ToArray();
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -39,6 +39,8 @@ namespace MediaBrowser.Controller.Session
             AdditionalUsers = Array.Empty<SessionUserInfo>();
             PlayState = new PlayerStateInfo();
             SessionControllers = Array.Empty<ISessionController>();
+            NowPlayingQueue = Array.Empty<QueueItem>();
+            NowPlayingQueueFullItems = Array.Empty<BaseItemDto>();
         }
 
         public PlayerStateInfo PlayState { get; set; }
@@ -219,9 +221,9 @@ namespace MediaBrowser.Controller.Session
             }
         }
 
-        public QueueItem[] NowPlayingQueue { get; set; }
+        public IReadOnlyList<QueueItem> NowPlayingQueue { get; set; }
 
-        public BaseItemDto[] NowPlayingQueueFullItems { get; set; }
+        public IReadOnlyList<BaseItemDto> NowPlayingQueueFullItems { get; set; }
 
         public bool HasCustomDeviceName { get; set; }
 

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -221,6 +221,8 @@ namespace MediaBrowser.Controller.Session
 
         public QueueItem[] NowPlayingQueue { get; set; }
 
+        public BaseItemDto[] NowPlayingQueueFullItems { get; set; }
+
         public bool HasCustomDeviceName { get; set; }
 
         public string PlaylistItemId { get; set; }


### PR DESCRIPTION
Needed for https://github.com/jellyfin/jellyfin-vue/pull/1040 and should be backwards compatible with any client.

(Not tested)


[openapi.json.txt](https://github.com/jellyfin/jellyfin/files/6489925/openapi.json.txt)
