### PR TITLE
Fix unit test RecordingHelperTests.GetRecordingName_Success.

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/RecordingHelper.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/RecordingHelper.cs
@@ -34,16 +34,16 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 {
                     if (info.OriginalAirDate.Value.Date.Equals(info.StartDate.Date))
                     {
-                        name += " " + GetDateString(info.StartDate);
+                        name += " " + GetDateTimeString(info.StartDate);
                     }
                     else
                     {
-                        name += " " + info.OriginalAirDate.Value.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        name += " " + GetDateString(info.OriginalAirDate.Value);
                     }
                 }
                 else
                 {
-                    name += " " + GetDateString(info.StartDate);
+                    name += " " + GetDateTimeString(info.StartDate);
                 }
 
                 if (!string.IsNullOrWhiteSpace(info.EpisodeTitle))
@@ -62,15 +62,20 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
             else
             {
-                name += " " + GetDateString(info.StartDate);
+                name += " " + GetDateTimeString(info.StartDate);
             }
 
             return name;
         }
 
-        private static string GetDateString(DateTime date)
+        private static string GetDateTimeString(DateTime date)
         {
             return date.ToLocalTime().ToString("yyyy_MM_dd_HH_mm_ss", CultureInfo.InvariantCulture);
+        }
+
+        private static string GetDateString(DateTime date)
+        {
+            return date.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Emby.Server.Implementations.LiveTv.EmbyTV;
 using MediaBrowser.Controller.LiveTv;
 using Xunit;
@@ -70,7 +71,7 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
 
             yield return new object[]
             {
-                "The Big Bang Theory 2018-12-06",
+                $"The Big Bang Theory {ToLocal("2018-12-06")}",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
@@ -81,7 +82,7 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
 
             yield return new object[]
             {
-                "The Big Bang Theory 2018-12-06 - The VCR Illumination",
+                $"The Big Bang Theory {ToLocal("2018-12-06")} - The VCR Illumination",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
@@ -91,18 +92,10 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 }
             };
 
-            yield return new object[]
-            {
-                "The Big Bang Theory 2018_12_06_21_06_00 - The VCR Illumination",
-                new TimerInfo
-                {
-                    Name = "The Big Bang Theory",
-                    StartDate = new DateTime(2018, 12, 6, 21, 6, 0, DateTimeKind.Local),
-                    IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6),
-                    EpisodeTitle = "The VCR Illumination"
-                }
-            };
+            string ToLocal(string date) => DateTime
+                .Parse(date, CultureInfo.InvariantCulture)
+                .ToLocalTime()
+                .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         [Theory]

--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
@@ -69,25 +69,26 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 }
             };
 
+            DateTime testOriginalAirDate = new DateTime(2018, 12, 6);
             yield return new object[]
             {
-                $"The Big Bang Theory {ToLocal("2018-12-06")}",
+                $"The Big Bang Theory {testOriginalAirDate.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
                     IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6)
+                    OriginalAirDate = testOriginalAirDate
                 }
             };
 
             yield return new object[]
             {
-                $"The Big Bang Theory {ToLocal("2018-12-06")} - The VCR Illumination",
+                $"The Big Bang Theory {testOriginalAirDate.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} - The VCR Illumination",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
                     IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6),
+                    OriginalAirDate = testOriginalAirDate,
                     EpisodeTitle = "The VCR Illumination"
                 }
             };
@@ -104,11 +105,6 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                     EpisodeTitle = "The VCR Illumination"
                 }
             };
-
-            string ToLocal(string date) => DateTime
-                .Parse(date, CultureInfo.InvariantCulture)
-                .ToLocalTime()
-                .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         [Theory]

--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
@@ -11,13 +11,16 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
     {
         public static IEnumerable<object[]> GetRecordingName_Success_TestData()
         {
+            DateTime testLocalStartDate = new DateTime(2020, 4, 20, 21, 6, 0, DateTimeKind.Local);
+            DateTime testOriginalAirDate = new DateTime(2018, 12, 6);
+
             yield return new object[]
             {
-                "The Incredibles 2020_04_20_21_06_00",
+                $"The Incredibles {GetDateTimeString(testLocalStartDate)}",
                 new TimerInfo
                 {
                     Name = "The Incredibles",
-                    StartDate = new DateTime(2020, 4, 20, 21, 6, 0, DateTimeKind.Local),
+                    StartDate = testLocalStartDate,
                     IsMovie = true
                 }
             };
@@ -35,11 +38,11 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
 
             yield return new object[]
             {
-                "The Big Bang Theory 2020_04_20_21_06_00",
+                $"The Big Bang Theory {GetDateTimeString(testLocalStartDate)}",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
-                    StartDate = new DateTime(2020, 4, 20, 21, 6, 0, DateTimeKind.Local),
+                    StartDate = testLocalStartDate,
                     IsProgramSeries = true,
                 }
             };
@@ -69,10 +72,9 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 }
             };
 
-            DateTime testOriginalAirDate = new DateTime(2018, 12, 6);
             yield return new object[]
             {
-                $"The Big Bang Theory {testOriginalAirDate.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+                $"The Big Bang Theory {GetDateString(testOriginalAirDate)}",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
@@ -83,7 +85,7 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
 
             yield return new object[]
             {
-                $"The Big Bang Theory {testOriginalAirDate.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} - The VCR Illumination",
+                $"The Big Bang Theory {GetDateString(testOriginalAirDate)} - The VCR Illumination",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
@@ -95,13 +97,13 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
 
             yield return new object[]
             {
-                "The Big Bang Theory 2018_12_06_21_06_00 - The VCR Illumination",
+                $"The Big Bang Theory {GetDateString(testOriginalAirDate)} - The VCR Illumination",
                 new TimerInfo
                 {
                     Name = "The Big Bang Theory",
-                    StartDate = new DateTime(2018, 12, 6, 21, 6, 0, DateTimeKind.Local),
+                    StartDate = testLocalStartDate,
                     IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6),
+                    OriginalAirDate = testOriginalAirDate,
                     EpisodeTitle = "The VCR Illumination"
                 }
             };
@@ -112,6 +114,16 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
         public static void GetRecordingName_Success(string expected, TimerInfo timerInfo)
         {
             Assert.Equal(expected, RecordingHelper.GetRecordingName(timerInfo));
+        }
+
+        private static string GetDateTimeString(DateTime date)
+        {
+            return date.ToLocalTime().ToString("yyyy_MM_dd_HH_mm_ss", CultureInfo.InvariantCulture);
+        }
+
+        private static string GetDateString(DateTime date)
+        {
+            return date.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
@@ -92,6 +92,19 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 }
             };
 
+            yield return new object[]
+            {
+                "The Big Bang Theory 2018_12_06_21_06_00 - The VCR Illumination",
+                new TimerInfo
+                {
+                    Name = "The Big Bang Theory",
+                    StartDate = new DateTime(2018, 12, 6, 21, 6, 0, DateTimeKind.Local),
+                    IsProgramSeries = true,
+                    OriginalAirDate = new DateTime(2018, 12, 6),
+                    EpisodeTitle = "The VCR Illumination"
+                }
+            };
+
             string ToLocal(string date) => DateTime
                 .Parse(date, CultureInfo.InvariantCulture)
                 .ToLocalTime()


### PR DESCRIPTION
**Changes**
The string representation of the date should be local.