### PR TITLE
Update README for .NET version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ These instructions will help you get set up with a local development environment
 
 ### Prerequisites
 
-Before the project can be built, you must first install the [.NET 5.0 SDK](https://dotnet.microsoft.com/download) on your system.
+Before the project can be built, you must first install the [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet) on your system.
 
 Instructions to run this project from the command line are included here, but you will also need to install an IDE if you want to debug the server while it is running. Any IDE that supports .NET Core development will work, but two options are recent versions of [Visual Studio](https://visualstudio.microsoft.com/downloads/) (at least 2017) and [Visual Studio Code](https://code.visualstudio.com/Download).
 


### PR DESCRIPTION
**Changes**

Now that `master` is updated to .NET 6.0, update the `README` documentation as well.

Also, the change updates the link to point to the expanded version select page of the Microsoft .NET downloads, since .NET 6.0 is still an RC.
