### PR TITLE
FIX: cannot compare bitstream of different video codec

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -198,36 +198,14 @@ namespace Jellyfin.Api.Helpers
 
                 if (!EncodingHelper.IsCopyCodec(state.OutputVideoCodec) && state.OutputVideoBitrate.HasValue)
                 {
-                    var isVideoResolutionNotRequested = !state.VideoRequest.Width.HasValue
-                        && !state.VideoRequest.Height.HasValue
-                        && !state.VideoRequest.MaxWidth.HasValue
-                        && !state.VideoRequest.MaxHeight.HasValue;
+                    var resolution = ResolutionNormalizer.Normalize(
+                        state.VideoStream?.BitRate,
+                        state.OutputVideoBitrate.Value,
+                        state.VideoRequest.MaxWidth,
+                        state.VideoRequest.MaxHeight);
 
-                    if (isVideoResolutionNotRequested
-                        && state.VideoStream != null
-                        && state.VideoRequest.VideoBitRate.HasValue
-                        && state.VideoStream.BitRate.HasValue
-                        && state.VideoRequest.VideoBitRate.Value >= state.VideoStream.BitRate.Value)
-                    {
-                        // Don't downscale the resolution if the width/height/MaxWidth/MaxHeight is not requested,
-                        // and the requested video bitrate is higher than source video bitrate.
-                        if (state.VideoStream.Width.HasValue || state.VideoStream.Height.HasValue)
-                        {
-                            state.VideoRequest.MaxWidth = state.VideoStream?.Width;
-                            state.VideoRequest.MaxHeight = state.VideoStream?.Height;
-                        }
-                    }
-                    else
-                    {
-                        var resolution = ResolutionNormalizer.Normalize(
-                            state.VideoStream?.BitRate,
-                            state.OutputVideoBitrate.Value,
-                            state.VideoRequest.MaxWidth,
-                            state.VideoRequest.MaxHeight);
-
-                        state.VideoRequest.MaxWidth = resolution.MaxWidth;
-                        state.VideoRequest.MaxHeight = resolution.MaxHeight;
-                    }
+                    state.VideoRequest.MaxWidth = resolution.MaxWidth;
+                    state.VideoRequest.MaxHeight = resolution.MaxHeight;
                 }
             }
 


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

It doesn't really make sense to compare bitstream rate of 2 different codec.
Not downscaling because, e.g., a hevc 9Mb/s is lower than a h264 10Mb/s is comparing pears and apples.

Partial revert of https://github.com/jellyfin/jellyfin/pull/4432

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
