### PR TITLE
- enable seek function when direct streaming over DLNA

### DIFF
--- a/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
+++ b/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
@@ -151,10 +151,12 @@ namespace MediaBrowser.Model.Dlna
                             DlnaFlags.InteractiveTransferMode |
                             DlnaFlags.DlnaV15;
 
-            // if (isDirectStream)
-            // {
-            //     flagValue = flagValue | DlnaFlags.ByteBasedSeek;
-            // }
+            if (isDirectStream)
+            {
+                flagValue |= DlnaFlags.ByteBasedSeek;
+            }
+
+            // Time based seek is curently disabled when streaming. On LG CX3 adding DlnaFlags.TimeBasedSeek and orgPn causes the DLNA playback to fail (format not supported). Further investigations are needed before enabling the remaining code paths.
             //  else if (runtimeTicks.HasValue)
             // {
             //     flagValue = flagValue | DlnaFlags.TimeBasedSeek;
@@ -208,6 +210,11 @@ namespace MediaBrowser.Model.Dlna
                 if (string.IsNullOrEmpty(orgPn))
                 {
                     contentFeatureList.Add(orgOp.TrimStart(';') + orgCi + dlnaflags);
+                }
+                else if (isDirectStream)
+                {
+                    // orgOp should be added all the time once the time based seek is resolved for transcoded streams
+                    contentFeatureList.Add("DLNA.ORG_PN=" + orgPn + orgOp + orgCi + dlnaflags);
                 }
                 else
                 {


### PR DESCRIPTION
When direct playing content over DLNA (no transcoding) on a LG CX3 TV the seek functionality is disabled.
Adding the DLNA.ORG_OP and appropriate byte seek flag restores the functionality for direct play.
Adding the DLNA.ORG_OP when transcoding breaks playback and requires further investigation so I haven't touched that particular code path.
