### PR TITLE
Add missing authorization attributes

### DIFF
--- a/Jellyfin.Api/Controllers/DashboardController.cs
+++ b/Jellyfin.Api/Controllers/DashboardController.cs
@@ -4,10 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using Jellyfin.Api.Attributes;
+using Jellyfin.Api.Constants;
 using Jellyfin.Api.Models;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Plugins;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -46,6 +48,7 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("web/ConfigurationPages")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Authorize(Policy = Policies.DefaultAuthorization)]
         public ActionResult<IEnumerable<ConfigurationPageInfo>> GetConfigurationPages(
             [FromQuery] bool? enableInMainMenu)
         {

--- a/Jellyfin.Api/Controllers/UserViewsController.cs
+++ b/Jellyfin.Api/Controllers/UserViewsController.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Api.Models.UserViewDtos;
@@ -15,6 +16,7 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Library;
 using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,6 +26,7 @@ namespace Jellyfin.Api.Controllers
     /// User views controller.
     /// </summary>
     [Route("")]
+    [Authorize(Policy = Policies.DefaultAuthorization)]
     public class UserViewsController : BaseJellyfinApiController
     {
         private readonly IUserManager _userManager;

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/DashboardControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/DashboardControllerTests.cs
@@ -14,6 +14,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
     {
         private readonly JellyfinApplicationFactory _factory;
         private readonly JsonSerializerOptions _jsonOpions = JsonDefaults.Options;
+        private static string? _accessToken;
 
         public DashboardControllerTests(JellyfinApplicationFactory factory)
         {
@@ -57,6 +58,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
         public async Task GetConfigurationPages_NoParams_AllConfigurationPages()
         {
             var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
 
             var response = await client.GetAsync("/web/ConfigurationPages").ConfigureAwait(false);
 
@@ -71,6 +73,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
         public async Task GetConfigurationPages_True_MainMenuConfigurationPages()
         {
             var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
 
             var response = await client.GetAsync("/web/ConfigurationPages?enableInMainMenu=true").ConfigureAwait(false);
 


### PR DESCRIPTION
Looking at the openapi file (unstable from march 13th) I noticed a few endpoints that shouldn't be unauthenticated. I'm quite sure the API calls from jf-web are authenticated but if it is not we can always revert the change in a later 10.8 beta.

**Changes**
- Add authorization attribute to GetConfigurationPages
- Add authorization attribute to UserViewsController

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
