### PR TITLE
Remove Obsolete attribute on enum

### DIFF
--- a/MediaBrowser.Model/Entities/ImageType.cs
+++ b/MediaBrowser.Model/Entities/ImageType.cs
@@ -50,7 +50,10 @@ namespace MediaBrowser.Model.Entities
         /// <summary>
         /// The screenshot.
         /// </summary>
-        [Obsolete("Screenshot image type is no longer used.")]
+        /// <remarks>
+        /// This enum value is obsolete.
+        /// XmlSerializer does not serialize/deserialize objects that are marked as [Obsolete].
+        /// </remarks>
         Screenshot = 8,
 
         /// <summary>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmlserializer?redirectedfrom=MSDN&view=net-5.0#objects-marked-with-the-obsolete-attribute-no-longer-serialized

Fixes loading the LibrarySettings for anyone who has configured the fetcher