### PR TITLE
Corrected Unraid template link

### DIFF
--- a/deployment/unraid/docker-templates/README.md
+++ b/deployment/unraid/docker-templates/README.md
@@ -8,7 +8,7 @@ Click on the Docker tab
 
 Add the following line under "Template Repositories" 
 
-https://github.com/jellyfin/jellyfin/blob/master/deployment/unraid/docker-templates
+https://github.com/jellyfin/jellyfin/test/master/deployment/unraid/docker-templates
 
 Click save than click on Add Container and select jellyfin.
 

--- a/deployment/unraid/docker-templates/README.md
+++ b/deployment/unraid/docker-templates/README.md
@@ -8,7 +8,7 @@ Click on the Docker tab
 
 Add the following line under "Template Repositories" 
 
-https://github.com/jellyfin/jellyfin/test/master/deployment/unraid/docker-templates
+https://github.com/jellyfin/jellyfin/tree/master/deployment/unraid/docker-templates
 
 Click save than click on Add Container and select jellyfin.
 


### PR DESCRIPTION
The link with 'blob' specified in the URL doesn't work for the current version of Unraid. Replacing 'blob' with 'tree' (which is where the 'blob' link resolves to) works fine.

Changes
Changed link referenced: https://github.com/jellyfin/jellyfin/blob/master/deployment/unraid/docker-templates

To this link: https://github.com/jellyfin/jellyfin/tree/master/deployment/unraid/docker-templates

Issues
Fixes template showing up in Unraid with the changes applied.