### PR TITLE
Remove ProtectClock for hardware encoding

### DIFF
--- a/debian/jellyfin.service
+++ b/debian/jellyfin.service
@@ -16,7 +16,6 @@ RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHostname=true
 ProtectKernelLogs=true


### PR DESCRIPTION
**Changes**
Remove `ProtectClock=true` in jellyfin.service

**Issues**
If enable hardware acceleration, ffmpeg doesn't find the gpu.
It worked fine when I erased that from my environment with NVIDIA GeForce RTX 2070 SUPER.