### PR TITLE
Fix spelling of artist K/DA in splitting whitelist

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -47,7 +47,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             "LOONA 1/3",
             "LOONA / yyxy",
             "LOONA / ODD EYE CIRCLE",
-            "KD/A"
+            "K/DA"
         };
 
         public MediaInfo GetMediaInfo(InternalMediaInfoResult data, VideoType? videoType, bool isAudio, string path, MediaProtocol protocol)


### PR DESCRIPTION
Spelling fix for artist K/DA. Checked the musicbrainz database to make sure "KD/A" is not a valid artist too. 