### PR TITLE
Only add internal files if the internal metadata path exists

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -705,9 +705,15 @@ namespace Emby.Server.Implementations.IO
         }
 
         /// <inheritdoc />
-        public virtual bool Exists(string path)
+        public virtual bool DirectoryExists(string path)
         {
-            return Directory.Exists(path) || File.Exists(path);
+            return Directory.Exists(path);
+        }
+
+        /// <inheritdoc />
+        public virtual bool FileExists(string path)
+        {
+            return File.Exists(path);
         }
 
         private EnumerationOptions GetEnumerationOptions(bool recursive)

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -704,6 +704,12 @@ namespace Emby.Server.Implementations.IO
             return Directory.EnumerateFileSystemEntries(path, "*", GetEnumerationOptions(recursive));
         }
 
+        /// <inheritdoc />
+        public virtual bool Exists(string path)
+        {
+            return Directory.Exists(path) || File.Exists(path);
+        }
+
         private EnumerationOptions GetEnumerationOptions(bool recursive)
         {
             return new EnumerationOptions

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -887,7 +887,7 @@ namespace MediaBrowser.Controller.Entities
             return Name;
         }
 
-        public string GetInternalMetadataPath()
+        public virtual string GetInternalMetadataPath()
         {
             var basePath = ConfigurationManager.ApplicationPaths.InternalMetadataPath;
 

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -79,9 +79,5 @@ namespace MediaBrowser.Controller.Providers
 
             return filePaths;
         }
-
-        /// <inheritdoc />
-        public bool PathExists(string path)
-            => Directory.Exists(path);
     }
 }

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using MediaBrowser.Model.IO;
 

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using MediaBrowser.Model.IO;
 
@@ -78,5 +79,9 @@ namespace MediaBrowser.Controller.Providers
 
             return filePaths;
         }
+
+        /// <inheritdoc />
+        public bool PathExists(string path)
+            => Directory.Exists(path);
     }
 }

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -16,12 +16,5 @@ namespace MediaBrowser.Controller.Providers
         IReadOnlyList<string> GetFilePaths(string path);
 
         IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);
-
-        /// <summary>
-        /// Does the path exist.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>Whether the path exists.</returns>
-        bool PathExists(string path);
     }
 }

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -16,5 +16,12 @@ namespace MediaBrowser.Controller.Providers
         IReadOnlyList<string> GetFilePaths(string path);
 
         IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);
+
+        /// <summary>
+        /// Does the path exist.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>Whether the path exists.</returns>
+        bool PathExists(string path);
     }
 }

--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -202,10 +202,17 @@ namespace MediaBrowser.Model.IO
         IEnumerable<FileSystemMetadata> GetDrives();
 
         /// <summary>
-        /// Determines whether the directory or file exists.
+        /// Determines whether the directory exists.
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>Whether the path exists.</returns>
-        bool Exists(string path);
+        bool DirectoryExists(string path);
+
+        /// <summary>
+        /// Determines whether the file exists.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>Whether the path exists.</returns>
+        bool FileExists(string path);
     }
 }

--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -200,5 +200,12 @@ namespace MediaBrowser.Model.IO
         void SetAttributes(string path, bool isHidden, bool readOnly);
 
         IEnumerable<FileSystemMetadata> GetDrives();
+
+        /// <summary>
+        /// Determines whether the directory or file exists.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>Whether the path exists.</returns>
+        bool Exists(string path);
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/AudioResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioResolver.cs
@@ -3,6 +3,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -16,13 +17,20 @@ namespace MediaBrowser.Providers.MediaInfo
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
+        /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         public AudioResolver(
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
+            IFileSystem fileSystem,
             NamingOptions namingOptions)
