### PR TITLE
Fix h264_v4l2m2m acceleration in Raspberry Pi 4

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1281,11 +1281,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 param += " -low_power 1";
             }
 
-            if (string.Equals(videoEncoder, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
-            {
-                param += " -pix_fmt yuv420p";
-            }
-
             var isVc1 = string.Equals(state.VideoStream?.Codec, "vc1", StringComparison.OrdinalIgnoreCase);
             var isLibX265 = string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase);
 
@@ -2695,6 +2690,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var vidDecoder = GetHardwareVideoDecoder(state, options) ?? string.Empty;
             var isSwDecoder = string.IsNullOrEmpty(vidDecoder);
             var isVaapiEncoder = vidEncoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase);
+            var isV4l2Encoder = vidEncoder.Contains("h264_v4l2m2m", StringComparison.OrdinalIgnoreCase);
 
             var doDeintH264 = state.DeInterlace("h264", true) || state.DeInterlace("avc", true);
             var doDeintHevc = state.DeInterlace("h265", true) || state.DeInterlace("hevc", true);
@@ -2722,6 +2718,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (isVaapiEncoder)
             {
                 outFormat = "nv12";
+            }
+            else if (isV4l2Encoder)
+            {
+                outFormat = "yuv420p";
             }
 
             // sw scale

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1283,7 +1283,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(videoEncoder, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
             {
-                param += " -pix_fmt nv21";
+                param += " -pix_fmt yuv420p";
             }
 
             var isVc1 = string.Equals(state.VideoStream?.Codec, "vc1", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixed by replacing pixel format from NV21 to yuv420p.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Error when enabling v4l acceleration in Raspberry Pi 4
Logs:
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'file:/srv/dev-disk-by-uuid-17558f66-a74f-4416-b283-4c70bb44b6f8/MediaLibrary/Movie/test.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 1
    compatible_brands: isomavc1
    creation_time   : 2015-04-23T22:01:41.000000Z
  Duration: 02:08:29.76, start: 0.000000, bitrate: 2173 kb/s
    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709/bt709/unknown), 1920x800 [SAR 1:1 DAR 12:5], 2075 kb/s, 23.98 fps, 23.98 tbr, 24k tbn, 47.95 tbc (default)
    Metadata:
      creation_time   : 2015-04-23T22:01:41.000000Z
      handler_name    : video.264#trackID=1:fps=23.976 - Imported with GPAC 0.5.0-rev
    Stream #0:1(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 93 kb/s (default)
    Metadata:
      creation_time   : 2015-04-23T22:01:53.000000Z
      handler_name    : GPAC ISO Audio Handler
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> h264 (h264_v4l2m2m))
  Stream #0:1 -> #0:1 (aac (native) -> aac (native))
Press [q] to stop, [?] for help
[h264_v4l2m2m @ 0x559ce26380] Using device /dev/video11
[h264_v4l2m2m @ 0x559ce26380] driver 'bcm2835-codec' on card 'bcm2835-codec-encode' in mplane mode
[h264_v4l2m2m @ 0x559ce26380] requesting formats: output=YU12 capture=H264
[h264_v4l2m2m @ 0x559ce26380] Encoder requires yuv420p pixel format.
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
Conversion failed!