### PR TITLE
Fix media path saving to wrong library when name duplicated

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2840,10 +2840,12 @@ namespace Emby.Server.Implementations.Library
 
             var existingNameCount = 1; // first numbered name will be 2
             var virtualFolderPath = Path.Combine(rootFolderPath, name);
+            var originalName = name;
             while (Directory.Exists(virtualFolderPath))
             {
                 existingNameCount++;
-                virtualFolderPath = Path.Combine(rootFolderPath, name + " " + existingNameCount);
+                name = originalName + existingNameCount;
+                virtualFolderPath = Path.Combine(rootFolderPath, name);
             }
 
             var mediaPathInfos = options.PathInfos;


### PR DESCRIPTION
**Changes**
- Update name so media paths store to correct library

**Issues**
@Shadowghost

> When adding a library with an already existing name on jf-web the library gets created but all folders you assigned to it will be added to the existing one (at least the UI says so). But the existing library edit dialogue does only show the original folder
> The new created library has the counter added (Like Music -> Music 2), so at least that part works as intended
