### PR TITLE
Ignore Test Controllers

### DIFF
--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/BaseJellyfinTestController.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/BaseJellyfinTestController.cs
@@ -1,0 +1,14 @@
+﻿using Jellyfin.Api;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers
+{
+    /// <summary>
+    /// Base controller for testing infrastructure.
+    /// Automatically ignored in generated openapi spec.
+    /// </summary>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    public class BaseJellyfinTestController : BaseJellyfinApiController
+    {
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/EncoderController.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/EncoderController.cs
@@ -3,12 +3,12 @@ using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Jellyfin.Api.Controllers
+namespace Jellyfin.Server.Integration.Tests.Controllers
 {
     /// <summary>
     /// Controller for testing the encoded url.
     /// </summary>
-    public class EncoderController : BaseJellyfinApiController
+    public class EncoderController : BaseJellyfinTestController
     {
         /// <summary>
         /// Tests the url decoding.


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/6179

I tried using `Swashbuckle.Aspnetcore.Cli` but ran into DI issues, so without adding a new webhost this tool can't currently be used.