### PR TITLE
Fix OpenAPI workflow not working with pull requests from forks

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
 
 jobs:
   openapi-head:
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
@@ -53,7 +55,7 @@ jobs:
 
   openapi-diff:
     name: OpenAPI - Difference
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     needs:
       - openapi-head


### PR DESCRIPTION
**Changes**

Changed the workflow to use the `pull_request_target` event instead of `pull_request`. I was not able to test this change.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
