### PR TITLE
Add first draft of keyframe extraction for Matroska

### DIFF
--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Emby.Dlna\Emby.Dlna.csproj" />
     <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
+    <ProjectReference Include="..\src\Jellyfin.MediaEncoding.Hls\Jellyfin.MediaEncoding.Hls.csproj" />
   </ItemGroup>
 
   <!-- Code Analyzers-->

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\Emby.Server.Implementations\Emby.Server.Implementations.csproj" />
     <ProjectReference Include="..\Jellyfin.Drawing.Skia\Jellyfin.Drawing.Skia.csproj" />
     <ProjectReference Include="..\Jellyfin.Server.Implementations\Jellyfin.Server.Implementations.csproj" />
+    <ProjectReference Include="..\src\Jellyfin.MediaEncoding.Hls\Jellyfin.MediaEncoding.Hls.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
+using Jellyfin.MediaEncoding.Hls.Extensions;
 using Jellyfin.Networking.Configuration;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Implementations;
@@ -104,6 +105,8 @@ namespace Jellyfin.Server
 
             services.AddHealthChecks()
                 .AddDbContextCheck<JellyfinDb>();
+
+            services.AddHlsPlaylistGenerator();
         }
 
         /// <summary>

--- a/Jellyfin.sln
+++ b/Jellyfin.sln
@@ -89,6 +89,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Extensions", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Extensions.Tests", "tests\Jellyfin.Extensions.Tests\Jellyfin.Extensions.Tests.csproj", "{332A5C7A-F907-47CA-910E-BE6F7371B9E0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.MediaEncoding.Keyframes", "src\Jellyfin.MediaEncoding.Keyframes\Jellyfin.MediaEncoding.Keyframes.csproj", "{06535CA1-4097-4360-85EB-5FB875D53239}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.MediaEncoding.Hls", "src\Jellyfin.MediaEncoding.Hls\Jellyfin.MediaEncoding.Hls.csproj", "{DA9FD356-4894-4830-B208-D6BCE3E65B11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +247,14 @@ Global
 		{332A5C7A-F907-47CA-910E-BE6F7371B9E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{332A5C7A-F907-47CA-910E-BE6F7371B9E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{332A5C7A-F907-47CA-910E-BE6F7371B9E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06535CA1-4097-4360-85EB-5FB875D53239}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06535CA1-4097-4360-85EB-5FB875D53239}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06535CA1-4097-4360-85EB-5FB875D53239}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06535CA1-4097-4360-85EB-5FB875D53239}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA9FD356-4894-4830-B208-D6BCE3E65B11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA9FD356-4894-4830-B208-D6BCE3E65B11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA9FD356-4894-4830-B208-D6BCE3E65B11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA9FD356-4894-4830-B208-D6BCE3E65B11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,6 +275,8 @@ Global
 		{A964008C-2136-4716-B6CB-B3426C22320A} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
 		{750B8757-BE3D-4F8C-941A-FBAD94904ADA} = {C9F0AB5D-F4D7-40C8-A353-3305C86D6D4C}
 		{332A5C7A-F907-47CA-910E-BE6F7371B9E0} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
+		{06535CA1-4097-4360-85EB-5FB875D53239} = {C9F0AB5D-F4D7-40C8-A353-3305C86D6D4C}
+		{DA9FD356-4894-4830-B208-D6BCE3E65B11} = {C9F0AB5D-F4D7-40C8-A353-3305C86D6D4C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3448830C-EBDC-426C-85CD-7BBB9651A7FE}

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -25,6 +25,12 @@ namespace MediaBrowser.Controller.MediaEncoding
         string EncoderPath { get; }
 
         /// <summary>
+        /// Gets the probe path.
+        /// </summary>
+        /// <value>The probe path.</value>
+        string ProbePath { get; }
+
+        /// <summary>
         /// Whether given encoder codec is supported.
         /// </summary>
         /// <param name="encoder">The encoder.</param>

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -91,6 +91,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public string EncoderPath => _ffmpegPath;
 
+        /// <inheritdoc />
+        public string ProbePath => _ffprobePath;
+
         /// <summary>
         /// Run at startup or if the user removes a Custom path from transcode page.
         /// Sets global variables FFmpegPath.

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 #nullable disable
 #pragma warning disable CS1591
 
