### PR TITLE
Restrict item refreshing to administrators

### DIFF
--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -53,7 +53,7 @@ namespace Jellyfin.Api.Controllers
         [Description("Refreshes metadata for an item.")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public ActionResult Post(
+        public ActionResult RefreshItem(
             [FromRoute, Required] Guid itemId,
             [FromQuery] MetadataRefreshMode metadataRefreshMode = MetadataRefreshMode.None,
             [FromQuery] MetadataRefreshMode imageRefreshMode = MetadataRefreshMode.None,

--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Api.Controllers
     /// Item Refresh Controller.
     /// </summary>
     [Route("Items")]
-    [Authorize(Policy = Policies.DefaultAuthorization)]
+    [Authorize(Policy = Policies.RequiresElevation)]
     public class ItemRefreshController : BaseJellyfinApiController
     {
         private readonly ILibraryManager _libraryManager;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Restrict item refreshing to administrators
  - This fixes #6815
  - jellyfin-web already checks if the user is an administrator for showing the button to refresh items in the item context menu
- Rename the operation for item refreshing to "RefreshItem" (was "Post") - this change is for generated api clients.

**Issues**

Fix #6815