### PR TITLE
Add OpenAPI workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,119 @@
+name: OpenAPI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  openapi-head:
+    name: OpenAPI - HEAD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Generate openapi.json
+        run: dotnet test -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@v2
+        with:
+          name: openapi-head
+          retention-days: 14
+          if-no-files-found: error
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net5.0/openapi.json
+
+  openapi-base:
+    name: OpenAPI - BASE
+    if: ${{ github.base_ref != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Generate openapi.json
+        run: dotnet test -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@v2
+        with:
+          name: openapi-base
+          retention-days: 14
+          if-no-files-found: error
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net5.0/openapi.json
+
+  openapi-diff:
+    name: OpenAPI - Difference
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - openapi-head
+      - openapi-base
+    steps:
+      - name: Download openapi-head
+        uses: actions/download-artifact@v2
+        with:
+          name: openapi-head
+          path: openapi-head
+      - name: Download openapi-base
+        uses: actions/download-artifact@v2
+        with:
+          name: openapi-base
+          path: openapi-base
+      - name: Workaround openapi-diff issue
+        run: |
+          sed -i 's/"allOf"/"oneOf"/g' openapi-head/openapi.json
+          sed -i 's/"allOf"/"oneOf"/g' openapi-base/openapi.json
+      - name: Calculate OpenAPI difference
+        uses: docker://openapitools/openapi-diff
+        continue-on-error: true
+        with:
+          args: --fail-on-changed --markdown openapi-changes.md openapi-base/openapi.json openapi-head/openapi.json
+      - id: read-diff
+        name: Read openapi-diff output
+        run: |
+          body=$(cat openapi-changes.md)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=body::$body
+      - name: Find difference comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          direction: last
+          body-includes: openapi-diff-workflow-comment
+      - name: Reply or edit difference comment (changed)
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        if: ${{ steps.read-diff.outputs.body != '' }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!--openapi-diff-workflow-comment-->
+            <details>
+            <summary>Changes in OpenAPI specification found. Expand to see details.</summary>
+
+            ${{ steps.read-diff.outputs.body }}
+
+            </details>
+      - name: Edit difference comment (unchanged)
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        if: ${{ steps.read-diff.outputs.body == '' && steps.find-comment.outputs.comment-id != '' }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!--openapi-diff-workflow-comment-->
+
+            No changes to OpenAPI specification found. See history of this comment for previous changes.

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           dotnet-version: '5.0.x'
       - name: Generate openapi.json
-        run: dotnet test -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+        run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
       - name: Upload openapi.json
         uses: actions/upload-artifact@v2
         with:
@@ -40,7 +40,7 @@ jobs:
         with:
           dotnet-version: '5.0.x'
       - name: Generate openapi.json
-        run: dotnet test -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+        run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
       - name: Upload openapi.json
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
+          include-prerelease: true
       - name: Generate openapi.json
         run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
       - name: Upload openapi.json
@@ -24,7 +25,7 @@ jobs:
           name: openapi-head
           retention-days: 14
           if-no-files-found: error
-          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net5.0/openapi.json
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net6.0/openapi.json
 
   openapi-base:
     name: OpenAPI - BASE
@@ -38,7 +39,8 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
+          include-prerelease: true
       - name: Generate openapi.json
         run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
       - name: Upload openapi.json
@@ -47,7 +49,7 @@ jobs:
           name: openapi-base
           retention-days: 14
           if-no-files-found: error
-          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net5.0/openapi.json
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net6.0/openapi.json
 
   openapi-diff:
     name: OpenAPI - Difference


### PR DESCRIPTION
**Changes**
Add a new workflow called that does the following things:
- Generate OpenAPI spec for master branch
  - although already available via azure on repo.jellyfin.org, this adds it the the GitHub interface
- Generate OpenAPI spec for master branch
  - Useful when I need to test something with the Kotlin SDK, or to inspect changes in the file
- Calculate difference between PR spec and baseline (target branch) spec using [openapi-diff](https://github.com/OpenAPITools/openapi-diff)
  - Diff is rendered using markdown and added as a comment to the PR
  - If the PR is updated it will update the existing comment
  - Comment uses a `<details>` element to prevent skyscraper tall comments
    - For example, when updating BaseItemDto

The comments will help reviewers to determine if a PR contains breaking API changes, which might not be easy to notice in the code reviews.

**To do**
Some work left for this PR that I need some help with:

- Need to use `pull_request_target` instead of `pull_request` BUT this would allow a malicious actor to expose secrets by making changes to the .NET code. No idea how to fix.
  - Need to use jellyfin-bot for comment
- Detect the commit of the base branch the head branch is based on to use as a baseline to prevent changes made in the API in base showing up in the diff.
  - example: property removed from baseitemdto in master would also show up in this PR if the change wasn't in master when this branch was created.
  - I don't think this is a huge issue right now as API changes are scarce, it could become an issue with jf 11 dev though.

**Issues**

**Example**
See my personal fork for an example of this workflow: https://github.com/nielsvanvelzen/jellyfin/pull/91

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
