### PR TITLE
Use correct id when finding existing dlna profile

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -416,7 +416,7 @@ namespace Emby.Dlna
         }
 
         /// <inheritdoc />
-        public void UpdateProfile(DeviceProfile profile)
+        public void UpdateProfile(string profileId, DeviceProfile profile)
         {
             profile = ReserializeProfile(profile);
 
@@ -430,7 +430,7 @@ namespace Emby.Dlna
                 throw new ArgumentException("Profile is missing Name");
             }
 
-            var current = GetProfileInfosInternal().First(i => string.Equals(i.Info.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
+            var current = GetProfileInfosInternal().First(i => string.Equals(i.Info.Id, profileId, StringComparison.OrdinalIgnoreCase));
 
             var newFilename = _fileSystem.GetValidFilename(profile.Name) + ".xml";
             var path = Path.Combine(UserProfilesPath, newFilename);

--- a/Jellyfin.Api/Controllers/DlnaController.cs
+++ b/Jellyfin.Api/Controllers/DlnaController.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
-            _dlnaManager.UpdateProfile(deviceProfile);
+            _dlnaManager.UpdateProfile(profileId, deviceProfile);
             return NoContent();
         }
     }

--- a/MediaBrowser.Controller/Dlna/IDlnaManager.cs
+++ b/MediaBrowser.Controller/Dlna/IDlnaManager.cs
@@ -37,8 +37,9 @@ namespace MediaBrowser.Controller.Dlna
         /// <summary>
         /// Updates the profile.
         /// </summary>
+        /// <param name="profileId">The profile id.</param>
         /// <param name="profile">The profile.</param>
-        void UpdateProfile(DeviceProfile profile);
+        void UpdateProfile(string profileId, DeviceProfile profile);
 
         /// <summary>
         /// Deletes the profile.


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/6738

Not sure how this broke, but this changes the check to match `GetProfile`

https://github.com/jellyfin/jellyfin/blob/master/Emby.Dlna/DlnaManager.cs#L295-L310