### PR TITLE
Add image/jpg to extension lookup

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -116,6 +116,7 @@ namespace MediaBrowser.Model.Net
             { "audio/x-wavpack", ".wv" },
 
             // Type image
+            { "image/jpg", ".jpg" },
             { "image/jpeg", ".jpg" },
             { "image/x-png", ".png" },
 

--- a/tests/Jellyfin.Model.Tests/Net/MimeTypesTests.cs
+++ b/tests/Jellyfin.Model.Tests/Net/MimeTypesTests.cs
@@ -124,6 +124,7 @@ namespace Jellyfin.Model.Tests.Net
         [InlineData("font/woff2", ".woff2")]
         [InlineData("image/bmp", ".bmp")]
         [InlineData("image/gif", ".gif")]
+        [InlineData("image/jpg", ".jpg")]
         [InlineData("image/jpeg", ".jpg")]
         [InlineData("image/png", ".png")]
         [InlineData("image/svg+xml", ".svg")]


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/7050
Fixes https://github.com/jellyfin/jellyfin/issues/7097

`image/jpg` may not be a valid mime-type, but it's required for our workflow