### PR TITLE
Fix network flooding issue

### DIFF
--- a/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
+++ b/Emby.Server.Implementations/EntryPoints/ExternalPortForwarding.cs
@@ -106,8 +106,6 @@ namespace Emby.Server.Implementations.EntryPoints
             NatUtility.StartDiscovery();
 
             _timer = new Timer((_) => _createdRules.Clear(), null, TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(10));
-
-            _deviceDiscovery.DeviceDiscovered += OnDeviceDiscoveryDeviceDiscovered;
         }
 
         private void Stop()
@@ -118,13 +116,6 @@ namespace Emby.Server.Implementations.EntryPoints
             NatUtility.DeviceFound -= OnNatUtilityDeviceFound;
 
             _timer?.Dispose();
-
-            _deviceDiscovery.DeviceDiscovered -= OnDeviceDiscoveryDeviceDiscovered;
-        }
-
-        private void OnDeviceDiscoveryDeviceDiscovered(object sender, GenericEventArgs<UpnpDeviceInfo> e)
-        {
-            NatUtility.Search(e.Argument.LocalIpAddress, NatProtocol.Upnp);
         }
 
         private async void OnNatUtilityDeviceFound(object sender, DeviceEventArgs e)


### PR DESCRIPTION
Remove link between DLNA and upnp.

UPnP does the port forwarding on the router by using SSDP broadcasts. DLNA does similar.

A link was placed between these to subsystems to speed up network device identification. This however, caused a loop whereby DLNA would pick up a device, and pass it to UPNP which would send out a notication, which DLNA would pick up and pass back to UPNP which would send out a notification. (Rinse and repeat) As each notification consists of 2-3 broadcasts, so the result is an exponential network flooding.