### PR TITLE
Remove some warnings from Models

### DIFF
--- a/MediaBrowser.Model/Configuration/TypeOptions.cs
+++ b/MediaBrowser.Model/Configuration/TypeOptions.cs
@@ -321,7 +321,9 @@ namespace MediaBrowser.Model.Configuration
 
         public string[] ImageFetcherOrder { get; set; }
 
+#pragma warning disable CA1721 // Property names should not match get methods
         public ImageOption[] ImageOptions { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
 
         public ImageOption GetImageOptions(ImageType type)
         {

--- a/MediaBrowser.Model/Dlna/MediaFormatProfile.cs
+++ b/MediaBrowser.Model/Dlna/MediaFormatProfile.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable CA1707
 
 namespace MediaBrowser.Model.Dlna
 {

--- a/MediaBrowser.Model/Drawing/ImageDimensions.cs
+++ b/MediaBrowser.Model/Drawing/ImageDimensions.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CS1591
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace MediaBrowser.Model.Drawing
@@ -7,7 +9,7 @@ namespace MediaBrowser.Model.Drawing
     /// <summary>
     /// Struct ImageDimensions.
     /// </summary>
-    public readonly struct ImageDimensions
+    public readonly struct ImageDimensions : IEquatable<ImageDimensions>
     {
         public ImageDimensions(int width, int height)
         {
@@ -27,9 +29,34 @@ namespace MediaBrowser.Model.Drawing
         /// <value>The width.</value>
         public int Width { get; }
 
-        public bool Equals(ImageDimensions size)
+        public static bool operator ==(ImageDimensions left, ImageDimensions right)
         {
-            return Width.Equals(size.Width) && Height.Equals(size.Height);
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ImageDimensions left, ImageDimensions right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals([AllowNull] object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            if (this.GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return Equals((ImageDimensions)obj);
+        }
+
+        public bool Equals(ImageDimensions other)
+        {
+            return Width.Equals(other.Width) && Height.Equals(other.Height);
         }
 
         /// <inheritdoc />
@@ -40,6 +67,11 @@ namespace MediaBrowser.Model.Drawing
                 "{0}-{1}",
                 Width,
                 Height);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Height.GetHashCode() * 17) + Width.GetHashCode();
         }
     }
 }

--- a/MediaBrowser.Model/GlobalSuppressions.cs
+++ b/MediaBrowser.Model/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Breaking Change")]

--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -51,7 +51,7 @@ namespace MediaBrowser.Model.IO
         /// <returns>A <see cref="FileSystemMetadata" /> object.</returns>
         /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata" /> object's
         /// <see cref="FileSystemMetadata.IsDirectory" /> property and the <see cref="FileSystemMetadata.Exists" /> property will both be set to false.</para>
-        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="M:IFileSystem.GetFileSystemInfo(System.String)" />.</para></remarks>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo(string)" />.</para></remarks>
         FileSystemMetadata GetFileInfo(string path);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace MediaBrowser.Model.IO
         /// <returns>A <see cref="FileSystemMetadata" /> object.</returns>
         /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata" /> object's
         /// <see cref="FileSystemMetadata.IsDirectory" /> property will be set to true and the <see cref="FileSystemMetadata.Exists" /> property will be set to false.</para>
-        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="M:IFileSystem.GetFileSystemInfo(System.String)" />.</para></remarks>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo(string)" />.</para></remarks>
         FileSystemMetadata GetDirectoryInfo(string path);
 
         /// <summary>


### PR DESCRIPTION
My second attempt, after getting some advice!

**Changes**

* Add equality overrides for ImageDimensions
* Ignore "Properties should not return arrays" with an assembly-level suppression
* Suppress underscores in enum names with a file-level suppression

**Issues**

Part of #2149
