### PR TITLE
ProbeResultNormalizer: fix framerate compare + tests

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -611,6 +611,17 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         /// <summary>
+        /// Determines whether a stream code time base is double the frame rate.
+        /// </summary>
+        /// <param name="averageFrameRate">average frame rate.</param>
+        /// <param name="codecTimeBase">codec time base string.</param>
+        /// <returns>true if the codec time base is double the frame rate.</returns>
+        internal static bool IsCodecTimeBaseDoubleTheFrameRate(float? averageFrameRate, string codecTimeBase)
+        {
+            return MathF.Abs(((averageFrameRate ?? 0) * (GetFrameRate(codecTimeBase) ?? 0)) - 0.5f) <= float.Epsilon;
+        }
+
+        /// <summary>
         /// Converts ffprobe stream info to our MediaStream class.
         /// </summary>
         /// <param name="isAudio">if set to <c>true</c> [is info].</param>
@@ -720,17 +731,16 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.AverageFrameRate = GetFrameRate(streamInfo.AverageFrameRate);
                 stream.RealFrameRate = GetFrameRate(streamInfo.RFrameRate);
 
-                // Some interlaced H.264 files in mp4 containers using MBAFF coding aren't flagged as being interlaced by FFprobe,
-                // so for H.264 files we also calculate the frame rate from the codec time base and check if it is double the reported
-                // frame rate (both rounded to the nearest integer) to determine if the file is interlaced
-                int roundedTimeBaseFPS = Convert.ToInt32(1 / GetFrameRate(stream.CodecTimeBase) ?? 0);
-                int roundedDoubleFrameRate = Convert.ToInt32(stream.AverageFrameRate * 2 ?? 0);
-
                 bool videoInterlaced = !string.IsNullOrWhiteSpace(streamInfo.FieldOrder)
                     && !string.Equals(streamInfo.FieldOrder, "progressive", StringComparison.OrdinalIgnoreCase);
+
+                // Some interlaced H.264 files in mp4 containers using MBAFF coding aren't flagged as being interlaced by FFprobe,
+                // so for H.264 files we also calculate the frame rate from the codec time base and check if it is double the reported
+                // frame rate to determine if the file is interlaced
+
                 bool h264MbaffCoded = string.Equals(stream.Codec, "h264", StringComparison.OrdinalIgnoreCase)
                     && string.IsNullOrWhiteSpace(streamInfo.FieldOrder)
-                    && roundedTimeBaseFPS == roundedDoubleFrameRate;
+                    && IsCodecTimeBaseDoubleTheFrameRate(stream.AverageFrameRate, stream.CodecTimeBase);
 
                 if (videoInterlaced || h264MbaffCoded)
                 {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1057,7 +1057,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            return divisor == 0f ? null : dividend / divisor;
+            return divisor == 0f || dividend == 0f ? null : dividend / divisor;
         }
 
         private void SetAudioRuntimeTicks(InternalMediaInfoResult result, MediaInfo data)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1067,7 +1067,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            return divisor == 0f || dividend == 0f ? null : dividend / divisor;
+            return divisor == 0f ? null : dividend / divisor;
         }
 
         private void SetAudioRuntimeTicks(InternalMediaInfoResult result, MediaInfo data)

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
         [InlineData("120/1", 120f)]
         [InlineData("1704753000/71073479", 23.98578237601117f)]
         [InlineData("0/0", null)]
+        [InlineData("0/1", null)]
         [InlineData("1/1000", 0.001f)]
         [InlineData("1/90000", 1.1111111E-05f)]
         [InlineData("1/48000", 2.0833333E-05f)]

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -25,7 +25,6 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
         [InlineData("120/1", 120f)]
         [InlineData("1704753000/71073479", 23.98578237601117f)]
         [InlineData("0/0", null)]
-        [InlineData("0/1", null)]
         [InlineData("1/1000", 0.001f)]
         [InlineData("1/90000", 1.1111111E-05f)]
         [InlineData("1/48000", 2.0833333E-05f)]

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -32,6 +32,16 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
         public void GetFrameRate_Success(string value, float? expected)
             => Assert.Equal(expected, ProbeResultNormalizer.GetFrameRate(value));
 
+        [Theory]
+        [InlineData(0.5f, "0/1", false)]
+        [InlineData(24.5f, "8/196", false)]
+        [InlineData(63.5f, "1/127", true)]
+        [InlineData(null, "1/60", false)]
+        [InlineData(30f, "2/120", true)]
+        [InlineData(59.999996f, "1563/187560", true)]
+        public void IsCodecTimeBaseDoubleTheFrameRate_Success(float? frameRate, string codecTimeBase, bool expected)
+            => Assert.Equal(expected, ProbeResultNormalizer.IsCodecTimeBaseDoubleTheFrameRate(frameRate, codecTimeBase));
+
         [Fact]
         public void GetMediaInfo_MetaData_Success()
         {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
The same fixes from https://github.com/jellyfin/jellyfin/pull/7120, but instead this includes some tests to ensure that the logic is correct. Was unsure on how I could push some commits to the existing branch so I made a new PR completely.

I could see why we wanted some tests, as the math conversion did seem quite complex, but after some testing it looks to be functioning correctly.

I broke out the method to make it testable, as the main method this logic sat in would require quite a lot of mocking which I am not too comfortable doing just yet, this stuff is still kinda black magic to me as I haven't ever written anything in C#.

**Issues**
No issues here, just fixing some ffprobe errors I was having previously from https://github.com/jellyfin/jellyfin/pull/7041
