### PR TITLE
Fix resolving local alternates

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -591,6 +591,10 @@ namespace Emby.Naming.Common
                     MediaType.Video)
             };
 
+            AllExtrasTypesFolderNames = VideoExtraRules
+                .Where(i => i.RuleType == ExtraRuleType.DirectoryName)
+                .ToDictionary(i => i.Token, i => i.ExtraType, StringComparer.OrdinalIgnoreCase);
+
             Format3DRules = new[]
             {
                 // Kodi rules:
@@ -679,6 +683,10 @@ namespace Emby.Naming.Common
                 ".mxf"
             });
 
+            VideoFileExtensions = extensions
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
             MultipleEpisodeExpressions = new[]
             {
                 @".*(\\|\/)[sS]?(?<seasonnumber>[0-9]{1,4})[xX](?<epnumber>[0-9]{1,3})((-| - )[0-9]{1,4}[eExX](?<endingepnumber>[0-9]{1,3}))+[^\\\/]*$",
@@ -695,25 +703,6 @@ namespace Emby.Naming.Common
             {
                 IsNamed = true
             }).ToArray();
-
-            VideoFileExtensions = extensions
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            AllExtrasTypesFolderNames = new Dictionary<string, ExtraType>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["trailers"] = ExtraType.Trailer,
-                ["theme-music"] = ExtraType.ThemeSong,
-                ["backdrops"] = ExtraType.ThemeVideo,
-                ["extras"] = ExtraType.Unknown,
-                ["behind the scenes"] = ExtraType.BehindTheScenes,
-                ["deleted scenes"] = ExtraType.DeletedScene,
-                ["interviews"] = ExtraType.Interview,
-                ["scenes"] = ExtraType.Scene,
-                ["samples"] = ExtraType.Sample,
-                ["shorts"] = ExtraType.Clip,
-                ["featurettes"] = ExtraType.Clip
-            };
 
             Compile();
         }

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -128,10 +128,9 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 return movie?.ExtraType == null ? movie : null;
             }
 
-            // Owned items will be caught by the video extra resolver
             if (args.Parent == null)
             {
-                return null;
+                return base.Resolve(args);
             }
 
             if (IsInvalid(args.Parent, collectionType))

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MovieResolverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MovieResolverTests.cs
@@ -1,0 +1,34 @@
+using Emby.Naming.Common;
+using Emby.Server.Implementations.Library.Resolvers.Movies;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class MovieResolverTests
+{
+    private static readonly NamingOptions _namingOptions = new();
+
+    [Fact]
+    public void Resolve_GivenLocalAlternateVersion_ResolvesToVideo()
+    {
+        var movieResolver = new MovieResolver(Mock.Of<IImageProcessor>(), _namingOptions);
+        var itemResolveArgs = new ItemResolveArgs(
+            Mock.Of<IServerApplicationPaths>(),
+            Mock.Of<IDirectoryService>())
+        {
+            Parent = null,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = "/movies/Black Panther (2018)/Black Panther (2018) - 1080p 3D.mk3d"
+            }
+        };
+
+        Assert.NotNull(movieResolver.Resolve(itemResolveArgs));
+    }
+}


### PR DESCRIPTION
**Changes**
- Restore resolver that handles local alternates
- Test resolver
- Generate extra folder names dictionary instead of duplicating hardcoded strings

**Issues**
Fixes #7189
Fixes #7155