### PR TITLE
Fix trailers duplication

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1102,12 +1102,14 @@ namespace Emby.Server.Implementations.Dto
 
             if (options.ContainsField(ItemFields.LocalTrailerCount))
             {
-                allExtras ??= item.GetExtras().ToArray();
-                dto.LocalTrailerCount = allExtras.Count(i => i.ExtraType == ExtraType.Trailer);
-
                 if (item is IHasTrailers hasTrailers)
                 {
-                    dto.LocalTrailerCount += hasTrailers.GetTrailerCount();
+                    dto.LocalTrailerCount = hasTrailers.GetTrailerCount();
+                }
+                else
+                {
+                    allExtras ??= item.GetExtras().ToArray();
+                    dto.LocalTrailerCount = allExtras.Count(i => i.ExtraType == ExtraType.Trailer);
                 }
             }
 

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1108,8 +1108,7 @@ namespace Emby.Server.Implementations.Dto
                 }
                 else
                 {
-                    allExtras ??= item.GetExtras().ToArray();
-                    dto.LocalTrailerCount = allExtras.Count(i => i.ExtraType == ExtraType.Trailer);
+                    dto.LocalTrailerCount = (allExtras ?? item.GetExtras()).Count(i => i.ExtraType == ExtraType.Trailer);
                 }
             }
 

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -206,21 +206,19 @@ namespace Jellyfin.Api.Controllers
                 : _libraryManager.GetItemById(itemId);
 
             var dtoOptions = new DtoOptions().AddClientFields(Request);
-            var dtosExtras = item.GetExtras(new[] { ExtraType.Trailer })
-                .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
-                .ToArray();
 
             if (item is IHasTrailers hasTrailers)
             {
                 var trailers = hasTrailers.LocalTrailers;
                 var dtosTrailers = _dtoService.GetBaseItemDtos(trailers, dtoOptions, user, item);
-                var allTrailers = new BaseItemDto[dtosExtras.Length + dtosTrailers.Count];
-                dtosExtras.CopyTo(allTrailers, 0);
-                dtosTrailers.CopyTo(allTrailers, dtosExtras.Length);
+                var allTrailers = new BaseItemDto[dtosTrailers.Count];
+                dtosTrailers.CopyTo(allTrailers, 0);
                 return allTrailers;
             }
 
-            return dtosExtras;
+            return item.GetExtras(new[] { ExtraType.Trailer })
+                .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
+                .ToArray();
         }
 
         /// <summary>

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -210,15 +210,12 @@ namespace Jellyfin.Api.Controllers
             if (item is IHasTrailers hasTrailers)
             {
                 var trailers = hasTrailers.LocalTrailers;
-                var dtosTrailers = _dtoService.GetBaseItemDtos(trailers, dtoOptions, user, item);
-                var allTrailers = new BaseItemDto[dtosTrailers.Count];
-                dtosTrailers.CopyTo(allTrailers, 0);
-                return allTrailers;
+                return Ok(_dtoService.GetBaseItemDtos(trailers, dtoOptions, user, item));
             }
 
-            return item.GetExtras(new[] { ExtraType.Trailer })
-                .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
-                .ToArray();
+            return Ok(item.GetExtras()
+                .Where(e => e.ExtraType == ExtraType.Trailer)
+                .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item)));
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
@@ -312,7 +312,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
                 var trailers = new List<MediaUrl>();
                 for (var i = 0; i < movieResult.Videos.Results.Count; i++)
                 {
-                    var video = movieResult.Videos.Results[0];
+                    var video = movieResult.Videos.Results[i];
                     if (!TmdbUtils.IsTrailerType(video))
                     {
                         continue;


### PR DESCRIPTION
**Changes**
- Fix duplication (same URL) of remote trailers
- Fix duplication of local trailers

**Issues**
- Wrong iterating over remote trailers causes duplication of remote trailers.
- `/LocalTrailers` endpoint returns doubled local trailers.
- `.LocalTrailerCount` is doubled as well.
