### PR TITLE
Use standard Authorization header in OpenAPI specification

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -278,7 +278,7 @@ namespace Jellyfin.Server.Extensions
                 {
                     Type = SecuritySchemeType.ApiKey,
                     In = ParameterLocation.Header,
-                    Name = "X-Emby-Authorization",
+                    Name = "Authorization",
                     Description = "API key header parameter"
                 });
 


### PR DESCRIPTION
**Changes**
- Changed the security scheme in the OpenAPI document to use `Authorization` instead of `X-Emby-Authorization` as the default authorization header.

Multiple clients have already moved to this new header and more are coming. Using HTTP-standards instead of magic is the recommended way of connecting to your Jellyfin server.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
