### PR TITLE
Respond on request when ffmpeg fails

### DIFF
--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -607,6 +607,10 @@ namespace Jellyfin.Api.Helpers
             {
                 StartThrottler(state, transcodingJob);
             }
+            else if (transcodingJob.ExitCode != 0)
+            {
+                throw new Exception(string.Format(CultureInfo.InvariantCulture, "FFmpeg exited with code {0}", transcodingJob.ExitCode));
+            }
 
             _logger.LogDebug("StartFfMpeg() finished successfully");
 
@@ -743,6 +747,7 @@ namespace Jellyfin.Api.Helpers
         private void OnFfMpegProcessExited(Process process, TranscodingJobDto job, StreamState state)
         {
             job.HasExited = true;
+            job.ExitCode = process.ExitCode;
 
             _logger.LogDebug("Disposing stream resources");
             state.Dispose();

--- a/Jellyfin.Api/Models/PlaybackDtos/TranscodingJobDto.cs
+++ b/Jellyfin.Api/Models/PlaybackDtos/TranscodingJobDto.cs
@@ -107,6 +107,11 @@ namespace Jellyfin.Api.Models.PlaybackDtos
         public bool HasExited { get; set; }
 
         /// <summary>
+        /// Gets or sets exit code.
+        /// </summary>
+        public int ExitCode { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether is user paused.
         /// </summary>
         public bool IsUserPaused { get; set; }


### PR DESCRIPTION
If the video file is totally bad, ffmpeg exits with a non-zero code, but the request remains unresponded.
HLS player spams the `levelLoadTimeOut` error.

**Changes**
Throw on FFmpeg non-zero exit code.

**Issues**
The request remains unresponded when ffmpeg fails.

**Sample**
This video is an HLS-fragment and must not be played.
https://user-images.githubusercontent.com/56478732/133689991-593b52d3-7c95-43fe-9c3d-7fdaa4ad2f9f.mp4

Ideally, we should probably add a client-side timeout as well.

