### PR TITLE
Fix explicit stream selection in MediaEncoder.ExtractImageInternal

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -503,15 +503,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             var inputArgument = GetInputArgument(inputFile, mediaSource);
 
-            if (isAudio)
-            {
-                if (imageStreamIndex.HasValue && imageStreamIndex.Value > 0)
-                {
-                    // It seems for audio files we need to subtract 1 (for the audio stream??)
-                    imageStreamIndex = imageStreamIndex.Value - 1;
-                }
-            }
-            else
+            if (!isAudio)
             {
                 // The failure of HDR extraction usually occurs when using custom ffmpeg that does not contain the zscale filter.
                 try
@@ -582,7 +574,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _ => string.Empty
             };
 
-            var mapArg = imageStreamIndex.HasValue ? (" -map 0:v:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
+            var mapArg = imageStreamIndex.HasValue ? (" -map 0:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
 
             var enableHdrExtraction = allowTonemap && string.Equals(videoStream?.VideoRange, "HDR", StringComparison.OrdinalIgnoreCase);
             if (enableHdrExtraction)

--- a/MediaBrowser.Providers/MediaInfo/VideoImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/VideoImageProvider.cs
@@ -88,22 +88,6 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (imageStream != null)
             {
-                // Instead of using the raw stream index, we need to use nth video/embedded image stream
-                var videoIndex = -1;
-                foreach (var mediaStream in mediaStreams)
-                {
-                    if (mediaStream.Type == MediaStreamType.Video ||
-                        mediaStream.Type == MediaStreamType.EmbeddedImage)
-                    {
-                        videoIndex++;
-                    }
-
-                    if (mediaStream == imageStream)
-                    {
-                        break;
-                    }
-                }
-
                 MediaSourceInfo mediaSource = new MediaSourceInfo
                 {
                     VideoType = item.VideoType,
@@ -111,7 +95,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     Protocol = item.PathProtocol.Value,
                 };
 
-                extractedImagePath = await _mediaEncoder.ExtractVideoImage(inputPath, item.Container, mediaSource, imageStream, videoIndex, cancellationToken).ConfigureAwait(false);
+                extractedImagePath = await _mediaEncoder.ExtractVideoImage(inputPath, item.Container, mediaSource, imageStream, imageStream.Index, cancellationToken).ConfigureAwait(false);
             }
             else
             {


### PR DESCRIPTION
**Changes**
The `map` parameter in the arguments passed to FFmpeg in MediaEncoder.ExtractImageInternal currently requires the `imageStreamIndex` to be the index of **video** streams within that file. For video files, we do extra work to figure out the correct index of the passed-in stream, but for audio files, we just use the absolute index of the stream (minus one, for some reason).

Instead of doing that, this change uses no stream specifier in the `map` parameter, and passes the absolute index for both audio and video files.

See here for more details about the `map` parameter syntax:

https://trac.ffmpeg.org/wiki/Map

The bug below goes into more detail.

**Issues**
Fixes #6424