### PR TITLE
Fix user DB migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Emby.Server.Implementations.Data;
-using Emby.Server.Implementations.Serialization;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions.Json;
@@ -10,6 +9,7 @@ using Jellyfin.Server.Implementations.Users;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Users;
 using Microsoft.Extensions.Logging;
 using SQLitePCL.pretty;
@@ -27,7 +27,7 @@ namespace Jellyfin.Server.Migrations.Routines
         private readonly ILogger<MigrateUserDb> _logger;
         private readonly IServerApplicationPaths _paths;
         private readonly JellyfinDbProvider _provider;
-        private readonly MyXmlSerializer _xmlSerializer;
+        private readonly IXmlSerializer _xmlSerializer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MigrateUserDb"/> class.
@@ -40,7 +40,7 @@ namespace Jellyfin.Server.Migrations.Routines
             ILogger<MigrateUserDb> logger,
             IServerApplicationPaths paths,
             JellyfinDbProvider provider,
-            MyXmlSerializer xmlSerializer)
+            IXmlSerializer xmlSerializer)
         {
             _logger = logger;
             _paths = paths;


### PR DESCRIPTION
```
[19:31:31] [FTL] [1] Main: Error while starting server.
System.InvalidOperationException: Unable to resolve service for type 'Emby.Server.Implementations.Serialization.MyXmlSerializer' while attempting to activate 'Jellyfin.Server.Migrations.Routines.MigrateUserDb'.
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Jellyfin.Server.Migrations.MigrationRunner.<>c__DisplayClass1_0.<Run>b__0(Type m) in /home/loma/dev/jellyfin/Jellyfin.Server/Migrations/MigrationRunner.cs:line 41
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.Linq.Enumerable.OfTypeIterator[TResult](IEnumerable source)+MoveNext()
   at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
   at Jellyfin.Server.Migrations.MigrationRunner.Run(CoreAppHost host, ILoggerFactory loggerFactory) in /home/loma/dev/jellyfin/Jellyfin.Server/Migrations/MigrationRunner.cs:line 40
   at Jellyfin.Server.Program.StartApp(StartupOptions options) in /home/loma/dev/jellyfin/Jellyfin.Server/Program.cs:line 194
```