### PR TITLE
Fix external file prefix bounded with symbols ignored by name matching

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -266,7 +266,7 @@ namespace Emby.Naming.Common
 
             MediaFlagDelimiters = new[]
             {
-                "."
+                '.'
             };
 
             MediaForcedFlags = new[]
@@ -715,7 +715,7 @@ namespace Emby.Naming.Common
         /// <summary>
         /// Gets or sets list of external media flag delimiters.
         /// </summary>
-        public string[] MediaFlagDelimiters { get; set; }
+        public char[] MediaFlagDelimiters { get; set; }
 
         /// <summary>
         /// Gets or sets list of external media forced flags.

--- a/Emby.Naming/ExternalFiles/ExternalPathParser.cs
+++ b/Emby.Naming/ExternalFiles/ExternalPathParser.cs
@@ -61,11 +61,11 @@ namespace Emby.Naming.ExternalFiles
             {
                 var languageString = extraString;
                 var titleString = string.Empty;
-                int separatorLength = separator.Length;
+                const int SeparatorLength = 1;
 
                 while (languageString.Length > 0)
                 {
-                    int lastSeparator = languageString.LastIndexOf(separator, StringComparison.OrdinalIgnoreCase);
+                    int lastSeparator = languageString.LastIndexOf(separator);
 
                     if (lastSeparator == -1)
                     {
@@ -73,7 +73,7 @@ namespace Emby.Naming.ExternalFiles
                     }
 
                     string currentSlice = languageString[lastSeparator..];
-                    string currentSliceWithoutSeparator = currentSlice[separatorLength..];
+                    string currentSliceWithoutSeparator = currentSlice[SeparatorLength..];
 
                     if (_namingOptions.MediaDefaultFlags.Any(s => currentSliceWithoutSeparator.Contains(s, StringComparison.OrdinalIgnoreCase)))
                     {
@@ -107,7 +107,7 @@ namespace Emby.Naming.ExternalFiles
                     languageString = languageString[..lastSeparator];
                 }
 
-                pathInfo.Title = separatorLength <= titleString.Length ? titleString[separatorLength..] : null;
+                pathInfo.Title = titleString.Length >= SeparatorLength ? titleString[SeparatorLength..] : null;
             }
 
             return pathInfo;

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -86,18 +86,20 @@ public class MediaInfoResolverTests
     }
 
     [Theory]
-    [InlineData("My.Video.srt", null)] // exact
-    [InlineData("My.Video.en.srt", "eng")]
-    [InlineData("MyVideo.en.srt", "eng")] // shorter title
-    [InlineData("My _ Video.en.srt", "eng")] // longer title
-    [InlineData("My.Video.en.srt", "eng", true)]
-    public void GetExternalFiles_FuzzyMatching_MatchesAndParsesToken(string file, string? language, bool metadataDirectory = false)
+    [InlineData("My.Video.mkv", "My.Video.srt", null)] // exact
+    [InlineData("My.Video.mkv", "My.Video.en.srt", "eng")]
+    [InlineData("My.Video.mkv", "MyVideo.en.srt", "eng")] // shorter title
+    [InlineData("My.Video.mkv", "My _ Video.en.srt", "eng")] // longer title
+    [InlineData("My.Video.mkv", "My.Video.en.srt", "eng", true)]
+    [InlineData("Example Movie (2021).mp4", "Example Movie (2021).English.Srt", "eng")]
+    [InlineData("[LTDB] Who Framed Roger Rabbit (1998) - [Bluray-1080p].mkv", "[LTDB] Who Framed Roger Rabbit (1998) - [Bluray-1080p].en.srt", "eng")]
+    public void GetExternalFiles_FuzzyMatching_MatchesAndParsesToken(string movie, string file, string? language, bool metadataDirectory = false)
     {
         BaseItem.MediaSourceManager = Mock.Of<IMediaSourceManager>();
 
         var video = new Movie
         {
-            Path = VideoDirectoryPath + "/My.Video.mkv"
+            Path = VideoDirectoryPath + "/" + movie
         };
 
         var directoryService = GetDirectoryServiceForExternalFile(file, metadataDirectory);


### PR DESCRIPTION
Unexpected limitations to `CompareInfo`:
- Ignored symbols at the end of a match aren't counted in the `matchLength`
- Ignored symbols at the beginning of a string prevent that string from matching a target prefix, *even if the same symbols are at the start of that prefix*

Code works but ended up a bit more clunky than I like, any suggestions for cleaning it up are welcome.

**Changes**
- Add handling for movie filenames that start/end with matching-ignored characters (whitespace, symbols)
- Add test cases based on linked issue
- Convert `MediaFlagDelimiter` back to char

**Issues**
Fixes #7361