### PR TITLE
Extend music parsing

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -181,6 +181,24 @@ namespace Emby.Naming.Common
                 "volume"
             };
 
+            ArtistSubfolders = new[]
+            {
+                "albums",
+                "broadcasts",
+                "bootlegs",
+                "compilations",
+                "dj-mixes",
+                "eps",
+                "live",
+                "mixtapes",
+                "others",
+                "remixes",
+                "singles",
+                "soundtracks",
+                "spokenwords",
+                "streets"
+            };
+
             AudioFileExtensions = new[]
             {
                 ".669",
@@ -731,6 +749,11 @@ namespace Emby.Naming.Common
         /// Gets or sets list of album stacking prefixes.
         /// </summary>
         public string[] AlbumStackingPrefixes { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of artist subfolders.
+        /// </summary>
+        public string[] ArtistSubfolders { get; set; }
 
         /// <summary>
         /// Gets or sets list of subtitle file extensions.

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -83,7 +83,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// </summary>
         /// <param name="path">The path to check.</param>
         /// <param name="directoryService">The directory service.</param>
-        /// <returns><c>true</c> if the provided path points to a music album, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the provided path points to a music album; otherwise, <c>false</c>.</returns>
         public bool IsMusicAlbum(string path, IDirectoryService directoryService)
         {
             return ContainsMusic(directoryService.GetFileSystemEntries(path), true, directoryService);
@@ -93,7 +93,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// Determine if the supplied resolve args should be considered a music album.
         /// </summary>
         /// <param name="args">The args.</param>
-        /// <returns><c>true</c> if [is music album] [the specified args], <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if [is music album] [the specified args]; otherwise, <c>false</c>.</returns>
         private bool IsMusicAlbum(ItemResolveArgs args)
         {
             if (args.IsDirectory)
@@ -121,7 +121,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// <summary>
         /// Determine if the supplied list contains what we should consider music.
         /// </summary>
-        /// <returns><c>true</c> if the provided path list contains music, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the provided path list contains music; otherwise, <c>false</c>.</returns>
         private bool ContainsMusic(
             ICollection<FileSystemMetadata> list,
             bool allowSubfolders,

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -98,7 +99,15 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
             // Args points to an album if parent is an Artist folder or it directly contains music
             if (args.IsDirectory)
             {
-                // if (args.Parent is MusicArtist) return true;  // saves us from testing children twice
+                foreach (var subfolder in _namingOptions.ArtistSubfolders)
+                {
+                    if (Path.GetDirectoryName(args.Path.AsSpan()).Equals(subfolder, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogDebug("Found release folder: {Path}", args.Path);
+                        return false;
+                    }
+                }
+
                 if (ContainsMusic(args.FileSystemChildren, true, args.DirectoryService))
                 {
                     return true;

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicAlbumResolver.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.Library.Resolvers.Audio
 {
     /// <summary>
-    /// Class MusicAlbumResolver.
+    /// The music album resolver.
     /// </summary>
     public class MusicAlbumResolver : ItemResolver<MusicAlbum>
     {
@@ -93,12 +93,12 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// Determine if the supplied resolve args should be considered a music album.
         /// </summary>
         /// <param name="args">The args.</param>
-        /// <returns><c>true</c> if [is music album] [the specified args]; otherwise, <c>false</c>.</returns>
+        /// <returns><c>true</c> if [is music album] [the specified args], <c>false</c> otherwise.</returns>
         private bool IsMusicAlbum(ItemResolveArgs args)
         {
-            // Args points to an album if parent is an Artist folder or it directly contains music
             if (args.IsDirectory)
             {
+                // If args is a artist subfolder it's not a music album
                 foreach (var subfolder in _namingOptions.ArtistSubfolders)
                 {
                     if (Path.GetDirectoryName(args.Path.AsSpan()).Equals(subfolder, StringComparison.OrdinalIgnoreCase))
@@ -108,6 +108,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
                     }
                 }
 
+                // If args contains music it's a music album
                 if (ContainsMusic(args.FileSystemChildren, true, args.DirectoryService))
                 {
                     return true;
@@ -120,22 +121,23 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// <summary>
         /// Determine if the supplied list contains what we should consider music.
         /// </summary>
+        /// <returns><c>true</c> if the provided path list contains music, <c>false</c> otherwise.</returns>
         private bool ContainsMusic(
             ICollection<FileSystemMetadata> list,
             bool allowSubfolders,
             IDirectoryService directoryService)
         {
-            // check for audio files before digging down into directories
+            // Check for audio files before digging down into directories
             var foundAudioFile = list.Any(fileSystemInfo => !fileSystemInfo.IsDirectory && AudioFileParser.IsAudioFile(fileSystemInfo.FullName, _namingOptions));
             if (foundAudioFile)
             {
-                // at least one audio file exists
+                // At least one audio file exists
                 return true;
             }
 
             if (!allowSubfolders)
             {
-                // not music since no audio file exists and we're not looking into subfolders
+                // Not music since no audio file exists and we're not looking into subfolders
                 return false;
             }
 

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace Emby.Server.Implementations.Library.Resolvers.Audio
 {
     /// <summary>
-    /// Class MusicArtistResolver.
+    /// The music artist resolver.
     /// </summary>
     public class MusicArtistResolver : ItemResolver<MusicArtist>
     {
@@ -23,8 +23,8 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// <summary>
         /// Initializes a new instance of the <see cref="MusicArtistResolver"/> class.
         /// </summary>
-        /// <param name="logger">The logger for the created <see cref="MusicAlbumResolver"/> instances.</param>
-        /// <param name="namingOptions">The naming options.</param>
+        /// <param name="logger">Instance of the <see cref="MusicAlbumResolver"/> interface.</param>
+        /// <param name="namingOptions">The <see cref="NamingOptions"/>.</param>
         public MusicArtistResolver(
             ILogger<MusicAlbumResolver> logger,
             NamingOptions namingOptions)
@@ -40,10 +40,10 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         public override ResolverPriority Priority => ResolverPriority.Second;
 
         /// <summary>
-        /// Resolves the specified args.
+        /// Resolves the specified resolver arguments.
         /// </summary>
-        /// <param name="args">The args.</param>
-        /// <returns>MusicArtist.</returns>
+        /// <param name="args">The resolver arguments.</param>
+        /// <returns>A <see cref="MusicArtist"/>.</returns>
         protected override MusicArtist Resolve(ItemResolveArgs args)
         {
             if (!args.IsDirectory)
@@ -82,23 +82,24 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             var albumResolver = new MusicAlbumResolver(_logger, _namingOptions);
 
-            // If we contain an album assume we are an artist folder
             var directories = args.FileSystemChildren.Where(i => i.IsDirectory);
 
             var result = Parallel.ForEach(directories, (fileSystemInfo, state) =>
             {
+                // If we contain a artist subfolder assume we are an artist folder
                 foreach (var subfolder in _namingOptions.ArtistSubfolders)
                 {
                     if (fileSystemInfo.Name.Equals(subfolder, StringComparison.OrdinalIgnoreCase))
                     {
-                        // stop once we see a artist subfolder
+                        // Stop once we see an artist subfolder
                         state.Stop();
                     }
                 }
 
+                // If we contain a music album assume we are an artist folder
                 if (albumResolver.IsMusicAlbum(fileSystemInfo.FullName, directoryService))
                 {
-                    // stop once we see a music album
+                    // Stop once we see a music album
                     state.Stop();
                 }
             });

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
@@ -61,7 +61,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             var isMusicMediaFolder = string.Equals(collectionType, CollectionType.Music, StringComparison.OrdinalIgnoreCase);
 
-            // If there's a collection type and it's not music, it can't be a series
+            // If there's a collection type and it's not music, it can't be a music artist
             if (!isMusicMediaFolder)
             {
                 return null;
@@ -87,6 +87,15 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             var result = Parallel.ForEach(directories, (fileSystemInfo, state) =>
             {
+                foreach (var subfolder in _namingOptions.ArtistSubfolders)
+                {
+                    if (fileSystemInfo.Name.Equals(subfolder, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // stop once we see a artist subfolder
+                        state.Stop();
+                    }
+                }
+
                 if (albumResolver.IsMusicAlbum(fileSystemInfo.FullName, directoryService))
                 {
                     // stop once we see a music album

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -54,7 +54,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         public string AlbumArtist => AlbumArtists.FirstOrDefault();
 
         [JsonIgnore]
-        public override bool SupportsPeople => false;
+        public override bool SupportsPeople => true;
 
         /// <summary>
         /// Gets the tracks.

--- a/MediaBrowser.Controller/Providers/ICustomMetadataProvider.cs
+++ b/MediaBrowser.Controller/Providers/ICustomMetadataProvider.cs
@@ -18,9 +18,9 @@ namespace MediaBrowser.Controller.Providers
         /// Fetches the metadata asynchronously.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <param name="options">The options.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>Task{ItemUpdateType}.</returns>
+        /// <param name="options">The <see cref="MetadataRefreshOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>A <see cref="Task"/> fetching the <see cref="ItemUpdateType"/>.</returns>
         Task<ItemUpdateType> FetchAsync(TItemType item, MetadataRefreshOptions options, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="PlaylistsNET" Version="1.2.1" />
-    <PackageReference Include="TagLibSharp" Version="2.2.0" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="TMDbLib" Version="1.9.2" />
   </ItemGroup>
 

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="PlaylistsNET" Version="1.2.1" />
+    <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="TMDbLib" Version="1.9.2" />
   </ItemGroup>
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -1,7 +1,5 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +19,9 @@ using TagLib;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
+    /// <summary>
+    /// Probes audio files for metadata.
+    /// </summary>
     public class AudioFileProber
     {
         private readonly IMediaEncoder _mediaEncoder;
@@ -28,6 +29,13 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly ILibraryManager _libraryManager;
         private readonly IMediaSourceManager _mediaSourceManager;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioFileProber"/> class.
+        /// </summary>
+        /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
+        /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
+        /// <param name="itemRepo">Instance of the <see cref="IItemRepository"/> interface.</param>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         public AudioFileProber(
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
@@ -40,6 +48,14 @@ namespace MediaBrowser.Providers.MediaInfo
             _mediaSourceManager = mediaSourceManager;
         }
 
+        /// <summary>
+        /// Probes the specified item for metadata.
+        /// </summary>
+        /// <param name="item">The item to probe.</param>
+        /// <param name="options">The <see cref="MetadataRefreshOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <typeparam name="T">The type of item to resolve.</typeparam>
+        /// <returns>A <see cref="Task"/> probing the item for metadata.</returns>
         public async Task<ItemUpdateType> Probe<T>(
             T item,
             MetadataRefreshOptions options,
@@ -80,9 +96,9 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <summary>
         /// Fetches the specified audio.
         /// </summary>
-        /// <param name="audio">The audio.</param>
-        /// <param name="mediaInfo">The media information.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="audio">The <see cref="Audio"/>.</param>
+        /// <param name="mediaInfo">The <see cref="Model.MediaInfo.MediaInfo"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         protected void Fetch(Audio audio, Model.MediaInfo.MediaInfo mediaInfo, CancellationToken cancellationToken)
         {
             audio.Container = mediaInfo.Container;
@@ -91,18 +107,15 @@ namespace MediaBrowser.Providers.MediaInfo
             audio.RunTimeTicks = mediaInfo.RunTimeTicks;
             audio.Size = mediaInfo.Size;
 
-            // var extension = (Path.GetExtension(audio.Path) ?? string.Empty).TrimStart('.');
-            // audio.Container = extension;
-
             FetchDataFromTags(audio);
 
             _itemRepo.SaveMediaStreams(audio.Id, mediaInfo.MediaStreams, cancellationToken);
         }
 
         /// <summary>
-        /// Fetches data from the tags dictionary.
+        /// Fetches data from the tags.
         /// </summary>
-        /// <param name="audio">The audio.</param>
+        /// <param name="audio">The <see cref="Audio"/>.</param>
         private void FetchDataFromTags(Audio audio)
         {
             var file = TagLib.File.Create(audio.Path);

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -138,6 +138,10 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 tags = file.GetTag(TagTypes.Apple);
             }
+            else if (tagTypes.HasFlag(TagTypes.Xiph))
+            {
+                tags = file.GetTag(TagTypes.Xiph);
+            }
             else if (tagTypes.HasFlag(TagTypes.AudibleMetadata))
             {
                 tags = file.GetTag(TagTypes.AudibleMetadata);

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -120,7 +118,7 @@ namespace MediaBrowser.Providers.MediaInfo
         {
             var file = TagLib.File.Create(audio.Path);
             var tagTypes = file.TagTypesOnDisk;
-            Tag tags = null;
+            Tag tags = new TagLib.Id3v2.Tag();
 
             if (tagTypes.HasFlag(TagTypes.Id3v2))
             {
@@ -151,7 +149,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 tags = file.GetTag(TagTypes.Id3v1);
             }
 
-            if (tags != null)
+            if (tags.IsEmpty)
             {
                 if (audio.SupportsPeople && !audio.LockedFields.Contains(MetadataField.Cast))
                 {

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -134,6 +134,10 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 tags = file.GetTag(TagTypes.FlacMetadata);
             }
+            else if (tagTypes.HasFlag(TagTypes.AudibleMetadata))
+            {
+                tags = file.GetTag(TagTypes.AudibleMetadata);
+            }
             else if (tagTypes.HasFlag(TagTypes.Id3v1))
             {
                 tags = file.GetTag(TagTypes.Id3v1);

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -134,6 +134,10 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 tags = file.GetTag(TagTypes.FlacMetadata);
             }
+            else if (tagTypes.HasFlag(TagTypes.Apple))
+            {
+                tags = file.GetTag(TagTypes.Apple);
+            }
             else if (tagTypes.HasFlag(TagTypes.AudibleMetadata))
             {
                 tags = file.GetTag(TagTypes.AudibleMetadata);

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,14 +21,14 @@ using TagLib;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
-    public class FFProbeAudioInfo
+    public class AudioFileProber
     {
         private readonly IMediaEncoder _mediaEncoder;
         private readonly IItemRepository _itemRepo;
         private readonly ILibraryManager _libraryManager;
         private readonly IMediaSourceManager _mediaSourceManager;
 
-        public FFProbeAudioInfo(
+        public AudioFileProber(
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
             IItemRepository itemRepo,
@@ -170,7 +169,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 audio.Album = tags.Album;
                 audio.IndexNumber = Convert.ToInt32(tags.Track);
                 audio.ParentIndexNumber = Convert.ToInt32(tags.Disc);
-                if(tags.Year != 0)
+                if (tags.Year != 0)
                 {
                     var year = Convert.ToInt32(tags.Year);
                     audio.ProductionYear = year;

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -118,7 +118,7 @@ namespace MediaBrowser.Providers.MediaInfo
         {
             var file = TagLib.File.Create(audio.Path);
             var tagTypes = file.TagTypesOnDisk;
-            Tag tags = new TagLib.Id3v2.Tag();
+            Tag? tags = null;
 
             if (tagTypes.HasFlag(TagTypes.Id3v2))
             {
@@ -149,7 +149,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 tags = file.GetTag(TagTypes.Id3v1);
             }
 
-            if (tags.IsEmpty)
+            if (tags != null)
             {
                 if (audio.SupportsPeople && !audio.LockedFields.Contains(MetadataField.Cast))
                 {

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -1,7 +1,5 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 using System;
 using System.IO;
 using System.Linq;
@@ -27,6 +25,9 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
+    /// <summary>
+    /// The probe provider.
+    /// </summary>
     public class ProbeProvider : ICustomMetadataProvider<Episode>,
         ICustomMetadataProvider<MusicVideo>,
         ICustomMetadataProvider<Movie>,
@@ -46,6 +47,22 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly AudioFileProber _audioProber;
         private readonly Task<ItemUpdateType> _cachedTask = Task.FromResult(ItemUpdateType.None);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProbeProvider"/> class.
+        /// </summary>
+        /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
+        /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
+        /// <param name="itemRepo">Instance of the <see cref="IItemRepository"/> interface.</param>
+        /// <param name="blurayExaminer">Instance of the <see cref="IBlurayExaminer"/> interface.</param>
+        /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+        /// <param name="encodingManager">Instance of the <see cref="IEncodingManager"/> interface.</param>
+        /// <param name="config">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+        /// <param name="subtitleManager">Instance of the <see cref="ISubtitleManager"/> interface.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+        /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/>.</param>
+        /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+        /// <param name="namingOptions">The <see cref="NamingOptions"/>.</param>
         public ProbeProvider(
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
@@ -81,11 +98,13 @@ namespace MediaBrowser.Providers.MediaInfo
                 _subtitleResolver);
         }
 
-        public string Name => "filemetadataprober";
+        /// <inheritdoc />
+        public string Name => "Probe Provider";
 
-        // Run last
+        /// <inheritdoc />
         public int Order => 100;
 
+        /// <inheritdoc />
         public bool HasChanged(BaseItem item, IDirectoryService directoryService)
         {
             var video = item as Video;
@@ -127,41 +146,56 @@ namespace MediaBrowser.Providers.MediaInfo
             return false;
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchVideoInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(MusicVideo item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchVideoInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchVideoInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Trailer item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchVideoInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Video item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchVideoInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Audio item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchAudioInfo(item, options, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(AudioBook item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchAudioInfo(item, options, cancellationToken);
         }
 
+        /// <summary>
+        /// Fetches video information for an item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="options">The <see cref="MetadataRefreshOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <typeparam name="T">The type of item to resolve.</typeparam>
+        /// <returns>A <see cref="Task"/> fetching the <see cref="ItemUpdateType"/> for an item.</returns>
         public Task<ItemUpdateType> FetchVideoInfo<T>(T item, MetadataRefreshOptions options, CancellationToken cancellationToken)
             where T : Video
         {
@@ -208,6 +242,14 @@ namespace MediaBrowser.Providers.MediaInfo
                 .FirstOrDefault(i => !string.IsNullOrWhiteSpace(i) && !i.StartsWith('#'));
         }
 
+        /// <summary>
+        /// Fetches audio information for an item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="options">The <see cref="MetadataRefreshOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <typeparam name="T">The type of item to resolve.</typeparam>
+        /// <returns>A <see cref="Task"/> fetching the <see cref="ItemUpdateType"/> for an item.</returns>
         public Task<ItemUpdateType> FetchAudioInfo<T>(T item, MetadataRefreshOptions options, CancellationToken cancellationToken)
             where T : Audio
         {

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -27,7 +27,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
-    public class FFProbeProvider : ICustomMetadataProvider<Episode>,
+    public class ProbeProvider : ICustomMetadataProvider<Episode>,
         ICustomMetadataProvider<MusicVideo>,
         ICustomMetadataProvider<Movie>,
         ICustomMetadataProvider<Trailer>,
@@ -39,14 +39,14 @@ namespace MediaBrowser.Providers.MediaInfo
         IPreRefreshProvider,
         IHasItemChangeMonitor
     {
-        private readonly ILogger<FFProbeProvider> _logger;
+        private readonly ILogger<ProbeProvider> _logger;
         private readonly AudioResolver _audioResolver;
         private readonly SubtitleResolver _subtitleResolver;
         private readonly FFProbeVideoInfo _videoProber;
-        private readonly FFProbeAudioInfo _audioProber;
+        private readonly AudioFileProber _audioProber;
         private readonly Task<ItemUpdateType> _cachedTask = Task.FromResult(ItemUpdateType.None);
 
-        public FFProbeProvider(
+        public ProbeProvider(
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
             IItemRepository itemRepo,
@@ -61,7 +61,8 @@ namespace MediaBrowser.Providers.MediaInfo
             ILoggerFactory loggerFactory,
             NamingOptions namingOptions)
         {
-            _logger = loggerFactory.CreateLogger<FFProbeProvider>();
+            _logger = loggerFactory.CreateLogger<ProbeProvider>();
+            _audioProber = new AudioFileProber(mediaSourceManager, mediaEncoder, itemRepo, libraryManager);
             _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _subtitleResolver = new SubtitleResolver(loggerFactory.CreateLogger<SubtitleResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _videoProber = new FFProbeVideoInfo(
@@ -78,10 +79,9 @@ namespace MediaBrowser.Providers.MediaInfo
                 libraryManager,
                 _audioResolver,
                 _subtitleResolver);
-            _audioProber = new FFProbeAudioInfo(mediaSourceManager, mediaEncoder, itemRepo, libraryManager);
         }
 
-        public string Name => "ffprobe";
+        public string Name => "filemetadataprober";
 
         // Run last
         public int Order => 100;

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,8 +13,19 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Music
 {
+    /// <summary>
+    /// The album metadata service.
+    /// </summary>
     public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AlbumMetadataService"/> class.
+        /// </summary>
+        /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/>.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+        /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         public AlbumMetadataService(
             IServerConfigurationManager serverConfigurationManager,
             ILogger<AlbumMetadataService> logger,

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -98,13 +98,16 @@ namespace MediaBrowser.Providers.Music
                 .ToArray();
 
             var musicbrainzAlbumArtistId = item.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-            var firstMusicbrainzAlbumArtistId = musicbrainzAlbumArtistIds[0];
-            if (!string.IsNullOrEmpty(firstMusicbrainzAlbumArtistId) &&
-                (string.IsNullOrEmpty(musicbrainzAlbumArtistId)
-                    || !musicbrainzAlbumArtistId.Equals(firstMusicbrainzAlbumArtistId, StringComparison.OrdinalIgnoreCase)))
+            if (musicbrainzAlbumArtistIds.Any())
             {
-                item.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, firstMusicbrainzAlbumArtistId);
-                updateType |= ItemUpdateType.MetadataEdit;
+                var firstMusicbrainzAlbumArtistId = musicbrainzAlbumArtistIds[0];
+                if (!string.IsNullOrEmpty(firstMusicbrainzAlbumArtistId)
+                    && (string.IsNullOrEmpty(musicbrainzAlbumArtistId)
+                        || !musicbrainzAlbumArtistId.Equals(firstMusicbrainzAlbumArtistId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    item.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, firstMusicbrainzAlbumArtistId);
+                    updateType |= ItemUpdateType.MetadataEdit;
+                }
             }
 
             if (!item.AlbumArtists.SequenceEqual(albumArtists, StringComparer.OrdinalIgnoreCase))
@@ -148,12 +151,16 @@ namespace MediaBrowser.Providers.Music
                 .ToArray();
 
             var musicbrainzAlbumId = item.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-            if (!String.IsNullOrEmpty(musicbrainzAlbumIds[0])
-                && (String.IsNullOrEmpty(musicbrainzAlbumId)
-                    || !musicbrainzAlbumId.Equals(musicbrainzAlbumIds[0], StringComparison.OrdinalIgnoreCase)))
+            if (musicbrainzAlbumIds.Any())
             {
-                item.SetProviderId(MetadataProvider.MusicBrainzAlbum, musicbrainzAlbumIds[0]!);
-                updateType |= ItemUpdateType.MetadataEdit;
+                var firstMusicbrainzAlbumId = musicbrainzAlbumIds[0];
+                if (!string.IsNullOrEmpty(firstMusicbrainzAlbumId)
+                    && (string.IsNullOrEmpty(musicbrainzAlbumId)
+                        || !musicbrainzAlbumId.Equals(firstMusicbrainzAlbumId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    item.SetProviderId(MetadataProvider.MusicBrainzAlbum, firstMusicbrainzAlbumId);
+                    updateType |= ItemUpdateType.MetadataEdit;
+                }
             }
 
             var musicbrainzReleaseGroupIds = songs
@@ -164,12 +171,16 @@ namespace MediaBrowser.Providers.Music
                 .ToArray();
 
             var musicbrainzReleaseGroupId = item.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-            if (!String.IsNullOrEmpty(musicbrainzReleaseGroupIds[0])
-                && (String.IsNullOrEmpty(musicbrainzReleaseGroupId)
-                    || !musicbrainzReleaseGroupId.Equals(musicbrainzReleaseGroupIds[0], StringComparison.OrdinalIgnoreCase)))
+            if (musicbrainzReleaseGroupIds.Any())
             {
-                item.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, musicbrainzReleaseGroupIds[0]!);
-                updateType |= ItemUpdateType.MetadataEdit;
+                var firstMusicbrainzReleaseGroupId = musicbrainzReleaseGroupIds[0];
+                if (!string.IsNullOrEmpty(firstMusicbrainzReleaseGroupId)
+                    && (string.IsNullOrEmpty(musicbrainzReleaseGroupId)
+                        || !musicbrainzReleaseGroupId.Equals(firstMusicbrainzReleaseGroupId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    item.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, firstMusicbrainzReleaseGroupId);
+                    updateType |= ItemUpdateType.MetadataEdit;
+                }
             }
 
             return updateType;
@@ -228,41 +239,29 @@ namespace MediaBrowser.Providers.Music
 
             if (replaceData || string.IsNullOrEmpty(targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist)))
             {
-                var targetAlbumArtistId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-                var sourceAlbumArtistId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-
-                if (!string.IsNullOrEmpty(sourceAlbumArtistId)
-                    && (string.IsNullOrEmpty(targetAlbumArtistId)
-                        || !targetAlbumArtistId.Equals(sourceAlbumArtistId, StringComparison.Ordinal)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, sourceAlbumArtistId);
-                }
+                setProviderId(sourceItem, targetItem, MetadataProvider.MusicBrainzAlbumArtist);
             }
 
             if (replaceData || string.IsNullOrEmpty(targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbum)))
             {
-                var targetAlbumId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-                var sourceAlbumId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-
-                if (!string.IsNullOrEmpty(sourceAlbumId)
-                    && (string.IsNullOrEmpty(targetAlbumId)
-                        || !targetAlbumId.Equals(sourceAlbumId, StringComparison.Ordinal)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbum, sourceAlbumId);
-                }
+                setProviderId(sourceItem, targetItem, MetadataProvider.MusicBrainzAlbum);
             }
 
             if (replaceData || string.IsNullOrEmpty(targetItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup)))
             {
-                var targetReleaseGroupId = targetItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-                var sourceReleaseGroupId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
+                setProviderId(sourceItem, targetItem, MetadataProvider.MusicBrainzReleaseGroup);
+            }
+        }
 
-                if (!string.IsNullOrEmpty(sourceReleaseGroupId)
-                    && (string.IsNullOrEmpty(targetReleaseGroupId)
-                        || !targetReleaseGroupId.Equals(sourceItem)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, sourceReleaseGroupId);
-                }
+        private void setProviderId(MusicAlbum sourceItem, MusicAlbum targetItem, MetadataProvider provider)
+        {
+            var source = sourceItem.GetProviderId(provider);
+            var target = targetItem.GetProviderId(provider);
+            if (!string.IsNullOrEmpty(source)
+                && (string.IsNullOrEmpty(target)
+                    || !target.Equals(source, StringComparison.Ordinal)))
+            {
+                targetItem.SetProviderId(provider, source);
             }
         }
     }

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -90,25 +90,7 @@ namespace MediaBrowser.Providers.Music
                 .Select(g => g.Key)
                 .ToArray();
 
-            var musicbrainzAlbumArtistIds = songs
-                .Select(i => i.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist))
-                .GroupBy(i => i)
-                .OrderByDescending(g => g.Count())
-                .Select(g => g.Key)
-                .ToArray();
-
-            var musicbrainzAlbumArtistId = item.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-            if (musicbrainzAlbumArtistIds.Any())
-            {
-                var firstMusicbrainzAlbumArtistId = musicbrainzAlbumArtistIds[0];
-                if (!string.IsNullOrEmpty(firstMusicbrainzAlbumArtistId)
-                    && (string.IsNullOrEmpty(musicbrainzAlbumArtistId)
-                        || !musicbrainzAlbumArtistId.Equals(firstMusicbrainzAlbumArtistId, StringComparison.OrdinalIgnoreCase)))
-                {
-                    item.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, firstMusicbrainzAlbumArtistId);
-                    updateType |= ItemUpdateType.MetadataEdit;
-                }
-            }
+            updateType |= setProviderIdFromSongs(item, songs, MetadataProvider.MusicBrainzAlbumArtist);
 
             if (!item.AlbumArtists.SequenceEqual(albumArtists, StringComparer.OrdinalIgnoreCase))
             {
@@ -143,45 +125,8 @@ namespace MediaBrowser.Providers.Music
         {
             var updateType = ItemUpdateType.None;
 
-            var musicbrainzAlbumIds = songs
-                .Select(i => i.GetProviderId(MetadataProvider.MusicBrainzAlbum))
-                .GroupBy(i => i)
-                .OrderByDescending(g => g.Count())
-                .Select(g => g.Key)
-                .ToArray();
-
-            var musicbrainzAlbumId = item.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-            if (musicbrainzAlbumIds.Any())
-            {
-                var firstMusicbrainzAlbumId = musicbrainzAlbumIds[0];
-                if (!string.IsNullOrEmpty(firstMusicbrainzAlbumId)
-                    && (string.IsNullOrEmpty(musicbrainzAlbumId)
-                        || !musicbrainzAlbumId.Equals(firstMusicbrainzAlbumId, StringComparison.OrdinalIgnoreCase)))
-                {
-                    item.SetProviderId(MetadataProvider.MusicBrainzAlbum, firstMusicbrainzAlbumId);
-                    updateType |= ItemUpdateType.MetadataEdit;
-                }
-            }
-
-            var musicbrainzReleaseGroupIds = songs
-                .Select(i => i.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup))
-                .GroupBy(i => i)
-                .OrderByDescending(g => g.Count())
-                .Select(g => g.Key)
-                .ToArray();
-
-            var musicbrainzReleaseGroupId = item.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-            if (musicbrainzReleaseGroupIds.Any())
-            {
-                var firstMusicbrainzReleaseGroupId = musicbrainzReleaseGroupIds[0];
-                if (!string.IsNullOrEmpty(firstMusicbrainzReleaseGroupId)
-                    && (string.IsNullOrEmpty(musicbrainzReleaseGroupId)
-                        || !musicbrainzReleaseGroupId.Equals(firstMusicbrainzReleaseGroupId, StringComparison.OrdinalIgnoreCase)))
-                {
-                    item.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, firstMusicbrainzReleaseGroupId);
-                    updateType |= ItemUpdateType.MetadataEdit;
-                }
-            }
+            updateType |= setProviderIdFromSongs(item, songs, MetadataProvider.MusicBrainzAlbum);
+            updateType |= setProviderIdFromSongs(item, songs, MetadataProvider.MusicBrainzReleaseGroup);
 
             return updateType;
         }
@@ -263,6 +208,30 @@ namespace MediaBrowser.Providers.Music
             {
                 targetItem.SetProviderId(provider, source);
             }
+        }
+
+        private ItemUpdateType setProviderIdFromSongs(BaseItem item, IReadOnlyList<Audio> songs, MetadataProvider provider)
+        {
+            var ids = songs
+                .Select(i => i.GetProviderId(provider))
+                .GroupBy(i => i)
+                .OrderByDescending(g => g.Count())
+                .Select(g => g.Key)
+                .ToArray();
+
+            var id = item.GetProviderId(provider);
+            if (ids.Any())
+            {
+                var firstId = ids[0];
+                if (!string.IsNullOrEmpty(firstId)
+                    && (string.IsNullOrEmpty(id)
+                        || !id.Equals(firstId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    item.SetProviderId(provider, firstId);
+                    return ItemUpdateType.MetadataEdit;
+                }
+            }
+            return ItemUpdateType.None;
         }
     }
 }

--- a/MediaBrowser.Providers/Music/AudioMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AudioMetadataService.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities.Audio;
@@ -12,8 +10,19 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Music
 {
+    /// <summary>
+    /// The audio metadata service.
+    /// </summary>
     public class AudioMetadataService : MetadataService<Audio, SongInfo>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioMetadataService"/> class.
+        /// </summary>
+        /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/>.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+        /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         public AudioMetadataService(
             IServerConfigurationManager serverConfigurationManager,
             ILogger<AudioMetadataService> logger,

--- a/MediaBrowser.Providers/Music/AudioMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AudioMetadataService.cs
@@ -33,6 +33,21 @@ namespace MediaBrowser.Providers.Music
         {
         }
 
+        private void SetProviderId(Audio sourceItem, Audio targetItem, bool replaceData, MetadataProvider provider)
+        {
+            var target = targetItem.GetProviderId(provider);
+            if (replaceData || string.IsNullOrEmpty(target))
+            {
+                var source = sourceItem.GetProviderId(provider);
+                if (!string.IsNullOrEmpty(source)
+                    && (string.IsNullOrEmpty(target)
+                        || !target.Equals(source, StringComparison.Ordinal)))
+                {
+                    targetItem.SetProviderId(provider, source);
+                }
+            }
+        }
+
         /// <inheritdoc />
         protected override void MergeData(MetadataResult<Audio> source, MetadataResult<Audio> target, MetadataField[] lockedFields, bool replaceData, bool mergeMetadataSettings)
         {
@@ -51,44 +66,9 @@ namespace MediaBrowser.Providers.Music
                 targetItem.Album = sourceItem.Album;
             }
 
-            var targetAlbumArtistId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-            if (replaceData || string.IsNullOrEmpty(targetAlbumArtistId))
-            {
-                var sourceAlbumArtistId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-
-                if (!string.IsNullOrEmpty(sourceAlbumArtistId)
-                    && (string.IsNullOrEmpty(targetAlbumArtistId)
-                        || !targetAlbumArtistId.Equals(sourceAlbumArtistId, StringComparison.Ordinal)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, sourceAlbumArtistId);
-                }
-            }
-
-            var targetAlbumId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-            if (replaceData || string.IsNullOrEmpty(targetAlbumId))
-            {
-                var sourceAlbumId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-
-                if (!string.IsNullOrEmpty(sourceAlbumId)
-                    && (string.IsNullOrEmpty(targetAlbumId)
-                        || !targetAlbumId.Equals(sourceAlbumId, StringComparison.Ordinal)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbum, sourceAlbumId);
-                }
-            }
-
-            var targetReleaseGroupId = targetItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-            if (replaceData || string.IsNullOrEmpty(targetReleaseGroupId))
-            {
-                var sourceReleaseGroupId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-
-                if (!string.IsNullOrEmpty(sourceReleaseGroupId)
-                    && (string.IsNullOrEmpty(targetReleaseGroupId)
-                        || !targetReleaseGroupId.Equals(sourceReleaseGroupId, StringComparison.Ordinal)))
-                {
-                    targetItem.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, sourceReleaseGroupId);
-                }
-            }
+            SetProviderId(sourceItem, targetItem, replaceData, MetadataProvider.MusicBrainzAlbumArtist);
+            SetProviderId(sourceItem, targetItem, replaceData, MetadataProvider.MusicBrainzAlbum);
+            SetProviderId(sourceItem, targetItem, replaceData, MetadataProvider.MusicBrainzReleaseGroup);
         }
     }
 }

--- a/MediaBrowser.Providers/Music/AudioMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AudioMetadataService.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
@@ -39,6 +40,45 @@ namespace MediaBrowser.Providers.Music
             if (replaceData || string.IsNullOrEmpty(targetItem.Album))
             {
                 targetItem.Album = sourceItem.Album;
+            }
+
+            var targetAlbumArtistId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
+            if (replaceData || string.IsNullOrEmpty(targetAlbumArtistId))
+            {
+                var sourceAlbumArtistId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
+
+                if (!string.IsNullOrEmpty(sourceAlbumArtistId)
+                    && (string.IsNullOrEmpty(targetAlbumArtistId)
+                        || !targetAlbumArtistId.Equals(sourceAlbumArtistId, StringComparison.Ordinal)))
+                {
+                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, sourceAlbumArtistId);
+                }
+            }
+
+            var targetAlbumId = targetItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
+            if (replaceData || string.IsNullOrEmpty(targetAlbumId))
+            {
+                var sourceAlbumId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzAlbum);
+
+                if (!string.IsNullOrEmpty(sourceAlbumId)
+                    && (string.IsNullOrEmpty(targetAlbumId)
+                        || !targetAlbumId.Equals(sourceAlbumId, StringComparison.Ordinal)))
+                {
+                    targetItem.SetProviderId(MetadataProvider.MusicBrainzAlbum, sourceAlbumId);
+                }
+            }
+
+            var targetReleaseGroupId = targetItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
+            if (replaceData || string.IsNullOrEmpty(targetReleaseGroupId))
+            {
+                var sourceReleaseGroupId = sourceItem.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
+
+                if (!string.IsNullOrEmpty(sourceReleaseGroupId)
+                    && (string.IsNullOrEmpty(targetReleaseGroupId)
+                        || !targetReleaseGroupId.Equals(sourceReleaseGroupId, StringComparison.Ordinal)))
+                {
+                    targetItem.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, sourceReleaseGroupId);
+                }
             }
         }
     }


### PR DESCRIPTION
Our music parser is notoriously inflexible, so I tried making it better.

**Changes**
* use TagLibSharp to properly read tags from files (preference in this order):
  1. ID3v2
  2. APE
  3. FLAC
  4. Audible
  5. ID3v1
* properly read multiple artists and album artist tags (ffprobe did not provide this)
* properly create and associate persons with tracks
* enable people association on albums
* add all artists from tracks as persons to album
* add album artists from tracks to the album
* add composers to tracks and albums
* add MusicBrainz releasegroup and album Ids to album
* allow subfolders named as the plural of [MusicBrain ReleaseGroups](https://musicbrainz.org/doc/Release_Group/Type)  to be present under an artist
* add proper replace logic to services (some may be duplicate)
* add xmldocs for modified files

**ToDo**
* write tests

**Examples**
Now valid structure:
```
Artist
|---- Compilations
       |---- Album 1
              |---- Track 1
              |---- Track 2
              |---- Track 3
       |---- Album 2
              |---- Track 1
       |---- Album 3
              |---- Track 1
|---- Singles
       |---- Single1
              |---- Track 1
              |---- Track 2
```

**Issues**
