### PR TITLE
Add mp4 track title fallback

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -688,6 +688,16 @@ namespace MediaBrowser.MediaEncoding.Probing
                 {
                     stream.BitDepth = streamInfo.BitsPerRawSample;
                 }
+
+                if (string.IsNullOrEmpty(stream.Title))
+                {
+                    // mp4 missing track title workaround: fall back to handler_name if populated
+                    string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
+                    if (!string.IsNullOrEmpty(handlerName))
+                    {
+                        stream.Title = handlerName;
+                    }
+                }
             }
             else if (string.Equals(streamInfo.CodecType, "subtitle", StringComparison.OrdinalIgnoreCase))
             {
@@ -696,6 +706,16 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedUndefined = _localization.GetLocalizedString("Undefined");
                 stream.LocalizedDefault = _localization.GetLocalizedString("Default");
                 stream.LocalizedForced = _localization.GetLocalizedString("Forced");
+
+                if (string.IsNullOrEmpty(stream.Title))
+                {
+                    // mp4 missing track title workaround: fall back to handler_name if populated and not the default "SubtitleHandler"
+                    string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
+                    if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SubtitleHandler", StringComparison.OrdinalIgnoreCase))
+                    {
+                        stream.Title = handlerName;
+                    }
+                }
             }
             else if (string.Equals(streamInfo.CodecType, "video", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
**Changes**

In the case that a track title isn't set for audio or subtitle tracks this change checks for a "handler_name" field to use as a title.

**Explanation**

Handbrake-produced mp4 files don't have a title set on audio or subtitle tracks, but looking at the handbrake code there's a check for mp4 file type that adds the title to the "handler_name" field: [Audio](https://github.com/HandBrake/HandBrake/blob/004a1ff49ddcbba8326ef6a5f58a1dd203f2f663/libhb/muxavformat.c#L783) [Subtitle](https://github.com/HandBrake/HandBrake/blob/004a1ff49ddcbba8326ef6a5f58a1dd203f2f663/libhb/muxavformat.c#L1062)

Additionally, there's a note in the ffmpeg encoder referencing the use of "handler_name" for track description: [movenc.c](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/master:/libavformat/movenc.c#l2840)

As this seems to be a common/accepted use of the field, Jellyfin should read it if there is no track title set.

**Issues**
Fixes #6638 

