### PR TITLE
Add option to change unix socket permissions

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -689,9 +689,9 @@ namespace Jellyfin.Server
             if (!string.IsNullOrEmpty(socketPerms))
             {
                 [DllImport("libc")]
-                static extern int chmod(string pathname, int mode);
+                static extern int Chmod(string pathname, int mode);
 
-                var exitCode = chmod(socketPath, Convert.ToInt32(socketPerms, 8));
+                var exitCode = Chmod(socketPath, Convert.ToInt32(socketPerms, 8));
 
                 if (exitCode < 0)
                 {

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -50,6 +50,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string UnixSocketPathKey = "kestrel:socketPath";
 
         /// <summary>
+        /// The permissions for the unix socket.
+        /// </summary>
+        public const string UnixSocketPermissionsKey = "kestrel:socketPermissions";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>
@@ -97,5 +102,13 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The unix socket path.</returns>
         public static string GetUnixSocketPath(this IConfiguration configuration)
             => configuration[UnixSocketPathKey];
+
+        /// <summary>
+        /// Gets the permissions for the unix socket from the <see cref="IConfiguration" />.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns>The unix socket permissions.</returns>
+        public static string GetUnixSocketPermissions(this IConfiguration configuration)
+            => configuration[UnixSocketPermissionsKey];
     }
 }


### PR DESCRIPTION
Using P/Invoke might look scary, but since we're limited to unices and libc, this should work pretty reliably.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
When new configuration parameter `kestrel:socketPermissions` is set (e.g. `0777`), try to change the unix socket's permissions to its value.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #5311
