### PR TITLE
Add 'includeAdult' option for TheMovieDb

### DIFF
--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -49,5 +49,7 @@
     <EmbeddedResource Include="Plugins\Omdb\Configuration\config.html" />
     <None Remove="Plugins\MusicBrainz\Configuration\config.html" />
     <EmbeddedResource Include="Plugins\MusicBrainz\Configuration\config.html" />
+    <None Remove="Plugins\Tmdb\Configuration\config.html" />
+    <EmbeddedResource Include="Plugins\Tmdb\Configuration\config.html" />
   </ItemGroup>
 </Project>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
@@ -1,0 +1,15 @@
+using MediaBrowser.Model.Plugins;
+
+namespace MediaBrowser.Providers.Plugins.Tmdb
+{
+    /// <summary>
+    /// Plugin configuration class for TMDb library.
+    /// </summary>
+    public class PluginConfiguration : BasePluginConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether include adult content when searching with TMDb.
+        /// </summary>
+        public bool IncludeAdult { get; set; }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TMDb</title>
+</head>
+<body>
+    <div data-role="page" class="page type-interior pluginConfigurationPage configPage" data-require="emby-input,emby-button,emby-checkbox">
+        <div data-role="content">
+            <div class="content-primary">
+                <form class="configForm">
+                    <label class="checkboxContainer">
+                        <input is="emby-checkbox" type="checkbox" id="includeAdult" />
+                        <span>Include adult content in search results.</span>
+                    </label>
+                    <br />
+                    <div>
+                        <button is="emby-button" type="submit" class="raised button-submit block"><span>Save</span></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <script type="text/javascript">
+            var PluginConfig = {
+                pluginId: "b8715ed1-6c47-4528-9ad3-f72deb539cd4"
+            };
+
+            document.querySelector('.configPage')
+                .addEventListener('pageshow', function () {
+                    Dashboard.showLoadingMsg();
+                    ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
+                        document.querySelector('#includeAdult').checked = config.IncludeAdult;
+                        Dashboard.hideLoadingMsg();
+                    });
+                });
+
+            
+            document.querySelector('.configForm')
+                .addEventListener('submit', function (e) {
+                    Dashboard.showLoadingMsg();
+    
+                    ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
+                        config.IncludeAdult = document.querySelector('#includeAdult').checked;
+                        ApiClient.updatePluginConfiguration(PluginConfig.pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                    });
+                    
+                    e.preventDefault();
+                    return false;
+                });
+        </script>
+    </div>
+</body>
+</html>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+
+namespace MediaBrowser.Providers.Plugins.Tmdb
+{
+    /// <summary>
+    /// Plugin class for the TMDb library.
+    /// </summary>
+    public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Plugin"/> class.
+        /// </summary>
+        /// <param name="applicationPaths">application paths.</param>
+        /// <param name="xmlSerializer">xml serializer.</param>
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+            : base(applicationPaths, xmlSerializer)
+        {
+            Instance = this;
+        }
+
+        /// <summary>
+        /// Gets the instance of TMDb plugin.
+        /// </summary>
+        public static Plugin Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override Guid Id => new Guid("b8715ed1-6c47-4528-9ad3-f72deb539cd4");
+
+        /// <inheritdoc/>
+        public override string Name => "TMDb";
+
+        /// <inheritdoc/>
+        public override string Description => "Get metadata for movies and other video content from TheMovieDb.";
+
+        // TODO remove when plugin removed from server.
+
+        /// <inheritdoc/>
+        public override string ConfigurationFileName => "Jellyfin.Plugin.Tmdb.xml";
+
+        /// <summary>
+        /// Return the plugin configuration page.
+        /// </summary>
+        /// <returns>PluginPageInfo.</returns>
+        public IEnumerable<PluginPageInfo> GetPages()
+        {
+            yield return new PluginPageInfo
+            {
+                Name = Name,
+                EmbeddedResourcePath = GetType().Namespace + ".Configuration.config.html"
+            };
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -358,7 +358,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             await EnsureClientConfigAsync().ConfigureAwait(false);
 
             var searchResults = await _tmDbClient
-                .SearchTvShowAsync(name, TmdbUtils.NormalizeLanguage(language), firstAirDateYear: year, cancellationToken: cancellationToken)
+                .SearchTvShowAsync(name, TmdbUtils.NormalizeLanguage(language), includeAdult: Plugin.Instance.Configuration.IncludeAdult, firstAirDateYear: year, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             if (searchResults.Results.Count > 0)
@@ -386,7 +386,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             await EnsureClientConfigAsync().ConfigureAwait(false);
 
             var searchResults = await _tmDbClient
-                .SearchPersonAsync(name, cancellationToken: cancellationToken)
+                .SearchPersonAsync(name, includeAdult: Plugin.Instance.Configuration.IncludeAdult, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             if (searchResults.Results.Count > 0)
@@ -428,7 +428,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             await EnsureClientConfigAsync().ConfigureAwait(false);
 
             var searchResults = await _tmDbClient
-                .SearchMovieAsync(name, TmdbUtils.NormalizeLanguage(language), year: year, cancellationToken: cancellationToken)
+                .SearchMovieAsync(name, TmdbUtils.NormalizeLanguage(language), includeAdult: Plugin.Instance.Configuration.IncludeAdult, year: year, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             if (searchResults.Results.Count > 0)


### PR DESCRIPTION
**Changes**
Some TV shows and movies are labeled as 'adult' at TheMovieDb. The TMDbLib uses the 'includeAdult' parameter to show this content in search results. This PR adds a configuration option to support this feature.