### PR TITLE
Add NVIDIA_VISIBLE_DEVICES=all environment variable to dockerfile

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 # Jellyfin Contributors
 
+ - [ddund](hhtps://github.com/ddund)
  - [1337joe](https://github.com/1337joe)
  - [97carmine](https://github.com/97carmine)
  - [Abbe98](https://github.com/Abbe98)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
+#
+ENV NVIDIA_VISIBLE_DEVICES=all
+
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} as builder
 WORKDIR /repo
 COPY . .


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

Following the [NVIDIA Contailer Toolkit installation guide for Podman](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#podman) and adding the NVIDIA_VISIBLE_DEVICES environment variable to the dockerfile I was able to get NVENC working with Jellyfin running through Podman. I thought maybe someone else might be interested in this. If it gets merged I could update the documentation as well but you only need to follow the guide and add `security-opt=label=disable` and `hooks-dir=/usr/share/containers/oci/hooks.d/` as options to the podman run command.

**Changes**
Added NVIDIA_VISIBLE_DEVICES=all to Dockerfile
