### PR TITLE
Update artwork repository urls

### DIFF
--- a/MediaBrowser.Providers/Plugins/StudioImages/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/StudioImages/Plugin.cs
@@ -12,8 +12,7 @@ namespace MediaBrowser.Providers.Plugins.StudioImages
 {
     public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
-        // TODO change this for a Jellyfin-hosted repository.
-        public const string DefaultServer = "https://raw.github.com/MediaBrowser/MediaBrowser.Resources/master/images/imagesbyname";
+        public const string DefaultServer = "https://raw.github.com/jellyfin/emby-artwork/master/studios";
 
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)

--- a/MediaBrowser.Providers/Plugins/StudioImages/StudiosImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/StudioImages/StudiosImageProvider.cs
@@ -110,19 +110,19 @@ namespace MediaBrowser.Providers.Studios
 
         private string GetUrl(string image, string filename)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}.jpg", repositoryUrl, image, filename);
+            return string.Format(CultureInfo.InvariantCulture, "{0}/images/{1}/{2}.jpg", repositoryUrl, image, filename);
         }
 
         private Task<string> EnsureThumbsList(string file, CancellationToken cancellationToken)
         {
-            string url = string.Format(CultureInfo.InvariantCulture, "{0}/studiothumbs.txt", repositoryUrl);
+            string url = string.Format(CultureInfo.InvariantCulture, "{0}/thumbs.txt", repositoryUrl);
 
             return EnsureList(url, file, _fileSystem, cancellationToken);
         }
 
         private Task<string> EnsurePosterList(string file, CancellationToken cancellationToken)
         {
-            string url = string.Format(CultureInfo.InvariantCulture, "{0}/studioposters.txt", repositoryUrl);
+            string url = string.Format(CultureInfo.InvariantCulture, "{0}/posters.txt", repositoryUrl);
 
             return EnsureList(url, file, _fileSystem, cancellationToken);
         }


### PR DESCRIPTION
**Changes**
Removes usage of the Emby Resources repository and replaces it with the [jellyfin/emby-artwork](https://github.com/jellyfin/emby-artwork) repository

**Issues**
Fixes #2567
