### PR TITLE
Fix OpenAPI spec generation for TranscodeReason

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ using Jellyfin.Server.Filters;
 using Jellyfin.Server.Formatters;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Session;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -427,6 +428,17 @@ namespace Jellyfin.Server.Extensions
                         Type = "string",
                         Nullable = true
                     }
+                });
+
+            // Manually describe Flags enum.
+            options.MapType<TranscodeReason>(() =>
+                new OpenApiSchema
+                {
+                    Type = "string",
+                    Enum = Enum.GetNames<TranscodeReason>()
+                        .Select(e => new OpenApiString(e))
+                        .Cast<IOpenApiAny>()
+                        .ToArray()
                 });
         }
     }


### PR DESCRIPTION
10.7
```c#
"TranscodeReason": {
        "enum": [
          "ContainerNotSupported",
          "VideoCodecNotSupported",
          "AudioCodecNotSupported",
          "ContainerBitrateExceedsLimit",
          "AudioBitrateNotSupported",
          "AudioChannelsNotSupported",
          "VideoResolutionNotSupported",
          "UnknownVideoStreamInfo",
          "UnknownAudioStreamInfo",
          "AudioProfileNotSupported",
          "AudioSampleRateNotSupported",
          "AnamorphicVideoNotSupported",
          "InterlacedVideoNotSupported",
          "SecondaryAudioNotSupported",
          "RefFramesNotSupported",
          "VideoBitDepthNotSupported",
          "VideoBitrateNotSupported",
          "VideoFramerateNotSupported",
          "VideoLevelNotSupported",
          "VideoProfileNotSupported",
          "AudioBitDepthNotSupported",
          "SubtitleCodecNotSupported",
          "DirectPlayError"
        ],
        "type": "string"
      },
```

10.8 (current master)
```c#
"TranscodeReason": {
        "enum": [
          [
            "ContainerNotSupported"
          ],
          [
            "VideoCodecNotSupported"
          ],
          [
            "AudioCodecNotSupported"
          ],
          [
            "SubtitleCodecNotSupported"
          ],
          [
            "AudioIsExternal"
          ],
          [
            "SecondaryAudioNotSupported"
          ],
          [
            "VideoProfileNotSupported"
          ],
          [
            "VideoLevelNotSupported"
          ],
          [
            "VideoResolutionNotSupported"
          ],
          [
            "VideoBitDepthNotSupported"
          ],
          [
            "VideoFramerateNotSupported"
          ],
          [
            "RefFramesNotSupported"
          ],
          [
            "AnamorphicVideoNotSupported"
          ],
          [
            "InterlacedVideoNotSupported"
          ],
          [
            "AudioChannelsNotSupported"
          ],
          [
            "AudioProfileNotSupported"
          ],
          [
            "AudioSampleRateNotSupported"
          ],
          [
            "AudioBitDepthNotSupported"
          ],
          [
            "ContainerBitrateExceedsLimit"
          ],
          [
            "VideoBitrateNotSupported"
          ],
          [
            "AudioBitrateNotSupported"
          ],
          [
            "UnknownVideoStreamInfo"
          ],
          [
            "UnknownAudioStreamInfo"
          ],
          [
            "DirectPlayError"
          ]
        ],
        "type": "integer",
        "format": "int32"
      },
```

this PR:
```c#
"TranscodeReason": {
            "enum": [
              "ContainerNotSupported",
              "VideoCodecNotSupported",
              "AudioCodecNotSupported",
              "SubtitleCodecNotSupported",
              "AudioIsExternal",
              "SecondaryAudioNotSupported",
              "VideoProfileNotSupported",
              "VideoLevelNotSupported",
              "VideoResolutionNotSupported",
              "VideoBitDepthNotSupported",
              "VideoFramerateNotSupported",
              "RefFramesNotSupported",
              "AnamorphicVideoNotSupported",
              "InterlacedVideoNotSupported",
              "AudioChannelsNotSupported",
              "AudioProfileNotSupported",
              "AudioSampleRateNotSupported",
              "AudioBitDepthNotSupported",
              "ContainerBitrateExceedsLimit",
              "VideoBitrateNotSupported",
              "AudioBitrateNotSupported",
              "UnknownVideoStreamInfo",
              "UnknownAudioStreamInfo",
              "DirectPlayError"
            ],
            "type": "string"
          }
```