### PR TITLE
Fix disposed exception when ffmpeg exits early in GetLiveHlsStream

### DIFF
--- a/Jellyfin.Api/Controllers/VideoHlsController.cs
+++ b/Jellyfin.Api/Controllers/VideoHlsController.cs
@@ -267,6 +267,9 @@ namespace Jellyfin.Api.Controllers
 
             // CTS lifecycle is managed internally.
             var cancellationTokenSource = new CancellationTokenSource();
+            // Due to CTS.Token calling ThrowIfDisposed (https://github.com/dotnet/runtime/issues/29970) we have to "cache" the token
+            // since it gets disposed when ffmpeg exits
+            var cancellationToken = cancellationTokenSource.Token;
             using var state = await StreamingHelpers.GetStreamingState(
                     streamingRequest,
                     Request,
@@ -281,7 +284,7 @@ namespace Jellyfin.Api.Controllers
                     _deviceManager,
                     _transcodingJobHelper,
                     TranscodingJobType,
-                    cancellationTokenSource.Token)
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             TranscodingJobDto? job = null;
@@ -290,7 +293,7 @@ namespace Jellyfin.Api.Controllers
             if (!System.IO.File.Exists(playlistPath))
             {
                 var transcodingLock = _transcodingJobHelper.GetTranscodingLock(playlistPath);
-                await transcodingLock.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+                await transcodingLock.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
                     if (!System.IO.File.Exists(playlistPath))
@@ -317,7 +320,7 @@ namespace Jellyfin.Api.Controllers
                         minSegments = state.MinSegments;
                         if (minSegments > 0)
                         {
-                            await HlsHelpers.WaitForMinimumSegmentCount(playlistPath, minSegments, _logger, cancellationTokenSource.Token).ConfigureAwait(false);
+                            await HlsHelpers.WaitForMinimumSegmentCount(playlistPath, minSegments, _logger, cancellationToken).ConfigureAwait(false);
                         }
                     }
                 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Save CTS.Token to a local variable so that we can continue checking if cancellation was requested or not. CTS is poorly designed in that it throws if it was disposed, but you can never really check if it was disposed.

**Issues**

<details>
<summary>Stacktrace</summary>

```
Jellyfin.Server.Middleware.ExceptionMiddleware: Error processing request. URL GET /videos/7e693bfc-251e-018c-f99e-82bb696d72ee/live.m3u8.
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.ThrowObjectDisposedException()
   at System.Threading.CancellationTokenSource.ThrowIfDisposed()
   at System.Threading.CancellationTokenSource.get_Token()
   at Jellyfin.Api.Controllers.VideoHlsController.GetLiveHlsStream(Guid itemId, String container, Nullable`1 static, String params, String tag, String deviceProfileId, String playSessionId, String segmentContainer, Nullable`1 segmentLength, Nullable`1 minSegments, String mediaSourceId, String deviceId, S
tring audioCodec, Nullable`1 enableAutoStreamCopy, Nullable`1 allowVideoStreamCopy, Nullable`1 allowAudioStreamCopy, Nullable`1 breakOnNonKeyFrames, Nullable`1 audioSampleRate, Nullable`1 maxAudioBitDepth, Nullable`1 audioBitRate, Nullable`1 audioChannels, Nullable`1 maxAudioChannels, String profile, Str
ing level, Nullable`1 framerate, Nullable`1 maxFramerate, Nullable`1 copyTimestamps, Nullable`1 startTimeTicks, Nullable`1 width, Nullable`1 height, Nullable`1 videoBitRate, Nullable`1 subtitleStreamIndex, Nullable`1 subtitleMethod, Nullable`1 maxRefFrames, Nullable`1 maxVideoBitDepth, Nullable`1 require
Avc, Nullable`1 deInterlace, Nullable`1 requireNonAnamorphic, Nullable`1 transcodingMaxAudioChannels, Nullable`1 cpuCoreLimit, String liveStreamId, Nullable`1 enableMpegtsM2TsMode, String videoCodec, String subtitleCodec, String transcodeReasons, Nullable`1 audioStreamIndex, Nullable`1 videoStreamIndex,
Nullable`1 context, Dictionary`2 streamOptions, Nullable`1 maxWidth, Nullable`1 maxHeight, Nullable`1 enableSubtitlesInManifest) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Api\Controllers\VideoHlsController.cs:line 320
   at lambda_method1082(Closure , Object )
   at Microsoft.Extensions.Internal.ObjectMethodExecutorAwaitable.Awaiter.GetResult()
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|19_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Jellyfin.Server.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\ServerStartupMessageMiddleware.cs:line 41
   at Jellyfin.Server.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\WebSocketHandlerMiddleware.cs:line 33
   at Jellyfin.Server.Middleware.IpBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\IpBasedAccessValidationMiddleware.cs:line 36
   at Jellyfin.Server.Middleware.LanFilteringMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\LanFilteringMiddleware.cs:line 42
   at Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler.HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Server.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\QueryStringDecodingMiddleware.cs:line 32
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Server.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\RobotsRedirectionMiddleware.cs:line 44
   at Jellyfin.Server.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\LegacyEmbyRouteRewriteMiddleware.cs:line 51
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
   at Jellyfin.Server.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\ResponseTimeMiddleware.cs:line 63
   at Jellyfin.Server.Middleware.ExceptionMiddleware.Invoke(HttpContext context) in C:\Users\claus\RiderProjects\jellyfin\Jellyfin.Server\Middleware\ExceptionMiddleware.cs:line 55
```
</details>
