### PR TITLE
Fix SA1642 warning

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/ExtraResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/ExtraResolver.cs
@@ -20,7 +20,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
         private readonly IItemResolver[] _videoResolvers;
 
         /// <summary>
-        /// Initializes an new instance of the <see cref="ExtraResolver"/> class.
+        /// Initializes a new instance of the <see cref="ExtraResolver"/> class.
         /// </summary>
         /// <param name="namingOptions">An instance of <see cref="NamingOptions"/>.</param>
         public ExtraResolver(NamingOptions namingOptions)


### PR DESCRIPTION
**Changes**
Fix summary documentation.

**Issues**
`warning SA1642: Constructor summary documentation should begin with standard text`