-            : base(localizationManager, mediaEncoder, namingOptions, DlnaProfileType.Audio)
-            {
+            : base(
+                localizationManager,
+                mediaEncoder,
+                fileSystem,
+                namingOptions,
+                DlnaProfileType.Audio)
+        {
         }
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
@@ -19,9 +19,9 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Subtitles;
-using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Logging;
 
@@ -58,11 +58,12 @@ namespace MediaBrowser.Providers.MediaInfo
             ISubtitleManager subtitleManager,
             IChapterManager chapterManager,
             ILibraryManager libraryManager,
+            IFileSystem fileSystem,
             NamingOptions namingOptions)
         {
             _logger = logger;
-            _audioResolver = new AudioResolver(localization, mediaEncoder, namingOptions);
-            _subtitleResolver = new SubtitleResolver(localization, mediaEncoder, namingOptions);
+            _audioResolver = new AudioResolver(localization, mediaEncoder, fileSystem, namingOptions);
+            _subtitleResolver = new SubtitleResolver(localization, mediaEncoder, fileSystem, namingOptions);
             _videoProber = new FFProbeVideoInfo(
                 _logger,
                 mediaSourceManager,

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -159,7 +159,7 @@ namespace MediaBrowser.Providers.MediaInfo
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (directoryService.PathExists(internalMetadataPath))
             {
-                files.AddRange(directoryService.GetFilePaths(video.GetInternalMetadataPath(), clearCache));
+                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
             }
 
             if (!files.Any())

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -154,7 +154,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             // Check if video folder exists
             string folder = video.ContainingFolderPath;
-            if (!_fileSystem.Exists(folder))
+            if (!_fileSystem.DirectoryExists(folder))
             {
                 return Array.Empty<ExternalPathParserResult>();
             }
@@ -163,7 +163,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             var files = directoryService.GetFilePaths(folder, clearCache).ToList();
             var internalMetadataPath = video.GetInternalMetadataPath();
-            if (_fileSystem.Exists(internalMetadataPath))
+            if (_fileSystem.DirectoryExists(internalMetadataPath))
             {
                 files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
             }

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -148,7 +148,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             // Check if video folder exists
             string folder = video.ContainingFolderPath;
-            if (!Directory.Exists(folder))
+            if (!directoryService.PathExists(folder))
             {
                 return Array.Empty<ExternalPathParserResult>();
             }
@@ -156,7 +156,11 @@ namespace MediaBrowser.Providers.MediaInfo
             var externalPathInfos = new List<ExternalPathParserResult>();
 
             var files = directoryService.GetFilePaths(folder, clearCache).ToList();
-            files.AddRange(directoryService.GetFilePaths(video.GetInternalMetadataPath(), clearCache));
+            var internalMetadataPath = video.GetInternalMetadataPath();
+            if (directoryService.PathExists(internalMetadataPath))
+            {
+                files.AddRange(directoryService.GetFilePaths(video.GetInternalMetadataPath(), clearCache));
+            }
 
             if (!files.Any())
             {

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
 
 namespace MediaBrowser.Providers.MediaInfo
@@ -43,6 +44,8 @@ namespace MediaBrowser.Providers.MediaInfo
         /// </summary>
         private readonly IMediaEncoder _mediaEncoder;
 
+        private readonly IFileSystem _fileSystem;
+
         /// <summary>
         /// The <see cref="NamingOptions"/> instance.
         /// </summary>
@@ -58,15 +61,18 @@ namespace MediaBrowser.Providers.MediaInfo
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
+        /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         /// <param name="type">The <see cref="DlnaProfileType"/> of the parsed file.</param>
         protected MediaInfoResolver(
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
+            IFileSystem fileSystem,
             NamingOptions namingOptions,
             DlnaProfileType type)
         {
             _mediaEncoder = mediaEncoder;
+            _fileSystem = fileSystem;
             _namingOptions = namingOptions;
             _type = type;
             _externalPathParser = new ExternalPathParser(namingOptions, localizationManager, _type);
@@ -148,7 +154,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             // Check if video folder exists
             string folder = video.ContainingFolderPath;
-            if (!directoryService.PathExists(folder))
+            if (!_fileSystem.Exists(folder))
             {
                 return Array.Empty<ExternalPathParserResult>();
             }
@@ -157,7 +163,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             var files = directoryService.GetFilePaths(folder, clearCache).ToList();
             var internalMetadataPath = video.GetInternalMetadataPath();
-            if (directoryService.PathExists(internalMetadataPath))
+            if (_fileSystem.Exists(internalMetadataPath))
             {
                 files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
             }

--- a/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
@@ -3,6 +3,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -16,13 +17,20 @@ namespace MediaBrowser.Providers.MediaInfo
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
+        /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         public SubtitleResolver(
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
+            IFileSystem fileSystem,
             NamingOptions namingOptions)
-            : base(localizationManager, mediaEncoder, namingOptions, DlnaProfileType.Subtitle)
-            {
+            : base(
+                localizationManager,
+                mediaEncoder,
+                fileSystem,
+                namingOptions,
+                DlnaProfileType.Subtitle)
+        {
         }
     }
 }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Providers.MediaInfo;
 using Moq;
 using Xunit;
@@ -45,7 +46,13 @@ public class AudioResolverTests
                 }
             }));
 
