### PR TITLE
Add/expose image settings for video extras

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2067,12 +2067,25 @@ namespace Emby.Server.Implementations.Library
             {
                 var parent = item.GetParent();
 
-                if (parent == null || parent is AggregateFolder)
+                if (parent is AggregateFolder)
                 {
                     break;
                 }
+                else if (parent == null)
+                {
+                    var owner = item.GetOwner();
 
-                item = parent;
+                    if (owner == null)
+                    {
+                        break;
+                    }
+
+                    item = owner;
+                }
+                else
+                {
+                    item = parent;
+                }
             }
 
             if (item == null)

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -921,14 +921,14 @@ namespace Jellyfin.Api.Controllers
             {
                 CollectionType.BoxSets => new[] { "BoxSet" },
                 CollectionType.Playlists => new[] { "Playlist" },
-                CollectionType.Movies => new[] { "Movie" },
-                CollectionType.TvShows => new[] { "Series", "Season", "Episode" },
+                CollectionType.Movies => new[] { "Movie", "Video" },
+                CollectionType.TvShows => new[] { "Series", "Season", "Episode", "Video" },
                 CollectionType.Books => new[] { "Book" },
                 CollectionType.Music => new[] { "MusicArtist", "MusicAlbum", "Audio", "MusicVideo" },
                 CollectionType.HomeVideos => new[] { "Video", "Photo" },
                 CollectionType.Photos => new[] { "Video", "Photo" },
                 CollectionType.MusicVideos => new[] { "MusicVideo" },
-                _ => new[] { "Series", "Season", "Episode", "Movie" }
+                _ => new[] { "Series", "Season", "Episode", "Movie", "Video" }
             };
         }
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2584,7 +2584,7 @@ namespace MediaBrowser.Controller.Entities
         {
             if (!AllowsMultipleImages(type))
             {
-                throw new ArgumentException("The change index operation is only applicable to backdrops and screen shots");
+                throw new ArgumentException("The change index operation is only applicable to types that allow multiple images");
             }
 
             var info1 = GetImageInfo(type, index1);
@@ -2807,6 +2807,11 @@ namespace MediaBrowser.Controller.Entities
             if (video == null)
             {
                 return Task.FromResult(true);
+            }
+
+            if (video.OwnerId == Guid.Empty)
+            {
+                video.OwnerId = this.Id;
             }
 
             return RefreshMetadataForOwnedItem(video, copyTitleMetadata, newOptions, cancellationToken);

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -93,12 +93,6 @@ namespace MediaBrowser.Model.Configuration
                 }
             }
 
-            if (type == "Trailer")
-            {
-                // fall back to generic extras options (if set)
-                return GetTypeOptions("Video");
-            }
-
             return null;
         }
     }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -93,6 +93,12 @@ namespace MediaBrowser.Model.Configuration
                 }
             }
 
+            if (type == "Trailer")
+            {
+                // fall back to generic extras options (if set)
+                return GetTypeOptions("Video");
+            }
+
             return null;
         }
     }


### PR DESCRIPTION
Old state: If no library `TypeOptions` are found for a type a default option is used that enables all image providers. This allows the usage of a dummy object for populating the options panel, but results in image providers that the user disabled for `Movie` being run on any extras, trailers, or secondary video files also in the directory with the primary movie file.

**Changes**
- Fall back to `Owner` on missing `Parent` when searching up the tree for the library root to allow options to be found for owned items.
- Fall back to `Video` when type `Trailer` not found in library options.
- Add check to ensure owned videos know their owner on metadata refresh (videos created from the `Video.LocalAlternateVersions` list didn't know their owner).
- Add `Video` library options to allow the user to modify image collection settings for video extras.

"Extras" would be a better name for the library options, but options are looked up by type name, and in this case the problematic files were of type types `Trailer` or `Video`.

**Issues**
Possibly related to #2355