### PR TITLE
Restore #5717 on 10.7.x

### DIFF
--- a/Jellyfin.Data/Entities/CustomItemDisplayPreferences.cs
+++ b/Jellyfin.Data/Entities/CustomItemDisplayPreferences.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Data.Entities
         /// <param name="client">The client.</param>
         /// <param name="preferenceKey">The preference key.</param>
         /// <param name="preferenceValue">The preference value.</param>
-        public CustomItemDisplayPreferences(Guid userId, Guid itemId, string client, string preferenceKey, string preferenceValue)
+        public CustomItemDisplayPreferences(Guid userId, Guid itemId, string client, string preferenceKey, string? preferenceValue)
         {
             UserId = userId;
             ItemId = itemId;
@@ -84,7 +84,6 @@ namespace Jellyfin.Data.Entities
         /// <remarks>
         /// Required.
         /// </remarks>
-        [Required]
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 }

--- a/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
+++ b/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
@@ -67,7 +67,7 @@ namespace Jellyfin.Server.Implementations.Users
         }
 
         /// <inheritdoc />
-        public Dictionary<string, string> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client)
+        public Dictionary<string, string?> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client)
         {
             return _dbContext.CustomItemDisplayPreferences
                 .AsQueryable()

--- a/MediaBrowser.Controller/IDisplayPreferencesManager.cs
+++ b/MediaBrowser.Controller/IDisplayPreferencesManager.cs
@@ -48,7 +48,7 @@ namespace MediaBrowser.Controller
         /// <param name="itemId">The item id.</param>
         /// <param name="client">The client string.</param>
         /// <returns>The dictionary of custom item display preferences.</returns>
-        Dictionary<string, string?> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client);
+        Dictionary<string, string> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client);
 
         /// <summary>
         /// Sets the custom item display preference for the user and client.

--- a/MediaBrowser.Controller/IDisplayPreferencesManager.cs
+++ b/MediaBrowser.Controller/IDisplayPreferencesManager.cs
@@ -48,7 +48,7 @@ namespace MediaBrowser.Controller
         /// <param name="itemId">The item id.</param>
         /// <param name="client">The client string.</param>
         /// <returns>The dictionary of custom item display preferences.</returns>
-        Dictionary<string, string> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client);
+        Dictionary<string, string?> ListCustomItemDisplayPreferences(Guid userId, Guid itemId, string client);
 
         /// <summary>
         /// Sets the custom item display preference for the user and client.


### PR DESCRIPTION
I'm running into this bug on 10.7.6, it's been fixed in master only so I want to backport it to the 10.7.z branch.

**Changes**
Backport #5717 on 10.7.z branch.


**Issue**
Stack trace with issue:
```
Jul 10 22:16:48 trinity docker[8567]: System.InvalidOperationException: The data is NULL at ordinal 5. This method can't be called on NULL values. Check using IsDBNull before calling.
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteValueReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteDataReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at lambda_method694(Closure , QueryContext , DbDataReader , ResultContext , SingleQueryResultCoordinator )
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.Enumerator.MoveNext()
Jul 10 22:16:48 trinity docker[8567]: System.InvalidOperationException: The data is NULL at ordinal 5. This method can't be called on NULL values. Check using IsDBNull before calling.
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteValueReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteDataReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at lambda_method694(Closure , QueryContext , DbDataReader , ResultContext , SingleQueryResultCoordinator )
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.Enumerator.MoveNext()
Jul 10 22:16:48 trinity docker[8567]: [02:16:48] [ERR] [39] Jellyfin.Server.Middleware.ExceptionMiddleware: Error processing request. URL GET /DisplayPreferences/usersettings.
Jul 10 22:16:48 trinity docker[8567]: System.InvalidOperationException: The data is NULL at ordinal 5. This method can't be called on NULL values. Check using IsDBNull before calling.
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteValueReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.Data.Sqlite.SqliteDataReader.GetString(Int32 ordinal)
Jul 10 22:16:48 trinity docker[8567]:    at lambda_method694(Closure , QueryContext , DbDataReader , ResultContext , SingleQueryResultCoordinator )
Jul 10 22:16:48 trinity docker[8567]:    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.Enumerator.MoveNext()
Jul 10 22:16:48 trinity docker[8567]:    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
Jul 10 22:16:48 trinity docker[8567]:    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
Jul 10 22:16:48 trinity docker[8567]:    at Jellyfin.Server.Implementations.Users.DisplayPreferencesManager.ListCustomItemDisplayPreferences(Guid userId, Guid itemId, String client)
Jul 10 22:16:48 trinity docker[8567]:    at Jellyfin.Api.Controllers.DisplayPreferencesController.GetDisplayPreferences(String displayPreferencesId, Guid userId, String client)
```