### PR TITLE
Use System.IO.Compression instead of SharpCompress for zips

### DIFF
--- a/Emby.Server.Implementations/Archiving/ZipClient.cs
+++ b/Emby.Server.Implementations/Archiving/ZipClient.cs
@@ -1,11 +1,8 @@
 using System.IO;
 using MediaBrowser.Model.IO;
-using SharpCompress.Archives.SevenZip;
-using SharpCompress.Archives.Tar;
 using SharpCompress.Common;
 using SharpCompress.Readers;
 using SharpCompress.Readers.GZip;
-using SharpCompress.Readers.Zip;
 
 namespace Emby.Server.Implementations.Archiving
 {
@@ -14,55 +11,6 @@ namespace Emby.Server.Implementations.Archiving
     /// </summary>
     public class ZipClient : IZipClient
     {
-        /// <summary>
-        /// Extracts all.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAll(string sourceFile, string targetPath, bool overwriteExistingFiles)
-        {
-            using var fileStream = File.OpenRead(sourceFile);
-            ExtractAll(fileStream, targetPath, overwriteExistingFiles);
-        }
-
-        /// <summary>
-        /// Extracts all.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAll(Stream source, string targetPath, bool overwriteExistingFiles)
-        {
-            using var reader = ReaderFactory.Open(source);
-            var options = new ExtractionOptions
-            {
-                ExtractFullPath = true
-            };
-
-            if (overwriteExistingFiles)
-            {
-                options.Overwrite = true;
-            }
-
-            Directory.CreateDirectory(targetPath);
-            reader.WriteAllToDirectory(targetPath, options);
-        }
-
-        /// <inheritdoc />
-        public void ExtractAllFromZip(Stream source, string targetPath, bool overwriteExistingFiles)
-        {
-            using var reader = ZipReader.Open(source);
-            var options = new ExtractionOptions
-            {
-                ExtractFullPath = true,
-                Overwrite = overwriteExistingFiles
-            };
-
-            Directory.CreateDirectory(targetPath);
-            reader.WriteAllToDirectory(targetPath, options);
-        }
-
         /// <inheritdoc />
         public void ExtractAllFromGz(Stream source, string targetPath, bool overwriteExistingFiles)
         {
@@ -93,70 +41,6 @@ namespace Emby.Server.Implementations.Archiving
 
                 reader.WriteEntryToFile(Path.Combine(targetPath, filename));
             }
-        }
-
-        /// <summary>
-        /// Extracts all from7z.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAllFrom7z(string sourceFile, string targetPath, bool overwriteExistingFiles)
-        {
-            using var fileStream = File.OpenRead(sourceFile);
-            ExtractAllFrom7z(fileStream, targetPath, overwriteExistingFiles);
-        }
-
-        /// <summary>
-        /// Extracts all from7z.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAllFrom7z(Stream source, string targetPath, bool overwriteExistingFiles)
-        {
-            using var archive = SevenZipArchive.Open(source);
-            using var reader = archive.ExtractAllEntries();
-            var options = new ExtractionOptions
-            {
-                ExtractFullPath = true,
-                Overwrite = overwriteExistingFiles
-            };
-
-            Directory.CreateDirectory(targetPath);
-            reader.WriteAllToDirectory(targetPath, options);
-        }
-
-        /// <summary>
-        /// Extracts all from tar.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAllFromTar(string sourceFile, string targetPath, bool overwriteExistingFiles)
-        {
-            using var fileStream = File.OpenRead(sourceFile);
-            ExtractAllFromTar(fileStream, targetPath, overwriteExistingFiles);
-        }
-
-        /// <summary>
-        /// Extracts all from tar.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        public void ExtractAllFromTar(Stream source, string targetPath, bool overwriteExistingFiles)
-        {
-            using var archive = TarArchive.Open(source);
-            using var reader = archive.ExtractAllEntries();
-            var options = new ExtractionOptions
-            {
-                ExtractFullPath = true,
-                Overwrite = overwriteExistingFiles
-            };
-
-            Directory.CreateDirectory(targetPath);
-            reader.WriteAllToDirectory(targetPath, options);
         }
     }
 }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -47,7 +48,6 @@ namespace Emby.Server.Implementations.Updates
         /// </summary>
         /// <value>The application host.</value>
         private readonly IServerApplicationHost _applicationHost;
