### PR TITLE
Fix warning in MediaBrowser.Controllers/Channels

### DIFF
--- a/MediaBrowser.Controller/Channels/Channel.cs
+++ b/MediaBrowser.Controller/Channels/Channel.cs
@@ -17,6 +17,12 @@ namespace MediaBrowser.Controller.Channels
 {
     public class Channel : Folder
     {
+        [JsonIgnore]
+        public override bool SupportsInheritedParentImages => false;
+
+        [JsonIgnore]
+        public override SourceType SourceType => SourceType.Channel;
+
         public override bool IsVisible(User user)
         {
             var blockedChannelsPreference = user.GetPreferenceValues<Guid>(PreferenceKind.BlockedChannels);
@@ -38,12 +44,6 @@ namespace MediaBrowser.Controller.Channels
 
             return base.IsVisible(user);
         }
-
-        [JsonIgnore]
-        public override bool SupportsInheritedParentImages => false;
-
-        [JsonIgnore]
-        public override SourceType SourceType => SourceType.Channel;
 
         protected override QueryResult<BaseItem> GetItemsInternal(InternalItemsQuery query)
         {

--- a/MediaBrowser.Controller/Channels/ChannelItemInfo.cs
+++ b/MediaBrowser.Controller/Channels/ChannelItemInfo.cs
@@ -1,6 +1,6 @@
 #nullable disable
 
-#pragma warning disable CS1591
+#pragma warning disable CA1002, CA2227, CS1591
 
 using System;
 using System.Collections.Generic;

--- a/MediaBrowser.Controller/Channels/ChannelItemResult.cs
+++ b/MediaBrowser.Controller/Channels/ChannelItemResult.cs
@@ -1,6 +1,6 @@
 #nullable disable
 
-#pragma warning disable CS1591
+#pragma warning disable CA1002, CA2227, CS1591
 
 using System.Collections.Generic;
 

--- a/MediaBrowser.Controller/Channels/IHasFolderAttributes.cs
+++ b/MediaBrowser.Controller/Channels/IHasFolderAttributes.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+﻿#pragma warning disable CA1819, CS1591
 
 namespace MediaBrowser.Controller.Channels
 {

--- a/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
+++ b/MediaBrowser.Controller/Channels/InternalChannelFeatures.cs
@@ -1,6 +1,6 @@
 #nullable disable
 
-#pragma warning disable CS1591
+#pragma warning disable CA1002, CA2227, CS1591
 
 using System.Collections.Generic;
 using MediaBrowser.Model.Channels;


### PR DESCRIPTION
Fixed the warnings for this directory.

Supports https://github.com/jellyfin/jellyfin/issues/2149