### PR TITLE
Reduce warnings in MediaBrowser.Controller

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -164,7 +164,7 @@ namespace Emby.Server.Implementations.Collections
                     DateCreated = DateTime.UtcNow
                 };
 
-                parentFolder.AddChild(collection, CancellationToken.None);
+                parentFolder.AddChild(collection);
 
                 if (options.ItemIdList.Count > 0)
                 {

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -147,7 +147,7 @@ namespace Emby.Server.Implementations.Playlists
 
                 playlist.SetMediaType(options.MediaType);
 
-                parentFolder.AddChild(playlist, CancellationToken.None);
+                parentFolder.AddChild(playlist);
 
                 await playlist.RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(_fileSystem)) { ForceSave = true }, CancellationToken.None)
                     .ConfigureAwait(false);

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1496,7 +1496,7 @@ namespace Jellyfin.Api.Controllers
                 args += " -ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture);
             }
 
-            args += _encodingHelper.GetAudioFilterParam(state, _encodingOptions, true);
+            args += _encodingHelper.GetAudioFilterParam(state, _encodingOptions);
 
             return args;
         }

--- a/Jellyfin.Api/Controllers/VideoHlsController.cs
+++ b/Jellyfin.Api/Controllers/VideoHlsController.cs
@@ -485,7 +485,7 @@ namespace Jellyfin.Api.Controllers
                 args += " -ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture);
             }
 
-            args += _encodingHelper.GetAudioFilterParam(state, _encodingOptions, true);
+            args += _encodingHelper.GetAudioFilterParam(state, _encodingOptions);
 
             return args;
         }

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -206,9 +206,8 @@ namespace MediaBrowser.Controller.Entities
         /// Adds the child.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="InvalidOperationException">Unable to add  + item.Name.</exception>
-        public void AddChild(BaseItem item, CancellationToken cancellationToken)
+        public void AddChild(BaseItem item)
         {
             item.SetParent(this);
 
@@ -1383,18 +1382,6 @@ namespace MediaBrowser.Controller.Entities
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Gets allowed recursive children of an item.
-        /// </summary>
-        /// <param name="user">The user.</param>
-        /// <param name="includeLinkedChildren">if set to <c>true</c> [include linked children].</param>
-        /// <returns>IEnumerable{BaseItem}.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public IEnumerable<BaseItem> GetRecursiveChildren(User user, bool includeLinkedChildren = true)
-        {
-            return GetRecursiveChildren(user, null);
         }
 
         public virtual IEnumerable<BaseItem> GetRecursiveChildren(User user, InternalItemsQuery query)

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -65,7 +65,7 @@ namespace MediaBrowser.Controller.Entities
             switch (viewType)
             {
                 case CollectionType.Folders:
-                    return GetResult(_libraryManager.GetUserRootFolder().GetChildren(user, true), queryParent, query);
+                    return GetResult(_libraryManager.GetUserRootFolder().GetChildren(user, true), query);
 
                 case CollectionType.TvShows:
                     return GetTvView(queryParent, user, query);
@@ -110,7 +110,7 @@ namespace MediaBrowser.Controller.Entities
                     return GetMovieMovies(queryParent, user, query);
 
                 case SpecialFolder.MovieCollections:
-                    return GetMovieCollections(queryParent, user, query);
+                    return GetMovieCollections(user, query);
 
                 case SpecialFolder.TvFavoriteEpisodes:
                     return GetFavoriteEpisodes(queryParent, user, query);
@@ -122,7 +122,7 @@ namespace MediaBrowser.Controller.Entities
                     {
                         if (queryParent is UserView)
                         {
-                            return GetResult(GetMediaFolders(user).OfType<Folder>().SelectMany(i => i.GetChildren(user, true)), queryParent, query);
+                            return GetResult(GetMediaFolders(user).OfType<Folder>().SelectMany(i => i.GetChildren(user, true)), query);
                         }
 
                         return queryParent.GetItems(query);
@@ -160,7 +160,7 @@ namespace MediaBrowser.Controller.Entities
                 GetUserView(SpecialFolder.MovieGenres, "Genres", "5", parent)
             };
 
-            return GetResult(list, parent, query);
+            return GetResult(list, query);
         }
 
         private QueryResult<BaseItem> GetFavoriteMovies(Folder parent, User user, InternalItemsQuery query)
@@ -207,7 +207,7 @@ namespace MediaBrowser.Controller.Entities
             return _libraryManager.GetItemsResult(query);
         }
 
-        private QueryResult<BaseItem> GetMovieCollections(Folder parent, User user, InternalItemsQuery query)
+        private QueryResult<BaseItem> GetMovieCollections(User user, InternalItemsQuery query)
         {
             query.Parent = null;
             query.IncludeItemTypes = new[] { nameof(BoxSet) };
@@ -275,9 +275,9 @@ namespace MediaBrowser.Controller.Entities
                     }
                 })
                 .Where(i => i != null)
