### PR TITLE
Move NormalizeDlnaMediaUrl logic inside the StreamInfo::ToUrl function.

### DIFF
--- a/Emby.Dlna/Didl/DidlBuilder.cs
+++ b/Emby.Dlna/Didl/DidlBuilder.cs
@@ -79,11 +79,6 @@ namespace Emby.Dlna.Didl
             _libraryManager = libraryManager;
         }
 
-        public static string NormalizeDlnaMediaUrl(string url)
-        {
-            return url + "&dlnaheaders=true";
-        }
-
         public string GetItemDidl(BaseItem item, User user, BaseItem context, string deviceId, Filter filter, StreamInfo streamInfo)
         {
             var settings = new XmlWriterSettings
@@ -309,7 +304,7 @@ namespace Emby.Dlna.Didl
         {
             writer.WriteStartElement(string.Empty, "res", NsDidl);
 
-            var url = NormalizeDlnaMediaUrl(streamInfo.ToUrl(_serverAddress, _accessToken));
+            var url = streamInfo.ToUrl(_serverAddress, _accessToken, true);
 
             var mediaSource = streamInfo.MediaSource;
 
@@ -388,7 +383,8 @@ namespace Emby.Dlna.Didl
                 streamInfo.TargetVideoCodecTag,
                 streamInfo.IsTargetAVC);
 
-            var filename = url.Substring(0, url.IndexOf('?', StringComparison.Ordinal));
+            int queryStart = url.IndexOf('?', StringComparison.Ordinal);
+            var filename = (queryStart >= 0) ? url.Substring(0, queryStart) : url;
 
             var mimeType = mediaProfile == null || string.IsNullOrEmpty(mediaProfile.MimeType)
                ? MimeTypes.GetMimeType(filename)
@@ -544,7 +540,7 @@ namespace Emby.Dlna.Didl
                 });
             }
 
-            var url = NormalizeDlnaMediaUrl(streamInfo.ToUrl(_serverAddress, _accessToken));
+            var url = streamInfo.ToUrl(_serverAddress, _accessToken, true);
 
             var mediaSource = streamInfo.MediaSource;
 

--- a/Emby.Dlna/PlayTo/PlayToController.cs
+++ b/Emby.Dlna/PlayTo/PlayToController.cs
@@ -505,7 +505,7 @@ namespace Emby.Dlna.PlayTo
             var playlistItem = GetPlaylistItem(item, mediaSources, profile, _session.DeviceId, mediaSourceId, audioStreamIndex, subtitleStreamIndex);
             playlistItem.StreamInfo.StartPositionTicks = startPostionTicks;
 
-            playlistItem.StreamUrl = DidlBuilder.NormalizeDlnaMediaUrl(playlistItem.StreamInfo.ToUrl(_serverAddress, _accessToken));
+            playlistItem.StreamUrl = playlistItem.StreamInfo.ToUrl(_serverAddress, _accessToken, true);
 
             var itemXml = new DidlBuilder(
                 profile,

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -282,7 +282,7 @@ namespace Jellyfin.Api.Helpers
                     mediaSource.SupportsDirectPlay = false;
                     mediaSource.SupportsDirectStream = false;
 
-                    mediaSource.TranscodingUrl = streamInfo.ToUrl("-", auth.Token).TrimStart('-');
+                    mediaSource.TranscodingUrl = streamInfo.ToUrl("-", auth.Token, false).TrimStart('-');
                     mediaSource.TranscodingUrl += "&allowVideoStreamCopy=false";
                     mediaSource.TranscodingUrl += "&allowAudioStreamCopy=false";
                     mediaSource.TranscodingContainer = streamInfo.Container;
@@ -293,7 +293,7 @@ namespace Jellyfin.Api.Helpers
                     if (mediaSource.SupportsTranscoding || mediaSource.SupportsDirectStream)
                     {
                         streamInfo.PlayMethod = PlayMethod.Transcode;
-                        mediaSource.TranscodingUrl = streamInfo.ToUrl("-", auth.Token).TrimStart('-');
+                        mediaSource.TranscodingUrl = streamInfo.ToUrl("-", auth.Token, false).TrimStart('-');
 
                         if (!allowVideoStreamCopy)
                         {

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -711,7 +711,7 @@ namespace MediaBrowser.Model.Dlna
                 options.SubtitleStreamIndex,
                 playlistItem.PlayMethod,
                 playlistItem.TranscodeReasons,
-                playlistItem.ToUrl("media:", "<token>"));
+                playlistItem.ToUrl("media:", "<token>", false));
 
             item.Container = NormalizeMediaSourceFormatIntoSingleContainer(item.Container, options.Profile, DlnaProfileType.Video, directPlayProfile);
             return playlistItem;

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -596,7 +596,7 @@ namespace MediaBrowser.Model.Dlna
             return null;
         }
 
-        public string ToUrl(string baseUrl, string accessToken)
+        public string ToUrl(string baseUrl, string accessToken, bool normalizeDlnaMediaUrl)
         {
             if (PlayMethod == PlayMethod.DirectPlay)
             {
@@ -638,6 +638,11 @@ namespace MediaBrowser.Model.Dlna
                 var encodedValue = pair.Value.Replace(" ", "%20", StringComparison.Ordinal);
 
                 list.Add(string.Format(CultureInfo.InvariantCulture, "{0}={1}", pair.Name, encodedValue));
+            }
+
+            if (normalizeDlnaMediaUrl)
+            {
+                list.Add("dlnaheaders=true");
             }
 
             string queryString = string.Join('&', list);

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -447,7 +447,7 @@ namespace Jellyfin.Model.Tests
 
         private static (string Path, NameValueCollection Query, string Filename, string Extension) ParseUri(StreamInfo val)
         {
-            var href = val.ToUrl("media:", "ACCESSTOKEN").Split("?", 2);
+            var href = val.ToUrl("media:", "ACCESSTOKEN", false).Split("?", 2);
             var path = href[0];
 
             var queryString = href.ElementAtOrDefault(1);


### PR DESCRIPTION
Moved the NormalizeDlnaMediaUrl logic inside StreamInfo::ToUrl function as the query parameters doesn't need to be applied when using PlayMethod.DirectPlay since the url is an actual file path.

Fix ArgumentOutOfRangeException present in
`var filename = url.Substring(0, url.IndexOf('?', StringComparison.Ordinal));`
when using PlayMethod.DirectPlay (url is a file path and has no '?').
