### PR TITLE
Hardware acceleration for jetson

### DIFF
--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -1,0 +1,116 @@
+# DESIGNED FOR BUILDING ON ARM64 ONLY
+#####################################
+# Requires binfm_misc registration
+# https://github.com/multiarch/qemu-user-static#binfmt_misc-register
+ARG DOTNET_VERSION=5.0
+
+
+FROM node:lts-alpine as web-builder
+ARG JELLYFIN_WEB_VERSION=master
+RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-sdk automake libtool make gcc musl-dev nasm python3 \
+ && curl -L https://github.com/jellyfin/jellyfin-web/archive/${JELLYFIN_WEB_VERSION}.tar.gz | tar zxf - \
+ && cd jellyfin-web-* \
+ && npm ci --no-audit --unsafe-perm \
+ && mv dist /dist
+
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM nvcr.io/nvidia/l4t-base:r32.5.0 as app
+
+# https://askubuntu.com/questions/972516/debian-frontend-environment-variable
+ARG DEBIAN_FRONTEND="noninteractive"
+# http://stackoverflow.com/questions/48162574/ddg#49462622
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+# https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(Native-GPU-Support)
+ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+RUN apt-get update && apt-get install -y gnupg libssl-dev ca-certificates \
+    && echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
+    && echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
+    && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+    && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    -o Dpkg::Options::=--force-confnew \
+    -o Dpkg::Options::=--force-confdef \
+    --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+    libfontconfig1 \
+    libfreetype6 \
+    libomxil-bellagio0 \
+    libomxil-bellagio-bin \
+    locales \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    git-core \
+    libass-dev \
+    libfreetype6-dev \
+    libgnutls28-dev \
+    libsdl2-dev \
+    libtool \
+    libva-dev \
+    libvdpau-dev \
+    libvorbis-dev \
+    libxcb1-dev \
+    libxcb-shm0-dev \
+    libxcb-xfixes0-dev \
+    meson \
+    ninja-build \
+    pkg-config \
+    texinfo \
+    wget \
+    yasm \
+    zlib1g-dev \
+    nvidia-l4t-jetson-multimedia-api \
+    # these might be overkill
+    libunistring-dev libx264-dev nasm libx265-dev libnuma-dev libvpx-dev libmp3lame-dev libopus-dev \
+    && apt-get clean autoclean -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /cache /config /media \
+    && chmod 777 /cache /config /media \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+
+RUN git clone https://github.com/jocover/jetson-ffmpeg.git \
+    && cd jetson-ffmpeg \
+    && git checkout 7baa3d8 \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make -j$(nproc) \
+    && make install \
+    && ldconfig \
+    && git clone git://source.ffmpeg.org/ffmpeg.git -b release/4.2 --depth=1 \
+    && cd ffmpeg \
+    && wget https://raw.githubusercontent.com/jocover/jetson-ffmpeg/7baa3d8232478b82799a90c37b86a986e4df1df2/ffmpeg_nvmpi.patch \
+    && git apply ffmpeg_nvmpi.patch \
+    && ./configure --enable-libopus --enable-libmp3lame --enable-libvpx --enable-gpl --enable-libx265 --enable-libx264 --enable-nvmpi \
+    && make -j$(nproc) \
+    && make install
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} as builder
+WORKDIR /repo
+COPY . .
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+# Discard objs - may cause failures if exists
+RUN find . -type d -name obj | xargs -r rm -r
+# Build
+RUN dotnet publish Jellyfin.Server --configuration Release --output="/jellyfin" --self-contained --runtime linux-arm64 "-p:DebugSymbols=false;DebugType=none"
+
+FROM app
+
+COPY --from=builder /jellyfin /jellyfin
+COPY --from=web-builder /dist /jellyfin/jellyfin-web
+
+EXPOSE 8096
+VOLUME /cache /config /media
+ENTRYPOINT ["./jellyfin/jellyfin", \
+    "--datadir", "/config", \
+    "--cachedir", "/cache", \
+    "--ffmpeg", "/usr/bin/ffmpeg"]

