### PR TITLE
ci: change OS packaging images to be quiet

### DIFF
--- a/deployment/Dockerfile.centos.amd64
+++ b/deployment/Dockerfile.centos.amd64
@@ -9,21 +9,21 @@ ENV ARTIFACT_DIR=/dist
 ENV IS_DOCKER=YES
 
 # Prepare CentOS environment
-RUN yum update -y \
- && yum install -y epel-release \
- && yum install -y @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel git
+RUN yum update -yq \
+  && yum install -yq epel-release \
+  && yum install -yq @buildsys-build rpmdevtools yum-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel git
 
 # Install DotNET SDK
 RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm \
- && rpmdev-setuptree \
- && yum install -y dotnet-sdk-${SDK_VERSION}
+  && rpmdev-setuptree \
+  && yum install -yq dotnet-sdk-${SDK_VERSION}
 
 # Create symlinks and directories
 RUN ln -sf ${SOURCE_DIR}/deployment/build.centos.amd64 /build.sh \
- && mkdir -p ${SOURCE_DIR}/SPECS \
- && ln -s ${SOURCE_DIR}/fedora/jellyfin.spec ${SOURCE_DIR}/SPECS/jellyfin.spec \
- && mkdir -p ${SOURCE_DIR}/SOURCES \
- && ln -s ${SOURCE_DIR}/fedora ${SOURCE_DIR}/SOURCES
+  && mkdir -p ${SOURCE_DIR}/SPECS \
+  && ln -s ${SOURCE_DIR}/fedora/jellyfin.spec ${SOURCE_DIR}/SPECS/jellyfin.spec \
+  && mkdir -p ${SOURCE_DIR}/SOURCES \
+  && ln -s ${SOURCE_DIR}/fedora ${SOURCE_DIR}/SOURCES
 
 VOLUME ${SOURCE_DIR}/
 

--- a/deployment/Dockerfile.debian.amd64
+++ b/deployment/Dockerfile.debian.amd64
@@ -13,7 +13,7 @@ ENV IS_DOCKER=YES
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     apt-transport-https debhelper gnupg \
-    wget devscripts mmv libc6-dev libcurl4-openssl-dev \
+    devscripts mmv libcurl4-openssl-dev \
     libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to build script

--- a/deployment/Dockerfile.debian.amd64
+++ b/deployment/Dockerfile.debian.amd64
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg \
+    wget devscripts mmv libc6-dev libcurl4-openssl-dev \
+    libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.amd64 /build.sh

--- a/deployment/Dockerfile.debian.amd64
+++ b/deployment/Dockerfile.debian.amd64
@@ -12,9 +12,9 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg \
-    devscripts mmv libcurl4-openssl-dev \
-    libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    apt-transport-https debhelper gnupg devscripts build-essential mmv \
+    libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev \
+    libssl1.1 liblttng-ust0
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.amd64 /build.sh

--- a/deployment/Dockerfile.debian.arm64
+++ b/deployment/Dockerfile.debian.arm64
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts mmv
+    apt-transport-https debhelper gnupg devscripts mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture arm64 \

--- a/deployment/Dockerfile.debian.arm64
+++ b/deployment/Dockerfile.debian.arm64
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts mmv
+    apt-transport-https debhelper gnupg devscripts build-essential mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture arm64 \

--- a/deployment/Dockerfile.debian.arm64
+++ b/deployment/Dockerfile.debian.arm64
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,23 +10,24 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture arm64 \
- && apt-get update \
- && apt-get install -y cross-gcc-dev \
- && TARGET_LIST="arm64" cross-gcc-gensource 8 \
- && cd cross-gcc-packages-amd64/cross-gcc-8-arm64 \
- && apt-get install -y gcc-8-source libstdc++-8-dev-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 libssl-dev:arm64 liblttng-ust0:arm64 libstdc++-8-dev:arm64
+  && apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends cross-gcc-dev \
+  && TARGET_LIST="arm64" cross-gcc-gensource 8 \
+  && cd cross-gcc-packages-amd64/cross-gcc-8-arm64 \
+  && apt-get install -yqq --no-install-recommends \
+    gcc-8-source libstdc++-8-dev-arm64-cross \
+    binutils-aarch64-linux-gnu bison flex libtool \
+    gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev \
+    systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip \
+    libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 \
+    libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 \
+    libfreetype6-dev:arm64 libssl-dev:arm64 liblttng-ust0:arm64 libstdc++-8-dev:arm64
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.arm64 /build.sh

