### PR TITLE
allow strm probe to succeed

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -458,6 +458,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 _logger.LogDebug("{ProcessFileName} {ProcessArgs}", process.StartInfo.FileName, process.StartInfo.Arguments);
             }
+
             using (var processWrapper = new ProcessWrapper(process, this))
             {
                 await using var memoryStream = new MemoryStream();

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -458,10 +458,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 _logger.LogDebug("{ProcessFileName} {ProcessArgs}", process.StartInfo.FileName, process.StartInfo.Arguments);
             }
-            
             using (var processWrapper = new ProcessWrapper(process, this))
             {
-                MemoryStream memoryStream = new MemoryStream();
+                await using var memoryStream = new MemoryStream();
                 _logger.LogDebug("Starting ffprobe with args {Args}", args);
                 StartProcess(processWrapper);
                 await process.StandardOutput.BaseStream.CopyToAsync(memoryStream, cancellationToken: cancellationToken);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -458,17 +458,19 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 _logger.LogDebug("{ProcessFileName} {ProcessArgs}", process.StartInfo.FileName, process.StartInfo.Arguments);
             }
-
+            
             using (var processWrapper = new ProcessWrapper(process, this))
             {
+                MemoryStream memoryStream = new MemoryStream();
                 _logger.LogDebug("Starting ffprobe with args {Args}", args);
                 StartProcess(processWrapper);
-
+                await process.StandardOutput.BaseStream.CopyToAsync(memoryStream, cancellationToken: cancellationToken);
+                memoryStream.Seek(0, SeekOrigin.Begin);
                 InternalMediaInfoResult result;
                 try
                 {
                     result = await JsonSerializer.DeserializeAsync<InternalMediaInfoResult>(
-                                        process.StandardOutput.BaseStream,
+                                        memoryStream,
                                         _jsonSerializerOptions,
                                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -100,7 +100,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             foreach (var pathInfo in pathInfos)
             {
-                if (!pathInfo.Path.EndsWith(".strm"))
+                if (!pathInfo.Path.AsSpan().EndsWith(".strm", StringComparison.OrdinalIgnoreCase))
                 {
                     var mediaInfo = await GetMediaInfo(pathInfo.Path, _type, cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -100,24 +100,27 @@ namespace MediaBrowser.Providers.MediaInfo
 
             foreach (var pathInfo in pathInfos)
             {
-                var mediaInfo = await GetMediaInfo(pathInfo.Path, _type, cancellationToken).ConfigureAwait(false);
-
-                if (mediaInfo.MediaStreams.Count == 1)
+                if (!pathInfo.Path.EndsWith(".strm"))
                 {
-                    MediaStream mediaStream = mediaInfo.MediaStreams[0];
-                    mediaStream.Index = startIndex++;
-                    mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
-                    mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
+                    var mediaInfo = await GetMediaInfo(pathInfo.Path, _type, cancellationToken).ConfigureAwait(false);
 
-                    mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
-                }
-                else
-                {
-                    foreach (MediaStream mediaStream in mediaInfo.MediaStreams)
+                    if (mediaInfo.MediaStreams.Count == 1)
                     {
+                        MediaStream mediaStream = mediaInfo.MediaStreams[0];
                         mediaStream.Index = startIndex++;
+                        mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
+                        mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
 
                         mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                    }
+                    else
+                    {
+                        foreach (MediaStream mediaStream in mediaInfo.MediaStreams)
+                        {
+                            mediaStream.Index = startIndex++;
+
+                            mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Changes**
don't attempt to run ffprobe on the .strm file itself in MediaInfoResolver,
in MediaEncoder, use a memorystream instead of the basestream because for some reason this is instrumental in ffprobing the remote media successfully

**Issues**
Fixes #7438 