--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -14,7 +14,9 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && mv dist /dist
 
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
-FROM nvcr.io/nvidia/l4t-base:r32.5.0 as app
+FROM mattangus/jetson-ffmpeg as app
+
+WORKDIR /
 
 # https://askubuntu.com/questions/972516/debian-frontend-environment-variable
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -24,69 +26,20 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
-RUN apt-get update && apt-get install -y gnupg libssl-dev ca-certificates \
-    && echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
-    && echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
-    && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
-    && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y \
-    -o Dpkg::Options::=--force-confnew \
-    -o Dpkg::Options::=--force-confdef \
-    --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-    libfontconfig1 \
-    libfreetype6 \
-    libomxil-bellagio0 \
-    libomxil-bellagio-bin \
-    locales \
-    autoconf \
-    automake \
-    build-essential \
-    cmake \
-    git-core \
-    libass-dev \
-    libfreetype6-dev \
-    libgnutls28-dev \
-    libsdl2-dev \
-    libtool \
-    libva-dev \
-    libvdpau-dev \
-    libvorbis-dev \
-    libxcb1-dev \
-    libxcb-shm0-dev \
-    libxcb-xfixes0-dev \
-    meson \
-    ninja-build \
-    pkg-config \
-    texinfo \
-    wget \
-    yasm \
-    zlib1g-dev \
-    nvidia-l4t-jetson-multimedia-api \
-    # these might be overkill
-    libunistring-dev libx264-dev nasm libx265-dev libnuma-dev libvpx-dev libmp3lame-dev libopus-dev \
-    && apt-get clean autoclean -y \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /cache /config /media \
-    && chmod 777 /cache /config /media \
-    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen \
-    && git clone https://github.com/jocover/jetson-ffmpeg.git \
-    && cd jetson-ffmpeg \
-    && git checkout 7baa3d8 \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && make -j$(nproc) \
-    && make install \
-    && ldconfig \
-    && git clone git://source.ffmpeg.org/ffmpeg.git -b release/4.2 --depth=1 \
-    && cd ffmpeg \
-    && wget https://raw.githubusercontent.com/jocover/jetson-ffmpeg/7baa3d8232478b82799a90c37b86a986e4df1df2/ffmpeg_nvmpi.patch \
-    && git apply ffmpeg_nvmpi.patch \
-    && ./configure --enable-libopus --enable-libmp3lame --enable-libvpx --enable-gpl --enable-libx265 --enable-libx264 --enable-nvmpi --prefix=/usr/ \
-    && make -j$(nproc) \
-    && make install
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+ libssl-dev \
+ ca-certificates \
+ libfontconfig1 \
+ libfreetype6 \
+ libomxil-bellagio0 \
+ libomxil-bellagio-bin \
+ locales \
+ && apt-get clean autoclean -y \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /cache /config /media \
+ && chmod 777 /cache /config /media \
+ && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 ENV LC_ALL en_US.UTF-8

--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -70,9 +70,8 @@ RUN apt-get update && apt-get install -y gnupg libssl-dev ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /cache /config /media \
     && chmod 777 /cache /config /media \
-    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-
-RUN git clone https://github.com/jocover/jetson-ffmpeg.git \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen \
+    && git clone https://github.com/jocover/jetson-ffmpeg.git \
     && cd jetson-ffmpeg \
     && git checkout 7baa3d8 \
     && mkdir build \
@@ -85,7 +84,7 @@ RUN git clone https://github.com/jocover/jetson-ffmpeg.git \
     && cd ffmpeg \
     && wget https://raw.githubusercontent.com/jocover/jetson-ffmpeg/7baa3d8232478b82799a90c37b86a986e4df1df2/ffmpeg_nvmpi.patch \
     && git apply ffmpeg_nvmpi.patch \
-    && ./configure --enable-libopus --enable-libmp3lame --enable-libvpx --enable-gpl --enable-libx265 --enable-libx264 --enable-nvmpi \
+    && ./configure --enable-libopus --enable-libmp3lame --enable-libvpx --enable-gpl --enable-libx265 --enable-libx264 --enable-nvmpi --prefix=/usr/ \
     && make -j$(nproc) \
     && make install
 
@@ -113,4 +112,4 @@ VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \
     "--cachedir", "/cache", \
-    "--ffmpeg", "/usr/local/bin/ffmpeg"]
+    "--ffmpeg", "/usr/bin/ffmpeg"]

--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -60,11 +60,13 @@ FROM app
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
-COPY scripts/ffmpeg-jetson-wrapper /usr/bin/ffmpeg-jetson-wapper
+COPY scripts/ffmpeg-jetson-wrapper /usr/bin/ffmpeg-jetson-wrapper
+
+RUN chmod +x /usr/bin/ffmpeg-jetson-wrapper
 
 EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \
     "--cachedir", "/cache", \