-        private readonly IZipClient _zipClient;
         private readonly object _currentInstallationsLock = new object();
 
         /// <summary>
@@ -69,7 +69,6 @@ namespace Emby.Server.Implementations.Updates
         /// <param name="eventManager">The <see cref="IEventManager"/>.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
         /// <param name="config">The <see cref="IServerConfigurationManager"/>.</param>
-        /// <param name="zipClient">The <see cref="IZipClient"/>.</param>
         /// <param name="pluginManager">The <see cref="IPluginManager"/>.</param>
         public InstallationManager(
             ILogger<InstallationManager> logger,
@@ -78,7 +77,6 @@ namespace Emby.Server.Implementations.Updates
             IEventManager eventManager,
             IHttpClientFactory httpClientFactory,
             IServerConfigurationManager config,
-            IZipClient zipClient,
             IPluginManager pluginManager)
         {
             _currentInstallations = new List<(InstallationInfo, CancellationTokenSource)>();
@@ -90,7 +88,6 @@ namespace Emby.Server.Implementations.Updates
             _eventManager = eventManager;
             _httpClientFactory = httpClientFactory;
             _config = config;
-            _zipClient = zipClient;
             _jsonSerializerOptions = JsonDefaults.Options;
             _pluginManager = pluginManager;
         }
@@ -560,7 +557,8 @@ namespace Emby.Server.Implementations.Updates
             }
 
             stream.Position = 0;
-            _zipClient.ExtractAllFromZip(stream, targetDir, true);
+            using var reader = new ZipArchive(stream);
+            reader.ExtractToDirectory(targetDir, true);
             await _pluginManager.GenerateManifest(package.PackageInfo, package.Version, targetDir, status).ConfigureAwait(false);
             _pluginManager.ImportPluginFrom(targetDir);
         }

--- a/MediaBrowser.Model/IO/IZipClient.cs
+++ b/MediaBrowser.Model/IO/IZipClient.cs
@@ -9,64 +9,8 @@ namespace MediaBrowser.Model.IO
     /// </summary>
     public interface IZipClient
     {
-        /// <summary>
-        /// Extracts all.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAll(string sourceFile, string targetPath, bool overwriteExistingFiles);
-
-        /// <summary>
-        /// Extracts all.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAll(Stream source, string targetPath, bool overwriteExistingFiles);
-
         void ExtractAllFromGz(Stream source, string targetPath, bool overwriteExistingFiles);
 
         void ExtractFirstFileFromGz(Stream source, string targetPath, string defaultFileName);
-
-        /// <summary>
-        /// Extracts all from zip.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAllFromZip(Stream source, string targetPath, bool overwriteExistingFiles);
-
-        /// <summary>
-        /// Extracts all from7z.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAllFrom7z(string sourceFile, string targetPath, bool overwriteExistingFiles);
-
-        /// <summary>
-        /// Extracts all from7z.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAllFrom7z(Stream source, string targetPath, bool overwriteExistingFiles);
-
-        /// <summary>
-        /// Extracts all from tar.
-        /// </summary>
-        /// <param name="sourceFile">The source file.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAllFromTar(string sourceFile, string targetPath, bool overwriteExistingFiles);
-
-        /// <summary>
-        /// Extracts all from tar.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="targetPath">The target path.</param>
-        /// <param name="overwriteExistingFiles">if set to <c>true</c> [overwrite existing files].</param>
-        void ExtractAllFromTar(Stream source, string targetPath, bool overwriteExistingFiles);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
@@ -44,7 +44,6 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
                 ConfigureMembers = true
             });
             _fixture.Inject(http);
-            _fixture.Inject<IZipClient>(new ZipClient());
             _installationManager = _fixture.Create<InstallationManager>();
         }
 


### PR DESCRIPTION
Also removes unused methods from ZipClient

Tested by installing a plugin