### PR TITLE
Remove unnecessary ToList  usage

### DIFF
--- a/Emby.Dlna/Eventing/DlnaEventManager.cs
+++ b/Emby.Dlna/Eventing/DlnaEventManager.cs
@@ -127,8 +127,7 @@ namespace Emby.Dlna.Eventing
         public Task TriggerEvent(string notificationType, IDictionary<string, string> stateVariables)
         {
             var subs = _subscriptions.Values
-                .Where(i => !i.IsExpired && string.Equals(notificationType, i.NotificationType, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+                .Where(i => !i.IsExpired && string.Equals(notificationType, i.NotificationType, StringComparison.OrdinalIgnoreCase));
 
             var tasks = subs.Select(i => TriggerEvent(i, stateVariables));
 

--- a/Emby.Naming/AudioBook/AudioBookListResolver.cs
+++ b/Emby.Naming/AudioBook/AudioBookListResolver.cs
@@ -36,8 +36,7 @@ namespace Emby.Naming.AudioBook
             // File with empty fullname will be sorted out here.
             var audiobookFileInfos = files
                 .Select(i => _audioBookResolver.Resolve(i.FullName))
-                .OfType<AudioBookFileInfo>()
-                .ToList();
+                .OfType<AudioBookFileInfo>();
 
             var stackResult = StackResolver.ResolveAudioBooks(audiobookFileInfos);
 
@@ -102,8 +101,7 @@ namespace Emby.Naming.AudioBook
                         {
                             var extra = ex
                                 .OrderBy(x => x.Container)
-                                .ThenBy(x => x.Path)
-                                .ToList();
+                                .ThenBy(x => x.Path);
 
                             stackFiles = stackFiles.Except(extra).ToList();
                             extras.AddRange(extra);

--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -29,7 +29,7 @@ namespace Emby.Naming.Video
                 .Where(i => i.ExtraType == null)
                 .Select(i => new FileSystemMetadata { FullName = i.Path, IsDirectory = i.IsDirectory });
 
-            var stackResult = StackResolver.Resolve(nonExtras, namingOptions);
+            var stackResult = StackResolver.Resolve(nonExtras, namingOptions).ToList();
 
             var remainingFiles = new List<VideoFileInfo>();
             var standaloneMedia = new List<VideoFileInfo>();

--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -29,7 +29,7 @@ namespace Emby.Naming.Video
                 .Where(i => i.ExtraType == null)
                 .Select(i => new FileSystemMetadata { FullName = i.Path, IsDirectory = i.IsDirectory });
 
-            var stackResult = StackResolver.Resolve(nonExtras, namingOptions).ToList();
+            var stackResult = StackResolver.Resolve(nonExtras, namingOptions);
 
             var remainingFiles = new List<VideoFileInfo>();
             var standaloneMedia = new List<VideoFileInfo>();

--- a/Emby.Notifications/NotificationManager.cs
+++ b/Emby.Notifications/NotificationManager.cs
@@ -88,8 +88,7 @@ namespace Emby.Notifications
             string description,
             CancellationToken cancellationToken)
         {
-            users = users.Where(i => IsEnabledForUser(service, i))
-                .ToList();
+            users = users.Where(i => IsEnabledForUser(service, i));
 
             var tasks = users.Select(i => SendNotification(request, service, title, description, i, cancellationToken));
 

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -210,7 +210,7 @@ namespace Emby.Server.Implementations.Collections
             var itemList = new List<BaseItem>();
 
             var linkedChildrenList = collection.GetLinkedChildren();
-            var currentLinkedChildrenIds = linkedChildrenList.Select(i => i.Id);
+            var currentLinkedChildrenIds = linkedChildrenList.Select(i => i.Id).ToList();
 
             foreach (var id in ids)
             {
@@ -300,7 +300,7 @@ namespace Emby.Server.Implementations.Collections
         {
             var results = new Dictionary<Guid, BaseItem>();
 
-            var allBoxSets = GetCollections(user);
+            var allBoxSets = GetCollections(user).ToList();
 
             foreach (var item in items)
             {

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -210,7 +210,7 @@ namespace Emby.Server.Implementations.Collections
             var itemList = new List<BaseItem>();
 
             var linkedChildrenList = collection.GetLinkedChildren();
-            var currentLinkedChildrenIds = linkedChildrenList.Select(i => i.Id).ToList();
+            var currentLinkedChildrenIds = linkedChildrenList.Select(i => i.Id);
 
             foreach (var id in ids)
             {
@@ -232,10 +232,7 @@ namespace Emby.Server.Implementations.Collections
 
             if (list.Count > 0)
             {
-                var newList = collection.LinkedChildren.ToList();
-                newList.AddRange(list);
-                collection.LinkedChildren = newList.ToArray();
-
+                collection.LinkedChildren = collection.LinkedChildren.Concat(list).ToArray();
                 collection.UpdateRatingToItems(linkedChildrenList);
 
                 await collection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None).ConfigureAwait(false);
@@ -303,7 +300,7 @@ namespace Emby.Server.Implementations.Collections
         {
             var results = new Dictionary<Guid, BaseItem>();
 
-            var allBoxSets = GetCollections(user).ToList();
+            var allBoxSets = GetCollections(user);
 
             foreach (var item in items)
             {

--- a/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
@@ -115,7 +115,7 @@ namespace Emby.Server.Implementations.EntryPoints
             {
             }
 
-            var collectionFolders = _libraryManager.GetCollectionFolders(item).ToList();
+            var collectionFolders = _libraryManager.GetCollectionFolders(item);
 
             foreach (var collectionFolder in collectionFolders)
             {

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -82,9 +82,7 @@ namespace Emby.Server.Implementations.IO
         public bool IsPathLocked(string path)
         {
             // This method is not used by the core but it used by auto-organize
-
-            var lockedPaths = _tempIgnoredPaths.Keys.ToList();
-            return lockedPaths.Any(i => _fileSystem.AreEqual(i, path) || _fileSystem.ContainsSubPath(i, path));
+            return _tempIgnoredPaths.Keys.Any(i => _fileSystem.AreEqual(i, path) || _fileSystem.ContainsSubPath(i, path));
         }
 
         public async void ReportFileSystemChangeComplete(string path, bool refreshPath)
@@ -145,8 +143,7 @@ namespace Emby.Server.Implementations.IO
                 .OfType<Folder>()
                 .SelectMany(f => f.PhysicalLocations)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(i => i)
-                .ToList();
+                .OrderBy(i => i);
 
             foreach (var path in paths)
             {
@@ -372,11 +369,8 @@ namespace Emby.Server.Implementations.IO
 
             var monitorPath = !IgnorePatterns.ShouldIgnore(path);
 
-            // Ignore certain files
-            var tempIgnorePaths = _tempIgnoredPaths.Keys.ToList();
-
-            // If the parent of an ignored path has a change event, ignore that too
-            if (tempIgnorePaths.Any(i =>
+            // Ignore certain files, If the parent of an ignored path has a change event, ignore that too
+            if (_tempIgnoredPaths.Keys.Any(i =>
             {
                 if (_fileSystem.AreEqual(i, path))
                 {
@@ -491,7 +485,7 @@ namespace Emby.Server.Implementations.IO
         {
             lock (_activeRefreshers)
             {
-                foreach (var refresher in _activeRefreshers.ToList())
+                foreach (var refresher in _activeRefreshers)
                 {
                     refresher.Completed -= OnNewRefresherCompleted;
                     refresher.Dispose();

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -366,7 +366,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             var children = item.IsFolder
-                ? ((Folder)item).GetRecursiveChildren(false).ToList()
+                ? ((Folder)item).GetRecursiveChildren(false)
                 : new List<BaseItem>();
 
             foreach (var metadataPath in GetMetadataPaths(item, children))
@@ -628,11 +628,9 @@ namespace Emby.Server.Implementations.Library
 
             var list = originalList.Where(i => i.IsDirectory)
                 .Select(i => _fileSystem.NormalizePath(i.FullName))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
+                .Distinct(StringComparer.OrdinalIgnoreCase);
 
-            var dupes = list.Where(subPath => !subPath.EndsWith(":\\", StringComparison.OrdinalIgnoreCase) && list.Any(i => _fileSystem.ContainsSubPath(i, subPath)))
-                .ToList();
+            var dupes = list.Where(subPath => !subPath.EndsWith(":\\", StringComparison.OrdinalIgnoreCase) && list.Any(i => _fileSystem.ContainsSubPath(i, subPath)));
 
             foreach (var dupe in dupes)
             {
@@ -1660,7 +1658,7 @@ namespace Emby.Server.Implementations.Library
             {
                 try
                 {
-                    return i.GetAllIntroFiles().ToList();
+                    return i.GetAllIntroFiles();
                 }
                 catch (Exception ex)
                 {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -366,7 +366,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             var children = item.IsFolder
-                ? ((Folder)item).GetRecursiveChildren(false)
+                ? ((Folder)item).GetRecursiveChildren(false).ToList()
                 : new List<BaseItem>();
 
             foreach (var metadataPath in GetMetadataPaths(item, children))
@@ -628,7 +628,8 @@ namespace Emby.Server.Implementations.Library
 
             var list = originalList.Where(i => i.IsDirectory)
                 .Select(i => _fileSystem.NormalizePath(i.FullName))
-                .Distinct(StringComparer.OrdinalIgnoreCase);
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             var dupes = list.Where(subPath => !subPath.EndsWith(":\\", StringComparison.OrdinalIgnoreCase) && list.Any(i => _fileSystem.ContainsSubPath(i, subPath)));
 


### PR DESCRIPTION
**Changes**
Remove unnecessary ToList usage in DlnaEventManager, AudioBookListResolver, NotificationManager, CollectionManager, LibraryChangedNotifier, LibraryMonitor and LibraryManager.

**Issues**
Part of: [#5355](https://github.com/jellyfin/jellyfin/issues/5355)