### PR TITLE
Strip out external file fuzzy name matching

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -266,7 +266,7 @@ namespace Emby.Naming.Common
 
             MediaFlagDelimiters = new[]
             {
-                "."
+                '.'
             };
 
             MediaForcedFlags = new[]
@@ -715,7 +715,7 @@ namespace Emby.Naming.Common
         /// <summary>
         /// Gets or sets list of external media flag delimiters.
         /// </summary>
-        public string[] MediaFlagDelimiters { get; set; }
+        public char[] MediaFlagDelimiters { get; set; }
 
         /// <summary>
         /// Gets or sets list of external media forced flags.

--- a/Emby.Naming/ExternalFiles/ExternalPathParser.cs
+++ b/Emby.Naming/ExternalFiles/ExternalPathParser.cs
@@ -61,11 +61,11 @@ namespace Emby.Naming.ExternalFiles
             {
                 var languageString = extraString;
                 var titleString = string.Empty;
-                int separatorLength = separator.Length;
+                const int SeparatorLength = 1;
 
                 while (languageString.Length > 0)
                 {
-                    int lastSeparator = languageString.LastIndexOf(separator, StringComparison.OrdinalIgnoreCase);
+                    int lastSeparator = languageString.LastIndexOf(separator);
 
                     if (lastSeparator == -1)
                     {
@@ -73,7 +73,7 @@ namespace Emby.Naming.ExternalFiles
                     }
 
                     string currentSlice = languageString[lastSeparator..];
-                    string currentSliceWithoutSeparator = currentSlice[separatorLength..];
+                    string currentSliceWithoutSeparator = currentSlice[SeparatorLength..];
 
                     if (_namingOptions.MediaDefaultFlags.Any(s => currentSliceWithoutSeparator.Contains(s, StringComparison.OrdinalIgnoreCase)))
                     {
@@ -107,7 +107,7 @@ namespace Emby.Naming.ExternalFiles
                     languageString = languageString[..lastSeparator];
                 }
 
-                pathInfo.Title = separatorLength <= titleString.Length ? titleString[separatorLength..] : null;
+                pathInfo.Title = titleString.Length >= SeparatorLength ? titleString[SeparatorLength..] : null;
             }
 
             return pathInfo;

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -25,16 +25,6 @@ namespace MediaBrowser.Providers.MediaInfo
     public abstract class MediaInfoResolver
     {
         /// <summary>
-        /// The <see cref="CompareOptions"/> instance.
-        /// </summary>
-        private const CompareOptions CompareOptions = System.Globalization.CompareOptions.IgnoreCase | System.Globalization.CompareOptions.IgnoreNonSpace | System.Globalization.CompareOptions.IgnoreSymbols;
-
-        /// <summary>
-        /// The <see cref="CompareInfo"/> instance.
-        /// </summary>
-        private readonly CompareInfo _compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-
-        /// <summary>
         /// The <see cref="ExternalPathParser"/> instance.
         /// </summary>
         private readonly ExternalPathParser _externalPathParser;
@@ -175,11 +165,12 @@ namespace MediaBrowser.Providers.MediaInfo
 
             foreach (var file in files)
             {
+                var prefixLength = video.FileNameWithoutExtension.Length;
                 var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file);
-                if (_compareInfo.IsPrefix(fileNameWithoutExtension, video.FileNameWithoutExtension, CompareOptions, out int matchLength)
-                    && (fileNameWithoutExtension.Length == matchLength || _namingOptions.MediaFlagDelimiters.Contains(fileNameWithoutExtension[matchLength].ToString())))
+                if (video.FileNameWithoutExtension.Equals(fileNameWithoutExtension[..prefixLength], StringComparison.OrdinalIgnoreCase)
+                    && (fileNameWithoutExtension.Length == prefixLength || _namingOptions.MediaFlagDelimiters.Contains(fileNameWithoutExtension[prefixLength])))
                 {
-                    var externalPathInfo = _externalPathParser.ParseFile(file, fileNameWithoutExtension[matchLength..]);
+                    var externalPathInfo = _externalPathParser.ParseFile(file, fileNameWithoutExtension[prefixLength..]);
 
                     if (externalPathInfo != null)
                     {

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -149,8 +149,6 @@ namespace MediaBrowser.Providers.MediaInfo
                 return Array.Empty<ExternalPathParserResult>();
             }
 
-            var externalPathInfos = new List<ExternalPathParserResult>();
-
             var files = directoryService.GetFilePaths(folder, clearCache).ToList();
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))
@@ -163,14 +161,15 @@ namespace MediaBrowser.Providers.MediaInfo
                 return Array.Empty<ExternalPathParserResult>();
             }
 
