### PR TITLE
Optimize Guid comparisons

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,1 +1,4 @@
 P:System.Threading.Tasks.Task`1.Result
+M:System.Guid.op_Equality(System.Guid,System.Guid)
+M:System.Guid.op_Inequality(System.Guid,System.Guid)
+M:System.Guid.Equals(System.Object)

--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -160,7 +160,7 @@ namespace Emby.Dlna.Didl
             else
             {
                 var parent = item.DisplayParentId;
-                if (!parent.Equals(Guid.Empty))
+                if (!parent.Equals(default))
                 {
                     writer.WriteAttributeString("parentID", GetClientId(parent, null));
                 }
@@ -657,7 +657,7 @@ namespace Emby.Dlna.Didl
                 else
                 {
                     var parent = folder.DisplayParentId;
-                    if (parent.Equals(Guid.Empty))
+                    if (parent.Equals(default))
                     {
                         writer.WriteAttributeString("parentID", "0");
                     }

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -174,7 +174,7 @@ namespace Emby.Dlna.PlayTo
                 await _sessionManager.OnPlaybackStart(newItemProgress).ConfigureAwait(false);
 
                 // Send a message to the DLNA device to notify what is the next track in the playlist.
-                var currentItemIndex = _playlist.FindIndex(item => item.StreamInfo.ItemId == streamInfo.ItemId);
+                var currentItemIndex = _playlist.FindIndex(item => item.StreamInfo.ItemId.Equals(streamInfo.ItemId));
                 if (currentItemIndex >= 0)
                 {
                     _currentPlaylistIndex = currentItemIndex;
@@ -349,7 +349,9 @@ namespace Emby.Dlna.PlayTo
         {
             _logger.LogDebug("{0} - Received PlayRequest: {1}", _session.DeviceName, command.PlayCommand);
 
-            var user = command.ControllingUserId.Equals(Guid.Empty) ? null : _userManager.GetUserById(command.ControllingUserId);
+            var user = command.ControllingUserId.Equals(default)
+                ? null :
+                _userManager.GetUserById(command.ControllingUserId);
 
             var items = new List<BaseItem>();
             foreach (var id in command.ItemIds)
@@ -392,7 +394,7 @@ namespace Emby.Dlna.PlayTo
                 _playlist.AddRange(playlist);
             }
 
-            if (!command.ControllingUserId.Equals(Guid.Empty))
+            if (!command.ControllingUserId.Equals(default))
             {
                 _sessionManager.LogSessionActivity(
                     _session.Client,
@@ -446,7 +448,9 @@ namespace Emby.Dlna.PlayTo
 
                 if (info.Item != null && !EnableClientSideSeek(info))
                 {
-                    var user = !_session.UserId.Equals(Guid.Empty) ? _userManager.GetUserById(_session.UserId) : null;
+                    var user = _session.UserId.Equals(default)
+                        ? null
+                        : _userManager.GetUserById(_session.UserId);
                     var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, info.SubtitleStreamIndex);
 
                     await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
@@ -764,7 +768,9 @@ namespace Emby.Dlna.PlayTo
                 {
                     var newPosition = GetProgressPositionTicks(info) ?? 0;
 
-                    var user = !_session.UserId.Equals(Guid.Empty) ? _userManager.GetUserById(_session.UserId) : null;
+                    var user = _session.UserId.Equals(default)
+                        ? null
+                        : _userManager.GetUserById(_session.UserId);
                     var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, newIndex, info.SubtitleStreamIndex);
 
                     await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
@@ -793,7 +799,9 @@ namespace Emby.Dlna.PlayTo
                 {
                     var newPosition = GetProgressPositionTicks(info) ?? 0;
 
-                    var user = !_session.UserId.Equals(Guid.Empty) ? _userManager.GetUserById(_session.UserId) : null;
+                    var user = _session.UserId.Equals(default)
+                        ? null
+                        : _userManager.GetUserById(_session.UserId);
                     var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, newIndex);
 
                     await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
@@ -949,7 +957,7 @@ namespace Emby.Dlna.PlayTo
                     }
                 }
 
-                return Guid.Empty;
+                return default;
             }
 
             public static StreamParams ParseFromUrl(string url, ILibraryManager libraryManager, IMediaSourceManager mediaSourceManager)
@@ -964,7 +972,7 @@ namespace Emby.Dlna.PlayTo
                     ItemId = GetItemId(url)
                 };
 
-                if (request.ItemId.Equals(Guid.Empty))
+                if (request.ItemId.Equals(default))
                 {
                     return request;
                 }

--- a/Emby.Notifications/NotificationEntryPoint.cs
+++ b/Emby.Notifications/NotificationEntryPoint.cs
@@ -112,7 +112,7 @@ namespace Emby.Notifications
 
             var userId = e.Argument.UserId;
 
-            if (!userId.Equals(Guid.Empty) && !GetOptions().IsEnabledToMonitorUser(type, userId))
+            if (!userId.Equals(default) && !GetOptions().IsEnabledToMonitorUser(type, userId))
             {
                 return;
             }

--- a/Emby.Server.Implementations/Channels/ChannelManager.cs
+++ b/Emby.Server.Implementations/Channels/ChannelManager.cs
@@ -162,7 +162,7 @@ namespace Emby.Server.Implementations.Channels
         /// <inheritdoc />
         public QueryResult<Channel> GetChannelsInternal(ChannelQuery query)
         {
-            var user = query.UserId.Equals(Guid.Empty)
+            var user = query.UserId.Equals(default)
                 ? null
                 : _userManager.GetUserById(query.UserId);
 
@@ -274,7 +274,7 @@ namespace Emby.Server.Implementations.Channels
         /// <inheritdoc />
         public QueryResult<BaseItemDto> GetChannels(ChannelQuery query)
         {
-            var user = query.UserId.Equals(Guid.Empty)
+            var user = query.UserId.Equals(default)
                 ? null
                 : _userManager.GetUserById(query.UserId);
 
@@ -474,7 +474,7 @@ namespace Emby.Server.Implementations.Channels
 
             item.ChannelId = id;
 
-            if (item.ParentId != parentFolderId)
+            if (!item.ParentId.Equals(parentFolderId))
             {
                 forceUpdate = true;
             }
@@ -715,7 +715,9 @@ namespace Emby.Server.Implementations.Channels
             // Find the corresponding channel provider plugin
             var channelProvider = GetChannelProvider(channel);
 
-            var parentItem = query.ParentId == Guid.Empty ? channel : _libraryManager.GetItemById(query.ParentId);
+            var parentItem = query.ParentId.Equals(default)
+                ? channel
+                : _libraryManager.GetItemById(query.ParentId);
 
             var itemsResult = await GetChannelItems(
                 channelProvider,
@@ -726,7 +728,7 @@ namespace Emby.Server.Implementations.Channels
                 cancellationToken)
                 .ConfigureAwait(false);
 
-            if (query.ParentId == Guid.Empty)
+            if (query.ParentId.Equals(default))
             {
                 query.Parent = channel;
             }

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -265,7 +265,7 @@ namespace Emby.Server.Implementations.Collections
             {
                 var childItem = _libraryManager.GetItemById(guidId);
 
-                var child = collection.LinkedChildren.FirstOrDefault(i => (i.ItemId.HasValue && i.ItemId.Value == guidId) || (childItem != null && string.Equals(childItem.Path, i.Path, StringComparison.OrdinalIgnoreCase)));
+                var child = collection.LinkedChildren.FirstOrDefault(i => (i.ItemId.HasValue && i.ItemId.Value.Equals(guidId)) || (childItem != null && string.Equals(childItem.Path, i.Path, StringComparison.OrdinalIgnoreCase)));
 
                 if (child == null)
                 {

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1308,7 +1308,7 @@ namespace Emby.Server.Implementations.Dto
 
                 var allImages = parent.ImageInfos;
 
-                if (logoLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Logo)) && dto.ParentLogoItemId == null)
+                if (logoLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Logo)) && dto.ParentLogoItemId is null)
                 {
                     var image = allImages.FirstOrDefault(i => i.Type == ImageType.Logo);
 
@@ -1319,7 +1319,7 @@ namespace Emby.Server.Implementations.Dto
                     }
                 }
 
-                if (artLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Art)) && dto.ParentArtItemId == null)
+                if (artLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Art)) && dto.ParentArtItemId is null)
                 {
                     var image = allImages.FirstOrDefault(i => i.Type == ImageType.Art);
 
@@ -1330,7 +1330,7 @@ namespace Emby.Server.Implementations.Dto
                     }
                 }
 
-                if (thumbLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Thumb)) && (dto.ParentThumbItemId == null || parent is Series) && parent is not ICollectionFolder && parent is not UserView)
+                if (thumbLimit > 0 && !(imageTags != null && imageTags.ContainsKey(ImageType.Thumb)) && (dto.ParentThumbItemId is null || parent is Series) && parent is not ICollectionFolder && parent is not UserView)
                 {
                     var image = allImages.FirstOrDefault(i => i.Type == ImageType.Thumb);
 

--- a/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
@@ -326,7 +326,7 @@ namespace Emby.Server.Implementations.EntryPoints
         {
             var userIds = _sessionManager.Sessions
                 .Select(i => i.UserId)
-                .Where(i => !i.Equals(Guid.Empty))
+                .Where(i => !i.Equals(default))
                 .Distinct()
                 .ToArray();
 

--- a/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
+++ b/Emby.Server.Implementations/HttpServer/Security/SessionContext.cs
@@ -47,7 +47,9 @@ namespace Emby.Server.Implementations.HttpServer.Security
         {
             var session = await GetSession(requestContext).ConfigureAwait(false);
 
-            return session.UserId.Equals(Guid.Empty) ? null : _userManager.GetUserById(session.UserId);
+            return session.UserId.Equals(default)
+                ? null
+                : _userManager.GetUserById(session.UserId);
         }
 
         public Task<User?> GetUser(object requestContext)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -755,7 +755,7 @@ namespace Emby.Server.Implementations.Library
                 Path = path
             };
 
-            if (folder.Id.Equals(Guid.Empty))
+            if (folder.Id.Equals(default))
             {
                 if (string.IsNullOrEmpty(folder.Path))
                 {
@@ -774,7 +774,7 @@ namespace Emby.Server.Implementations.Library
                 folder = dbItem;
             }
 
-            if (folder.ParentId != rootFolder.Id)
+            if (!folder.ParentId.Equals(rootFolder.Id))
             {
                 folder.ParentId = rootFolder.Id;
                 folder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
@@ -1252,7 +1252,7 @@ namespace Emby.Server.Implementations.Library
         /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
         public BaseItem GetItemById(Guid id)
         {
-            if (id == Guid.Empty)
+            if (id.Equals(default))
             {
                 throw new ArgumentException("Guid can't be empty", nameof(id));
             }
@@ -1274,7 +1274,7 @@ namespace Emby.Server.Implementations.Library
 
         public List<BaseItem> GetItemList(InternalItemsQuery query, bool allowExternalContent)
         {
-            if (query.Recursive && query.ParentId != Guid.Empty)
+            if (query.Recursive && !query.ParentId.Equals(default))
             {
                 var parent = GetItemById(query.ParentId);
                 if (parent != null)
@@ -1298,7 +1298,7 @@ namespace Emby.Server.Implementations.Library
 
         public int GetCount(InternalItemsQuery query)
         {
-            if (query.Recursive && !query.ParentId.Equals(Guid.Empty))
+            if (query.Recursive && !query.ParentId.Equals(default))
             {
                 var parent = GetItemById(query.ParentId);
                 if (parent != null)
@@ -1456,7 +1456,7 @@ namespace Emby.Server.Implementations.Library
 
         public QueryResult<BaseItem> GetItemsResult(InternalItemsQuery query)
         {
-            if (query.Recursive && !query.ParentId.Equals(Guid.Empty))
+            if (query.Recursive && !query.ParentId.Equals(default))
             {
                 var parent = GetItemById(query.ParentId);
                 if (parent != null)
@@ -1512,7 +1512,7 @@ namespace Emby.Server.Implementations.Library
         private void AddUserToQuery(InternalItemsQuery query, User user, bool allowExternalContent = true)
         {
             if (query.AncestorIds.Length == 0 &&
-                query.ParentId.Equals(Guid.Empty) &&
+                query.ParentId.Equals(default) &&
                 query.ChannelIds.Count == 0 &&
                 query.TopParentIds.Length == 0 &&
                 string.IsNullOrEmpty(query.AncestorWithPresentationUniqueKey) &&
@@ -1540,7 +1540,7 @@ namespace Emby.Server.Implementations.Library
                 }
 
                 // Translate view into folders
-                if (!view.DisplayParentId.Equals(Guid.Empty))
+                if (!view.DisplayParentId.Equals(default))
                 {
                     var displayParent = GetItemById(view.DisplayParentId);
                     if (displayParent != null)
@@ -1551,7 +1551,7 @@ namespace Emby.Server.Implementations.Library
                     return Array.Empty<Guid>();
                 }
 
-                if (!view.ParentId.Equals(Guid.Empty))
+                if (!view.ParentId.Equals(default))
                 {
                     var displayParent = GetItemById(view.ParentId);
                     if (displayParent != null)
@@ -2153,7 +2153,7 @@ namespace Emby.Server.Implementations.Library
                 return null;
             }
 
-            while (!item.ParentId.Equals(Guid.Empty))
+            while (!item.ParentId.Equals(default))
             {
                 var parent = item.GetParent();
                 if (parent == null || parent is AggregateFolder)
@@ -2231,7 +2231,9 @@ namespace Emby.Server.Implementations.Library
             string viewType,
             string sortName)
         {
-            var parentIdString = parentId.Equals(Guid.Empty) ? null : parentId.ToString("N", CultureInfo.InvariantCulture);
+            var parentIdString = parentId.Equals(default)
+                ? null
+                : parentId.ToString("N", CultureInfo.InvariantCulture);
             var idValues = "38_namedview_" + name + user.Id.ToString("N", CultureInfo.InvariantCulture) + (parentIdString ?? string.Empty) + (viewType ?? string.Empty);
 
             var id = GetNewItemId(idValues, typeof(UserView));
@@ -2265,7 +2267,7 @@ namespace Emby.Server.Implementations.Library
 
             var refresh = isNew || DateTime.UtcNow - item.DateLastRefreshed >= _viewRefreshInterval;
 
-            if (!refresh && !item.DisplayParentId.Equals(Guid.Empty))
+            if (!refresh && !item.DisplayParentId.Equals(default))
             {
                 var displayParent = GetItemById(item.DisplayParentId);
                 refresh = displayParent != null && displayParent.DateLastSaved > item.DateLastRefreshed;
@@ -2332,7 +2334,7 @@ namespace Emby.Server.Implementations.Library
 
             var refresh = isNew || DateTime.UtcNow - item.DateLastRefreshed >= _viewRefreshInterval;
 
-            if (!refresh && !item.DisplayParentId.Equals(Guid.Empty))
+            if (!refresh && !item.DisplayParentId.Equals(default))
             {
                 var displayParent = GetItemById(item.DisplayParentId);
                 refresh = displayParent != null && displayParent.DateLastSaved > item.DateLastRefreshed;
@@ -2365,7 +2367,9 @@ namespace Emby.Server.Implementations.Library
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var parentIdString = parentId.Equals(Guid.Empty) ? null : parentId.ToString("N", CultureInfo.InvariantCulture);
+            var parentIdString = parentId.Equals(default)
+                ? null
+                : parentId.ToString("N", CultureInfo.InvariantCulture);
             var idValues = "37_namedview_" + name + (parentIdString ?? string.Empty) + (viewType ?? string.Empty);
             if (!string.IsNullOrEmpty(uniqueId))
             {
@@ -2409,7 +2413,7 @@ namespace Emby.Server.Implementations.Library
 
             var refresh = isNew || DateTime.UtcNow - item.DateLastRefreshed >= _viewRefreshInterval;
 
-            if (!refresh && !item.DisplayParentId.Equals(Guid.Empty))
+            if (!refresh && !item.DisplayParentId.Equals(default))
             {
                 var displayParent = GetItemById(item.DisplayParentId);
                 refresh = displayParent != null && displayParent.DateLastSaved > item.DateLastRefreshed;

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -514,10 +514,10 @@ namespace Emby.Server.Implementations.Library
             _logger.LogInformation("Live stream opened: {@MediaSource}", mediaSource);
             var clone = JsonSerializer.Deserialize<MediaSourceInfo>(json, _jsonOptions);
 
-            if (!request.UserId.Equals(Guid.Empty))
+            if (!request.UserId.Equals(default))
             {
                 var user = _userManager.GetUserById(request.UserId);
-                var item = request.ItemId.Equals(Guid.Empty)
+                var item = request.ItemId.Equals(default)
                     ? null
                     : _libraryManager.GetItemById(request.ItemId);
                 SetDefaultAudioAndSubtitleStreamIndexes(item, clone, user);

--- a/Emby.Server.Implementations/Library/MusicManager.cs
+++ b/Emby.Server.Implementations/Library/MusicManager.cs
@@ -80,7 +80,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     return Guid.Empty;
                 }
-            }).Where(i => !i.Equals(Guid.Empty)).ToArray();
+            }).Where(i => !i.Equals(default)).ToArray();
 
             return GetInstantMixFromGenreIds(genreIds, user, dtoOptions);
         }

--- a/Emby.Server.Implementations/Library/SearchEngine.cs
+++ b/Emby.Server.Implementations/Library/SearchEngine.cs
@@ -30,7 +30,7 @@ namespace Emby.Server.Implementations.Library
         public QueryResult<SearchHintInfo> GetSearchHints(SearchQuery query)
         {
             User user = null;
-            if (query.UserId != Guid.Empty)
+            if (!query.UserId.Equals(default))
             {
                 user = _userManager.GetUserById(query.UserId);
             }
@@ -168,10 +168,10 @@ namespace Emby.Server.Implementations.Library
                 {
                     Fields = new ItemFields[]
                     {
-                         ItemFields.AirTime,
-                         ItemFields.DateCreated,
-                         ItemFields.ChannelInfo,
-                         ItemFields.ParentId
+                        ItemFields.AirTime,
+                        ItemFields.DateCreated,
+                        ItemFields.ChannelInfo,
+                        ItemFields.ParentId
                     }
                 }
             };
@@ -180,12 +180,12 @@ namespace Emby.Server.Implementations.Library
 
             if (searchQuery.IncludeItemTypes.Length == 1 && searchQuery.IncludeItemTypes[0] == BaseItemKind.MusicArtist)
             {
-                if (!searchQuery.ParentId.Equals(Guid.Empty))
+                if (!searchQuery.ParentId.Equals(default))
                 {
                     searchQuery.AncestorIds = new[] { searchQuery.ParentId };
+                    searchQuery.ParentId = Guid.Empty;
                 }
 
-                searchQuery.ParentId = Guid.Empty;
                 searchQuery.IncludeItemsByName = true;
                 searchQuery.IncludeItemTypes = Array.Empty<BaseItemKind>();
                 mediaItems = _libraryManager.GetAllArtists(searchQuery).Items.Select(i => i.Item).ToList();

--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -142,7 +142,7 @@ namespace Emby.Server.Implementations.Library
 
                     if (index == -1
                         && i is UserView view
-                        && view.DisplayParentId != Guid.Empty)
+                        && !view.DisplayParentId.Equals(default))
                     {
                         index = Array.IndexOf(orders, view.DisplayParentId);
                     }
@@ -214,7 +214,7 @@ namespace Emby.Server.Implementations.Library
                 }
                 else
                 {
-                    var current = list.FirstOrDefault(i => i.Item1 != null && i.Item1.Id == container.Id);
+                    var current = list.FirstOrDefault(i => i.Item1 != null && i.Item1.Id.Equals(container.Id));
 
                     if (current != null)
                     {
@@ -244,7 +244,7 @@ namespace Emby.Server.Implementations.Library
 
             var parents = new List<BaseItem>();
 
-            if (!parentId.Equals(Guid.Empty))
+            if (!parentId.Equals(default))
             {
                 var parentItem = _libraryManager.GetItemById(parentId);
                 if (parentItem is Channel)

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2024,7 +2024,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                         await writer.WriteElementStringAsync(null, "genre", null, genre).ConfigureAwait(false);
                     }
 
-                    var people = item.Id.Equals(Guid.Empty) ? new List<PersonInfo>() : _libraryManager.GetPeople(item);
+                    var people = item.Id.Equals(default) ? new List<PersonInfo>() : _libraryManager.GetPeople(item);
 
                     var directors = people
                         .Where(i => IsPersonType(i, PersonType.Director))
@@ -2382,7 +2382,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             string channelId = seriesTimer.RecordAnyChannel ? null : seriesTimer.ChannelId;
 
-            if (string.IsNullOrWhiteSpace(channelId) && !parent.ChannelId.Equals(Guid.Empty))
+            if (string.IsNullOrWhiteSpace(channelId) && !parent.ChannelId.Equals(default))
             {
                 if (!tempChannelCache.TryGetValue(parent.ChannelId, out LiveTvChannel channel))
                 {
@@ -2441,7 +2441,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         {
             string channelId = null;
 
-            if (!programInfo.ChannelId.Equals(Guid.Empty))
+            if (!programInfo.ChannelId.Equals(default))
             {
                 if (!tempChannelCache.TryGetValue(programInfo.ChannelId, out LiveTvChannel channel))
                 {

--- a/Emby.Server.Implementations/LiveTv/LiveTvDtoService.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvDtoService.cs
@@ -456,7 +456,7 @@ namespace Emby.Server.Implementations.LiveTv
                 info.Id = timer.ExternalId;
             }
 
-            if (!dto.ChannelId.Equals(Guid.Empty) && string.IsNullOrEmpty(info.ChannelId))
+            if (!dto.ChannelId.Equals(default) && string.IsNullOrEmpty(info.ChannelId))
             {
                 var channel = _libraryManager.GetItemById(dto.ChannelId);
 
@@ -522,7 +522,7 @@ namespace Emby.Server.Implementations.LiveTv
                 info.Id = timer.ExternalId;
             }
 
-            if (!dto.ChannelId.Equals(Guid.Empty) && string.IsNullOrEmpty(info.ChannelId))
+            if (!dto.ChannelId.Equals(default) && string.IsNullOrEmpty(info.ChannelId))
             {
                 var channel = _libraryManager.GetItemById(dto.ChannelId);
 

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -176,7 +176,9 @@ namespace Emby.Server.Implementations.LiveTv
 
         public QueryResult<BaseItem> GetInternalChannels(LiveTvChannelQuery query, DtoOptions dtoOptions, CancellationToken cancellationToken)
         {
-            var user = query.UserId == Guid.Empty ? null : _userManager.GetUserById(query.UserId);
+            var user = query.UserId.Equals(default)
+                ? null
+                : _userManager.GetUserById(query.UserId);
 
             var topFolder = GetInternalLiveTvFolder(cancellationToken);
 
@@ -1268,7 +1270,7 @@ namespace Emby.Server.Implementations.LiveTv
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (itemId.Equals(Guid.Empty))
+                if (itemId.Equals(default))
                 {
                     // Somehow some invalid data got into the db. It probably predates the boundary checking
                     continue;
@@ -1528,7 +1530,9 @@ namespace Emby.Server.Implementations.LiveTv
 
         public QueryResult<BaseItemDto> GetRecordings(RecordingQuery query, DtoOptions options)
         {
-            var user = query.UserId.Equals(Guid.Empty) ? null : _userManager.GetUserById(query.UserId);
+            var user = query.UserId.Equals(default)
+                ? null
+                : _userManager.GetUserById(query.UserId);
 
             RemoveFields(options);
 
@@ -1587,7 +1591,7 @@ namespace Emby.Server.Implementations.LiveTv
             if (!string.IsNullOrEmpty(query.ChannelId))
             {
                 var guid = new Guid(query.ChannelId);
-                timers = timers.Where(i => guid == _tvDtoService.GetInternalChannelId(i.Item2.Name, i.Item1.ChannelId));
+                timers = timers.Where(i => _tvDtoService.GetInternalChannelId(i.Item2.Name, i.Item1.ChannelId).Equals(guid));
             }
 
             if (!string.IsNullOrEmpty(query.SeriesTimerId))
@@ -1595,7 +1599,7 @@ namespace Emby.Server.Implementations.LiveTv
                 var guid = new Guid(query.SeriesTimerId);
 
                 timers = timers
-                    .Where(i => _tvDtoService.GetInternalSeriesTimerId(i.Item1.SeriesTimerId) == guid);
+                    .Where(i => _tvDtoService.GetInternalSeriesTimerId(i.Item1.SeriesTimerId).Equals(guid));
             }
 
             if (!string.IsNullOrEmpty(query.Id))
@@ -1657,7 +1661,7 @@ namespace Emby.Server.Implementations.LiveTv
             if (!string.IsNullOrEmpty(query.ChannelId))
             {
                 var guid = new Guid(query.ChannelId);
-                timers = timers.Where(i => guid == _tvDtoService.GetInternalChannelId(i.Item2.Name, i.Item1.ChannelId));
+                timers = timers.Where(i => _tvDtoService.GetInternalChannelId(i.Item2.Name, i.Item1.ChannelId).Equals(guid));
             }
 
             if (!string.IsNullOrEmpty(query.SeriesTimerId))
@@ -1665,7 +1669,7 @@ namespace Emby.Server.Implementations.LiveTv
                 var guid = new Guid(query.SeriesTimerId);
 
                 timers = timers
-                    .Where(i => _tvDtoService.GetInternalSeriesTimerId(i.Item1.SeriesTimerId) == guid);
+                    .Where(i => _tvDtoService.GetInternalSeriesTimerId(i.Item1.SeriesTimerId).Equals(guid));
             }
 
             if (!string.IsNullOrEmpty(query.Id))

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -139,7 +139,9 @@ namespace Emby.Server.Implementations.Playlists
                     {
                         new Share
                         {
-                            UserId = options.UserId.Equals(Guid.Empty) ? null : options.UserId.ToString("N", CultureInfo.InvariantCulture),
+                            UserId = options.UserId.Equals(default)
+                                ? null
+                                : options.UserId.ToString("N", CultureInfo.InvariantCulture),
                             CanEdit = true
                         }
                     }
@@ -188,7 +190,7 @@ namespace Emby.Server.Implementations.Playlists
 
         public Task AddToPlaylistAsync(Guid playlistId, IReadOnlyCollection<Guid> itemIds, Guid userId)
         {
-            var user = userId.Equals(Guid.Empty) ? null : _userManager.GetUserById(userId);
+            var user = userId.Equals(default) ? null : _userManager.GetUserById(userId);
 
             return AddToPlaylistInternal(playlistId, itemIds, user, new DtoOptions(false)
             {

--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -483,7 +483,7 @@ namespace Emby.Server.Implementations.Plugins
                     var pluginStr = instance.Version.ToString();
                     bool changed = false;
                     if (string.Equals(manifest.Version, pluginStr, StringComparison.Ordinal)
-                        || manifest.Id != instance.Id)
+                        || !manifest.Id.Equals(instance.Id))
                     {
                         // If a plugin without a manifest failed to load due to an external issue (eg config),
                         // this updates the manifest to the actual plugin values.

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -373,7 +373,7 @@ namespace Emby.Server.Implementations.Session
                 info.MediaSourceId = info.ItemId.ToString("N", CultureInfo.InvariantCulture);
             }
 
-            if (!info.ItemId.Equals(Guid.Empty) && info.Item == null && libraryItem != null)
+            if (!info.ItemId.Equals(default) && info.Item == null && libraryItem != null)
             {
                 var current = session.NowPlayingItem;
 
@@ -553,21 +553,23 @@ namespace Emby.Server.Implementations.Session
         {
             var users = new List<User>();
 
-            if (session.UserId != Guid.Empty)
+            if (session.UserId.Equals(default))
             {
-                var user = _userManager.GetUserById(session.UserId);
-
-                if (user == null)
-                {
-                    throw new InvalidOperationException("User not found");
-                }
-
-                users.Add(user);
-
-                users.AddRange(session.AdditionalUsers
-                    .Select(i => _userManager.GetUserById(i.UserId))
-                    .Where(i => i != null));
+                return users;
             }
+
+            var user = _userManager.GetUserById(session.UserId);
+
+            if (user == null)
+            {
+                throw new InvalidOperationException("User not found");
+            }
+
+            users.Add(user);
+
+            users.AddRange(session.AdditionalUsers
+                .Select(i => _userManager.GetUserById(i.UserId))
+                .Where(i => i != null));
 
             return users;
         }
@@ -660,7 +662,7 @@ namespace Emby.Server.Implementations.Session
 
             var session = GetSession(info.SessionId);
 
-            var libraryItem = info.ItemId == Guid.Empty
+            var libraryItem = info.ItemId.Equals(default)
                 ? null
                 : GetNowPlayingItem(session, info.ItemId);
 
@@ -755,7 +757,7 @@ namespace Emby.Server.Implementations.Session
 
             var session = GetSession(info.SessionId);
 
-            var libraryItem = info.ItemId.Equals(Guid.Empty)
+            var libraryItem = info.ItemId.Equals(default)
                 ? null
                 : GetNowPlayingItem(session, info.ItemId);
 
@@ -892,7 +894,7 @@ namespace Emby.Server.Implementations.Session
 
             session.StopAutomaticProgress();
 
-            var libraryItem = info.ItemId.Equals(Guid.Empty)
+            var libraryItem = info.ItemId.Equals(default)
                 ? null
                 : GetNowPlayingItem(session, info.ItemId);
 
@@ -902,7 +904,7 @@ namespace Emby.Server.Implementations.Session
                 info.MediaSourceId = info.ItemId.ToString("N", CultureInfo.InvariantCulture);
             }
 
-            if (!info.ItemId.Equals(Guid.Empty) && info.Item == null && libraryItem != null)
+            if (!info.ItemId.Equals(default) && info.Item == null && libraryItem != null)
             {
                 var current = session.NowPlayingItem;
 
@@ -1122,7 +1124,7 @@ namespace Emby.Server.Implementations.Session
 
             var session = GetSessionToRemoteControl(sessionId);
 
-            var user = session.UserId == Guid.Empty ? null : _userManager.GetUserById(session.UserId);
+            var user = session.UserId.Equals(default) ? null : _userManager.GetUserById(session.UserId);
 
             List<BaseItem> items;
 
@@ -1177,7 +1179,7 @@ namespace Emby.Server.Implementations.Session
                                 EnableImages = false
                             })
                         .Where(i => !i.IsVirtualItem)
-                        .SkipWhile(i => i.Id != episode.Id)
+                        .SkipWhile(i => !i.Id.Equals(episode.Id))
                         .ToList();
 
                     if (episodes.Count > 0)
@@ -1191,7 +1193,7 @@ namespace Emby.Server.Implementations.Session
             {
                 var controllingSession = GetSession(controllingSessionId);
                 AssertCanControl(session, controllingSession);
-                if (!controllingSession.UserId.Equals(Guid.Empty))
+                if (!controllingSession.UserId.Equals(default))
                 {
                     command.ControllingUserId = controllingSession.UserId;
                 }
@@ -1310,7 +1312,7 @@ namespace Emby.Server.Implementations.Session
             {
                 var controllingSession = GetSession(controllingSessionId);
                 AssertCanControl(session, controllingSession);
-                if (!controllingSession.UserId.Equals(Guid.Empty))
+                if (!controllingSession.UserId.Equals(default))
                 {
                     command.ControllingUserId = controllingSession.UserId.ToString("N", CultureInfo.InvariantCulture);
                 }
@@ -1383,12 +1385,12 @@ namespace Emby.Server.Implementations.Session
 
             var session = GetSession(sessionId);
 
-            if (session.UserId == userId)
+            if (session.UserId.Equals(userId))
             {
                 throw new ArgumentException("The requested user is already the primary user of the session.");
             }
 
-            if (session.AdditionalUsers.All(i => i.UserId != userId))
+            if (session.AdditionalUsers.All(i => !i.UserId.Equals(userId)))
             {
                 var user = _userManager.GetUserById(userId);
 
@@ -1458,7 +1460,7 @@ namespace Emby.Server.Implementations.Session
             CheckDisposed();
 
             User user = null;
-            if (request.UserId != Guid.Empty)
+            if (!request.UserId.Equals(default))
             {
                 user = _userManager.GetUserById(request.UserId);
             }
@@ -1787,7 +1789,7 @@ namespace Emby.Server.Implementations.Session
                 throw new ArgumentNullException(nameof(info));
             }
 
-            var user = info.UserId == Guid.Empty
+            var user = info.UserId.Equals(default)
                 ? null
                 : _userManager.GetUserById(info.UserId);
 

--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -553,7 +553,7 @@ namespace Emby.Server.Implementations.SyncPlay
             if (playingItemRemoved)
             {
                 var itemId = PlayQueue.GetPlayingItemId();
-                if (!itemId.Equals(Guid.Empty))
+                if (!itemId.Equals(default))
                 {
                     var item = _libraryManager.GetItemById(itemId);
                     RunTimeTicks = item.RunTimeTicks ?? 0;

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -271,7 +271,7 @@ namespace Emby.Server.Implementations.TV
                         .Cast<Episode>();
                     if (lastWatchedEpisode != null)
                     {
-                        sortedConsideredEpisodes = sortedConsideredEpisodes.SkipWhile(episode => episode.Id != lastWatchedEpisode.Id).Skip(1);
+                        sortedConsideredEpisodes = sortedConsideredEpisodes.SkipWhile(episode => !episode.Id.Equals(lastWatchedEpisode.Id)).Skip(1);
                     }
 
                     nextEpisode = sortedConsideredEpisodes.FirstOrDefault();

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -227,9 +227,9 @@ namespace Emby.Server.Implementations.Updates
                 availablePackages = availablePackages.Where(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             }
 
-            if (id != default)
+            if (!id.Equals(default))
             {
-                availablePackages = availablePackages.Where(x => x.Id == id);
+                availablePackages = availablePackages.Where(x => x.Id.Equals(id));
             }
 
             if (specificVersion != null)
@@ -399,7 +399,7 @@ namespace Emby.Server.Implementations.Updates
         {
             lock (_currentInstallationsLock)
             {
-                var install = _currentInstallations.Find(x => x.Info.Id == id);
+                var install = _currentInstallations.Find(x => x.Info.Id.Equals(id));
                 if (install == default((InstallationInfo, CancellationTokenSource)))
                 {
                     return false;
@@ -498,7 +498,7 @@ namespace Emby.Server.Implementations.Updates
                 var compatibleVersions = GetCompatibleVersions(pluginCatalog, plugin.Name, plugin.Id, minVersion: plugin.Version);
                 var version = compatibleVersions.FirstOrDefault(y => y.Version > plugin.Version);
 
-                if (version != null && CompletedInstallations.All(x => x.Id != version.Id))
+                if (version != null && CompletedInstallations.All(x => !x.Id.Equals(version.Id)))
                 {
                     yield return version;
                 }

--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Api.Controllers
             User? user = null;
             BaseItem parentItem = _libraryManager.GetParentItem(parentId, userId);
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Equals(default))
             {
                 user = _userManager.GetUserById(userId.Value);
             }
@@ -329,7 +329,7 @@ namespace Jellyfin.Api.Controllers
             User? user = null;
             BaseItem parentItem = _libraryManager.GetParentItem(parentId, userId);
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Equals(default))
             {
                 user = _userManager.GetUserById(userId.Value);
             }
@@ -467,7 +467,7 @@ namespace Jellyfin.Api.Controllers
 
             var item = _libraryManager.GetArtist(name, dtoOptions);
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Value.Equals(default))
             {
                 var user = _userManager.GetUserById(userId.Value);
 

--- a/Jellyfin.Api/Controllers/ChannelsController.cs
+++ b/Jellyfin.Api/Controllers/ChannelsController.cs
@@ -125,9 +125,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] sortBy,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var query = new InternalItemsQuery(user)
             {
@@ -199,9 +199,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] channelIds)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var query = new InternalItemsQuery(user)
             {

--- a/Jellyfin.Api/Controllers/FilterController.cs
+++ b/Jellyfin.Api/Controllers/FilterController.cs
@@ -52,9 +52,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] includeItemTypes,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] mediaTypes)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             BaseItem? item = null;
             if (includeItemTypes.Length != 1
@@ -144,9 +144,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? isSeries,
             [FromQuery] bool? recursive)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             BaseItem? parentItem = null;
             if (includeItemTypes.Length == 1

--- a/Jellyfin.Api/Controllers/GenresController.cs
+++ b/Jellyfin.Api/Controllers/GenresController.cs
@@ -95,7 +95,9 @@ namespace Jellyfin.Api.Controllers
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, false, imageTypeLimit, enableImageTypes);
 
-            User? user = userId.HasValue && userId != Guid.Empty ? _userManager.GetUserById(userId.Value) : null;
+            User? user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var parentItem = _libraryManager.GetParentItem(parentId, userId);
 
@@ -157,29 +159,26 @@ namespace Jellyfin.Api.Controllers
             var dtoOptions = new DtoOptions()
                 .AddClientFields(Request);
 
-            Genre item = new Genre();
-            if (genreName.IndexOf(BaseItem.SlugChar, StringComparison.OrdinalIgnoreCase) != -1)
+            Genre? item;
+            if (genreName.Contains(BaseItem.SlugChar, StringComparison.OrdinalIgnoreCase))
             {
-                var result = GetItemFromSlugName<Genre>(_libraryManager, genreName, dtoOptions, BaseItemKind.Genre);
-
-                if (result != null)
-                {
-                    item = result;
-                }
+                item = GetItemFromSlugName<Genre>(_libraryManager, genreName, dtoOptions, BaseItemKind.Genre);
             }
             else
             {
                 item = _libraryManager.GetGenre(genreName);
             }
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
-            {
-                var user = _userManager.GetUserById(userId.Value);
+            item ??= new Genre();
 
-                return _dtoService.GetBaseItemDto(item, dtoOptions, user);
+            if (userId is null || userId.Value.Equals(default))
+            {
+                return _dtoService.GetBaseItemDto(item, dtoOptions);
             }
 
-            return _dtoService.GetBaseItemDto(item, dtoOptions);
+            var user = _userManager.GetUserById(userId.Value);
+
+            return _dtoService.GetBaseItemDto(item, dtoOptions, user);
         }
 
         private T? GetItemFromSlugName<T>(ILibraryManager libraryManager, string name, DtoOptions dtoOptions, BaseItemKind baseItemKind)

--- a/Jellyfin.Api/Controllers/InstantMixController.cs
+++ b/Jellyfin.Api/Controllers/InstantMixController.cs
@@ -75,9 +75,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var item = _libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -111,9 +111,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var album = _libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -147,9 +147,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var playlist = (Playlist)_libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -182,9 +182,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? imageTypeLimit,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -218,9 +218,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var item = _libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -254,9 +254,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var item = _libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -327,9 +327,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
         {
             var item = _libraryManager.GetItemById(id);
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -228,7 +228,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool enableTotalRecordCount = true,
             [FromQuery] bool? enableImages = true)
         {
-            var user = userId == Guid.Empty ? null : _userManager.GetUserById(userId);
+            var user = userId.Equals(default) ? null : _userManager.GetUserById(userId);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
@@ -799,7 +799,7 @@ namespace Jellyfin.Api.Controllers
             var ancestorIds = Array.Empty<Guid>();
 
             var excludeFolderIds = user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes);
-            if (parentIdGuid.Equals(Guid.Empty) && excludeFolderIds.Length > 0)
+            if (parentIdGuid.Equals(default) && excludeFolderIds.Length > 0)
             {
                 ancestorIds = _libraryManager.GetUserRootFolder().GetChildren(user, true)
                     .Where(i => i is Folder)
@@ -812,7 +812,7 @@ namespace Jellyfin.Api.Controllers
             if (excludeActiveSessions)
             {
                 excludeItemIds = _sessionManager.Sessions
-                    .Where(s => s.UserId == userId && s.NowPlayingItem != null)
+                    .Where(s => s.UserId.Equals(userId) && s.NowPlayingItem != null)
                     .Select(s => s.NowPlayingItem.Id)
                     .ToArray();
             }

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -149,14 +149,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] Guid? userId,
             [FromQuery] bool inheritFromParent = false)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
-            var item = itemId.Equals(Guid.Empty)
-                ? (!userId.Equals(Guid.Empty)
-                    ? _libraryManager.GetUserRootFolder()
-                    : _libraryManager.RootFolder)
+            var item = itemId.Equals(default)
+                ? (userId is null || userId.Value.Equals(default)
+                    ? _libraryManager.RootFolder
+                    : _libraryManager.GetUserRootFolder())
                 : _libraryManager.GetItemById(itemId);
 
             if (item == null)
@@ -215,14 +215,14 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] Guid? userId,
             [FromQuery] bool inheritFromParent = false)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
-            var item = itemId.Equals(Guid.Empty)
-                ? (!userId.Equals(Guid.Empty)
-                    ? _libraryManager.GetUserRootFolder()
-                    : _libraryManager.RootFolder)
+            var item = itemId.Equals(default)
+                ? (userId is null || userId.Value.Equals(default)
+                    ? _libraryManager.RootFolder
+                    : _libraryManager.GetUserRootFolder())
                 : _libraryManager.GetItemById(itemId);
 
             if (item == null)
@@ -407,9 +407,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] Guid? userId,
             [FromQuery] bool? isFavorite)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var counts = new ItemCounts
             {
@@ -449,9 +449,9 @@ namespace Jellyfin.Api.Controllers
 
             var baseItemDtos = new List<BaseItemDto>();
 
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var dtoOptions = new DtoOptions().AddClientFields(Request);
             BaseItem? parent = item.GetParent();
@@ -689,10 +689,10 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? limit,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields)
         {
-            var item = itemId.Equals(Guid.Empty)
-                ? (!userId.Equals(Guid.Empty)
-                    ? _libraryManager.GetUserRootFolder()
-                    : _libraryManager.RootFolder)
+            var item = itemId.Equals(default)
+                ? (userId is null || userId.Value.Equals(default)
+                    ? _libraryManager.RootFolder
+                    : _libraryManager.GetUserRootFolder())
                 : _libraryManager.GetItemById(itemId);
 
             if (item is Episode || (item is IItemByName && item is not MusicArtist))
@@ -700,9 +700,9 @@ namespace Jellyfin.Api.Controllers
                 return new QueryResult<BaseItemDto>();
             }
 
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request);
 

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -180,9 +180,9 @@ namespace Jellyfin.Api.Controllers
                 dtoOptions,
                 CancellationToken.None);
 
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var fieldsList = dtoOptions.Fields.ToList();
             fieldsList.Remove(ItemFields.CanDelete);
@@ -211,10 +211,10 @@ namespace Jellyfin.Api.Controllers
         [Authorize(Policy = Policies.DefaultAuthorization)]
         public ActionResult<BaseItemDto> GetChannel([FromRoute, Required] Guid channelId, [FromQuery] Guid? userId)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
-            var item = channelId.Equals(Guid.Empty)
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
+            var item = channelId.Equals(default)
                 ? _libraryManager.GetUserRootFolder()
                 : _libraryManager.GetItemById(channelId);
 
@@ -382,9 +382,9 @@ namespace Jellyfin.Api.Controllers
         [Authorize(Policy = Policies.DefaultAuthorization)]
         public ActionResult<QueryResult<BaseItemDto>> GetRecordingFolders([FromQuery] Guid? userId)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var folders = _liveTvManager.GetRecordingFolders(user);
 
             var returnArray = _dtoService.GetBaseItemDtos(folders, new DtoOptions(), user);
@@ -404,10 +404,10 @@ namespace Jellyfin.Api.Controllers
         [Authorize(Policy = Policies.DefaultAuthorization)]
         public ActionResult<BaseItemDto> GetRecording([FromRoute, Required] Guid recordingId, [FromQuery] Guid? userId)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
-            var item = recordingId.Equals(Guid.Empty) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(recordingId);
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
+            var item = recordingId.Equals(default) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(recordingId);
 
             var dtoOptions = new DtoOptions()
                 .AddClientFields(Request);
@@ -561,9 +561,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery] bool enableTotalRecordCount = true)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var query = new InternalItemsQuery(user)
             {
@@ -588,7 +588,7 @@ namespace Jellyfin.Api.Controllers
                 GenreIds = genreIds
             };
 
-            if (librarySeriesId != null && !librarySeriesId.Equals(Guid.Empty))
+            if (librarySeriesId.HasValue && !librarySeriesId.Equals(default))
             {
                 query.IsSeries = true;
 
@@ -617,7 +617,7 @@ namespace Jellyfin.Api.Controllers
         [Authorize(Policy = Policies.DefaultAuthorization)]
         public async Task<ActionResult<QueryResult<BaseItemDto>>> GetPrograms([FromBody] GetProgramsDto body)
         {
-            var user = body.UserId.Equals(Guid.Empty) ? null : _userManager.GetUserById(body.UserId);
+            var user = body.UserId.Equals(default) ? null : _userManager.GetUserById(body.UserId);
 
             var query = new InternalItemsQuery(user)
             {
@@ -642,7 +642,7 @@ namespace Jellyfin.Api.Controllers
                 GenreIds = body.GenreIds
             };
 
-            if (!body.LibrarySeriesId.Equals(Guid.Empty))
+            if (!body.LibrarySeriesId.Equals(default))
             {
                 query.IsSeries = true;
 
@@ -700,9 +700,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? enableUserData,
             [FromQuery] bool enableTotalRecordCount = true)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var query = new InternalItemsQuery(user)
             {
@@ -738,9 +738,9 @@ namespace Jellyfin.Api.Controllers
             [FromRoute, Required] string programId,
             [FromQuery] Guid? userId)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             return await _liveTvManager.GetProgram(programId, CancellationToken.None, user).ConfigureAwait(false);
         }

--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -68,9 +68,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int categoryLimit = 5,
             [FromQuery] int itemLimit = 8)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var dtoOptions = new DtoOptions { Fields = fields }
                 .AddClientFields(Request);
 

--- a/Jellyfin.Api/Controllers/MusicGenresController.cs
+++ b/Jellyfin.Api/Controllers/MusicGenresController.cs
@@ -95,7 +95,9 @@ namespace Jellyfin.Api.Controllers
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, false, imageTypeLimit, enableImageTypes);
 
-            User? user = userId.HasValue && userId != Guid.Empty ? _userManager.GetUserById(userId.Value) : null;
+            User? user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var parentItem = _libraryManager.GetParentItem(parentId, userId);
 
@@ -156,7 +158,7 @@ namespace Jellyfin.Api.Controllers
                 item = _libraryManager.GetMusicGenre(genreName);
             }
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Value.Equals(default))
             {
                 var user = _userManager.GetUserById(userId.Value);
 

--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -82,12 +82,9 @@ namespace Jellyfin.Api.Controllers
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
 
-            User? user = null;
-
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
-            {
-                user = _userManager.GetUserById(userId.Value);
-            }
+            User? user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var isFavoriteInFilters = filters.Any(f => f == ItemFilter.IsFavorite);
             var peopleItems = _libraryManager.GetPeopleItems(new InternalPeopleQuery(
@@ -127,7 +124,7 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Value.Equals(default))
             {
                 var user = _userManager.GetUserById(userId.Value);
                 return _dtoService.GetBaseItemDto(item, dtoOptions, user);

--- a/Jellyfin.Api/Controllers/PlaylistsController.cs
+++ b/Jellyfin.Api/Controllers/PlaylistsController.cs
@@ -181,7 +181,9 @@ namespace Jellyfin.Api.Controllers
                 return NotFound();
             }
 
-            var user = !userId.Equals(Guid.Empty) ? _userManager.GetUserById(userId) : null;
+            var user = userId.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId);
 
             var items = playlist.GetManageableItems().ToArray();
 

--- a/Jellyfin.Api/Controllers/SearchController.cs
+++ b/Jellyfin.Api/Controllers/SearchController.cs
@@ -205,7 +205,7 @@ namespace Jellyfin.Api.Controllers
                     break;
             }
 
-            if (!item.ChannelId.Equals(Guid.Empty))
+            if (!item.ChannelId.Equals(default))
             {
                 var channel = _libraryManager.GetItemById(item.ChannelId);
                 result.ChannelName = channel?.Name;

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -74,7 +74,7 @@ namespace Jellyfin.Api.Controllers
                 result = result.Where(i => string.Equals(i.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase));
             }
 
-            if (controllableByUserId.HasValue && !controllableByUserId.Equals(Guid.Empty))
+            if (controllableByUserId.HasValue && !controllableByUserId.Equals(default))
             {
                 result = result.Where(i => i.SupportsRemoteControl);
 
@@ -82,12 +82,12 @@ namespace Jellyfin.Api.Controllers
 
                 if (!user.HasPermission(PermissionKind.EnableRemoteControlOfOtherUsers))
                 {
-                    result = result.Where(i => i.UserId.Equals(Guid.Empty) || i.ContainsUser(controllableByUserId.Value));
+                    result = result.Where(i => i.UserId.Equals(default) || i.ContainsUser(controllableByUserId.Value));
                 }
 
                 if (!user.HasPermission(PermissionKind.EnableSharedDeviceControl))
                 {
-                    result = result.Where(i => !i.UserId.Equals(Guid.Empty));
+                    result = result.Where(i => !i.UserId.Equals(default));
                 }
 
                 if (activeWithinSeconds.HasValue && activeWithinSeconds.Value > 0)

--- a/Jellyfin.Api/Controllers/StudiosController.cs
+++ b/Jellyfin.Api/Controllers/StudiosController.cs
@@ -91,7 +91,9 @@ namespace Jellyfin.Api.Controllers
                 .AddClientFields(Request)
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
 
-            User? user = userId.HasValue && userId != Guid.Empty ? _userManager.GetUserById(userId.Value) : null;
+            User? user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var parentItem = _libraryManager.GetParentItem(parentId, userId);
 
@@ -141,7 +143,7 @@ namespace Jellyfin.Api.Controllers
             var dtoOptions = new DtoOptions().AddClientFields(Request);
 
             var item = _libraryManager.GetStudio(name);
-            if (userId.HasValue && !userId.Equals(Guid.Empty))
+            if (userId.HasValue && !userId.Equals(default))
             {
                 var user = _userManager.GetUserById(userId.Value);
 

--- a/Jellyfin.Api/Controllers/SuggestionsController.cs
+++ b/Jellyfin.Api/Controllers/SuggestionsController.cs
@@ -63,7 +63,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? limit,
             [FromQuery] bool enableTotalRecordCount = false)
         {
-            var user = !userId.Equals(Guid.Empty) ? _userManager.GetUserById(userId) : null;
+            var user = userId.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId);
 
             var dtoOptions = new DtoOptions().AddClientFields(Request);
             var result = _libraryManager.GetItemsResult(new InternalItemsQuery(user)

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -107,9 +107,9 @@ namespace Jellyfin.Api.Controllers
                 },
                 options);
 
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var returnItems = _dtoService.GetBaseItemDtos(result.Items, options, user);
 
@@ -145,9 +145,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes,
             [FromQuery] bool? enableUserData)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             var minPremiereDate = DateTime.UtcNow.Date.AddDays(-1);
 
@@ -216,9 +216,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool? enableUserData,
             [FromQuery] string? sortBy)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             List<BaseItem> episodes;
 
@@ -332,9 +332,9 @@ namespace Jellyfin.Api.Controllers
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes,
             [FromQuery] bool? enableUserData)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
             if (_libraryManager.GetItemById(seriesId) is not Series series)
             {

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -534,7 +534,7 @@ namespace Jellyfin.Api.Controllers
         public ActionResult<UserDto> GetCurrentUser()
         {
             var userId = ClaimHelpers.GetUserId(Request.HttpContext.User);
-            if (userId == null)
+            if (userId is null)
             {
                 return BadRequest();
             }

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -76,7 +76,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty)
+            var item = itemId.Equals(default)
                 ? _libraryManager.GetUserRootFolder()
                 : _libraryManager.GetItemById(itemId);
 
@@ -116,7 +116,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty)
+            var item = itemId.Equals(default)
                 ? _libraryManager.GetUserRootFolder()
                 : _libraryManager.GetItemById(itemId);
 
@@ -197,7 +197,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty)
+            var item = itemId.Equals(default)
                 ? _libraryManager.GetUserRootFolder()
                 : _libraryManager.GetItemById(itemId);
 
@@ -227,7 +227,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty)
+            var item = itemId.Equals(default)
                 ? _libraryManager.GetUserRootFolder()
                 : _libraryManager.GetItemById(itemId);
 
@@ -347,7 +347,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(itemId);
+            var item = itemId.Equals(default) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(itemId);
 
             // Get the user data for this item
             var data = _userDataRepository.GetUserData(user, item);
@@ -370,7 +370,7 @@ namespace Jellyfin.Api.Controllers
         {
             var user = _userManager.GetUserById(userId);
 
-            var item = itemId.Equals(Guid.Empty) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(itemId);
+            var item = itemId.Equals(default) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(itemId);
 
             // Get the user data for this item
             var data = _userDataRepository.GetUserData(user, item);

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -109,14 +109,14 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<QueryResult<BaseItemDto>> GetAdditionalPart([FromRoute, Required] Guid itemId, [FromQuery] Guid? userId)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
 
-            var item = itemId.Equals(Guid.Empty)
-                ? (!userId.Equals(Guid.Empty)
-                    ? _libraryManager.GetUserRootFolder()
-                    : _libraryManager.RootFolder)
+            var item = itemId.Equals(default)
+                ? (userId is null || userId.Value.Equals(default)
+                    ? _libraryManager.RootFolder
+                    : _libraryManager.GetUserRootFolder())
                 : _libraryManager.GetItemById(itemId);
 
             var dtoOptions = new DtoOptions();
@@ -221,7 +221,7 @@ namespace Jellyfin.Api.Controllers
 
             var alternateVersionsOfPrimary = primaryVersion.LinkedAlternateVersions.ToList();
 
-            foreach (var item in items.Where(i => i.Id != primaryVersion.Id))
+            foreach (var item in items.Where(i => !i.Id.Equals(primaryVersion.Id)))
             {
                 item.SetPrimaryVersionId(primaryVersion.Id.ToString("N", CultureInfo.InvariantCulture));
 

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -89,9 +89,9 @@ namespace Jellyfin.Api.Helpers
             string? mediaSourceId = null,
             string? liveStreamId = null)
         {
-            var user = userId.HasValue && !userId.Equals(Guid.Empty)
-                ? _userManager.GetUserById(userId.Value)
-                : null;
+            var user = userId is null || userId.Value.Equals(default)
+                ? null
+                : _userManager.GetUserById(userId.Value);
             var item = _libraryManager.GetItemById(id);
             var result = new PlaybackInfoResponse();
 

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -102,7 +102,7 @@ namespace Jellyfin.Api.Helpers
             };
 
             var auth = await authorizationContext.GetAuthorizationInfo(httpRequest).ConfigureAwait(false);
-            if (!auth.UserId.Equals(Guid.Empty))
+            if (!auth.UserId.Equals(default))
             {
                 state.User = userManager.GetUserById(auth.UserId);
             }
@@ -151,7 +151,7 @@ namespace Jellyfin.Api.Helpers
                         ? mediaSources[0]
                         : mediaSources.Find(i => string.Equals(i.Id, streamingRequest.MediaSourceId, StringComparison.Ordinal));
 
-                    if (mediaSource == null && Guid.Parse(streamingRequest.MediaSourceId) == streamingRequest.Id)
+                    if (mediaSource == null && Guid.Parse(streamingRequest.MediaSourceId).Equals(streamingRequest.Id))
                     {
                         mediaSource = mediaSources[0];
                     }

--- a/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
+++ b/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
@@ -56,7 +56,7 @@ namespace Jellyfin.Server.Implementations.Activity
 
             if (query.HasUserId.HasValue)
             {
-                entries = entries.Where(entry => entry.UserId != Guid.Empty == query.HasUserId.Value );
+                entries = entries.Where(entry => (!entry.UserId.Equals(default)) == query.HasUserId.Value);
             }
 
             return new QueryResult<ActivityLogEntry>(

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -120,7 +120,7 @@ namespace Jellyfin.Server.Implementations.Devices
 
             if (query.UserId.HasValue)
             {
-                devices = devices.Where(device => device.UserId == query.UserId.Value);
+                devices = devices.Where(device => device.UserId.Equals(query.UserId.Value));
             }
 
             if (query.DeviceId != null)

--- a/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
+++ b/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Server.Implementations.Users
             var prefs = _dbContext.DisplayPreferences
                 .Include(pref => pref.HomeSections)
                 .FirstOrDefault(pref =>
-                    pref.UserId == userId && string.Equals(pref.Client, client) && pref.ItemId == itemId);
+                    pref.UserId.Equals(userId) && string.Equals(pref.Client, client) && pref.ItemId.Equals(itemId));
 
             if (prefs == null)
             {
@@ -47,7 +47,7 @@ namespace Jellyfin.Server.Implementations.Users
         public ItemDisplayPreferences GetItemDisplayPreferences(Guid userId, Guid itemId, string client)
         {
             var prefs = _dbContext.ItemDisplayPreferences
-                .FirstOrDefault(pref => pref.UserId == userId && pref.ItemId == itemId && string.Equals(pref.Client, client));
+                .FirstOrDefault(pref => pref.UserId.Equals(userId) && pref.ItemId.Equals(itemId) && string.Equals(pref.Client, client));
 
             if (prefs == null)
             {
@@ -63,7 +63,7 @@ namespace Jellyfin.Server.Implementations.Users
         {
             return _dbContext.ItemDisplayPreferences
                 .AsQueryable()
-                .Where(prefs => prefs.UserId == userId && prefs.ItemId != Guid.Empty && string.Equals(prefs.Client, client))
+                .Where(prefs => prefs.UserId.Equals(userId) && !prefs.ItemId.Equals(default) && string.Equals(prefs.Client, client))
                 .ToList();
         }
 
@@ -72,8 +72,8 @@ namespace Jellyfin.Server.Implementations.Users
         {
             return _dbContext.CustomItemDisplayPreferences
                 .AsQueryable()
-                .Where(prefs => prefs.UserId == userId
-                                && prefs.ItemId == itemId
+                .Where(prefs => prefs.UserId.Equals(userId)
+                                && prefs.ItemId.Equals(itemId)
                                 && string.Equals(prefs.Client, client))
                 .ToDictionary(prefs => prefs.Key, prefs => prefs.Value);
         }
@@ -83,8 +83,8 @@ namespace Jellyfin.Server.Implementations.Users
         {
             var existingPrefs = _dbContext.CustomItemDisplayPreferences
                 .AsQueryable()
-                .Where(prefs => prefs.UserId == userId
-                                && prefs.ItemId == itemId
+                .Where(prefs => prefs.UserId.Equals(userId)
+                                && prefs.ItemId.Equals(itemId)
                                 && string.Equals(prefs.Client, client));
             _dbContext.CustomItemDisplayPreferences.RemoveRange(existingPrefs);
 

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -107,7 +107,7 @@ namespace Jellyfin.Server.Implementations.Users
         /// <inheritdoc/>
         public User? GetUserById(Guid id)
         {
-            if (id == Guid.Empty)
+            if (id.Equals(default))
             {
                 throw new ArgumentException("Guid can't be empty", nameof(id));
             }
@@ -146,8 +146,7 @@ namespace Jellyfin.Server.Implementations.Users
 
             if (await dbContext.Users
                 .AsQueryable()
-                .Where(u => u.Username == newName && u.Id != user.Id)
-                .AnyAsync()
+                .AnyAsync(u => u.Username == newName && !u.Id.Equals(user.Id))
                 .ConfigureAwait(false))
             {
                 throw new ArgumentException(string.Format(
@@ -597,7 +596,7 @@ namespace Jellyfin.Server.Implementations.Users
                            .Include(u => u.Preferences)
                            .Include(u => u.AccessSchedules)
                            .Include(u => u.ProfileImage)
-                           .FirstOrDefault(u => u.Id == userId)
+                           .FirstOrDefault(u => u.Id.Equals(userId))
                        ?? throw new ArgumentException("No user exists with given Id!");
 
             user.SubtitleMode = config.SubtitleMode;
@@ -631,7 +630,7 @@ namespace Jellyfin.Server.Implementations.Users
                            .Include(u => u.Preferences)
                            .Include(u => u.AccessSchedules)
                            .Include(u => u.ProfileImage)
-                           .FirstOrDefault(u => u.Id == userId)
+                           .FirstOrDefault(u => u.Id.Equals(userId))
                        ?? throw new ArgumentException("No user exists with given Id!");
 
             // The default number of login attempts is 3, but for some god forsaken reason it's sent to the server as "0"

--- a/MediaBrowser.Controller/Entities/AggregateFolder.cs
+++ b/MediaBrowser.Controller/Entities/AggregateFolder.cs
@@ -187,14 +187,14 @@ namespace MediaBrowser.Controller.Entities
         /// <exception cref="ArgumentNullException">The id is empty.</exception>
         public BaseItem FindVirtualChild(Guid id)
         {
-            if (id.Equals(Guid.Empty))
+            if (id.Equals(default))
             {
                 throw new ArgumentNullException(nameof(id));
             }
 
             foreach (var child in _virtualChildren)
             {
-                if (child.Id == id)
+                if (child.Id.Equals(id))
                 {
                     return child;
                 }

--- a/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
@@ -24,7 +24,7 @@ namespace MediaBrowser.Controller.Entities.Audio
     public class MusicArtist : Folder, IItemByName, IHasMusicGenres, IHasDualAccess, IHasLookupInfo<ArtistInfo>
     {
         [JsonIgnore]
-        public bool IsAccessedByName => ParentId.Equals(Guid.Empty);
+        public bool IsAccessedByName => ParentId.Equals(default);
 
         [JsonIgnore]
         public override bool IsFolder => !IsAccessedByName;

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -231,7 +231,7 @@ namespace MediaBrowser.Controller.Entities
         {
             get
             {
-                if (!ChannelId.Equals(Guid.Empty))
+                if (!ChannelId.Equals(default))
                 {
                     return SourceType.Channel;
                 }
@@ -521,7 +521,7 @@ namespace MediaBrowser.Controller.Entities
             get
             {
                 var id = DisplayParentId;
-                if (id.Equals(Guid.Empty))
+                if (id.Equals(default))
                 {
                     return null;
                 }
@@ -737,7 +737,7 @@ namespace MediaBrowser.Controller.Entities
         public virtual bool StopRefreshIfLocalMetadataFound => true;
 
         [JsonIgnore]
-        protected virtual bool SupportsOwnedItems => !ParentId.Equals(Guid.Empty) && IsFileProtocol;
+        protected virtual bool SupportsOwnedItems => !ParentId.Equals(default) && IsFileProtocol;
 
         [JsonIgnore]
         public virtual bool SupportsPeople => false;
@@ -848,7 +848,7 @@ namespace MediaBrowser.Controller.Entities
         public BaseItem GetOwner()
         {
             var ownerId = OwnerId;
-            return ownerId.Equals(Guid.Empty) ? null : LibraryManager.GetItemById(ownerId);
+            return ownerId.Equals(default) ? null : LibraryManager.GetItemById(ownerId);
         }
 
         public bool CanDelete(User user, List<Folder> allCollectionFolders)
@@ -984,12 +984,12 @@ namespace MediaBrowser.Controller.Entities
         public BaseItem GetParent()
         {
             var parentId = ParentId;
-            if (!parentId.Equals(Guid.Empty))
+            if (parentId.Equals(default))
             {
-                return LibraryManager.GetItemById(parentId);
+                return null;
             }
 
-            return null;
+            return LibraryManager.GetItemById(parentId);
         }
 
         public IEnumerable<BaseItem> GetParents()
@@ -1397,7 +1397,7 @@ namespace MediaBrowser.Controller.Entities
             var tasks = extras.Select(i =>
             {
                 var subOptions = new MetadataRefreshOptions(options);
-                if (i.OwnerId != ownerId || i.ParentId != Guid.Empty)
+                if (!i.OwnerId.Equals(ownerId) || !i.ParentId.Equals(default))
                 {
                     i.OwnerId = ownerId;
                     i.ParentId = Guid.Empty;
@@ -1736,7 +1736,7 @@ namespace MediaBrowser.Controller.Entities
             // First get using the cached Id
             if (info.ItemId.HasValue)
             {
-                if (info.ItemId.Value.Equals(Guid.Empty))
+                if (info.ItemId.Value.Equals(default))
                 {
                     return null;
                 }
@@ -2657,7 +2657,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <inheritdoc />
-        public bool Equals(BaseItem other) => Id == other?.Id;
+        public bool Equals(BaseItem other) => other is not null && other.Id.Equals(Id);
 
         /// <inheritdoc />
         public override int GetHashCode() => HashCode.Combine(Id);

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -213,7 +213,7 @@ namespace MediaBrowser.Controller.Entities
         {
             item.SetParent(this);
 
-            if (item.Id.Equals(Guid.Empty))
+            if (item.Id.Equals(default))
             {
                 item.Id = LibraryManager.GetNewItemId(item.Path, item.GetType());
             }
@@ -730,7 +730,9 @@ namespace MediaBrowser.Controller.Entities
                 return PostFilterAndSort(items, query, true);
             }
 
-            if (this is not UserRootFolder && this is not AggregateFolder && query.ParentId == Guid.Empty)
+            if (this is not UserRootFolder
+                && this is not AggregateFolder
+                && query.ParentId.Equals(default))
             {
                 query.Parent = this;
             }
@@ -1492,7 +1494,7 @@ namespace MediaBrowser.Controller.Entities
             {
                 if (i.ItemId.HasValue)
                 {
-                    if (i.ItemId.Value == itemId)
+                    if (i.ItemId.Value.Equals(itemId))
                     {
                         return true;
                     }
@@ -1502,7 +1504,7 @@ namespace MediaBrowser.Controller.Entities
 
                 var child = GetLinkedChild(i);
 
-                if (child != null && child.Id == itemId)
+                if (child != null && child.Id.Equals(itemId))
                 {
                     return true;
                 }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -74,12 +74,12 @@ namespace MediaBrowser.Controller.Entities.TV
             get
             {
                 var seriesId = SeriesId;
-                if (seriesId.Equals(Guid.Empty))
+                if (seriesId.Equals(default))
                 {
                     seriesId = FindSeriesId();
                 }
 
-                return !seriesId.Equals(Guid.Empty) ? (LibraryManager.GetItemById(seriesId) as Series) : null;
+                return seriesId.Equals(default) ? null : (LibraryManager.GetItemById(seriesId) as Series);
             }
         }
 
@@ -89,12 +89,12 @@ namespace MediaBrowser.Controller.Entities.TV
             get
             {
                 var seasonId = SeasonId;
-                if (seasonId.Equals(Guid.Empty))
+                if (seasonId.Equals(default))
                 {
                     seasonId = FindSeasonId();
                 }
 
-                return !seasonId.Equals(Guid.Empty) ? (LibraryManager.GetItemById(seasonId) as Season) : null;
+                return seasonId.Equals(default) ? null : (LibraryManager.GetItemById(seasonId) as Season);
             }
         }
 
@@ -271,7 +271,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
             var seasonId = SeasonId;
 
-            if (!seasonId.Equals(Guid.Empty) && !list.Contains(seasonId))
+            if (!seasonId.Equals(default) && !list.Contains(seasonId))
             {
                 list.Add(seasonId);
             }

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -48,12 +48,12 @@ namespace MediaBrowser.Controller.Entities.TV
             get
             {
                 var seriesId = SeriesId;
-                if (seriesId == Guid.Empty)
+                if (seriesId.Equals(default))
                 {
                     seriesId = FindSeriesId();
                 }
 
-                return seriesId == Guid.Empty ? null : (LibraryManager.GetItemById(seriesId) as Series);
+                return seriesId.Equals(default) ? null : (LibraryManager.GetItemById(seriesId) as Series);
             }
         }
 

--- a/MediaBrowser.Controller/Entities/UserView.cs
+++ b/MediaBrowser.Controller/Entities/UserView.cs
@@ -69,11 +69,11 @@ namespace MediaBrowser.Controller.Entities
         /// <inheritdoc />
         public override IEnumerable<Guid> GetIdsForAncestorQuery()
         {
-            if (!DisplayParentId.Equals(Guid.Empty))
+            if (!DisplayParentId.Equals(default))
             {
                 yield return DisplayParentId;
             }
-            else if (!ParentId.Equals(Guid.Empty))
+            else if (!ParentId.Equals(default))
             {
                 yield return ParentId;
             }
@@ -94,11 +94,11 @@ namespace MediaBrowser.Controller.Entities
         {
             var parent = this as Folder;
 
-            if (!DisplayParentId.Equals(Guid.Empty))
+            if (!DisplayParentId.Equals(default))
             {
                 parent = LibraryManager.GetItemById(DisplayParentId) as Folder ?? parent;
             }
-            else if (!ParentId.Equals(Guid.Empty))
+            else if (!ParentId.Equals(default))
             {
                 parent = LibraryManager.GetItemById(ParentId) as Folder ?? parent;
             }

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -988,7 +988,7 @@ namespace MediaBrowser.Controller.Entities
         public static IEnumerable<BaseItem> FilterForAdjacency(List<BaseItem> list, string adjacentToId)
         {
             var adjacentToIdGuid = new Guid(adjacentToId);
-            var adjacentToItem = list.FirstOrDefault(i => i.Id == adjacentToIdGuid);
+            var adjacentToItem = list.FirstOrDefault(i => i.Id.Equals(adjacentToIdGuid));
 
             var index = list.IndexOf(adjacentToItem);
 
@@ -1005,7 +1005,7 @@ namespace MediaBrowser.Controller.Entities
                 nextId = list[index + 1].Id;
             }
 
-            return list.Where(i => i.Id == previousId || i.Id == nextId || i.Id == adjacentToIdGuid);
+            return list.Where(i => i.Id.Equals(previousId) || i.Id.Equals(nextId) || i.Id.Equals(adjacentToIdGuid));
         }
     }
 }

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -455,7 +455,7 @@ namespace MediaBrowser.Controller.Entities
             foreach (var child in LinkedAlternateVersions)
             {
                 // Reset the cached value
-                if (child.ItemId.HasValue && child.ItemId.Value.Equals(Guid.Empty))
+                if (child.ItemId.HasValue && child.ItemId.Value.Equals(default))
                 {
                     child.ItemId = null;
                 }

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -233,7 +233,7 @@ namespace MediaBrowser.Controller.Playlists
                 return base.IsVisible(user);
             }
 
-            if (user.Id == OwnerUserId)
+            if (user.Id.Equals(OwnerUserId))
             {
                 return true;
             }
@@ -244,8 +244,8 @@ namespace MediaBrowser.Controller.Playlists
                 return base.IsVisible(user);
             }
 
-            var userId = user.Id.ToString("N", CultureInfo.InvariantCulture);
-            return shares.Any(share => string.Equals(share.UserId, userId, StringComparison.OrdinalIgnoreCase));
+            var userId = user.Id;
+            return shares.Any(share => Guid.TryParse(share.UserId, out var id) && id.Equals(userId));
         }
 
         public override bool IsVisibleStandalone(User user)

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1444,7 +1444,7 @@ namespace MediaBrowser.Model.Dlna
 
         private static void ValidateAudioInput(AudioOptions options)
         {
-            if (options.ItemId.Equals(Guid.Empty))
+            if (options.ItemId.Equals(default))
             {
                 throw new ArgumentException("ItemId is required");
             }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -412,7 +412,7 @@ namespace MediaBrowser.Providers.Manager
             }
 
             // If this restriction is ever lifted, movie xml providers will have to be updated to prevent owned items like trailers from reading those files
-            if (!item.OwnerId.Equals(Guid.Empty))
+            if (!item.OwnerId.Equals(default))
             {
                 if (provider is ILocalMetadataProvider || provider is IRemoteMetadataProvider)
                 {
@@ -781,7 +781,7 @@ namespace MediaBrowser.Providers.Manager
         {
             BaseItem referenceItem = null;
 
-            if (!searchInfo.ItemId.Equals(Guid.Empty))
+            if (!searchInfo.ItemId.Equals(default))
             {
                 referenceItem = _libraryManager.GetItemById(searchInfo.ItemId);
             }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonNullableGuidConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonNullableGuidConverter.cs
@@ -16,14 +16,15 @@ namespace Jellyfin.Extensions.Json.Converters
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, Guid? value, JsonSerializerOptions options)
         {
-            if (value == Guid.Empty)
+            // null got handled higher up the call stack
+            var val = value!.Value;
+            if (val.Equals(default))
             {
                 writer.WriteNullValue();
             }
             else
             {
-                // null got handled higher up the call stack
-                JsonGuidConverter.WriteInternal(writer, value!.Value);
+                JsonGuidConverter.WriteInternal(writer, val);
             }
         }
     }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/EmbeddedImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/EmbeddedImageProviderTests.cs
@@ -148,7 +148,7 @@ namespace Jellyfin.Providers.Tests.MediaInfo
             var mediaSourceManager = new Mock<IMediaSourceManager>(MockBehavior.Strict);
             mediaSourceManager.Setup(i => i.GetMediaAttachments(item.Id))
                 .Returns(mediaAttachments);
-            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId == item.Id && q.Type == MediaStreamType.EmbeddedImage)))
+            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId.Equals(item.Id) && q.Type == MediaStreamType.EmbeddedImage)))
                 .Returns(mediaStreams);
             return mediaSourceManager.Object;
         }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/VideoImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/VideoImageProviderTests.cs
@@ -116,9 +116,9 @@ namespace Jellyfin.Providers.Tests.MediaInfo
             }
 
             var mediaSourceManager = new Mock<IMediaSourceManager>(MockBehavior.Strict);
-            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId == item.Id && q.Index == item.DefaultVideoStreamIndex)))
+            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId.Equals(item.Id) && q.Index == item.DefaultVideoStreamIndex)))
                 .Returns(defaultStreamList);
-            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId == item.Id && q.Type == MediaStreamType.Video)))
+            mediaSourceManager.Setup(i => i.GetMediaStreams(It.Is<MediaStreamQuery>(q => q.ItemId.Equals(item.Id) && q.Type == MediaStreamType.Video)))
                 .Returns(mediaStreams);
             return mediaSourceManager.Object;
         }

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
@@ -130,7 +130,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
             var users = await JsonSerializer.DeserializeAsync<UserDto[]>(
                 await client.GetStreamAsync("Users").ConfigureAwait(false), _jsonOpions).ConfigureAwait(false);
-            var user = users!.First(x => x.Id == _testUserId);
+            var user = users!.First(x => x.Id.Equals(_testUserId));
             Assert.True(user.HasPassword);
             Assert.True(user.HasConfiguredPassword);
         }
@@ -153,7 +153,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
             var users = await JsonSerializer.DeserializeAsync<UserDto[]>(
                 await client.GetStreamAsync("Users").ConfigureAwait(false), _jsonOpions).ConfigureAwait(false);
-            var user = users!.First(x => x.Id == _testUserId);
+            var user = users!.First(x => x.Id.Equals(_testUserId));
             Assert.False(user.HasPassword);
             Assert.False(user.HasConfiguredPassword);
         }


### PR DESCRIPTION
* Use Guid.Equals(Guid) instead of the == override
* Ban the usage of Guid.Equals(Object) to prevent accidental boxing
* Compare to default(Guid) instead of Guid.Empty
