### PR TITLE
Refresh episodes before seasons

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -137,6 +137,8 @@ namespace MediaBrowser.Providers.TV
             // Loop through the unique season numbers
             foreach (var episode in episodesInSeriesFolder)
             {
+                await episode.RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken).ConfigureAwait(false);
+
                 // Null season numbers will have a 'dummy' season created because seasons are always required.
                 var seasonNumber = episode.ParentIndexNumber >= 0 ? episode.ParentIndexNumber : null;
                 var existingSeason = seasons.FirstOrDefault(i => i.IndexNumber == seasonNumber);


### PR DESCRIPTION
Refresh episodes before seasons to get the know which season to append the episode to. I don't know if this should be done on every refresh of the series item, or only on the initial refresh, but this PR adds it to to every refresh.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Refresh episodes before seasons

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
