### PR TITLE
Rewatching next up

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -140,7 +140,7 @@ namespace Emby.Server.Implementations.TV
             var currentUser = user;
 
             var allNextUp = seriesKeys
-                .Select(i => GetNextUp(i, currentUser, dtoOptions));
+                .Select(i => GetNextUp(i, currentUser, dtoOptions, request.Rewatching));
 
             // If viewing all next up for all series, remove first episodes
             // But if that returns empty, keep those first episodes (avoid completely empty view)
@@ -186,9 +186,9 @@ namespace Emby.Server.Implementations.TV
         /// Gets the next up.
         /// </summary>
         /// <returns>Task{Episode}.</returns>
-        private Tuple<DateTime, Func<Episode>> GetNextUp(string seriesKey, User user, DtoOptions dtoOptions)
+        private Tuple<DateTime, Func<Episode>> GetNextUp(string seriesKey, User user, DtoOptions dtoOptions, bool rewatching)
         {
-            var lastWatchedEpisode = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            var lastQuery = new InternalItemsQuery(user)
             {
                 AncestorWithPresentationUniqueKey = null,
                 SeriesPresentationUniqueKey = seriesKey,
@@ -202,23 +202,43 @@ namespace Emby.Server.Implementations.TV
                     Fields = new[] { ItemFields.SortName },
                     EnableImages = false
                 }
-            }).Cast<Episode>().FirstOrDefault();
+            };
+
+            if (rewatching)
+            {
+                // find last watched by date played, not by newest episode watched
+                lastQuery.OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending) };
+            }
+
+            var lastWatchedEpisode = _libraryManager.GetItemList(lastQuery).Cast<Episode>().FirstOrDefault();
 
             Func<Episode> getEpisode = () =>
             {
-                var nextEpisode = _libraryManager.GetItemList(new InternalItemsQuery(user)
+                var nextQuery = new InternalItemsQuery(user)
                 {
                     AncestorWithPresentationUniqueKey = null,
                     SeriesPresentationUniqueKey = seriesKey,
                     IncludeItemTypes = new[] { BaseItemKind.Episode },
                     OrderBy = new[] { (ItemSortBy.SortName, SortOrder.Ascending) },
                     Limit = 1,
-                    IsPlayed = false,
+                    IsPlayed = rewatching,
                     IsVirtualItem = false,
                     ParentIndexNumberNotEquals = 0,
                     MinSortName = lastWatchedEpisode?.SortName,
                     DtoOptions = dtoOptions
-                }).Cast<Episode>().FirstOrDefault();
+                };
+
+                Episode nextEpisode;
+                if (rewatching)
+                {
+                    nextQuery.Limit = 2;
+                    // get watched episode after most recently watched
+                    nextEpisode = _libraryManager.GetItemList(nextQuery).Cast<Episode>().ElementAtOrDefault(1);
+                }
+                else
+                {
+                    nextEpisode = _libraryManager.GetItemList(nextQuery).Cast<Episode>().FirstOrDefault();
+                }
 
                 if (_configurationManager.Configuration.DisplaySpecialsWithinSeasons)
                 {
@@ -228,7 +248,7 @@ namespace Emby.Server.Implementations.TV
                         SeriesPresentationUniqueKey = seriesKey,
                         ParentIndexNumber = 0,
                         IncludeItemTypes = new[] { BaseItemKind.Episode },
-                        IsPlayed = false,
+                        IsPlayed = rewatching,
                         IsVirtualItem = false,
                         DtoOptions = dtoOptions
                     })

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -68,6 +68,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="nextUpDateCutoff">Optional. Starting date of shows to show in Next Up section.</param>
         /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
         /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
+        /// <param name="rewatching">Whether to get a rewatching next up instead of standard next up.</param>
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>
         [HttpGet("NextUp")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -84,7 +85,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? enableUserData,
             [FromQuery] DateTime? nextUpDateCutoff,
             [FromQuery] bool enableTotalRecordCount = true,
-            [FromQuery] bool disableFirstEpisode = false)
+            [FromQuery] bool disableFirstEpisode = false,
+            [FromQuery] bool rewatching = false)
         {
             var options = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
@@ -100,7 +102,8 @@ namespace Jellyfin.Api.Controllers
                     UserId = userId ?? Guid.Empty,
                     EnableTotalRecordCount = enableTotalRecordCount,
                     DisableFirstEpisode = disableFirstEpisode,
-                    NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue
+                    NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue,
+                    Rewatching = rewatching
                 },
                 options);
 

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -14,6 +14,7 @@ namespace MediaBrowser.Model.Querying
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
             NextUpDateCutoff = DateTime.MinValue;
+            Rewatching = false;
         }
 
         /// <summary>
@@ -81,5 +82,10 @@ namespace MediaBrowser.Model.Querying
         /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
         /// </summary>
         public DateTime NextUpDateCutoff { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether getting rewatching next up list.
+        /// </summary>
+        public bool Rewatching { get; set; }
     }
 }


### PR DESCRIPTION
If you're watching a watched series again, this will find the watched episode after the most recently watched episode. This is something I've wanted for a while since our family tends to rewatch favorite shows.

I was able to get this functionality with minimal changes to the existing Next Up methods. 

There's a PR in JF-web that depends on this.

![image](https://user-images.githubusercontent.com/991618/151263476-2611084d-725b-4759-aee7-7165feff7890.png)
