### PR TITLE
Allow zero activity log retention days

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
@@ -60,7 +60,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         public Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
         {
             var retentionDays = _serverConfigurationManager.Configuration.ActivityLogRetentionDays;
-            if (!retentionDays.HasValue || retentionDays <= 0)
+            if (!retentionDays.HasValue || retentionDays < 0)
             {
                 throw new Exception($"Activity Log Retention days must be at least 0. Currently: {retentionDays}");
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
The error message states that "Activity Log Retention days must be at least 0", but it fails with a value of zero, despite the message. This PR allows a value of 0.

A value of 0 is useful because it allows clearing the entire activity log through the "Clean Activity Log" task.

**Issues**
This is somewhat related to https://features.jellyfin.org/posts/1161/disable-or-anonymize-activity-logs