### PR TITLE
tmdb - update available series end status

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -264,7 +264,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             series.RunTimeTicks = seriesResult.EpisodeRunTime.Select(i => TimeSpan.FromMinutes(i).Ticks).FirstOrDefault();
 
-            if (string.Equals(seriesResult.Status, "Ended", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(seriesResult.Status, "Ended", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(seriesResult.Status, "Canceled", StringComparison.OrdinalIgnoreCase))
             {
                 series.Status = SeriesStatus.Ended;
                 series.EndDate = seriesResult.LastAirDate;


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/7475

All possible responses aren't documented, but the example in the schema shows "Ended".
I confirmed that "Canceled" is also a valid status using the api.

https://developers.themoviedb.org/3/tv/get-tv-details