### PR TITLE
[Bugfix] Report transcoding complete

### DIFF
--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -753,6 +753,8 @@ namespace Jellyfin.Api.Helpers
             job.HasExited = true;
             job.ExitCode = process.ExitCode;
 
+            ReportTranscodingProgress(job, state, null, null, null, null, null);
+
             _logger.LogDebug("Disposing stream resources");
             state.Dispose();
 


### PR DESCRIPTION
Currently, when transcoding finishes it is not reported - leaving the UI with an incomplete transcode %

**Changes**
Report transcoding progress as empty / complete when the transcoding job finishes