### PR TITLE
Require userId in getItems and getTrailers endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -143,7 +143,7 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("Items")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<QueryResult<BaseItemDto>> GetItems(
-            [FromQuery] Guid? userId,
+            [FromQuery] Guid userId,
             [FromQuery] string? maxOfficialRating,
             [FromQuery] bool? hasThemeSong,
             [FromQuery] bool? hasThemeVideo,
@@ -224,8 +224,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool enableTotalRecordCount = true,
             [FromQuery] bool? enableImages = true)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
+            var user = !userId.Equals(Guid.Empty)
+                ? _userManager.GetUserById(userId)
                 : null;
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -114,7 +114,7 @@ namespace Jellyfin.Api.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<QueryResult<BaseItemDto>> GetTrailers(
-            [FromQuery] Guid? userId,
+            [FromQuery] Guid userId,
             [FromQuery] string? maxOfficialRating,
             [FromQuery] bool? hasThemeSong,
             [FromQuery] bool? hasThemeVideo,


### PR DESCRIPTION
**Changes**

The user is expected to be not-null meaning the userId parameter is required. I'm quite sure a lot of other endpoints require the userId too as they often fallback to `Guid.Empty` which might throw exceptions from somewhere deeper in the code (although not tested)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
