### PR TITLE
Take into account the streams dlnaheaders query parameter set by the DidlBuilder NormalizeDlnaMediaUrl function

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -90,6 +90,7 @@ namespace Jellyfin.Api.Helpers
             }
 
             var enableDlnaHeaders = !string.IsNullOrWhiteSpace(streamingRequest.Params) ||
+                                    streamingRequest.StreamOptions.ContainsKey("dlnaheaders") ||
                                     string.Equals(httpRequest.Headers["GetContentFeatures.DLNA.ORG"], "1", StringComparison.OrdinalIgnoreCase);
 
             var state = new StreamState(mediaSourceManager, transcodingJobType, transcodingJobHelper)


### PR DESCRIPTION
[DidlBuilder.cs#L84](https://github.com/jellyfin/jellyfin/blob/976e3160b8d558aaa3e944892a3362f004bc93a6/Emby.Dlna/Didl/DidlBuilder.cs#L84) appends the dlnaheaders=true query parameter to all the DLNA urls.
This parameter seems to be ignored when processing the video stream and the DLNA headers are only added in two specific cases:
- "GetContentFeatures.DLNA.ORG" is 1
- streamingRequest.Params is provided

I think it's worth clearing up the intentions of the original code.