### PR TITLE
Fix h264_v4l2m2m acceleration in Raspberry Pi 4

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1281,11 +1281,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 param += " -low_power 1";
             }
 
-            if (string.Equals(videoEncoder, "h264_v4l2m2m", StringComparison.OrdinalIgnoreCase))
-            {
-                param += " -pix_fmt nv21";
-            }
-
             var isVc1 = string.Equals(state.VideoStream?.Codec, "vc1", StringComparison.OrdinalIgnoreCase);
             var isLibX265 = string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase);
 
@@ -2695,6 +2690,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var vidDecoder = GetHardwareVideoDecoder(state, options) ?? string.Empty;
             var isSwDecoder = string.IsNullOrEmpty(vidDecoder);
             var isVaapiEncoder = vidEncoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase);
+            var isV4l2Encoder = vidEncoder.Contains("h264_v4l2m2m", StringComparison.OrdinalIgnoreCase);
 
             var doDeintH264 = state.DeInterlace("h264", true) || state.DeInterlace("avc", true);
             var doDeintHevc = state.DeInterlace("h265", true) || state.DeInterlace("hevc", true);
@@ -2722,6 +2718,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (isVaapiEncoder)
             {
                 outFormat = "nv12";
+            }
+            else if (isV4l2Encoder)
+            {
+                outFormat = "yuv420p";
             }
 
             // sw scale


### PR DESCRIPTION
## Changes
Fixed by replacing pixel format from NV21 to yuv420p.

Applied the suggestions that @nyanmisaka asked for in #7227 

## Issues
Error when enabling v4l acceleration in Raspberry Pi 4. I utilized the LinuxServer.io Nightly Container to test:

```
sudo docker run -d \
  --name=jellyfin \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=America/Denver \
  -e JELLYFIN_PublishedServerUrl=192.168.1.2 \
  -p 8096:8096 \
  -p 8920:8920 \
  -p 7359:7359/udp \
  -p 1900:1900/udp \
  -v ~/jellyfin_dev/lscrio_nightly_library:/config \
  -v ~/jellyfin_dev/media:/media \
  --restart unless-stopped \
  --device=/dev/video10:/dev/video10 \
  --device=/dev/video11:/dev/video11 \
  --device=/dev/video12:/dev/video12 \
  lscr.io/linuxserver/jellyfin:nightly
```

I attempted to play Big Buck Bunny (Creative Commons Licensed Video); specifically bbb_sunflower_1080p_30fps_normal.mp4 available from https://download.blender.org/demo/movies/BBB/

