### PR TITLE
Add extracting attachments for ffmpeg to burn subtitles with correct fonts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@
  - [mitchfizz05](https://github.com/mitchfizz05)
  - [MrTimscampi](https://github.com/MrTimscampi)
  - [n8225](https://github.com/n8225)
+ - [Nalsai](https://github.com/Nalsai)
  - [Narfinger](https://github.com/Narfinger)
  - [NathanPickard](https://github.com/NathanPickard)
  - [neilsb](https://github.com/neilsb)

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
@@ -42,6 +43,8 @@ namespace Jellyfin.Api.Helpers
         /// </summary>
         private static readonly Dictionary<string, SemaphoreSlim> _transcodingLocks = new Dictionary<string, SemaphoreSlim>();
 
+        private readonly IAttachmentExtractor _attachmentExtractor;
+        private readonly IApplicationPaths _appPaths;
         private readonly IAuthorizationContext _authorizationContext;
         private readonly EncodingHelper _encodingHelper;
         private readonly IFileSystem _fileSystem;
@@ -55,6 +58,8 @@ namespace Jellyfin.Api.Helpers
         /// <summary>
         /// Initializes a new instance of the <see cref="TranscodingJobHelper"/> class.
         /// </summary>
+        /// <param name="attachmentExtractor">Instance of the <see cref="IAttachmentExtractor"/> interface.</param>
+        /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
         /// <param name="logger">Instance of the <see cref="ILogger{TranscodingJobHelpers}"/> interface.</param>
         /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
@@ -65,6 +70,8 @@ namespace Jellyfin.Api.Helpers
         /// <param name="encodingHelper">Instance of <see cref="EncodingHelper"/>.</param>
         /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
         public TranscodingJobHelper(
+            IAttachmentExtractor attachmentExtractor,
+            IApplicationPaths appPaths,
             ILogger<TranscodingJobHelper> logger,
             IMediaSourceManager mediaSourceManager,
             IFileSystem fileSystem,
@@ -75,6 +82,8 @@ namespace Jellyfin.Api.Helpers
             EncodingHelper encodingHelper,
             ILoggerFactory loggerFactory)
         {
+            _attachmentExtractor = attachmentExtractor;
+            _appPaths = appPaths;
             _logger = logger;
             _mediaSourceManager = mediaSourceManager;
             _fileSystem = fileSystem;
@@ -511,6 +520,13 @@ namespace Jellyfin.Api.Helpers
             if (string.IsNullOrEmpty(_mediaEncoder.EncoderPath))
             {
                 throw new ArgumentException("FFmpeg path not set.");
+            }
+
+            // If subtitles get burned in fonts may need to be extracted from the media file
+            if (state.SubtitleStream != null && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode)
+            {
+                var attachmentPath = Path.Combine(_appPaths.CachePath, "attachments", state.MediaSource.Id);
+                await _attachmentExtractor.ExtractAllAttachments(state.MediaPath, state.MediaSource, attachmentPath, CancellationToken.None).ConfigureAwait(false);
             }
 
             var process = new Process

--- a/MediaBrowser.Controller/MediaEncoding/IAttachmentExtractor.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IAttachmentExtractor.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Controller.MediaEncoding
@@ -16,6 +17,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             BaseItem item,
             string mediaSourceId,
             int attachmentStreamIndex,
+            CancellationToken cancellationToken);
+        Task ExtractAllAttachments(
+            string inputFile,
+            MediaSourceInfo mediaSource,
+            string outputPath,
             CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
**Changes**
When burning in subtitles, attachments to the video file get extracted and the path gets supplied as fontsdir to ffmpeg. This way, ffmpeg can burn in subtitles with the correct fonts, when they are attached to the video and not installed on the system.

**Issues**
Fixes #1589 (subtitles will now render correctly when burning them, like in the Plex screenshot)
Would fix 2. of #7208, but by looking at the mediainfo, I think the font is missing completely there (not on system or media file) 


Theres some commented out code concerning fallbackFontPath with TODO in EncodingHelper. There can only be one fontsdir supplied to ffmpeg, so it wouldn't work together. But also, you shouldn't supply a directory with lots of fonts to ffmpeg, because that can slow the start of the transcoding down (ffmpeg needs to index all fonts in there first). You can just install fonts on the system for the jellyfin user (or with this pull request attach them to the file), so I don't think fallbackFontPath should be / needs to be added to ffmpeg when burning subtitles.