### PR TITLE
Fix resolved type for Trailers

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -132,7 +132,15 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
             // Handle owned items
             if (args.Parent == null)
             {
-                return base.Resolve(args);
+                var ownedItem = base.Resolve(args);
+
+                // Re-resolve items that have their own type
+                if (ownedItem.ExtraType == ExtraType.Trailer)
+                {
+                    ownedItem = ResolveVideo<Trailer>(args, false);
+                }
+
+                return ownedItem;
             }
 
             if (IsInvalid(args.Parent, collectionType))


### PR DESCRIPTION
The refactored extras resolving produces trailers of type `Video` instead of their specific type `Trailer`, this corrects that.

From the front-end everything seems to work as-is, but there are image providers and a metadata provider that support `Trailer` (but not `Video`) that don't currently run.