### PR TITLE
Fix routeMediaSourceId route parameter in SubtitleController GetSubtitle

### DIFF
--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -196,7 +196,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startPositionTicks">The start position of the subtitle in ticks.</param>
         /// <response code="200">File returned.</response>
         /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
-        [HttpGet("Videos/{routeItemId}/routeMediaSourceId/Subtitles/{routeIndex}/Stream.{routeFormat}")]
+        [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesFile("text/*")]
         public async Task<ActionResult> GetSubtitle(


### PR DESCRIPTION
**Changes**

Introduced in #5624 this PR fixes an issue with a broken route parameter the Kotlin SDK was complaining about.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
