### PR TITLE
Revert "chore: Add a read only connection for routes like Shows/NextUp"

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -98,16 +98,8 @@ namespace Emby.Server.Implementations.Data
         /// <value>The write connection.</value>
         protected SQLiteDatabaseConnection WriteConnection { get; set; }
 
-        protected SQLiteDatabaseConnection ReadConnection { get; set; }
-
         protected ManagedConnection GetConnection(bool readOnly = false)
         {
-            if (readOnly)
-            {
-                ReadConnection ??= SQLite3.Open(DbFilePath, ConnectionFlags.ReadOnly, null);
-                return new ManagedConnection(ReadConnection, null);
-            }
-
             WriteLock.Wait();
             if (WriteConnection != null)
             {

--- a/Emby.Server.Implementations/Data/ManagedConnection.cs
+++ b/Emby.Server.Implementations/Data/ManagedConnection.cs
@@ -9,13 +9,13 @@ namespace Emby.Server.Implementations.Data
 {
     public sealed class ManagedConnection : IDisposable
     {
-        private readonly SemaphoreSlim? _writeLock;
+        private readonly SemaphoreSlim _writeLock;
 
         private SQLiteDatabaseConnection? _db;
 
-        private bool _disposed;
+        private bool _disposed = false;
 
-        public ManagedConnection(SQLiteDatabaseConnection db, SemaphoreSlim? writeLock)
+        public ManagedConnection(SQLiteDatabaseConnection db, SemaphoreSlim writeLock)
         {
             _db = db;
             _writeLock = writeLock;
@@ -73,7 +73,7 @@ namespace Emby.Server.Implementations.Data
                 return;
             }
 
-            _writeLock?.Release();
+            _writeLock.Release();
 
             _db = null; // Don't dispose it
             _disposed = true;


### PR DESCRIPTION
Reverts jellyfin/jellyfin#7240

```
[23:15:02] [ERR] [25] Emby.Server.Implementations.ScheduledTasks.TaskManager: Error
Locked: SQLitePCL.pretty.SQLiteException: database table is locked: TypedBaseItems
   at SQLitePCL.pretty.SQLiteException.Throw(Int32 rc, Int32 extended, String msg)
   at SQLitePCL.pretty.SQLiteException.CheckOk(sqlite3 db, Int32 rc)
   at SQLitePCL.pretty.StatementImpl.MoveNext()
   at Emby.Server.Implementations.Data.SqliteItemRepository.<>c__DisplayClass33_0.<SaveImages>b__0(IDatabaseConnection db)
   at SQLitePCL.pretty.DatabaseConnection.<>c__DisplayClass20_0.<RunInTransaction>b__0(IDatabaseConnection db)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction[T](IDatabaseConnection This, Func`2 f, TransactionMode mode)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction(IDatabaseConnection This, Action`1 action, TransactionMode mode)
   at Emby.Server.Implementations.Data.ManagedConnection.RunInTransaction(Action`1 action, TransactionMode mode)
   at Emby.Server.Implementations.Data.SqliteItemRepository.SaveImages(BaseItem item)
   at Emby.Server.Implementations.Library.LibraryManager.UpdateImagesAsync(BaseItem item, Boolean forceUpdate)
   at MediaBrowser.Controller.Entities.Folder.ValidateChildrenInternal2(IProgress`1 progress, Boolean recursive, Boolean refreshChildMetadata, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.ValidateChildrenInternal(IProgress`1 progress, Boolean recursive, Boolean refreshChildMetadata, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.<>c__DisplayClass71_0`1.<<RunTasks>b__1>d.MoveNext()
```