### PR TITLE
Improve subtitle filename parsing

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
@@ -169,7 +169,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                         // Try to translate to three character code, use as title if not a valid language
                         var culture = _localization.FindLanguageInfo(currentSliceString);
-                        if (culture == null)
+                        if (culture == null || language != null)
                         {
                             if (title == null)
                             {

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1002 // Do not expose generic lists
 
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Providers.MediaInfo;
@@ -11,6 +12,24 @@ namespace Jellyfin.Providers.Tests.MediaInfo
 {
     public class SubtitleResolverTests
     {
+        private readonly ILocalizationManager _localizationManager;
+
+        public SubtitleResolverTests()
+        {
+            var englishCultureDto = new CultureDto()
+            {
+                Name = "English",
+                DisplayName = "English",
+                ThreeLetterISOLanguageNames = new[] { "eng" },
+                TwoLetterISOLanguageName = "en"
+            };
+
+            var localizationManager = new Mock<ILocalizationManager>(MockBehavior.Loose);
+            localizationManager.Setup(lm => lm.FindLanguageInfo(It.IsRegex(@"en.*", RegexOptions.IgnoreCase)))
+                .Returns(englishCultureDto);
+            _localizationManager = localizationManager.Object;
+        }
+
         public static TheoryData<List<MediaStream>, string, int, string[], MediaStream[]> AddExternalSubtitleStreams_GivenMixedFilenames_ReturnsValidSubtitles_TestData()
         {
             var data = new TheoryData<List<MediaStream>, string, int, string[], MediaStream[]>();
@@ -41,18 +60,18 @@ namespace Jellyfin.Providers.Tests.MediaInfo
                 },
                 new[]
                 {
-                    CreateMediaStream("/video/My.Video.srt", "srt", null, index++),
-                    CreateMediaStream("/video/My.Video.vtt", "vtt", null, index++),
-                    CreateMediaStream("/video/My.Video.ass", "ass", null, index++),
-                    CreateMediaStream("/video/My.Video.sub", "sub", null, index++),
-                    CreateMediaStream("/video/My.Video.ssa", "ssa", null, index++),
-                    CreateMediaStream("/video/My.Video.smi", "smi", null, index++),
-                    CreateMediaStream("/video/My.Video.sami", "sami", null, index++),
-                    CreateMediaStream("/video/My.Video.en.srt", "srt", "en", index++),
-                    CreateMediaStream("/video/My.Video.default.en.srt", "srt", "en", index++, isDefault: true),
-                    CreateMediaStream("/video/My.Video.default.forced.en.srt", "srt", "en", index++, isForced: true, isDefault: true),
-                    CreateMediaStream("/video/My.Video.en.default.forced.srt", "srt", "en", index++, isForced: true, isDefault: true),
-                    CreateMediaStream("/video/My.Video.With.Additional.Garbage.en.srt", "srt", "en", index),
+                    CreateMediaStream("/video/My.Video.srt", "srt", null, null, index++),
+                    CreateMediaStream("/video/My.Video.vtt", "vtt", null, null, index++),
+                    CreateMediaStream("/video/My.Video.ass", "ass", null, null, index++),
+                    CreateMediaStream("/video/My.Video.sub", "sub", null, null, index++),
+                    CreateMediaStream("/video/My.Video.ssa", "ssa", null, null, index++),
+                    CreateMediaStream("/video/My.Video.smi", "smi", null, null, index++),
+                    CreateMediaStream("/video/My.Video.sami", "sami", null, null, index++),
+                    CreateMediaStream("/video/My.Video.en.srt", "srt", "eng", null, index++),
+                    CreateMediaStream("/video/My.Video.default.en.srt", "srt", "eng", null, index++, isDefault: true),
+                    CreateMediaStream("/video/My.Video.default.forced.en.srt", "srt", "eng", null, index++, isForced: true, isDefault: true),
+                    CreateMediaStream("/video/My.Video.en.default.forced.srt", "srt", "eng", null, index++, isForced: true, isDefault: true),
+                    CreateMediaStream("/video/My.Video.With.Additional.Garbage.en.srt", "srt", "eng", "With.Additional.Garbage", index),
                 });
 
             return data;
@@ -62,7 +81,7 @@ namespace Jellyfin.Providers.Tests.MediaInfo
         [MemberData(nameof(AddExternalSubtitleStreams_GivenMixedFilenames_ReturnsValidSubtitles_TestData))]
         public void AddExternalSubtitleStreams_GivenMixedFilenames_ReturnsValidSubtitles(List<MediaStream> streams, string videoPath, int startIndex, string[] files, MediaStream[] expectedResult)
         {
-            new SubtitleResolver(Mock.Of<ILocalizationManager>()).AddExternalSubtitleStreams(streams, videoPath, startIndex, files);
+            new SubtitleResolver(_localizationManager).AddExternalSubtitleStreams(streams, videoPath, startIndex, files);
 
             Assert.Equal(expectedResult.Length, streams.Count);
             for (var i = 0; i < expectedResult.Length; i++)
@@ -71,53 +90,59 @@ namespace Jellyfin.Providers.Tests.MediaInfo
                 var actual = streams[i];
 
                 Assert.Equal(expected.Index, actual.Index);
+                Assert.Equal(expected.Codec, actual.Codec);
                 Assert.Equal(expected.Type, actual.Type);
                 Assert.Equal(expected.IsExternal, actual.IsExternal);
                 Assert.Equal(expected.Path, actual.Path);
                 Assert.Equal(expected.IsDefault, actual.IsDefault);
                 Assert.Equal(expected.IsForced, actual.IsForced);
                 Assert.Equal(expected.Language, actual.Language);
+                Assert.Equal(expected.Title, actual.Title);
             }
         }
 
         [Theory]
-        [InlineData("/video/My Video.mkv", "/video/My Video.srt", "srt", null, false, false)]
-        [InlineData("/video/My Video.mkv", "/video/my video.srt", "srt", null, false, false)]
-        [InlineData("/video/My Video.mkv", "/video/My Vidèo.srt", "srt", null, false, false)]
-        [InlineData("/video/My_Video.mkv", "/video/My. Video.srt", "srt", null, false, false)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.srt", "srt", null, false, false)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.foreign.srt", "srt", null, true, false)]
-        [InlineData("/video/My Video.mkv", "/video/My Video.forced.srt", "srt", null, true, false)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.srt", "srt", null, false, true)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.forced.default.srt", "srt", null, true, true)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.srt", "srt", "en", false, false)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.en.srt", "srt", "en", false, true)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.forced.en.srt", "srt", "en", true, true)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.default.forced.srt", "srt", "en", true, true)]
-        [InlineData("/video/My.Video.mkv", "/video/My.Video.Track Label.srt", "srt", "Track Label", false, false)]
-        [InlineData("/video/MyVideo.mkv", "/video/My.Video.Track Label.srt", "srt", "Track Label", false, false)]
-        [InlineData("/video/My _ Video.mkv", "/video/MyVideo.Track Label.srt", "srt", "Track Label", false, false)]
-        public void AddExternalSubtitleStreams_GivenSingleFile_ReturnsExpectedSubtitle(string videoPath, string file, string codec, string? language, bool isForced, bool isDefault)
+        [InlineData("/video/My Video.mkv", "/video/My Video.srt", "srt", null, null, false, false)]
+        [InlineData("/video/My Video.mkv", "/video/My Video.ass", "ass", null, null, false, false)]
+        [InlineData("/video/My Video.mkv", "/video/my video.srt", "srt", null, null, false, false)]
+        [InlineData("/video/My Video.mkv", "/video/My Vidèo.srt", "srt", null, null, false, false)]
+        [InlineData("/video/My_Video.mkv", "/video/My. Video.srt", "srt", null, null, false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.srt", "srt", null, null, false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.foreign.srt", "srt", null, null, true, false)]
+        [InlineData("/video/My Video.mkv", "/video/My Video.forced.srt", "srt", null, null, true, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.srt", "srt", null, null, false, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.forced.default.srt", "srt", null, null, true, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.srt", "srt", "eng", null, false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.en.srt", "srt", "eng", null, false, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.default.forced.en.srt", "srt", "eng", null, true, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.default.forced.srt", "srt", "eng", null, true, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.Track Label.srt", "srt", null, "Track Label", false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.Track.Label.srt", "srt", null, "Track.Label", false, false)]
+        [InlineData("/video/MyVideo.mkv", "/video/My.Video.Track Label.srt", "srt", null, "Track Label", false, false)]
+        [InlineData("/video/My _ Video.mkv", "/video/MyVideo.Track Label.srt", "srt", null, "Track Label", false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.Track Label.en.default.forced.srt", "srt", "eng", "Track Label", true, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.default.forced.Track Label.srt", "srt", "eng", "Track Label", true, true)]
+        public void AddExternalSubtitleStreams_GivenSingleFile_ReturnsExpectedSubtitle(string videoPath, string file, string codec, string? language, string? title, bool isForced, bool isDefault)
         {
             var streams = new List<MediaStream>();
-            var expected = CreateMediaStream(file, codec, language, 0, isForced, isDefault);
-
-            new SubtitleResolver(Mock.Of<ILocalizationManager>()).AddExternalSubtitleStreams(streams, videoPath, 0, new[] { file });
+            new SubtitleResolver(_localizationManager).AddExternalSubtitleStreams(streams, videoPath, 0, new[] { file });
 
             Assert.Single(streams);
-
             var actual = streams[0];
 
+            var expected = CreateMediaStream(file, codec, language, title, 0, isForced, isDefault);
             Assert.Equal(expected.Index, actual.Index);
+            Assert.Equal(expected.Codec, actual.Codec);
             Assert.Equal(expected.Type, actual.Type);
             Assert.Equal(expected.IsExternal, actual.IsExternal);
             Assert.Equal(expected.Path, actual.Path);
             Assert.Equal(expected.IsDefault, actual.IsDefault);
             Assert.Equal(expected.IsForced, actual.IsForced);
             Assert.Equal(expected.Language, actual.Language);
+            Assert.Equal(expected.Title, actual.Title);
         }
 
