### PR TITLE
Add TranscodingProfile conditions

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -699,6 +699,7 @@ namespace MediaBrowser.Model.Dlna
                     if (playlistItem.PlayMethod != PlayMethod.DirectPlay)
                     {
                         playlistItem.PlayMethod = PlayMethod.Transcode;
+                        ApplyTranscodingConditions(playlistItem, transcodingProfile.Conditions, null, true, true);
                     }
                 }
             }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -699,7 +699,11 @@ namespace MediaBrowser.Model.Dlna
                     if (playlistItem.PlayMethod != PlayMethod.DirectPlay)
                     {
                         playlistItem.PlayMethod = PlayMethod.Transcode;
-                        ApplyTranscodingConditions(playlistItem, transcodingProfile.Conditions, null, true, true);
+
+                        if ((playlistItem.TranscodeReasons & (VideoReasons | TranscodeReason.ContainerBitrateExceedsLimit)) != 0)
+                        {
+                            ApplyTranscodingConditions(playlistItem, transcodingProfile.Conditions, null, true, true);
+                        }
                     }
                 }
             }

--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
 
@@ -7,6 +8,11 @@ namespace MediaBrowser.Model.Dlna
 {
     public class TranscodingProfile
     {
+        public TranscodingProfile()
+        {
+            Conditions = Array.Empty<ProfileCondition>();
+        }
+
         [XmlAttribute("container")]
         public string Container { get; set; } = string.Empty;
 
@@ -60,6 +66,8 @@ namespace MediaBrowser.Model.Dlna
         [DefaultValue(false)]
         [XmlAttribute("breakOnNonKeyFrames")]
         public bool BreakOnNonKeyFrames { get; set; }
+
+        public ProfileCondition[] Conditions { get; set; }
 
         public string[] GetAudioCodecs()
         {


### PR DESCRIPTION
The idea is to add some control over the transcoding profile separately from the direct profiles.
For example, no resolution limit for DirectPlay, but no more screen size for transcoding.
Ideally, we need global conditions as well.

**Changes**
Add TranscodingProfile conditions
