### PR TITLE
Update to .NET SDK 5.0.302

### DIFF
--- a/.ci/azure-pipelines-abi.yml
+++ b/.ci/azure-pipelines-abi.yml
@@ -7,7 +7,7 @@ parameters:
   default: "ubuntu-latest"
 - name: DotNetSdkVersion
   type: string
-  default: 5.0.103
+  default: 5.0.302
 
 jobs:
   - job: CompatibilityCheck

--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -1,7 +1,7 @@
 parameters:
   LinuxImage: 'ubuntu-latest'
   RestoreBuildProjects: 'Jellyfin.Server/Jellyfin.Server.csproj'
-  DotNetSdkVersion: 5.0.103
+  DotNetSdkVersion: 5.0.302
 
 jobs:
   - job: Build

--- a/.ci/azure-pipelines-test.yml
+++ b/.ci/azure-pipelines-test.yml
@@ -10,7 +10,7 @@ parameters:
   default: "tests/**/*Tests.csproj"
 - name: DotNetSdkVersion
   type: string
-  default: 5.0.103
+  default: 5.0.302
 
 jobs:
   - job: Test

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
 - name: RestoreBuildProjects
   value: 'Jellyfin.Server/Jellyfin.Server.csproj'
 - name: DotNetSdkVersion
-  value: 5.0.103
+  value: 5.0.302
 
 pr:
   autoCancel: true


### PR DESCRIPTION
The .NET SDK that Jellyfin is uses is still failing to download on the Microsoft CDN. I don't know when that will be resolved. Seems like a good opportunity to jump to a later product version.

.NET SDK 5.0.302 is the July 2021 release. https://dotnet.microsoft.com/download/dotnet/5.0

Note: Sorry for the force-push. I had some content in my branch from fixing Jellfyfin warnings and had to rebase to remove it.

Interesting. This release archive is also failing to download. I reported that.