### PR TITLE
Increase timeout for subtitle extraction to 30min

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -151,6 +151,7 @@
  - [peterspenler](https://github.com/peterspenler)
  - [MBR-0001](https://github.com/MBR-0001)
  - [jonas-resch](https://github.com/jonas-resch)
+ - [vgambier](https://github.com/vgambier)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -440,7 +440,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     throw;
                 }
 
-                var ranToCompletion = await process.WaitForExitAsync(TimeSpan.FromMinutes(5)).ConfigureAwait(false);
+                var ranToCompletion = await process.WaitForExitAsync(TimeSpan.FromMinutes(30)).ConfigureAwait(false);
 
                 if (!ranToCompletion)
                 {


### PR DESCRIPTION
**Changes**
Increase timeout value for subtitle extraction operation from 5 minutes to 30 minutes. In some cases, ffmpeg takes over 5 minutes to extract the subtitle even though nothing is wrong with the file and the extraction is possible.

Arguably the fact that some video files take this long might indicate that this extraction step should be (optionally?) done in advance, otherwise there will be 5 to 30 minutes of the file playing without subtitles.

**Issues**
Addresses #6672
