### PR TITLE
Make tags import from TMDB configurable

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
@@ -11,5 +11,15 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// Gets or sets a value indicating whether include adult content when searching with TMDb.
         /// </summary>
         public bool IncludeAdult { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether tags should be imported for series from TMDb.
+        /// </summary>
+        public bool ExcludeTagsSeries { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether tags should be imported for movies from TMDb.
+        /// </summary>
+        public bool ExcludeTagsMovies { get; set; }
     }
 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
@@ -29,20 +29,24 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
                         document.querySelector('#includeAdult').checked = config.IncludeAdult;
+                        document.querySelector('#excludeTagsSeries').checked = config.ExcludeTagsSeries;
+                        document.querySelector('#excludeTagsMovies').checked = config.ExcludeTagsMovies;
                         Dashboard.hideLoadingMsg();
                     });
                 });
 
-            
+
             document.querySelector('.configForm')
                 .addEventListener('submit', function (e) {
                     Dashboard.showLoadingMsg();
-    
+
                     ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
                         config.IncludeAdult = document.querySelector('#includeAdult').checked;
+                        config.ExcludeTagsSeries = document.querySelector('#excludeTagsSeries').checked;
+                        config.ExcludeTagsMovies = document.querySelector('#excludeTagsMovies').checked;
                         ApiClient.updatePluginConfiguration(PluginConfig.pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });
-                    
+
                     e.preventDefault();
                     return false;
                 });

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -57,11 +57,17 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
 
             await EnsureClientConfigAsync().ConfigureAwait(false);
 
+            var extraMethods = MovieMethods.Credits | MovieMethods.Releases | MovieMethods.Images | MovieMethods.Videos;
+            if (!(Plugin.Instance?.Configuration.ExcludeTagsMovies).GetValueOrDefault())
+            {
+                extraMethods |= MovieMethods.Keywords;
+            }
+
             movie = await _tmDbClient.GetMovieAsync(
                 tmdbId,
                 TmdbUtils.NormalizeLanguage(language),
                 imageLanguages,
-                MovieMethods.Credits | MovieMethods.Releases | MovieMethods.Images | MovieMethods.Keywords | MovieMethods.Videos,
+                extraMethods,
                 cancellationToken).ConfigureAwait(false);
 
             if (movie != null)
@@ -123,11 +129,17 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
 
             await EnsureClientConfigAsync().ConfigureAwait(false);
 
+            var extraMethods = TvShowMethods.Credits | TvShowMethods.Images | TvShowMethods.ExternalIds | TvShowMethods.Videos | TvShowMethods.ContentRatings | TvShowMethods.EpisodeGroups;
+            if (!(Plugin.Instance?.Configuration.ExcludeTagsSeries).GetValueOrDefault())
+            {
+                extraMethods |= TvShowMethods.Keywords;
+            }
+
             series = await _tmDbClient.GetTvShowAsync(
                 tmdbId,
                 language: TmdbUtils.NormalizeLanguage(language),
                 includeImageLanguage: imageLanguages,
-                extraMethods: TvShowMethods.Credits | TvShowMethods.Images | TvShowMethods.Keywords | TvShowMethods.ExternalIds | TvShowMethods.Videos | TvShowMethods.ContentRatings | TvShowMethods.EpisodeGroups,
+                extraMethods: extraMethods,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (series != null)


### PR DESCRIPTION
Added new settings to disable tags import from TMDB for Movies and Series. Most tags are only available in English, so other languages should be able to disable the import. I don't like the naming of most tags, so I would disable them even with English as language.

**Changes**
Settings have "Exclude" in their name, so default behaviour without a configuration change is to import the tags (act as before)

**Issues**
https://github.com/jellyfin/jellyfin-plugin-tmdb/issues/10

**Hint**
Don't test the same movie/serie again after a configuration change. Providers use an IMemoryCache and if a movie/serie/person/... is in cache, the refresh doesn't trigger a new search, it uses the data from cache. A configuration change for some (all?) settings should clear the cache imho (only a language change is safe, the language is part of the key from cache), but that's a problem for all providers and not part of this PR.