### PR TITLE
Load all types when checking plugin DLLs

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -126,7 +126,8 @@ namespace Emby.Server.Implementations.Plugins
                     {
                         assembly = Assembly.LoadFrom(file);
 
-                        assembly.GetExportedTypes();
+                        // Load all required types to verify that the plugin will load
+                        assembly.GetTypes();
                     }
                     catch (FileLoadException ex)
                     {
@@ -134,7 +135,7 @@ namespace Emby.Server.Implementations.Plugins
                         ChangePluginState(plugin, PluginStatus.Malfunctioned);
                         continue;
                     }
-                    catch (TypeLoadException ex) // Undocumented exception
+                    catch (SystemException ex) when (ex is TypeLoadException or ReflectionTypeLoadException) // Undocumented exception
                     {
                         _logger.LogError(ex, "Failed to load assembly {Path}. This error occurs when a plugin references an incompatible version of one of the shared libraries. Disabling plugin.", file);
                         ChangePluginState(plugin, PluginStatus.NotSupported);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
GetExportedTypes only loads public types. GetTypes loads everything that is required.

**Issues**
Fixes #6776 
