### PR TITLE
Add new priority level to ResolverPriority for plugins

### DIFF
--- a/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
+++ b/MediaBrowser.Controller/Resolvers/ResolverPriority.cs
@@ -6,6 +6,11 @@ namespace MediaBrowser.Controller.Resolvers
     public enum ResolverPriority
     {
         /// <summary>
+        /// The highest priority. Used by plugins to bypass the default server resolvers.
+        /// </summary>
+        Plugin = 0,
+
+        /// <summary>
         /// The first.
         /// </summary>
         First = 1,


### PR DESCRIPTION
With some changes in 10.8 it's not easy to get a plugin defined resolver prioritized anymore. Adding a new level which is not used by the server makes this a lot easier. Technically this is a feature addition and technically we don't support it, but it would make me happy to get this into 10.8... :)

**Changes**

- Add new priority level to ResolverPriority for plugins

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