-        _audioResolver = new AudioResolver(localizationManager, mediaEncoder.Object, new NamingOptions());
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
+            .Returns(true);
+        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
+            .Returns(true);
+
+        _audioResolver = new AudioResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
     [Theory]

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
@@ -47,9 +47,9 @@ public class AudioResolverTests
             }));
 
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
             .Returns(true);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
             .Returns(true);
 
         _audioResolver = new AudioResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -150,6 +150,8 @@ public class MediaInfoResolverTests
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
         directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
+        directoryService.Setup(ds => ds.PathExists(It.IsAny<string>()))
+            .Returns(true);
 
         var mediaEncoder = Mock.Of<IMediaEncoder>(MockBehavior.Strict);
 
@@ -299,6 +301,10 @@ public class MediaInfoResolverTests
             .Returns(files);
         directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
+        directoryService.Setup(ds => ds.PathExists(It.IsRegex(MetadataDirectoryRegex)))
+            .Returns(true);
+        directoryService.Setup(ds => ds.PathExists(It.IsRegex(VideoDirectoryRegex)))
+            .Returns(true);
 
         List<MediaStream> GenerateMediaStreams()
         {
@@ -369,6 +375,11 @@ public class MediaInfoResolverTests
             directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(Array.Empty<string>());
         }
+
+        directoryService.Setup(ds => ds.PathExists(It.IsRegex(MetadataDirectoryRegex)))
+            .Returns(true);
+        directoryService.Setup(ds => ds.PathExists(It.IsRegex(VideoDirectoryRegex)))
+            .Returns(true);
 
         return directoryService.Object;
     }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -63,11 +63,11 @@ public class MediaInfoResolverTests
             }));
 
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-        fileSystem.Setup(fs => fs.Exists(It.IsAny<string>()))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>()))
             .Returns(false);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(VideoDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(VideoDirectoryRegex)))
             .Returns(true);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MetadataDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
         _subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
@@ -300,9 +300,9 @@ public class MediaInfoResolverTests
             }));
 
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(VideoDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(VideoDirectoryRegex)))
             .Returns(true);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MetadataDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
         var subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
@@ -372,9 +372,9 @@ public class MediaInfoResolverTests
             }));
 
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(VideoDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(VideoDirectoryRegex)))
             .Returns(true);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MetadataDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
         var subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -47,9 +47,9 @@ public class SubtitleResolverTests
             }));
 
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
             .Returns(true);
-        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
+        fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
             .Returns(true);
 
         _subtitleResolver = new SubtitleResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Providers.MediaInfo;
 using Moq;
 using Xunit;
@@ -45,7 +46,13 @@ public class SubtitleResolverTests
                 }
             }));
 
-        _subtitleResolver = new SubtitleResolver(localizationManager, mediaEncoder.Object, new NamingOptions());
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.VideoDirectoryRegex)))
+            .Returns(true);
+        fileSystem.Setup(fs => fs.Exists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
+            .Returns(true);
+
+        _subtitleResolver = new SubtitleResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
     [Theory]


### PR DESCRIPTION
Fixes regression from https://github.com/jellyfin/jellyfin/pull/7255/