### PR TITLE
Readd .strm as an allowed extension for videos

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,6 +117,7 @@
  - [ssenart](https://github.com/ssenart)
  - [stanionascu](https://github.com/stanionascu)
  - [stevehayles](https://github.com/stevehayles)
+ - [StollD](https://github.com/StollD)
  - [SuperSandro2000](https://github.com/SuperSandro2000)
  - [tbraeutigam](https://github.com/tbraeutigam)
  - [teacupx](https://github.com/teacupx)

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -66,6 +66,7 @@ namespace Emby.Naming.Common
                 ".rec",
                 ".rm",
                 ".rmvb",
+                ".strm",
                 ".svq3",
                 ".tp",
                 ".ts",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

https://github.com/jellyfin/jellyfin/commit/719b707281b078405daeea90811c2b4d7b40d624 removed `.strm` as an allowed extension for videos. As a result, `.strm` files are ignored during a library scan.

I wasn't able to figure out if this was an accident or done on purpose. If it wasn't an accident, please disregard this PR.
