### PR TITLE
Hide ISO 639-2 special codes in display titles

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -17,6 +17,18 @@ namespace MediaBrowser.Model.Entities
     /// </summary>
     public class MediaStream
     {
+        private static readonly string[] _specialCodes =
+        {
+            // Uncoded languages.
+            "mis",
+            // Multiple languages.
+            "mul",
+            // Undetermined.
+            "und",
+            // No linguistic content; not applicable.
+            "zxx"
+        };
+
         /// <summary>
         /// Gets or sets the codec.
         /// </summary>
@@ -137,7 +149,8 @@ namespace MediaBrowser.Model.Entities
                     {
                         var attributes = new List<string>();
 
-                        if (!string.IsNullOrEmpty(Language))
+                        // Do not display the language code in display titles if unset or set to a special code. Show it in all other cases (possibly expanded).
+                        if (!string.IsNullOrEmpty(Language) && !_specialCodes.Contains(Language, StringComparer.OrdinalIgnoreCase))
                         {
                             // Get full language string i.e. eng -> English. Will not work for some languages which use ISO 639-2/B instead of /T codes.
                             string fullLanguage = CultureInfo

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Jellyfin.Extensions;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
@@ -150,7 +151,7 @@ namespace MediaBrowser.Model.Entities
                         var attributes = new List<string>();
 
                         // Do not display the language code in display titles if unset or set to a special code. Show it in all other cases (possibly expanded).
-                        if (!string.IsNullOrEmpty(Language) && !_specialCodes.Contains(Language, StringComparer.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(Language) && !_specialCodes.Contains(Language, StringComparison.OrdinalIgnoreCase))
                         {
                             // Get full language string i.e. eng -> English. Will not work for some languages which use ISO 639-2/B instead of /T codes.
                             string fullLanguage = CultureInfo


### PR DESCRIPTION
This has bugged me for a while now.

Jellyfin shows the language for audio streams, if it is present in metadata. This is great and correct.

However, there are audio streams that make use of ISO 639-2 special codes. Those then look like this:

![before](https://user-images.githubusercontent.com/4279661/156206695-4d13bc11-d49e-492a-adba-6c4e7e8b1861.PNG)

"und" is ISO-special for undetermined, which is confusing for users (especially as "und" is also a word in german). Generally I think some of these specials are rarely known, e.g who knows that "zxx" is "no linguistic content; not applicable".

Therefore I believe having these specials displayed prominently in display titles is wrong. I get that there is still value in displaying this information - it's technical data that may be of interest to more technical users. Hence I did **not** remove language codes displaying from metadata - just from the display title.

Not it looks like this, much cleaner IMHO:

![after](https://user-images.githubusercontent.com/4279661/156207278-8500f2dd-511c-4c9f-9365-a193d97abcab.PNG)

Language codes are still shown in associated metadata:

![metadata](https://user-images.githubusercontent.com/4279661/156207392-6d3f7444-15e2-4419-8422-05e9f2612cda.PNG)

There are also more language codes that Jellyfin currently can't expand (ISO 639-2 B codes for example), but here I think that there is still value in displaying them, hence they are not filtered. It's just the specials that cause more confusion than providing information to users.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

Filters ISO639-2 special codes (except the reserved range - whoever uses that hopefully knows what they're doing) from display titles.

**Testing**

As shown in the screenshots above, manually verified that this works as intended.
