### PR TITLE
Allow ExternalId to be used on all BaseItems

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1425,12 +1425,9 @@ namespace MediaBrowser.Controller.Entities
         {
             var list = new List<string>();
 
-            if (SourceType == SourceType.Channel)
+            if (!string.IsNullOrEmpty(ExternalId))
             {
-                if (!string.IsNullOrEmpty(ExternalId))
-                {
-                    list.Add(ExternalId);
-                }
+                list.Add(ExternalId);
             }
 
             list.Add(Id.ToString());


### PR DESCRIPTION
Allow the `ExternalId` field to be set for all `BaseItem`s. It is currently only used by the Live TV featues. My use case would be to use the field on `Series` entries as it would be a great escape hatch for plugins to forcefully merge entries without (invalidly) using the ImDB id — which I'm currently doing — or the TvDB id, which are the only other two ids besides the `ExternalId` allowed for merging series together. This behavior is hard coded in [the Series entry](https://github.com/jellyfin/jellyfin/blob/a26509a98a07889c9c947e8b3992ab00d6249960/MediaBrowser.Controller/Entities/TV/Series.cs#L177-L185) which results in me resulting to a hacky spaghetti :spaghetti: workaround like [this](https://github.com/ShokoAnime/Shokofin/blob/267e41249864cbdec8c178cce334fc7eea7b1344/Shokofin/Providers/SeriesProvider.cs#L172-L173) in order to merge the series before this change.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Change the `GetUserDataKeys` method for the `BaseItem` to allow the `ExternalId` to be used as an escape hatch for plugins using an "_unsupported_" id to merge series. This change makes the code more error prone if used incorrectly but also gives plugins (and the core) more control over the merging process if used correctly — as there is no collision detection if multiple plugins (and/or other providers) use the `ExternalId` so it would be up to each plugin to make sure it plays nice with the other plugins (and/or providers).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