-    "--ffmpeg", "/usr/bin/ffmpeg-jetson-wapper"]
+    "--ffmpeg", "/usr/bin/ffmpeg-jetson-wrapper"]

--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -113,4 +113,4 @@ VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \
     "--cachedir", "/cache", \
-    "--ffmpeg", "/usr/bin/ffmpeg"]
+    "--ffmpeg", "/usr/local/bin/ffmpeg"]

--- a/Dockerfile.arm64-jetson
+++ b/Dockerfile.arm64-jetson
@@ -60,9 +60,11 @@ FROM app
 COPY --from=builder /jellyfin /jellyfin
 COPY --from=web-builder /dist /jellyfin/jellyfin-web
 
+COPY scripts/ffmpeg-jetson-wrapper /usr/bin/ffmpeg-jetson-wapper
+
 EXPOSE 8096
 VOLUME /cache /config /media
 ENTRYPOINT ["./jellyfin/jellyfin", \
     "--datadir", "/config", \
     "--cachedir", "/cache", \
-    "--ffmpeg", "/usr/bin/ffmpeg"]
+    "--ffmpeg", "/usr/bin/ffmpeg-jetson-wapper"]

--- a/scripts/ffmpeg-jetson-wrapper
+++ b/scripts/ffmpeg-jetson-wrapper
@@ -5,7 +5,7 @@ SHELLDIR=$(dirname "`realpath \"$0\"`")
 FORCE_HW_DECODE=true
 FORCE_HW_ENCODE=true
 
-echo "WRAPPER OLD: " $0 "$@"
+# echo "WRAPPER OLD: " $0 "$@"
 
 skipnext=false
 next_is_input=false
@@ -66,7 +66,7 @@ for arg in "$@"; do
     video_codec=$($SHELLDIR/ffprobe -i "$arg" 2>&1 | sed -nE 's/^\s*Stream .* Video: ([[:alnum:]]*).*$/\1/p')
     # get pixel format
     pix_format=$($SHELLDIR/ffprobe -v error -hide_banner -of default=noprint_wrappers=0 -print_format flat  -select_streams v:0 -show_entries stream=pix_fmt "$arg" 2>&1 | sed 's/streams\.stream\.0\.pix_fmt=//g' | sed 's/"//g')
-    echo "pix: " $pix_format
+    # echo "pix: " $pix_format
     if [ "$pix_format" == "yuv420p" ] || [ "$pix_format" == "yuvj420p" ]; then
         newargs_prepend=("-c:v" "${video_codec}_nvmpi")
     else
@@ -87,6 +87,6 @@ if $FORCE_HW_ENCODE && ! $crf; then
   newargs+=("-rc:v" "vbr")
 fi
 
-echo "WRAPPER NEW: " $SHELLDIR/ffmpeg "${newargs_prepend[@]}" "${newargs_in[@]}" "${newargs_out[@]}"
+# echo "WRAPPER NEW: " $SHELLDIR/ffmpeg "${newargs_prepend[@]}" "${newargs_in[@]}" "${newargs_out[@]}"
 
 exec $SHELLDIR/ffmpeg "${newargs_prepend[@]}" "${newargs_in[@]}" "${newargs_out[@]}"

