### PR TITLE
Add 'IsHdr' codec condition

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -231,7 +231,8 @@ namespace Emby.Dlna.Didl
                 streamInfo.TargetVideoStreamCount,
                 streamInfo.TargetAudioStreamCount,
                 streamInfo.TargetVideoCodecTag,
-                streamInfo.IsTargetAVC);
+                streamInfo.IsTargetAVC,
+                streamInfo.IsTargetHDR);
 
             foreach (var contentFeature in contentFeatureList)
             {
@@ -386,7 +387,8 @@ namespace Emby.Dlna.Didl
                 streamInfo.TargetVideoStreamCount,
                 streamInfo.TargetAudioStreamCount,
                 streamInfo.TargetVideoCodecTag,
-                streamInfo.IsTargetAVC);
+                streamInfo.IsTargetAVC,
+                streamInfo.IsTargetHDR);
 
             var filename = url.Substring(0, url.IndexOf('?', StringComparison.Ordinal));
 

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -567,7 +567,8 @@ namespace Emby.Dlna.PlayTo
                         streamInfo.TargetVideoStreamCount,
                         streamInfo.TargetAudioStreamCount,
                         streamInfo.TargetVideoCodecTag,
-                        streamInfo.IsTargetAVC);
+                        streamInfo.IsTargetAVC,
+                        streamInfo.IsTargetHDR);
 
                 return list.Count == 0 ? null : list[0];
             }

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -156,6 +156,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <param name="maxWidth">Optional. The max width.</param>
@@ -214,6 +215,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions,
             [FromQuery] int? maxWidth,
@@ -269,6 +271,7 @@ namespace Jellyfin.Api.Controllers
                 TranscodeReasons = transcodeReasons,
                 AudioStreamIndex = audioStreamIndex,
                 VideoStreamIndex = videoStreamIndex,
+                RequireNonHdr = requireNonHdr ?? false,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions,
                 MaxHeight = maxHeight,
@@ -402,6 +405,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
@@ -458,6 +462,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions,
             [FromQuery] bool enableAdaptiveBitrateStreaming = true)
@@ -510,6 +515,7 @@ namespace Jellyfin.Api.Controllers
                 TranscodeReasons = transcodeReasons,
                 AudioStreamIndex = audioStreamIndex,
                 VideoStreamIndex = videoStreamIndex,
+                RequireNonHdr = requireNonHdr ?? false,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions,
                 EnableAdaptiveBitrateStreaming = enableAdaptiveBitrateStreaming
@@ -734,6 +740,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
@@ -788,6 +795,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions)
         {
@@ -840,6 +848,7 @@ namespace Jellyfin.Api.Controllers
                 TranscodeReasons = transcodeReasons,
                 AudioStreamIndex = audioStreamIndex,
                 VideoStreamIndex = videoStreamIndex,
+                RequireNonHdr = requireNonHdr ?? false,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions
             };
@@ -1065,6 +1074,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
@@ -1123,6 +1133,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions)
         {
@@ -1175,6 +1186,7 @@ namespace Jellyfin.Api.Controllers
                 TranscodeReasons = transcodeReasons,
                 AudioStreamIndex = audioStreamIndex,
                 VideoStreamIndex = videoStreamIndex,
+                RequireNonHdr = requireNonHdr ?? false,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions
             };

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -313,6 +313,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
@@ -371,6 +372,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions)
         {
@@ -428,6 +430,7 @@ namespace Jellyfin.Api.Controllers
                 TranscodeReasons = transcodeReasons,
                 AudioStreamIndex = audioStreamIndex,
                 VideoStreamIndex = videoStreamIndex,
+                RequireNonHdr = requireNonHdr ?? false,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions
             };
@@ -569,6 +572,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="transcodeReasons">Optional. The transcoding reason.</param>
         /// <param name="audioStreamIndex">Optional. The index of the audio stream to use. If omitted the first audio stream will be used.</param>
         /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
+        /// <param name="requireNonHdr">Optional. Whether to require a non HDR stream.</param>
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <response code="200">Video stream returned.</response>
@@ -627,6 +631,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? transcodeReasons,
             [FromQuery] int? audioStreamIndex,
             [FromQuery] int? videoStreamIndex,
