### PR TITLE
SsdpHttpClient: Ensure successful status code before reading response

### DIFF
--- a/Emby.Dlna/PlayTo/SsdpHttpClient.cs
+++ b/Emby.Dlna/PlayTo/SsdpHttpClient.cs
@@ -45,10 +45,12 @@ namespace Emby.Dlna.PlayTo
                     header,
                     cancellationToken)
                 .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             return await XDocument.LoadAsync(
                 stream,
-                LoadOptions.PreserveWhitespace,
+                LoadOptions.None,
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -86,6 +88,7 @@ namespace Emby.Dlna.PlayTo
             using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
                 .SendAsync(options, HttpCompletionOption.ResponseHeadersRead)
                 .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
         }
 
         public async Task<XDocument> GetDataAsync(string url, CancellationToken cancellationToken)
@@ -94,12 +97,13 @@ namespace Emby.Dlna.PlayTo
             options.Headers.UserAgent.ParseAdd(USERAGENT);
             options.Headers.TryAddWithoutValidation("FriendlyName.DLNA.ORG", FriendlyName);
             using var response = await _httpClientFactory.CreateClient(NamedClient.Default).SendAsync(options, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 return await XDocument.LoadAsync(
                     stream,
-                    LoadOptions.PreserveWhitespace,
+                    LoadOptions.None,
                     cancellationToken).ConfigureAwait(false);
             }
             catch


### PR DESCRIPTION
Before:
```
[21:37:55] [ERR] [19] Emby.Dlna.Main.DlnaEntryPoint: Error updating device info for XXX
System.Xml.XmlException: Root element is missing.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   at System.Xml.XmlTextReaderImpl.ParseDocumentContentAsync_ReadData(Boolean needMoreChars)
   at System.Xml.Linq.XDocument.LoadAsyncInternal(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
   at System.Xml.Linq.XDocument.LoadAsync(Stream stream, LoadOptions options, CancellationToken cancellationToken)
   at Emby.Dlna.PlayTo.SsdpHttpClient.SendCommandAsync(String baseUrl, DeviceService service, String command, String postData, String header, CancellationToken cancellationToken) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/SsdpHttpClient.cs:line 50
   at Emby.Dlna.PlayTo.SsdpHttpClient.SendCommandAsync(String baseUrl, DeviceService service, String command, String postData, String header, CancellationToken cancellationToken) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/SsdpHttpClient.cs:line 50
   at Emby.Dlna.PlayTo.Device.GetTransportInfo(TransportCommands avCommands, CancellationToken cancellationToken) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 706
   at Emby.Dlna.PlayTo.Device.TimerCallback(Object sender) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 522
```

After:
```
[22:09:29] [ERR] [19] Emby.Dlna.Main.DlnaEntryPoint: Error updating device info for XXX
System.Net.Http.HttpRequestException: Response status code does not indicate success: 403 (Forbidden).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at Emby.Dlna.PlayTo.SsdpHttpClient.SendCommandAsync(String baseUrl, DeviceService service, String command, String postData, String header, CancellationToken cancellationToken) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/SsdpHttpClient.cs:line 48
   at Emby.Dlna.PlayTo.Device.GetTransportInfo(TransportCommands avCommands, CancellationToken cancellationToken) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 706
   at Emby.Dlna.PlayTo.Device.TimerCallback(Object sender) in /home/bond/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 522
```