### PR TITLE
Deprecate LibraryOptions.EnableInternetProviders

### DIFF
--- a/MediaBrowser.Controller/BaseItemManager/BaseItemManager.cs
+++ b/MediaBrowser.Controller/BaseItemManager/BaseItemManager.cs
@@ -55,11 +55,6 @@ namespace MediaBrowser.Controller.BaseItemManager
                 return typeOptions.MetadataFetchers.Contains(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
             }
 
-            if (!libraryOptions.EnableInternetProviders)
-            {
-                return false;
-            }
-
             var itemConfig = _serverConfigurationManager.Configuration.MetadataOptions.FirstOrDefault(i => string.Equals(i.ItemType, baseItem.GetType().Name, StringComparison.OrdinalIgnoreCase));
 
             return itemConfig == null || !itemConfig.DisabledMetadataFetchers.Contains(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
@@ -84,11 +79,6 @@ namespace MediaBrowser.Controller.BaseItemManager
             if (typeOptions != null)
             {
                 return typeOptions.ImageFetchers.Contains(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
-            }
-
-            if (!libraryOptions.EnableInternetProviders)
-            {
-                return false;
             }
 
             var itemConfig = _serverConfigurationManager.Configuration.MetadataOptions.FirstOrDefault(i => string.Equals(i.ItemType, baseItem.GetType().Name, StringComparison.OrdinalIgnoreCase));

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -21,7 +21,6 @@ namespace MediaBrowser.Model.Configuration
             SaveSubtitlesWithMedia = true;
             EnableRealtimeMonitor = true;
             PathInfos = Array.Empty<MediaPathInfo>();
-            EnableInternetProviders = true;
             EnableAutomaticSeriesGrouping = true;
             SeasonZeroDisplayName = "Specials";
         }
@@ -38,6 +37,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool SaveLocalMetadata { get; set; }
 
+        [Obsolete("Disable remote providers in TypeOptions instead")]
         public bool EnableInternetProviders { get; set; }
 
         public bool EnableAutomaticSeriesGrouping { get; set; }


### PR DESCRIPTION
**Changes**
Deprecate LibraryOptions.EnableInternetProviders

**Rationale**
1. This is hardcoded to true without exposing to user in [library options page (web)](https://github.com/jellyfin/jellyfin-web/blob/4db454d95e3cc30e7807ca7f7faa252bf0dc9e56/src/components/libraryoptionseditor/libraryoptionseditor.js#L503) so even if you change it in the settings file manually it will be overridden when you next modify the library settings through the interface.
2. Not evaluated unless the library options don't configure providers for a type, but the only types that aren't configured by the library options don't actually tree up to a library to find this setting (People, Trailers, etc)
3. Currently disables `IDynamicImageProvider` (extracted from video file) as well as `IRemoteImageProvider` (fetched from internet), which is not what's implied by the name.

Long story short, disabling remote providers in a library is better done by simply unchecking the boxes for them in the library options panel.