### PR TITLE
Fix System.OverflowException with ffprobe

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1057,7 +1057,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            return divisor == 0f ? null : dividend / divisor;
+            return divisor == 0f || dividend == 0f ? null : dividend / divisor;
         }
 
         private void SetAudioRuntimeTicks(InternalMediaInfoResult result, MediaInfo data)

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
         [InlineData("120/1", 120f)]
         [InlineData("1704753000/71073479", 23.98578237601117f)]
         [InlineData("0/0", null)]
+        [InlineData("0/1", null)]
         [InlineData("1/1000", 0.001f)]
         [InlineData("1/90000", 1.1111111E-05f)]
         [InlineData("1/48000", 2.0833333E-05f)]


### PR DESCRIPTION
**Changes**
I was getting errors with some media files where the `CodecTimeBase` was set to `0/1`. This caused the `ffprobe` math to generate a divide by zero bug which then flowed onto a full error with the following stack trace: 

```
System.OverflowException: Value was either too large or too small for an Int32.
   at System.Convert.ToInt32(Double value)
   at System.Convert.ToInt32(Single value)
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.GetMediaStream(Boolean isAudio, MediaStreamInfo streamInfo, MediaFormatInfo formatInfo)
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.<>c__DisplayClass10_0.<GetMediaInfo>b__0(MediaStreamInfo s)
   at System.Linq.Enumerable.SelectListIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToList()
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.GetMediaInfo(InternalMediaInfoResult data, Nullable`1 videoType, Boolean isAudio, String path, MediaProtocol protocol)
   at MediaBrowser.MediaEncoding.Encoder.MediaEncoder.GetMediaInfoInternal(String inputPath, String primaryPath, MediaProtocol protocol, Boolean extractChapters, String probeSizeArgument, Boolean isAudio, Nullable`1 videoType, Boolean forceEnableLogging, CancellationToken cancellationToken)
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.ProbeVideo[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken)
```

If the dividend is also 0, we should return `null` instead since a framerate of 0 seems kinda off? 

OR an alternative could be to add some logic before the `1 / GetFrameRate(....) ?? 0`. Not sure what would be best but this fixed my issues with my library.

**Issues**
Sorry didnt really make an issue for this, I just found this bug on my own server
