### PR TITLE
Add DisableEmbeddedSubtitles setting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -217,3 +217,4 @@
  - [olsh](https://github.com/olsh)
  - [lbenini](https://github.com/lbenini)
  - [gnuyent](https://github.com/gnuyent)
+ - [Matthew Jones](https://github.com/matthew-jones-uk)

--- a/MediaBrowser.Model/Configuration/EmbeddedSubtitleOptions.cs
+++ b/MediaBrowser.Model/Configuration/EmbeddedSubtitleOptions.cs
@@ -1,0 +1,30 @@
+namespace MediaBrowser.Model.Configuration
+{
+    /// <summary>
+    /// An enum representing the options to disable embedded subs.
+    /// </summary>
+    public enum EmbeddedSubtitleOptions
+    {
+
+        /// <summary>
+        /// Allow all embedded subs.
+        /// </summary>
+        AllowAll,
+
+        /// <summary>
+        /// Allow only embedded subs that are text based.
+        /// </summary>
+        AllowText,
+
+        /// <summary>
+        /// Allow only embedded subs that are image based.
+        /// </summary>
+        AllowImage,
+
+        /// <summary>
+        /// Disable all embedded subs.
+        /// </summary>
+        AllowNone,
+    }
+
+}

--- a/MediaBrowser.Model/Configuration/EmbeddedSubtitleOptions.cs
+++ b/MediaBrowser.Model/Configuration/EmbeddedSubtitleOptions.cs
@@ -9,22 +9,22 @@ namespace MediaBrowser.Model.Configuration
         /// <summary>
         /// Allow all embedded subs.
         /// </summary>
-        AllowAll,
+        AllowAll = 0,
 
         /// <summary>
         /// Allow only embedded subs that are text based.
         /// </summary>
-        AllowText,
+        AllowText = 1,
 
         /// <summary>
         /// Allow only embedded subs that are image based.
         /// </summary>
-        AllowImage,
+        AllowImage = 2,
 
         /// <summary>
         /// Disable all embedded subs.
         /// </summary>
-        AllowNone,
+        AllowNone = 3,
     }
 
 }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -84,6 +84,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool AutomaticallyAddToCollection { get; set; }
 
+        public bool DisableEmbeddedSubtitles { get; set; }
+
         public TypeOptions[] TypeOptions { get; set; }
 
         public TypeOptions? GetTypeOptions(string type)

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -84,7 +84,9 @@ namespace MediaBrowser.Model.Configuration
 
         public bool AutomaticallyAddToCollection { get; set; }
 
-        public bool DisableEmbeddedSubtitles { get; set; }
+        public bool DisableEmbeddedTextSubtitles { get; set; }
+
+        public bool DisableEmbeddedImageSubtitles { get; set; }
 
         public TypeOptions[] TypeOptions { get; set; }
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -15,6 +15,7 @@ namespace MediaBrowser.Model.Configuration
 
             SkipSubtitlesIfAudioTrackMatches = true;
             RequirePerfectSubtitleMatch = true;
+            AllowEmbeddedSubtitles = EmbeddedSubtitleOptions.AllowAll;
 
             AutomaticallyAddToCollection = true;
             EnablePhotos = true;
@@ -84,9 +85,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool AutomaticallyAddToCollection { get; set; }
 
-        public bool DisableEmbeddedTextSubtitles { get; set; }
-
-        public bool DisableEmbeddedImageSubtitles { get; set; }
+        public EmbeddedSubtitleOptions AllowEmbeddedSubtitles { get; set; }
 
         public TypeOptions[] TypeOptions { get; set; }
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -229,13 +229,13 @@ namespace MediaBrowser.Providers.MediaInfo
                 video.Video3DFormat ??= mediaInfo.Video3DFormat;
             }
 
-            if (libraryOptions.DisableEmbeddedImageSubtitles)
+            if (libraryOptions.AllowEmbeddedSubtitles == EmbeddedSubtitleOptions.AllowText || libraryOptions.AllowEmbeddedSubtitles == EmbeddedSubtitleOptions.AllowNone)
             {
                 _logger.LogDebug("Disabling embedded image subtitles for {Path} due to DisableEmbeddedImageSubtitles setting", video.Path);
                 mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && !i.IsTextSubtitleStream);
             }
 
-            if (libraryOptions.DisableEmbeddedTextSubtitles)
+            if (libraryOptions.AllowEmbeddedSubtitles == EmbeddedSubtitleOptions.AllowImage || libraryOptions.AllowEmbeddedSubtitles == EmbeddedSubtitleOptions.AllowNone)
             {
                 _logger.LogDebug("Disabling embedded text subtitles for {Path} due to DisableEmbeddedTextSubtitles setting", video.Path);
                 mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && i.IsTextSubtitleStream);

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -231,7 +231,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (libraryOptions.DisableEmbeddedSubtitles)
             {
-                _logger.LogDebug("Disabling embedded subtitles due to DisableEmbeddedSubtitles setting");
+                _logger.LogDebug("Disabling embedded subtitles for {Path} due to DisableEmbeddedSubtitles setting", video.Path);
                 mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal);
             }
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -229,6 +229,12 @@ namespace MediaBrowser.Providers.MediaInfo
                 video.Video3DFormat ??= mediaInfo.Video3DFormat;
             }
 
+            if (libraryOptions.DisableEmbeddedSubtitles)
+            {
+                _logger.LogInformation("Disabling embedded subtitles due to DisableEmbeddedSubtitles setting.");
+                mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal);
+            }
+
             var videoStream = mediaStreams.FirstOrDefault(i => i.Type == MediaStreamType.Video);
 
             video.Height = videoStream?.Height ?? 0;

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -231,7 +231,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (libraryOptions.DisableEmbeddedSubtitles)
             {
-                _logger.LogInformation("Disabling embedded subtitles due to DisableEmbeddedSubtitles setting.");
+                _logger.LogDebug("Disabling embedded subtitles due to DisableEmbeddedSubtitles setting");
                 mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal);
             }
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -229,10 +229,16 @@ namespace MediaBrowser.Providers.MediaInfo
                 video.Video3DFormat ??= mediaInfo.Video3DFormat;
             }
 
-            if (libraryOptions.DisableEmbeddedSubtitles)
+            if (libraryOptions.DisableEmbeddedImageSubtitles)
             {
-                _logger.LogDebug("Disabling embedded subtitles for {Path} due to DisableEmbeddedSubtitles setting", video.Path);
-                mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal);
+                _logger.LogDebug("Disabling embedded image subtitles for {Path} due to DisableEmbeddedImageSubtitles setting", video.Path);
+                mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && !i.IsTextSubtitleStream);
+            }
+
+            if (libraryOptions.DisableEmbeddedTextSubtitles)
+            {
+                _logger.LogDebug("Disabling embedded text subtitles for {Path} due to DisableEmbeddedTextSubtitles setting", video.Path);
+                mediaStreams.RemoveAll(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && i.IsTextSubtitleStream);
             }
 
             var videoStream = mediaStreams.FirstOrDefault(i => i.Type == MediaStreamType.Video);


### PR DESCRIPTION
Option to disable embedded subs being added to metadata on library scan. This helps with setups that handle embedded subs badly.

Implements https://features.jellyfin.org/posts/985/hide-embedded-subtitles