-                .Select(i => GetUserViewWithName(i.Name, SpecialFolder.MovieGenre, i.SortName, parent));
+                .Select(i => GetUserViewWithName(SpecialFolder.MovieGenre, i.SortName, parent));
 
-            return GetResult(genres, parent, query);
+            return GetResult(genres, query);
         }
 
         private QueryResult<BaseItem> GetMovieGenreItems(Folder queryParent, Folder displayParent, User user, InternalItemsQuery query)
@@ -323,7 +323,7 @@ namespace MediaBrowser.Controller.Entities
                 GetUserView(SpecialFolder.TvGenres, "Genres", "6", parent)
             };
 
-            return GetResult(list, parent, query);
+            return GetResult(list, query);
         }
 
         private QueryResult<BaseItem> GetTvLatest(Folder parent, User user, InternalItemsQuery query)
@@ -403,9 +403,9 @@ namespace MediaBrowser.Controller.Entities
                     }
                 })
                 .Where(i => i != null)
-                .Select(i => GetUserViewWithName(i.Name, SpecialFolder.TvGenre, i.SortName, parent));
+                .Select(i => GetUserViewWithName(SpecialFolder.TvGenre, i.SortName, parent));
 
-            return GetResult(genres, parent, query);
+            return GetResult(genres, query);
         }
 
         private QueryResult<BaseItem> GetTvGenreItems(Folder queryParent, Folder displayParent, User user, InternalItemsQuery query)
@@ -432,13 +432,12 @@ namespace MediaBrowser.Controller.Entities
 
         private QueryResult<BaseItem> GetResult<T>(
             IEnumerable<T> items,
-            BaseItem queryParent,
             InternalItemsQuery query)
             where T : BaseItem
         {
             items = items.Where(i => Filter(i, query.User, query, _userDataManager, _libraryManager));
 
-            return PostFilterAndSort(items, queryParent, null, query, _libraryManager, _config);
+            return PostFilterAndSort(items, null, query, _libraryManager);
         }
 
         public static bool FilterItem(BaseItem item, InternalItemsQuery query)
@@ -448,11 +447,9 @@ namespace MediaBrowser.Controller.Entities
 
         public static QueryResult<BaseItem> PostFilterAndSort(
             IEnumerable<BaseItem> items,
-            BaseItem queryParent,
             int? totalRecordLimit,
             InternalItemsQuery query,
-            ILibraryManager libraryManager,
-            IServerConfigurationManager configurationManager)
+            ILibraryManager libraryManager)
         {
             var user = query.User;
 
@@ -1001,7 +998,7 @@ namespace MediaBrowser.Controller.Entities
             return new BaseItem[] { parent };
         }
 
-        private UserView GetUserViewWithName(string name, string type, string sortName, BaseItem parent)
+        private UserView GetUserViewWithName(string type, string sortName, BaseItem parent)
         {
             return _userViewManager.GetUserSubView(parent.Id, parent.Id.ToString("N", CultureInfo.InvariantCulture), type, sortName);
         }

--- a/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
@@ -82,7 +82,7 @@ namespace MediaBrowser.Controller.LiveTv
             return "TvChannel";
         }
 
-        public IEnumerable<BaseItem> GetTaggedItems(IEnumerable<BaseItem> inputItems)
+        public IEnumerable<BaseItem> GetTaggedItems()
         {
             return new List<BaseItem>();
         }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1692,7 +1692,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             return 128000;
         }
 
-        public string GetAudioFilterParam(EncodingJobInfo state, EncodingOptions encodingOptions, bool isHls)
+        public string GetAudioFilterParam(EncodingJobInfo state, EncodingOptions encodingOptions)
         {
             var channels = state.OutputAudioChannels;
 
@@ -3836,7 +3836,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 args += " -ar " + state.OutputAudioSampleRate.Value.ToString(_usCulture);
             }
 
-            args += GetAudioFilterParam(state, encodingOptions, false);
+            args += GetAudioFilterParam(state, encodingOptions);
 
             return args;
         }

--- a/MediaBrowser.Controller/Providers/ItemLookupInfo.cs
+++ b/MediaBrowser.Controller/Providers/ItemLookupInfo.cs
@@ -23,7 +23,7 @@ namespace MediaBrowser.Controller.Providers
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the original title
+        /// Gets or sets the original title.
         /// </summary>
         /// <value>The original title of the item.</value>
         public string OriginalTitle { get; set; }

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -187,7 +187,7 @@ namespace MediaBrowser.Providers.TV
                 SeriesName = series.Name
             };
 
-            series.AddChild(season, cancellationToken);
+            series.AddChild(season);
 
             await season.RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes:
[SA1629] Documentation text should end with a period
[CA1801] Parameter is never used. Remove the parameter or use it in the method body.

Remaining:
CA1711
CA2227
CA1002
CA1819
SA1201
SA1622
CA1051
SA1401
SA1306
CA1008
CA1721
SA1214
CA2211
SA1203
CA1044
SA1615
SA1611
SA1618
SA1627
CA1707
SA1614
CA1508
SA1617
CA1826
CA1835
CA1033
CA1724
CA1711
SA1629

