### PR TITLE
Use SSL for tmdb images

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -498,7 +498,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 return null;
             }
 
-            return _tmDbClient.GetImageUrl(size, path).ToString();
+            return _tmDbClient.GetImageUrl(size, path, true).ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
Use SSL for TMDB image URLs to allow image thumbnails to load for identify and image search

**Issues**
Fixes #6925