### PR TITLE
Order extra rules so directory takes precedence over naming

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -582,6 +582,12 @@ namespace Emby.Naming.Common
                     ExtraType.Clip,
                     ExtraRuleType.Suffix,
                     "-short",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Unknown,
+                    ExtraRuleType.Suffix,
+                    "-extra",
                     MediaType.Video)
             };
 

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -411,6 +411,66 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
+                    ExtraType.ThemeVideo,
+                    ExtraRuleType.DirectoryName,
+                    "backdrops",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.ThemeSong,
+                    ExtraRuleType.DirectoryName,
+                    "theme-music",
+                    MediaType.Audio),
+
+                new ExtraRule(
+                    ExtraType.BehindTheScenes,
+                    ExtraRuleType.DirectoryName,
+                    "behind the scenes",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.DeletedScene,
+                    ExtraRuleType.DirectoryName,
+                    "deleted scenes",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Interview,
+                    ExtraRuleType.DirectoryName,
+                    "interviews",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Scene,
+                    ExtraRuleType.DirectoryName,
+                    "scenes",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Sample,
+                    ExtraRuleType.DirectoryName,
+                    "samples",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Clip,
+                    ExtraRuleType.DirectoryName,
+                    "shorts",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Clip,
+                    ExtraRuleType.DirectoryName,
+                    "featurettes",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Unknown,
+                    ExtraRuleType.DirectoryName,
+                    "extras",
+                    MediaType.Video),
+
+                new ExtraRule(
                     ExtraType.Trailer,
                     ExtraRuleType.Filename,
                     "trailer",
@@ -471,21 +531,9 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
-                    ExtraType.ThemeVideo,
-                    ExtraRuleType.DirectoryName,
-                    "backdrops",
-                    MediaType.Video),
-
-                new ExtraRule(
                     ExtraType.ThemeSong,
                     ExtraRuleType.Filename,
                     "theme",
-                    MediaType.Audio),
-
-                new ExtraRule(
-                    ExtraType.ThemeSong,
-                    ExtraRuleType.DirectoryName,
-                    "theme-music",
                     MediaType.Audio),
 
                 new ExtraRule(
@@ -534,54 +582,6 @@ namespace Emby.Naming.Common
                     ExtraType.Clip,
                     ExtraRuleType.Suffix,
                     "-short",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.BehindTheScenes,
-                    ExtraRuleType.DirectoryName,
-                    "behind the scenes",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.DeletedScene,
-                    ExtraRuleType.DirectoryName,
-                    "deleted scenes",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Interview,
-                    ExtraRuleType.DirectoryName,
-                    "interviews",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Scene,
-                    ExtraRuleType.DirectoryName,
-                    "scenes",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Sample,
-                    ExtraRuleType.DirectoryName,
-                    "samples",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Clip,
-                    ExtraRuleType.DirectoryName,
-                    "shorts",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Clip,
-                    ExtraRuleType.DirectoryName,
-                    "featurettes",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Unknown,
-                    ExtraRuleType.DirectoryName,
-                    "extras",
                     MediaType.Video)
             };
 

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -60,7 +60,8 @@ public class FindExtrasTests
             "/movies/Up/Up.mkv",
             "/movies/Up/Up - trailer.mkv",
             "/movies/Up/Up - sample.mkv",
-            "/movies/Up/Up something else.mkv"
+            "/movies/Up/Up something else.mkv",
+            "/movies/Up/Up-extra.mkv"
         };
 
         var files = paths.Select(p => new FileSystemMetadata
@@ -71,10 +72,11 @@ public class FindExtrasTests
 
         var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
 
-        Assert.Equal(2, extras.Count);
-        Assert.Equal(ExtraType.Trailer, extras[0].ExtraType);
-        Assert.Equal(typeof(Trailer), extras[0].GetType());
-        Assert.Equal(ExtraType.Sample, extras[1].ExtraType);
+        Assert.Equal(3, extras.Count);
+        Assert.Equal(ExtraType.Unknown, extras[0].ExtraType);
+        Assert.Equal(ExtraType.Trailer, extras[1].ExtraType);
+        Assert.Equal(typeof(Trailer), extras[1].GetType());
+        Assert.Equal(ExtraType.Sample, extras[2].ExtraType);
     }
 
     [Fact]

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -92,7 +92,8 @@ public class FindExtrasTests
             "/movies/Up/behind the scenes",
             "/movies/Up/behind the scenes.mkv",
             "/movies/Up/Up - sample.mkv",
-            "/movies/Up/Up something else.mkv"
+            "/movies/Up/Up something else.mkv",
+            "/movies/Up/extras"
         };
 
         _fileSystemMock.Setup(f => f.GetFiles(
@@ -140,6 +141,21 @@ public class FindExtrasTests
                 }
             }).Verifiable();
 
+        _fileSystemMock.Setup(f => f.GetFiles(
+                "/movies/Up/extras",
+                It.IsAny<string[]>(),
+                false,
+                false))
+            .Returns(new List<FileSystemMetadata>
+            {
+                new()
+                {
+                    FullName = "/movies/Up/extras/Honest Trailer.mkv",
+                    Name = "Honest Trailer.mkv",
+                    IsDirectory = false
+                }
+            }).Verifiable();
+
         var files = paths.Select(p => new FileSystemMetadata
         {
             FullName = p,
@@ -150,17 +166,19 @@ public class FindExtrasTests
         var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
 
         _fileSystemMock.Verify();
-        Assert.Equal(6, extras.Count);
-        Assert.Equal(ExtraType.Trailer, extras[0].ExtraType);
-        Assert.Equal(typeof(Trailer), extras[0].GetType());
+        Assert.Equal(7, extras.Count);
+        Assert.Equal(ExtraType.Unknown, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
         Assert.Equal(ExtraType.Trailer, extras[1].ExtraType);
         Assert.Equal(typeof(Trailer), extras[1].GetType());
-        Assert.Equal(ExtraType.BehindTheScenes, extras[2].ExtraType);
-        Assert.Equal(ExtraType.Sample, extras[3].ExtraType);
-        Assert.Equal(ExtraType.ThemeSong, extras[4].ExtraType);
-        Assert.Equal(typeof(Audio), extras[4].GetType());
+        Assert.Equal(ExtraType.Trailer, extras[2].ExtraType);
+        Assert.Equal(typeof(Trailer), extras[2].GetType());
+        Assert.Equal(ExtraType.BehindTheScenes, extras[3].ExtraType);
+        Assert.Equal(ExtraType.Sample, extras[4].ExtraType);
         Assert.Equal(ExtraType.ThemeSong, extras[5].ExtraType);
         Assert.Equal(typeof(Audio), extras[5].GetType());
+        Assert.Equal(ExtraType.ThemeSong, extras[6].ExtraType);
+        Assert.Equal(typeof(Audio), extras[6].GetType());
     }
 
     [Fact]


### PR DESCRIPTION
Currently an item named "honest trailer.mkv" in the "extras" directory will fail to be attached to the movie as an extra because the suffix naming rule (` trailer`) is matched first by `ExtraRuleResolver` but `ExtraResolver` throws it out because the prefix doesn't match the movie name. Reordering the rules so directories are evaluated first fixes this.

**Changes**
- Moved `ExtraRuleType.DirectoryName` rules to top of list
- Added suffix rule `-extra` for consistency since it was the only directory not supported by a suffix rule
- Added tests for both rule changes

**Issues**
Fixes #7183
Fixes #3422 (indirectly - anything in the "extras" folder will now resolve as `ExtraType.Unknown` so it won't be picked up as a trailer)