### PR TITLE
Use sha hash instead of branch name for OpenAPI workflow head reference

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
This should fix pull requests comparing their specification against the latest from the master branch and use the commit the branch was originally created of.

**Changes**

- Use sha hash instead of branch name for OpenAPI workflow head reference

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
