### PR TITLE
Automatically bump stable versions in build

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -39,6 +39,14 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
+  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
+    displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+  - script: './bump-version $(JellyfinVersion)'
+    displayName: Bump internal version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
   - script: 'docker build -f deployment/Dockerfile.$(BuildConfiguration) -t jellyfin-server-$(BuildConfiguration) deployment'
     displayName: 'Build Dockerfile'
 
@@ -80,6 +88,14 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
+  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
+    displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+  - script: './bump-version $(JellyfinVersion)'
+    displayName: Bump internal version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
   - task: DownloadPipelineArtifact@2
     displayName: 'Download OpenAPI Spec'
     inputs:
@@ -125,6 +141,10 @@ jobs:
   steps:
   - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
     displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+  - script: './bump-version $(JellyfinVersion)'
+    displayName: Bump internal version (stable)
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
   - task: Docker@2

--- a/bump_version
+++ b/bump_version
@@ -52,7 +52,8 @@ echo $old_version
 
 # Set the build.yaml version to the specified new_version
 old_version_sed="$( sed 's/\./\\./g' <<<"${old_version}" )" # Escape the '.' chars
-sed -i "s/${old_version_sed}/${new_version}/g" ${build_file}
+new_version_sed="$( cut -f1 -d'-' <<<"${new_version}" )"
+sed -i "s/${old_version_sed}/${new_version_sed}/g" ${build_file}
 
 # update nuget package version
 for subproject in ${jellyfin_subprojects[@]}; do
@@ -64,26 +65,27 @@ for subproject in ${jellyfin_subprojects[@]}; do
             | sed -E 's/<VersionPrefix>([0-9\.]+[-a-z0-9]*)<\/VersionPrefix>/\1/'
     )"
     echo old nuget version: $old_version
+    new_version_sed="$( cut -f1 -d'-' <<<"${new_version}" )"
 
     # Set the nuget version to the specified new_version
-    sed -i "s|${old_version}|${new_version}|g" ${subproject}
+    sed -i "s|${old_version}|${new_version_sed}|g" ${subproject}
 done
 
 if [[ ${new_version} == *"-"* ]]; then
-    new_version_deb="$( sed 's/-/~/g' <<<"${new_version}" )"
+    new_version_pkg="$( sed 's/-/~/g' <<<"${new_version}" )"
 else
-    new_version_deb="${new_version}-1"
+    new_version_pkg="${new_version}-1"
 fi
 
 # Update the metapackage equivs file
 debian_equivs_file="debian/metapackage/jellyfin"
-sed -i "s/${old_version_sed}/${new_version}/g" ${debian_equivs_file}
+sed -i "s/${old_version_sed}/${new_version_pkg}/g" ${debian_equivs_file}
 
 # Write out a temporary Debian changelog with our new stuff appended and some templated formatting
 debian_changelog_file="debian/changelog"
 debian_changelog_temp="$( mktemp )"
 # Create new temp file with our changelog
-echo -e "jellyfin-server (${new_version_deb}) unstable; urgency=medium
+echo -e "jellyfin-server (${new_version_pkg}) unstable; urgency=medium
 
   * New upstream version ${new_version}; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v${new_version}
 
@@ -104,7 +106,7 @@ pushd ${fedora_spec_temp_dir}
 # Split out the stuff before and after changelog
 csplit jellyfin.spec  "/^%changelog/" # produces xx00 xx01
 # Update the version in xx00
-sed -i "s/${old_version_sed}/${new_version_sed}/g" xx00
+sed -i "s/${old_version_sed}/${new_version_pkg}/g" xx00
 # Remove the header from xx01
 sed -i '/^%changelog/d' xx01
 # Create new temp file with our changelog
@@ -121,5 +123,5 @@ mv ${fedora_spec_temp} ${fedora_spec_file}
 rm -rf ${fedora_spec_temp_dir}
 
 # Stage the changed files for commit
-git add ${shared_version_file} ${build_file} ${debian_equivs_file} ${debian_changelog_file} ${fedora_spec_file}
+git add .
 git status

--- a/bump_version
+++ b/bump_version
@@ -126,4 +126,4 @@ rm -rf ${fedora_spec_temp_dir}
 
 # Stage the changed files for commit
 git add .
-git status
+git status -v

--- a/bump_version
+++ b/bump_version
@@ -73,8 +73,10 @@ done
 
 if [[ ${new_version} == *"-"* ]]; then
     new_version_pkg="$( sed 's/-/~/g' <<<"${new_version}" )"
+    new_version_deb_sup=""
 else
-    new_version_pkg="${new_version}-1"
+    new_version_pkg="${new_version}"
+    new_version_deb_sup="-1"
 fi
 
 # Update the metapackage equivs file
@@ -85,7 +87,7 @@ sed -i "s/${old_version_sed}/${new_version_pkg}/g" ${debian_equivs_file}
 debian_changelog_file="debian/changelog"
 debian_changelog_temp="$( mktemp )"
 # Create new temp file with our changelog
-echo -e "jellyfin-server (${new_version_pkg}) unstable; urgency=medium
+echo -e "jellyfin-server (${new_version_pkg}${new_version_deb_sup}) unstable; urgency=medium
 
   * New upstream version ${new_version}; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v${new_version}
 


### PR DESCRIPTION
Should prevent strangeness with building these for pre-releases or actual release versions (if the script wasn't manually run before). Whatever the Git tag is, becomes the package version. Could be expanded to avoid needing to manually `bump_version` at all ever if we put in placeholders, though this might break other builds. Would need careful evaluation before expanding that.

With a properly bumped stable release this shouldn't change anything, but for pre-releases it will change the version automatically.

Avoids needing to do #6853 manually (for both Debian and Fedora/CentOS packages).

Basically, adds a run of `bump_version` to the build CI, taking the Git tag as the version to bump to.