### PR TITLE
Prevent additional errors on startup/shutdown

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -223,12 +223,16 @@ namespace Jellyfin.Server
             }
             finally
             {
-                _logger.LogInformation("Running query planner optimizations in the database... This might take a while");
-                // Run before disposing the application
-                using var context = appHost.Resolve<JellyfinDbProvider>().CreateContext();
-                if (context.Database.IsSqlite())
+                // Don't throw additional exception if startup failed.
+                if (appHost.ServiceProvider != null)
                 {
-                    context.Database.ExecuteSqlRaw("PRAGMA optimize");
+                    _logger.LogInformation("Running query planner optimizations in the database... This might take a while");
+                    // Run before disposing the application
+                    using var context = appHost.Resolve<JellyfinDbProvider>().CreateContext();
+                    if (context.Database.IsSqlite())
+                    {
+                        context.Database.ExecuteSqlRaw("PRAGMA optimize");
+                    }
                 }
 
                 appHost.Dispose();


### PR DESCRIPTION
Prevent an exception from being thrown if startup fails. 
As seen in https://github.com/jellyfin/jellyfin/issues/6776

```
[09:31:18] [FTL] [1] Main: Unhandled Exception
System.ArgumentNullException: Value cannot be null. (Parameter 'provider')
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService[T](IServiceProvider provider)
   at Emby.Server.Implementations.ApplicationHost.Resolve[T]() in /home/crobibero/Code/jellyfin/Emby.Server.Implementations/ApplicationHost.cs:line 408
   at Jellyfin.Server.Program.StartApp(StartupOptions options) in /home/crobibero/Code/jellyfin/Jellyfin.Server/Program.cs:line 231
   at Jellyfin.Server.Program.<Main>(String[] args)
```