### PR TITLE
Parse the unused chapter id field from ffmpeg output as a long

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/MediaChapter.cs
+++ b/MediaBrowser.MediaEncoding/Probing/MediaChapter.cs
@@ -12,7 +12,7 @@ namespace MediaBrowser.MediaEncoding.Probing
     public class MediaChapter
     {
         [JsonPropertyName("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonPropertyName("time_base")]
         public string TimeBase { get; set; }


### PR DESCRIPTION
ffmpeg 5.0 is producing values well outside the range of an int in the chapter id field. From the linked issue:
```
"chapters": [
        {
            "id": 251446668167383985,
            "time_base": "1/1000000000",
            "start": 0,
            "start_time": "0.000000",
            "end": 99766333333,
            "end_time": "99.766333"
        },
```

The `Id` field only exists in jellyfin to parse the json output: it's not used in any way downstream (see [here](https://github.com/jellyfin/jellyfin/blob/e26446f9c06d23d483d7c3db40888d51d37fdcdc/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs#L1433) for the use of `MediaChapter`).

**Changes**
- Parse the unused chapter id from ffmpeg output of as a long

**Issues**
Fixes #7355