### PR TITLE
Fix PGS burn-in on certain iGPU such as Iris Plus 655

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3381,7 +3381,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
 
                     // qsv requires a fixed pool size.
-                    // default to 64 otherwise if will fails on certain iGPU.
+                    // default to 64 otherwise it will fail on certain iGPU.
                     subFilters.Add("hwupload=extra_hw_frames=64");
 
                     var (overlayW, overlayH) = GetFixedOutputSize(inW, inH, reqW, reqH, reqMaxW, reqMaxH);
@@ -3590,7 +3590,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
 
                     // qsv requires a fixed pool size.
-                    // default to 64 otherwise if will fails on certain iGPU.
+                    // default to 64 otherwise it will fail on certain iGPU.
                     subFilters.Add("hwupload=extra_hw_frames=64");
 
                     var (overlayW, overlayH) = GetFixedOutputSize(inW, inH, reqW, reqH, reqMaxW, reqMaxH);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3381,7 +3381,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
 
                     // qsv requires a fixed pool size.
-                    subFilters.Add("hwupload=extra_hw_frames=32");
+                    // default to 64 otherwise if will fails on certain iGPU.
+                    subFilters.Add("hwupload=extra_hw_frames=64");
 
                     var (overlayW, overlayH) = GetFixedOutputSize(inW, inH, reqW, reqH, reqMaxW, reqMaxH);
                     var overlaySize = (overlayW.HasValue && overlayH.HasValue)
@@ -3589,7 +3590,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
 
                     // qsv requires a fixed pool size.
-                    subFilters.Add("hwupload=extra_hw_frames=32");
+                    // default to 64 otherwise if will fails on certain iGPU.
+                    subFilters.Add("hwupload=extra_hw_frames=64");
 
                     var (overlayW, overlayH) = GetFixedOutputSize(inW, inH, reqW, reqH, reqMaxW, reqMaxH);
                     var overlaySize = (overlayW.HasValue && overlayH.HasValue)


### PR DESCRIPTION
**Changes**
- Use a larger frame pool as per https://trac.ffmpeg.org/wiki/Hardware/QuickSync

**Issues**
Fixes https://github.com/jellyfin/jellyfin-ffmpeg/issues/95