-        private static MediaStream CreateMediaStream(string path, string codec, string? language, int index, bool isForced = false, bool isDefault = false)
+        private static MediaStream CreateMediaStream(string path, string codec, string? language, string? title, int index, bool isForced = false, bool isDefault = false)
         {
             return new()
             {
@@ -128,7 +153,8 @@ namespace Jellyfin.Providers.Tests.MediaInfo
                 Path = path,
                 IsDefault = isDefault,
                 IsForced = isForced,
-                Language = language
+                Language = language,
+                Title = title
             };
         }
     }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -82,6 +82,9 @@ namespace Jellyfin.Providers.Tests.MediaInfo
 
         [Theory]
         [InlineData("/video/My Video.mkv", "/video/My Video.srt", "srt", null, false, false)]
+        [InlineData("/video/My Video.mkv", "/video/my video.srt", "srt", null, false, false)]
+        [InlineData("/video/My Video.mkv", "/video/My Vidèo.srt", "srt", null, false, false)]
+        [InlineData("/video/My_Video.mkv", "/video/My. Video.srt", "srt", null, false, false)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.srt", "srt", null, false, false)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.foreign.srt", "srt", null, true, false)]
         [InlineData("/video/My Video.mkv", "/video/My Video.forced.srt", "srt", null, true, false)]
