### PR TITLE
Fix docker build error armhf

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -14,7 +14,7 @@ RUN apk add curl git zlib zlib-dev autoconf g++ make libpng-dev gifsicle alpine-
  && mv dist /dist
 
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
-FROM arm32v7/debian:stable-slim as app
+FROM arm32v7/debian:buster-slim as app
 
 # https://askubuntu.com/questions/972516/debian-frontend-environment-variable
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -28,10 +28,12 @@ COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 # curl: setup & healthcheck
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl && \
+ curl -ks http://archive.raspberrypi.org/debian/raspberrypi.gpg.key | apt-key add - && \
  curl -ks https://repo.jellyfin.org/debian/jellyfin_team.gpg.key | apt-key add - && \
  curl -ks https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
  echo 'deb [arch=armhf] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list && \
  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
+ echo "deb [arch=armhf] http://archive.raspberrypi.org/debian buster main" > /etc/apt/sources.list.d/raspberrypi.list && \
  apt-get update && \
  apt-get install --no-install-recommends --no-install-suggests -y \
  jellyfin-ffmpeg \


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
I added a repo that contains libraspberrypi0 and specified the image for Debian buster instead of bullseye to resolve the other issues. It's not an ideal fix but better that than it not building at all I think.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
When building on a raspberry pi, I get errors related to libraspberrypi0 not being found, but also errors related to libx265.
