### PR TITLE
Comparing PremiereDate when episode comparison would otherwise be equal.

### DIFF
--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -151,7 +151,6 @@ namespace Emby.Server.Implementations.Sorting
             if (comparisonResult == 0 && x.PremiereDate.HasValue && y.PremiereDate.HasValue)
             {
                 comparisonResult = DateTime.Compare(x.PremiereDate.Value, y.PremiereDate.Value);
-                }
             }
 
             return comparisonResult;

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -154,7 +154,7 @@ namespace Emby.Server.Implementations.Sorting
                 }
             }
 
-            return compare_val;
+            return comparisonResult;
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -146,12 +146,11 @@ namespace Emby.Server.Implementations.Sorting
         {
             var xValue = ((x.ParentIndexNumber ?? -1) * 1000) + (x.IndexNumber ?? -1);
             var yValue = ((y.ParentIndexNumber ?? -1) * 1000) + (y.IndexNumber ?? -1);
-            var compare_val = xValue.CompareTo(yValue);
-            if (compare_val == 0)
+            var comparisonResult = xValue.CompareTo(yValue);
+            // If equal, compare premiere dates
+            if (comparisonResult == 0 && x.PremiereDate.HasValue && y.PremiereDate.HasValue)
             {
-                if (x.PremiereDate.HasValue & y.PremiereDate.HasValue)
-                {
-                    compare_val = DateTime.Compare(x.PremiereDate.Value, y.PremiereDate.Value);
+                comparisonResult = DateTime.Compare(x.PremiereDate.Value, y.PremiereDate.Value);
                 }
             }
 

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -28,16 +28,6 @@ namespace Emby.Server.Implementations.Sorting
                 throw new ArgumentNullException(nameof(y));
             }
 
-            if (x.PremiereDate.HasValue && y.PremiereDate.HasValue)
-            {
-                var val = DateTime.Compare(x.PremiereDate.Value, y.PremiereDate.Value);
-
-                if (val != 0)
-                {
-                    // return val;
-                }
-            }
-
             var episode1 = x as Episode;
             var episode2 = y as Episode;
 
@@ -156,8 +146,16 @@ namespace Emby.Server.Implementations.Sorting
         {
             var xValue = ((x.ParentIndexNumber ?? -1) * 1000) + (x.IndexNumber ?? -1);
             var yValue = ((y.ParentIndexNumber ?? -1) * 1000) + (y.IndexNumber ?? -1);
+            var compare_val = xValue.CompareTo(yValue);
+            if (compare_val == 0)
+            {
+                if (x.PremiereDate.HasValue & y.PremiereDate.HasValue)
+                {
+                    compare_val = DateTime.Compare(x.PremiereDate.Value, y.PremiereDate.Value);
+                }
+            }
 
-            return xValue.CompareTo(yValue);
+            return compare_val;
         }
 
         /// <summary>

--- a/tests/Jellyfin.Server.Implementations.Tests/Sorting/AiredEpisodeOrderComparerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Sorting/AiredEpisodeOrderComparerTests.cs
@@ -172,6 +172,25 @@ namespace Jellyfin.Server.Implementations.Tests.Sorting
                     new Episode { ParentIndexNumber = 0, IndexNumber = 1, AirsBeforeSeasonNumber = 1, AirsBeforeEpisodeNumber = 2 },
                     1
                 };
+                // Premiere Date
+                yield return new object?[]
+                {
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 12, 0, 0, 0) },
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 12, 0, 0, 0) },
+                    0
+                };
+                yield return new object?[]
+                {
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 11, 0, 0, 0) },
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 12, 0, 0, 0) },
+                    -1
+                };
+                yield return new object?[]
+                {
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 12, 0, 0, 0) },
+                    new Episode { ParentIndexNumber = 1, IndexNumber = 1, PremiereDate = new DateTime(2021, 09, 11, 0, 0, 0) },
+                    1
+                };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
In cases where two episodes have the same episode and season, comparing the PremiereDate to further sort them.

**Issues**
Fixes #6269 