@@ -91,6 +94,9 @@ namespace Jellyfin.Providers.Tests.MediaInfo
         [InlineData("/video/My.Video.mkv", "/video/My.Video.default.en.srt", "srt", "en", false, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.default.forced.en.srt", "srt", "en", true, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.en.default.forced.srt", "srt", "en", true, true)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.Track Label.srt", "srt", "Track Label", false, false)]
+        [InlineData("/video/MyVideo.mkv", "/video/My.Video.Track Label.srt", "srt", "Track Label", false, false)]
+        [InlineData("/video/My _ Video.mkv", "/video/MyVideo.Track Label.srt", "srt", "Track Label", false, false)]
         public void AddExternalSubtitleStreams_GivenSingleFile_ReturnsExpectedSubtitle(string videoPath, string file, string codec, string? language, bool isForced, bool isDefault)
         {
             var streams = new List<MediaStream>();

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -23,10 +23,19 @@ namespace Jellyfin.Providers.Tests.MediaInfo
                 ThreeLetterISOLanguageNames = new[] { "eng" },
                 TwoLetterISOLanguageName = "en"
             };
+            var frenchCultureDto = new CultureDto()
+            {
+                Name = "French",
+                DisplayName = "French",
+                ThreeLetterISOLanguageNames = new[] { "fre", "fra" },
+                TwoLetterISOLanguageName = "fr"
+            };
 
             var localizationManager = new Mock<ILocalizationManager>(MockBehavior.Loose);
             localizationManager.Setup(lm => lm.FindLanguageInfo(It.IsRegex(@"en.*", RegexOptions.IgnoreCase)))
                 .Returns(englishCultureDto);
+            localizationManager.Setup(lm => lm.FindLanguageInfo(It.IsRegex(@"fr.*", RegexOptions.IgnoreCase)))
+                .Returns(frenchCultureDto);
             _localizationManager = localizationManager.Object;
         }
 
@@ -113,6 +122,8 @@ namespace Jellyfin.Providers.Tests.MediaInfo
         [InlineData("/video/My.Video.mkv", "/video/My.Video.default.srt", "srt", null, null, false, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.forced.default.srt", "srt", null, null, true, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.en.srt", "srt", "eng", null, false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.fr.en.srt", "srt", "eng", "fr", false, false)]
+        [InlineData("/video/My.Video.mkv", "/video/My.Video.en.fr.srt", "srt", "fre", "en", false, false)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.default.en.srt", "srt", "eng", null, false, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.default.forced.en.srt", "srt", "eng", null, true, true)]
         [InlineData("/video/My.Video.mkv", "/video/My.Video.en.default.forced.srt", "srt", "eng", null, true, true)]


### PR DESCRIPTION
**Changes**
- Improve fuzzy name matching to ignore: case, accents, symbols/whitespace
- Add tests for name fuzzy matching
- Put text that doesn't parse as a language in the Title field instead of using language as a label

**Issues**
Fixes #7057