### PR TITLE
Remove support for IDs in paths

### DIFF
--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using MediaBrowser.Common.Providers;
 
 namespace Emby.Server.Implementations.Library
 {
@@ -9,44 +8,6 @@ namespace Emby.Server.Implementations.Library
     /// </summary>
     public static class PathExtensions
     {
-        /// <summary>
-        /// Gets the attribute value.
-        /// </summary>
-        /// <param name="str">The STR.</param>
-        /// <param name="attribute">The attrib.</param>
-        /// <returns>System.String.</returns>
-        /// <exception cref="ArgumentException"><paramref name="str" /> or <paramref name="attribute" /> is empty.</exception>
-        public static string? GetAttributeValue(this string str, string attribute)
-        {
-            if (str.Length == 0)
-            {
-                throw new ArgumentException("String can't be empty.", nameof(str));
-            }
-
-            if (attribute.Length == 0)
-            {
-                throw new ArgumentException("String can't be empty.", nameof(attribute));
-            }
-
-            string srch = "[" + attribute + "=";
-            int start = str.IndexOf(srch, StringComparison.OrdinalIgnoreCase);
-            if (start != -1)
-            {
-                start += srch.Length;
-                int end = str.IndexOf(']', start);
-                return str.Substring(start, end - start);
-            }
-
-            // for imdbid we also accept pattern matching
-            if (string.Equals(attribute, "imdbid", StringComparison.OrdinalIgnoreCase))
-            {
-                var match = ProviderIdParsers.TryFindImdbId(str, out var imdbId);
-                return match ? imdbId.ToString() : null;
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Replaces a sub path with another sub path and normalizes the final path.
         /// </summary>

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/BoxSetResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/BoxSetResolver.cs
@@ -45,34 +45,5 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
 
             return null;
         }
-
-        /// <summary>
-        /// Sets the initial item values.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="args">The args.</param>
-        protected override void SetInitialItemValues(BoxSet item, ItemResolveArgs args)
-        {
-            base.SetInitialItemValues(item, args);
-
-            SetProviderIdFromPath(item);
-        }
-
-        /// <summary>
-        /// Sets the provider id from path.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        private static void SetProviderIdFromPath(BaseItem item)
-        {
-            // we need to only look at the name of this actual item (not parents)
-            var justName = Path.GetFileName(item.Path);
-
-            var id = justName.GetAttributeValue("tmdbid");
-
-            if (!string.IsNullOrEmpty(id))
-            {
-                item.SetProviderId(MetadataProvider.Tmdb, id);
-            }
-        }
     }
 }

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -323,53 +323,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
         }
 
         /// <summary>
-        /// Sets the initial item values.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="args">The args.</param>
-        protected override void SetInitialItemValues(Video item, ItemResolveArgs args)
-        {
-            base.SetInitialItemValues(item, args);
-
-            SetProviderIdsFromPath(item);
-        }
-
-        /// <summary>
-        /// Sets the provider id from path.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        private static void SetProviderIdsFromPath(Video item)
-        {
-            if (item is Movie || item is MusicVideo)
-            {
-                // We need to only look at the name of this actual item (not parents)
-                var justName = item.IsInMixedFolder ? Path.GetFileName(item.Path) : Path.GetFileName(item.ContainingFolderPath);
-
-                if (!string.IsNullOrEmpty(justName))
-                {
-                    // check for tmdb id
-                    var tmdbid = justName.GetAttributeValue("tmdbid");
-
-                    if (!string.IsNullOrWhiteSpace(tmdbid))
-                    {
-                        item.SetProviderId(MetadataProvider.Tmdb, tmdbid);
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(item.Path))
-                {
-                    // check for imdb id - we use full media path, as we can assume, that this will match in any use case (wither id in parent dir or in file name)
-                    var imdbid = item.Path.GetAttributeValue("imdbid");
-
-                    if (!string.IsNullOrWhiteSpace(imdbid))
-                    {
-                        item.SetProviderId(MetadataProvider.Imdb, imdbid);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
         /// Finds a movie based on a child file system entries.
         /// </summary>
         /// <returns>Movie.</returns>

--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
@@ -160,34 +160,5 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
 
             return seasonNumber.HasValue;
         }
-
-        /// <summary>
-        /// Sets the initial item values.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="args">The args.</param>
-        protected override void SetInitialItemValues(Series item, ItemResolveArgs args)
-        {
-            base.SetInitialItemValues(item, args);
-
-            SetProviderIdFromPath(item, args.Path);
-        }
-
-        /// <summary>
-        /// Sets the provider id from path.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="path">The path.</param>
-        private static void SetProviderIdFromPath(Series item, string path)
-        {
-            var justName = Path.GetFileName(path);
-
-            var id = justName.GetAttributeValue("tvdbid");
-
-            if (!string.IsNullOrEmpty(id))
-            {
-                item.SetProviderId(MetadataProvider.Tvdb, id);
-            }
-        }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/PathExtensionsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/PathExtensionsTests.cs
@@ -7,25 +7,6 @@ namespace Jellyfin.Server.Implementations.Tests.Library
     public class PathExtensionsTests
     {
         [Theory]
-        [InlineData("Superman: Red Son [imdbid=tt10985510]", "imdbid", "tt10985510")]
-        [InlineData("Superman: Red Son - tt10985510", "imdbid", "tt10985510")]
-        [InlineData("Superman: Red Son", "imdbid", null)]
-        [InlineData("Superman: Red Son", "something", null)]
-        public void GetAttributeValue_ValidArgs_Correct(string input, string attribute, string? expectedResult)
-        {
-            Assert.Equal(expectedResult, PathExtensions.GetAttributeValue(input, attribute));
-        }
-
-        [Theory]
-        [InlineData("", "")]
-        [InlineData("Superman: Red Son [imdbid=tt10985510]", "")]
-        [InlineData("", "imdbid")]
-        public void GetAttributeValue_EmptyString_ThrowsArgumentException(string input, string attribute)
-        {
-            Assert.Throws<ArgumentException>(() => PathExtensions.GetAttributeValue(input, attribute));
-        }
-
-        [Theory]
         [InlineData("C:/Users/jeff/myfile.mkv", "C:/Users/jeff", "/home/jeff", "/home/jeff/myfile.mkv")]
         [InlineData("C:/Users/jeff/myfile.mkv", "C:/Users/jeff/", "/home/jeff", "/home/jeff/myfile.mkv")]
         [InlineData("/home/jeff/music/jeff's band/consistently inconsistent.mp3", "/home/jeff/music/jeff's band", "/home/not jeff", "/home/not jeff/consistently inconsistent.mp3")]


### PR DESCRIPTION
**Changes**

This feature makes path resolving more complex than needed, and is a (worse) duplicate of the Kodi-compatible [Parsing NFOs](https://kodi.wiki/view/NFO_files/Parsing) (which we already support).

This removes the inferior and limited path parsing of IDs, in favor of keeping (and encouraging the use of) Parsing NFOs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
