### PR TITLE
Disable UseAppHost in portable deployment

### DIFF
--- a/deployment/build.portable
+++ b/deployment/build.portable
@@ -16,7 +16,7 @@ else
 fi
 
 # Build archives
-dotnet publish Jellyfin.Server --configuration Release --output dist/jellyfin-server_${version}/ "-p:DebugSymbols=false;DebugType=none;UseAppHost=true"
+dotnet publish Jellyfin.Server --configuration Release --output dist/jellyfin-server_${version}/ "-p:DebugSymbols=false;DebugType=none;UseAppHost=false"
 tar -czf jellyfin-server_${version}_portable.tar.gz -C dist jellyfin-server_${version}
 rm -rf dist/jellyfin-server_${version}
 


### PR DESCRIPTION
**Changes**
This disables `UseAppHost` in portable deployments, which builds an unnecessary `x86_64-linux` binary, which does not work without the .NET Core runtime.

[Per Microsoft](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-framework-dependent):
> You can create an executable for a specific platform by passing the -r <RID> --self-contained false parameters to the dotnet publish command. When the -r parameter is omitted, an executable is created for your current platform. Any NuGet packages that have platform-specific dependencies for the targeted platform are copied to the publish folder. If you don't need a platfrom-specific executable, you can specify <UseAppHost>False</UseAppHost> in the project file.
