### PR TITLE
Respect lock state when updating season 0 name

### DIFF
--- a/MediaBrowser.Providers/TV/SeasonMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeasonMetadataService.cs
@@ -35,7 +35,7 @@ namespace MediaBrowser.Providers.TV
         {
             var updatedType = base.BeforeSaveInternal(item, isFullRefresh, updateType);
 
-            if (item.IndexNumber.HasValue && item.IndexNumber.Value == 0)
+            if (item.IndexNumber == 0 && !item.IsLocked && !item.LockedFields.Contains(MetadataField.Name))
             {
                 var seasonZeroDisplayName = LibraryManager.GetLibraryOptions(item).SeasonZeroDisplayName;
 


### PR DESCRIPTION
**Changes**
Check the locked state of the item/field when resetting the Specials season name to the library default

**Issues**
Fixes #7096
