### PR TITLE
Fix OpenAPI workflow fork cloning

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -9,6 +9,7 @@ jobs:
   openapi-head:
     name: OpenAPI - HEAD
     runs-on: ubuntu-latest
+    permissions: read-all
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -34,6 +35,7 @@ jobs:
     name: OpenAPI - BASE
     if: ${{ github.base_ref != '' }}
     runs-on: ubuntu-latest
+    permissions: read-all
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
**Changes**

- Specify repository in actions/checkout to fix cloning of forks
- Change to read-only permissions for GITHUB_TOKEN to prevent h@ckers

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
