### PR TITLE
Clean up duplicate TmdbImageProvider code

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
@@ -67,40 +67,12 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var remoteImages = new List<RemoteImageInfo>();
+            var posters = collection.Images.Posters;
+            var backdrops = collection.Images.Backdrops;
+            var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            for (var i = 0; i < collection.Images.Posters.Count; i++)
-            {
-                var poster = collection.Images.Posters[i];
-                remoteImages.Add(new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetPosterUrl(poster.FilePath),
-                    CommunityRating = poster.VoteAverage,
-                    VoteCount = poster.VoteCount,
-                    Width = poster.Width,
-                    Height = poster.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(poster.Iso_639_1, language),
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    RatingType = RatingType.Score
-                });
-            }
-
-            for (var i = 0; i < collection.Images.Backdrops.Count; i++)
-            {
-                var backdrop = collection.Images.Backdrops[i];
-                remoteImages.Add(new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetBackdropUrl(backdrop.FilePath),
-                    CommunityRating = backdrop.VoteAverage,
-                    VoteCount = backdrop.VoteCount,
-                    Width = backdrop.Width,
-                    Height = backdrop.Height,
-                    ProviderName = Name,
-                    Type = ImageType.Backdrop,
-                    RatingType = RatingType.Score
-                });
-            }
+            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
@@ -71,8 +71,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
             var backdrops = collection.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
-            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
+            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
+            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetImageProvider.cs
@@ -13,7 +13,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 
@@ -71,8 +70,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
             var backdrops = collection.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
-            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language, remoteImages);
+            _tmdbClientManager.ConvertBackdropsToRemoteImageInfo(backdrops, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
@@ -87,8 +87,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
             var backdrops = movie.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
-            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language, remoteImages);
+            _tmdbClientManager.ConvertBackdropsToRemoteImageInfo(backdrops, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
@@ -13,7 +13,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using TMDbLib.Objects.Find;
@@ -84,40 +83,12 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var remoteImages = new List<RemoteImageInfo>();
+            var posters = movie.Images.Posters;
+            var backdrops = movie.Images.Backdrops;
+            var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            for (var i = 0; i < movie.Images.Posters.Count; i++)
-            {
-                var poster = movie.Images.Posters[i];
-                remoteImages.Add(new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetPosterUrl(poster.FilePath),
-                    CommunityRating = poster.VoteAverage,
-                    VoteCount = poster.VoteCount,
-                    Width = poster.Width,
-                    Height = poster.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(poster.Iso_639_1, language),
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    RatingType = RatingType.Score
-                });
-            }
-
-            for (var i = 0; i < movie.Images.Backdrops.Count; i++)
-            {
-                var backdrop = movie.Images.Backdrops[i];
-                remoteImages.Add(new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetPosterUrl(backdrop.FilePath),
-                    CommunityRating = backdrop.VoteAverage,
-                    VoteCount = backdrop.VoteCount,
-                    Width = backdrop.Width,
-                    Height = backdrop.Height,
-                    ProviderName = Name,
-                    Type = ImageType.Backdrop,
-                    RatingType = RatingType.Score
-                });
-            }
+            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieImageProvider.cs
@@ -87,8 +87,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
             var backdrops = movie.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
-            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
+            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
+            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
@@ -63,7 +63,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
             var profiles = personResult.Images.Profiles;
             var remoteImages = new List<RemoteImageInfo>(profiles.Count);
 