Logs:
```
/videos/d5ad2552-0eb3-b844-42ab-18959bd04aee/hls1/main/0.ts

{"Protocol":0,"Id":"d5ad25520eb3b84442ab18959bd04aee","Path":"/media/bbb_sunflower_1080p_30fps_normal.mp4","EncoderPath":null,"EncoderProtocol":null,"Type":0,"Container":"mov,mp4,m4a,3gp,3g2,mj2","Size":276134947,"Name":"bbb_sunflower_1080p_30fps_normal","IsRemote":false,"ETag":"86d621b252d2ca5c08790a5a62f67460","RunTimeTicks":6345333330,"ReadAtNativeFramerate":false,"IgnoreDts":false,"IgnoreIndex":false,"GenPtsInput":false,"SupportsTranscoding":true,"SupportsDirectStream":true,"SupportsDirectPlay":true,"IsInfiniteStream":false,"RequiresOpening":false,"OpenToken":null,"RequiresClosing":false,"LiveStreamId":null,"BufferMs":null,"RequiresLooping":false,"SupportsProbing":true,"VideoType":0,"IsoType":null,"Video3DFormat":null,"MediaStreams":[{"Codec":"h264","CodecTag":"avc1","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/30000","CodecTimeBase":null,"Title":null,"VideoRange":"SDR","LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"1080p H264 SDR","NalLengthSize":"0","IsInterlaced":false,"IsAVC":false,"ChannelLayout":null,"BitRate":2998715,"BitDepth":8,"RefFrames":1,"PacketLength":null,"Channels":null,"SampleRate":null,"IsDefault":true,"IsForced":false,"Height":1080,"Width":1920,"AverageFrameRate":30,"RealFrameRate":30,"Profile":"High","Type":1,"AspectRatio":"16:9","Index":0,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":"yuv420p","Level":41,"IsAnamorphic":null},{"Codec":"mp3","CodecTag":"mp4a","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":null,"Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - MP3 - Stereo - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"stereo","BitRate":160000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":2,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":1,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null},{"Codec":"ac3","CodecTag":"ac-3","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":null,"Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - Dolby Digital - 5.1 - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"5.1","BitRate":320000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":6,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":2,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null}],"MediaAttachments":[],"Formats":[],"Bitrate":3481424,"Timestamp":null,"RequiredHttpHeaders":{},"TranscodingUrl":null,"TranscodingSubProtocol":null,"TranscodingContainer":null,"AnalyzeDurationMs":null,"DefaultAudioStreamIndex":null,"DefaultSubtitleStreamIndex":null}

/usr/lib/jellyfin-ffmpeg/ffmpeg -autorotate 0 -i file:"/media/bbb_sunflower_1080p_30fps_normal.mp4" -map_metadata -1 -map_chapters -1 -threads 0 -map 0:0 -map 0:1 -map -0:s -codec:v:0 h264_v4l2m2m -pix_fmt nv21 -b:v 1340000 -maxrate 1340000 -bufsize 2680000 -level 41 -force_key_frames:0 "expr:gte(t,0+n_forced*3)" -g:v:0 90 -keyint_min:v:0 90 -sc_threshold:v:0 0 -vf "setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale=trunc(min(max(iw\,ih*dar)\,720)/64)*64:trunc(ow/dar/2)*2,format=yuv420p" -codec:a:0 aac -ac 2 -ab 160000 -copyts -avoid_negative_ts disabled -max_muxing_queue_size 2048 -f hls -max_delay 5000000 -hls_time 3 -hls_segment_type mpegts -start_number 0 -hls_segment_filename "/config/data/transcodes/6455b04d4d7a3a52bfb0fff8471fa805%d.ts" -hls_playlist_type vod -hls_list_size 0 -y "/config/data/transcodes/6455b04d4d7a3a52bfb0fff8471fa805.m3u8"


ffmpeg version 4.4.1-Jellyfin Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.3.0-17ubuntu1~20.04)
  configuration: --prefix=/usr/lib/jellyfin-ffmpeg --target-os=linux --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-static --enable-gmp --enable-gnutls --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265 --enable-libzvbi --enable-libzimg --toolchain=hardened --enable-cross-compile --arch=arm64 --cross-prefix=/usr/bin/aarch64-linux-gnu-
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'file:/media/bbb_sunflower_1080p_30fps_normal.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 1
    compatible_brands: isomavc1
    creation_time   : 2013-12-16T17:44:39.000000Z
    title           : Big Buck Bunny, Sunflower version
    artist          : Blender Foundation 2008, Janus Bager Kristensen 2013
    comment         : Creative Commons Attribution 3.0 - http://bbb3d.renderfarming.net
    genre           : Animation
    composer        : Sacha Goedegebure
  Duration: 00:10:34.53, start: 0.000000, bitrate: 3481 kb/s
  Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 2998 kb/s, 30 fps, 30 tbr, 30k tbn, 60 tbc (default)
    Metadata:
      creation_time   : 2013-12-16T17:44:39.000000Z
      handler_name    : GPAC ISO Video Handler
      vendor_id       : [0][0][0][0]
  Stream #0:1(und): Audio: mp3 (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
    Metadata:
      creation_time   : 2013-12-16T17:44:42.000000Z
      handler_name    : GPAC ISO Audio Handler
      vendor_id       : [0][0][0][0]
  Stream #0:2(und): Audio: ac3 (ac-3 / 0x332D6361), 48000 Hz, 5.1(side), fltp, 320 kb/s (default)
    Metadata:
      creation_time   : 2013-12-16T17:44:42.000000Z
      handler_name    : GPAC ISO Audio Handler
      vendor_id       : [0][0][0][0]
    Side data:
      audio service type: main
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> h264 (h264_v4l2m2m))
  Stream #0:1 -> #0:1 (mp3 (mp3float) -> aac (native))
Press [q] to stop, [?] for help
[h264_v4l2m2m @ 0xaaaab9a08ec0] Using device /dev/video11
[h264_v4l2m2m @ 0xaaaab9a08ec0] driver 'bcm2835-codec' on card 'bcm2835-codec-encode' in mplane mode
[h264_v4l2m2m @ 0xaaaab9a08ec0] requesting formats: output=YU12 capture=H264
[h264_v4l2m2m @ 0xaaaab9a08ec0] Encoder requires yuv420p pixel format.
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
Conversion failed!
```

