### PR TITLE
Update M3U Channel Name Precedence

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
@@ -295,11 +295,11 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 }
             }
 
-            attributes.TryGetValue("tvg-name", out string name);
+            string name = nameInExtInf;
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                name = nameInExtInf;
+                attributes.TryGetValue("tvg-name", out name);
             }
 
             if (string.IsNullOrWhiteSpace(name))


### PR DESCRIPTION
**Changes**
Sets the ExtInf display name to have a higher precedence than the `tvg-name` attribute for channel names.

Usually `namInExtInf` is a more descriptive and human readable name if both it and `tvg-name` are available. `tvg-name` is more likely to be an internal identifier such as just the channel number with a prefix in my provider's case.