+            [FromQuery] bool? requireNonHdr,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions)
         {
@@ -680,6 +685,7 @@ namespace Jellyfin.Api.Controllers
                 transcodeReasons,
                 audioStreamIndex,
                 videoStreamIndex,
+                requireNonHdr,
                 context,
                 streamOptions);
         }

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -312,7 +312,7 @@ namespace Jellyfin.Api.Helpers
 
                 responseHeaders.Add(
                     "contentFeatures.dlna.org",
-                    ContentFeatureBuilder.BuildVideoHeader(profile, state.OutputContainer, videoCodec, audioCodec, state.OutputWidth, state.OutputHeight, state.TargetVideoBitDepth, state.OutputVideoBitrate, state.TargetTimestamp, isStaticallyStreamed, state.RunTimeTicks, state.TargetVideoProfile, state.TargetVideoLevel, state.TargetFramerate, state.TargetPacketLength, state.TranscodeSeekInfo, state.IsTargetAnamorphic, state.IsTargetInterlaced, state.TargetRefFrames, state.TargetVideoStreamCount, state.TargetAudioStreamCount, state.TargetVideoCodecTag, state.IsTargetAVC).FirstOrDefault() ?? string.Empty);
+                    ContentFeatureBuilder.BuildVideoHeader(profile, state.OutputContainer, videoCodec, audioCodec, state.OutputWidth, state.OutputHeight, state.TargetVideoBitDepth, state.OutputVideoBitrate, state.TargetTimestamp, isStaticallyStreamed, state.RunTimeTicks, state.TargetVideoProfile, state.TargetVideoLevel, state.TargetFramerate, state.TargetPacketLength, state.TranscodeSeekInfo, state.IsTargetAnamorphic, state.IsTargetInterlaced, state.TargetRefFrames, state.TargetVideoStreamCount, state.TargetAudioStreamCount, state.TargetVideoCodecTag, state.IsTargetAVC, state.IsTargetHDR).FirstOrDefault() ?? string.Empty);
             }
         }
 
@@ -543,7 +543,8 @@ namespace Jellyfin.Api.Helpers
                     state.TargetVideoStreamCount,
                     state.TargetAudioStreamCount,
                     state.TargetVideoCodecTag,
-                    state.IsTargetAVC);
+                    state.IsTargetAVC,
+                    state.IsTargetHDR);
 
             if (mediaProfile != null)
             {

--- a/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
+++ b/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
@@ -145,6 +145,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public bool RequireNonAnamorphic { get; set; }
 
+        public bool RequireNonHdr { get; set; }
+
         public int? TranscodingMaxAudioChannels { get; set; }
 
         public int? CpuCoreLimit { get; set; }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1660,6 +1660,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
             }
 
+            if (videoStream.IsHDR && request.RequireNonHdr)
+            {
+                return false;
+            }
+
             // Can't stream copy if we're burning in subtitles
             if (request.SubtitleStreamIndex.HasValue
                 && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -463,6 +463,19 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
         }
 
+        public bool? IsTargetHDR
+        {
+            get
+            {
+                if (BaseRequest.Static || EncodingHelper.IsCopyCodec(OutputVideoCodec))
+                {
+                    return VideoStream?.IsHDR;
+                }
+
+                return false;
+            }
+        }
+
         public int? TargetVideoStreamCount
         {
             get

--- a/MediaBrowser.Model/Dlna/ConditionProcessor.cs
+++ b/MediaBrowser.Model/Dlna/ConditionProcessor.cs
@@ -26,7 +26,8 @@ namespace MediaBrowser.Model.Dlna
             int? numVideoStreams,
             int? numAudioStreams,
             string? videoCodecTag,
-            bool? isAvc)
+            bool? isAvc,
+            bool? isHdr)
         {
             switch (condition.Property)
             {
@@ -62,6 +63,8 @@ namespace MediaBrowser.Model.Dlna
                     return IsConditionSatisfied(condition, numVideoStreams);
                 case ProfileConditionValue.VideoTimestamp:
                     return IsConditionSatisfied(condition, timestamp);
+                case ProfileConditionValue.IsHdr:
+                    return IsConditionSatisfied(condition, isHdr);
                 default:
                     return true;
             }

--- a/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
+++ b/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
@@ -138,7 +138,8 @@ namespace MediaBrowser.Model.Dlna
             int? numVideoStreams,
             int? numAudioStreams,
             string videoCodecTag,
-            bool? isAvc)
+            bool? isAvc,
+            bool? isHdr)
         {
             // first bit means Time based seek supported, second byte range seek supported (not sure about the order now), so 01 = only byte seek, 10 = time based, 11 = both, 00 = none
             string orgOp = ";DLNA.ORG_OP=" + DlnaMaps.GetOrgOpValue(runtimeTicks > 0, isDirectStream, transcodeSeekInfo);
@@ -186,7 +187,8 @@ namespace MediaBrowser.Model.Dlna
                 numVideoStreams,
                 numAudioStreams,
                 videoCodecTag,
-                isAvc);
+                isAvc,
+                isHdr);
 
             var orgPnValues = new List<string>();
 

