### PR TITLE
Improve fps for cuda tonemap in sw decoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2893,8 +2893,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             var memoryOutput = false;
-            var isUploadForOclTonemap = isSwDecoder && doCuTonemap;
-            if ((isNvDecoder && isSwEncoder) || isUploadForOclTonemap)
+            var isUploadForCuTonemap = isSwDecoder && doCuTonemap;
+            if ((isNvDecoder && isSwEncoder) || (isUploadForCuTonemap && hasSubs))
             {
                 memoryOutput = true;
 
@@ -2904,7 +2904,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             // OUTPUT yuv420p surface(memory)
-            if (isSwDecoder && isNvencEncoder)
+            if (isSwDecoder && isNvencEncoder && !isUploadForCuTonemap)
             {
                 memoryOutput = true;
             }


### PR DESCRIPTION
**Changes**
- Improve fps for cuda tonemap in sw decoding, avoid second copy if subtitle is not applied.

AV1 4K HDR -> 1080p SDR:  62fps -> 85fps with Zen2 8c16t+gtx1650