### PR TITLE
Send SourceBranch to collect-server.azure.sh

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -181,7 +181,7 @@ jobs:
     inputs:
       sshEndpoint: repository
       runOptions: 'commands'
-      commands: nohup sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber) &
+      commands: nohup sudo /srv/repository/collect-server.azure.sh /srv/repository/incoming/azure $(Build.BuildNumber) $(Build.SourceBranch) &
 
 - job: PublishNuget
   displayName: 'Publish NuGet packages'


### PR DESCRIPTION
**Changes**
Sends the `Build.SourceBranch` variable into collect-server.azure.sh. This can be used to determine if a release is a pre-release or not based on the tag append.

**Issues**
N/A