### PR TITLE
Properly detect Dolby Vision files derived from AV1, AVC and HEVC

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -104,6 +104,19 @@ namespace MediaBrowser.Model.Entities
                     return "HDR";
                 }
 
+                // For some Dolby Vision files, no color transfer is provided, so check the codec
+
+                var codecTag = CodecTag;
+
+                if (string.Equals(codecTag, "dva1", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(codecTag, "dvav", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(codecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(codecTag, "dav1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "HDR";
+                }
+
                 return "SDR";
             }
         }


### PR DESCRIPTION
**Changes**

Some Dolby Vision files use a codec derived from AV1, AVC or HEVC, which is registered by the MP4RA as a different code (See https://mp4ra.org/#/codecs).

This adds a new branch in the video range detection, after the transfer function, to properly mark all these codecs as being HDR.  

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
