### PR TITLE
Users/rmcn96/fix readonly image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY . .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 # because of changes in docker and systemd we need to not build in parallel at the moment
 # see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
-RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=false;DebugType=none"
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=true;DebugType=Full"
 
 FROM app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY . .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 # because of changes in docker and systemd we need to not build in parallel at the moment
 # see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
-RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=false;DebugType=none"
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=true;DebugType=Full"
 
 FROM app
 
@@ -76,6 +76,7 @@ COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
 EXPOSE 8096
+EXPOSE 3702 4025 4024 4022 4020
 VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
 EXPOSE 8096
+EXPOSE 3702 4025 4024 4022 4020
 VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY . .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 # because of changes in docker and systemd we need to not build in parallel at the moment
 # see https://success.docker.com/article/how-to-reserve-resource-temporarily-unavailable-errors-due-to-tasksmax-setting
-RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=true;DebugType=Full"
+RUN dotnet publish Jellyfin.Server --disable-parallel --configuration Release --output="/jellyfin" --self-contained --runtime linux-x64 "-p:DebugSymbols=false;DebugType=none"
 
 FROM app
 
@@ -76,7 +76,6 @@ COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
 EXPOSE 8096
-EXPOSE 3702 4025 4024 4022 4020
 VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -189,6 +189,11 @@ namespace MediaBrowser.Providers.Manager
                 catch (FileNotFoundException)
                 {
                 }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation("Exception caught: ", ex.Message);
+                    throw;
+                }
                 finally
                 {
                     _libraryMonitor.ReportFileSystemChangeComplete(currentPath, false);

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -191,6 +191,7 @@ namespace MediaBrowser.Providers.Manager
                 }
                 catch (Exception ex)
                 {
+
                     _logger.LogInformation("Exception caught: ", ex.Message);
                     throw;
                 }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -190,7 +190,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                 }
                 catch (Exception ex)
-                {
+                { 
                     _logger.LogInformation("Exception caught: ", ex.Message);
                     throw;
                 }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -191,7 +191,6 @@ namespace MediaBrowser.Providers.Manager
                 }
                 catch (Exception ex)
                 {
-
                     _logger.LogInformation("Exception caught: ", ex.Message);
                     throw;
                 }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -189,10 +189,9 @@ namespace MediaBrowser.Providers.Manager
                 catch (FileNotFoundException)
                 {
                 }
-                catch (Exception ex)
+                catch (IOException e) when (e.Message.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogInformation("Exception caught: ", ex.Message);
-                    throw;
+                    _logger.LogInformation("Could not delete {currentPath}, read only file system.", currentPath);
                 }
                 finally
                 {

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -190,7 +190,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                 }
                 catch (Exception ex)
-                { 
+                {
                     _logger.LogInformation("Exception caught: ", ex.Message);
                     throw;
                 }

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -335,6 +335,7 @@ namespace MediaBrowser.Providers.Manager
 
             foreach (var image in item.GetImages(type))
             {
+                var deletedThisIteration = false;
                 if (!image.IsLocalFile)
                 {
                     deletedImages.Add(image);
@@ -344,7 +345,7 @@ namespace MediaBrowser.Providers.Manager
                 try
                 {
                     _fileSystem.DeleteFile(image.Path);
-                    deleted = true;
+                    deletedThisIteration = true;
                 }
                 catch (FileNotFoundException)
                 {
@@ -352,6 +353,11 @@ namespace MediaBrowser.Providers.Manager
                 catch (Exception e)
                 {
                     _logger.LogError("Could not delete file ", e.Message);
+                    deletedThisIteration = false;
+                }
+                finally
+                {
+                    deleted = deleted || deletedThisIteration;
                 }
             }
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -349,6 +349,7 @@ namespace MediaBrowser.Providers.Manager
                 }
                 catch (FileNotFoundException)
                 {
+                    deletedThisIteration = false;
                 }
                 catch (IOException e) when (e.Message.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase))
                 {
@@ -357,7 +358,7 @@ namespace MediaBrowser.Providers.Manager
                 }
                 finally
                 {
-                    deleted = deleted || deletedThisIteration;
+                    deleted |= deletedThisIteration;
                 }
             }
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -335,7 +335,6 @@ namespace MediaBrowser.Providers.Manager
 
             foreach (var image in item.GetImages(type))
             {
-                var deletedThisIteration = false;
                 if (!image.IsLocalFile)
                 {
                     deletedImages.Add(image);
@@ -345,20 +344,14 @@ namespace MediaBrowser.Providers.Manager
                 try
                 {
                     _fileSystem.DeleteFile(image.Path);
-                    deletedThisIteration = true;
+                    deleted = true;
                 }
                 catch (FileNotFoundException)
                 {
-                    deletedThisIteration = false;
                 }
                 catch (IOException e) when (e.Message.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogInformation("Could not delete {provider}, read only file system.", image.Path);
-                    deletedThisIteration = false;
-                }
-                finally
-                {
-                    deleted |= deletedThisIteration;
                 }
             }
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -349,6 +349,10 @@ namespace MediaBrowser.Providers.Manager
                 catch (FileNotFoundException)
                 {
                 }
+                catch (Exception e)
+                {
+                    _logger.LogError("Could not delete file ", e.Message);
+                }
             }
 
             item.RemoveImages(deletedImages);

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -350,9 +350,9 @@ namespace MediaBrowser.Providers.Manager
                 catch (FileNotFoundException)
                 {
                 }
-                catch (Exception e)
+                catch (IOException e) when (e.Message.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogError("Could not delete file ", e.Message);
+                    _logger.LogInformation("Could not delete {provider}, read only file system.", image.Path);
                     deletedThisIteration = false;
                 }
                 finally


### PR DESCRIPTION
**Changes**
To reproduce: Media is stored on a read-only medium, such as a readonly mount.  Have a piece of media that has a cover art automatically read in by the media scanner.  If you try to replace that cover art, the API would return a 500 error due to the underlying system being read only.

The issue is resolved by handling the read-only IO Exception in the same manner it handles files that are not found.  It now ignores the error (because it is not allowed to delete the file), and continues with the metadata changes.  In the internal DB it recognizes that the art has been changed, while the original file is untouched.
