### PR TITLE
Fix images "not loading" after manual identification

### DIFF
--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -18,6 +18,12 @@ namespace MediaBrowser.Model.Extensions
         /// <returns>The ordered remote image infos.</returns>
         public static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedLanguage)
         {
+            if (string.IsNullOrWhiteSpace(requestedLanguage))
+            {
+                // Default to English if no requested language is specified.
+                requestedLanguage = "en";
+            }
+
             var isRequestedLanguageEn = string.Equals(requestedLanguage, "en", StringComparison.OrdinalIgnoreCase);
 
             return remoteImageInfos.OrderByDescending(i =>
@@ -27,14 +33,16 @@ namespace MediaBrowser.Model.Extensions
                         return 3;
                     }
 
-                    if (!isRequestedLanguageEn && string.Equals("en", i.Language, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return 2;
-                    }
-
                     if (string.IsNullOrEmpty(i.Language))
                     {
+                        // Assume empty image language is likely to be English.
                         return isRequestedLanguageEn ? 3 : 2;
+                    }
+
+                    if (!isRequestedLanguageEn && string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Prioritize English over non-requested languages.
+                        return 2;
                     }
 
                     return 0;

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -275,7 +275,7 @@ namespace MediaBrowser.Providers.Manager
                     item,
                     new RemoteImageQuery(provider.Name)
                     {
-                        IncludeAllLanguages = false,
+                        IncludeAllLanguages = true,
                         IncludeDisabledProviders = false,
                     },
                     cancellationToken).ConfigureAwait(false);
@@ -469,7 +469,7 @@ namespace MediaBrowser.Providers.Manager
             CancellationToken cancellationToken)
         {
             var eligibleImages = images
-                .Where(i => i.Type == type && !(i.Width.HasValue && i.Width.Value < minWidth))
+                .Where(i => i.Type == type && i.Width >= minWidth)
                 .ToList();
 
             if (EnableImageStub(item) && eligibleImages.Count > 0)

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -24,6 +24,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Subtitles;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
@@ -235,14 +236,7 @@ namespace MediaBrowser.Providers.Manager
 
             var preferredLanguage = item.GetPreferredMetadataLanguage();
 
-            var languages = new List<string>();
-            if (!query.IncludeAllLanguages && !string.IsNullOrWhiteSpace(preferredLanguage))
-            {
-                languages.Add(preferredLanguage);
-            }
-
-            // TODO include [query.IncludeAllLanguages] as an argument to the providers
-            var tasks = providers.Select(i => GetImages(item, i, languages, cancellationToken, query.ImageType));
+            var tasks = providers.Select(i => GetImages(item, i, preferredLanguage, query.IncludeAllLanguages, cancellationToken, query.ImageType));
 
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -254,17 +248,21 @@ namespace MediaBrowser.Providers.Manager
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="provider">The provider.</param>
-        /// <param name="preferredLanguages">The preferred languages.</param>
+        /// <param name="preferredLanguage">The preferred language.</param>
+        /// <param name="includeAllLanguages">Whether to include all languages in results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="type">The type.</param>
         /// <returns>Task{IEnumerable{RemoteImageInfo}}.</returns>
         private async Task<IEnumerable<RemoteImageInfo>> GetImages(
             BaseItem item,
             IRemoteImageProvider provider,
-            IReadOnlyCollection<string> preferredLanguages,
+            string preferredLanguage,
+            bool includeAllLanguages,
             CancellationToken cancellationToken,
             ImageType? type = null)
         {
+            bool hasPreferredLanguage = !string.IsNullOrWhiteSpace(preferredLanguage);
+
             try
             {
                 var result = await provider.GetImages(item, cancellationToken).ConfigureAwait(false);
@@ -274,14 +272,17 @@ namespace MediaBrowser.Providers.Manager
                     result = result.Where(i => i.Type == type.Value);
                 }
 
-                if (preferredLanguages.Count > 0)
+                if (!includeAllLanguages && hasPreferredLanguage)
                 {
-                    result = result.Where(i => string.IsNullOrEmpty(i.Language) ||
-                                               preferredLanguages.Contains(i.Language, StringComparer.OrdinalIgnoreCase) ||
+                    // Filter out languages that do not match the preferred languages.
+                    //
+                    // TODO: should exception case of "en" (English) eventually be removed?
+                    result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
+                                               string.Equals(preferredLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
                                                string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
                 }
 
-                return result;
+                return result.OrderByLanguageDescending(preferredLanguage);
             }
             catch (OperationCanceledException)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
@@ -101,7 +101,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
                 });
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
@@ -13,7 +13,6 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
 using TMDbLib.Objects.Find;
 
@@ -118,7 +117,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
                 });
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
@@ -10,7 +10,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.People
@@ -77,7 +76,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
                 };
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
@@ -12,7 +12,6 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV
@@ -92,7 +91,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 };
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -81,7 +81,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 };
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
@@ -13,7 +13,6 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV
@@ -107,7 +106,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 };
             }
 
-            return remoteImages.OrderByLanguageDescending(language);
+            return remoteImages;
         }
 
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)


### PR DESCRIPTION
**Changes**

This change fixes a bug where images (usually of type `Primary`) seem to "not load" after the user custom identifies and matches the metadata with a particular source. This is due to the fact that search results shown on the UI will show primary covers from another language if those are the only covers available (#6467 shows that it is probably common in anime). However, in the previous internal logic, the image filtering does not allow for images from all languages, leading to a confusing mismatch between UI/UX and internal metadata tagging logic.

The fix enables images from all languages to be included during internal image fetching but adds logic to order results by the preferred languages so that the preferred language settings are still honored. If there are images available in the preferred language, they will be ordered before other results.


**Issues**

Fixes #3676
Fixes #6467 