### PR TITLE
Fix album index sorts

### DIFF
--- a/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
+++ b/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
@@ -34,6 +34,11 @@ namespace Emby.Server.Implementations.Sorting
                 throw new ArgumentNullException(nameof(y));
             }
 
+            if (!x.IndexNumber.HasValue && !y.IndexNumber.HasValue)
+            {
+                return 0;
+            }
+
             if (!x.IndexNumber.HasValue)
             {
                 return -1;

--- a/Emby.Server.Implementations/Sorting/ParentIndexNumberComparer.cs
+++ b/Emby.Server.Implementations/Sorting/ParentIndexNumberComparer.cs
@@ -34,6 +34,11 @@ namespace Emby.Server.Implementations.Sorting
                 throw new ArgumentNullException(nameof(y));
             }
 
+            if (!x.ParentIndexNumber.HasValue && !y.ParentIndexNumber.HasValue)
+            {
+                return 0;
+            }
+
             if (!x.ParentIndexNumber.HasValue)
             {
                 return -1;

--- a/tests/Jellyfin.Server.Implementations.Tests/Sorting/IndexNumberComparerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Sorting/IndexNumberComparerTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Emby.Server.Implementations.Sorting;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Sorting;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Sorting;
+
+public class IndexNumberComparerTests
+{
+    private readonly IBaseItemComparer _cmp = new IndexNumberComparer();
+
+    private static TheoryData<BaseItem?, BaseItem?> Compare_GivenNull_ThrowsArgumentNullException_TestData()
+        => new()
+        {
+            { null, new Audio() },
+            { new Audio(), null }
+        };
+
+    [Theory]
+    [MemberData(nameof(Compare_GivenNull_ThrowsArgumentNullException_TestData))]
+    public void Compare_GivenNull_ThrowsArgumentNullException(BaseItem? x, BaseItem? y)
+    {
+        Assert.Throws<ArgumentNullException>(() => _cmp.Compare(x, y));
+    }
+
+    [Theory]
+    [InlineData(null, null, 0)]
+    [InlineData(0, null, 1)]
+    [InlineData(null, 0, -1)]
+    [InlineData(1, 1, 0)]
+    [InlineData(0, 1, -1)]
+    [InlineData(1, 0, 1)]
+    public void Compare_ValidIndices_SortsExpected(int? index1, int? index2, int expected)
+    {
+        BaseItem x = new Audio
+        {
+            IndexNumber = index1
+        };
+        BaseItem y = new Audio
+        {
+            IndexNumber = index2
+        };
+
+        Assert.Equal(expected, _cmp.Compare(x, y));
+        Assert.Equal(-expected, _cmp.Compare(y, x));
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Sorting/ParentIndexNumberComparerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Sorting/ParentIndexNumberComparerTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Emby.Server.Implementations.Sorting;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Sorting;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Sorting;
+
+public class ParentIndexNumberComparerTests
+{
+    private readonly IBaseItemComparer _cmp = new ParentIndexNumberComparer();
+
+    private static TheoryData<BaseItem?, BaseItem?> Compare_GivenNull_ThrowsArgumentNullException_TestData()
+        => new()
+        {
+            { null, new Audio() },
+            { new Audio(), null }
+        };
+
+    [Theory]
+    [MemberData(nameof(Compare_GivenNull_ThrowsArgumentNullException_TestData))]
+    public void Compare_GivenNull_ThrowsArgumentNullException(BaseItem? x, BaseItem? y)
+    {
+        Assert.Throws<ArgumentNullException>(() => _cmp.Compare(x, y));
+    }
+
+    [Theory]
+    [InlineData(null, null, 0)]
+    [InlineData(0, null, 1)]
+    [InlineData(null, 0, -1)]
+    [InlineData(1, 1, 0)]
+    [InlineData(0, 1, -1)]
+    [InlineData(1, 0, 1)]
+    public void Compare_ValidIndices_SortsExpected(int? parentIndex1, int? parentIndex2, int expected)
+    {
+        BaseItem x = new Audio
+        {
+            ParentIndexNumber = parentIndex1
+        };
+        BaseItem y = new Audio
+        {
+            ParentIndexNumber = parentIndex2
+        };
+
+        Assert.Equal(expected, _cmp.Compare(x, y));
+        Assert.Equal(-expected, _cmp.Compare(y, x));
+    }
+}


### PR DESCRIPTION
Given an album with over 16 tracks with null disc/track fields the sorters would fail because comparing null values tried to change order differently when called (a,b) vs (b,a).

**Changes**
- Add check so nulls will result in valid sort

**Issues**
Fixes #7533
Fixes jellyfin/jellyfin-web#3532
