### PR TITLE
Optimizations & Simplifications - Removed multiple from String.Split to Span

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -278,7 +278,7 @@ namespace Emby.Dlna
 
                     profile = ReserializeProfile(tempProfile);
 
-                    profile.Id = path.ToLowerInvariant().GetMD5().ToString("N", CultureInfo.InvariantCulture);
+                    profile.Id = path.ToLowerInvariant().GetMD5();
 
                     _profiles[path] = new Tuple<InternalProfileInfo, DeviceProfile>(GetInternalProfileInfo(_fileSystem.GetFileInfo(path), type), profile);
 
@@ -416,7 +416,7 @@ namespace Emby.Dlna
         {
             profile = ReserializeProfile(profile);
 
-            if (string.IsNullOrEmpty(profile.Id))
+            if (profile.Id.Equals(Guid.Empty))
             {
                 throw new ArgumentException("Profile is missing Id");
             }
@@ -426,7 +426,7 @@ namespace Emby.Dlna
                 throw new ArgumentException("Profile is missing Name");
             }
 
-            var current = GetProfileInfosInternal().First(i => string.Equals(i.Info.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
+            var current = GetProfileInfosInternal().First(i => string.Equals(i.Info.Id, profile.Id.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
 
             var newFilename = _fileSystem.GetValidFilename(profile.Name) + ".xml";
             var path = Path.Combine(UserProfilesPath, newFilename);

--- a/Emby.Dlna/PlayTo/PlayToManager.cs
+++ b/Emby.Dlna/PlayTo/PlayToManager.cs
@@ -217,7 +217,7 @@ namespace Emby.Dlna.PlayTo
 
                 _sessionManager.ReportCapabilities(sessionInfo.Id, new ClientCapabilities
                 {
-                    PlayableMediaTypes = profile.GetSupportedMediaTypes(),
+                    PlayableMediaTypes = profile.SupportedMediaTypes.Split(','),
 
                     SupportedCommands = new[]
                     {

--- a/Emby.Dlna/Profiles/DefaultProfile.cs
+++ b/Emby.Dlna/Profiles/DefaultProfile.cs
@@ -12,7 +12,7 @@ namespace Emby.Dlna.Profiles
     {
         public DefaultProfile()
         {
-            Id = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+            Id = Guid.NewGuid();
             Name = "Generic Device";
 
             ProtocolInfo = "http-get:*:video/mpeg:*,http-get:*:video/mp4:*,http-get:*:video/vnd.dlna.mpeg-tts:*,http-get:*:video/avi:*,http-get:*:video/x-matroska:*,http-get:*:video/x-ms-wmv:*,http-get:*:video/wtv:*,http-get:*:audio/mpeg:*,http-get:*:audio/mp3:*,http-get:*:audio/mp4:*,http-get:*:audio/x-ms-wma:*,http-get:*:audio/wav:*,http-get:*:audio/L16:*,http-get:*:image/jpeg:*,http-get:*:image/png:*,http-get:*:image/gif:*,http-get:*:image/tiff:*";

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -46,24 +46,15 @@ namespace Emby.Dlna.Server
 
             builder.Append("<?xml version=\"1.0\"?>");
 
-            builder.Append("<root");
+            builder.Append("<root xmlns:dlna=\"urn:schemas-dlna-org:device-1-0\" xmlns=\"urn:schemas-upnp-org:device-1-0\"");
 
-            var attributes = _profile.XmlRootAttributes.ToList();
-
-            attributes.Insert(0, new XmlAttribute
+            if (_profile.XmlRootAttributes != null)
             {
-                Name = "xmlns:dlna",
-                Value = "urn:schemas-dlna-org:device-1-0"
-            });
-            attributes.Insert(0, new XmlAttribute
-            {
-                Name = "xmlns",
-                Value = "urn:schemas-upnp-org:device-1-0"
-            });
-
-            foreach (var att in attributes)
-            {
-                builder.AppendFormat(CultureInfo.InvariantCulture, " {0}=\"{1}\"", att.Name, att.Value);
+                var attributes = _profile.XmlRootAttributes.ToList();
+                foreach (var att in attributes)
+                {
+                    builder.AppendFormat(CultureInfo.InvariantCulture, " {0}=\"{1}\"", att.Name, att.Value);
+                }
             }
 
             builder.Append('>');

--- a/MediaBrowser.Model/Dlna/CodecProfile.cs
+++ b/MediaBrowser.Model/Dlna/CodecProfile.cs
@@ -1,70 +1,71 @@
-#nullable disable
-#pragma warning disable CS1591
-
 using System;
-using System.Linq;
 using System.Xml.Serialization;
+using MediaBrowser.Model.Extensions;
 
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// Defines the <see cref="CodecProfile"/>.
+    /// </summary>
     public class CodecProfile
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodecProfile"/> class.
+        /// </summary>
         public CodecProfile()
         {
             Conditions = Array.Empty<ProfileCondition>();
             ApplyConditions = Array.Empty<ProfileCondition>();
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="DlnaProfileType"/> which this container must meet.
+        /// </summary>
         [XmlAttribute("type")]
         public CodecType Type { get; set; }
 
+        /// <summary>
+        /// Gets or sets the list of <see cref="ProfileCondition"/> which this profile must meet.
+        /// </summary>
         public ProfileCondition[] Conditions { get; set; }
 
+        /// <summary>
+        /// Gets or sets the list of <see cref="ProfileCondition"/> to apply if this profile is met.
+        /// </summary>
         public ProfileCondition[] ApplyConditions { get; set; }
 
+        /// <summary>
+        /// Gets or sets the codec(s) that this profile applies to.
+        /// </summary>
         [XmlAttribute("codec")]
-        public string Codec { get; set; }
+        public string? Codec { get; set; }
 
+        /// <summary>
+        /// Gets or sets the container(s) which this profile will be applied to.
+        /// </summary>
         [XmlAttribute("container")]
-        public string Container { get; set; }
+        public string? Container { get; set; }
 
-        public string[] GetCodecs()
+        /// <summary>
+        /// Checks to see whether the codecs and containers contain the given parameters.
+        /// </summary>
+        /// <param name="codec">The codec to match.</param>
+        /// <param name="container">The container to match.</param>
+        /// <returns>True if both conditions are met.</returns>
+        public bool ContainsAnyCodec(string? codec, string container)
         {
-            return ContainerProfile.SplitValue(Codec);
+            return Container.ContainsContainer(false, container) && Codec.ContainsContainer(false, codec);
         }
 
-        private bool ContainsContainer(string container)
+        /// <summary>
+        /// Checks to see whether the codecs and containers contain the given parameters.
+        /// </summary>
+        /// <param name="codec">The codec to match.</param>
+        /// <param name="container">The container to match.</param>
+        /// <returns>True if both conditions are met.</returns>
+        public bool ContainsAnyCodec(ReadOnlySpan<char> codec, string container)
         {
-            return ContainerProfile.ContainsContainer(Container, container);
-        }
-
-        public bool ContainsAnyCodec(string codec, string container)
-        {
-            return ContainsAnyCodec(ContainerProfile.SplitValue(codec), container);
-        }
-
-        public bool ContainsAnyCodec(string[] codec, string container)
-        {
-            if (!ContainsContainer(container))
-            {
-                return false;
-            }
-
-            var codecs = GetCodecs();
-            if (codecs.Length == 0)
-            {
-                return true;
-            }
-
-            foreach (var val in codec)
-            {
-                if (codecs.Contains(val, StringComparer.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return Container.ContainsContainer(false, container) && Codec.ContainsContainer(false, codec);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/CodecProfile.cs
+++ b/MediaBrowser.Model/Dlna/CodecProfile.cs
@@ -19,7 +19,7 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="DlnaProfileType"/> which this container must meet.
+        /// Gets or sets the <see cref="CodecType"/> which this container must meet.
         /// </summary>
         [XmlAttribute("type")]
         public CodecType Type { get; set; }

--- a/MediaBrowser.Model/Dlna/ContainerProfile.cs
+++ b/MediaBrowser.Model/Dlna/ContainerProfile.cs
@@ -1,74 +1,39 @@
-#pragma warning disable CS1591
-
 using System;
-using System.Linq;
 using System.Xml.Serialization;
+using MediaBrowser.Model.Extensions;
 
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// Defines the <see cref="ContainerProfile"/>.
+    /// </summary>
     public class ContainerProfile
     {
+        /// <summary>
+        /// Gets or sets the <see cref="DlnaProfileType"/> which this container must meet.
+        /// </summary>
         [XmlAttribute("type")]
         public DlnaProfileType Type { get; set; }
 
-        public ProfileCondition[]? Conditions { get; set; } = Array.Empty<ProfileCondition>();
+        /// <summary>
+        /// Gets or sets the list of <see cref="ProfileCondition"/> which this container will be applied to.
+        /// </summary>
+        public ProfileCondition[]? Conditions { get; set; }
 
+        /// <summary>
+        /// Gets or sets the container(s) which this container must meet.
+        /// </summary>
         [XmlAttribute("container")]
-        public string Container { get; set; } = string.Empty;
+        public string? Container { get; set; }
 
-        public static string[] SplitValue(string? value)
+        /// <summary>
+        /// Returns true if an item in <paramref name="container"/> appears in the <see cref="Container"/> property.
+        /// </summary>
+        /// <param name="container">The item to match.</param>
+        /// <returns>The result of the operation.</returns>
+        public bool ContainsContainer(ReadOnlySpan<char> container)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return Array.Empty<string>();
-            }
-
-            return value.Split(',', StringSplitOptions.RemoveEmptyEntries);
-        }
-
-        public bool ContainsContainer(string? container)
-        {
-            var containers = SplitValue(Container);
-
-            return ContainsContainer(containers, container);
-        }
-
-        public static bool ContainsContainer(string? profileContainers, string? inputContainer)
-        {
-            var isNegativeList = false;
-            if (profileContainers != null && profileContainers.StartsWith('-'))
-            {
-                isNegativeList = true;
-                profileContainers = profileContainers.Substring(1);
-            }
-
-            return ContainsContainer(SplitValue(profileContainers), isNegativeList, inputContainer);
-        }
-
-        public static bool ContainsContainer(string[]? profileContainers, string? inputContainer)
-        {
-            return ContainsContainer(profileContainers, false, inputContainer);
-        }
-
-        public static bool ContainsContainer(string[]? profileContainers, bool isNegativeList, string? inputContainer)
-        {
-            if (profileContainers == null || profileContainers.Length == 0)
-            {
-                // Empty profiles always support all containers/codecs
-                return true;
-            }
-
-            var allInputContainers = SplitValue(inputContainer);
-
-            foreach (var container in allInputContainers)
-            {
-                if (profileContainers.Contains(container, StringComparer.OrdinalIgnoreCase))
-                {
-                    return !isNegativeList;
-                }
-            }
-
-            return isNegativeList;
+            return Container.ContainsContainer(container);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
+++ b/MediaBrowser.Model/Dlna/DirectPlayProfile.cs
@@ -1,37 +1,65 @@
-#pragma warning disable CS1591
-
-using System.ComponentModel.DataAnnotations;
 using System.Xml.Serialization;
+using MediaBrowser.Model.Extensions;
 
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// Defines the <see cref="DirectPlayProfile"/>.
+    /// </summary>
     public class DirectPlayProfile
     {
+        /// <summary>
+        /// Gets or sets the container.
+        /// </summary>
         [XmlAttribute("container")]
-        public string? Container { get; set; }
+        public string Container { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Gets or sets the audio codec.
+        /// </summary>
         [XmlAttribute("audioCodec")]
         public string? AudioCodec { get; set; }
 
+        /// <summary>
+        /// Gets or sets the video codec.
+        /// </summary>
         [XmlAttribute("videoCodec")]
         public string? VideoCodec { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Dlna profile type.
+        /// </summary>
         [XmlAttribute("type")]
         public DlnaProfileType Type { get; set; }
 
+        /// <summary>
+        /// Returns whether the <see cref="Container"/> supports the <paramref name="container"/>.
+        /// </summary>
+        /// <param name="container">The container to match against.</param>
+        /// <returns>True if supported.</returns>
         public bool SupportsContainer(string container)
         {
-            return ContainerProfile.ContainsContainer(Container, container);
+            return Container.ContainsContainer(container);
         }
 
+        /// <summary>
+        /// Returns whether the <see cref="VideoCodec"/> supports the <paramref name="codec"/>.
+        /// </summary>
+        /// <param name="codec">The codec to match against.</param>
+        /// <returns>True if supported.</returns>
         public bool SupportsVideoCodec(string codec)
         {
-            return Type == DlnaProfileType.Video && ContainerProfile.ContainsContainer(VideoCodec, codec);
+            return Type == DlnaProfileType.Video && VideoCodec.ContainsContainer(codec);
         }
 
+        /// <summary>
+        /// Returns whether the <see cref="AudioCodec"/> supports the <paramref name="codec"/>.
+        /// </summary>
+        /// <param name="codec">The codec to match against.</param>
+        /// <returns>True if supported.</returns>
         public bool SupportsAudioCodec(string codec)
         {
-            return (Type == DlnaProfileType.Audio || Type == DlnaProfileType.Video) && ContainerProfile.ContainsContainer(AudioCodec, codec);
+            return Type != DlnaProfileType.Photo && AudioCodec.ContainsContainer(codec);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/ResponseProfile.cs
+++ b/MediaBrowser.Model/Dlna/ResponseProfile.cs
@@ -31,21 +31,9 @@ namespace MediaBrowser.Model.Dlna
         [XmlAttribute("mimeType")]
         public string MimeType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the container(s) which this profile will be applied to.
+        /// </summary>
         public ProfileCondition[] Conditions { get; set; }
-
-        public string[] GetContainers()
-        {
-            return ContainerProfile.SplitValue(Container);
-        }
-
-        public string[] GetAudioCodecs()
-        {
-            return ContainerProfile.SplitValue(AudioCodec);
-        }
-
-        public string[] GetVideoCodecs()
-        {
-            return ContainerProfile.SplitValue(VideoCodec);
-        }
     }
 }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
@@ -56,7 +57,7 @@ namespace MediaBrowser.Model.Dlna
             foreach (StreamInfo stream in streams)
             {
                 stream.DeviceId = options.DeviceId;
-                stream.DeviceProfileId = options.Profile.Id;
+                stream.DeviceProfileId = options.Profile.Id.ToString("N", CultureInfo.InvariantCulture);
             }
 
             return GetOptimalStream(streams, options.GetMaxBitrate(true) ?? 0);
@@ -89,7 +90,7 @@ namespace MediaBrowser.Model.Dlna
             foreach (StreamInfo stream in streams)
             {
                 stream.DeviceId = options.DeviceId;
-                stream.DeviceProfileId = options.Profile.Id;
+                stream.DeviceProfileId = options.Profile.Id.ToString("N", CultureInfo.InvariantCulture);
             }
 
             return GetOptimalStream(streams, options.GetMaxBitrate(false) ?? 0);
@@ -234,29 +235,28 @@ namespace MediaBrowser.Model.Dlna
                 return null;
             }
 
-            var formats = ContainerProfile.SplitValue(inputContainer);
-
-            if (formats.Length == 1)
+            if (!inputContainer.Contains(',') || profile == null)
             {
-                return formats[0];
+                return inputContainer;
             }
 
-            if (profile != null)
+            var formats = inputContainer.SpanSplit(',');
+            foreach (var format in formats)
             {
-                foreach (var format in formats)
+                foreach (var directPlayProfile in profile.DirectPlayProfiles)
                 {
-                    foreach (var directPlayProfile in profile.DirectPlayProfiles)
+                    if (directPlayProfile.Type == type)
                     {
-                        if (directPlayProfile.Type == type
-                            && directPlayProfile.SupportsContainer(format))
+                        var formatStr = format.ToString();
+                        if (directPlayProfile.SupportsContainer(formatStr))
                         {
-                            return format;
+                            return formatStr;
                         }
                     }
                 }
             }
 
-            return formats[0];
+            return inputContainer;
         }
 
         private StreamInfo BuildAudioItem(MediaSourceInfo item, AudioOptions options)
@@ -794,12 +794,12 @@ namespace MediaBrowser.Model.Dlna
 
                         if (applyConditions)
                         {
-                            var transcodingVideoCodecs = ContainerProfile.SplitValue(transcodingProfile.VideoCodec);
+                            var transcodingVideoCodecs = transcodingProfile.VideoCodec.SpanSplit(',');
                             foreach (var transcodingVideoCodec in transcodingVideoCodecs)
                             {
                                 if (i.ContainsAnyCodec(transcodingVideoCodec, transcodingProfile.Container))
                                 {
-                                    ApplyTranscodingConditions(playlistItem, i.Conditions, transcodingVideoCodec, true, isFirstAppliedCodecProfile);
+                                    ApplyTranscodingConditions(playlistItem, i.Conditions, transcodingVideoCodec.ToString(), true, isFirstAppliedCodecProfile);
                                     isFirstAppliedCodecProfile = false;
                                 }
                             }
@@ -838,12 +838,12 @@ namespace MediaBrowser.Model.Dlna
 
                         if (applyConditions)
                         {
-                            var transcodingAudioCodecs = ContainerProfile.SplitValue(transcodingProfile.AudioCodec);
+                            var transcodingAudioCodecs = transcodingProfile.AudioCodec.SpanSplit(',');
                             foreach (var transcodingAudioCodec in transcodingAudioCodecs)
                             {
                                 if (i.ContainsAnyCodec(transcodingAudioCodec, transcodingProfile.Container))
                                 {
-                                    ApplyTranscodingConditions(playlistItem, i.Conditions, transcodingAudioCodec, true, isFirstAppliedCodecProfile);
+                                    ApplyTranscodingConditions(playlistItem, i.Conditions, transcodingAudioCodec.ToString(), true, isFirstAppliedCodecProfile);
                                     isFirstAppliedCodecProfile = false;
                                 }
                             }
@@ -1257,7 +1257,7 @@ namespace MediaBrowser.Model.Dlna
                         continue;
                     }
 
-                    if (!ContainerProfile.ContainsContainer(profile.Container, outputContainer))
+                    if (!profile.Container.ContainsContainer(outputContainer))
                     {
                         continue;
                     }
@@ -1286,7 +1286,7 @@ namespace MediaBrowser.Model.Dlna
                         continue;
                     }
 
-                    if (!ContainerProfile.ContainsContainer(profile.Container, outputContainer))
+                    if (!profile.Container.ContainsContainer(outputContainer))
                     {
                         continue;
                     }
@@ -1317,16 +1317,11 @@ namespace MediaBrowser.Model.Dlna
         {
             if (!string.IsNullOrEmpty(transcodingContainer))
             {
-                string[] normalizedContainers = ContainerProfile.SplitValue(transcodingContainer);
-
-                if (ContainerProfile.ContainsContainer(normalizedContainers, "ts")
-                    || ContainerProfile.ContainsContainer(normalizedContainers, "mpegts")
-                    || ContainerProfile.ContainsContainer(normalizedContainers, "mp4"))
+                if (transcodingContainer.ContainsContainer("ts,mpegts,mp4"))
                 {
                     return false;
                 }
-                else if (ContainerProfile.ContainsContainer(normalizedContainers, "mkv")
-                    || ContainerProfile.ContainsContainer(normalizedContainers, "matroska"))
+                else if (transcodingContainer.ContainsContainer("mkv,matroska"))
                 {
                     return true;
                 }

--- a/MediaBrowser.Model/Dlna/SubtitleProfile.cs
+++ b/MediaBrowser.Model/Dlna/SubtitleProfile.cs
@@ -1,9 +1,8 @@
 #nullable disable
 #pragma warning disable CS1591
 
-using System;
-using System.Linq;
 using System.Xml.Serialization;
+using MediaBrowser.Model.Extensions;
 
 namespace MediaBrowser.Model.Dlna
 {
@@ -24,11 +23,6 @@ namespace MediaBrowser.Model.Dlna
         [XmlAttribute("container")]
         public string Container { get; set; }
 
-        public string[] GetLanguages()
-        {
-            return ContainerProfile.SplitValue(Language);
-        }
-
         public bool SupportsLanguage(string subLanguage)
         {
             if (string.IsNullOrEmpty(Language))
@@ -41,8 +35,7 @@ namespace MediaBrowser.Model.Dlna
                 subLanguage = "und";
             }
 
-            var languages = GetLanguages();
-            return languages.Length == 0 || languages.Contains(subLanguage, StringComparer.OrdinalIgnoreCase);
+            return Language.ContainsContainer(subLanguage);
         }
     }
 }

--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -1,7 +1,7 @@
 #pragma warning disable CS1591
 
+using System;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Xml.Serialization;
 
 namespace MediaBrowser.Model.Dlna
@@ -61,10 +61,5 @@ namespace MediaBrowser.Model.Dlna
         [DefaultValue(false)]
         [XmlAttribute("breakOnNonKeyFrames")]
         public bool BreakOnNonKeyFrames { get; set; }
-
-        public string[] GetAudioCodecs()
-        {
-            return ContainerProfile.SplitValue(AudioCodec);
-        }
     }
 }

--- a/MediaBrowser.Model/Extensions/ContainerExtensions.cs
+++ b/MediaBrowser.Model/Extensions/ContainerExtensions.cs
@@ -1,0 +1,124 @@
+using System;
+
+namespace MediaBrowser.Model.Extensions
+{
+    /// <summary>
+    /// Defines the <see cref="ContainerExtensions"/> class.
+    /// </summary>
+    public static class ContainerExtensions
+    {
+        /// <summary>
+        /// Compares two containers, returning true if an item in <paramref name="inputContainer"/> does not exist
+        /// in <paramref name="profileContainers"/>.
+        /// </summary>
+        /// <param name="profileContainers">The comma-delimited string being searched.
+        /// If the parameter begins with the - character, the operation is reversed.</param>
+        /// <param name="inputContainer">The comma-delimited string being matched.</param>
+        /// <returns>The result of the operation.</returns>
+        public static bool ContainsContainer(this string? profileContainers, string? inputContainer)
+        {
+            var isNegativeList = string.IsNullOrEmpty(inputContainer);
+            if (profileContainers != null && profileContainers.StartsWith('-'))
+            {
+                isNegativeList = true;
+                profileContainers = profileContainers[1..];
+            }
+
+            return ContainsContainer(profileContainers, isNegativeList, inputContainer);
+        }
+
+        /// <summary>
+        /// Compares two containers, returning true if an item in <paramref name="inputContainer"/> does not exist
+        /// in <paramref name="profileContainers"/>.
+        /// </summary>
+        /// <param name="profileContainers">The comma-delimited string being searched.
+        /// If the parameter begins with the - character, the operation is reversed.</param>
+        /// <param name="inputContainer">The comma-delimited string being matched.</param>
+        /// <returns>The result of the operation.</returns>
+        public static bool ContainsContainer(this string? profileContainers, ReadOnlySpan<char> inputContainer)
+        {
+            var isNegativeList = inputContainer.IsEmpty;
+            if (profileContainers != null && profileContainers.StartsWith('-'))
+            {
+                isNegativeList = true;
+                profileContainers = profileContainers[1..];
+            }
+
+            return ContainsContainer(profileContainers, isNegativeList, inputContainer);
+        }
+
+        /// <summary>
+        /// Compares two containers, returning <paramref name="isNegativeList"/> if an item in <paramref name="inputContainer"/>
+        /// does not exist in <paramref name="profileContainers"/>.
+        /// </summary>
+        /// <param name="profileContainers">The comma-delimited string being searched.</param>
+        /// <param name="isNegativeList">The boolean result to return if a match is not found.</param>
+        /// <param name="inputContainer">The comma-delimited string being matched.</param>
+        /// <returns>The result of the operation.</returns>
+        public static bool ContainsContainer(this string? profileContainers, bool isNegativeList, string? inputContainer)
+        {
+            if (string.IsNullOrEmpty(profileContainers))
+            {
+                // Empty profiles always support all containers/codecs.
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(inputContainer))
+            {
+                return isNegativeList;
+            }
+
+            var allInputContainers = inputContainer.SpanSplit(',');
+            foreach (var container in allInputContainers)
+            {
+                var allProfileContainers = profileContainers.SpanSplit(',');
+                foreach (var profile in allProfileContainers)
+                {
+                    if (MemoryExtensions.Equals(profile, container, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return !isNegativeList;
+                    }
+                }
+            }
+
+            return isNegativeList;
+        }
+
+        /// <summary>
+        /// Compares two containers, returning <paramref name="isNegativeList"/> if an item in <paramref name="inputContainer"/>
+        /// does not exist in <paramref name="profileContainers"/>.
+        /// </summary>
+        /// <param name="profileContainers">The comma-delimited string being searched.</param>
+        /// <param name="isNegativeList">The boolean result to return if a match is not found.</param>
+        /// <param name="inputContainer">The comma-delimited string being matched.</param>
+        /// <returns>The result of the operation.</returns>
+        public static bool ContainsContainer(this string? profileContainers, bool isNegativeList, ReadOnlySpan<char> inputContainer)
+        {
+            if (string.IsNullOrEmpty(profileContainers))
+            {
+                // Empty profiles always support all containers/codecs.
+                return true;
+            }
+
+            if (inputContainer == null)
+            {
+                return isNegativeList;
+            }
+
+            var allInputContainers = inputContainer.Split(',');
+            foreach (var container in allInputContainers)
+            {
+                var allProfileContainers = profileContainers.SpanSplit(',');
+                foreach (var profile in allProfileContainers)
+                {
+                    if (MemoryExtensions.Equals(profile, container, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return !isNegativeList;
+                    }
+                }
+            }
+
+            return isNegativeList;
+        }
+    }
+}

--- a/MediaBrowser.Model/Extensions/ContainerExtensions.cs
+++ b/MediaBrowser.Model/Extensions/ContainerExtensions.cs
@@ -69,9 +69,9 @@ namespace MediaBrowser.Model.Extensions
             }
 
             var allInputContainers = inputContainer.SpanSplit(',');
+            var allProfileContainers = profileContainers.SpanSplit(',');
             foreach (var container in allInputContainers)
             {
-                var allProfileContainers = profileContainers.SpanSplit(',');
                 foreach (var profile in allProfileContainers)
                 {
                     if (MemoryExtensions.Equals(profile, container, StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Model/Extensions/ContainerExtensions.cs
+++ b/MediaBrowser.Model/Extensions/ContainerExtensions.cs
@@ -106,9 +106,9 @@ namespace MediaBrowser.Model.Extensions
             }
 
             var allInputContainers = inputContainer.Split(',');
+            var allProfileContainers = profileContainers.SpanSplit(',');
             foreach (var container in allInputContainers)
             {
-                var allProfileContainers = profileContainers.SpanSplit(',');
                 foreach (var profile in allProfileContainers)
                 {
                     if (MemoryExtensions.Equals(profile, container, StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.Model/Extensions/SplitStringExtensions.cs
+++ b/MediaBrowser.Model/Extensions/SplitStringExtensions.cs
@@ -1,0 +1,95 @@
+/*
+MIT License
+
+Copyright (c) 2019 Gérald Barré
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#pragma warning disable CS1591
+#pragma warning disable CA1034
+using System;
+using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+
+namespace MediaBrowser.Model.Extensions
+{
+    /// <summary>
+    /// Extension class for splitting lines without unnecessary allocations.
+    /// </summary>
+    public static class SplitStringExtensions
+    {
+        /// <summary>
+        /// Creates a new string split enumerator.
+        /// </summary>
+        /// <param name="str">The string to split.</param>
+        /// <param name="separator">The separator to split on.</param>
+        /// <returns>The enumerator struct.</returns>
+        [Pure]
+        public static SplitEnumerator SpanSplit(this string str, char separator) => new (str.AsSpan(), separator);
+
+        /// <summary>
+        /// Creates a new span split enumerator.
+        /// </summary>
+        /// <param name="str">The span to split.</param>
+        /// <param name="separator">The separator to split on.</param>
+        /// <returns>The enumerator struct.</returns>
+        [Pure]
+        public static SplitEnumerator Split(this ReadOnlySpan<char> str, char separator) => new (str, separator);
+
+        [StructLayout(LayoutKind.Auto)]
+        public ref struct SplitEnumerator
+        {
+            private readonly char _separator;
+            private ReadOnlySpan<char> _str;
+
+            public SplitEnumerator(ReadOnlySpan<char> str, char separator)
+            {
+                _str = str;
+                _separator = separator;
+                Current = default;
+            }
+
+            public ReadOnlySpan<char> Current { get; private set; }
+
+            public readonly SplitEnumerator GetEnumerator() => this;
+
+            public bool MoveNext()
+            {
+                if (_str.Length == 0)
+                {
+                    return false;
+                }
+
+                var span = _str;
+                var index = span.IndexOf(_separator);
+                if (index == -1)
+                {
+                    _str = ReadOnlySpan<char>.Empty;
+                    Current = span;
+                    return true;
+                }
+
+                Current = span.Slice(0, index);
+                _str = span[(index + 1)..];
+                return true;
+            }
+        }
+    }
+}

--- a/tests/Jellyfin.Model.Tests/Dlna/ContainerProfileTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/ContainerProfileTests.cs
@@ -1,4 +1,6 @@
+using System;
 using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Extensions;
 using Xunit;
 
 namespace Jellyfin.Model.Tests.Dlna
@@ -11,9 +13,42 @@ namespace Jellyfin.Model.Tests.Dlna
         [InlineData(null)]
         [InlineData("")]
         [InlineData("mp4")]
-        public void ContainsContainer_EmptyContainerProfile_True(string? containers)
+        public void ContainsContainer_EmptyContainerProfile_True(string containers)
         {
             Assert.True(_emptyContainerProfile.ContainsContainer(containers));
+        }
+
+        [InlineData("mp3,mpeg", "mp3")]
+        [InlineData("mp3,mpeg", "")]
+        [InlineData("mp3,mpeg", null)]
+        [InlineData("mp3,mpeg,avi", "mp3,avi")]
+        [InlineData("-mp3,mpeg", "avi")]
+        [InlineData("-mp3,mpeg,avi", "mp4,jpg")]
+        [Theory]
+        public void ContainsContainer_Contains_True(string container, string extension)
+        {
+            Assert.True(container.ContainsContainer(extension));
+        }
+
+        [InlineData("mp3,mpeg", "avi")]
+        [InlineData("mp3,mpeg,avi", "mp4,jpg")]
+        [InlineData("-mp3,mpeg", "mp3")]
+        [InlineData("-mp3,mpeg,avi", "mpeg,avi")]
+        [Theory]
+        public void ContainsContainer_Contains_False(string container, string extension)
+        {
+            Assert.False(container.ContainsContainer(extension));
+        }
+
+        [InlineData("mp3,mpeg", "mp3")]
+        [InlineData("mp3,mpeg", "")]
+        [InlineData("mp3,mpeg,avi", "mp3,avi")]
+        [InlineData("-mp3,mpeg", "avi")]
+        [InlineData("-mp3,mpeg,avi", "mp4,jpg")]
+        [Theory]
+        public void ContainsContainer_Contains_True_SpanVersion(string container, string extension)
+        {
+            Assert.True(container.ContainsContainer(extension.AsSpan()));
         }
     }
 }


### PR DESCRIPTION
Replaced all string.Split with Spans.
Simplified container contains code
Commented.
Nullable'd.
Added more tests.

Changed Profile.Id to Guid - in prep for DLNA plugin.

Before anyone points it out - i've had to duplicate the SplitStringExtension.cs as it cannot be accessed from model.
Looking to move this code out post DLNA plugins, so this is really only a temp step.