--- a/deployment/Dockerfile.debian.armhf
+++ b/deployment/Dockerfile.debian.armhf
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts mmv
+    apt-transport-https debhelper gnupg devscripts build-essential mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture armhf \

--- a/deployment/Dockerfile.debian.armhf
+++ b/deployment/Dockerfile.debian.armhf
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts mmv
+    apt-transport-https debhelper gnupg devscripts mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture armhf \

--- a/deployment/Dockerfile.debian.armhf
+++ b/deployment/Dockerfile.debian.armhf
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,23 +10,25 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts mmv
 
 # Prepare the cross-toolchain
 RUN dpkg --add-architecture armhf \
- && apt-get update \
- && apt-get install -y cross-gcc-dev \
- && TARGET_LIST="armhf" cross-gcc-gensource 8 \
- && cd cross-gcc-packages-amd64/cross-gcc-8-armhf \
- && apt-get install -y gcc-8-source libstdc++-8-dev-armhf-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip binutils-arm-linux-gnueabihf libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf libssl-dev:armhf liblttng-ust0:armhf libstdc++-8-dev:armhf
+  && apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends cross-gcc-dev \
+  && TARGET_LIST="armhf" cross-gcc-gensource 8 \
+  && cd cross-gcc-packages-amd64/cross-gcc-8-armhf \
+  && apt-get install -yqq --no-install-recommends\
+    gcc-8-source libstdc++-8-dev-armhf-cross \
+    binutils-aarch64-linux-gnu bison flex libtool gdb \
+    sharutils netbase libmpc-dev libmpfr-dev libgmp-dev \
+    systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
+    zip binutils-arm-linux-gnueabihf libc6-dev:armhf \
+    linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf \
+    libfontconfig1-dev:armhf libfreetype6-dev:armhf libssl-dev:armhf \
+    liblttng-ust0:armhf libstdc++-8-dev:armhf
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.armhf /build.sh

--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -9,18 +9,18 @@ ENV ARTIFACT_DIR=/dist
 ENV IS_DOCKER=YES
 
 # Prepare Fedora environment
-RUN dnf update -y \
- && dnf install -y @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd
+RUN dnf update -yq \
+  && dnf install -yq @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd
 
 # Install DotNET SDK
-RUN dnf install -y dotnet-sdk-${SDK_VERSION} dotnet-runtime-${SDK_VERSION}
+RUN dnf install -yq dotnet-sdk-${SDK_VERSION} dotnet-runtime-${SDK_VERSION}
 
 # Create symlinks and directories
 RUN ln -sf ${SOURCE_DIR}/deployment/build.fedora.amd64 /build.sh \
- && mkdir -p ${SOURCE_DIR}/SPECS \
- && ln -s ${SOURCE_DIR}/fedora/jellyfin.spec ${SOURCE_DIR}/SPECS/jellyfin.spec \
- && mkdir -p ${SOURCE_DIR}/SOURCES \
- && ln -s ${SOURCE_DIR}/fedora ${SOURCE_DIR}/SOURCES
+  && mkdir -p ${SOURCE_DIR}/SPECS \
+  && ln -s ${SOURCE_DIR}/fedora/jellyfin.spec ${SOURCE_DIR}/SPECS/jellyfin.spec \
+  && mkdir -p ${SOURCE_DIR}/SOURCES \
+  && ln -s ${SOURCE_DIR}/fedora ${SOURCE_DIR}/SOURCES
 
 VOLUME ${SOURCE_DIR}/
 

--- a/deployment/Dockerfile.linux.amd64
+++ b/deployment/Dockerfile.linux.amd64
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts \
+    apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 

--- a/deployment/Dockerfile.linux.amd64
+++ b/deployment/Dockerfile.linux.amd64
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64 /build.sh

--- a/deployment/Dockerfile.linux.amd64
+++ b/deployment/Dockerfile.linux.amd64
@@ -12,8 +12,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script

