### PR TITLE
Read file length for symlinks,

### DIFF
--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Server.Infrastructure
         /// <summary>
         /// Initializes a new instance of the <see cref="SymlinkFollowingPhysicalFileResultExecutor"/> class.
         /// </summary>
-        /// <param name="loggerFactory"></param>
+        /// <param name="loggerFactory">An instance of the <see cref="ILoggerFactory"/> interface.</param>
         public SymlinkFollowingPhysicalFileResultExecutor(ILoggerFactory loggerFactory) : base(loggerFactory)
         {
         }
@@ -95,13 +95,15 @@ namespace Jellyfin.Server.Infrastructure
 
             if (range != null)
             {
-                return SendFileAsync(result.FileName,
+                return SendFileAsync(
+                    result.FileName,
                     response,
                     offset: range.From ?? 0L,
                     count: rangeLength);
             }
 
-            return SendFileAsync(result.FileName,
+            return SendFileAsync(
+                result.FileName,
                 response,
                 offset: 0,
                 count: null);

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -136,7 +136,7 @@ namespace Jellyfin.Server.Infrastructure
 
             fileStream.Seek(offset, SeekOrigin.Begin);
             await StreamCopyOperation
-                .CopyToAsync(fileStream, response.Body, count, bufferSize, CancellationToken.None)
+                .CopyToAsync(fileStream, response.Body, count, BufferSize, CancellationToken.None)
                 .ConfigureAwait(true);
         }
 

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -140,10 +140,6 @@ namespace Jellyfin.Server.Infrastructure
                 .ConfigureAwait(true);
         }
 
-        private static bool IsSymLink(string path)
-        {
-            var fileInfo = new FileInfo(path);
-            return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
-        }
+        private static bool IsSymLink(string path) => (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
     }
 }

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿// The MIT License (MIT)
+//
+// Copyright (c) .NET Foundation and Contributors
+//
+// All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -124,7 +124,7 @@ namespace Jellyfin.Server.Infrastructure
             }
 
             // Copied from SendFileFallback.SendFileAsync
-            const int bufferSize = 1024 * 16;
+            const int BufferSize = 1024 * 16;
 
             await using var fileStream = new FileStream(
                 filePath,

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -131,7 +131,7 @@ namespace Jellyfin.Server.Infrastructure
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.ReadWrite,
-                bufferSize: bufferSize,
+                bufferSize: BufferSize,
                 options: (AsyncFile.UseAsyncIO ? FileOptions.Asynchronous : FileOptions.None) | FileOptions.SequentialScan);
 
             fileStream.Seek(offset, SeekOrigin.Begin);

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -55,7 +55,7 @@ namespace Jellyfin.Server.Infrastructure
             // This may or may not be fixed in .NET 6, but looks like it will not https://github.com/dotnet/aspnetcore/issues/34371
             if ((fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
             {
-                using Stream thisFileStream = AsyncFile.OpenRead(path);
+                using Stream thisFileStream = File.OpenRead(path);
                 length = thisFileStream.Length;
             }
 

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Server.Infrastructure
+{
+    /// <inheritdoc />
+    public class SymlinkFollowingPhysicalFileResultExecutor : PhysicalFileResultExecutor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SymlinkFollowingPhysicalFileResultExecutor"/> class.
+        /// </summary>
+        /// <param name="loggerFactory"></param>
+        public SymlinkFollowingPhysicalFileResultExecutor(ILoggerFactory loggerFactory) : base(loggerFactory)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override FileMetadata GetFileInfo(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            var length = fileInfo.Length;
+            // This may or may not be fixed in .NET 6, but looks like it will not https://github.com/dotnet/aspnetcore/issues/34371
+            if ((fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+            {
+                using Stream thisFileStream = AsyncFile.OpenRead(path);
+                length = thisFileStream.Length;
+            }
+
+            return new FileMetadata
+            {
+                Exists = fileInfo.Exists,
+                Length = length,
+                LastModified = fileInfo.LastWriteTimeUtc
+            };
+        }
+
+        /// <inheritdoc />
+        protected override Task WriteFileAsync(ActionContext context, PhysicalFileResult result, RangeItemHeaderValue range, long rangeLength)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            if (range != null && rangeLength == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            // It's a bit of wasted IO to perform this check again, but non-symlinks shouldn't use this code
+            if (!IsSymLink(result.FileName))
+            {
+                return base.WriteFileAsync(context, result, range, rangeLength);
+            }
+
+            var response = context.HttpContext.Response;
+
+            if (range != null)
+            {
+                return SendFileAsync(result.FileName,
+                    response,
+                    offset: range.From ?? 0L,
+                    count: rangeLength);
+            }
+
+            return SendFileAsync(result.FileName,
+                response,
+                offset: 0,
+                count: null);
+        }
+
+        private async Task SendFileAsync(string filePath, HttpResponse response, long offset, long? count)
+        {
+            var fileInfo = GetFileInfo(filePath);
+            if (offset < 0 || offset > fileInfo.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
+            }
+
+            if (count.HasValue
+                && (count.Value < 0 || count.Value > fileInfo.Length - offset))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), count, string.Empty);
+            }
+
+            // Copied from SendFileFallback.SendFileAsync
+            const int bufferSize = 1024 * 16;
+
+            await using var fileStream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite,
+                bufferSize: bufferSize,
+                options: (AsyncFile.UseAsyncIO ? FileOptions.Asynchronous : FileOptions.None) | FileOptions.SequentialScan);
+
+            fileStream.Seek(offset, SeekOrigin.Begin);
+            await StreamCopyOperation
+                .CopyToAsync(fileStream, response.Body, count, bufferSize, CancellationToken.None)
+                .ConfigureAwait(true);
+        }
+
+        private static bool IsSymLink(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+    }
+}

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Jellyfin.Networking.Configuration;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Implementations;
+using Jellyfin.Server.Infrastructure;
 using Jellyfin.Server.Middleware;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
@@ -14,6 +15,8 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -56,6 +59,9 @@ namespace Jellyfin.Server
             {
                 options.HttpsPort = _serverApplicationHost.HttpsPort;
             });
+
+            // TODO remove once this is fixed upstream https://github.com/dotnet/aspnetcore/issues/34371
+            services.AddSingleton<IActionResultExecutor<PhysicalFileResult>, SymlinkFollowingPhysicalFileResultExecutor>();
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
 
             services.AddJellyfinApiSwagger();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Created a subclass of `PhysicalFileResultExecutor` and replaced it in the DI container. It unfortunately reads the file attributes 1-2 times more than its superclass, but `FileInfo` is called multiple times even outside `PhysicalFileResultExecutor`. Therefore I have copied parts of static extensions methods eg. https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/SendFileFallback.cs to get the desired result.

The new executor is only used for symlinks.

Supersedes #5775 and #5824. And a huge thanks for the research done by both PR authors.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/5521
