### PR TITLE
Use the Memory overload for ReadAsync

### DIFF
--- a/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
+++ b/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
@@ -75,13 +75,17 @@ namespace Jellyfin.Api.Helpers
 
         /// <inheritdoc />
         public override int Read(byte[] buffer, int offset, int count)
+            => Read(buffer.AsSpan(offset, count));
+
+        /// <inheritdoc />
+        public override int Read(Span<byte> buffer)
         {
             int totalBytesRead = 0;
             var stopwatch = Stopwatch.StartNew();
 
             while (KeepReading(stopwatch.ElapsedMilliseconds))
             {
-                totalBytesRead += _stream.Read(buffer, offset, count);
+                totalBytesRead += _stream.Read(buffer);
                 if (totalBytesRead > 0)
                 {
                     break;

--- a/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
+++ b/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
@@ -175,7 +175,7 @@ namespace Jellyfin.Api.Helpers
         private bool KeepReading(long elapsed)
         {
             // If the job is null it's a live stream and will require user action to close, but don't keep it open indefinitely
-            return (!_job?.HasExited ?? true) && elapsed < _timeoutMs;
+            return !_job?.HasExited ?? elapsed < _timeoutMs;
         }
     }
 }

--- a/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
+++ b/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
@@ -175,7 +175,7 @@ namespace Jellyfin.Api.Helpers
         private bool KeepReading(long elapsed)
         {
             // If the job is null it's a live stream and will require user action to close, but don't keep it open indefinitely
-            return (!_job?.HasExited ?? false) || elapsed < _timeoutMs;
+            return (!_job?.HasExited ?? true) && elapsed < _timeoutMs;
         }
     }
 }

--- a/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
+++ b/Jellyfin.Api/Helpers/ProgressiveFileStream.cs
@@ -17,7 +17,6 @@ namespace Jellyfin.Api.Helpers
         private readonly TranscodingJobDto? _job;
         private readonly TranscodingJobHelper? _transcodingJobHelper;
         private readonly int _timeoutMs;
-        private int _bytesWritten;
         private bool _disposed;
 
         /// <summary>
@@ -108,7 +107,6 @@ namespace Jellyfin.Api.Helpers
 
             while (KeepReading(stopwatch.ElapsedMilliseconds))
             {
-                cancellationToken.ThrowIfCancellationRequested();
                 totalBytesRead += await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
                 if (totalBytesRead > 0)
                 {
@@ -164,11 +162,9 @@ namespace Jellyfin.Api.Helpers
 
         private void UpdateBytesWritten(int totalBytesRead)
         {
-            _bytesWritten += totalBytesRead;
-
             if (_job != null)
             {
-                _job.BytesDownloaded = Math.Max(_job.BytesDownloaded ?? _bytesWritten, _bytesWritten);
+                _job.BytesDownloaded += totalBytesRead;
             }
         }
 

--- a/Jellyfin.Api/Models/PlaybackDtos/TranscodingJobDto.cs
+++ b/Jellyfin.Api/Models/PlaybackDtos/TranscodingJobDto.cs
@@ -134,7 +134,7 @@ namespace Jellyfin.Api.Models.PlaybackDtos
         /// <summary>
         /// Gets or sets bytes downloaded.
         /// </summary>
-        public long? BytesDownloaded { get; set; }
+        public long BytesDownloaded { get; set; }
 
         /// <summary>
         /// Gets or sets bytes transcoded.

--- a/Jellyfin.Api/Models/PlaybackDtos/TranscodingThrottler.cs
+++ b/Jellyfin.Api/Models/PlaybackDtos/TranscodingThrottler.cs
@@ -141,7 +141,7 @@ namespace Jellyfin.Api.Models.PlaybackDtos
 
         private bool IsThrottleAllowed(TranscodingJobDto job, int thresholdSeconds)
         {
-            var bytesDownloaded = job.BytesDownloaded ?? 0;
+            var bytesDownloaded = job.BytesDownloaded;
             var transcodingPositionTicks = job.TranscodingPositionTicks ?? 0;
             var downloadPositionTicks = job.DownloadPositionTicks ?? 0;
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1835

I can't test this properly. Requires some testing with Live tv.