### PR TITLE
Fix maximum video resolution for dynamic HLS controller

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -385,6 +385,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startTimeTicks">Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.</param>
         /// <param name="width">Optional. The fixed horizontal resolution of the encoded video.</param>
         /// <param name="height">Optional. The fixed vertical resolution of the encoded video.</param>
+        /// <param name="maxWidth">Optional. The maximum horizontal resolution of the encoded video.</param>
+        /// <param name="maxHeight">Optional. The maximum vertical resolution of the encoded video.</param>
         /// <param name="videoBitRate">Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this will be left to encoder defaults.</param>
         /// <param name="subtitleStreamIndex">Optional. The index of the subtitle stream to use. If omitted no subtitles will be used.</param>
         /// <param name="subtitleMethod">Optional. Specify the subtitle delivery method.</param>
@@ -441,6 +443,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] long? startTimeTicks,
             [FromQuery] int? width,
             [FromQuery] int? height,
+            [FromQuery] int? maxWidth,
+            [FromQuery] int? maxHeight,
             [FromQuery] int? videoBitRate,
             [FromQuery] int? subtitleStreamIndex,
             [FromQuery] SubtitleDeliveryMethod? subtitleMethod,
@@ -493,6 +497,8 @@ namespace Jellyfin.Api.Controllers
                 StartTimeTicks = startTimeTicks,
                 Width = width,
                 Height = height,
+                MaxWidth = maxWidth,
+                MaxHeight = maxHeight,
                 VideoBitRate = videoBitRate,
                 SubtitleStreamIndex = subtitleStreamIndex,
                 SubtitleMethod = subtitleMethod ?? SubtitleDeliveryMethod.Encode,
@@ -717,6 +723,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startTimeTicks">Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.</param>
         /// <param name="width">Optional. The fixed horizontal resolution of the encoded video.</param>
         /// <param name="height">Optional. The fixed vertical resolution of the encoded video.</param>
+        /// <param name="maxWidth">Optional. The maximum horizontal resolution of the encoded video.</param>
+        /// <param name="maxHeight">Optional. The maximum vertical resolution of the encoded video.</param>
         /// <param name="videoBitRate">Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this will be left to encoder defaults.</param>
         /// <param name="subtitleStreamIndex">Optional. The index of the subtitle stream to use. If omitted no subtitles will be used.</param>
         /// <param name="subtitleMethod">Optional. Specify the subtitle delivery method.</param>
@@ -771,6 +779,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] long? startTimeTicks,
             [FromQuery] int? width,
             [FromQuery] int? height,
+            [FromQuery] int? maxWidth,
+            [FromQuery] int? maxHeight,
             [FromQuery] int? videoBitRate,
             [FromQuery] int? subtitleStreamIndex,
             [FromQuery] SubtitleDeliveryMethod? subtitleMethod,
@@ -823,6 +833,8 @@ namespace Jellyfin.Api.Controllers
                 StartTimeTicks = startTimeTicks,
                 Width = width,
                 Height = height,
+                MaxWidth = maxWidth,
+                MaxHeight = maxHeight,
                 VideoBitRate = videoBitRate,
                 SubtitleStreamIndex = subtitleStreamIndex,
                 SubtitleMethod = subtitleMethod ?? SubtitleDeliveryMethod.Encode,
@@ -1048,6 +1060,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startTimeTicks">Optional. Specify a starting offset, in ticks. 1 tick = 10000 ms.</param>
         /// <param name="width">Optional. The fixed horizontal resolution of the encoded video.</param>
         /// <param name="height">Optional. The fixed vertical resolution of the encoded video.</param>
+        /// <param name="maxWidth">Optional. The maximum horizontal resolution of the encoded video.</param>
+        /// <param name="maxHeight">Optional. The maximum vertical resolution of the encoded video.</param>
         /// <param name="videoBitRate">Optional. Specify a video bitrate to encode to, e.g. 500000. If omitted this will be left to encoder defaults.</param>
         /// <param name="subtitleStreamIndex">Optional. The index of the subtitle stream to use. If omitted no subtitles will be used.</param>
         /// <param name="subtitleMethod">Optional. Specify the subtitle delivery method.</param>
@@ -1106,6 +1120,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] long? startTimeTicks,
             [FromQuery] int? width,
             [FromQuery] int? height,
+            [FromQuery] int? maxWidth,
+            [FromQuery] int? maxHeight,
             [FromQuery] int? videoBitRate,
             [FromQuery] int? subtitleStreamIndex,
             [FromQuery] SubtitleDeliveryMethod? subtitleMethod,
@@ -1158,6 +1174,8 @@ namespace Jellyfin.Api.Controllers
                 StartTimeTicks = startTimeTicks,
                 Width = width,
                 Height = height,
+                MaxWidth = maxWidth,
+                MaxHeight = maxHeight,
                 VideoBitRate = videoBitRate,
                 SubtitleStreamIndex = subtitleStreamIndex,
                 SubtitleMethod = subtitleMethod ?? SubtitleDeliveryMethod.Encode,


### PR DESCRIPTION
This is required for video playback from the browser.
_Probably something unnecessary._

**Changes**
Fix maximum video resolution for dynamic HLS controller

**Issues**
The maximum video resolution is not taken into account when playing video from the browser.

**See also**
#6274