### PR TITLE
Deprecate ImageType.Screenshot and ItemFields.Screenshot

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -755,15 +755,6 @@ namespace Emby.Server.Implementations.Dto
                 dto.BackdropImageTags = GetTagsAndFillBlurhashes(dto, item, ImageType.Backdrop, backdropLimit);
             }
 
-            if (options.ContainsField(ItemFields.ScreenshotImageTags))
-            {
-                var screenshotLimit = options.GetImageLimit(ImageType.Screenshot);
-                if (screenshotLimit > 0)
-                {
-                    dto.ScreenshotImageTags = GetTagsAndFillBlurhashes(dto, item, ImageType.Screenshot, screenshotLimit);
-                }
-            }
-
             if (options.ContainsField(ItemFields.Genres))
             {
                 dto.Genres = item.Genres;

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2577,7 +2577,7 @@ namespace MediaBrowser.Controller.Entities
 
         public bool AllowsMultipleImages(ImageType type)
         {
-            return type == ImageType.Backdrop || type == ImageType.Screenshot || type == ImageType.Chapter;
+            return type == ImageType.Backdrop || type == ImageType.Chapter;
         }
 
         public Task SwapImagesAsync(ImageType type, int index1, int index2)

--- a/MediaBrowser.Model/Entities/ImageType.cs
+++ b/MediaBrowser.Model/Entities/ImageType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediaBrowser.Model.Entities
 {
     /// <summary>
@@ -48,6 +50,7 @@ namespace MediaBrowser.Model.Entities
         /// <summary>
         /// The screenshot.
         /// </summary>
+        [Obsolete("Screenshot image type is no longer used.")]
         Screenshot = 8,
 
         /// <summary>

--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CS1591
 
+using System;
+
 namespace MediaBrowser.Model.Querying
 {
     /// <summary>
@@ -143,6 +145,7 @@ namespace MediaBrowser.Model.Querying
         /// <summary>
         /// The screenshot image tags.
         /// </summary>
+        [Obsolete("Screenshot image type is no longer used.")]
         ScreenshotImageTags,
 
         SeriesPrimaryImage,

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -439,9 +439,6 @@ namespace MediaBrowser.Providers.Manager
                 case ImageType.Backdrop:
                     filename = GetBackdropSaveFilename(item.GetImages(type), "backdrop", "backdrop", imageIndex);
                     break;
-                case ImageType.Screenshot:
-                    filename = GetBackdropSaveFilename(item.GetImages(type), "screenshot", "screenshot", imageIndex);
-                    break;
                 default:
                     filename = type.ToString().ToLowerInvariant();
                     break;

--- a/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
@@ -207,10 +207,8 @@ namespace Jellyfin.Providers.Tests.Manager
         [Theory]
         [InlineData(ImageType.Primary, 1, false)]
         [InlineData(ImageType.Backdrop, 2, false)]
-        [InlineData(ImageType.Screenshot, 2, false)]
         [InlineData(ImageType.Primary, 1, true)]
         [InlineData(ImageType.Backdrop, 2, true)]
-        [InlineData(ImageType.Screenshot, 2, true)]
         public async void RefreshImages_PopulatedItemPopulatedProviderDynamic_UpdatesImagesIfForced(ImageType imageType, int imageCount, bool forceRefresh)
         {
             var item = GetItemWithImages(imageType, imageCount, false);


### PR DESCRIPTION
Opposite of #6779

**Changes**
- Remove references to `ImageType.Screenshot` and `ItemFields.Screenshot` and deprecate the enum entries.

For reference, the `Game` type that had screenshots was removed in [8985fb8d58c9b968b8e773276d7c3902aa4d55f3](https://github.com/jellyfin/jellyfin/commit/8985fb8d58c9b968b8e773276d7c3902aa4d55f3).