### PR TITLE
Use == instead of Object.Equals to avoid closure allocation

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2739,7 +2739,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <inheritdoc />
-        public bool Equals(BaseItem other) => Equals(Id, other?.Id);
+        public bool Equals(BaseItem other) => Id == other?.Id;
 
         /// <inheritdoc />
         public override int GetHashCode() => HashCode.Combine(Id);


### PR DESCRIPTION
It's not the biggest offender but it performs two closure allocations per call. The `==` (which Guid implements) does not need closure.
