### PR TITLE
Use artist backdrop for generated library image

### DIFF
--- a/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -149,6 +149,9 @@ namespace Jellyfin.Drawing.Skia
 
             canvas.DrawText(libraryName, width / 2f, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
 
+            paintColor.Dispose();
+            textPaint.Dispose();
+
             return bitmap;
         }
 

--- a/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -112,7 +112,7 @@ namespace Jellyfin.Drawing.Skia
             canvas.DrawImage(residedBackdrop, 0, 0);
 
             // draw shadow rectangle
-            var paintColor = new SKPaint
+            using var paintColor = new SKPaint
             {
                 Color = SKColors.Black.WithAlpha(0x78),
                 Style = SKPaintStyle.Fill
@@ -130,7 +130,7 @@ namespace Jellyfin.Drawing.Skia
             }
 
             // draw library name
-            var textPaint = new SKPaint
+            using var textPaint = new SKPaint
             {
                 Color = SKColors.White,
                 Style = SKPaintStyle.Fill,
@@ -148,9 +148,6 @@ namespace Jellyfin.Drawing.Skia
             }
 
             canvas.DrawText(libraryName, width / 2f, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
-
-            paintColor.Dispose();
-            textPaint.Dispose();
 
             return bitmap;
         }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
@@ -2384,6 +2385,17 @@ namespace MediaBrowser.Controller.Entities
                     DateModified = chapter.ImageDateModified,
                     Type = imageType
                 };
+            }
+
+            // Music albums usually don't have dedicated backdrops, so return one from the artist instead
+            if (GetType() == typeof(MusicAlbum) && imageType == ImageType.Backdrop)
+            {
+                var artist = FindParent<MusicArtist>();
+
+                if (artist != null)
+                {
+                    return artist.GetImages(imageType).ElementAtOrDefault(imageIndex);
+                }
             }
 
             return GetImages(imageType)


### PR DESCRIPTION
**Changes**

Use the artist backdrop for music library images, instead of the primary image of the album.

Before
![image](https://user-images.githubusercontent.com/19396809/124338688-9e7ed400-dba9-11eb-96f0-ac490fd10ca7.png)
After
![image](https://user-images.githubusercontent.com/19396809/124338693-a63e7880-dba9-11eb-8f13-46c090b1b9c9.png)

Rider also complained about paintColor and textPaint not being properly disposed, so I added that too.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
