### PR TITLE
Enable child items to be returned if a musicAlbum

### DIFF
--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -265,6 +265,11 @@ namespace MediaBrowser.Controller.Entities
 
         public bool? IsDeadPerson { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether album sub-folders should be returned if they exist.
+        /// </summary>
+        public bool? DisplayAlbumFolders { get; set; }
+
         public InternalItemsQuery()
         {
             AlbumArtistIds = Array.Empty<Guid>();


### PR DESCRIPTION
Required core change to enable dlna folder view to work as expected. (https://github.com/jellyfin/jellyfin/issues/5793)

Enables DLNA folders to show the folder structure, not just the logical name.

![image](https://user-images.githubusercontent.com/22121540/118564899-1c595e00-b769-11eb-8bc8-099dde785b35.png)

Normal library view remains the same.

![image](https://user-images.githubusercontent.com/22121540/118565030-62aebd00-b769-11eb-8237-8a10aea2d2b9.png)
