### PR TITLE
UserView Thumbnail fixes

### DIFF
--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -135,7 +135,7 @@ namespace Emby.Server.Implementations.Images
 
         protected virtual IEnumerable<string> GetStripCollageImagePaths(BaseItem primaryItem, IEnumerable<BaseItem> items)
         {
-            var useBackdrop = primaryItem is CollectionFolder;
+            var useBackdrop = primaryItem is CollectionFolder || primaryItem is UserView;
             return items
                 .Select(i =>
                 {

--- a/Emby.Server.Implementations/Images/DynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/DynamicImageProvider.cs
@@ -84,16 +84,20 @@ namespace Emby.Server.Implementations.Images
             }).GroupBy(x => x.Id)
             .Select(x => x.First());
 
+            List<BaseItem> returnItems;
             if (isUsingCollectionStrip)
             {
-                return items
+                returnItems = items
                     .Where(i => i.HasImage(ImageType.Primary) || i.HasImage(ImageType.Thumb))
                     .ToList();
+                returnItems.Shuffle();
+                return returnItems;
             }
-
-            return items
+            returnItems = items
                 .Where(i => i.HasImage(ImageType.Primary))
                 .ToList();
+            returnItems.Shuffle();
+            return returnItems;
         }
 
         protected override bool Supports(BaseItem item)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

- UserView thumbnail (like when you group multiple libraries of the same type together on the homepage) was using poster images, not backdrop. 
- Image selected would never change, shuffle available items with images.