--- a/deployment/Dockerfile.linux.amd64-musl
+++ b/deployment/Dockerfile.linux.amd64-musl
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts \
+    apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 

--- a/deployment/Dockerfile.linux.amd64-musl
+++ b/deployment/Dockerfile.linux.amd64-musl
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64-musl /build.sh

--- a/deployment/Dockerfile.linux.amd64-musl
+++ b/deployment/Dockerfile.linux.amd64-musl
@@ -12,8 +12,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script

--- a/deployment/Dockerfile.linux.arm64
+++ b/deployment/Dockerfile.linux.arm64
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=arm64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.arm64 /build.sh

--- a/deployment/Dockerfile.linux.arm64
+++ b/deployment/Dockerfile.linux.arm64
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts \
+    apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 

--- a/deployment/Dockerfile.linux.arm64
+++ b/deployment/Dockerfile.linux.arm64
@@ -12,8 +12,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script

--- a/deployment/Dockerfile.linux.armhf
+++ b/deployment/Dockerfile.linux.armhf
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=armhf
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.armhf /build.sh

--- a/deployment/Dockerfile.linux.armhf
+++ b/deployment/Dockerfile.linux.armhf
@@ -12,7 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts \
+    apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 

--- a/deployment/Dockerfile.linux.armhf
+++ b/deployment/Dockerfile.linux.armhf
@@ -12,8 +12,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script

--- a/deployment/Dockerfile.macos
+++ b/deployment/Dockerfile.macos
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -11,15 +10,11 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.macos /build.sh

--- a/deployment/Dockerfile.macos
+++ b/deployment/Dockerfile.macos
@@ -12,8 +12,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script

--- a/deployment/Dockerfile.portable
+++ b/deployment/Dockerfile.portable
@@ -11,8 +11,9 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget \
-    devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.portable /build.sh

--- a/deployment/Dockerfile.portable
+++ b/deployment/Dockerfile.portable
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -10,15 +9,10 @@ ENV DEB_BUILD_OPTIONS=noddebs
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget \
+    devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.portable /build.sh

--- a/deployment/Dockerfile.ubuntu.amd64
+++ b/deployment/Dockerfile.ubuntu.amd64
@@ -11,15 +11,18 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN wget -q https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
+  && mkdir -p dotnet-sdk \
+  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
+  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.ubuntu.amd64 /build.sh

--- a/deployment/Dockerfile.ubuntu.amd64
+++ b/deployment/Dockerfile.ubuntu.amd64
@@ -13,8 +13,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg wget ca-certificates devscripts \
+    mmv build-essential libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Install dotnet repository

--- a/deployment/Dockerfile.ubuntu.arm64
+++ b/deployment/Dockerfile.ubuntu.arm64
@@ -11,34 +11,40 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts mmv
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN wget -q https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
+  && mkdir -p dotnet-sdk \
+  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
+  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
 # Prepare the cross-toolchain
 RUN rm /etc/apt/sources.list \
- && export CODENAME="$( lsb_release -c -s )" \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
- && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
- && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
- && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
- && dpkg --add-architecture arm64 \
- && apt-get update \
- && apt-get install -y cross-gcc-dev \
- && TARGET_LIST="arm64" cross-gcc-gensource 6 \
- && cd cross-gcc-packages-amd64/cross-gcc-6-arm64 \
- && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
- && apt-get install -y gcc-6-source libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64 libssl-dev:arm64
+  && export CODENAME="$( lsb_release -c -s )" \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
+  && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
+  && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
+  && echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/arm64.list \
+  && dpkg --add-architecture arm64 \
+  && apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends cross-gcc-dev \
+  && TARGET_LIST="arm64" cross-gcc-gensource 6 \
+  && cd cross-gcc-packages-amd64/cross-gcc-6-arm64 \
+  && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
+  && apt-get install -yqq --no-install-recommends \
+    gcc-6-source libstdc++6-arm64-cross binutils-aarch64-linux-gnu \
+    bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev \
+    libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
+    zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 \
+    libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64 libssl-dev:arm64
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.ubuntu.arm64 /build.sh

--- a/deployment/Dockerfile.ubuntu.arm64
+++ b/deployment/Dockerfile.ubuntu.arm64
@@ -13,7 +13,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts mmv
+    apt-transport-https debhelper gnupg wget ca-certificates devscripts \
+    mmv build-essential lsb-release
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current

