### PR TITLE
Add an option for dropping specific subtitle formats using the DLNA SubtitleProfile

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -462,6 +462,11 @@ namespace Jellyfin.Api.Helpers
 
         private void AddSubtitles(StreamState state, IEnumerable<MediaStream> subtitles, StringBuilder builder, ClaimsPrincipal user)
         {
+            if (state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Drop)
+            {
+                return;
+            }
+
             var selectedIndex = state.SubtitleStream == null || state.SubtitleDeliveryMethod != SubtitleDeliveryMethod.Hls ? (int?)null : state.SubtitleStream.Index;
             const string Format = "#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"subs\",NAME=\"{0}\",DEFAULT={1},FORCED={2},AUTOSELECT=YES,URI=\"{3}\",LANGUAGE=\"{4}\"";
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1220,7 +1220,9 @@ namespace MediaBrowser.Model.Dlna
             {
                 var subtitleProfile = GetSubtitleProfile(item, subtitleStream, options.Profile.SubtitleProfiles, playMethod, _transcoderSupport, item.Container, null);
 
-                if (subtitleProfile.Method != SubtitleDeliveryMethod.External && subtitleProfile.Method != SubtitleDeliveryMethod.Embed)
+                if (subtitleProfile.Method != SubtitleDeliveryMethod.Drop
+                    && subtitleProfile.Method != SubtitleDeliveryMethod.External
+                    && subtitleProfile.Method != SubtitleDeliveryMethod.Embed)
                 {
                     _logger.LogDebug("Not eligible for {0} due to unsupported subtitles", playMethod);
                     return (false, TranscodeReason.SubtitleCodecNotSupported);

--- a/MediaBrowser.Model/Dlna/SubtitleDeliveryMethod.cs
+++ b/MediaBrowser.Model/Dlna/SubtitleDeliveryMethod.cs
@@ -25,6 +25,11 @@ namespace MediaBrowser.Model.Dlna
         /// <summary>
         /// Serve the subtitles as a separate HLS stream.
         /// </summary>
-        Hls = 3
+        Hls = 3,
+
+        /// <summary>
+        /// Drop the subtitle.
+        /// </summary>
+        Drop = 4
     }
 }


### PR DESCRIPTION
Currently there is no option to stop DLNA from transcoding when encountering specific subtitle formats.
A new Drop option was added to the SubtitleProfile that should allow us to control when we want avoid transcoding.

For the end user it should be easier to ignore embedded PGSSUB subtitles from the DLNA profile and provide an external subtitle than to modify large video files.