### PR TITLE
Config option to import season name from TMDB

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
@@ -23,6 +23,11 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         public bool ExcludeTagsMovies { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether season name should be imported from TMDb.
+        /// </summary>
+        public bool ImportSeasonName { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating the maximum number of cast members to fetch for an item.
         /// </summary>
         public int MaxCastMembers { get; set; } = 15;

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
@@ -20,6 +20,10 @@
                         <input is="emby-checkbox" type="checkbox" id="excludeTagsMovies" />
                         <span>Exclude tags/keywords from metadata fetched for movies.</span>
                     </label>
+                    <label class="checkboxContainer">
+                        <input is="emby-checkbox" type="checkbox" id="importSeasonName" />
+                        <span>Import season name from metadata fetched for series.</span>
+                    </label>
                     <div class="inputContainer">
                         <input is="emby-input" type="number" id="maxCastMembers" pattern="[0-9]*" required min="0" max="1000" label="Max Cast Members" />
                         <div class="fieldDescription">The maximum number of cast members to fetch for an item.</div>
@@ -98,6 +102,7 @@
                         document.querySelector('#includeAdult').checked = config.IncludeAdult;
                         document.querySelector('#excludeTagsSeries').checked = config.ExcludeTagsSeries;
                         document.querySelector('#excludeTagsMovies').checked = config.ExcludeTagsMovies;
+                        document.querySelector('#importSeasonName').checked = config.ImportSeasonName;
 
                         var maxCastMembers = document.querySelector('#maxCastMembers');
                         maxCastMembers.value = config.MaxCastMembers;
@@ -120,6 +125,7 @@
                         config.IncludeAdult = document.querySelector('#includeAdult').checked;
                         config.ExcludeTagsSeries = document.querySelector('#excludeTagsSeries').checked;
                         config.ExcludeTagsMovies = document.querySelector('#excludeTagsMovies').checked;
+                        config.ImportSeasonName = document.querySelector('#importSeasonName').checked;
                         config.MaxCastMembers = document.querySelector('#maxCastMembers').value;
                         config.PosterSize = document.querySelector('#selectPosterSize').value;
                         config.BackdropSize = document.querySelector('#selectBackdropSize').value;

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
@@ -59,6 +59,11 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 Overview = seasonResult.Overview
             };
 
+            if ((Plugin.Instance?.Configuration.ImportSeasonName).GetValueOrDefault())
+            {
+                result.Item.Name = seasonResult.Name;
+            }
+
             if (!string.IsNullOrEmpty(seasonResult.ExternalIds?.TvdbId))
             {
                 result.Item.SetProviderId(MetadataProvider.Tvdb, seasonResult.ExternalIds.TvdbId);

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
@@ -59,7 +59,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 Overview = seasonResult.Overview
             };
 
-            if ((Plugin.Instance?.Configuration.ImportSeasonName).GetValueOrDefault())
+            if (Plugin.Instance.Configuration.ImportSeasonName)
             {
                 result.Item.Name = seasonResult.Name;
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Adds a configuration option to TMDB plugin to import season names from TMDB. Defaults to false, so same behavior is maintained.

I tested with a couple series, some with season names, some with out. Worked fine. I was not able to reproduce errors described in #4948 or #4134. Additional testing would be welcomed.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2320