@@ -37,6 +39,7 @@ namespace MediaBrowser.Model.Configuration
             EnableHardwareEncoding = true;
             AllowHevcEncoding = false;
             EnableSubtitleExtraction = true;
+            AllowAutomaticKeyframeExtractionForExtensions = Array.Empty<string>();
             HardwareDecodingCodecs = new string[] { "h264", "vc1" };
         }
 
@@ -111,5 +114,7 @@ namespace MediaBrowser.Model.Configuration
         public bool EnableSubtitleExtraction { get; set; }
 
         public string[] HardwareDecodingCodecs { get; set; }
+
+        public string[] AllowAutomaticKeyframeExtractionForExtensions { get; set; }
     }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Extensions/MediaEncodingHlsServiceCollectionExtensions.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Extensions/MediaEncodingHlsServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Jellyfin.MediaEncoding.Hls.Playlist;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.MediaEncoding.Hls.Extensions
+{
+    /// <summary>
+    /// Extensions for the <see cref="IServiceCollection"/> interface.
+    /// </summary>
+    public static class MediaEncodingHlsServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the hls playlist generators to the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="serviceCollection">An instance of the <see cref="IServiceCollection"/> interface.</param>
+        /// <returns>The updated service collection.</returns>
+        public static IServiceCollection AddHlsPlaylistGenerator(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.AddSingleton<IDynamicHlsPlaylistGenerator, DynamicHlsPlaylistGenerator>();
+        }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Hls/Jellyfin.MediaEncoding.Hls.csproj
+++ b/src/Jellyfin.MediaEncoding.Hls/Jellyfin.MediaEncoding.Hls.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Code Analyzers-->
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Jellyfin.MediaEncoding.Keyframes\Jellyfin.MediaEncoding.Keyframes.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.AspNetCore.App.Ref\5.0.0\ref\net5.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
@@ -1,0 +1,57 @@
+﻿namespace Jellyfin.MediaEncoding.Hls.Playlist
+{
+    /// <summary>
+    /// Request class for the <see cref="IDynamicHlsPlaylistGenerator.CreateMainPlaylist(CreateMainPlaylistRequest)"/> method.
+    /// </summary>
+    public class CreateMainPlaylistRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateMainPlaylistRequest"/> class.
+        /// </summary>
+        /// <param name="filePath">The absolute file path to the file.</param>
+        /// <param name="desiredSegmentLengthMs">The desired segment length in milliseconds.</param>
+        /// <param name="totalRuntimeTicks">The total duration of the file in ticks.</param>
+        /// <param name="segmentContainer">The desired segment container eg. "ts".</param>
+        /// <param name="endpointPrefix">The URI prefix for the relative URL in the playlist.</param>
+        /// <param name="queryString">The desired query string to append (must start with ?).</param>
+        public CreateMainPlaylistRequest(string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString)
+        {
+            FilePath = filePath;
+            DesiredSegmentLengthMs = desiredSegmentLengthMs;
+            TotalRuntimeTicks = totalRuntimeTicks;
+            SegmentContainer = segmentContainer;
+            EndpointPrefix = endpointPrefix;
+            QueryString = queryString;
+        }
+
+        /// <summary>
+        /// Gets the file path.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Gets the desired segment length in milliseconds.
+        /// </summary>
+        public int DesiredSegmentLengthMs { get; }
+
+        /// <summary>
+        /// Gets the total runtime in ticks.
+        /// </summary>
+        public long TotalRuntimeTicks { get; }
+
+        /// <summary>
+        /// Gets the segment container.
+        /// </summary>
+        public string SegmentContainer { get; }
+
+        /// <summary>
+        /// Gets the endpoint prefix for the URL.
+        /// </summary>
+        public string EndpointPrefix { get; }
+
+        /// <summary>
+        /// Gets the query string.
+        /// </summary>
+        public string QueryString { get; }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Jellyfin.Extensions.Json;
+using Jellyfin.MediaEncoding.Keyframes;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Extensions;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.MediaEncoding;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.MediaEncoding.Hls.Playlist
+{
+    /// <inheritdoc />
+    public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
+    {
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
+        private readonly IServerConfigurationManager _serverConfigurationManager;
+        private readonly IMediaEncoder _mediaEncoder;
+        private readonly IApplicationPaths _applicationPaths;
+        private readonly KeyframeExtractor _keyframeExtractor;
+        private const string DefaultContainerExtension = ".ts";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicHlsPlaylistGenerator"/> class.
+        /// </summary>
+        /// <param name="serverConfigurationManager">An instance of the see <see cref="IServerConfigurationManager"/> interface.</param>
+        /// <param name="mediaEncoder">An instance of the see <see cref="IMediaEncoder"/> interface.</param>
+        /// <param name="applicationPaths">An instance of the <see cref="IApplicationPaths"/> interface.</param>
+        /// <param name="loggerFactory">An instance of the see <see cref="ILoggerFactory"/> interface.</param>
+        public DynamicHlsPlaylistGenerator(IServerConfigurationManager serverConfigurationManager, IMediaEncoder mediaEncoder, IApplicationPaths applicationPaths, ILoggerFactory loggerFactory)
+        {
+            _serverConfigurationManager = serverConfigurationManager;
+            _mediaEncoder = mediaEncoder;
+            _applicationPaths = applicationPaths;
+            _keyframeExtractor = new KeyframeExtractor(loggerFactory.CreateLogger<KeyframeExtractor>());
+        }
+
+        private string KeyframeCachePath => Path.Combine(_applicationPaths.DataPath, "keyframes");
+
+        /// <inheritdoc />
+        public string CreateMainPlaylist(CreateMainPlaylistRequest request)
+        {
+            IReadOnlyList<double> segments;
+            if (IsExtractionAllowed(request.FilePath))
+            {
+                segments = ComputeSegments(request.FilePath, request.DesiredSegmentLengthMs);
+            }
+            else
+            {
+                segments = ComputeEqualLengthSegments(request.DesiredSegmentLengthMs, request.TotalRuntimeTicks);
+            }
+
+            var segmentExtension = GetSegmentFileExtension(request.SegmentContainer);
+
+            // http://ffmpeg.org/ffmpeg-all.html#toc-hls-2
+            var isHlsInFmp4 = string.Equals(segmentExtension, "mp4", StringComparison.OrdinalIgnoreCase);
+            var hlsVersion = isHlsInFmp4 ? "7" : "3";
+
+            var builder = new StringBuilder(128);
+
+            builder.AppendLine("#EXTM3U")
+                .AppendLine("#EXT-X-PLAYLIST-TYPE:VOD")
+                .Append("#EXT-X-VERSION:")
+                .Append(hlsVersion)
+                .AppendLine()
+                .Append("#EXT-X-TARGETDURATION:")
+                .Append(Math.Ceiling(segments.Count > 0 ? segments.Max() : request.DesiredSegmentLengthMs))
+                .AppendLine()
+                .AppendLine("#EXT-X-MEDIA-SEQUENCE:0");
+
+            var index = 0;
+
+            if (isHlsInFmp4)
+            {
+                builder.Append("#EXT-X-MAP:URI=\"")
+                    .Append(request.EndpointPrefix)
+                    .Append("-1")
+                    .Append(segmentExtension)
+                    .Append(request.QueryString)
+                    .Append('"')
+                    .AppendLine();
+            }
+
+            double currentRuntimeInSeconds = 0;
+            foreach (var length in segments)
+            {
+                builder.Append("#EXTINF:")
+                    .Append(length.ToString("0.0000", CultureInfo.InvariantCulture))
+                    .AppendLine(", nodesc")
+                    .Append(request.EndpointPrefix)
+                    .Append(index++)
+                    .Append(segmentExtension)
+                    .Append(request.QueryString)
+                    .Append("&runtimeTicks=")
+                    .Append(TimeSpan.FromSeconds(currentRuntimeInSeconds).Ticks)
+                    .Append("&actualSegmentLengthTicks=")
+                    .Append(TimeSpan.FromSeconds(length).Ticks)
+                    .AppendLine();
+
+                currentRuntimeInSeconds += length;
+            }
+
+            builder.AppendLine("#EXT-X-ENDLIST");
+
+            return builder.ToString();
+        }
+
+        private IReadOnlyList<double> ComputeSegments(string filePath, int desiredSegmentLengthMs)
+        {
+            KeyframeData keyframeData;
+            var cachePath = GetCachePath(filePath);
+            if (TryReadFromCache(cachePath, out var cachedResult))
+            {
+                keyframeData = cachedResult;
+            }
+            else
+            {
+                keyframeData = _keyframeExtractor.GetKeyframeData(filePath, _mediaEncoder.ProbePath, string.Empty);
+                CacheResult(cachePath, keyframeData);
+            }
+
+            long lastKeyframe = 0;
+            var result = new List<double>();
+            // Scale the segment length to ticks to match the keyframes
+            var desiredSegmentLengthTicks = TimeSpan.FromMilliseconds(desiredSegmentLengthMs).Ticks;
+            var desiredCutTime = desiredSegmentLengthTicks;
+            for (var j = 0; j < keyframeData.KeyframeTicks.Count; j++)
+            {
+                var keyframe = keyframeData.KeyframeTicks[j];
+                if (keyframe >= desiredCutTime)
+                {
+                    var currentSegmentLength = keyframe - lastKeyframe;
+                    result.Add(TimeSpan.FromTicks(currentSegmentLength).TotalSeconds);
+                    lastKeyframe = keyframe;
+                    desiredCutTime += desiredSegmentLengthTicks;
+                }
+            }
+
+            result.Add(TimeSpan.FromTicks(keyframeData.TotalDuration - lastKeyframe).TotalSeconds);
+            return result;
+        }
+
+        private void CacheResult(string cachePath, KeyframeData keyframeData)
+        {
+            var json = JsonSerializer.Serialize(keyframeData, _jsonOptions);
+            Directory.CreateDirectory(Path.GetDirectoryName(cachePath) ?? throw new ArgumentException($"Provided path ({cachePath}) is not valid.", nameof(cachePath)));
+            File.WriteAllText(cachePath, json);
+        }
+
+        private string GetCachePath(string filePath)
+        {
+            var lastWriteTimeUtc = File.GetLastWriteTimeUtc(filePath);
+            ReadOnlySpan<char> filename = (filePath + "_" + lastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture)).GetMD5() + ".json";
+            var prefix = filename.Slice(0, 1);
+
+            return Path.Join(KeyframeCachePath, prefix, filename);
+        }
+
+        private bool TryReadFromCache(string cachePath, [NotNullWhen(true)] out KeyframeData? cachedResult)
+        {
+            if (File.Exists(cachePath))
+            {
+                var bytes = File.ReadAllBytes(cachePath);
+                cachedResult = JsonSerializer.Deserialize<KeyframeData>(bytes, _jsonOptions);
+                return cachedResult != null;
+            }
+
+            cachedResult = null;
+            return false;
+        }
+
+        private bool IsExtractionAllowed(ReadOnlySpan<char> filePath)
+        {
+            // Remove the leading dot
+            var extension = Path.GetExtension(filePath)[1..];
+            var allowedExtensions = _serverConfigurationManager.GetEncodingOptions().AllowAutomaticKeyframeExtractionForExtensions;
+            for (var i = 0; i < allowedExtensions.Length; i++)
+            {
+                var allowedExtension = allowedExtensions[i];
+                if (extension.Equals(allowedExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static double[] ComputeEqualLengthSegments(long desiredSegmentLengthMs, long totalRuntimeTicks)
+        {
+            var segmentLengthTicks = TimeSpan.FromMilliseconds(desiredSegmentLengthMs).Ticks;
+            var wholeSegments = totalRuntimeTicks / segmentLengthTicks;
+            var remainingTicks = totalRuntimeTicks % segmentLengthTicks;
+
+            var segmentsLen = wholeSegments + (remainingTicks == 0 ? 0 : 1);
+            var segments = new double[segmentsLen];
+            for (int i = 0; i < wholeSegments; i++)
+            {
+                segments[i] = desiredSegmentLengthMs;
+            }
+
+            if (remainingTicks != 0)
+            {
+                segments[^1] = TimeSpan.FromTicks(remainingTicks).TotalSeconds;
+            }
+
+            return segments;
+        }
+
+        // TODO copied from DynamicHlsController
+        private static string GetSegmentFileExtension(string segmentContainer)
+        {
+            if (!string.IsNullOrWhiteSpace(segmentContainer))
+            {
+                return "." + segmentContainer;
+            }
+
+            return DefaultContainerExtension;
+        }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/IDynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/IDynamicHlsPlaylistGenerator.cs
@@ -1,0 +1,15 @@
+﻿namespace Jellyfin.MediaEncoding.Hls.Playlist
+{
+    /// <summary>
+    /// Generator for dynamic HLS playlists where the segment lengths aren't known in advance.
+    /// </summary>
+    public interface IDynamicHlsPlaylistGenerator
+    {
+        /// <summary>
+        /// Creates the main playlist containing the main video or audio stream.
+        /// </summary>
+        /// <param name="request">An instance of the <see cref="CreateMainPlaylistRequest"/> class.</param>
+        /// <returns></returns>
+        string CreateMainPlaylist(CreateMainPlaylistRequest request);
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Jellyfin.MediaEncoding.Keyframes.FfProbe
+{
+    public static class FfProbeKeyframeExtractor
+    {
+        // TODO
+        public static KeyframeData GetKeyframeData(string ffProbePath, string filePath) => throw new NotImplementedException();
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfTool/FfToolKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfTool/FfToolKeyframeExtractor.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Jellyfin.MediaEncoding.Keyframes.FfTool
+{
+    public static class FfToolKeyframeExtractor
+    {
+        // TODO
+        public static KeyframeData GetKeyframeData(string ffProbePath, string filePath) => throw new NotImplementedException();
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Jellyfin.MediaEncoding.Keyframes.csproj
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Jellyfin.MediaEncoding.Keyframes.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>Jellyfin.MediaEncoding.Keyframes</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NEbml" Version="0.11.0" />
+  </ItemGroup>
+
+  <!-- Code Analyzers-->
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.AspNetCore.App.Ref\5.0.0\ref\net5.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/Jellyfin.MediaEncoding.Keyframes/KeyframeData.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/KeyframeData.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace Jellyfin.MediaEncoding.Keyframes
+{
+    public class KeyframeData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyframeData"/> class.
+        /// </summary>
+        /// <param name="totalDuration">The total duration of the video stream in ticks.</param>
+        /// <param name="keyframeTicks">The video keyframes in ticks.</param>
+        public KeyframeData(long totalDuration, IReadOnlyList<long> keyframeTicks)
+        {
+            TotalDuration = totalDuration;
+            KeyframeTicks = keyframeTicks;
+        }
+
+        /// <summary>
+        /// Gets the total duration of the stream in ticks.
+        /// </summary>
+        public long TotalDuration { get; }
+
+        /// <summary>
+        /// Gets the keyframes in ticks.
+        /// </summary>
+        public IReadOnlyList<long> KeyframeTicks { get; }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/KeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/KeyframeExtractor.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using Jellyfin.MediaEncoding.Keyframes.FfProbe;
+using Jellyfin.MediaEncoding.Keyframes.FfTool;
+using Jellyfin.MediaEncoding.Keyframes.Matroska;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.MediaEncoding.Keyframes
+{
+    /// <summary>
+    /// Manager class for the set of keyframe extractors.
+    /// </summary>
+    public class KeyframeExtractor
+    {
+        private readonly ILogger<KeyframeExtractor> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyframeExtractor"/> class.
+        /// </summary>
+        /// <param name="logger">An instance of the <see cref="ILogger{KeyframeExtractor}"/> interface.</param>
+        public KeyframeExtractor(ILogger<KeyframeExtractor> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Extracts the keyframe positions from a video file.
+        /// </summary>
+        /// <param name="filePath">Absolute file path to the media file.</param>
+        /// <param name="ffProbePath">Absolute file path to the ffprobe executable.</param>
+        /// <param name="ffToolPath">Absolute file path to the fftool executable.</param>
+        /// <returns></returns>
+        public KeyframeData GetKeyframeData(string filePath, string ffProbePath, string ffToolPath)
+        {
+            var extension = Path.GetExtension(filePath);
+            if (string.Equals(extension, ".mkv", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    return MatroskaKeyframeExtractor.GetKeyframeData(filePath);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    _logger.LogError(ex, "{MatroskaKeyframeExtractor} failed to extract keyframes", nameof(MatroskaKeyframeExtractor));
+                }
+            }
+
+            if (!string.IsNullOrEmpty(ffToolPath))
+            {
+                return FfToolKeyframeExtractor.GetKeyframeData(ffToolPath, filePath);
+            }
+
+            return FfProbeKeyframeExtractor.GetKeyframeData(ffProbePath, filePath);
+        }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Extensions/EbmlReaderExtensions.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Extensions/EbmlReaderExtensions.cs
@@ -1,0 +1,181 @@
+using System;
+using Jellyfin.MediaEncoding.Keyframes.Matroska.Models;
+using NEbml.Core;
+
+namespace Jellyfin.MediaEncoding.Keyframes.Matroska.Extensions
+{
+    /// <summary>
+    /// Extension methods for the <see cref="EbmlReader"/> class.
+    /// </summary>
+    internal static class EbmlReaderExtensions
+    {
+        /// <summary>
+        /// Traverses the current container to find the element with <paramref name="identifier"/> identifier.
+        /// </summary>
+        /// <param name="reader">An instance of <see cref="EbmlReader"/>.</param>
+        /// <param name="identifier">The element identifier.</param>
+        /// <returns>A value indicating whether the element was found.</returns>
+        internal static bool FindElement(this EbmlReader reader, ulong identifier)
+        {
+            while (reader.ReadNext())
+            {
+                if (reader.ElementId.EncodedValue == identifier)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads the current position in the file as an unsigned integer converted from binary.
+        /// </summary>
+        /// <param name="reader">An instance of <see cref="EbmlReader"/>.</param>
+        /// <returns>The unsigned integer.</returns>
+        internal static uint ReadUIntFromBinary(this EbmlReader reader)
+        {
+            var buffer = new byte[4];
+            reader.ReadBinary(buffer, 0, 4);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(buffer);
+            }
+
+            return BitConverter.ToUInt32(buffer);
+        }
+
+        /// <summary>
+        /// Reads from the start of the file to retrieve the SeekHead segment.
+        /// </summary>
+        /// <param name="reader">An instance of <see cref="EbmlReader"/>.</param>
+        /// <returns>Instance of <see cref="SeekHead"/></returns>
+        internal static SeekHead ReadSeekHead(this EbmlReader reader)
+        {
+            reader = reader ?? throw new ArgumentNullException(nameof(reader));
+
+            if (reader.ElementPosition != 0)
+            {
+                throw new InvalidOperationException("File position must be at 0");
+            }
+
+            // Skip the header
+            if (!reader.FindElement(MatroskaConstants.SegmentContainer))
+            {
+                throw new InvalidOperationException("Expected a segment container");
+            }
+
+            reader.EnterContainer();
+
+            long? tracksPosition = null;
+            long? cuesPosition = null;
+            long? infoPosition = null;
+            // The first element should be a SeekHead otherwise we'll have to search manually
+            if (!reader.FindElement(MatroskaConstants.SeekHead))
+            {
+                throw new InvalidOperationException("Expected a SeekHead");
+            }
+
+            reader.EnterContainer();
+            while (reader.FindElement(MatroskaConstants.Seek))
+            {
+                reader.EnterContainer();
+                reader.ReadNext();
+                var type = (ulong)reader.ReadUIntFromBinary();
+                switch (type)
+                {
+                    case MatroskaConstants.Tracks:
+                        reader.ReadNext();
+                        tracksPosition = (long)reader.ReadUInt();
+                        break;
+                    case MatroskaConstants.Cues:
+                        reader.ReadNext();
+                        cuesPosition = (long)reader.ReadUInt();
+                        break;
+                    case MatroskaConstants.Info:
+                        reader.ReadNext();
+                        infoPosition = (long)reader.ReadUInt();
+                        break;
+                }
+
+                reader.LeaveContainer();
+
+                if (tracksPosition.HasValue && cuesPosition.HasValue && infoPosition.HasValue)
+                {
+                    break;
+                }
+            }
+
+            reader.LeaveContainer();
+
+            if (!tracksPosition.HasValue || !cuesPosition.HasValue || !infoPosition.HasValue)
+            {
+                throw new InvalidOperationException("SeekHead is missing or does not contain Info, Tracks and Cues positions");
+            }
+
+            return new SeekHead(infoPosition.Value, tracksPosition.Value, cuesPosition.Value);
+        }
+
+        /// <summary>
+        /// Reads from SegmentContainer to retrieve the Info segment.
+        /// </summary>
+        /// <param name="reader">An instance of <see cref="EbmlReader"/>.</param>
+        /// <returns>Instance of <see cref="Info"/></returns>
+        internal static Info ReadInfo(this EbmlReader reader, long position)
+        {
+            reader.ReadAt(position);
+
+            double? duration = null;
+            reader.EnterContainer();
+            // Mandatory element
+            reader.FindElement(MatroskaConstants.TimestampScale);
+            var timestampScale = reader.ReadUInt();
+
+            if (reader.FindElement(MatroskaConstants.Duration))
+            {
+                duration = reader.ReadFloat();
+            }
+
+            reader.LeaveContainer();
+
+            return new Info((long)timestampScale, duration);
+        }
+
+        /// <summary>
+        /// Enters the Tracks segment and reads all tracks to find the specified type.
+        /// </summary>
+        /// <param name="reader">Instance of <see cref="EbmlReader"/>.</param>
+        /// <param name="tracksPosition">The relative position of the tracks segment.</param>
+        /// <param name="type">The track type identifier.</param>
+        /// <returns>The first track number with the specified type.</returns>
+        /// <exception cref="InvalidOperationException">Stream type is not found.</exception>
+        internal static ulong FindFirstTrackNumberByType(this EbmlReader reader, long tracksPosition, ulong type)
+        {
+            reader.ReadAt(tracksPosition);
+
+            reader.EnterContainer();
+            while (reader.FindElement(MatroskaConstants.TrackEntry))
+            {
+                reader.EnterContainer();
+                // Mandatory element
+                reader.FindElement(MatroskaConstants.TrackNumber);
+                var trackNumber = reader.ReadUInt();
+
+                // Mandatory element
+                reader.FindElement(MatroskaConstants.TrackType);
+                var trackType = reader.ReadUInt();
+
+                reader.LeaveContainer();
+                if (trackType == MatroskaConstants.TrackTypeVideo)
+                {
+                    reader.LeaveContainer();
+                    return trackNumber;
+                }
+            }
+
+            reader.LeaveContainer();
+
+            throw new InvalidOperationException($"No stream with type {type} found");
+        }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Matroska/MatroskaConstants.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Matroska/MatroskaConstants.cs
@@ -1,0 +1,31 @@
+﻿namespace Jellyfin.MediaEncoding.Keyframes.Matroska
+{
+    /// <summary>
+    /// Constants for the Matroska identifiers.
+    /// </summary>
+    public static class MatroskaConstants
+    {
+        internal const ulong SegmentContainer = 0x18538067;
+
+        internal const ulong SeekHead = 0x114D9B74;
+        internal const ulong Seek = 0x4DBB;
+
+        internal const ulong Info = 0x1549A966;
+        internal const ulong TimestampScale = 0x2AD7B1;
+        internal const ulong Duration = 0x4489;
+
+        internal const ulong Tracks = 0x1654AE6B;
+        internal const ulong TrackEntry = 0xAE;
+        internal const ulong TrackNumber = 0xD7;
+        internal const ulong TrackType = 0x83;
+
+        internal const ulong TrackTypeVideo = 0x1;
+        internal const ulong TrackTypeSubtitle = 0x11;
+
+        internal const ulong Cues = 0x1C53BB6B;
+        internal const ulong CueTime = 0xB3;
+        internal const ulong CuePoint = 0xBB;
+        internal const ulong CueTrackPositions = 0xB7;
+        internal const ulong CuePointTrackNumber = 0xF7;
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Matroska/MatroskaKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Matroska/MatroskaKeyframeExtractor.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Jellyfin.MediaEncoding.Keyframes.Matroska.Extensions;
+using NEbml.Core;
+
+namespace Jellyfin.MediaEncoding.Keyframes.Matroska
+{
+    /// <summary>
+    /// The keyframe extractor for the matroska container.
+    /// </summary>
+    public static class MatroskaKeyframeExtractor
+    {
+        /// <summary>
+        /// Extracts the keyframes in ticks (scaled using the container timestamp scale) from the matroska container.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        /// <returns>An instance of <see cref="KeyframeData"/>.</returns>
+        public static KeyframeData GetKeyframeData(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var reader = new EbmlReader(stream);
+
+            var seekHead = reader.ReadSeekHead();
+            var info = reader.ReadInfo(seekHead.InfoPosition);
+            var videoTrackNumber = reader.FindFirstTrackNumberByType(seekHead.TracksPosition, MatroskaConstants.TrackTypeVideo);
+
+            var keyframes = new List<long>();
+            reader.ReadAt(seekHead.CuesPosition);
+            reader.EnterContainer();
+
+            while (reader.FindElement(MatroskaConstants.CuePoint))
+            {
+                reader.EnterContainer();
+                ulong? trackNumber = null;
+                // Mandatory element
+                reader.FindElement(MatroskaConstants.CueTime);
+                var cueTime = reader.ReadUInt();
+
+                // Mandatory element
+                reader.FindElement(MatroskaConstants.CueTrackPositions);
+                reader.EnterContainer();
+                if (reader.FindElement(MatroskaConstants.CuePointTrackNumber))
+                {
+                    trackNumber = reader.ReadUInt();
+                }
+
+                reader.LeaveContainer();
+
+                if (trackNumber == videoTrackNumber)
+                {
+                    keyframes.Add(ScaleToNanoseconds(cueTime, info.TimestampScale));
+                }
+
+                reader.LeaveContainer();
+            }
+
+            reader.LeaveContainer();
+
+            var result = new KeyframeData(ScaleToNanoseconds(info.Duration ?? 0, info.TimestampScale), keyframes);
+            return result;
+        }
+
+        private static long ScaleToNanoseconds(ulong unscaledValue, long timestampScale)
+        {
+            // TimestampScale is in nanoseconds, scale it to get the value in ticks, 1 tick == 100 ns
+            return (long)unscaledValue * timestampScale / 100;
+        }
+
+        private static long ScaleToNanoseconds(double unscaledValue, long timestampScale)
+        {
+            // TimestampScale is in nanoseconds, scale it to get the value in ticks, 1 tick == 100 ns
+            return Convert.ToInt64(unscaledValue * timestampScale / 100);
+        }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Models/Info.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Models/Info.cs
@@ -1,0 +1,29 @@
+﻿namespace Jellyfin.MediaEncoding.Keyframes.Matroska.Models
+{
+    /// <summary>
+    /// The matroska Info segment.
+    /// </summary>
+    internal class Info
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Info"/> class.
+        /// </summary>
+        /// <param name="timestampScale">The timestamp scale in nanoseconds.</param>
+        /// <param name="duration">The duration of the entire file.</param>
+        public Info(long timestampScale, double? duration)
+        {
+            TimestampScale = timestampScale;
+            Duration = duration;
+        }
+
+        /// <summary>
+        /// Gets the timestamp scale in nanoseconds.
+        /// </summary>
+        public long TimestampScale { get; }
+
+        /// <summary>
+        /// Gets the total duration of the file.
+        /// </summary>
+        public double? Duration { get; }
+    }
+}

--- a/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Models/SeekHead.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/Matroska/Models/SeekHead.cs
@@ -1,0 +1,36 @@
+﻿namespace Jellyfin.MediaEncoding.Keyframes.Matroska.Models
+{
+    /// <summary>
+    /// The matroska SeekHead segment. All positions are relative to the Segment container.
+    /// </summary>
+    internal class SeekHead
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SeekHead"/> class.
+        /// </summary>
+        /// <param name="infoPosition">The relative file position of the info segment.</param>
+        /// <param name="tracksPosition">The relative file position of the tracks segment.</param>
+        /// <param name="cuesPosition">The relative file position of the cues segment.</param>
+        public SeekHead(long infoPosition, long tracksPosition, long cuesPosition)
+        {
+            InfoPosition = infoPosition;
+            TracksPosition = tracksPosition;
+            CuesPosition = cuesPosition;
+        }
+
+        /// <summary>
+        /// Gets relative file position of the info segment.
+        /// </summary>
+        public long InfoPosition { get; }
+
+        /// <summary>
+        /// Gets the relative file position of the tracks segment.
+        /// </summary>
+        public long TracksPosition { get; }
+
+        /// <summary>
+        /// Gets the relative file position of the cues segment.
+        /// </summary>
+        public long CuesPosition { get; }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Only MKV supported for now.

- Added a config option to allow specific container formats to have its keyframes extracted.
- Very simple Matroska parser to extract the keyframe positions.
- Fallback to the old dynamic segment calculator.
