### PR TITLE
Lowering the VRAM usage on NVDEC decoder

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -771,10 +771,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 args.Append(GetCudaDeviceArgs(0, CudaAlias))
                      .Append(GetFilterHwDeviceArgs(CudaAlias));
-
-                // workaround for "No decoder surfaces left" error,
-                // but will increase vram usage. https://trac.ffmpeg.org/ticket/7562
-                args.Append(" -extra_hw_frames 3");
             }
             else if (string.Equals(optHwaccelType, "amf", StringComparison.OrdinalIgnoreCase))
             {
@@ -4431,7 +4427,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 if (options.EnableEnhancedNvdecDecoder && isCudaSupported && isCodecAvailable)
                 {
-                    return " -hwaccel cuda" + (outputHwSurface ? " -hwaccel_output_format cuda" : string.Empty) + (isAv1 ? " -c:v av1" : string.Empty);
+                    // set -threads 1 to nvdec decoder explicitly since it doesn't implement threading support.
+                    return " -hwaccel cuda" + (outputHwSurface ? " -hwaccel_output_format cuda" : string.Empty) + " -threads 1" + (isAv1 ? " -c:v av1" : string.Empty);
                 }
             }
 


### PR DESCRIPTION

**Changes**
- Set `-threads 1` to NVDEC decoder explicitly since it doesn't implement threading support. The default number of threads in NVDEC reserves too much VRAM without actually using them.
- Remove the `extra_hw_frames` workaround since it has been fixed by switching to yuv420p instead of nv12(disabling passthrough mode) in cuda pipeline. (save ~100MiB VRAM too)

**Issues**
![image](https://user-images.githubusercontent.com/14953024/156197818-bef1c7f7-c6b4-4c75-b7ba-b107fb0d6971.png)

VRAM usage:

4k 10bit HEVC ->1080p H264
1474 MiB -> **712 MiB**

1080p 10bit HEVC -> 1080p H264
491 MiB -> **293 MiB**

observed by `nvidia-smi 511.79` on GTX 1650