### PR TITLE
Fix filtering images without dimensions

### DIFF
--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -457,7 +457,7 @@ namespace MediaBrowser.Providers.Manager
             CancellationToken cancellationToken)
         {
             var eligibleImages = images
-                .Where(i => i.Type == type && i.Width >= minWidth)
+                .Where(i => i.Type == type && (i.Width == null || i.Width >= minWidth))
                 .ToList();
 
             if (EnableImageStub(item) && eligibleImages.Count > 0)


### PR DESCRIPTION
Required for remote image providers that don't specify dimensions
Fixes https://github.com/jellyfin/jellyfin-plugin-tvmaze/issues/34