### PR TITLE
chore: Add a read only connection for routes like Shows/NextUp

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -97,6 +97,7 @@ namespace Emby.Server.Implementations.Data
         /// </summary>
         /// <value>The write connection.</value>
         protected SQLiteDatabaseConnection WriteConnection { get; set; }
+
         protected SQLiteDatabaseConnection ReadConnection { get; set; }
 
         protected ManagedConnection GetConnection(bool readOnly = false)
@@ -104,7 +105,7 @@ namespace Emby.Server.Implementations.Data
             if (readOnly)
             {
                 ReadConnection ??= SQLite3.Open(DbFilePath, ConnectionFlags.ReadOnly, null);
-                return new ManagedConnection(ReadConnection, null!);
+                return new ManagedConnection(ReadConnection, null);
             }
 
             WriteLock.Wait();

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -103,8 +103,8 @@ namespace Emby.Server.Implementations.Data
         {
             if (readOnly)
             {
-                ReadConnection ??= SQLite3.Open(DbFilePath, DefaultConnectionFlags | ConnectionFlags.ReadOnly, null);
-                return new ManagedConnection(ReadConnection, null);
+                ReadConnection ??= SQLite3.Open(DbFilePath, ConnectionFlags.ReadOnly, null);
+                return new ManagedConnection(ReadConnection, null!);
             }
 
             WriteLock.Wait();

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -97,9 +97,16 @@ namespace Emby.Server.Implementations.Data
         /// </summary>
         /// <value>The write connection.</value>
         protected SQLiteDatabaseConnection WriteConnection { get; set; }
+        protected SQLiteDatabaseConnection ReadConnection { get; set; }
 
         protected ManagedConnection GetConnection(bool readOnly = false)
         {
+            if (readOnly)
+            {
+                ReadConnection ??= SQLite3.Open(DbFilePath, DefaultConnectionFlags | ConnectionFlags.ReadOnly, null);
+                return new ManagedConnection(ReadConnection, null);
+            }
+
             WriteLock.Wait();
             if (WriteConnection != null)
             {

--- a/Emby.Server.Implementations/Data/ManagedConnection.cs
+++ b/Emby.Server.Implementations/Data/ManagedConnection.cs
@@ -9,11 +9,12 @@ namespace Emby.Server.Implementations.Data
 {
     public sealed class ManagedConnection : IDisposable
     {
-        private readonly SemaphoreSlim _writeLock;
+        private readonly SemaphoreSlim? _writeLock;
 
         private SQLiteDatabaseConnection? _db;
 
-        private bool _disposed = false;
+        private bool _disposed;
+
 
         public ManagedConnection(SQLiteDatabaseConnection db, SemaphoreSlim writeLock)
         {
@@ -73,7 +74,7 @@ namespace Emby.Server.Implementations.Data
                 return;
             }
 
-            _writeLock.Release();
+            _writeLock?.Release();
 
             _db = null; // Don't dispose it
             _disposed = true;

--- a/Emby.Server.Implementations/Data/ManagedConnection.cs
+++ b/Emby.Server.Implementations/Data/ManagedConnection.cs
@@ -15,8 +15,7 @@ namespace Emby.Server.Implementations.Data
 
         private bool _disposed;
 
-
-        public ManagedConnection(SQLiteDatabaseConnection db, SemaphoreSlim writeLock)
+        public ManagedConnection(SQLiteDatabaseConnection db, SemaphoreSlim? writeLock)
         {
             _db = db;
             _writeLock = writeLock;


### PR DESCRIPTION
This is an atempt to reduce the number of locks reported on #7237 by having a connection that can be shared among the threads without a semaphore
