### PR TITLE
Fix the path to the extracted fonts on Windows

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1086,7 +1086,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var fontPath = Path.Combine(_appPaths.CachePath, "attachments", state.MediaSource.Id);
             var fontParam = string.Format(
                 CultureInfo.InvariantCulture,
-                ":fontsdir={0}",
+                ":fontsdir='{0}'",
                 _mediaEncoder.EscapeSubtitleFilterPath(fontPath));
 
             // TODO
@@ -1143,7 +1143,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "subtitles='{0}:si={1}{2}{3}{4}'{5}",
+                "subtitles=f='{0}':si={1}{2}{3}{4}{5}",
                 _mediaEncoder.EscapeSubtitleFilterPath(mediaPath),
                 state.InternalSubtitleStreamOffset.ToString(CultureInfo.InvariantCulture),
                 alphaParam,


### PR DESCRIPTION
**Changes**
- Fix the path to the extracted fonts on Windows
`[subtitles @ 00000242d17da380] Unable to parse option value "C\:/Users/..."`


**Issues**
Fixes #7275
