### PR TITLE
Remove special HTTP HEAD processing

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1954,7 +1954,7 @@ namespace Jellyfin.Api.Controllers
                 return Task.CompletedTask;
             });
 
-            return FileStreamResponseHelpers.GetStaticFileResult(segmentPath, MimeTypes.GetMimeType(segmentPath), false, HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(segmentPath, MimeTypes.GetMimeType(segmentPath), HttpContext);
         }
 
         private long GetEndPositionTicks(StreamState state, int requestedIndex)

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1954,7 +1954,7 @@ namespace Jellyfin.Api.Controllers
                 return Task.CompletedTask;
             });
 
-            return FileStreamResponseHelpers.GetStaticFileResult(segmentPath, MimeTypes.GetMimeType(segmentPath), HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(segmentPath, MimeTypes.GetMimeType(segmentPath));
         }
 
         private long GetEndPositionTicks(StreamState state, int requestedIndex)

--- a/Jellyfin.Api/Controllers/HlsSegmentController.cs
+++ b/Jellyfin.Api/Controllers/HlsSegmentController.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Api.Controllers
                 return BadRequest("Invalid segment.");
             }
 
-            return FileStreamResponseHelpers.GetStaticFileResult(file, MimeTypes.GetMimeType(file), false, HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(file, MimeTypes.GetMimeType(file), HttpContext);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Jellyfin.Api.Controllers
                 return Task.CompletedTask;
             });
 
-            return FileStreamResponseHelpers.GetStaticFileResult(path, MimeTypes.GetMimeType(path), false, HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(path, MimeTypes.GetMimeType(path), HttpContext);
         }
     }
 }

--- a/Jellyfin.Api/Controllers/HlsSegmentController.cs
+++ b/Jellyfin.Api/Controllers/HlsSegmentController.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Api.Controllers
                 return BadRequest("Invalid segment.");
             }
 
-            return FileStreamResponseHelpers.GetStaticFileResult(file, MimeTypes.GetMimeType(file), HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(file, MimeTypes.GetMimeType(file));
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Jellyfin.Api.Controllers
                 return Task.CompletedTask;
             });
 
-            return FileStreamResponseHelpers.GetStaticFileResult(path, MimeTypes.GetMimeType(path), HttpContext);
+            return FileStreamResponseHelpers.GetStaticFileResult(path, MimeTypes.GetMimeType(path));
         }
     }
 }

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -559,8 +559,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -643,8 +642,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -727,8 +725,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -811,8 +808,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -895,8 +891,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -979,8 +974,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1063,8 +1057,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1147,8 +1140,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1231,8 +1223,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1315,8 +1306,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1399,8 +1389,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1483,8 +1472,7 @@ namespace Jellyfin.Api.Controllers
                     blur,
                     backgroundColor,
                     foregroundLayer,
-                    item,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase))
+                    item)
                 .ConfigureAwait(false);
         }
 
@@ -1585,7 +1573,6 @@ namespace Jellyfin.Api.Controllers
                     backgroundColor,
                     foregroundLayer,
                     null,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase),
                     info)
                 .ConfigureAwait(false);
         }
@@ -1687,7 +1674,6 @@ namespace Jellyfin.Api.Controllers
                     backgroundColor,
                     foregroundLayer,
                     null,
-                    Request.Method.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase),
                     info)
                 .ConfigureAwait(false);
         }
@@ -1772,7 +1758,6 @@ namespace Jellyfin.Api.Controllers
             string? backgroundColor,
             string? foregroundLayer,
             BaseItem? item,
-            bool isHeadRequest,
             ItemImageInfo? imageInfo = null)
         {
             if (percentPlayed.HasValue)
@@ -1843,8 +1828,7 @@ namespace Jellyfin.Api.Controllers
                 imageInfo,
                 outputFormats,
                 cacheDuration,
-                responseHeaders,
-                isHeadRequest).ConfigureAwait(false);
+                responseHeaders).ConfigureAwait(false);
         }
 
         private ImageFormat[] GetOutputFormats(ImageFormat? format)
@@ -1941,8 +1925,7 @@ namespace Jellyfin.Api.Controllers
             ItemImageInfo imageInfo,
             IReadOnlyCollection<ImageFormat> supportedFormats,
             TimeSpan? cacheDuration,
-            IDictionary<string, string> headers,
-            bool isHeadRequest)
+            IDictionary<string, string> headers)
         {
             if (!imageInfo.IsLocalFile && item != null)
             {

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -2020,12 +2020,6 @@ namespace Jellyfin.Api.Controllers
                 }
             }
 
-            // if the request is a head request, return a NoContent result with the same headers as it would with a GET request
-            if (isHeadRequest)
-            {
-                return NoContent();
-            }
-
             return PhysicalFile(imagePath, imageContentType ?? MediaTypeNames.Text.Plain);
         }
     }

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -499,8 +499,7 @@ namespace Jellyfin.Api.Controllers
 
                 return FileStreamResponseHelpers.GetStaticFileResult(
                     state.MediaPath,
-                    contentType,
-                    HttpContext);
+                    contentType);
             }
 
             // Need to start ffmpeg (because media can't be returned directly)

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -470,7 +470,7 @@ namespace Jellyfin.Api.Controllers
                 StreamingHelpers.AddDlnaHeaders(state, Response.Headers, true, state.Request.StartTimeTicks, Request, _dlnaManager);
 
                 var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, isHeadRequest, httpClient, HttpContext).ConfigureAwait(false);
