### PR TITLE
Update Intel Compute Runtime Resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 # https://github.com/intel/compute-runtime/releases
-ARG GMMLIB_VERSION=20.3.2
-ARG IGC_VERSION=1.0.5435
-ARG NEO_VERSION=20.46.18421
-ARG LEVEL_ZERO_VERSION=1.0.18421
+ARG GMMLIB_VERSION=21.2.1
+ARG IGC_VERSION=1.0.8517
+ARG NEO_VERSION=21.35.20826
+ARG LEVEL_ZERO_VERSION=1.2.20826
 
 # Install dependencies:
 # mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.


### PR DESCRIPTION
**Changes**
Updating the Intel Compute Resources used for Intel VAAPI dependencies. At the time of posting, the latest version was [21.35.20826](https://github.com/intel/compute-runtime/releases/tag/21.35.20826)

**Side Note** 
With these changes I can update the docker container to run with VAAPI on my Intel i3 10100 like so: 
```
// Free Drivers
apt -y update && apt -y install intel-media-va-driver vainfo
// To use Non-Free Drivers
echo 'deb http://ftp.au.debian.org/debian bullseye non-free' >> /etc/apt/sources.list \
&& apt -y update && apt -y install intel-media-va-driver-non-free vainfo
```
Previously I would have issues running `vainfo` with `intel-gmmlib` being too out of date for the latest intel-media-va-driver API