--- a/MediaBrowser.Model/Dlna/DeviceProfile.cs
+++ b/MediaBrowser.Model/Dlna/DeviceProfile.cs
@@ -434,6 +434,7 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="numAudioStreams">The number of audio streams.</param>
         /// <param name="videoCodecTag">The video Codec tag.</param>
         /// <param name="isAvc">True if Avc.</param>
+        /// <param name="isHdr">True if HDR.</param>
         /// <returns>The <see cref="ResponseProfile"/>.</returns>
         public ResponseProfile? GetVideoMediaProfile(
             string container,
@@ -454,7 +455,8 @@ namespace MediaBrowser.Model.Dlna
             int? numVideoStreams,
             int? numAudioStreams,
             string videoCodecTag,
-            bool? isAvc)
+            bool? isAvc,
+            bool? isHdr)
         {
             foreach (var i in ResponseProfiles)
             {
@@ -483,7 +485,7 @@ namespace MediaBrowser.Model.Dlna
                 var anyOff = false;
                 foreach (ProfileCondition c in i.Conditions)
                 {
-                    if (!ConditionProcessor.IsVideoConditionSatisfied(GetModelProfileCondition(c), width, height, bitDepth, videoBitrate, videoProfile, videoLevel, videoFramerate, packetLength, timestamp, isAnamorphic, isInterlaced, refFrames, numVideoStreams, numAudioStreams, videoCodecTag, isAvc))
+                    if (!ConditionProcessor.IsVideoConditionSatisfied(GetModelProfileCondition(c), width, height, bitDepth, videoBitrate, videoProfile, videoLevel, videoFramerate, packetLength, timestamp, isAnamorphic, isInterlaced, refFrames, numVideoStreams, numAudioStreams, videoCodecTag, isAvc, isHdr))
                     {
                         anyOff = true;
                         break;

--- a/MediaBrowser.Model/Dlna/ProfileConditionValue.cs
+++ b/MediaBrowser.Model/Dlna/ProfileConditionValue.cs
@@ -26,6 +26,7 @@ namespace MediaBrowser.Model.Dlna
         IsAvc = 20,
         IsInterlaced = 21,
         AudioSampleRate = 22,
-        AudioBitDepth = 23
+        AudioBitDepth = 23,
+        IsHdr = 24
     }
 }

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -51,6 +51,8 @@ namespace MediaBrowser.Model.Dlna
 
         public bool RequireNonAnamorphic { get; set; }
 
+        public bool RequireNonHdr { get; set; }
+
         public bool CopyTimestamps { get; set; }
 
         public bool EnableMpegtsM2TsMode { get; set; }
@@ -494,6 +496,19 @@ namespace MediaBrowser.Model.Dlna
             }
         }
 
+        public bool? IsTargetHDR
+        {
+            get
+            {
+                if (IsDirectStream)
+                {
+                    return TargetVideoStream == null ? null : TargetVideoStream.IsHDR;
+                }
+
+                return false;
+            }
+        }
+
         public int? TargetWidth
         {
             get
@@ -729,6 +744,11 @@ namespace MediaBrowser.Model.Dlna
                 if (item.RequireNonAnamorphic)
                 {
                     list.Add(new NameValuePair("RequireNonAnamorphic", item.RequireNonAnamorphic.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()));
+                }
+
+                if (item.RequireNonHdr)
+                {
+                    list.Add(new NameValuePair("RequireNonHdr", item.RequireNonHdr.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()));
                 }
 
                 list.Add(new NameValuePair("TranscodingMaxAudioChannels", item.TranscodingMaxAudioChannels.HasValue ? item.TranscodingMaxAudioChannels.Value.ToString(CultureInfo.InvariantCulture) : string.Empty));

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -121,6 +121,18 @@ namespace MediaBrowser.Model.Entities
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has HDR.
+        /// </summary>
+        /// <value><c>true</c> if this instance has HDR; otherwise, <c>false</c>.</value>
+        public bool IsHDR
+        {
+            get
+            {
+                return string.Equals(VideoRange, "HDR", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
         public string LocalizedUndefined { get; set; }
 
         public string LocalizedDefault { get; set; }

--- a/MediaBrowser.Model/Session/TranscodeReason.cs
+++ b/MediaBrowser.Model/Session/TranscodeReason.cs
@@ -27,6 +27,7 @@ namespace MediaBrowser.Model.Session
         AudioBitDepthNotSupported = 20,
         SubtitleCodecNotSupported = 21,
         DirectPlayError = 22,
-        AudioIsExternal = 23
+        AudioIsExternal = 23,
+        VideoRangeNotSupported = 24
     }
 }


### PR DESCRIPTION
_This is my old PR. I haven't tested it since that day._

The idea is that the client can limit the color range - block HDR even if it is supported.

**Changes**
Add 'IsHdr' codec condition

_I think it would be better to replace `IsHdr` with a string of video ranges._