### PR TITLE
Detect MultiDisc format "[Prefix][No]: [Subtitle]".

### DIFF
--- a/Emby.Naming/Audio/AlbumParser.cs
+++ b/Emby.Naming/Audio/AlbumParser.cs
@@ -43,6 +43,7 @@ namespace Emby.Naming.Audio
             // Remove whitespace
             filename = filename.Replace('-', ' ');
             filename = filename.Replace('.', ' ');
+            filename = filename.Replace(':', ' ');
             filename = filename.Replace('(', ' ');
             filename = filename.Replace(')', ' ');
             filename = Regex.Replace(filename, @"\s+", " ");

--- a/tests/Jellyfin.Naming.Tests/Music/MultiDiscAlbumTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Music/MultiDiscAlbumTests.cs
@@ -40,6 +40,7 @@ namespace Jellyfin.Naming.Tests.Music
         [InlineData(@"D:/Video/MBTestLibrary/VideoTest/music/.38 special/anth/Disc 2", true)]
         [InlineData(@"[1985] Opportunities (Let's make lots of money) (1985)", false)]
         [InlineData(@"Blah 04(Encores and Folk Songs)", false)]
+        [InlineData(@"CD 02: Remixes", true)]
         public void AlbumParser_MultidiscPath_Identifies(string path, bool result)
         {
             var parser = new AlbumParser(_namingOptions);


### PR DESCRIPTION
**Changes**
This PR adds support for MultiDisc folders with the naming scheme "[Prefix][No]: [Subtitle]" by replacing colons in the normalize/sanitize step of AlbumParser.

**Issues**
I am not aware of any.