### PR TITLE
Remove superfluous "SoundHandler" from audio stream names

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,7 @@
  - [Froghut](https://github.com/Froghut)
  - [fruhnow](https://github.com/fruhnow)
  - [geilername](https://github.com/geilername)
+ - [GermanCoding](https://github.com/GermanCoding)
  - [gnattu](https://github.com/gnattu)
  - [GodTamIt](https://github.com/GodTamIt)
  - [grafixeyehero](https://github.com/grafixeyehero)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -691,9 +691,9 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: fall back to handler_name if populated
+                    // mp4 missing track title workaround: fall back to handler_name if populated and not the default "SoundHandler"
                     string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
-                    if (!string.IsNullOrEmpty(handlerName))
+                    if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SoundHandler", StringComparison.OrdinalIgnoreCase))
                     {
                         stream.Title = handlerName;
                     }


### PR DESCRIPTION
Since the introduction of PR https://github.com/jellyfin/jellyfin/pull/6639, `handler_name`s of audio streams are used as track titles, if there is no explicit title metadata.

However, I noticed that the large majority of video files in my collection (2300+ files):

- have no explicit track titles (hence PR 6639 applies to them)
- but they *also* have not set the `handler_name` to anything useful. 

Instead those files are all using the (apparent) [ffmpeg] default value of `SoundHandler` as their track title. This causes confusion in the UI, as users now see most audio tracks as being named something like

`SoundHandler - English - AAC - 5.1 - Default`

which may be confusing for them ("what does SoundHandler mean?"). Having SoundHandler here is not useful and IMHO worse than having no track title displayed at all (note that audio language is still shown, if metadata is present).

**Changes**

PR https://github.com/jellyfin/jellyfin/pull/6639 had explicitly blocklisted "SubtitleHandler" for subtitles, to avoid exactly the same issue, but for subtitle tracks. I propose to add the exact same blocklisting for "SoundHandler" on audio tracks. This PR does this, by replicating the same behaviour.

**Issues**
Relates to issue https://github.com/jellyfin/jellyfin/issues/6638

**Testing**
I ran a custom build of jellyfin with this change and checked how it affects the `DisplayTitle` returned for items from the controller. Works as intended, SoundHandler no longer shows in any video files - but other metadata is still displayed, and it also works if the handler name differs from SoundHandler.

Note that a (forced) metadata update may needed for existing items to see the changes, as this changes how probing is done.