### PR TITLE
Fix playback of complex BluRay ISOs

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -367,7 +367,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string GetInputArgument(string inputFile, MediaSourceInfo mediaSource)
         {
             var prefix = "file";
-            if (mediaSource.VideoType == VideoType.BluRay)
+            if (mediaSource.VideoType == VideoType.BluRay ||
+                mediaSource.IsoType == IsoType.BluRay)
             {
                 prefix = "bluray";
             }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -367,8 +367,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string GetInputArgument(string inputFile, MediaSourceInfo mediaSource)
         {
             var prefix = "file";
-            if (mediaSource.VideoType == VideoType.BluRay ||
-                mediaSource.IsoType == IsoType.BluRay)
+            if (mediaSource.VideoType == VideoType.BluRay
+                || mediaSource.IsoType == IsoType.BluRay)
             {
                 prefix = "bluray";
             }

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -147,7 +147,8 @@ namespace MediaBrowser.Providers.MediaInfo
                     {
                         Path = path,
                         Protocol = protocol,
-                        VideoType = item.VideoType
+                        VideoType = item.VideoType,
+                        IsoType = item.IsoType
                     }
                 },
                 cancellationToken);


### PR DESCRIPTION
`ffmpeg` is able to play some simple (BluRay) ISO disc images via the `file:` protocol. Other, more complex discs, with multiple playlists, may cause `bluray.iso: Invalid data found when processing input`. Using the `bluray:` protocol and `ffmpeg` compiled with `libbluray`, the disc will properly play the main playlist.

To ensure that there's no regression with DVD playback. The `bluray:` protocol will be used only for `VideoType.BluRay` or `IsoType.BluRay`. To have the ISO file tagged as `IsoType.BluRay`, the file has to be named as e.g.: `NAME.bluray.iso`

**Changes**
* Use `bluray:` protocol for ISO files tagged as BluRay disc.

**Issues**
Fixes the issue described in https://github.com/jellyfin/jellyfin/issues/5617#issuecomment-856557009
