### PR TITLE
Ignore JSON serialization for special features of movie.

### DIFF
--- a/MediaBrowser.Controller/Entities/Movies/Movie.cs
+++ b/MediaBrowser.Controller/Entities/Movies/Movie.cs
@@ -20,6 +20,7 @@ namespace MediaBrowser.Controller.Entities.Movies
     public class Movie : Video, IHasSpecialFeatures, IHasTrailers, IHasLookupInfo<MovieInfo>, ISupportsBoxSetGrouping
     {
         /// <inheritdoc />
+        [JsonIgnore]
         public IReadOnlyList<Guid> SpecialFeatureIds => GetExtras()
             .Where(extra => extra.ExtraType != null && extra is Video)
             .Select(extra => extra.Id)


### PR DESCRIPTION
_Continuation of #7136_

**Changes**
Add `JsonIgnore` to special features of movie.

**Issues**
When refreshing the metadata of the video with a local trailer, the server gets stuck trying to read the database and save the item at the same time.
