### PR TITLE
Update artist split whitelist

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -49,7 +49,8 @@ namespace MediaBrowser.MediaEncoding.Probing
             "LOONA 1/3",
             "LOONA / yyxy",
             "LOONA / ODD EYE CIRCLE",
-            "K/DA"
+            "K/DA",
+            "22/7"
         };
 
         public MediaInfo GetMediaInfo(InternalMediaInfoResult data, VideoType? videoType, bool isAudio, string path, MediaProtocol protocol)


### PR DESCRIPTION
Add [22/7](https://musicbrainz.org/artist/4d1c86ff-1287-4d9a-8c01-19585a5e1bea) group to the split whitelist, as the slash is a part of their name.

**Changes**
Add `22/7` to split whitelist.

**Issues**
Another artist workaround for issue discussed in https://github.com/jellyfin/jellyfin/issues/2305