### PR TITLE
Remove unreachable branches from JsonConverters

### DIFF
--- a/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Extensions.Json.Converters
     /// Convert delimited string to array of type.
     /// </summary>
     /// <typeparam name="T">Type to convert to.</typeparam>
-    public abstract class JsonDelimitedArrayConverter<T> : JsonConverter<T[]?>
+    public abstract class JsonDelimitedArrayConverter<T> : JsonConverter<T[]>
     {
         private readonly TypeConverter _typeConverter;
 
@@ -31,9 +31,9 @@ namespace Jellyfin.Extensions.Json.Converters
         {
             if (reader.TokenType == JsonTokenType.String)
             {
-                // GetString can't return null here because we already handled it above
-                var stringEntries = reader.GetString()?.Split(Delimiter, StringSplitOptions.RemoveEmptyEntries);
-                if (stringEntries == null || stringEntries.Length == 0)
+                // null got handled higher up the call stack
+                var stringEntries = reader.GetString()!.Split(Delimiter, StringSplitOptions.RemoveEmptyEntries);
+                if (stringEntries.Length == 0)
                 {
                     return Array.Empty<T>();
                 }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonGuidConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonGuidConverter.cs
@@ -12,15 +12,19 @@ namespace Jellyfin.Extensions.Json.Converters
     {
         /// <inheritdoc />
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var guidStr = reader.GetString();
-            return guidStr == null ? Guid.Empty : new Guid(guidStr);
-        }
+            => reader.TokenType == JsonTokenType.Null
+                ? Guid.Empty
+                : ReadInternal(ref reader);
+
+        // TODO: optimize by parsing the UTF8 bytes instead of converting to string first
+        internal static Guid ReadInternal(ref Utf8JsonReader reader)
+            => Guid.Parse(reader.GetString()!); // null got handled higher up the call stack
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.ToString("N", CultureInfo.InvariantCulture));
-        }
+            => WriteInternal(writer, value);
+
+        internal static void WriteInternal(Utf8JsonWriter writer, Guid value)
+            => writer.WriteStringValue(value.ToString("N", CultureInfo.InvariantCulture));
     }
 }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonNullableGuidConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonNullableGuidConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -12,21 +11,19 @@ namespace Jellyfin.Extensions.Json.Converters
     {
         /// <inheritdoc />
         public override Guid? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var guidStr = reader.GetString();
-            return guidStr == null ? null : new Guid(guidStr);
-        }
+            => JsonGuidConverter.ReadInternal(ref reader);
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, Guid? value, JsonSerializerOptions options)
         {
-            if (value == null || value == Guid.Empty)
+            if (value == Guid.Empty)
             {
                 writer.WriteNullValue();
             }
             else
             {
-                writer.WriteStringValue(value.Value.ToString("N", CultureInfo.InvariantCulture));
+                // null got handled higher up the call stack
+                JsonGuidConverter.WriteInternal(writer, value!.Value);
             }
         }
     }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonNullableStructConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonNullableStructConverter.cs
@@ -15,13 +15,10 @@ namespace Jellyfin.Extensions.Json.Converters
         /// <inheritdoc />
         public override TStruct? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                return null;
-            }
-
             // Token is empty string.
-            if (reader.TokenType == JsonTokenType.String && ((reader.HasValueSequence && reader.ValueSequence.IsEmpty) || reader.ValueSpan.IsEmpty))
+            if (reader.TokenType == JsonTokenType.String
+                && ((reader.HasValueSequence && reader.ValueSequence.IsEmpty)
+                    || (!reader.HasValueSequence && reader.ValueSpan.IsEmpty)))
             {
                 return null;
             }
@@ -31,15 +28,6 @@ namespace Jellyfin.Extensions.Json.Converters
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TStruct? value, JsonSerializerOptions options)
-        {
-            if (value.HasValue)
-            {
-                JsonSerializer.Serialize(writer, value.Value, options);
-            }
-            else
-            {
-                writer.WriteNullValue();
-            }
-        }
+            => JsonSerializer.Serialize(writer, value!.Value, options); // null got handled higher up the call stack
     }
 }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonStringConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonStringConverter.cs
@@ -13,20 +13,11 @@ namespace Jellyfin.Extensions.Json.Converters
     {
         /// <inheritdoc />
         public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return reader.TokenType switch
-            {
-                JsonTokenType.Null => null,
-                JsonTokenType.String => reader.GetString(),
-                _ => GetRawValue(reader)
-            };
-        }
+            => reader.TokenType == JsonTokenType.String ? reader.GetString() : GetRawValue(reader);
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value);
-        }
+            => writer.WriteStringValue(value);
 
         private static string GetRawValue(Utf8JsonReader reader)
         {


### PR DESCRIPTION
* If the type is a reference type we don't have to handle null ourselves
* `reader.ValueSpan` is only valid if `reader.HasValueSequence` is false

