### PR TITLE
Remove all instances of en-US culture

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -41,8 +41,6 @@ namespace Emby.Dlna.Didl
         private const string NsUpnp = "urn:schemas-upnp-org:metadata-1-0/upnp/";
         private const string NsDlna = "urn:schemas-dlna-org:metadata-1-0/";
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         private readonly DeviceProfile _profile;
         private readonly IImageProcessor _imageProcessor;
         private readonly string _serverAddress;
@@ -317,7 +315,7 @@ namespace Emby.Dlna.Didl
 
             if (mediaSource.RunTimeTicks.HasValue)
             {
-                writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", _usCulture));
+                writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", CultureInfo.InvariantCulture));
             }
 
             if (filter.Contains("res@size"))
@@ -328,7 +326,7 @@ namespace Emby.Dlna.Didl
 
                     if (size.HasValue)
                     {
-                        writer.WriteAttributeString("size", size.Value.ToString(_usCulture));
+                        writer.WriteAttributeString("size", size.Value.ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -342,7 +340,7 @@ namespace Emby.Dlna.Didl
 
             if (targetChannels.HasValue)
             {
-                writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(_usCulture));
+                writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (filter.Contains("res@resolution"))
@@ -361,12 +359,12 @@ namespace Emby.Dlna.Didl
 
             if (targetSampleRate.HasValue)
             {
-                writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(_usCulture));
+                writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (totalBitrate.HasValue)
             {
-                writer.WriteAttributeString("bitrate", totalBitrate.Value.ToString(_usCulture));
+                writer.WriteAttributeString("bitrate", totalBitrate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             var mediaProfile = _profile.GetVideoMediaProfile(
@@ -552,7 +550,7 @@ namespace Emby.Dlna.Didl
 
             if (mediaSource.RunTimeTicks.HasValue)
             {
-                writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", _usCulture));
+                writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", CultureInfo.InvariantCulture));
             }
 
             if (filter.Contains("res@size"))
@@ -563,7 +561,7 @@ namespace Emby.Dlna.Didl
 
                     if (size.HasValue)
                     {
-                        writer.WriteAttributeString("size", size.Value.ToString(_usCulture));
+                        writer.WriteAttributeString("size", size.Value.ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -575,17 +573,17 @@ namespace Emby.Dlna.Didl
 
             if (targetChannels.HasValue)
             {
-                writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(_usCulture));
+                writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (targetSampleRate.HasValue)
             {
-                writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(_usCulture));
+                writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (targetAudioBitrate.HasValue)
             {
-                writer.WriteAttributeString("bitrate", targetAudioBitrate.Value.ToString(_usCulture));
+                writer.WriteAttributeString("bitrate", targetAudioBitrate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             var mediaProfile = _profile.GetAudioMediaProfile(
@@ -639,7 +637,7 @@ namespace Emby.Dlna.Didl
 
             writer.WriteAttributeString("restricted", "1");
             writer.WriteAttributeString("searchable", "1");
-            writer.WriteAttributeString("childCount", childCount.ToString(_usCulture));
+            writer.WriteAttributeString("childCount", childCount.ToString(CultureInfo.InvariantCulture));
 
             var clientId = GetClientId(folder, stubType);
 
@@ -931,11 +929,11 @@ namespace Emby.Dlna.Didl
 
             if (item.IndexNumber.HasValue)
             {
-                AddValue(writer, "upnp", "originalTrackNumber", item.IndexNumber.Value.ToString(_usCulture), NsUpnp);
+                AddValue(writer, "upnp", "originalTrackNumber", item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture), NsUpnp);
 
                 if (item is Episode)
                 {
-                    AddValue(writer, "upnp", "episodeNumber", item.IndexNumber.Value.ToString(_usCulture), NsUpnp);
+                    AddValue(writer, "upnp", "episodeNumber", item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture), NsUpnp);
                 }
             }
         }

--- a/Emby.Dlna/Eventing/DlnaEventManager.cs
+++ b/Emby.Dlna/Eventing/DlnaEventManager.cs
@@ -26,8 +26,6 @@ namespace Emby.Dlna.Eventing
         private readonly ILogger _logger;
         private readonly IHttpClientFactory _httpClientFactory;
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         public DlnaEventManager(ILogger logger, IHttpClientFactory httpClientFactory)
         {
             _httpClientFactory = httpClientFactory;
@@ -83,7 +81,7 @@ namespace Emby.Dlna.Eventing
             if (!string.IsNullOrEmpty(header))
             {
                 // Starts with SECOND-
-                if (int.TryParse(header.AsSpan().RightPart('-'), NumberStyles.Integer, _usCulture, out var val))
+                if (int.TryParse(header.AsSpan().RightPart('-'), NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
                 {
                     return val;
                 }
@@ -106,7 +104,7 @@ namespace Emby.Dlna.Eventing
             var response = new EventSubscriptionResponse(string.Empty, "text/plain");
 
             response.Headers["SID"] = subscriptionId;
-            response.Headers["TIMEOUT"] = string.IsNullOrEmpty(requestedTimeoutString) ? ("SECOND-" + timeoutSeconds.ToString(_usCulture)) : requestedTimeoutString;
+            response.Headers["TIMEOUT"] = string.IsNullOrEmpty(requestedTimeoutString) ? ("SECOND-" + timeoutSeconds.ToString(CultureInfo.InvariantCulture)) : requestedTimeoutString;
 
             return response;
         }
@@ -163,7 +161,7 @@ namespace Emby.Dlna.Eventing
             options.Headers.TryAddWithoutValidation("NT", subscription.NotificationType);
             options.Headers.TryAddWithoutValidation("NTS", "upnp:propchange");
             options.Headers.TryAddWithoutValidation("SID", subscription.Id);
-            options.Headers.TryAddWithoutValidation("SEQ", subscription.TriggerCount.ToString(_usCulture));
+            options.Headers.TryAddWithoutValidation("SEQ", subscription.TriggerCount.ToString(CultureInfo.InvariantCulture));
 
             try
             {

--- a/Emby.Dlna/PlayTo/Device.cs
+++ b/Emby.Dlna/PlayTo/Device.cs
@@ -20,8 +20,6 @@ namespace Emby.Dlna.PlayTo
 {
     public class Device : IDisposable
     {
-        private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
-
         private readonly IHttpClientFactory _httpClientFactory;
 
         private readonly ILogger _logger;
@@ -640,7 +638,7 @@ namespace Emby.Dlna.PlayTo
                 return;
             }
 
-            Volume = int.Parse(volumeValue, UsCulture);
+            Volume = int.Parse(volumeValue, CultureInfo.InvariantCulture);
 
             if (Volume > 0)
             {
@@ -842,7 +840,7 @@ namespace Emby.Dlna.PlayTo
             if (!string.IsNullOrWhiteSpace(duration)
                 && !string.Equals(duration, "NOT_IMPLEMENTED", StringComparison.OrdinalIgnoreCase))
             {
-                Duration = TimeSpan.Parse(duration, UsCulture);
+                Duration = TimeSpan.Parse(duration, CultureInfo.InvariantCulture);
             }
             else
             {
@@ -854,7 +852,7 @@ namespace Emby.Dlna.PlayTo
 
             if (!string.IsNullOrWhiteSpace(position) && !string.Equals(position, "NOT_IMPLEMENTED", StringComparison.OrdinalIgnoreCase))
             {
-                Position = TimeSpan.Parse(position, UsCulture);
+                Position = TimeSpan.Parse(position, CultureInfo.InvariantCulture);
             }
 
             var track = result.Document.Descendants("TrackMetaData").FirstOrDefault();
@@ -1194,8 +1192,8 @@ namespace Emby.Dlna.PlayTo
             var depth = element.GetDescendantValue(UPnpNamespaces.Ud.GetName("depth"));
             var url = element.GetDescendantValue(UPnpNamespaces.Ud.GetName("url"));
 
-            var widthValue = int.Parse(width, NumberStyles.Integer, UsCulture);
-            var heightValue = int.Parse(height, NumberStyles.Integer, UsCulture);
+            var widthValue = int.Parse(width, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            var heightValue = int.Parse(height, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
             return new DeviceIcon
             {

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -30,8 +30,6 @@ namespace Emby.Dlna.PlayTo
 {
     public class PlayToController : ISessionController, IDisposable
     {
-        private static readonly CultureInfo _usCulture = CultureInfo.ReadOnly(new CultureInfo("en-US"));
-
         private readonly SessionInfo _session;
         private readonly ISessionManager _sessionManager;
         private readonly ILibraryManager _libraryManager;
@@ -716,7 +714,7 @@ namespace Emby.Dlna.PlayTo
                 case GeneralCommandType.SetAudioStreamIndex:
                     if (command.Arguments.TryGetValue("Index", out string index))
                     {
-                        if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
+                        if (int.TryParse(index, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
                         {
                             return SetAudioStreamIndex(val);
                         }
@@ -728,7 +726,7 @@ namespace Emby.Dlna.PlayTo
                 case GeneralCommandType.SetSubtitleStreamIndex:
                     if (command.Arguments.TryGetValue("Index", out index))
                     {
-                        if (int.TryParse(index, NumberStyles.Integer, _usCulture, out var val))
+                        if (int.TryParse(index, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
                         {
                             return SetSubtitleStreamIndex(val);
                         }
@@ -740,7 +738,7 @@ namespace Emby.Dlna.PlayTo
                 case GeneralCommandType.SetVolume:
                     if (command.Arguments.TryGetValue("Volume", out string vol))
                     {
-                        if (int.TryParse(vol, NumberStyles.Integer, _usCulture, out var volume))
+                        if (int.TryParse(vol, NumberStyles.Integer, CultureInfo.InvariantCulture, out var volume))
                         {
                             return _device.SetVolume(volume, cancellationToken);
                         }

--- a/Emby.Dlna/PlayTo/SsdpHttpClient.cs
+++ b/Emby.Dlna/PlayTo/SsdpHttpClient.cs
@@ -20,8 +20,6 @@ namespace Emby.Dlna.PlayTo
         private const string USERAGENT = "Microsoft-Windows/6.2 UPnP/1.0 Microsoft-DLNA DLNADOC/1.50";
         private const string FriendlyName = "Jellyfin";
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         private readonly IHttpClientFactory _httpClientFactory;
 
         public SsdpHttpClient(IHttpClientFactory httpClientFactory)
@@ -80,10 +78,10 @@ namespace Emby.Dlna.PlayTo
         {
             using var options = new HttpRequestMessage(new HttpMethod("SUBSCRIBE"), url);
             options.Headers.UserAgent.ParseAdd(USERAGENT);
-            options.Headers.TryAddWithoutValidation("HOST", ip + ":" + port.ToString(_usCulture));
-            options.Headers.TryAddWithoutValidation("CALLBACK", "<" + localIp + ":" + eventport.ToString(_usCulture) + ">");
+            options.Headers.TryAddWithoutValidation("HOST", ip + ":" + port.ToString(CultureInfo.InvariantCulture));
+            options.Headers.TryAddWithoutValidation("CALLBACK", "<" + localIp + ":" + eventport.ToString(CultureInfo.InvariantCulture) + ">");
             options.Headers.TryAddWithoutValidation("NT", "upnp:event");
-            options.Headers.TryAddWithoutValidation("TIMEOUT", "Second-" + timeOut.ToString(_usCulture));
+            options.Headers.TryAddWithoutValidation("TIMEOUT", "Second-" + timeOut.ToString(CultureInfo.InvariantCulture));
 
             using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
                 .SendAsync(options, HttpCompletionOption.ResponseHeadersRead)

--- a/Emby.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/Emby.Dlna/Server/DescriptionXmlBuilder.cs
@@ -15,7 +15,6 @@ namespace Emby.Dlna.Server
     {
         private readonly DeviceProfile _profile;
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly string _serverUdn;
         private readonly string _serverAddress;
         private readonly string _serverName;
@@ -193,10 +192,10 @@ namespace Emby.Dlna.Server
                     .Append(SecurityElement.Escape(icon.MimeType ?? string.Empty))
                     .Append("</mimetype>");
                 builder.Append("<width>")
-                    .Append(SecurityElement.Escape(icon.Width.ToString(_usCulture)))
+                    .Append(SecurityElement.Escape(icon.Width.ToString(CultureInfo.InvariantCulture)))
                     .Append("</width>");
                 builder.Append("<height>")
-                    .Append(SecurityElement.Escape(icon.Height.ToString(_usCulture)))
+                    .Append(SecurityElement.Escape(icon.Height.ToString(CultureInfo.InvariantCulture)))
                     .Append("</height>");
                 builder.Append("<depth>")
                     .Append(SecurityElement.Escape(icon.Depth ?? string.Empty))

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -23,7 +23,6 @@ namespace Emby.Server.Implementations.MediaEncoder
 {
     public class EncodingManager : IEncodingManager
     {
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly IFileSystem _fileSystem;
         private readonly ILogger<EncodingManager> _logger;
         private readonly IMediaEncoder _encoder;
@@ -193,7 +192,7 @@ namespace Emby.Server.Implementations.MediaEncoder
 
         private string GetChapterImagePath(Video video, long chapterPositionTicks)
         {
-            var filename = video.DateModified.Ticks.ToString(_usCulture) + "_" + chapterPositionTicks.ToString(_usCulture) + ".jpg";
+            var filename = video.DateModified.Ticks.ToString(CultureInfo.InvariantCulture) + "_" + chapterPositionTicks.ToString(CultureInfo.InvariantCulture) + ".jpg";
 
             return Path.Combine(GetChapterImagesPath(video), filename);
         }

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -2007,7 +2007,7 @@ namespace Jellyfin.Api.Controllers
                     Response.Headers.Add(HeaderNames.CacheControl, "public");
                 }
 
-                Response.Headers.Add(HeaderNames.LastModified, dateImageModified.ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss \"GMT\"", new CultureInfo("en-US", false)));
+                Response.Headers.Add(HeaderNames.LastModified, dateImageModified.ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss \"GMT\"", CultureInfo.InvariantCulture));
 
                 // if the image was not modified since "ifModifiedSinceHeader"-header, return a HTTP status code 304 not modified
                 if (!(dateImageModified > ifModifiedSinceHeader) && cacheDuration.HasValue)

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -376,7 +376,7 @@ namespace Jellyfin.Api.Controllers
                 var endPositionTicks = Math.Min(runtime, positionTicks + segmentLengthTicks);
 
                 var url = string.Format(
-                    CultureInfo.CurrentCulture,
+                    CultureInfo.InvariantCulture,
                     "stream.vtt?CopyTimestamps=true&AddVttTimeMap=true&StartPositionTicks={0}&EndPositionTicks={1}&api_key={2}",
                     positionTicks.ToString(CultureInfo.InvariantCulture),
                     endPositionTicks.ToString(CultureInfo.InvariantCulture),

--- a/MediaBrowser.Controller/Entities/Year.cs
+++ b/MediaBrowser.Controller/Entities/Year.cs
@@ -57,9 +57,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IList<BaseItem> GetTaggedItems(InternalItemsQuery query)
         {
-            var usCulture = new CultureInfo("en-US");
-
-            if (!int.TryParse(Name, NumberStyles.Integer, usCulture, out var year))
+            if (!int.TryParse(Name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year))
             {
                 return new List<BaseItem>();
             }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -21,8 +21,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 {
     public class EncodingHelper
     {
-        private static readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         private readonly IMediaEncoder _mediaEncoder;
         private readonly ISubtitleEncoder _subtitleEncoder;
 
@@ -816,7 +814,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public static string NormalizeTranscodingLevel(EncodingJobInfo state, string level)
         {
-            if (double.TryParse(level, NumberStyles.Any, _usCulture, out double requestLevel))
+            if (double.TryParse(level, NumberStyles.Any, CultureInfo.InvariantCulture, out double requestLevel))
             {
                 if (string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase))
@@ -911,7 +909,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 CultureInfo.InvariantCulture,
                 "subtitles='{0}:si={1}'{2}",
                 _mediaEncoder.EscapeSubtitleFilterPath(mediaPath),
-                state.InternalSubtitleStreamOffset.ToString(_usCulture),
+                state.InternalSubtitleStreamOffset.ToString(CultureInfo.InvariantCulture),
                 // fallbackFontParam,
                 setPtsParam);
         }
@@ -1217,7 +1215,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 param += string.Format(
                     CultureInfo.InvariantCulture,
                     " -speed 16 -quality good -profile:v {0} -slices 8 -crf {1} -qmin {2} -qmax {3}",
-                    profileScore.ToString(_usCulture),
+                    profileScore.ToString(CultureInfo.InvariantCulture),
                     crf,
                     qmin,
                     qmax);
@@ -1289,7 +1287,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var framerate = GetFramerateParam(state);
             if (framerate.HasValue)
             {
-                param += string.Format(CultureInfo.InvariantCulture, " -r {0}", framerate.Value.ToString(_usCulture));
+                param += string.Format(CultureInfo.InvariantCulture, " -r {0}", framerate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             var targetVideoCodec = state.ActualOutputVideoCodec;
@@ -1393,7 +1391,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 else if (string.Equals(videoEncoder, "hevc_qsv", StringComparison.OrdinalIgnoreCase))
                 {
                     // hevc_qsv use -level 51 instead of -level 153.
-                    if (double.TryParse(level, NumberStyles.Any, _usCulture, out double hevcLevel))
+                    if (double.TryParse(level, NumberStyles.Any, CultureInfo.InvariantCulture, out double hevcLevel))
                     {
                         param += " -level " + (hevcLevel / 3);
                     }
@@ -1555,7 +1553,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // If a specific level was requested, the source must match or be less than
             var level = state.GetRequestedLevel(videoStream.Codec);
             if (!string.IsNullOrEmpty(level)
-                && double.TryParse(level, NumberStyles.Any, _usCulture, out var requestLevel))
+                && double.TryParse(level, NumberStyles.Any, CultureInfo.InvariantCulture, out var requestLevel))
             {
                 if (!videoStream.Level.HasValue)
                 {
@@ -1803,7 +1801,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 && state.AudioStream.Channels.Value > 5
                 && !encodingOptions.DownMixAudioBoost.Equals(1))
             {
-                filters.Add("volume=" + encodingOptions.DownMixAudioBoost.ToString(_usCulture));
+                filters.Add("volume=" + encodingOptions.DownMixAudioBoost.ToString(CultureInfo.InvariantCulture));
             }
 
             var isCopyingTimestamps = state.CopyTimestamps || state.TranscodingType != TranscodingJobType.Progressive;
@@ -2434,8 +2432,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     if (isExynosV4L2)
                     {
-                        var widthParam = requestedWidth.Value.ToString(_usCulture);
-                        var heightParam = requestedHeight.Value.ToString(_usCulture);
+                        var widthParam = requestedWidth.Value.ToString(CultureInfo.InvariantCulture);
+                        var heightParam = requestedHeight.Value.ToString(CultureInfo.InvariantCulture);
 
                         filters.Add(
                             string.Format(
@@ -2453,8 +2451,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // If Max dimensions were supplied, for width selects lowest even number between input width and width req size and selects lowest even number from in width*display aspect and requested size
                 else if (requestedMaxWidth.HasValue && requestedMaxHeight.HasValue)
                 {
-                    var maxWidthParam = requestedMaxWidth.Value.ToString(_usCulture);
-                    var maxHeightParam = requestedMaxHeight.Value.ToString(_usCulture);
+                    var maxWidthParam = requestedMaxWidth.Value.ToString(CultureInfo.InvariantCulture);
+                    var maxHeightParam = requestedMaxHeight.Value.ToString(CultureInfo.InvariantCulture);
 
                     if (isExynosV4L2)
                     {
@@ -2486,7 +2484,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
                     else
                     {
-                        var widthParam = requestedWidth.Value.ToString(_usCulture);
+                        var widthParam = requestedWidth.Value.ToString(CultureInfo.InvariantCulture);
 
                         filters.Add(
                             string.Format(
@@ -2499,7 +2497,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // If a fixed height was requested
                 else if (requestedHeight.HasValue)
                 {
-                    var heightParam = requestedHeight.Value.ToString(_usCulture);
+                    var heightParam = requestedHeight.Value.ToString(CultureInfo.InvariantCulture);
 
                     if (isExynosV4L2)
                     {
@@ -2522,7 +2520,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // If a max width was requested
                 else if (requestedMaxWidth.HasValue)
                 {
-                    var maxWidthParam = requestedMaxWidth.Value.ToString(_usCulture);
+                    var maxWidthParam = requestedMaxWidth.Value.ToString(CultureInfo.InvariantCulture);
 
                     if (isExynosV4L2)
                     {
@@ -2545,7 +2543,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // If a max height was requested
                 else if (requestedMaxHeight.HasValue)
                 {
-                    var maxHeightParam = requestedMaxHeight.Value.ToString(_usCulture);
+                    var maxHeightParam = requestedMaxHeight.Value.ToString(CultureInfo.InvariantCulture);
 
                     if (isExynosV4L2)
                     {
@@ -4122,12 +4120,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (bitrate.HasValue)
             {
-                args += " -ab " + bitrate.Value.ToString(_usCulture);
+                args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
             }
 
             if (state.OutputAudioSampleRate.HasValue)
             {
-                args += " -ar " + state.OutputAudioSampleRate.Value.ToString(_usCulture);
+                args += " -ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture);
             }
 
             args += GetAudioFilterParam(state, encodingOptions);
@@ -4143,12 +4141,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (bitrate.HasValue)
             {
-                audioTranscodeParams.Add("-ab " + bitrate.Value.ToString(_usCulture));
+                audioTranscodeParams.Add("-ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (state.OutputAudioChannels.HasValue)
             {
-                audioTranscodeParams.Add("-ac " + state.OutputAudioChannels.Value.ToString(_usCulture));
+                audioTranscodeParams.Add("-ac " + state.OutputAudioChannels.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             // opus will fail on 44100
@@ -4156,7 +4154,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 if (state.OutputAudioSampleRate.HasValue)
                 {
-                    audioTranscodeParams.Add("-ar " + state.OutputAudioSampleRate.Value.ToString(_usCulture));
+                    audioTranscodeParams.Add("-ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture));
                 }
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -13,7 +13,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 {
     public class JobLogger
     {
-        private static readonly CultureInfo _usCulture = CultureInfo.ReadOnly(new CultureInfo("en-US"));
         private readonly ILogger _logger;
 
         public JobLogger(ILogger logger)
@@ -87,7 +86,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     var rate = parts[i + 1];
 
-                    if (float.TryParse(rate, NumberStyles.Any, _usCulture, out var val))
+                    if (float.TryParse(rate, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
                     {
                         framerate = val;
                     }
@@ -96,7 +95,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     var rate = part.Split('=', 2)[^1];
 
-                    if (float.TryParse(rate, NumberStyles.Any, _usCulture, out var val))
+                    if (float.TryParse(rate, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
                     {
                         framerate = val;
                     }
@@ -106,7 +105,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     var time = part.Split('=', 2)[^1];
 
-                    if (TimeSpan.TryParse(time, _usCulture, out var val))
+                    if (TimeSpan.TryParse(time, CultureInfo.InvariantCulture, out var val))
                     {
                         var currentMs = startMs + val.TotalMilliseconds;
 
@@ -128,7 +127,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                     if (scale.HasValue)
                     {
-                        if (long.TryParse(size, NumberStyles.Any, _usCulture, out var val))
+                        if (long.TryParse(size, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
                         {
                             bytesTranscoded = val * scale.Value;
                         }
@@ -147,7 +146,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                     if (scale.HasValue)
                     {
-                        if (float.TryParse(rate, NumberStyles.Any, _usCulture, out var val))
+                        if (float.TryParse(rate, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
                         {
                             bitRate = (int)Math.Ceiling(val * scale.Value);
                         }

--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -60,8 +60,6 @@ namespace MediaBrowser.LocalMetadata.Images
 
         private readonly IFileSystem _fileSystem;
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalImageProvider"/> class.
         /// </summary>
@@ -434,7 +432,7 @@ namespace MediaBrowser.LocalMetadata.Images
 
             var seasonMarker = seasonNumber.Value == 0
                                    ? "-specials"
-                                   : seasonNumber.Value.ToString("00", _usCulture);
+                                   : seasonNumber.Value.ToString("00", CultureInfo.InvariantCulture);
 
             // Get this one directly from the file system since we have to go up a level
             if (!string.Equals(prefix, seasonMarker, StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
+++ b/MediaBrowser.LocalMetadata/Parsers/BaseItemXmlParser.cs
@@ -21,8 +21,6 @@ namespace MediaBrowser.LocalMetadata.Parsers
     public class BaseItemXmlParser<T>
         where T : BaseItem
     {
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         private Dictionary<string, string>? _validProviderIds;
 
         /// <summary>
@@ -180,7 +178,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
 
                     if (!string.IsNullOrEmpty(text))
                     {
-                        if (float.TryParse(text, NumberStyles.Any, _usCulture, out var value))
+                        if (float.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                         {
                             item.CriticRating = value;
                         }
@@ -332,7 +330,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
 
                     if (!string.IsNullOrWhiteSpace(text))
                     {
-                        if (int.TryParse(text.AsSpan().LeftPart(' '), NumberStyles.Integer, _usCulture, out var runtime))
+                        if (int.TryParse(text.AsSpan().LeftPart(' '), NumberStyles.Integer, CultureInfo.InvariantCulture, out var runtime))
                         {
                             item.RunTimeTicks = TimeSpan.FromMinutes(runtime).Ticks;
                         }
@@ -1095,7 +1093,7 @@ namespace MediaBrowser.LocalMetadata.Parsers
 
                             if (!string.IsNullOrWhiteSpace(val))
                             {
-                                if (int.TryParse(val, NumberStyles.Integer, _usCulture, out var intVal))
+                                if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intVal))
                                 {
                                     sortOrder = intVal;
                                 }

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -25,8 +25,6 @@ namespace MediaBrowser.LocalMetadata.Savers
         /// </summary>
         public const string DateAddedFormat = "yyyy-MM-dd HH:mm:ss";
 
-        private static readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseXmlSaver"/> class.
         /// </summary>
@@ -205,7 +203,7 @@ namespace MediaBrowser.LocalMetadata.Savers
 
             if (item.CriticRating.HasValue)
             {
-                writer.WriteElementString("CriticRating", item.CriticRating.Value.ToString(_usCulture));
+                writer.WriteElementString("CriticRating", item.CriticRating.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (!string.IsNullOrEmpty(item.Overview))
@@ -289,12 +287,12 @@ namespace MediaBrowser.LocalMetadata.Savers
 
             if (item.CommunityRating.HasValue)
             {
-                writer.WriteElementString("Rating", item.CommunityRating.Value.ToString(_usCulture));
+                writer.WriteElementString("Rating", item.CommunityRating.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (item.ProductionYear.HasValue && item is not Person)
             {
-                writer.WriteElementString("ProductionYear", item.ProductionYear.Value.ToString(_usCulture));
+                writer.WriteElementString("ProductionYear", item.ProductionYear.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (item is IHasAspectRatio hasAspectRatio)
@@ -322,7 +320,7 @@ namespace MediaBrowser.LocalMetadata.Savers
             {
                 var timespan = TimeSpan.FromTicks(runTimeTicks.Value);
 
-                writer.WriteElementString("RunningTime", Math.Floor(timespan.TotalMinutes).ToString(_usCulture));
+                writer.WriteElementString("RunningTime", Math.Floor(timespan.TotalMinutes).ToString(CultureInfo.InvariantCulture));
             }
 
             if (item.ProviderIds != null)
@@ -395,7 +393,7 @@ namespace MediaBrowser.LocalMetadata.Savers
 
                     if (person.SortOrder.HasValue)
                     {
-                        writer.WriteElementString("SortOrder", person.SortOrder.Value.ToString(_usCulture));
+                        writer.WriteElementString("SortOrder", person.SortOrder.Value.ToString(CultureInfo.InvariantCulture));
                     }
 
                     writer.WriteEndElement();

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -43,11 +43,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         internal const int DefaultHdrImageExtractionTimeout = 20000;
 
-        /// <summary>
-        /// The us culture.
-        /// </summary>
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         private readonly ILogger<MediaEncoder> _logger;
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IFileSystem _fileSystem;
@@ -687,7 +682,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         public string GetTimeParameter(TimeSpan time)
         {
-            return time.ToString(@"hh\:mm\:ss\.fff", _usCulture);
+            return time.ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
         }
 
         public async Task ExtractVideoImagesOnInterval(
@@ -704,11 +699,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             var inputArgument = GetInputArgument(inputFile, mediaSource);
 
-            var vf = "fps=fps=1/" + interval.TotalSeconds.ToString(_usCulture);
+            var vf = "fps=fps=1/" + interval.TotalSeconds.ToString(CultureInfo.InvariantCulture);
 
             if (maxWidth.HasValue)
             {
-                var maxWidthParam = maxWidth.Value.ToString(_usCulture);
+                var maxWidthParam = maxWidth.Value.ToString(CultureInfo.InvariantCulture);
 
                 vf += string.Format(CultureInfo.InvariantCulture, ",scale=min(iw\\,{0}):trunc(ow/dar/2)*2", maxWidthParam);
             }

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -30,7 +30,6 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private static readonly Regex _performerPattern = new (@"(?<name>.*) \((?<instrument>.*)\)");
 
-        private readonly CultureInfo _usCulture = new ("en-US");
         private readonly ILogger _logger;
         private readonly ILocalizationManager _localization;
 
@@ -83,7 +82,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (!string.IsNullOrEmpty(data.Format.BitRate))
                 {
-                    if (int.TryParse(data.Format.BitRate, NumberStyles.Any, _usCulture, out var value))
+                    if (int.TryParse(data.Format.BitRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                     {
                         info.Bitrate = value;
                     }
@@ -191,7 +190,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (data.Format != null && !string.IsNullOrEmpty(data.Format.Duration))
                 {
-                    info.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(data.Format.Duration, _usCulture)).Ticks;
+                    info.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(data.Format.Duration, CultureInfo.InvariantCulture)).Ticks;
                 }
 
                 FetchWtvInfo(info, data);
@@ -673,7 +672,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (!string.IsNullOrEmpty(streamInfo.SampleRate))
                 {
-                    if (int.TryParse(streamInfo.SampleRate, NumberStyles.Any, _usCulture, out var value))
+                    if (int.TryParse(streamInfo.SampleRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                     {
                         stream.SampleRate = value;
                     }
@@ -802,7 +801,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             if (!string.IsNullOrEmpty(streamInfo.BitRate))
             {
-                if (int.TryParse(streamInfo.BitRate, NumberStyles.Any, _usCulture, out var value))
+                if (int.TryParse(streamInfo.BitRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                 {
                     bitrate = value;
                 }
@@ -815,7 +814,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 && (stream.Type == MediaStreamType.Video || (isAudio && stream.Type == MediaStreamType.Audio)))
             {
                 // If the stream info doesn't have a bitrate get the value from the media format info
-                if (int.TryParse(formatInfo.BitRate, NumberStyles.Any, _usCulture, out var value))
+                if (int.TryParse(formatInfo.BitRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                 {
                     bitrate = value;
                 }
@@ -921,8 +920,8 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             var parts = (original ?? string.Empty).Split(':');
             if (!(parts.Length == 2 &&
-                int.TryParse(parts[0], NumberStyles.Any, _usCulture, out var width) &&
-                int.TryParse(parts[1], NumberStyles.Any, _usCulture, out var height) &&
+                int.TryParse(parts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var width) &&
+                int.TryParse(parts[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var height) &&
                 width > 0 &&
                 height > 0))
             {
@@ -1008,11 +1007,11 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             if (parts.Length == 2)
             {
-                result = float.Parse(parts[0], _usCulture) / float.Parse(parts[1], _usCulture);
+                result = float.Parse(parts[0], CultureInfo.InvariantCulture) / float.Parse(parts[1], CultureInfo.InvariantCulture);
             }
             else
             {
-                result = float.Parse(parts[0], _usCulture);
+                result = float.Parse(parts[0], CultureInfo.InvariantCulture);
             }
 
             return float.IsNaN(result) ? null : result;
@@ -1039,7 +1038,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             // If we got something, parse it
             if (!string.IsNullOrEmpty(duration))
             {
-                data.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(duration, _usCulture)).Ticks;
+                data.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(duration, CultureInfo.InvariantCulture)).Ticks;
             }
         }
 
@@ -1101,7 +1100,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return;
             }
 
-            info.Size = string.IsNullOrEmpty(data.Format.Size) ? null : long.Parse(data.Format.Size, _usCulture);
+            info.Size = string.IsNullOrEmpty(data.Format.Size) ? null : long.Parse(data.Format.Size, CultureInfo.InvariantCulture);
         }
 
         private void SetAudioInfoFromTags(MediaInfo audio, IReadOnlyDictionary<string, string> tags)
@@ -1144,7 +1143,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                         {
                             Name = match.Groups["name"].Value,
                             Type = PersonType.Actor,
-                            Role = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(match.Groups["instrument"].Value)
+                            Role = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(match.Groups["instrument"].Value)
                         });
                     }
                 }
@@ -1443,7 +1442,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                     .ToArray();
             }
 
-            if (tags.TryGetValue("WM/OriginalReleaseTime", out var year) && int.TryParse(year, NumberStyles.Integer, _usCulture, out var parsedYear))
+            if (tags.TryGetValue("WM/OriginalReleaseTime", out var year) && int.TryParse(year, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedYear))
             {
                 video.ProductionYear = parsedYear;
             }

--- a/MediaBrowser.Model/Globalization/ILocalizationManager.cs
+++ b/MediaBrowser.Model/Globalization/ILocalizationManager.cs
@@ -56,10 +56,10 @@ namespace MediaBrowser.Model.Globalization
         IEnumerable<LocalizationOption> GetLocalizationOptions();
 
         /// <summary>
-        /// Returns the correct <see cref="CultureInfo" /> for the given language.
+        /// Returns the correct <see cref="CultureDto" /> for the given language.
         /// </summary>
         /// <param name="language">The language.</param>
-        /// <returns>The correct <see cref="CultureInfo" /> for the given language.</returns>
+        /// <returns>The correct <see cref="CultureDto" /> for the given language.</returns>
         CultureDto? FindLanguageInfo(string language);
     }
 }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -29,8 +29,6 @@ namespace MediaBrowser.Providers.Manager
     /// </summary>
     public class ImageSaver
     {
-        private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
-
         /// <summary>
         /// The _config.
         /// </summary>
@@ -377,7 +375,7 @@ namespace MediaBrowser.Providers.Manager
 
                     var seasonMarker = season.IndexNumber.Value == 0
                                            ? "-specials"
-                                           : season.IndexNumber.Value.ToString("00", UsCulture);
+                                           : season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
 
                     var imageFilename = "season" + seasonMarker + "-landscape" + extension;
 
@@ -400,7 +398,7 @@ namespace MediaBrowser.Providers.Manager
 
                     var seasonMarker = season.IndexNumber.Value == 0
                                            ? "-specials"
-                                           : season.IndexNumber.Value.ToString("00", UsCulture);
+                                           : season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
 
                     var imageFilename = "season" + seasonMarker + "-banner" + extension;
 
@@ -495,12 +493,12 @@ namespace MediaBrowser.Providers.Manager
             var filenames = images.Select(i => Path.GetFileNameWithoutExtension(i.Path)).ToList();
 
             var current = 1;
-            while (filenames.Contains(numberedIndexPrefix + current.ToString(UsCulture), StringComparer.OrdinalIgnoreCase))
+            while (filenames.Contains(numberedIndexPrefix + current.ToString(CultureInfo.InvariantCulture), StringComparer.OrdinalIgnoreCase))
             {
                 current++;
             }
 
-            return numberedIndexPrefix + current.ToString(UsCulture);
+            return numberedIndexPrefix + current.ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -539,7 +537,7 @@ namespace MediaBrowser.Providers.Manager
 
                         var seasonMarker = season.IndexNumber.Value == 0
                                                ? "-specials"
-                                               : season.IndexNumber.Value.ToString("00", UsCulture);
+                                               : season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
 
                         var imageFilename = "season" + seasonMarker + "-fanart" + extension;
 
@@ -556,7 +554,7 @@ namespace MediaBrowser.Providers.Manager
 
                 if (item.IsInMixedFolder)
                 {
-                    return new[] { GetSavePathForItemInMixedFolder(item, type, "fanart" + outputIndex.ToString(UsCulture), extension) };
+                    return new[] { GetSavePathForItemInMixedFolder(item, type, "fanart" + outputIndex.ToString(CultureInfo.InvariantCulture), extension) };
                 }
 
                 var extraFanartFilename = GetBackdropSaveFilename(item.GetImages(ImageType.Backdrop), "fanart", "fanart", outputIndex);
@@ -568,7 +566,7 @@ namespace MediaBrowser.Providers.Manager
 
                 if (EnableExtraThumbsDuplication)
                 {
-                    list.Add(Path.Combine(item.ContainingFolderPath, "extrathumbs", "thumb" + outputIndex.ToString(UsCulture) + extension));
+                    list.Add(Path.Combine(item.ContainingFolderPath, "extrathumbs", "thumb" + outputIndex.ToString(CultureInfo.InvariantCulture) + extension));
                 }
 
                 return list.ToArray();
@@ -582,7 +580,7 @@ namespace MediaBrowser.Providers.Manager
 
                     var seasonMarker = season.IndexNumber.Value == 0
                                            ? "-specials"
-                                           : season.IndexNumber.Value.ToString("00", UsCulture);
+                                           : season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture);
 
                     var imageFilename = "season" + seasonMarker + "-poster" + extension;
 

--- a/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
@@ -26,7 +26,6 @@ namespace MediaBrowser.Providers.Plugins.Omdb
         private readonly IFileSystem _fileSystem;
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IHttpClientFactory _httpClientFactory;
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly IApplicationHost _appHost;
         private readonly JsonSerializerOptions _jsonOptions;
 
@@ -79,7 +78,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             if (!string.IsNullOrEmpty(result.Year) && result.Year.Length >= 4
-                && int.TryParse(result.Year.AsSpan().Slice(0, 4), NumberStyles.Number, _usCulture, out var year)
+                && int.TryParse(result.Year.AsSpan().Slice(0, 4), NumberStyles.Number, CultureInfo.InvariantCulture, out var year)
                 && year >= 0)
             {
                 item.ProductionYear = year;
@@ -93,14 +92,14 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             if (!string.IsNullOrEmpty(result.imdbVotes)
-                && int.TryParse(result.imdbVotes, NumberStyles.Number, _usCulture, out var voteCount)
+                && int.TryParse(result.imdbVotes, NumberStyles.Number, CultureInfo.InvariantCulture, out var voteCount)
                 && voteCount >= 0)
             {
                 // item.VoteCount = voteCount;
             }
 
             if (!string.IsNullOrEmpty(result.imdbRating)
-                && float.TryParse(result.imdbRating, NumberStyles.Any, _usCulture, out var imdbRating)
+                && float.TryParse(result.imdbRating, NumberStyles.Any, CultureInfo.InvariantCulture, out var imdbRating)
                 && imdbRating >= 0)
             {
                 item.CommunityRating = imdbRating;
@@ -191,7 +190,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             if (!string.IsNullOrEmpty(result.Year) && result.Year.Length >= 4
-                && int.TryParse(result.Year.AsSpan().Slice(0, 4), NumberStyles.Number, _usCulture, out var year)
+                && int.TryParse(result.Year.AsSpan().Slice(0, 4), NumberStyles.Number, CultureInfo.InvariantCulture, out var year)
                 && year >= 0)
             {
                 item.ProductionYear = year;
@@ -205,14 +204,14 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             if (!string.IsNullOrEmpty(result.imdbVotes)
-                && int.TryParse(result.imdbVotes, NumberStyles.Number, _usCulture, out var voteCount)
+                && int.TryParse(result.imdbVotes, NumberStyles.Number, CultureInfo.InvariantCulture, out var voteCount)
                 && voteCount >= 0)
             {
                 // item.VoteCount = voteCount;
             }
 
             if (!string.IsNullOrEmpty(result.imdbRating)
-                && float.TryParse(result.imdbRating, NumberStyles.Any, _usCulture, out var imdbRating)
+                && float.TryParse(result.imdbRating, NumberStyles.Any, CultureInfo.InvariantCulture, out var imdbRating)
                 && imdbRating >= 0)
             {
                 item.CommunityRating = imdbRating;

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -58,8 +58,6 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             _directoryService = directoryService;
         }
 
-        protected CultureInfo UsCulture { get; } = new CultureInfo("en-US");
-
         /// <summary>
         /// Gets the logger.
         /// </summary>
@@ -309,7 +307,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                         if (!string.IsNullOrEmpty(text))
                         {
-                            if (float.TryParse(text, NumberStyles.Any, UsCulture, out var value))
+                            if (float.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                             {
                                 item.CriticRating = value;
                             }
@@ -370,7 +368,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         var val = reader.ReadElementContentAsString();
                         if (!string.IsNullOrWhiteSpace(val) && userData != null)
                         {
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var count))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
                             {
                                 userData.PlayCount = count;
                             }
@@ -475,7 +473,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                         if (!string.IsNullOrWhiteSpace(text))
                         {
-                            if (int.TryParse(text.AsSpan().LeftPart(' '), NumberStyles.Integer, UsCulture, out var runtime))
+                            if (int.TryParse(text.AsSpan().LeftPart(' '), NumberStyles.Integer, CultureInfo.InvariantCulture, out var runtime))
                             {
                                 item.RunTimeTicks = TimeSpan.FromMinutes(runtime).Ticks;
                             }
@@ -1265,7 +1263,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                                 if (!string.IsNullOrWhiteSpace(val))
                                 {
-                                    if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var intVal))
+                                    if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intVal))
                                     {
                                         sortOrder = intVal;
                                     }

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -163,7 +163,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         if (!string.IsNullOrWhiteSpace(val))
                         {
                             // int.TryParse is local aware, so it can be problematic, force us culture
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var rval))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rval))
                             {
                                 item.AirsBeforeEpisodeNumber = rval;
                             }
@@ -179,7 +179,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         if (!string.IsNullOrWhiteSpace(val))
                         {
                             // int.TryParse is local aware, so it can be problematic, force us culture
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var rval))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rval))
                             {
                                 item.AirsAfterSeasonNumber = rval;
                             }
@@ -195,7 +195,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         if (!string.IsNullOrWhiteSpace(val))
                         {
                             // int.TryParse is local aware, so it can be problematic, force us culture
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var rval))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rval))
                             {
                                 item.AirsBeforeSeasonNumber = rval;
                             }
@@ -211,7 +211,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         if (!string.IsNullOrWhiteSpace(val))
                         {
                             // int.TryParse is local aware, so it can be problematic, force us culture
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var rval))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rval))
                             {
                                 item.AirsBeforeSeasonNumber = rval;
                             }
@@ -227,7 +227,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         if (!string.IsNullOrWhiteSpace(val))
                         {
                             // int.TryParse is local aware, so it can be problematic, force us culture
-                            if (int.TryParse(val, NumberStyles.Integer, UsCulture, out var rval))
+                            if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rval))
                             {
                                 item.AirsBeforeEpisodeNumber = rval;
                             }

--- a/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
@@ -17,8 +17,6 @@ namespace MediaBrowser.XbmcMetadata.Savers
     /// </summary>
     public class EpisodeNfoSaver : BaseNfoSaver
     {
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="EpisodeNfoSaver"/> class.
         /// </summary>
@@ -60,17 +58,17 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
             if (episode.IndexNumber.HasValue)
             {
-                writer.WriteElementString("episode", episode.IndexNumber.Value.ToString(_usCulture));
+                writer.WriteElementString("episode", episode.IndexNumber.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (episode.IndexNumberEnd.HasValue)
             {
-                writer.WriteElementString("episodenumberend", episode.IndexNumberEnd.Value.ToString(_usCulture));
+                writer.WriteElementString("episodenumberend", episode.IndexNumberEnd.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (episode.ParentIndexNumber.HasValue)
             {
-                writer.WriteElementString("season", episode.ParentIndexNumber.Value.ToString(_usCulture));
+                writer.WriteElementString("season", episode.ParentIndexNumber.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (episode.PremiereDate.HasValue)
@@ -84,28 +82,28 @@ namespace MediaBrowser.XbmcMetadata.Savers
             {
                 if (episode.AirsAfterSeasonNumber.HasValue && episode.AirsAfterSeasonNumber.Value != -1)
                 {
-                    writer.WriteElementString("airsafter_season", episode.AirsAfterSeasonNumber.Value.ToString(_usCulture));
+                    writer.WriteElementString("airsafter_season", episode.AirsAfterSeasonNumber.Value.ToString(CultureInfo.InvariantCulture));
                 }
 
                 if (episode.AirsBeforeEpisodeNumber.HasValue && episode.AirsBeforeEpisodeNumber.Value != -1)
                 {
-                    writer.WriteElementString("airsbefore_episode", episode.AirsBeforeEpisodeNumber.Value.ToString(_usCulture));
+                    writer.WriteElementString("airsbefore_episode", episode.AirsBeforeEpisodeNumber.Value.ToString(CultureInfo.InvariantCulture));
                 }
 
                 if (episode.AirsBeforeSeasonNumber.HasValue && episode.AirsBeforeSeasonNumber.Value != -1)
                 {
-                    writer.WriteElementString("airsbefore_season", episode.AirsBeforeSeasonNumber.Value.ToString(_usCulture));
+                    writer.WriteElementString("airsbefore_season", episode.AirsBeforeSeasonNumber.Value.ToString(CultureInfo.InvariantCulture));
                 }
 
                 if (episode.AirsBeforeEpisodeNumber.HasValue && episode.AirsBeforeEpisodeNumber.Value != -1)
                 {
-                    writer.WriteElementString("displayepisode", episode.AirsBeforeEpisodeNumber.Value.ToString(_usCulture));
+                    writer.WriteElementString("displayepisode", episode.AirsBeforeEpisodeNumber.Value.ToString(CultureInfo.InvariantCulture));
                 }
 
                 var specialSeason = episode.AiredSeasonNumber;
                 if (specialSeason.HasValue && specialSeason.Value != -1)
                 {
-                    writer.WriteElementString("displayseason", specialSeason.Value.ToString(_usCulture));
+                    writer.WriteElementString("displayseason", specialSeason.Value.ToString(CultureInfo.InvariantCulture));
                 }
             }
         }


### PR DESCRIPTION
The only area that I know differs between Invariant culture an en-US is default Date formatting, and currency sign.

Regex used: `CultureInfo(?!\.InvariantCulture)`

Remaining CultureInfos: 
https://github.com/jellyfin/jellyfin/blob/82cb6851786d4fb24952d77d869f9e9c005a960a/MediaBrowser.Model/Entities/MediaStream.cs#L143-L146
https://github.com/jellyfin/jellyfin/blob/82cb6851786d4fb24952d77d869f9e9c005a960a/MediaBrowser.Model/Entities/MediaStream.cs#L237-L240