### PR TITLE
Add label for external audio/sub tracks

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -5970,6 +5970,7 @@ AND Type = @InternalPersonType)");
                 item.LocalizedUndefined = _localization.GetLocalizedString("Undefined");
                 item.LocalizedDefault = _localization.GetLocalizedString("Default");
                 item.LocalizedForced = _localization.GetLocalizedString("Forced");
+                item.LocalizedExternal = _localization.GetLocalizedString("External");
             }
 
             return item;

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -12,6 +12,7 @@
     "Default": "Default",
     "DeviceOfflineWithName": "{0} has disconnected",
     "DeviceOnlineWithName": "{0} is connected",
+    "External": "External",
     "FailedLoginAttemptWithUserName": "Failed login try from {0}",
     "Favorites": "Favorites",
     "Folders": "Folders",

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -706,6 +706,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedUndefined = _localization.GetLocalizedString("Undefined");
                 stream.LocalizedDefault = _localization.GetLocalizedString("Default");
                 stream.LocalizedForced = _localization.GetLocalizedString("Forced");
+                stream.LocalizedExternal = _localization.GetLocalizedString("External");
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -140,6 +140,8 @@ namespace MediaBrowser.Model.Entities
 
         public string LocalizedForced { get; set; }
 
+        public string LocalizedExternal { get; set; }
+
         public string DisplayTitle
         {
             get
@@ -182,6 +184,11 @@ namespace MediaBrowser.Model.Entities
                         if (IsDefault)
                         {
                             attributes.Add(string.IsNullOrEmpty(LocalizedDefault) ? "Default" : LocalizedDefault);
+                        }
+
+                        if (IsExternal)
+                        {
+                            attributes.Add(string.IsNullOrEmpty(LocalizedExternal) ? "External" : LocalizedExternal);
                         }
 
                         if (!string.IsNullOrEmpty(Title))
@@ -272,6 +279,11 @@ namespace MediaBrowser.Model.Entities
                         if (!string.IsNullOrEmpty(Codec))
                         {
                             attributes.Add(Codec.ToUpperInvariant());
+                        }
+
+                        if (IsExternal)
+                        {
+                            attributes.Add(string.IsNullOrEmpty(LocalizedExternal) ? "External" : LocalizedExternal);
                         }
 
                         if (!string.IsNullOrEmpty(Title))

--- a/tests/Jellyfin.Model.Tests/Entities/MediaStreamTests.cs
+++ b/tests/Jellyfin.Model.Tests/Entities/MediaStreamTests.cs
@@ -5,23 +5,24 @@ namespace Jellyfin.Model.Tests.Entities
 {
     public class MediaStreamTests
     {
-        public static TheoryData<MediaStream, string> Get_DisplayTitle_TestData()
+        public static TheoryData<string, MediaStream> Get_DisplayTitle_TestData()
         {
-            var data = new TheoryData<MediaStream, string>();
+            var data = new TheoryData<string, MediaStream>();
 
             data.Add(
-                    new MediaStream
-                    {
-                        Type = MediaStreamType.Subtitle,
-                        Title = "English",
-                        Language = string.Empty,
-                        IsForced = false,
-                        IsDefault = false,
-                        Codec = "ASS"
-                    },
-                    "English - Und - ASS");
+                "English - Und - ASS",
+                new MediaStream
+                {
+                    Type = MediaStreamType.Subtitle,
+                    Title = "English",
+                    Language = string.Empty,
+                    IsForced = false,
+                    IsDefault = false,
+                    Codec = "ASS"
+                });
 
             data.Add(
+                "English - Und",
                 new MediaStream
                 {
                     Type = MediaStreamType.Subtitle,
@@ -30,10 +31,10 @@ namespace Jellyfin.Model.Tests.Entities
                     IsForced = false,
                     IsDefault = false,
                     Codec = string.Empty
-                },
-                "English - Und");
+                });
 
             data.Add(
+                "English",
                 new MediaStream
                 {
                     Type = MediaStreamType.Subtitle,
@@ -42,10 +43,10 @@ namespace Jellyfin.Model.Tests.Entities
                     IsForced = false,
                     IsDefault = false,
                     Codec = string.Empty
-                },
-                "English");
+                });
 
             data.Add(
+                "English - Default - Forced - SRT",
                 new MediaStream
                 {
                     Type = MediaStreamType.Subtitle,
@@ -54,10 +55,23 @@ namespace Jellyfin.Model.Tests.Entities
                     IsForced = true,
                     IsDefault = true,
                     Codec = "SRT"
-                },
-                "English - Default - Forced - SRT");
+                });
 
             data.Add(
+                "Title - EN - Default - Forced - SRT - External",
+                new MediaStream
+                {
+                    Type = MediaStreamType.Subtitle,
+                    Title = "Title",
+                    Language = "EN",
+                    IsForced = true,
+                    IsDefault = true,
+                    Codec = "SRT",
+                    IsExternal = true
+                });
+
+            data.Add(
+                "Und",
                 new MediaStream
                 {
                     Type = MediaStreamType.Subtitle,
@@ -66,15 +80,27 @@ namespace Jellyfin.Model.Tests.Entities
                     IsForced = false,
                     IsDefault = false,
                     Codec = null
-                },
-                "Und");
+                });
+
+            data.Add(
+                "Title - AAC - Default - External",
+                new MediaStream
+                {
+                    Type = MediaStreamType.Audio,
+                    Title = "Title",
+                    Language = null,
+                    IsForced = false,
+                    IsDefault = true,
+                    Codec = "AAC",
+                    IsExternal = true
+                });
 
             return data;
         }
 
         [Theory]
         [MemberData(nameof(Get_DisplayTitle_TestData))]
-        public void Get_DisplayTitle_should_return_valid_title(MediaStream mediaStream, string expected)
+        public void Get_DisplayTitle_should_return_valid_title(string expected, MediaStream mediaStream)
         {
             Assert.Equal(expected, mediaStream.DisplayTitle);
         }


### PR DESCRIPTION
This is my first time touching localization strings (since #7379 has no reviews), definitely let me know if anything there looks questionable.

**Changes**
- Add a flag to the display of audio and subtitle tracks to indicate if they are external files
- Reordered parameters in `MediaStreamTests` to put the easier to read parameter first (to make it more obvious which case is failing)

**Issues**
https://features.jellyfin.org/posts/1298/sdh-hi-and-cc-subtitles
https://features.jellyfin.org/posts/771/show-external-subtitles-as-external
