### PR TITLE
Add fallback for image downloads with bad reported MediaType

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -30,6 +30,7 @@ using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using Priority_Queue;
@@ -186,6 +187,12 @@ namespace MediaBrowser.Providers.Manager
             if (contentType.Equals(MediaTypeNames.Text.Html, StringComparison.OrdinalIgnoreCase))
             {
                 throw new HttpRequestException("Invalid image received.", null, HttpStatusCode.NotFound);
+            }
+
+            // some iptv/epg providers don't correctly report media type, extract from url if no extension found
+            if (string.IsNullOrWhiteSpace(MimeTypes.ToExtension(contentType)))
+            {
+                contentType = MimeTypes.GetMimeType(url);
             }
 
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
`ImageSaver` uses `contentType` to determine the file extension to use when saving the image.

Some IPTV/EPG providers serve images that report as types that don't map to extensions (such as `binary/octet-stream`), resulting in no channel icon and logged exceptions every time one is downloaded and can't be saved.

This may be a more general fix for the tvheadend workaround on line 177, but I have been unable to reproduce that case on my dev machine to verify.

**Changes**
- Add fallback for image downloads with bad MediaType