+                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, HttpContext).ConfigureAwait(false);
             }
 
             if (@static.HasValue && @static.Value && state.InputProtocol != MediaProtocol.File)
@@ -500,7 +500,6 @@ namespace Jellyfin.Api.Controllers
                 return FileStreamResponseHelpers.GetStaticFileResult(
                     state.MediaPath,
                     contentType,
-                    isHeadRequest,
                     HttpContext);
             }
 

--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -167,8 +167,7 @@ namespace Jellyfin.Api.Helpers
 
                 return FileStreamResponseHelpers.GetStaticFileResult(
                     state.MediaPath,
-                    contentType,
-                    _httpContextAccessor.HttpContext);
+                    contentType);
             }
 
             // Need to start ffmpeg (because media can't be returned directly)

--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -138,7 +138,7 @@ namespace Jellyfin.Api.Helpers
                 StreamingHelpers.AddDlnaHeaders(state, _httpContextAccessor.HttpContext.Response.Headers, true, streamingRequest.StartTimeTicks, _httpContextAccessor.HttpContext.Request, _dlnaManager);
 
                 var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, isHeadRequest, httpClient, _httpContextAccessor.HttpContext).ConfigureAwait(false);
+                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, _httpContextAccessor.HttpContext).ConfigureAwait(false);
             }
 
             if (streamingRequest.Static && state.InputProtocol != MediaProtocol.File)
@@ -168,7 +168,6 @@ namespace Jellyfin.Api.Helpers
                 return FileStreamResponseHelpers.GetStaticFileResult(
                     state.MediaPath,
                     contentType,
-                    isHeadRequest,
                     _httpContextAccessor.HttpContext);
             }
 

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -22,14 +22,12 @@ namespace Jellyfin.Api.Helpers
         /// Returns a static file from a remote source.
         /// </summary>
         /// <param name="state">The current <see cref="StreamState"/>.</param>
-        /// <param name="isHeadRequest">Whether the current request is a HTTP HEAD request so only the headers get returned.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> making the remote request.</param>
         /// <param name="httpContext">The current http context.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
         /// <returns>A <see cref="Task{ActionResult}"/> containing the API response.</returns>
         public static async Task<ActionResult> GetStaticRemoteStreamResult(
             StreamState state,
-            bool isHeadRequest,
             HttpClient httpClient,
             HttpContext httpContext,
             CancellationToken cancellationToken = default)
@@ -53,17 +51,13 @@ namespace Jellyfin.Api.Helpers
         /// </summary>
         /// <param name="path">The path to the file.</param>
         /// <param name="contentType">The content type of the file.</param>
-        /// <param name="isHeadRequest">Whether the current request is a HTTP HEAD request so only the headers get returned.</param>
         /// <param name="httpContext">The current http context.</param>
         /// <returns>An <see cref="ActionResult"/> the file.</returns>
         public static ActionResult GetStaticFileResult(
             string path,
             string contentType,
-            bool isHeadRequest,
             HttpContext httpContext)
         {
-            httpContext.Response.ContentType = contentType;
-
             return new PhysicalFileResult(path, contentType) { EnableRangeProcessing = true };
         }
 

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -51,12 +51,10 @@ namespace Jellyfin.Api.Helpers
         /// </summary>
         /// <param name="path">The path to the file.</param>
         /// <param name="contentType">The content type of the file.</param>
-        /// <param name="httpContext">The current http context.</param>
         /// <returns>An <see cref="ActionResult"/> the file.</returns>
         public static ActionResult GetStaticFileResult(
             string path,
-            string contentType,
-            HttpContext httpContext)
+            string contentType)
         {
             return new PhysicalFileResult(path, contentType) { EnableRangeProcessing = true };
         }

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -45,12 +45,6 @@ namespace Jellyfin.Api.Helpers
 
             httpContext.Response.Headers[HeaderNames.AcceptRanges] = "none";
 
-            if (isHeadRequest)
-            {
-                httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
-                return new OkResult();
-            }
-
             return new FileStreamResult(await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false), contentType);
         }
 
@@ -69,12 +63,6 @@ namespace Jellyfin.Api.Helpers
             HttpContext httpContext)
         {
             httpContext.Response.ContentType = contentType;
-
-            // if the request is a head request, return an OkResult (200) with the same headers as it would with a GET request
-            if (isHeadRequest)
-            {
-                return new OkResult();
-            }
 
             return new PhysicalFileResult(path, contentType) { EnableRangeProcessing = true };
         }


### PR DESCRIPTION
Removing this allows HTTP 206 Partial Content responses and lets some clients(popcorn hour namely) play static videos from JF.