### PR TITLE
Fixed crash in MigrationRunner by checking migration for file existance

### DIFF
--- a/Jellyfin.Server/Migrations/MigrationRunner.cs
+++ b/Jellyfin.Server/Migrations/MigrationRunner.cs
@@ -75,11 +75,9 @@ namespace Jellyfin.Server.Migrations
 
             var xmlSerializer = new MyXmlSerializer();
             var migrationConfigPath = Path.Join(appPaths.ConfigurationDirectoryPath, MigrationsListStore.StoreKey.ToLowerInvariant() + ".xml");
-            if (!File.Exists(migrationConfigPath))
-            {
-                return;
-            }
-            var migrationOptions = (MigrationOptions)xmlSerializer.DeserializeFromFile(typeof(MigrationOptions), migrationConfigPath)!;
+            var migrationOptions = File.Exists(migrationConfigPath)
+                 ? (MigrationOptions)xmlSerializer.DeserializeFromFile(typeof(MigrationOptions), migrationConfigPath)!
+                 : new MigrationOptions();
 
             // We have to deserialize it manually since the configuration manager may overwrite it
             var serverConfig = (ServerConfiguration)xmlSerializer.DeserializeFromFile(typeof(ServerConfiguration), appPaths.SystemConfigurationFilePath)!;

--- a/Jellyfin.Server/Migrations/MigrationRunner.cs
+++ b/Jellyfin.Server/Migrations/MigrationRunner.cs
@@ -75,6 +75,10 @@ namespace Jellyfin.Server.Migrations
 
             var xmlSerializer = new MyXmlSerializer();
             var migrationConfigPath = Path.Join(appPaths.ConfigurationDirectoryPath, MigrationsListStore.StoreKey.ToLowerInvariant() + ".xml");
+            if (!File.Exists(migrationConfigPath))
+            {
+                return;
+            }
             var migrationOptions = (MigrationOptions)xmlSerializer.DeserializeFromFile(typeof(MigrationOptions), migrationConfigPath)!;
 
             // We have to deserialize it manually since the configuration manager may overwrite it


### PR DESCRIPTION
Fixed crash in MigrationRunner by checking for migration file existance

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
By checking for the existance of migrationConfigPath before attempting to load it, the server does not throw an unhandled exception or crash.
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #6992 
