### PR TITLE
fix HLS transcoding on android tv -- dont use -noaccurate_seek for hls transcode

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2167,6 +2167,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     // Important: If this is ever re-enabled, make sure not to use it with wtv because it breaks seeking
                     if (!string.Equals(state.InputContainer, "wtv", StringComparison.OrdinalIgnoreCase)
                         && state.TranscodingType != TranscodingJobType.Progressive
+                        && state.TranscodingType != TranscodingJobType.Hls
                         && !state.EnableBreakOnNonKeyFrames(outputVideoCodec)
                         && (state.BaseRequest.StartTimeTicks ?? 0) > 0)
                     {


### PR DESCRIPTION
**Changes**
* dont use -noaccurate_seek for hls

**Issues**
* exoplayer in the Android TV client would get chunks with video that starts earlier than their timestamps. Typically it would be around 4 seconds behind.

   when testing with https://github.com/jellyfin/jellyfin/pull/6600 on Android-TV I found segments were still inaccurate (off by the time difference between two keyframes), even though the requested time was keyframe-aligned. I assume this is because even though the requested timestamp is keyframe aligned, ffmpeg still only goes up until the preceding keyframe.

  This issue also occurred in the android (mobile) client using the web player backend

  The main resulting issue is that subtitles handled externally can't be synced to the video

**Notes**
* with both hls and progressive encodes excluded, and dash not supported, I'm not sure if this block will ever run