### PR TITLE
Add ability to search by -

### DIFF
--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -37,7 +37,7 @@ namespace Emby.Server.Implementations.Library
                 var attributeEnd = attributeIndex + attribute.Length;
                 if (attributeIndex > 0
                     && str[attributeIndex - 1] == '['
-                    && str[attributeEnd] == '=')
+                    && (str[attributeEnd] == '=' || str[attributeEnd] == '-'))
                 {
                     var closingIndex = str[attributeEnd..].IndexOf(']');
                     // Must be at least 1 character before the closing bracket.

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/PathExtensionsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/PathExtensionsTests.cs
@@ -8,13 +8,17 @@ namespace Jellyfin.Server.Implementations.Tests.Library
     {
         [Theory]
         [InlineData("Superman: Red Son [imdbid=tt10985510]", "imdbid", "tt10985510")]
+        [InlineData("Superman: Red Son [imdbid-tt10985510]", "imdbid", "tt10985510")]
         [InlineData("Superman: Red Son - tt10985510", "imdbid", "tt10985510")]
         [InlineData("Superman: Red Son", "imdbid", null)]
         [InlineData("Superman: Red Son", "something", null)]
         [InlineData("Superman: Red Son [imdbid1=tt11111111][imdbid=tt10985510]", "imdbid", "tt10985510")]
+        [InlineData("Superman: Red Son [imdbid1-tt11111111][imdbid=tt10985510]", "imdbid", "tt10985510")]
         [InlineData("Superman: Red Son [tmdbid=618355][imdbid=tt10985510]", "imdbid", "tt10985510")]
-        [InlineData("Superman: Red Son [tmdbid=618355][imdbid=tt10985510]", "tmdbid", "618355")]
+        [InlineData("Superman: Red Son [tmdbid-618355][imdbid-tt10985510]", "imdbid", "tt10985510")]
+        [InlineData("Superman: Red Son [tmdbid-618355][imdbid-tt10985510]", "tmdbid", "618355")]
         [InlineData("[tmdbid=618355]", "tmdbid", "618355")]
+        [InlineData("[tmdbid-618355]", "tmdbid", "618355")]
         [InlineData("tmdbid=111111][tmdbid=618355]", "tmdbid", "618355")]
         [InlineData("[tmdbid=618355]tmdbid=111111]", "tmdbid", "618355")]
         [InlineData("tmdbid=618355]", "tmdbid", null)]
@@ -23,6 +27,8 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("tmdbid=", "tmdbid", null)]
         [InlineData("tmdbid", "tmdbid", null)]
         [InlineData("[tmdbid=][imdbid=tt10985510]", "tmdbid", null)]
+        [InlineData("[tmdbid-][imdbid-tt10985510]", "tmdbid", null)]
+        [InlineData("Superman: Red Son [tmdbid-618355][tmdbid=1234567]", "tmdbid", "618355")]
         public void GetAttributeValue_ValidArgs_Correct(string input, string attribute, string? expectedResult)
         {
             Assert.Equal(expectedResult, PathExtensions.GetAttributeValue(input, attribute));


### PR DESCRIPTION
By popular request, this adds the ability for the provider id to be found 

`[tvdbid=12345]` or `[tvdbid-12345]`, first in the filename is the winner.