--- a/scripts/ffmpeg-jetson-wrapper
+++ b/scripts/ffmpeg-jetson-wrapper
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+SHELLDIR=$(dirname "`realpath \"$0\"`")
+
+FORCE_HW_DECODE=true
+FORCE_HW_ENCODE=true
+
+echo "WRAPPER OLD: " $0 "$@"
+
+skipnext=false
+next_is_input=false
+crf=false
+codec_is_for_input=true
+newargs_prepend=()
+newargs_in=()
+newargs_out=()
+is_input=true
+next_is_maxrate=false
+for arg in "$@"; do
+  if $skipnext; then
+    skipnext=false
+    continue
+  fi
+  if [ "$arg" = "-crf" ] && $FORCE_HW_ENCODE; then
+    skipnext=true
+    # `-crf <num>` is not supported. but `-rc vbr/crf` is
+    newargs+=("-rc" "crf")
+    crf=true
+    continue
+  fi
+  if [ "$arg" = "-x264opts:0" ] && $FORCE_HW_ENCODE; then
+    continue
+  fi
+  if [[ $arg == subme* ]] && $FORCE_HW_ENCODE; then
+    continue
+  fi
+  if [ "$arg" == "libx264" ] && $FORCE_HW_ENCODE; then arg="h264_nvmpi"; fi
+  if [ "$arg" == "libx265" ] && $FORCE_HW_ENCODE; then arg="hevc_nvmpi"; fi
+  # Profile mapping
+  if [ "$arg" == "veryslow" ] && $FORCE_HW_ENCODE; then arg="slow"; fi
+  if [ "$arg" == "slower" ] && $FORCE_HW_ENCODE; then arg="slow"; fi
+  if [ "$arg" == "slow" ] && $FORCE_HW_ENCODE; then arg="slow"; fi
+  if [ "$arg" == "medium" ] && $FORCE_HW_ENCODE; then arg="medium"; fi
+  if [ "$arg" == "fast" ] && $FORCE_HW_ENCODE; then arg="fast"; fi
+  if [ "$arg" == "veryfast" ] && $FORCE_HW_ENCODE; then arg="fast"; fi
+  if [ "$arg" == "superfast" ] && $FORCE_HW_ENCODE; then arg="ultrafast"; fi
+  if [ "$arg" == "ultrafast" ] && $FORCE_HW_ENCODE; then arg="ultrafast"; fi
+  if $is_input; then
+    newargs_in+=("$arg")
+  else
+    newargs_out+=("$arg")
+  fi
+  if $next_is_maxrate && $FORCE_HW_ENCODE; then
+    next_is_maxrate=false
+    # Set bitrate to maxrate
+    # jellyfin only limits bit rate. But the hwencoder needs a suggestion
+    newargs_out+=("-b:v")
+    newargs_out+=("$arg")
+  fi
+  if [ "$arg" = "-maxrate" ]; then
+    next_is_maxrate=true
+  fi
+
+  if $next_is_input; then
+    next_is_input=false
+    video_codec=$($SHELLDIR/ffprobe -i "$arg" 2>&1 | sed -nE 's/^\s*Stream .* Video: ([[:alnum:]]*).*$/\1/p')
+    # get pixel format
+    pix_format=$($SHELLDIR/ffprobe -v error -hide_banner -of default=noprint_wrappers=0 -print_format flat  -select_streams v:0 -show_entries stream=pix_fmt "$arg" 2>&1 | sed 's/streams\.stream\.0\.pix_fmt=//g' | sed 's/"//g')
+    echo "pix: " $pix_format
+    if [ "$pix_format" == "yuv420p" ] || [ "$pix_format" == "yuvj420p" ]; then
+        newargs_prepend=("-c:v" "${video_codec}_nvmpi")
+    else
+        # pixel format not supported
+        newargs_prepend=("-c:v" "${video_codec}")
+    fi
+    is_input=false
+  fi
+  if [ "$arg" = "-i" ]; then
+    codec_is_for_input=false
+    next_is_input=true
+  fi
+
+done
+
+if $FORCE_HW_ENCODE && ! $crf; then
+  # Default to vbr if crf was not set
+  newargs+=("-rc:v" "vbr")
+fi
+
+echo "WRAPPER NEW: " $SHELLDIR/ffmpeg "${newargs_prepend[@]}" "${newargs_in[@]}" "${newargs_out[@]}"
+
+exec $SHELLDIR/ffmpeg "${newargs_prepend[@]}" "${newargs_in[@]}" "${newargs_out[@]}"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Adds a docker file for building and installing [jocover/jetson-ffmpeg](https://github.com/jocover/jetson-ffmpeg) to allow for hardware acceleration for the nvidia jetson.

I have tested this on the jetson nano. Please let me know if there is a better way to handle the jetson case. Currently you can find a built image on dockerhub (https://hub.docker.com/r/mattangus/jellyfin-jetson).

docker **needs** to be run with `--runtime nvidia`. 

for some reason I could only get it to work with `docker-compose` by adding `mkdir /usr/lib/jellyfin-ffmpeg; ln -s /usr/bin/ffmpeg /usr/lib/jellyfin-ffmpeg/ffmpeg` to the entry point.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Implements: https://github.com/jellyfin/jellyfin/issues/5674 (or https://features.jellyfin.org/posts/1118/add-jetson-ffmpeg-nvmpi-support)

