### PR TITLE
Read past empty elements

### DIFF
--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -319,6 +319,12 @@ namespace MediaBrowser.Providers.Music
                     {
                         case "name-credit":
                         {
+                            if (reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                break;
+                            }
+
                             using var subReader = reader.ReadSubtree();
                             return ParseArtistNameCredit(subReader);
                         }
@@ -355,6 +361,12 @@ namespace MediaBrowser.Providers.Music
                     {
                         case "artist":
                             {
+                                if (reader.IsEmptyElement)
+                                {
+                                    reader.Read();
+                                    break;
+                                }
+
                                 var id = reader.GetAttribute("id");
                                 using var subReader = reader.ReadSubtree();
                                 return ParseArtistArtistCredit(subReader, id);
@@ -457,8 +469,8 @@ namespace MediaBrowser.Providers.Music
             };
 
             using var reader = XmlReader.Create(oReader, settings);
-            reader.MoveToContent();
-            reader.Read();
+            await reader.MoveToContentAsync().ConfigureAwait(false);
+            await reader.ReadAsync().ConfigureAwait(false);
 
             // Loop through each element
             while (!reader.EOF && reader.ReadState == ReadState.Interactive)
@@ -471,7 +483,7 @@ namespace MediaBrowser.Providers.Music
                         {
                             if (reader.IsEmptyElement)
                             {
-                                reader.Read();
+                                await reader.ReadAsync().ConfigureAwait(false);
                                 continue;
                             }
 
@@ -481,14 +493,14 @@ namespace MediaBrowser.Providers.Music
 
                         default:
                         {
-                            reader.Skip();
+                            await reader.SkipAsync().ConfigureAwait(false);
                             break;
                         }
                     }
                 }
                 else
                 {
-                    reader.Read();
+                    await reader.ReadAsync().ConfigureAwait(false);
                 }
             }
 
@@ -755,6 +767,12 @@ namespace MediaBrowser.Providers.Music
 
                             case "artist-credit":
                                 {
+                                    if (reader.IsEmptyElement)
+                                    {
+                                        reader.Read();
+                                        break;
+                                    }
+
                                     using var subReader = reader.ReadSubtree();
                                     var artist = ParseArtistCredit(subReader);
 

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -784,7 +784,13 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                 case "fanart":
                     {
-                        var subtree = reader.ReadSubtree();
+                        if (reader.IsEmptyElement)
+                        {
+                            reader.Read();
+                            break;
+                        }
+
+                        using var subtree = reader.ReadSubtree();
                         if (!subtree.ReadToDescendant("thumb"))
                         {
                             break;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
ReadSubtree does not advance the reader, so when the element is empty it will keep reading the empty element forever. I have added some extra IsEmptyElement checks

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/6858
