### PR TITLE
Use RandomAccess instead of a FileStream where it makes sense

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -246,9 +246,9 @@ namespace Emby.Server.Implementations.IO
                     {
                         try
                         {
-                            using (Stream thisFileStream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1))
+                            using (var fileHandle = File.OpenHandle(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                             {
-                                result.Length = thisFileStream.Length;
+                                result.Length = RandomAccess.GetLength(fileHandle);
                             }
                         }
                         catch (FileNotFoundException ex)

--- a/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
+++ b/Jellyfin.Server/Infrastructure/SymlinkFollowingPhysicalFileResultExecutor.cs
@@ -55,8 +55,8 @@ namespace Jellyfin.Server.Infrastructure
             // This may or may not be fixed in .NET 6, but looks like it will not https://github.com/dotnet/aspnetcore/issues/34371
             if ((fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
             {
-                using Stream thisFileStream = File.OpenRead(path);
-                length = thisFileStream.Length;
+                using var fileHandle = File.OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                length = RandomAccess.GetLength(fileHandle);
             }
 
             return new FileMetadata


### PR DESCRIPTION
`RandomAccess.GetLength` is used internally in `FileStream.Length`
Using it directly reduces the number of allocated objects