### PR TITLE
add auto-bump_version workflow

### DIFF
--- a/.github/workflows/auto-bump_version.yml
+++ b/.github/workflows/auto-bump_version.yml
@@ -1,0 +1,96 @@
+name: Auto bump_version
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      TAG_BRANCH:
+        required: true
+        description: release-x.y.z
+      NEXT_VERSION:
+        required: true
+        description: x.y.z
+
+jobs:
+  auto_bump_version:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' && !contains(github.event.release.tag_name, 'rc') }}
+    env:
+      TAG_BRANCH: ${{ github.event.release.target_commitish }}
+    steps:
+      - name: Wait for deploy checks to finish
+        uses: jitterbit/await-check-suites@v1
+        with:
+          ref: ${{ env.TAG_BRANCH }}
+          intervalSeconds: 60
+          timeoutSeconds: 3600
+
+      - name: Setup YQ
+        uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: v4.9.6
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TAG_BRANCH }}
+
+      - name: Setup EnvVars
+        run: |-
+          CURRENT_VERSION=$(yq e '.version' build.yaml)
+          CURRENT_MAJOR_MINOR=${CURRENT_VERSION%.*}
+          CURRENT_PATCH=${CURRENT_VERSION##*.}
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+          echo "CURRENT_MAJOR_MINOR=${CURRENT_MAJOR_MINOR}" >> $GITHUB_ENV
+          echo "CURRENT_PATCH=${CURRENT_PATCH}" >> $GITHUB_ENV
+          echo "NEXT_VERSION=${CURRENT_MAJOR_MINOR}.$(($CURRENT_PATCH + 1))" >> $GITHUB_ENV
+
+      - name: Run bump_version
+        run: ./bump_version ${{ env.NEXT_VERSION }}
+
+      - name: Commit Changes
+        run: |-
+          git config user.name "jellyfin-bot"
+          git config user.email "team@jellyfin.org"
+          git checkout ${{ env.TAG_BRANCH }}
+          git commit -am "Bump version to ${{ env.NEXT_VERSION }}"
+          git push origin ${{ env.TAG_BRANCH }}
+
+  manual_bump_version:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    env:
+      TAG_BRANCH: ${{ github.event.inputs.TAG_BRANCH }}
+    steps:
+      - name: Setup YQ
+        uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: v4.9.6
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TAG_BRANCH }}
+
+      - name: Setup EnvVars
+        run: |-
+          CURRENT_VERSION=$(yq e '.version' build.yaml)
+          CURRENT_MAJOR_MINOR=${CURRENT_VERSION%.*}
+          CURRENT_PATCH=${CURRENT_VERSION##*.}
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+          echo "CURRENT_MAJOR_MINOR=${CURRENT_MAJOR_MINOR}" >> $GITHUB_ENV
+          echo "CURRENT_PATCH=${CURRENT_PATCH}" >> $GITHUB_ENV
+          echo "NEXT_VERSION=${{ github.event.inputs.NEXT_VERSION }}" >> $GITHUB_ENV
+
+      - name: Run bump_version
+        run: ./bump_version ${{ env.NEXT_VERSION }}
+
+      - name: Commit Changes
+        run: |-
+          git config user.name "jellyfin-bot"
+          git config user.email "team@jellyfin.org"
+          git checkout ${{ env.TAG_BRANCH }}
+          git commit -am "Bump version to ${{ env.NEXT_VERSION }}"
+          git push origin ${{ env.TAG_BRANCH }}

--- a/.github/workflows/auto-bump_version.yml
+++ b/.github/workflows/auto-bump_version.yml
@@ -63,26 +63,12 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     env:
       TAG_BRANCH: ${{ github.event.inputs.TAG_BRANCH }}
+      NEXT_VERSION: ${{ github.event.inputs.NEXT_VERSION }}
     steps:
-      - name: Setup YQ
-        uses: chrisdickinson/setup-yq@latest
-        with:
-          yq-version: v4.9.6
-
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           ref: ${{ env.TAG_BRANCH }}
-
-      - name: Setup EnvVars
-        run: |-
-          CURRENT_VERSION=$(yq e '.version' build.yaml)
-          CURRENT_MAJOR_MINOR=${CURRENT_VERSION%.*}
-          CURRENT_PATCH=${CURRENT_VERSION##*.}
-          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
-          echo "CURRENT_MAJOR_MINOR=${CURRENT_MAJOR_MINOR}" >> $GITHUB_ENV
-          echo "CURRENT_PATCH=${CURRENT_PATCH}" >> $GITHUB_ENV
-          echo "NEXT_VERSION=${{ github.event.inputs.NEXT_VERSION }}" >> $GITHUB_ENV
 
       - name: Run bump_version
         run: ./bump_version ${{ env.NEXT_VERSION }}

--- a/.github/workflows/repo-bump-version.yaml
+++ b/.github/workflows/repo-bump-version.yaml
@@ -1,4 +1,4 @@
-name: Auto bump_version
+name: '🆙 Auto bump_version'
 
 on:
   release:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup YQ
         uses: chrisdickinson/setup-yq@latest
         with:
-          yq-version: v4.9.6
+          yq-version: v4.9.8
 
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description

This PR adds a basic GH Action workflow to automatically run the [bump_version](https://github.com/jellyfin/jellyfin/blob/master/bump_version) script on a `release-x.y.z` branch as soon as a release gets published and commit its changes to that branch.
I made the assumption that the CI triggered to publish a release propergates its results back via the GH Checks API, terefor the workflow will wait until all checks of the tagged commit are successful or will time out after 1h.

### NOTES

* for this to work on 10.7.x we would have to 'backport' this workflow into that branch (as it will only work if it exists in the branch associated to the release)
* for RC versions the auto bump wont trigger as I cannot predict the future and say if the next release will be a `rc` too. However, this action can be triggered manually and will  bump the version to the specified in the manual trigger

### Changes

* add auto-bump_version workflow

### Issues

* n/a
