### PR TITLE
Proxy remote image fetching through the server

### DIFF
--- a/Jellyfin.Api/Controllers/RemoteImageController.cs
+++ b/Jellyfin.Api/Controllers/RemoteImageController.cs
@@ -3,9 +3,15 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Constants;
+using MediaBrowser.Common.Extensions;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
@@ -13,7 +19,9 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Api.Controllers
 {
@@ -23,23 +31,30 @@ namespace Jellyfin.Api.Controllers
     [Route("")]
     public class RemoteImageController : BaseJellyfinApiController
     {
+        private const string RemoteImagesRoute = "RemoteImages";
+        private const string FetchRoute = "Fetch";
+
         private readonly IProviderManager _providerManager;
         private readonly IServerApplicationPaths _applicationPaths;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILibraryManager _libraryManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteImageController"/> class.
         /// </summary>
         /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+        /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
         /// <param name="applicationPaths">Instance of the <see cref="IServerApplicationPaths"/> interface.</param>
         /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         public RemoteImageController(
             IProviderManager providerManager,
             IServerApplicationPaths applicationPaths,
+            IHttpClientFactory httpClientFactory,
             ILibraryManager libraryManager)
         {
             _providerManager = providerManager;
             _applicationPaths = applicationPaths;
+            _httpClientFactory = httpClientFactory;
             _libraryManager = libraryManager;
         }
 
@@ -55,7 +70,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">Remote Images returned.</response>
         /// <response code="404">Item not found.</response>
         /// <returns>Remote Image Result.</returns>
-        [HttpGet("Items/{itemId}/RemoteImages")]
+        [HttpGet($"Items/{{itemId}}/{RemoteImagesRoute}")]
         [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -83,6 +98,20 @@ namespace Jellyfin.Api.Controllers
                     },
                     CancellationToken.None)
                 .ConfigureAwait(false);
+
+            var fetchUrlPrefix = GetFetchUrlPrefix();
+            foreach (var image in images)
+            {
+                if (!string.IsNullOrWhiteSpace(image.Url))
+                {
+                    image.Url = fetchUrlPrefix + WebUtility.UrlEncode(image.Url);
+                }
+
+                if (!string.IsNullOrWhiteSpace(image.ThumbnailUrl))
+                {
+                    image.ThumbnailUrl = fetchUrlPrefix + WebUtility.UrlEncode(image.ThumbnailUrl);
+                }
+            }
 
             var imageArray = images.ToArray();
             var allProviders = _providerManager.GetRemoteImageProviderInfo(item);
@@ -120,7 +149,7 @@ namespace Jellyfin.Api.Controllers
         /// <response code="200">Returned remote image providers.</response>
         /// <response code="404">Item not found.</response>
         /// <returns>List of remote image providers.</returns>
-        [HttpGet("Items/{itemId}/RemoteImages/Providers")]
+        [HttpGet($"Items/{{itemId}}/{RemoteImagesRoute}/Providers")]
         [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -144,7 +173,8 @@ namespace Jellyfin.Api.Controllers
         /// <response code="204">Remote image downloaded.</response>
         /// <response code="404">Remote image not found.</response>
         /// <returns>Download status.</returns>
-        [HttpPost("Items/{itemId}/RemoteImages/Download")]
+        /// <remarks>This endpoint downloads the remote image to the library.</remarks>
+        [HttpPost($"Items/{{itemId}}/{RemoteImagesRoute}/Download")]
         [Authorize(Policy = Policies.RequiresElevation)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -159,11 +189,68 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
+            var fetchUrlPrefix = GetFetchUrlPrefix();
+            if (imageUrl!.StartsWith(fetchUrlPrefix))
+            {
+                imageUrl = WebUtility.UrlDecode(imageUrl.Substring(fetchUrlPrefix.Length));
+            }
+
             await _providerManager.SaveImage(item, imageUrl, type, null, CancellationToken.None)
                 .ConfigureAwait(false);
 
             await item.UpdateToRepositoryAsync(ItemUpdateType.ImageUpdate, CancellationToken.None).ConfigureAwait(false);
             return NoContent();
+        }
+
+        /// <summary>
+        /// Fetches a remote image for an item.
+        /// </summary>
+        /// <param name="itemId">Item Id.</param>
+        /// <param name="imageUrl">The image url.</param>
+        /// <response code="200">Remote image fetched.</response>
+        /// <response code="404">Remote image not found.</response>
+        /// <returns>The fetched image.</returns>
+        /// <remarks>This endpoint fetches and returns the remote image to the client without updating the library.</remarks>
+        [HttpGet($"Items/{{itemId}}/{RemoteImagesRoute}/{FetchRoute}")]
+        [HttpHead($"Items/{{itemId}}/{RemoteImagesRoute}/{FetchRoute}", Name = "HeadRemoteImage")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesImageFile]
+        public async Task<ActionResult> FetchRemoteImage(
+            [FromRoute, Required] Guid itemId,
+            [FromQuery] string? imageUrl)
+        {
+            // Fetching remote image does not depend on the library item, but this check is still useful to prevent
+            // abuse. This endpoint does not require authorization and cannot since image requests in web clients
+            // are initiated by the browsers, not the JavaScript XHR.
+            var item = _libraryManager.GetItemById(itemId);
+            if (item == null)
+            {
+                return NotFound();
+            }
+
+            var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
+            var response = await httpClient.GetAsync(imageUrl).ConfigureAwait(false);
+            var contentType = response.Content.Headers.ContentType ?? new MediaTypeHeaderValue("image/jpeg");
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            return new FileStreamResult(stream, contentType!.ToString());
+        }
+
+        /// <summary>
+        /// Gets the item-aware url prefix for the fetch endpoint.
+        /// </summary>
+        /// <returns>The item-aware url prefix for the fetch endpoint.</returns>
+        private string GetFetchUrlPrefix()
+        {
+            var path = UriHelper.BuildRelative(HttpContext.Request.PathBase, HttpContext.Request.Path);
+            var remoteImagesRouteIndex = path.LastIndexOf(RemoteImagesRoute);
+            if (remoteImagesRouteIndex < 0)
+            {
+                throw new ResourceNotFoundException(RemoteImagesRoute);
+            }
+
+            path = path.Substring(0, remoteImagesRouteIndex + RemoteImagesRoute.Length);
+            return $"{path}/{FetchRoute}?imageUrl=";
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
Proxy remote image fetching through the server:

- Add a `GET Items/{itemId}/RemoteImages/Fetch` endpoint which expects an `imageUrl` query parameter, and proxies the `GET {imageUrl}` request on behalf of the client.
- Modify the `GET Items/{itemId}/RemoteImages` endpoint to return remote image urls using the `Fetch` endpoint, i.e. `Items/{itemId}/RemoteImages/Fetch?imageUrl={rawImageUrl}` instead of plain `{rawImageUrl}`.
- Modify the `POST Items/{itemId}/RemoteImages/Download` endpoint to strip out the `Fetch` endpoint prefix, i.e. removing the `Items/{itemId}/RemoteImages/Fetch?imageUrl=` prefix to get the raw image url.

This is useful when:

- The user wants to make sure all scraping requests are initiated from the server side because, e.g., the server uses a VPN for scraping.
- The remote image url is not accessible from clients, e.g. when the remote image url points to an custom endpoint hosted next to the Jellyfin server.

Configuration option ideas not included in this PR:

1. Add a server configuration to globally enable or disable proxying for remote image requests.
2. Add a server configuration to selectively enable proxying for remote image requests if and only if the remote host or IP matches a configured list.

I think 1 is good but 2 might be an overkill. Alternatively I can also see a case for not providing an option at all.

**Issues**
n/a
