### PR TITLE
Fix supportsTranscoding not reflecting user permissions sometimes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -224,3 +224,4 @@
  - [lbenini](https://github.com/lbenini)
  - [gnuyent](https://github.com/gnuyent)
  - [Matthew Jones](https://github.com/matthew-jones-uk)
+ - [Jakob Kukla](https://github.com/jakobkukla)

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -172,24 +172,16 @@ namespace Emby.Server.Implementations.Library
 
             foreach (var source in dynamicMediaSources)
             {
-                if (user != null)
-                {
-                    SetDefaultAudioAndSubtitleStreamIndexes(item, source, user);
-                }
-
                 // Validate that this is actually possible
                 if (source.SupportsDirectStream)
                 {
                     source.SupportsDirectStream = SupportsDirectStream(source.Path, source.Protocol);
                 }
 
-                list.Add(source);
-            }
-
-            if (user != null)
-            {
-                foreach (var source in list)
+                if (user != null)
                 {
+                    SetDefaultAudioAndSubtitleStreamIndexes(item, source, user);
+
                     if (string.Equals(item.MediaType, MediaType.Audio, StringComparison.OrdinalIgnoreCase))
                     {
                         source.SupportsTranscoding = user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding);
@@ -200,6 +192,8 @@ namespace Emby.Server.Implementations.Library
                         source.SupportsDirectStream = user.HasPermission(PermissionKind.EnablePlaybackRemuxing);
                     }
                 }
+
+                list.Add(source);
             }
 
             return SortMediaSources(list);
@@ -338,6 +332,16 @@ namespace Emby.Server.Implementations.Library
                 foreach (var source in sources)
                 {
                     SetDefaultAudioAndSubtitleStreamIndexes(item, source, user);
+
+                    if (string.Equals(item.MediaType, MediaType.Audio, StringComparison.OrdinalIgnoreCase))
+                    {
+                        source.SupportsTranscoding = user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding);
+                    }
+                    else if (string.Equals(item.MediaType, MediaType.Video, StringComparison.OrdinalIgnoreCase))
+                    {
+                        source.SupportsTranscoding = user.HasPermission(PermissionKind.EnableVideoPlaybackTranscoding);
+                        source.SupportsDirectStream = user.HasPermission(PermissionKind.EnablePlaybackRemuxing);
+                    }
                 }
             }
 


### PR DESCRIPTION
When making an API call that requests `MediaSources` with the `fields` field, the `supportsTranscoding` property does not report false even if the user doesn't have permission to transcode (e.g. `/Users/{userId}/Items`). On the contrary other requests like `/Items/{itemId}/PlaybackInfo` give back the expected result.

**Changes**

Always return the expected value by checking the users transcoding permission in `GetStaticMediaSources()` as well.