### PR TITLE
Flush the XmlWriter before calling the StringBuilder ToString() method

### DIFF
--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -395,6 +395,7 @@ namespace Emby.Dlna.ContentDirectory
                 }
 
                 writer.WriteFullEndElement();
+                writer.Flush();
                 xmlWriter.WriteElementString("Result", builder.ToString());
             }
 
@@ -484,6 +485,7 @@ namespace Emby.Dlna.ContentDirectory
                 }
 
                 writer.WriteFullEndElement();
+                writer.Flush();
                 xmlWriter.WriteElementString("Result", builder.ToString());
             }
 


### PR DESCRIPTION
During the code cleanup done in https://github.com/jellyfin/jellyfin/pull/6808 the StringBuilder ToString() method call was moved before the destruction of the XmlWriter.

This PR adds a manual call to Flush the XmlWriter in order to have the correct data inside the StringBuilder.

If preferred I can update the PR to have the "builder.ToString()" called outside the scope of the XmlWriter and restore the original behavior with the automatic flush (but would undo the "Reduce indentation" commit).
