### PR TITLE
Fix redirect logic if request path is exactly the base url

### DIFF
--- a/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
@@ -58,9 +58,12 @@ namespace Jellyfin.Server.Middleware
                     return;
                 }
 
-                if (!startsWithBaseUrl)
+                if (!startsWithBaseUrl
+                    || localPath.Equals(baseUrlPrefix, StringComparison.OrdinalIgnoreCase)
+                    // Local path is /baseUrl/
+                    || (localPath.Length == baseUrlPrefix.Length + 1 && localPath[^1] == '/'))
                 {
-                    // Always redirect back to the default path if the base prefix is invalid or missing
+                    // Always redirect back to the default path if the base prefix is invalid, missing, or is the full path.
                     _logger.LogDebug("Normalizing an URL at {LocalPath}", localPath);
                     httpContext.Response.Redirect(baseUrlPrefix + "/" + _configuration[ConfigurationExtensions.DefaultRedirectKey]);
                     return;

--- a/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
+++ b/Jellyfin.Server/Middleware/BaseUrlRedirectionMiddleware.cs
@@ -59,7 +59,7 @@ namespace Jellyfin.Server.Middleware
                 }
 
                 if (!startsWithBaseUrl
-                    || localPath.Equals(baseUrlPrefix, StringComparison.OrdinalIgnoreCase)
+                    || localPath.Length == baseUrlPrefix.Length
                     // Local path is /baseUrl/
                     || (localPath.Length == baseUrlPrefix.Length + 1 && localPath[^1] == '/'))
                 {


### PR DESCRIPTION
Fixes server not redirecting when the path is exactly `/basePath` or `/basePath/`