### PR TITLE
Fix external file check for shorter names

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -166,7 +166,8 @@ namespace MediaBrowser.Providers.MediaInfo
             foreach (var file in files)
             {
                 var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.AsSpan());
-                if (prefix.Equals(fileNameWithoutExtension[..prefix.Length], StringComparison.OrdinalIgnoreCase)
+                if (fileNameWithoutExtension.Length >= prefix.Length
+                    && prefix.Equals(fileNameWithoutExtension[..prefix.Length], StringComparison.OrdinalIgnoreCase)
                     && (fileNameWithoutExtension.Length == prefix.Length || _namingOptions.MediaFlagDelimiters.Contains(fileNameWithoutExtension[prefix.Length])))
                 {
                     var externalPathInfo = _externalPathParser.ParseFile(file, fileNameWithoutExtension[prefix.Length..].ToString());

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -157,6 +157,7 @@ public class MediaInfoResolverTests
     }
 
     [Theory]
+    [InlineData("cover.jpg")]
     [InlineData("My.Video.mp3")]
     [InlineData("My.Video.png")]
     [InlineData("My.Video.txt")]


### PR DESCRIPTION
Missed a case that the `CompareInfo` prefix check handled automatically...

**Changes**
- Fix `ArgumentOutOfRangeException` on files with shorter names than the movie

**Issues**
Fix for #7394
