### PR TITLE
Implement Comparers for (Parent)IndexNumber

### DIFF
--- a/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
+++ b/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
@@ -1,0 +1,50 @@
+using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Sorting;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.Sorting
+{
+    /// <summary>
+    /// Class IndexNumberComparer.
+    /// </summary>
+    public class IndexNumberComparer : IBaseItemComparer
+    {
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name => ItemSortBy.IndexNumber;
+
+        /// <summary>
+        /// Compares the specified x.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <returns>System.Int32.</returns>
+        public int Compare(BaseItem? x, BaseItem? y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+
+            if (!x.IndexNumber.HasValue)
+            {
+                return -1;
+            }
+
+            if (!y.IndexNumber.HasValue)
+            {
+                return 1;
+            }
+
+            return x.IndexNumber.Value.CompareTo(y.IndexNumber.Value);
+        }
+    }
+}

--- a/Emby.Server.Implementations/Sorting/ParentIndexNumberComparer.cs
+++ b/Emby.Server.Implementations/Sorting/ParentIndexNumberComparer.cs
@@ -1,0 +1,50 @@
+using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Sorting;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.Sorting
+{
+    /// <summary>
+    /// Class ParentIndexNumberComparer.
+    /// </summary>
+    public class ParentIndexNumberComparer : IBaseItemComparer
+    {
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name => ItemSortBy.ParentIndexNumber;
+
+        /// <summary>
+        /// Compares the specified x.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <returns>System.Int32.</returns>
+        public int Compare(BaseItem? x, BaseItem? y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+
+            if (!x.ParentIndexNumber.HasValue)
+            {
+                return -1;
+            }
+
+            if (!y.ParentIndexNumber.HasValue)
+            {
+                return 1;
+            }
+
+            return x.ParentIndexNumber.Value.CompareTo(y.ParentIndexNumber.Value);
+        }
+    }
+}

--- a/MediaBrowser.Model/Querying/ItemSortBy.cs
+++ b/MediaBrowser.Model/Querying/ItemSortBy.cs
@@ -102,5 +102,9 @@ namespace MediaBrowser.Model.Querying
         public const string DateLastContentAdded = "DateLastContentAdded";
 
         public const string SeriesDatePlayed = "SeriesDatePlayed";
+
+        public const string ParentIndexNumber = "ParentIndexNumber";
+
+        public const string IndexNumber = "IndexNumber";
     }
 }


### PR DESCRIPTION
Can be used in item queries to sort by ParentIndexNumber and IndexNumber (used for disc and track numbers for example).

Closes #7323.