### PR TITLE
Use local time for RecordingHelperTests

### DIFF
--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/RecordingHelperTests.cs
@@ -61,7 +61,7 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 {
                     Name = "The Big Bang Theory",
                     IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6)
+                    OriginalAirDate = new DateTime(2018, 12, 6, 0, 0, 0, DateTimeKind.Local)
                 });
 
             data.Add(
@@ -70,7 +70,7 @@ namespace Jellyfin.Server.Implementations.Tests.LiveTv
                 {
                     Name = "The Big Bang Theory",
                     IsProgramSeries = true,
-                    OriginalAirDate = new DateTime(2018, 12, 6),
+                    OriginalAirDate = new DateTime(2018, 12, 6, 0, 0, 0, DateTimeKind.Local),
                     EpisodeTitle = "The VCR Illumination"
                 });
 


### PR DESCRIPTION
**Changes**
Sets DateTimeKind to Local. When timezone is negative UTC, the date goes back one day and causes tests to fail.