### PR TITLE
Fix #7147: Don't return subtitles in mismatched format

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -141,12 +141,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             var inputFormat = subtitle.Format;
 
-            // Return the original if we don't have any way of converting it
-            if (!TryGetWriter(outputFormat, out var writer))
-            {
-                return subtitle.Stream;
-            }
-
             // Return the original if the same format is being requested
             // Character encoding was already handled in GetSubtitleStream
             if (string.Equals(inputFormat, outputFormat, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Don't return subtitles of one format in a file with the wrong extension.

**Issues**
Fixes #7147