+            var externalPathInfos = new List<ExternalPathParserResult>();
+            ReadOnlySpan<char> prefix = video.FileNameWithoutExtension;
             foreach (var file in files)
             {
-                var prefixLength = video.FileNameWithoutExtension.Length;
-                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file);
-                if (video.FileNameWithoutExtension.Equals(fileNameWithoutExtension[..prefixLength], StringComparison.OrdinalIgnoreCase)
-                    && (fileNameWithoutExtension.Length == prefixLength || _namingOptions.MediaFlagDelimiters.Contains(fileNameWithoutExtension[prefixLength])))
+                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.AsSpan());
+                if (prefix.Equals(fileNameWithoutExtension[..prefix.Length], StringComparison.OrdinalIgnoreCase)
+                    && (fileNameWithoutExtension.Length == prefix.Length || _namingOptions.MediaFlagDelimiters.Contains(fileNameWithoutExtension[prefix.Length])))
                 {
-                    var externalPathInfo = _externalPathParser.ParseFile(file, fileNameWithoutExtension[prefixLength..]);
+                    var externalPathInfo = _externalPathParser.ParseFile(file, fileNameWithoutExtension[prefix.Length..].ToString());
 
                     if (externalPathInfo != null)
                     {

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -133,18 +133,18 @@ public class MediaInfoResolverTests
     }
 
     [Theory]
-    [InlineData("My.Video.srt", null)] // exact
-    [InlineData("My.Video.en.srt", "eng")]
-    [InlineData("MyVideo.en.srt", "eng")] // shorter title
-    [InlineData("My _ Video.en.srt", "eng")] // longer title
-    [InlineData("My.Video.en.srt", "eng", true)]
-    public void GetExternalFiles_FuzzyMatching_MatchesAndParsesToken(string file, string? language, bool metadataDirectory = false)
+    [InlineData("My.Video.mkv", "My.Video.srt", null)]
+    [InlineData("My.Video.mkv", "My.Video.en.srt", "eng")]
+    [InlineData("My.Video.mkv", "My.Video.en.srt", "eng", true)]
+    [InlineData("Example Movie (2021).mp4", "Example Movie (2021).English.Srt", "eng")]
+    [InlineData("[LTDB] Who Framed Roger Rabbit (1998) - [Bluray-1080p].mkv", "[LTDB] Who Framed Roger Rabbit (1998) - [Bluray-1080p].en.srt", "eng")]
+    public void GetExternalFiles_NameMatching_MatchesAndParsesToken(string movie, string file, string? language, bool metadataDirectory = false)
     {
         BaseItem.MediaSourceManager = Mock.Of<IMediaSourceManager>();
 
         var video = new Movie
         {
-            Path = VideoDirectoryPath + "/My.Video.mkv"
+            Path = VideoDirectoryPath + "/" + movie
         };
 
         var directoryService = GetDirectoryServiceForExternalFile(file, metadataDirectory);
@@ -162,7 +162,7 @@ public class MediaInfoResolverTests
     [InlineData("My.Video.txt")]
     [InlineData("My.Video Sequel.srt")]
     [InlineData("Some.Other.Video.srt")]
-    public void GetExternalFiles_FuzzyMatching_RejectsNonMatches(string file)
+    public void GetExternalFiles_NameMatching_RejectsNonMatches(string file)
     {
         BaseItem.MediaSourceManager = Mock.Of<IMediaSourceManager>();
 
@@ -344,7 +344,7 @@ public class MediaInfoResolverTests
         var files = new string[fileCount];
         for (int i = 0; i < fileCount; i++)
         {
-            files[i] = $"{VideoDirectoryPath}/MyVideo.{i}.srt";
+            files[i] = $"{VideoDirectoryPath}/My.Video.{i}.srt";
         }
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);


### PR DESCRIPTION
**Changes**
- Remove fuzzy matching for code simplicity
- Add test cases based on linked issue
- Convert `MediaFlagDelimiter` back to char

**Issues**
Fixes #7361
Supersedes #7393