### PR TITLE
Change DLNA description requests to obey profiles, format UUID correctly

### DIFF
--- a/Emby.Dlna/DlnaManager.cs
+++ b/Emby.Dlna/DlnaManager.cs
@@ -456,7 +456,7 @@ namespace Emby.Dlna
         /// <inheritdoc />
         public string GetServerDescriptionXml(IHeaderDictionary headers, string serverUuId, string serverAddress)
         {
-            var profile = GetDefaultProfile();
+            var profile = GetProfile(headers) ?? GetDefaultProfile();
 
             var serverId = _appHost.SystemId;
 

--- a/Emby.Dlna/Main/DlnaEntryPoint.cs
+++ b/Emby.Dlna/Main/DlnaEntryPoint.cs
@@ -362,7 +362,7 @@ namespace Emby.Dlna.Main
                 guid = text.GetMD5();
             }
 
-            return guid.ToString("N", CultureInfo.InvariantCulture);
+            return guid.ToString("D", CultureInfo.InvariantCulture);
         }
 
         private void SetProperies(SsdpDevice device, string fullDeviceType)


### PR DESCRIPTION
Changes the DLNA description XML requests to obey profile-specific information rather than using the default profile. Also changes the UUID to be formatted in the correct style, allowing the server to be properly detected by more clients.