### PR TITLE
NFO: fix thumb tags without aspect

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -778,7 +778,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                 case "thumb":
                     {
-                        FetchThumbNode(reader, itemResult);
+                        FetchThumbNode(reader, itemResult, "thumb");
                         break;
                     }
 
@@ -796,7 +796,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             break;
                         }
 
-                        FetchThumbNode(subtree, itemResult);
+                        FetchThumbNode(subtree, itemResult, "fanart");
                         break;
                     }
 
@@ -819,16 +819,21 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             }
         }
 
-        private void FetchThumbNode(XmlReader reader, MetadataResult<T> itemResult)
+        private void FetchThumbNode(XmlReader reader, MetadataResult<T> itemResult, string parentNode)
         {
             var artType = reader.GetAttribute("aspect");
             var val = reader.ReadElementContentAsString();
 
             // artType is null if the thumb node is a child of the fanart tag
             // -> set image type to fanart
-            if (string.IsNullOrWhiteSpace(artType))
+            if (string.IsNullOrWhiteSpace(artType) && parentNode.Equals("fanart", StringComparison.Ordinal))
             {
                 artType = "fanart";
+            }
+            else if (string.IsNullOrWhiteSpace(artType))
+            {
+                // Sonarr writes thumb tags for posters without aspect property
+                artType = "poster";
             }
 
             // skip:

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -123,6 +123,20 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
+        public void Parse_GivenFileWithThumbWithoutAspect_Success()
+        {
+            var result = new MetadataResult<Episode>()
+            {
+                Item = new Episode()
+            };
+
+            _parser.Fetch(result, "Test Data/Sonarr-Thumb.nfo", CancellationToken.None);
+
+            Assert.Single(result.RemoteImages.Where(x => x.Type == ImageType.Primary));
+            Assert.Equal("https://artworks.thetvdb.com/banners/episodes/359095/7081317.jpg", result.RemoteImages.First(x => x.Type == ImageType.Primary).Url);
+        }
+
+        [Fact]
         public void Fetch_WithNullItem_ThrowsArgumentException()
         {
             var result = new MetadataResult<Episode>();

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -125,7 +125,7 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         [Fact]
         public void Parse_GivenFileWithThumbWithoutAspect_Success()
         {
-            var result = new MetadataResult<Episode>()
+            var result = new MetadataResult<Episode>
             {
                 Item = new Episode()
             };

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Sonarr-Thumb.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Sonarr-Thumb.nfo
@@ -1,0 +1,34 @@
+<episodedetails>
+  <title>Sometimes a Genius's Every Action Is at the Mercy of X</title>
+  <season>1</season>
+  <episode>8</episode>
+  <aired>2019-05-26</aired>
+  <plot>After Nariyuki wins a smartphone in a lottery, he can't wait to use it for apps like the dictionary, schedule managing, and the like. He also learns that studying in the bathtub is effective and quickly puts the method into practice.</plot>
+  <uniqueid type="sonarr" default="true">4289</uniqueid>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/359095/7081317.jpg</thumb>
+  <watched>false</watched>
+  <fileinfo>
+    <streamdetails>
+      <video>
+        <aspect>1.77777779</aspect>
+        <bitrate>2208901</bitrate>
+        <codec>x265</codec>
+        <framerate>23.976</framerate>
+        <height>1080</height>
+        <scantype></scantype>
+        <width>1920</width>
+        <duration>23.683416666666666</duration>
+        <durationinseconds>1421</durationinseconds>
+      </video>
+      <audio>
+        <bitrate>1468567</bitrate>
+        <channels>2</channels>
+        <codec>FLAC</codec>
+        <language>Japanese / Japanese</language>
+      </audio>
+      <subtitle>
+        <language>English</language>
+      </subtitle>
+    </streamdetails>
+  </fileinfo>
+</episodedetails>


### PR DESCRIPTION
**Changes**
Thumb tags within a fanart tag that have no aspect set are backdrops.

Thumb tags on a root level that have no aspect set are posters.

**Issues**
Fixes #7285
