### PR TITLE
Add IsAutomated property to SubtitleSearchRequest

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -149,6 +149,7 @@
  - [skyfrk](https://github.com/skyfrk)
  - [ianjazz246](https://github.com/ianjazz246)
  - [peterspenler](https://github.com/peterspenler)
+ - [MBR-0001](https://github.com/MBR-0001)
 
 # Emby Contributors
 

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -127,7 +127,7 @@ namespace Jellyfin.Api.Controllers
         {
             var video = (Video)_libraryManager.GetItemById(itemId);
 
-            return await _subtitleManager.SearchSubtitles(video, language, isPerfectMatch, CancellationToken.None).ConfigureAwait(false);
+            return await _subtitleManager.SearchSubtitles(video, language, isPerfectMatch, false, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
+++ b/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
@@ -31,12 +31,14 @@ namespace MediaBrowser.Controller.Subtitles
         /// <param name="video">The video.</param>
         /// <param name="language">Subtitle language.</param>
         /// <param name="isPerfectMatch">Require perfect match.</param>
+        /// <param name="isAutomated">Request is automated.</param>
         /// <param name="cancellationToken">CancellationToken to use for the operation.</param>
         /// <returns>Subtitles, wrapped in task.</returns>
         Task<RemoteSubtitleInfo[]> SearchSubtitles(
             Video video,
             string language,
             bool? isPerfectMatch,
+            bool isAutomated,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/MediaBrowser.Controller/Subtitles/SubtitleSearchRequest.cs
+++ b/MediaBrowser.Controller/Subtitles/SubtitleSearchRequest.cs
@@ -51,5 +51,7 @@ namespace MediaBrowser.Controller.Subtitles
         public string[] DisabledSubtitleFetchers { get; set; }
 
         public string[] SubtitleFetcherOrder { get; set; }
+
+        public bool IsAutomated { get; set; }
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -557,6 +557,7 @@ namespace MediaBrowser.Providers.MediaInfo
                         subtitleDownloadLanguages,
                         libraryOptions.DisabledSubtitleFetchers,
                         libraryOptions.SubtitleFetcherOrder,
+                        true,
                         cancellationToken).ConfigureAwait(false);
 
                 // Rescan

--- a/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
@@ -36,6 +36,7 @@ namespace MediaBrowser.Providers.MediaInfo
             IEnumerable<string> languages,
             string[] disabledSubtitleFetchers,
             string[] subtitleFetcherOrder,
+            bool isAutomated,
             CancellationToken cancellationToken)
         {
             var downloadedLanguages = new List<string>();
@@ -51,6 +52,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     lang,
                     disabledSubtitleFetchers,
                     subtitleFetcherOrder,
+                    isAutomated,
                     cancellationToken).ConfigureAwait(false);
 
                 if (downloaded)
@@ -71,6 +73,7 @@ namespace MediaBrowser.Providers.MediaInfo
             string lang,
             string[] disabledSubtitleFetchers,
             string[] subtitleFetcherOrder,
+            bool isAutomated,
             CancellationToken cancellationToken)
         {
             if (video.VideoType != VideoType.VideoFile)
@@ -109,6 +112,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 disabledSubtitleFetchers,
                 subtitleFetcherOrder,
                 mediaType,
+                isAutomated,
                 cancellationToken);
         }
 
@@ -122,6 +126,7 @@ namespace MediaBrowser.Providers.MediaInfo
             string[] disabledSubtitleFetchers,
             string[] subtitleFetcherOrder,
             VideoContentType mediaType,
+            bool isAutomated,
             CancellationToken cancellationToken)
         {
             // There's already subtitles for this language
@@ -169,7 +174,8 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 IsPerfectMatch = requirePerfectMatch,
                 DisabledSubtitleFetchers = disabledSubtitleFetchers,
-                SubtitleFetcherOrder = subtitleFetcherOrder
+                SubtitleFetcherOrder = subtitleFetcherOrder,
+                IsAutomated = isAutomated
             };
 
             if (video is Episode episode)

--- a/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
@@ -197,6 +197,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     subtitleDownloadLanguages,
                     libraryOptions.DisabledSubtitleFetchers,
                     libraryOptions.SubtitleFetcherOrder,
+                    true,
                     cancellationToken).ConfigureAwait(false);
 
             // Rescan

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -274,7 +274,7 @@ namespace MediaBrowser.Providers.Subtitles
         }
 
         /// <inheritdoc />
-        public Task<RemoteSubtitleInfo[]> SearchSubtitles(Video video, string language, bool? isPerfectMatch, CancellationToken cancellationToken)
+        public Task<RemoteSubtitleInfo[]> SearchSubtitles(Video video, string language, bool? isPerfectMatch, bool isAutomated, CancellationToken cancellationToken)
         {
             if (video.VideoType != VideoType.VideoFile)
             {
@@ -308,7 +308,8 @@ namespace MediaBrowser.Providers.Subtitles
                 ProductionYear = video.ProductionYear,
                 ProviderIds = video.ProviderIds,
                 RuntimeTicks = video.RunTimeTicks,
-                IsPerfectMatch = isPerfectMatch ?? false
+                IsPerfectMatch = isPerfectMatch ?? false,
+                IsAutomated = isAutomated
             };
 
             if (video is Episode episode)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This PR adds the `IsAutomated` property to `SubtitleSearchRequest`, this is useful to subtitle providers in certain scenarios (for example, if the request is automated and the provider is unable to download subtitles at that moment it can return 0 results but still allow the user to search for subtitles)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
partially fixes (adding some random text here so it doesn't actually close the issue) https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/63
