### PR TITLE
Fix: Plugin implementing IServerEntryPoint and IBasePlugin gets instantiated TWICE.

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -478,7 +478,7 @@ namespace Emby.Server.Implementations
 
             Logger.LogInformation("ServerId: {0}", SystemId);
 
-            var entryPoints = GetExports<IServerEntryPoint>();
+            var entryPoints = GetExports<IServerEntryPoint>(CreateUninstantiatedClasses);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -1363,6 +1363,19 @@ namespace Emby.Server.Implementations
             }
 
             _disposed = true;
+        }
+
+        private IServerEntryPoint CreateUninstantiatedClasses(Type type)
+        {
+            var pluginInstance = _pluginManager.Plugins.FirstOrDefault(p => p.Instance.GetType() == type);
+            if (pluginInstance != null)
+            {
+                return (IServerEntryPoint)pluginInstance.Instance;
+            }
+            else
+            {
+                return (IServerEntryPoint)CreateInstanceSafe(type);
+            }
         }
     }
 


### PR DESCRIPTION
**Issue:**

If a plugin implements both the IServerEntryPoint and IBasePlugin<T> interfaces it is currently **instantiated twice**, once as a plugin, and again as a IServerEntryPoint.

This change only creates a new instance if it hasn't already been instantiated in the plugin creation stage, otherwise the plugin generated instance is used.

The current workaround is to create two classes, one a IBasePlugin, and the other a IServerEntryPoint. With this change, only one class is required.