### PR TITLE
Don't prefer OMDB rating over all other providers

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderUtils.cs
+++ b/MediaBrowser.Providers/Manager/ProviderUtils.cs
@@ -55,7 +55,7 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            if (replaceData || !target.CommunityRating.HasValue || (source.CommunityRating.HasValue && string.Equals(sourceResult.Provider, "The Open Movie Database", StringComparison.OrdinalIgnoreCase)))
+            if (replaceData || !target.CommunityRating.HasValue)
             {
                 target.CommunityRating = source.CommunityRating;
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Currently Jellyfin prefers community rating received from OMDB metadata provider over all other providers, regardless of the priorities set by the user. Here I remove this unconditional priority, the choice of rating will follow the configured order of the providers, as for the rest of the metadata.
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
None found
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