-            TmdbUtils.ConvertProfilesToRemoteImageInfo(profiles, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertProfilesToRemoteImageInfo(profiles, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
@@ -63,7 +63,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
             var profiles = personResult.Images.Profiles;
             var remoteImages = new List<RemoteImageInfo>(profiles.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(profiles, _tmdbClientManager.GetProfileUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertProfilesToRemoteImageInfo(profiles, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
@@ -60,21 +60,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var remoteImages = new RemoteImageInfo[personResult.Images.Profiles.Count];
+            var profiles = personResult.Images.Profiles;
+            var remoteImages = new List<RemoteImageInfo>(profiles.Count);
 
-            for (var i = 0; i < personResult.Images.Profiles.Count; i++)
-            {
-                var image = personResult.Images.Profiles[i];
-                remoteImages[i] = new RemoteImageInfo
-                {
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    Width = image.Width,
-                    Height = image.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(image.Iso_639_1, language),
-                    Url = _tmdbClientManager.GetProfileUrl(image.FilePath)
-                };
-            }
+            TmdbUtils.ConvertToRemoteImageInfo(profiles, _tmdbClientManager.GetProfileUrl, ImageType.Primary, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 
@@ -75,23 +74,9 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var remoteImages = new RemoteImageInfo[stills.Count];
-            for (var i = 0; i < stills.Count; i++)
-            {
-                var image = stills[i];
-                remoteImages[i] = new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetStillUrl(image.FilePath),
-                    CommunityRating = image.VoteAverage,
-                    VoteCount = image.VoteCount,
-                    Width = image.Width,
-                    Height = image.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(image.Iso_639_1, language),
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    RatingType = RatingType.Score
-                };
-            }
+            var remoteImages = new List<RemoteImageInfo>(stills.Count);
+
+            TmdbUtils.ConvertToRemoteImageInfo(stills, _tmdbClientManager.GetStillUrl, ImageType.Primary, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
@@ -76,7 +76,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var remoteImages = new List<RemoteImageInfo>(stills.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(stills, _tmdbClientManager.GetStillUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertStillsToRemoteImageInfo(stills, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeImageProvider.cs
@@ -76,7 +76,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var remoteImages = new List<RemoteImageInfo>(stills.Count);
 
-            TmdbUtils.ConvertStillsToRemoteImageInfo(stills, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertStillsToRemoteImageInfo(stills, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -63,7 +63,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var remoteImages = new List<RemoteImageInfo>(posters.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -63,7 +63,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var remoteImages = new List<RemoteImageInfo>(posters.Count);
 
-            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -11,7 +11,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 
@@ -62,23 +61,9 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var remoteImages = new RemoteImageInfo[posters.Count];
-            for (var i = 0; i < posters.Count; i++)
-            {
-                var image = posters[i];
-                remoteImages[i] = new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetPosterUrl(image.FilePath),
-                    CommunityRating = image.VoteAverage,
-                    VoteCount = image.VoteCount,
-                    Width = image.Width,
-                    Height = image.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(image.Iso_639_1, language),
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    RatingType = RatingType.Score
-                };
-            }
+            var remoteImages = new List<RemoteImageInfo>(posters.Count);
+
+            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
@@ -71,8 +71,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             var backdrops = series.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
-            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
+            _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language, remoteImages);
+            _tmdbClientManager.ConvertBackdropsToRemoteImageInfo(backdrops, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
@@ -71,8 +71,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             var backdrops = series.Images.Backdrops;
             var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
-            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
+            TmdbUtils.ConvertPostersToRemoteImageInfo(posters, _tmdbClientManager, language, remoteImages);
+            TmdbUtils.ConvertBackdropsToRemoteImageInfo(backdrops, _tmdbClientManager, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesImageProvider.cs
@@ -11,7 +11,6 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 
@@ -70,41 +69,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var posters = series.Images.Posters;
             var backdrops = series.Images.Backdrops;
+            var remoteImages = new List<RemoteImageInfo>(posters.Count + backdrops.Count);
 
-            var remoteImages = new RemoteImageInfo[posters.Count + backdrops.Count];
-
-            for (var i = 0; i < posters.Count; i++)
-            {
-                var poster = posters[i];
-                remoteImages[i] = new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetPosterUrl(poster.FilePath),
-                    CommunityRating = poster.VoteAverage,
-                    VoteCount = poster.VoteCount,
-                    Width = poster.Width,
-                    Height = poster.Height,
-                    Language = TmdbUtils.AdjustImageLanguage(poster.Iso_639_1, language),
-                    ProviderName = Name,
-                    Type = ImageType.Primary,
-                    RatingType = RatingType.Score
-                };
-            }
-
-            for (var i = 0; i < backdrops.Count; i++)
-            {
-                var backdrop = series.Images.Backdrops[i];
-                remoteImages[posters.Count + i] = new RemoteImageInfo
-                {
-                    Url = _tmdbClientManager.GetBackdropUrl(backdrop.FilePath),
-                    CommunityRating = backdrop.VoteAverage,
-                    VoteCount = backdrop.VoteCount,
-                    Width = backdrop.Width,
-                    Height = backdrop.Height,
-                    ProviderName = Name,
-                    Type = ImageType.Backdrop,
-                    RatingType = RatingType.Score
-                };
-            }
+            TmdbUtils.ConvertToRemoteImageInfo(posters, _tmdbClientManager.GetPosterUrl, ImageType.Primary, language, remoteImages);
+            TmdbUtils.ConvertToRemoteImageInfo(backdrops, _tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, language, remoteImages);
 
             return remoteImages;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -1,4 +1,4 @@
-#nullable disable
+﻿#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -471,33 +471,39 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         }
 
         /// <summary>
+        /// Handles bad path checking and builds the absolute url.
+        /// </summary>
+        /// <param name="size">The image size to fetch.</param>
+        /// <param name="path">The relative URL of the image.</param>
+        /// <returns>The absolute URL.</returns>
+        private string GetUrl(string size, string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            return _tmDbClient.GetImageUrl(size, path).ToString();
+        }
+
+        /// <summary>
         /// Gets the absolute URL of the poster.
         /// </summary>
         /// <param name="posterPath">The relative URL of the poster.</param>
         /// <returns>The absolute URL.</returns>
         public string GetPosterUrl(string posterPath)
         {
-            if (string.IsNullOrEmpty(posterPath))
-            {
-                return null;
-            }
-
-            return _tmDbClient.GetImageUrl(_tmDbClient.Config.Images.PosterSizes[^1], posterPath).ToString();
+            return GetUrl(_tmDbClient.Config.Images.PosterSizes[^1], posterPath);
         }
 
         /// <summary>
         /// Gets the absolute URL of the backdrop image.
         /// </summary>
-        /// <param name="posterPath">The relative URL of the backdrop image.</param>
+        /// <param name="backdropPath">The relative URL of the backdrop image.</param>
         /// <returns>The absolute URL.</returns>
-        public string GetBackdropUrl(string posterPath)
+        public string GetBackdropUrl(string backdropPath)
         {
-            if (string.IsNullOrEmpty(posterPath))
-            {
-                return null;
-            }
-
-            return _tmDbClient.GetImageUrl(_tmDbClient.Config.Images.BackdropSizes[^1], posterPath).ToString();
+            return GetUrl(_tmDbClient.Config.Images.BackdropSizes[^1], backdropPath);
         }
 
         /// <summary>
@@ -507,12 +513,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <returns>The absolute URL.</returns>
         public string GetProfileUrl(string actorProfilePath)
         {
-            if (string.IsNullOrEmpty(actorProfilePath))
-            {
-                return null;
-            }
-
-            return _tmDbClient.GetImageUrl(_tmDbClient.Config.Images.ProfileSizes[^1], actorProfilePath).ToString();
+            return GetUrl(_tmDbClient.Config.Images.ProfileSizes[^1], actorProfilePath);
         }
 
         /// <summary>
@@ -522,12 +523,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <returns>The absolute URL.</returns>
         public string GetStillUrl(string filePath)
         {
-            if (string.IsNullOrEmpty(filePath))
-            {
-                return null;
-            }
-
-            return _tmDbClient.GetImageUrl(_tmDbClient.Config.Images.StillSizes[^1], filePath).ToString();
+            return GetUrl(_tmDbClient.Config.Images.StillSizes[^1], filePath);
         }
 
         private Task EnsureClientConfigAsync()
@@ -542,7 +538,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             GC.SuppressFinalize(this);
         }
 
-/// <summary>
+        /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -196,6 +196,54 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         }
 
         /// <summary>
+        /// Converts poster <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
+        /// </summary>
+        /// <param name="images">The input images.</param>
+        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
+        /// <param name="requestLanguage">The requested language.</param>
+        /// <param name="results">The collection to add the remote images into.</param>
+        public static void ConvertPostersToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
+        {
+            ConvertToRemoteImageInfo(images, tmdbClientManager.GetPosterUrl, ImageType.Primary, requestLanguage, results);
+        }
+
+        /// <summary>
+        /// Converts backdrop <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
+        /// </summary>
+        /// <param name="images">The input images.</param>
+        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
+        /// <param name="requestLanguage">The requested language.</param>
+        /// <param name="results">The collection to add the remote images into.</param>
+        public static void ConvertBackdropsToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
+        {
+            ConvertToRemoteImageInfo(images, tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, requestLanguage, results);
+        }
+
+        /// <summary>
+        /// Converts profile <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
+        /// </summary>
+        /// <param name="images">The input images.</param>
+        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
+        /// <param name="requestLanguage">The requested language.</param>
+        /// <param name="results">The collection to add the remote images into.</param>
+        public static void ConvertProfilesToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
+        {
+            ConvertToRemoteImageInfo(images, tmdbClientManager.GetProfileUrl, ImageType.Primary, requestLanguage, results);
+        }
+
+        /// <summary>
+        /// Converts still <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
+        /// </summary>
+        /// <param name="images">The input images.</param>
+        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
+        /// <param name="requestLanguage">The requested language.</param>
+        /// <param name="results">The collection to add the remote images into.</param>
+        public static void ConvertStillsToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
+        {
+            ConvertToRemoteImageInfo(images, tmdbClientManager.GetStillUrl, ImageType.Primary, requestLanguage, results);
+        }
+
+        /// <summary>
         /// Converts <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
         /// </summary>
         /// <param name="images">The input images.</param>
@@ -203,7 +251,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <param name="type">The type of the image.</param>
         /// <param name="requestLanguage">The requested language.</param>
         /// <param name="results">The collection to add the remote images into.</param>
-        public static void ConvertToRemoteImageInfo(List<ImageData> images, Func<string, string> imageUrlConverter, ImageType type, string requestLanguage, List<RemoteImageInfo> results)
+        private static void ConvertToRemoteImageInfo(List<ImageData> images, Func<string, string> imageUrlConverter, ImageType type, string requestLanguage, List<RemoteImageInfo> results)
         {
             for (var i = 0; i < images.Count; i++)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
 using TMDbLib.Objects.General;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb
@@ -191,6 +193,34 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             var newRating = ratingPrefix + ratingValue;
 
             return newRating.Replace("DE-", "FSK-", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Converts <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
+        /// </summary>
+        /// <param name="images">The input images.</param>
+        /// <param name="imageUrlConverter">The relevant <see cref="TmdbClientManager"/> Get<i>Type</i>Url function to get the absolute url of the image.</param>
+        /// <param name="type">The type of the image.</param>
+        /// <param name="requestLanguage">The requested language.</param>
+        /// <param name="results">The collection to add the remote images into.</param>
+        public static void ConvertToRemoteImageInfo(List<ImageData> images, Func<string, string> imageUrlConverter, ImageType type, string requestLanguage, List<RemoteImageInfo> results)
+        {
+            for (var i = 0; i < images.Count; i++)
+            {
+                var image = images[i];
+                results.Add(new RemoteImageInfo
+                {
+                    Url = imageUrlConverter(image.FilePath),
+                    CommunityRating = image.VoteAverage,
+                    VoteCount = image.VoteCount,
+                    Width = image.Width,
+                    Height = image.Height,
+                    Language = AdjustImageLanguage(image.Iso_639_1, requestLanguage),
+                    ProviderName = ProviderName,
+                    Type = type,
+                    RatingType = RatingType.Score
+                });
+            }
         }
     }
 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Providers;
 using TMDbLib.Objects.General;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb
@@ -193,82 +191,6 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             var newRating = ratingPrefix + ratingValue;
 
             return newRating.Replace("DE-", "FSK-", StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Converts poster <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
-        /// </summary>
-        /// <param name="images">The input images.</param>
-        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
-        /// <param name="requestLanguage">The requested language.</param>
-        /// <param name="results">The collection to add the remote images into.</param>
-        public static void ConvertPostersToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
-        {
-            ConvertToRemoteImageInfo(images, tmdbClientManager.GetPosterUrl, ImageType.Primary, requestLanguage, results);
-        }
-
-        /// <summary>
-        /// Converts backdrop <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
-        /// </summary>
-        /// <param name="images">The input images.</param>
-        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
-        /// <param name="requestLanguage">The requested language.</param>
-        /// <param name="results">The collection to add the remote images into.</param>
-        public static void ConvertBackdropsToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
-        {
-            ConvertToRemoteImageInfo(images, tmdbClientManager.GetBackdropUrl, ImageType.Backdrop, requestLanguage, results);
-        }
-
-        /// <summary>
-        /// Converts profile <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
-        /// </summary>
-        /// <param name="images">The input images.</param>
-        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
-        /// <param name="requestLanguage">The requested language.</param>
-        /// <param name="results">The collection to add the remote images into.</param>
-        public static void ConvertProfilesToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
-        {
-            ConvertToRemoteImageInfo(images, tmdbClientManager.GetProfileUrl, ImageType.Primary, requestLanguage, results);
-        }
-
-        /// <summary>
-        /// Converts still <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
-        /// </summary>
-        /// <param name="images">The input images.</param>
-        /// <param name="tmdbClientManager">The client manager to use for resolving image urls.</param>
-        /// <param name="requestLanguage">The requested language.</param>
-        /// <param name="results">The collection to add the remote images into.</param>
-        public static void ConvertStillsToRemoteImageInfo(List<ImageData> images, TmdbClientManager tmdbClientManager, string requestLanguage, List<RemoteImageInfo> results)
-        {
-            ConvertToRemoteImageInfo(images, tmdbClientManager.GetStillUrl, ImageType.Primary, requestLanguage, results);
-        }
-
-        /// <summary>
-        /// Converts <see cref="ImageData"/>s into <see cref="RemoteImageInfo"/>s.
-        /// </summary>
-        /// <param name="images">The input images.</param>
-        /// <param name="imageUrlConverter">The relevant <see cref="TmdbClientManager"/> Get<i>Type</i>Url function to get the absolute url of the image.</param>
-        /// <param name="type">The type of the image.</param>
-        /// <param name="requestLanguage">The requested language.</param>
-        /// <param name="results">The collection to add the remote images into.</param>
-        private static void ConvertToRemoteImageInfo(List<ImageData> images, Func<string, string> imageUrlConverter, ImageType type, string requestLanguage, List<RemoteImageInfo> results)
-        {
-            for (var i = 0; i < images.Count; i++)
-            {
-                var image = images[i];
-                results.Add(new RemoteImageInfo
-                {
-                    Url = imageUrlConverter(image.FilePath),
-                    CommunityRating = image.VoteAverage,
-                    VoteCount = image.VoteCount,
-                    Width = image.Width,
-                    Height = image.Height,
-                    Language = AdjustImageLanguage(image.Iso_639_1, requestLanguage),
-                    ProviderName = ProviderName,
-                    Type = type,
-                    RatingType = RatingType.Score
-                });
-            }
         }
     }
 }

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Providers;
-using MediaBrowser.Providers.Plugins.Tmdb;
-using TMDbLib.Objects.General;
+﻿using MediaBrowser.Providers.Plugins.Tmdb;
 using Xunit;
 
 namespace Jellyfin.Providers.Tests.Tmdb
@@ -40,88 +35,6 @@ namespace Jellyfin.Providers.Tests.Tmdb
         public static void AdjustImageLanguage_Valid_Success(string imageLanguage, string requestLanguage, string expected)
         {
             Assert.Equal(expected, TmdbUtils.AdjustImageLanguage(imageLanguage, requestLanguage));
-        }
-
-        private static TheoryData<ImageType, ImageData, RemoteImageInfo> GetConvertedImages()
-        {
-            return new TheoryData<ImageType, ImageData, RemoteImageInfo>
-            {
-                {
-                    ImageType.Primary,
-                    new ()
-                    {
-                        Width = 1,
-                        Height = 1,
-                        AspectRatio = 1,
-                        FilePath = "path 1",
-                        Iso_639_1 = "en",
-                        VoteAverage = 1.2,
-                        VoteCount = 5
-                    },
-                    new ()
-                    {
-                        Type = ImageType.Primary,
-                        Width = 1,
-                        Height = 1,
-                        Url = "converted path 1",
-                        Language = "en-US",
-                        CommunityRating = 1.2,
-                        VoteCount = 5,
-                        RatingType = RatingType.Score,
-                        ProviderName = TmdbUtils.ProviderName
-                    }
-                },
-                {
-                    ImageType.Backdrop,
-                    new ()
-                    {
-                        Width = 4,
-                        Height = 2,
-                        AspectRatio = 2,
-                        FilePath = "path 2",
-                        Iso_639_1 = null,
-                        VoteAverage = 0,
-                        VoteCount = 0
-                    },
-                    new ()
-                    {
-                        Type = ImageType.Backdrop,
-                        Width = 4,
-                        Height = 2,
-                        Url = "converted path 2",
-                        Language = null,
-                        CommunityRating = 0,
-                        VoteCount = 0,
-                        RatingType = RatingType.Score,
-                        ProviderName = TmdbUtils.ProviderName
-                    }
-                }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(GetConvertedImages))]
-        public static void ConvertToRemoteImageInfo_ImageList_ConvertsAll(ImageType type, ImageData input, RemoteImageInfo expected)
-        {
-            var images = new List<ImageData> { input };
-            string UrlConverter(string s)
-                => "converted " + s;
-            var language = "en-US";
-
-            var results = new List<RemoteImageInfo>(images.Count);
-            TmdbUtils.ConvertToRemoteImageInfo(images, UrlConverter, type, language, results);
-
-            Assert.Single(results);
-
-            Assert.Equal(expected.Type, results[0].Type);
-            Assert.Equal(expected.Width, results[0].Width);
-            Assert.Equal(expected.Height, results[0].Height);
-            Assert.Equal(expected.Url, results[0].Url);
-            Assert.Equal(expected.Language, results[0].Language);
-            Assert.Equal(expected.CommunityRating, results[0].CommunityRating);
-            Assert.Equal(expected.VoteCount, results[0].VoteCount);
-            Assert.Equal(expected.RatingType, results[0].RatingType);
-            Assert.Equal(expected.ProviderName, results[0].ProviderName);
         }
     }
 }

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -1,4 +1,9 @@
-﻿using MediaBrowser.Providers.Plugins.Tmdb;
+﻿using System.Collections.Generic;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Plugins.Tmdb;
+using TMDbLib.Objects.General;
 using Xunit;
 
 namespace Jellyfin.Providers.Tests.Tmdb
@@ -22,6 +27,101 @@ namespace Jellyfin.Providers.Tests.Tmdb
         public static void NormalizeLanguage_Invalid_Equal(string? input, string? expected)
         {
             Assert.Equal(expected, TmdbUtils.NormalizeLanguage(input!));
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData(null, "en-US", null)]
+        [InlineData("en", null, "en")]
+        [InlineData("en", "en-US", "en-US")]
+        [InlineData("fr-CA", "fr-BE", "fr-CA")]
+        [InlineData("fr-CA", "fr", "fr-CA")]
+        [InlineData("de", "en-US", "de")]
+        public static void AdjustImageLanguage_Valid_Success(string imageLanguage, string requestLanguage, string expected)
+        {
+            Assert.Equal(expected, TmdbUtils.AdjustImageLanguage(imageLanguage, requestLanguage));
+        }
+
+        private static TheoryData<ImageType, ImageData, RemoteImageInfo> GetConvertedImages()
+        {
+            return new TheoryData<ImageType, ImageData, RemoteImageInfo>
+            {
+                {
+                    ImageType.Primary,
+                    new ()
+                    {
+                        Width = 1,
+                        Height = 1,
+                        AspectRatio = 1,
+                        FilePath = "path 1",
+                        Iso_639_1 = "en",
+                        VoteAverage = 1.2,
+                        VoteCount = 5
+                    },
+                    new ()
+                    {
+                        Type = ImageType.Primary,
+                        Width = 1,
+                        Height = 1,
+                        Url = "converted path 1",
+                        Language = "en-US",
+                        CommunityRating = 1.2,
+                        VoteCount = 5,
+                        RatingType = RatingType.Score,
+                        ProviderName = TmdbUtils.ProviderName
+                    }
+                },
+                {
+                    ImageType.Backdrop,
+                    new ()
+                    {
+                        Width = 4,
+                        Height = 2,
+                        AspectRatio = 2,
+                        FilePath = "path 2",
+                        Iso_639_1 = null,
+                        VoteAverage = 0,
+                        VoteCount = 0
+                    },
+                    new ()
+                    {
+                        Type = ImageType.Backdrop,
+                        Width = 4,
+                        Height = 2,
+                        Url = "converted path 2",
+                        Language = null,
+                        CommunityRating = 0,
+                        VoteCount = 0,
+                        RatingType = RatingType.Score,
+                        ProviderName = TmdbUtils.ProviderName
+                    }
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetConvertedImages))]
+        public static void ConvertToRemoteImageInfo_ImageList_ConvertsAll(ImageType type, ImageData input, RemoteImageInfo expected)
+        {
+            var images = new List<ImageData> { input };
+            string UrlConverter(string s)
+                => "converted " + s;
+            var language = "en-US";
+
+            var results = new List<RemoteImageInfo>(images.Count);
+            TmdbUtils.ConvertToRemoteImageInfo(images, UrlConverter, type, language, results);
+
+            Assert.Single(results);
+
+            Assert.Equal(expected.Type, results[0].Type);
+            Assert.Equal(expected.Width, results[0].Width);
+            Assert.Equal(expected.Height, results[0].Height);
+            Assert.Equal(expected.Url, results[0].Url);
+            Assert.Equal(expected.Language, results[0].Language);
+            Assert.Equal(expected.CommunityRating, results[0].CommunityRating);
+            Assert.Equal(expected.VoteCount, results[0].VoteCount);
+            Assert.Equal(expected.RatingType, results[0].RatingType);
+            Assert.Equal(expected.ProviderName, results[0].ProviderName);
         }
     }
 }


### PR DESCRIPTION
**Changes**
- Extract copy-pasted code to convert `ImageData` to `RemoteImageInfo` and add test for new method
- Extract boilerplate GetTypeUrl code into a private helper method.

I was looking at the TMDb plugin to add logo support (next TMDbLib release should support logos) and I noticed there were some copy/paste errors (missing language where the API returns it, using `GetPosterUrl` for a backdrop, etc). Low impact, but seeing as the code showed proof that the duplication was hurting maintainability I figured it was worth cleaning up now.