### PR TITLE
Disable allOf output when generating OpenAPI spec

### DIFF
--- a/Emby.Server.Implementations/IStartupOptions.cs
+++ b/Emby.Server.Implementations/IStartupOptions.cs
@@ -33,5 +33,11 @@ namespace Emby.Server.Implementations
         /// Gets the value of the --published-server-url command line option.
         /// </summary>
         string? PublishedServerUrl { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether allOf output should be disabled.
+        /// Added with the --disable-openapi-allof command line option.
+        /// </summary>
+        public bool DisableOpenApiAllOf { get; }
     }
 }

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -255,8 +255,9 @@ namespace Jellyfin.Server.Extensions
         /// Adds Swagger to the service collection.
         /// </summary>
         /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="disableOpenApiAllOf">Whether to disable allOf generation.</param>
         /// <returns>The updated service collection.</returns>
-        public static IServiceCollection AddJellyfinApiSwagger(this IServiceCollection serviceCollection)
+        public static IServiceCollection AddJellyfinApiSwagger(this IServiceCollection serviceCollection, bool disableOpenApiAllOf)
         {
             return serviceCollection.AddSwaggerGen(c =>
             {
@@ -308,8 +309,12 @@ namespace Jellyfin.Server.Extensions
                                ?? null;
                     });
 
-                // Allow parameters to properly be nullable.
-                c.UseAllOfToExtendReferenceSchemas();
+                if (!disableOpenApiAllOf)
+                {
+                    // Allow parameters to properly be nullable.
+                    c.UseAllOfToExtendReferenceSchemas();
+                }
+
                 c.SupportNonNullableReferenceTypes();
 
                 // TODO - remove when all types are supported in System.Text.Json

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
+using Emby.Server.Implementations;
 using Jellyfin.Networking.Configuration;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Implementations;
@@ -30,18 +31,22 @@ namespace Jellyfin.Server
     {
         private readonly IServerConfigurationManager _serverConfigurationManager;
         private readonly IServerApplicationHost _serverApplicationHost;
+        private readonly IStartupOptions _startupOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup" /> class.
         /// </summary>
         /// <param name="serverConfigurationManager">The server configuration manager.</param>
         /// <param name="serverApplicationHost">The server application host.</param>
+        /// <param name="startupOptions">The server startup options.</param>
         public Startup(
             IServerConfigurationManager serverConfigurationManager,
-            IServerApplicationHost serverApplicationHost)
+            IServerApplicationHost serverApplicationHost,
+            IStartupOptions startupOptions)
         {
             _serverConfigurationManager = serverConfigurationManager;
             _serverApplicationHost = serverApplicationHost;
+            _startupOptions = startupOptions;
         }
 
         /// <summary>
@@ -58,7 +63,7 @@ namespace Jellyfin.Server
             });
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
 
-            services.AddJellyfinApiSwagger();
+            services.AddJellyfinApiSwagger(_startupOptions.DisableOpenApiAllOf);
 
             // configure custom legacy authentication
             services.AddCustomAuthentication();

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -76,6 +76,10 @@ namespace Jellyfin.Server
         [Option("published-server-url", Required = false, HelpText = "Jellyfin Server URL to publish via auto discover process")]
         public string? PublishedServerUrl { get; set; }
 
+        /// <inheritdoc />
+        [Option("disable-openapi-allof", Required = false, HelpText = "Disables allOf output in generated OpenAPI spec")]
+        public bool DisableOpenApiAllOf { get; set; }
+
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.
         /// </summary>


### PR DESCRIPTION
Adds runtime flag `--disable-openapi-allof`

[openapi-master-alt.json.txt](https://github.com/jellyfin/jellyfin/files/7032505/openapi-master-alt.json.txt)
[openapi-10.7.6-alt.json.txt](https://github.com/jellyfin/jellyfin/files/7032541/openapi-10.7.6-alt.json.txt)