### PR TITLE
Pull request target

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,5 +1,5 @@
 comment:
-  header: Hello @{{ issue.user.login }}
+  header: Hello!
   footer: "\
     ---\n\n
     > This is an automated comment created by the [peaceiris/actions-label-commenter]. \

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,7 +1,7 @@
 name: Automation
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   main:

--- a/.github/workflows/check-backport.yml
+++ b/.github/workflows/check-backport.yml
@@ -1,7 +1,10 @@
 name: Stable Backport Check
 on:
   issue_comment:
-  pull_request:
+    types:
+      - created
+      - edited
+  pull_request_target:
     types:
       - labeled
       - synchronize

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -20,3 +20,5 @@ jobs:
 
       - name: Label Commenter
         uses: peaceiris/actions-label-commenter@v1
+        with:
+          github_token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,6 +1,9 @@
 name: Automatic Rebase
 on:
   issue_comment:
+    types:
+      - created
+      - edited
 
 jobs:
   rebase:


### PR DESCRIPTION
* Don't trigger command-based workflows when the comments are deleted.
* Use ``pull_request_target`` event instead of ``pull_request`` to trigger workflows from forks as explained [here](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)