## Comments
I have tested this change on my Raspberry Pi by performing the following:

1. Pulled my git repository and switched to my branch
    ```
    git clone https://github.com/aolszowka/jellyfin.git
    git switch aolszowka-EncodingHelperChanges
    ```

2. Built the Docker Image
    ```
    sudo docker build . --file Dockerfile.arm64 --rm --tag jttest:git
    ```

3. Executed the Container
    ```
    sudo docker run -it \
    -p 8096:8096 \
    -v ~/jellyfin_dev/git_library:/config \
    -v ~/jellyfin_dev/media:/media \
    --device=/dev/video10:/dev/video10 \
    --device=/dev/video11:/dev/video11 \
    --device=/dev/video12:/dev/video12 \
    jttest:git
    ```

4. Configure to use V4L2
![image](https://user-images.githubusercontent.com/2592881/153213041-ab58e196-46f3-426c-a915-d4f2e74ed8e5.png)

5. Attempted to replay by selecting something that required transcoding. Here's the log:
    ```
    /videos/d5ad2552-0eb3-b844-42ab-18959bd04aee/hls1/main/0.ts

    {"Protocol":0,"Id":"d5ad25520eb3b84442ab18959bd04aee","Path":"/media/bbb_sunflower_1080p_30fps_normal.mp4","EncoderPath":null,"EncoderProtocol":null,"Type":0,"Container":"mov,mp4,m4a,3gp,3g2,mj2","Size":276134944,"Name":"bbb_sunflower_1080p_30fps_normal","IsRemote":false,"ETag":"86d621b252d2ca5c08790a5a62f67460","RunTimeTicks":6345333248,"ReadAtNativeFramerate":false,"IgnoreDts":false,"IgnoreIndex":false,"GenPtsInput":false,"SupportsTranscoding":true,"SupportsDirectStream":true,"SupportsDirectPlay":true,"IsInfiniteStream":false,"RequiresOpening":false,"OpenToken":null,"RequiresClosing":false,"LiveStreamId":null,"BufferMs":null,"RequiresLooping":false,"SupportsProbing":true,"VideoType":0,"IsoType":null,"Video3DFormat":null,"MediaStreams":[{"Codec":"h264","CodecTag":"avc1","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/30000","CodecTimeBase":"1/60","Title":null,"VideoRange":"SDR","LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"1080i H264 SDR","NalLengthSize":"0","IsInterlaced":true,"IsAVC":false,"ChannelLayout":null,"BitRate":2998715,"BitDepth":8,"RefFrames":1,"PacketLength":null,"Channels":null,"SampleRate":null,"IsDefault":true,"IsForced":false,"Height":1080,"Width":1920,"AverageFrameRate":30,"RealFrameRate":30,"Profile":"High","Type":1,"AspectRatio":"16:9","Index":0,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":"yuv420p","Level":41,"IsAnamorphic":null},{"Codec":"mp3","CodecTag":"mp4a","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":"1/48000","Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - MP3 - Stereo - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"stereo","BitRate":160000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":2,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":1,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null},{"Codec":"ac3","CodecTag":"ac-3","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":"1/48000","Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - Dolby Digital - 5.1 - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"5.1","BitRate":320000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":6,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":2,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null}],"MediaAttachments":[],"Formats":[],"Bitrate":3481424,"Timestamp":null,"RequiredHttpHeaders":{},"TranscodingUrl":null,"TranscodingSubProtocol":null,"TranscodingContainer":null,"AnalyzeDurationMs":null,"DefaultAudioStreamIndex":null,"DefaultSubtitleStreamIndex":null}

    /usr/bin/ffmpeg -autorotate 0 -i file:"/media/bbb_sunflower_1080p_30fps_normal.mp4" -map_metadata -1 -map_chapters -1 -threads 0 -map 0:0 -map 0:1 -map -0:s -codec:v:0 h264_v4l2m2m -b:v 3840000 -maxrate 3840000 -bufsize 7680000 -level 41 -force_key_frames:0 "expr:gte(t,0+n_forced*3)" -g:v:0 90 -keyint_min:v:0 90 -sc_threshold:v:0 0 -vf "setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,yadif=0:-1:0,scale=trunc(min(max(iw\,ih*dar)\,min(1920\,1080*dar))/64)*64:trunc(min(max(iw/dar\,ih)\,min(1920/dar\,1080))/2)*2,format=yuv420p" -codec:a:0 copy -strict -2 -copyts -avoid_negative_ts disabled -max_muxing_queue_size 2048 -f hls -max_delay 5000000 -hls_time 3 -hls_segment_type mpegts -start_number 0 -hls_segment_filename "/cache/8e2173a83a4b58562ebe2f9835e7d685%d.ts" -hls_playlist_type vod -hls_list_size 0 -y "/cache/8e2173a83a4b58562ebe2f9835e7d685.m3u8"


    ffmpeg version 4.3.3-0+deb11u1 Copyright (c) 2000-2021 the FFmpeg developers
    built with gcc 10 (Debian 10.2.1-6)
    configuration: --prefix=/usr --extra-version=0+deb11u1 --toolchain=hardened --libdir=/usr/lib/aarch64-linux-gnu --incdir=/usr/include/aarch64-linux-gnu --arch=arm64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-pocketsphinx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
    libavutil      56. 51.100 / 56. 51.100
    libavcodec     58. 91.100 / 58. 91.100
    libavformat    58. 45.100 / 58. 45.100
    libavdevice    58. 10.100 / 58. 10.100
    libavfilter     7. 85.100 /  7. 85.100
    libavresample   4.  0.  0 /  4.  0.  0
    libswscale      5.  7.100 /  5.  7.100
    libswresample   3.  7.100 /  3.  7.100
    libpostproc    55.  7.100 / 55.  7.100
    Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'file:/media/bbb_sunflower_1080p_30fps_normal.mp4':
    Metadata:
        major_brand     : isom
        minor_version   : 1
        compatible_brands: isomavc1
        creation_time   : 2013-12-16T17:44:39.000000Z
        title           : Big Buck Bunny, Sunflower version
        artist          : Blender Foundation 2008, Janus Bager Kristensen 2013
        comment         : Creative Commons Attribution 3.0 - http://bbb3d.renderfarming.net
        genre           : Animation
        composer        : Sacha Goedegebure
    Duration: 00:10:34.53, start: 0.000000, bitrate: 3481 kb/s
        Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 2998 kb/s, 30 fps, 30 tbr, 30k tbn, 60 tbc (default)
        Metadata:
        creation_time   : 2013-12-16T17:44:39.000000Z
        handler_name    : GPAC ISO Video Handler
        Stream #0:1(und): Audio: mp3 (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
        Metadata:
        creation_time   : 2013-12-16T17:44:42.000000Z
        handler_name    : GPAC ISO Audio Handler
        Stream #0:2(und): Audio: ac3 (ac-3 / 0x332D6361), 48000 Hz, 5.1(side), fltp, 320 kb/s (default)
        Metadata:
        creation_time   : 2013-12-16T17:44:42.000000Z
        handler_name    : GPAC ISO Audio Handler
        Side data:
        audio service type: main
    Stream mapping:
    Stream #0:0 -> #0:0 (h264 (native) -> h264 (h264_v4l2m2m))
    Stream #0:1 -> #0:1 (copy)
    Press [q] to stop, [?] for help
    [h264_v4l2m2m @ 0xaaaadba07c00] Using device /dev/video11
    [h264_v4l2m2m @ 0xaaaadba07c00] driver 'bcm2835-codec' on card 'bcm2835-codec-encode' in mplane mode
    [h264_v4l2m2m @ 0xaaaadba07c00] requesting formats: output=YU12 capture=H264
    [h264_v4l2m2m @ 0xaaaadba07c00] Failed to set gop size: Invalid argument
    Output #0, hls, to '/cache/8e2173a83a4b58562ebe2f9835e7d685.m3u8':
    Metadata:
        encoder         : Lavf58.45.100
        Stream #0:0: Video: h264 (h264_v4l2m2m), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], q=-1--1, 3840 kb/s, 30 fps, 90k tbn, 30 tbc (default)
        Metadata:
        encoder         : Lavc58.91.100 h264_v4l2m2m
        Stream #0:1: Audio: mp3 (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
    [h264_v4l2m2m @ 0xaaaadba07c00] All capture buffers returned to userspace. Increase num_capture_buffers to prevent device deadlock or dropped packets/frames.
        Last message repeated 5 times
    frame=   11 fps=0.0 q=-0.0 size=N/A time=00:00:00.48 bitrate=N/A speed=0.925x    
    [h264_v4l2m2m @ 0xaaaadba07c00] All capture buffers returned to userspace. Increase num_capture_buffers to prevent device deadlock or dropped packets/frames.
        Last message repeated 6 times
    frame=   24 fps= 23 q=-0.0 size=N/A time=00:00:00.63 bitrate=N/A speed=0.619x    
    [h264_v4l2m2m @ 0xaaaadba07c00] All capture buffers returned to userspace. Increase num_capture_buffers to prevent device deadlock or dropped packets/frames.
        Last message repeated 6 times
    frame=   38 fps= 25 q=-0.0 size=N/A time=00:00:01.10 bitrate=N/A speed=0.713x    
    [h264_v4l2m2m @ 0xaaaadba07c00] All capture buffers returned to userspace. Increase num_capture_buffers to prevent device deadlock or dropped packets/frames.
        Last message repeated 6 times
    frame=   53 fps= 26 q=-0.0 size=N/A time=00:00:01.60 bitrate=N/A speed=0.779x    
    [h264_v4l2m2m @ 0xaaaadba07c00] All capture buffers returned to userspace. Increase num_capture_buffers to prevent device deadlock or dropped packets/frames.
        Last message repeated 6 times
    ```

The performance is still pretty bad, making me wonder if this is even being hardware accelerated at all? Here's a non-hardware accelerated setting:

```
/videos/d5ad2552-0eb3-b844-42ab-18959bd04aee/hls1/main/0.ts
{"Protocol":0,"Id":"d5ad25520eb3b84442ab18959bd04aee","Path":"/media/bbb_sunflower_1080p_30fps_normal.mp4","EncoderPath":null,"EncoderProtocol":null,"Type":0,"Container":"mov,mp4,m4a,3gp,3g2,mj2","Size":276134944,"Name":"bbb_sunflower_1080p_30fps_normal","IsRemote":false,"ETag":"86d621b252d2ca5c08790a5a62f67460","RunTimeTicks":6345333248,"ReadAtNativeFramerate":false,"IgnoreDts":false,"IgnoreIndex":false,"GenPtsInput":false,"SupportsTranscoding":true,"SupportsDirectStream":true,"SupportsDirectPlay":true,"IsInfiniteStream":false,"RequiresOpening":false,"OpenToken":null,"RequiresClosing":false,"LiveStreamId":null,"BufferMs":null,"RequiresLooping":false,"SupportsProbing":true,"VideoType":0,"IsoType":null,"Video3DFormat":null,"MediaStreams":[{"Codec":"h264","CodecTag":"avc1","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/30000","CodecTimeBase":"1/60","Title":null,"VideoRange":"SDR","LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"1080i H264 SDR","NalLengthSize":"0","IsInterlaced":true,"IsAVC":false,"ChannelLayout":null,"BitRate":2998715,"BitDepth":8,"RefFrames":1,"PacketLength":null,"Channels":null,"SampleRate":null,"IsDefault":true,"IsForced":false,"Height":1080,"Width":1920,"AverageFrameRate":30,"RealFrameRate":30,"Profile":"High","Type":1,"AspectRatio":"16:9","Index":0,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":"yuv420p","Level":41,"IsAnamorphic":null},{"Codec":"mp3","CodecTag":"mp4a","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":"1/48000","Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - MP3 - Stereo - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"stereo","BitRate":160000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":2,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":1,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null},{"Codec":"ac3","CodecTag":"ac-3","Language":"und","ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"Comment":null,"TimeBase":"1/48000","CodecTimeBase":"1/48000","Title":"GPAC ISO Audio Handler","VideoRange":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"DisplayTitle":"GPAC ISO Audio Handler - Und - Dolby Digital - 5.1 - Default","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"5.1","BitRate":320000,"BitDepth":null,"RefFrames":null,"PacketLength":null,"Channels":6,"SampleRate":48000,"IsDefault":true,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":2,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null}],"MediaAttachments":[],"Formats":[],"Bitrate":3481424,"Timestamp":null,"RequiredHttpHeaders":{},"TranscodingUrl":null,"TranscodingSubProtocol":null,"TranscodingContainer":null,"AnalyzeDurationMs":null,"DefaultAudioStreamIndex":null,"DefaultSubtitleStreamIndex":null}
/usr/bin/ffmpeg -f mov,mp4,m4a,3gp,3g2,mj2 -autorotate 0 -i file:"/media/bbb_sunflower_1080p_30fps_normal.mp4" -map_metadata -1 -map_chapters -1 -threads 0 -map 0:0 -map 0:1 -map -0:s -codec:v:0 libx264 -preset veryfast -crf 23 -maxrate 3840000 -bufsize 7680000 -profile:v:0 high -level 41 -x264opts:0 subme=0:me_range=4:rc_lookahead=10:me=dia:no_chroma_me:8x8dct=0:partitions=none -force_key_frames:0 "expr:gte(t,0+n_forced*3)" -vf "setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,yadif=0:-1:0,scale=trunc(min(max(iw\,ih*dar)\,min(1920\,1080*dar))/2)*2:trunc(min(max(iw/dar\,ih)\,min(1920/dar\,1080))/2)*2,format=yuv420p" -codec:a:0 copy -strict -2 -copyts -avoid_negative_ts disabled -max_muxing_queue_size 2048 -f hls -max_delay 5000000 -hls_time 3 -hls_segment_type mpegts -start_number 0 -hls_segment_filename "/cache/e281e2a1847c2efd1dcf553110c78863%d.ts" -hls_playlist_type vod -hls_list_size 0 -y "/cache/e281e2a1847c2efd1dcf553110c78863.m3u8"
ffmpeg version 4.3.3-0+deb11u1 Copyright (c) 2000-2021 the FFmpeg developers
built with gcc 10 (Debian 10.2.1-6)
configuration: --prefix=/usr --extra-version=0+deb11u1 --toolchain=hardened --libdir=/usr/lib/aarch64-linux-gnu --incdir=/usr/include/aarch64-linux-gnu --arch=arm64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-pocketsphinx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
libavutil      56. 51.100 / 56. 51.100
libavcodec     58. 91.100 / 58. 91.100
libavformat    58. 45.100 / 58. 45.100
libavdevice    58. 10.100 / 58. 10.100
libavfilter     7. 85.100 /  7. 85.100
libavresample   4.  0.  0 /  4.  0.  0
libswscale      5.  7.100 /  5.  7.100
libswresample   3.  7.100 /  3.  7.100
libpostproc    55.  7.100 / 55.  7.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'file:/media/bbb_sunflower_1080p_30fps_normal.mp4':
Metadata:
    major_brand     : isom
    minor_version   : 1
    compatible_brands: isomavc1
    creation_time   : 2013-12-16T17:44:39.000000Z
    title           : Big Buck Bunny, Sunflower version
    artist          : Blender Foundation 2008, Janus Bager Kristensen 2013
    comment         : Creative Commons Attribution 3.0 - http://bbb3d.renderfarming.net
    genre           : Animation
    composer        : Sacha Goedegebure
Duration: 00:10:34.53, start: 0.000000, bitrate: 3481 kb/s
    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 2998 kb/s, 30 fps, 30 tbr, 30k tbn, 60 tbc (default)
    Metadata:
    creation_time   : 2013-12-16T17:44:39.000000Z
    handler_name    : GPAC ISO Video Handler
    Stream #0:1(und): Audio: mp3 (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
    Metadata:
    creation_time   : 2013-12-16T17:44:42.000000Z
    handler_name    : GPAC ISO Audio Handler
    Stream #0:2(und): Audio: ac3 (ac-3 / 0x332D6361), 48000 Hz, 5.1(side), fltp, 320 kb/s (default)
    Metadata:
    creation_time   : 2013-12-16T17:44:42.000000Z
    handler_name    : GPAC ISO Audio Handler
    Side data:
    audio service type: main
Stream mapping:
Stream #0:0 -> #0:0 (h264 (native) -> h264 (libx264))
Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
[libx264 @ 0xaaaaf19c0b60] using SAR=1/1
[libx264 @ 0xaaaaf19c0b60] using cpu capabilities: ARMv8 NEON
[libx264 @ 0xaaaaf19c0b60] profile Main, level 4.1, 4:2:0, 8-bit
[libx264 @ 0xaaaaf19c0b60] 264 - core 160 r3011 cde9a93 - H.264/MPEG-4 AVC codec - Copyleft 2003-2020 - http://www.videolan.org/x264.html - options: cabac=1 ref=1 deblock=1:0:0 analyse=0x1:0 me=dia subme=0 psy=1 psy_rd=1.00:0.00 mixed_ref=0 me_range=4 chroma_me=0 trellis=0 8x8dct=0 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=0 threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=1 keyint=250 keyint_min=25 scenecut=40 intra_refresh=0 rc_lookahead=10 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 vbv_maxrate=3840 vbv_bufsize=7680 crf_max=0.0 nal_hrd=none filler=0 ip_ratio=1.40 aq=1:1.00
Output #0, hls, to '/cache/e281e2a1847c2efd1dcf553110c78863.m3u8':
Metadata:
    encoder         : Lavf58.45.100
    Stream #0:0: Video: h264 (libx264), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], q=-1--1, 30 fps, 90k tbn, 30 tbc (default)
    Metadata:
    encoder         : Lavc58.91.100 libx264
    Side data:
    cpb: bitrate max/min/avg: 3840000/0/0 buffer size: 7680000 vbv_delay: N/A
    Stream #0:1: Audio: mp3 (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
frame=    9 fps=0.0 q=0.0 size=N/A time=00:00:00.00 bitrate=N/A speed=   0x    
frame=   20 fps= 19 q=0.0 size=N/A time=00:00:00.48 bitrate=N/A speed=0.45x    
frame=   32 fps= 20 q=29.0 size=N/A time=00:00:00.96 bitrate=N/A speed=0.604x    
frame=   45 fps= 21 q=29.0 size=N/A time=00:00:01.44 bitrate=N/A speed=0.683x    
frame=   58 fps= 22 q=29.0 size=N/A time=00:00:01.92 bitrate=N/A speed=0.733x    
frame=   71 fps= 23 q=29.0 size=N/A time=00:00:02.40 bitrate=N/A speed=0.766x    
frame=   84 fps= 23 q=29.0 size=N/A time=00:00:02.88 bitrate=N/A speed=0.792x    
frame=   96 fps= 23 q=29.0 size=N/A time=00:00:02.90 bitrate=N/A speed=0.701x    
frame=  110 fps= 24 q=29.0 size=N/A time=00:00:03.36 bitrate=N/A speed=0.723x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788630.ts' for writing
frame=  122 fps= 24 q=29.0 size=N/A time=00:00:03.84 bitrate=N/A speed=0.742x    
frame=  133 fps= 23 q=29.0 size=N/A time=00:00:04.32 bitrate=N/A speed=0.754x    
frame=  143 fps= 23 q=29.0 size=N/A time=00:00:04.80 bitrate=N/A speed=0.769x    
frame=  151 fps= 22 q=29.0 size=N/A time=00:00:04.80 bitrate=N/A speed=0.708x    
frame=  161 fps= 22 q=29.0 size=N/A time=00:00:05.28 bitrate=N/A speed=0.725x    
frame=  173 fps= 22 q=29.0 size=N/A time=00:00:05.76 bitrate=N/A speed=0.738x    
frame=  185 fps= 22 q=29.0 size=N/A time=00:00:06.24 bitrate=N/A speed=0.749x    
frame=  197 fps= 22 q=29.0 size=N/A time=00:00:06.24 bitrate=N/A speed=0.703x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788631.ts' for writing
frame=  206 fps= 22 q=29.0 size=N/A time=00:00:06.72 bitrate=N/A speed=0.715x    
frame=  215 fps= 22 q=29.0 size=N/A time=00:00:07.20 bitrate=N/A speed=0.727x    
frame=  226 fps= 22 q=29.0 size=N/A time=00:00:07.20 bitrate=N/A speed=0.687x    
frame=  236 fps= 21 q=29.0 size=N/A time=00:00:07.68 bitrate=N/A speed=0.698x    
frame=  246 fps= 21 q=29.0 size=N/A time=00:00:08.16 bitrate=N/A speed=0.708x    
frame=  254 fps= 21 q=29.0 size=N/A time=00:00:08.18 bitrate=N/A speed=0.677x    
frame=  265 fps= 21 q=29.0 size=N/A time=00:00:08.64 bitrate=N/A speed=0.685x    
frame=  274 fps= 21 q=30.0 size=N/A time=00:00:09.12 bitrate=N/A speed=0.695x    
frame=  283 fps= 21 q=34.0 size=N/A time=00:00:09.14 bitrate=N/A speed=0.669x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788632.ts' for writing
frame=  294 fps= 21 q=32.0 size=N/A time=00:00:09.60 bitrate=N/A speed=0.675x    
frame=  304 fps= 21 q=32.0 size=N/A time=00:00:10.08 bitrate=N/A speed=0.683x    
frame=  314 fps= 21 q=33.0 size=N/A time=00:00:10.56 bitrate=N/A speed=0.691x    
frame=  324 fps= 20 q=32.0 size=N/A time=00:00:10.56 bitrate=N/A speed=0.667x    
frame=  334 fps= 20 q=32.0 size=N/A time=00:00:11.04 bitrate=N/A speed=0.676x    
frame=  344 fps= 20 q=31.0 size=N/A time=00:00:11.52 bitrate=N/A speed=0.683x    
frame=  354 fps= 20 q=31.0 size=N/A time=00:00:11.52 bitrate=N/A speed=0.663x    
frame=  364 fps= 20 q=32.0 size=N/A time=00:00:12.00 bitrate=N/A speed=0.671x    
frame=  374 fps= 20 q=37.0 size=N/A time=00:00:12.48 bitrate=N/A speed=0.677x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788633.ts' for writing
frame=  384 fps= 20 q=33.0 size=N/A time=00:00:12.48 bitrate=N/A speed=0.659x    
frame=  393 fps= 20 q=30.0 size=N/A time=00:00:12.96 bitrate=N/A speed=0.666x    
frame=  403 fps= 20 q=32.0 size=N/A time=00:00:13.44 bitrate=N/A speed=0.673x    
frame=  413 fps= 20 q=32.0 size=N/A time=00:00:13.44 bitrate=N/A speed=0.656x    
frame=  423 fps= 20 q=33.0 size=N/A time=00:00:13.92 bitrate=N/A speed=0.663x    
frame=  433 fps= 20 q=34.0 size=N/A time=00:00:14.40 bitrate=N/A speed=0.669x    
frame=  442 fps= 20 q=33.0 size=N/A time=00:00:14.42 bitrate=N/A speed=0.655x    
frame=  453 fps= 20 q=31.0 size=N/A time=00:00:14.88 bitrate=N/A speed=0.66x    
frame=  464 fps= 20 q=37.0 size=N/A time=00:00:15.36 bitrate=N/A speed=0.665x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788634.ts' for writing
frame=  474 fps= 20 q=31.0 size=N/A time=00:00:15.84 bitrate=N/A speed=0.67x    
frame=  484 fps= 20 q=29.0 size=N/A time=00:00:15.84 bitrate=N/A speed=0.656x    
frame=  494 fps= 20 q=29.0 size=N/A time=00:00:16.32 bitrate=N/A speed=0.662x    
frame=  503 fps= 20 q=33.0 size=N/A time=00:00:16.80 bitrate=N/A speed=0.667x    
frame=  513 fps= 20 q=31.0 size=N/A time=00:00:16.80 bitrate=N/A speed=0.653x    
[hls @ 0xaaaaf19acfb0] Opening '/cache/e281e2a1847c2efd1dcf553110c788635.ts' for writing
frame=  521 fps= 20 q=-1.0 Lsize=N/A time=00:00:17.36 bitrate=N/A speed=0.656x    
video:6326kB audio:338kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
[libx264 @ 0xaaaaf19c0b60] frame I:9     Avg QP:17.35  size: 94389
[libx264 @ 0xaaaaf19c0b60] frame P:146   Avg QP:21.88  size: 27512
[libx264 @ 0xaaaaf19c0b60] frame B:366   Avg QP:25.55  size:  4402
[libx264 @ 0xaaaaf19c0b60] consecutive B-frames:  5.0%  2.7%  4.0% 88.3%
[libx264 @ 0xaaaaf19c0b60] mb I  I16..4: 65.9%  0.0% 34.1%
[libx264 @ 0xaaaaf19c0b60] mb P  I16..4: 14.3%  0.0%  0.0%  P16..4: 28.8%  0.0%  0.0%  0.0%  0.0%    skip:56.9%
[libx264 @ 0xaaaaf19c0b60] mb B  I16..4:  1.9%  0.0%  0.0%  B16..8:  4.7%  0.0%  0.0%  direct: 7.1%  skip:86.4%  L0:45.2% L1:40.6% BI:14.2%
[libx264 @ 0xaaaaf19c0b60] coded y,uvDC,uvAC intra: 11.4% 23.1% 8.7% inter: 5.7% 6.0% 0.3%
[libx264 @ 0xaaaaf19c0b60] i16 v,h,dc,p: 74% 15%  7%  5%
[libx264 @ 0xaaaaf19c0b60] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 20% 17% 22%  5%  9%  6%  6%  7%  9%
[libx264 @ 0xaaaaf19c0b60] i8c dc,h,v,p: 70% 16% 10%  4%
[libx264 @ 0xaaaaf19c0b60] Weighted P-Frames: Y:10.3% UV:10.3%
[libx264 @ 0xaaaaf19c0b60] kb/s:2983.88
```
