### PR TITLE
Allow media without streams to playback 

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -744,7 +744,7 @@ namespace MediaBrowser.Model.Dlna
                 {
                     var videoCodecs = ContainerProfile.SplitValue(transcodingProfile.VideoCodec);
 
-                    if (ContainerProfile.ContainsContainer(videoCodecs, item.VideoStream.Codec))
+                    if (ContainerProfile.ContainsContainer(videoCodecs, item.VideoStream?.Codec))
                     {
                         var videoCodec = transcodingProfile.VideoCodec;
                         var container = transcodingProfile.Container;
@@ -770,28 +770,28 @@ namespace MediaBrowser.Model.Dlna
         {
             // prefer matching video codecs
             var videoCodecs = ContainerProfile.SplitValue(videoCodec);
-            var directVideoCodec = ContainerProfile.ContainsContainer(videoCodecs, videoStream.Codec) ? videoStream.Codec : null;
+            var directVideoCodec = ContainerProfile.ContainsContainer(videoCodecs, videoStream?.Codec) ? videoStream?.Codec : null;
             playlistItem.VideoCodecs = directVideoCodec != null ? new[] { directVideoCodec } : videoCodecs;
 
             // copy video codec options as a starting point, this applies to transcode and direct-stream
-            playlistItem.MaxFramerate = videoStream.AverageFrameRate;
-            var qualifier = videoStream.Codec;
-            if (videoStream.Level.HasValue)
+            playlistItem.MaxFramerate = videoStream?.AverageFrameRate;
+            var qualifier = videoStream?.Codec;
+            if (videoStream?.Level != null)
             {
                 playlistItem.SetOption(qualifier, "level", videoStream.Level.Value.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (videoStream.BitDepth.HasValue)
+            if (videoStream?.BitDepth != null)
             {
                 playlistItem.SetOption(qualifier, "videobitdepth", videoStream.BitDepth.Value.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (!string.IsNullOrEmpty(videoStream.Profile))
+            if (!string.IsNullOrEmpty(videoStream?.Profile))
             {
                 playlistItem.SetOption(qualifier, "profile", videoStream.Profile.ToLowerInvariant());
             }
 
-            if (videoStream.Level != 0)
+            if (videoStream != null && videoStream.Level != 0)
             {
                 playlistItem.SetOption(qualifier, "level", videoStream.Level.ToString());
             }

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -223,12 +223,17 @@ namespace Jellyfin.Model.Tests
         // RokuSSPlus
         [InlineData("RokuSSPlus", "mp4-h264-ac3-aac-srt-2600k", PlayMethod.DirectPlay, (TranscodeReason)0, "Remux")] // #6450
         [InlineData("RokuSSPlus", "mp4-hevc-ac3-aac-srt-15200k", PlayMethod.DirectPlay, (TranscodeReason)0, "Remux")] // #6450
+        // no streams
+        [InlineData("Chrome", "no-streams", PlayMethod.Transcode, TranscodeReason.VideoCodecNotSupported, "Transcode")] // #6450
         public async Task BuildVideoItemWithDirectPlayExplicitStreams(string deviceName, string mediaSource, PlayMethod? playMethod, TranscodeReason why = (TranscodeReason)0, string transcodeMode = "DirectStream", string transcodeProtocol = "")
         {
             var options = await GetVideoOptions(deviceName, mediaSource);
             var streamCount = options.MediaSources[0].MediaStreams.Count;
-            options.AudioStreamIndex = streamCount - 2;
-            options.SubtitleStreamIndex = streamCount - 1;
+            if (streamCount > 0)
+            {
+                options.AudioStreamIndex = streamCount - 2;
+                options.SubtitleStreamIndex = streamCount - 1;
+            }
 
             var streamInfo = BuildVideoItemSimpleTest(options, playMethod, why, transcodeMode, transcodeProtocol);
             Assert.Equal(streamInfo?.AudioStreamIndex, options.AudioStreamIndex);

--- a/tests/Jellyfin.Model.Tests/Test Data/MediaSourceInfo-no-streams.json
+++ b/tests/Jellyfin.Model.Tests/Test Data/MediaSourceInfo-no-streams.json
@@ -1,0 +1,17 @@
+{
+    "Id": "f6eab7118618ab26e61e495a1853481a",
+    "Path": "/Media/MyVideo-WEBDL-2160p.mp4",
+    "Container": "mov,mp4,m4a,3gp,3g2,mj2",
+    "Size": 6521110016,
+    "Name": "MyVideo WEBDL-2160p",
+    "ETag": "a2fb84b618ba2467fe377543f879e9bf",
+    "RunTimeTicks": 34318510080,
+    "SupportsTranscoding": true,
+    "SupportsDirectStream": true,
+    "SupportsDirectPlay": true,
+    "SupportsProbing": true,
+    "MediaStreams": [],
+    "Bitrate": 15201382,
+    "DefaultAudioStreamIndex": null,
+    "DefaultSubtitleStreamIndex": null
+}


### PR DESCRIPTION
Fixes playback attempts where the source doesn't provide the streams the user is attempting to playback, typically from internet sources.