### PR TITLE
Include played and unplayed results in the same next up request

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -126,7 +126,8 @@ namespace Emby.Server.Implementations.TV
                     parentsFolders.ToList())
                 .Cast<Episode>()
                 .Where(episode => !string.IsNullOrEmpty(episode.SeriesPresentationUniqueKey))
-                .Select(GetUniqueSeriesKey);
+                .Select(GetUniqueSeriesKey)
+                .ToList();
 
             // Avoid implicitly captured closure
             var episodes = GetNextUpEpisodes(request, user, items, options);
@@ -134,7 +135,7 @@ namespace Emby.Server.Implementations.TV
             return GetResult(episodes, request);
         }
 
-        public IEnumerable<Episode> GetNextUpEpisodes(NextUpQuery request, User user, IEnumerable<string> seriesKeys, DtoOptions dtoOptions)
+        public IEnumerable<Episode> GetNextUpEpisodes(NextUpQuery request, User user, IReadOnlyList<string> seriesKeys, DtoOptions dtoOptions)
         {
             // Avoid implicitly captured closure
             var currentUser = user;

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -140,7 +140,15 @@ namespace Emby.Server.Implementations.TV
             var currentUser = user;
 
             var allNextUp = seriesKeys
-                .Select(i => GetNextUp(i, currentUser, dtoOptions, request.Rewatching));
+                .Select(i => GetNextUp(i, currentUser, dtoOptions, false));
+
+            if (request.EnableRewatching)
+            {
+                allNextUp = allNextUp.Concat(
+                    seriesKeys.Select(i => GetNextUp(i, currentUser, dtoOptions, true))
+                )
+                .OrderByDescending(i => i.Item1);
+            }
 
             // If viewing all next up for all series, remove first episodes
             // But if that returns empty, keep those first episodes (avoid completely empty view)

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -68,7 +68,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="nextUpDateCutoff">Optional. Starting date of shows to show in Next Up section.</param>
         /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
         /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
-        /// <param name="rewatching">Whether to get a rewatching next up instead of standard next up.</param>
+        /// <param name="enableRewatching">Whether to include watched episode in next up results.</param>
         /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>
         [HttpGet("NextUp")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -86,7 +86,7 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] DateTime? nextUpDateCutoff,
             [FromQuery] bool enableTotalRecordCount = true,
             [FromQuery] bool disableFirstEpisode = false,
-            [FromQuery] bool rewatching = false)
+            [FromQuery] bool enableRewatching = false)
         {
             var options = new DtoOptions { Fields = fields }
                 .AddClientFields(Request)
@@ -103,7 +103,7 @@ namespace Jellyfin.Api.Controllers
                     EnableTotalRecordCount = enableTotalRecordCount,
                     DisableFirstEpisode = disableFirstEpisode,
                     NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue,
-                    Rewatching = rewatching
+                    EnableRewatching = enableRewatching
                 },
                 options);
 

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -14,7 +14,7 @@ namespace MediaBrowser.Model.Querying
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
             NextUpDateCutoff = DateTime.MinValue;
-            Rewatching = false;
+            EnableRewatching = false;
         }
 
         /// <summary>
@@ -86,6 +86,6 @@ namespace MediaBrowser.Model.Querying
         /// <summary>
         /// Gets or sets a value indicating whether getting rewatching next up list.
         /// </summary>
-        public bool Rewatching { get; set; }
+        public bool EnableRewatching { get; set; }
     }
 }


### PR DESCRIPTION
**Changes**
Updates the new "rewatching" feature of Next Up to be returned with the normal results that is controlled by a user setting in web.

![Screenshot 2022-03-01 at 00-47-27 Jellyfin](https://user-images.githubusercontent.com/3450688/156112843-d59e102c-849b-4156-b1a1-887191e4ad00.png)

![Screenshot 2022-03-01 at 00-50-58 Jellyfin](https://user-images.githubusercontent.com/3450688/156112873-e85abf51-b788-4df9-8e6f-f14ed091651d.png)

**Issues**
N/A
