### PR TITLE
Let the UI show which DTS profile is in use

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -155,6 +155,7 @@
  - [MBR-0001](https://github.com/MBR-0001)
  - [jonas-resch](https://github.com/jonas-resch)
  - [vgambier](https://github.com/vgambier)
+ - [MinecraftPlaye](https://github.com/MinecraftPlaye)
 
 # Emby Contributors
 

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -161,7 +161,7 @@ namespace MediaBrowser.Model.Entities
                             attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                         }
 
-                        if (!string.IsNullOrEmpty(Codec) && !string.Equals(Codec, "dca", StringComparison.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(Codec) && !string.Equals(Codec, "dca", StringComparison.OrdinalIgnoreCase) && !string.Equals(Codec, "dts", StringComparison.OrdinalIgnoreCase))
                         {
                             attributes.Add(AudioCodec.GetFriendlyName(Codec));
                         }


### PR DESCRIPTION
**Changes**
There are different profiles for DTS. For example, both DTS and DTS-HD
MA use the same codec, but provide a different profile.

With this PR, the different profiles can be displayed in e.g. Jellyfin Web (with no changes required there).

Below is an example file showing both an audio track with an DTS and an DTS-HD MA profile. Both use the DTS codec. Without this PR, both audio tracks would only show up as "DTS". 
![image](https://user-images.githubusercontent.com/9168045/156903924-ae382f9a-61dd-4f52-adb2-21386615af2d.png)

