### PR TITLE
Delete user playback position

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@
  - [cryptobank](https://github.com/cryptobank)
  - [cvium](https://github.com/cvium)
  - [dannymichel](https://github.com/dannymichel)
+ - [DanWillman](https://github.com/DanWillman)
  - [DaveChild](https://github.com/DaveChild)
  - [Delgan](https://github.com/Delgan)
  - [dcrdev](https://github.com/dcrdev)

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -325,6 +325,26 @@ namespace Jellyfin.Api.Controllers
             return Ok(dtos);
         }
 
+        /// <summary>
+        /// Delete user playback position.
+        /// </summary>
+        /// <param name="userId">Which user to delete resume position for.</param>
+        /// <param name="itemId">Item uuid from user's library to reset.</param>
+        /// <returns>No content.</returns>
+        [HttpDelete("Users/{userId}/Items/{itemId}/PlaybackPosition")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public ActionResult DeleteResumeStatus([FromRoute, Required] Guid userId, [FromRoute, Required] Guid itemId)
+        {
+            var user = _userManager.GetUserById(userId);
+            var item = itemId.Equals(Guid.Empty) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(itemId);
+            var data = _userDataRepository.GetUserData(user, item);
+
+            data.PlaybackPositionTicks = 0;
+
+            _userDataRepository.SaveUserData(user, item, data, UserDataSaveReason.PlaybackFinished, CancellationToken.None);
+            return NoContent();
+        }
+
         private async Task RefreshItemOnDemandIfNeeded(BaseItem item)
         {
             if (item is Person)


### PR DESCRIPTION
**Changes**
Adds an endpoint for deleting/resetting the user playback position to 0.

[Feature Request](https://features.jellyfin.org/posts/517/add-an-option-to-remove-an-item-from-continue-watching)