### PR TITLE
disable project automation workflows in forks

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -11,6 +11,7 @@ jobs:
   label:
     name: Labeling
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'jellyfin/jellyfin' }}
     steps:
       - name: Apply label
         uses: eps1lon/actions-label-merge-conflict@v2.0.1
@@ -22,6 +23,7 @@ jobs:
   project:
     name: Project board
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'jellyfin/jellyfin' }}
     steps:
       - name: Remove from 'Current Release' project
         uses: alex-page/github-project-automation-plus@v0.7.1


### PR DESCRIPTION
### Description 

these workflows always fail in forks due to missing tokens etc. so this PR adds a condition so they only run here

### Changes

* add if check to automation workflow steps to prevent running in forks

### Issues

* n/a?