--- a/deployment/Dockerfile.ubuntu.armhf
+++ b/deployment/Dockerfile.ubuntu.armhf
@@ -13,7 +13,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts mmv
+    apt-transport-https debhelper gnupg wget ca-certificates devscripts \
+    mmv build-essential lsb-release
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current

--- a/deployment/Dockerfile.ubuntu.armhf
+++ b/deployment/Dockerfile.ubuntu.armhf
@@ -11,34 +11,40 @@ ENV ARCH=amd64
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts mmv
 
 # Install dotnet repository
 # https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN wget -q https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
+  && mkdir -p dotnet-sdk \
+  && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
+  && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
 
 # Prepare the cross-toolchain
 RUN rm /etc/apt/sources.list \
- && export CODENAME="$( lsb_release -c -s )" \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
- && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
- && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
- && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
- && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
- && dpkg --add-architecture armhf \
- && apt-get update \
- && apt-get install -y cross-gcc-dev \
- && TARGET_LIST="armhf" cross-gcc-gensource 6 \
- && cd cross-gcc-packages-amd64/cross-gcc-6-armhf \
- && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
- && apt-get install -y gcc-6-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf libssl-dev:armhf
+  && export CODENAME="$( lsb_release -c -s )" \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/amd64.list \
+  && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
+  && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
+  && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
+  && echo "deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse" >>/etc/apt/sources.list.d/armhf.list \
+  && dpkg --add-architecture armhf \
+  && apt-get update -yqq \
+  && apt-get install -yqq cross-gcc-dev \
+  && TARGET_LIST="armhf" cross-gcc-gensource 6 \
+  && cd cross-gcc-packages-amd64/cross-gcc-6-armhf \
+  && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
+  && apt-get install -yqq --no-install-recommends \
+    gcc-6-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf \
+    bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev \
+    libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
+    zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf \
+    libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf libssl-dev:armhf
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.armhf /build.sh

--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -1,8 +1,7 @@
-FROM debian:10
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
-ARG SDK_VERSION=5.0
 # Docker run environment
 ENV SOURCE_DIR=/jellyfin
 ENV ARTIFACT_DIR=/dist
@@ -10,15 +9,11 @@ ENV DEB_BUILD_OPTIONS=noddebs
 ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
-RUN apt-get update \
- && apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
-
-# Install dotnet repository
-# https://dotnet.microsoft.com/download/linux-package-manager/debian9/sdk-current
-RUN wget https://download.visualstudio.microsoft.com/download/pr/8468e541-a99a-4191-8470-654fa0747a9a/cb32548d2fd3d60ef3fe8fc80cd735ef/dotnet-sdk-5.0.302-linux-x64.tar.gz -O dotnet-sdk.tar.gz \
- && mkdir -p dotnet-sdk \
- && tar -xzf dotnet-sdk.tar.gz -C dotnet-sdk \
- && ln -s $( pwd )/dotnet-sdk/dotnet /usr/bin/dotnet
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    apt-transport-https debhelper gnupg wget devscripts \
+    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.windows.amd64 /build.sh

--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -11,8 +11,8 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg wget devscripts \
-    mmv libc6-dev libcurl4-openssl-dev libfontconfig1-dev \
+    apt-transport-https debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
 
 # Link to docker-build script

--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -11,7 +11,7 @@ ENV IS_DOCKER=YES
 # Prepare Debian build environment
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    apt-transport-https debhelper gnupg devscripts \
+    apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
 


### PR DESCRIPTION
### Description

To lessen the burden of the review for my ci PR i extracted my changes for the OS packaging Images.
This PR quiets down the package manager installs, since their log can be mostly ignored for the package builds.
Additionally, I noticed that we where already using debian 10 as the base but where manually installing dotnet, so I exchanged the base images where that was the case and dropped the explicit download of the dotnet sdk.

### Change(s)

* quiet down the OS packaging docker images (mostly setting package managers to be quiet)
* changes to use the dotnet/sdk image where possible (it is debian 10 just like the one it replaces)
* slightly changes the indent in the OS packaging docker files

### Issue(s)

* extracted from #6364 
