### PR TITLE
Fix NamedConfiguration API Generation

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -399,6 +399,12 @@ namespace Emby.Server.Implementations.AppBase
         }
 
         /// <inheritdoc />
+        public ConfigurationStore[] GetConfigurationStores()
+        {
+            return _configurationStores;
+        }
+
+        /// <inheritdoc />
         public Type GetConfigurationType(string key)
         {
             return GetConfigurationStore(key)

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -86,21 +86,23 @@ namespace Jellyfin.Api.Controllers
         /// Updates named configuration.
         /// </summary>
         /// <param name="key">Configuration key.</param>
+        /// <param name="configuration">Configuration.</param>
         /// <response code="204">Named configuration updated.</response>
         /// <returns>Update status.</returns>
         [HttpPost("Configuration/{key}")]
         [Authorize(Policy = Policies.RequiresElevation)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> UpdateNamedConfiguration([FromRoute, Required] string key)
+        public ActionResult UpdateNamedConfiguration([FromRoute, Required] string key, [FromBody, Required] JsonDocument configuration)
         {
             var configurationType = _configurationManager.GetConfigurationType(key);
-            var configuration = await JsonSerializer.DeserializeAsync(Request.Body, configurationType, _serializerOptions).ConfigureAwait(false);
-            if (configuration == null)
+            var deserializedConfiguration = configuration.Deserialize(configurationType, _serializerOptions);
+
+            if (deserializedConfiguration == null)
             {
                 throw new ArgumentException("Body doesn't contain a valid configuration");
             }
 
-            _configurationManager.SaveConfiguration(key, configuration);
+            _configurationManager.SaveConfiguration(key, deserializedConfiguration);
             return NoContent();
         }
 

--- a/Jellyfin.Server/Filters/AdditionalModelFilter.cs
+++ b/Jellyfin.Server/Filters/AdditionalModelFilter.cs
@@ -1,4 +1,5 @@
-﻿using MediaBrowser.Common.Plugins;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.ApiClient;
 using MediaBrowser.Model.Entities;
@@ -14,6 +15,17 @@ namespace Jellyfin.Server.Filters
     /// </summary>
     public class AdditionalModelFilter : IDocumentFilter
     {
+        private readonly IServerConfigurationManager _serverConfigurationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdditionalModelFilter"/> class.
+        /// </summary>
+        /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+        public AdditionalModelFilter(IServerConfigurationManager serverConfigurationManager)
+        {
+            _serverConfigurationManager = serverConfigurationManager;
+        }
+
         /// <inheritdoc />
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {
@@ -29,6 +41,11 @@ namespace Jellyfin.Server.Filters
 
             context.SchemaGenerator.GenerateSchema(typeof(SessionMessageType), context.SchemaRepository);
             context.SchemaGenerator.GenerateSchema(typeof(ServerDiscoveryInfo), context.SchemaRepository);
+
+            foreach (var configuration in _serverConfigurationManager.GetConfigurationStores())
+            {
+                context.SchemaGenerator.GenerateSchema(configuration.ConfigurationType, context.SchemaRepository);
+            }
         }
     }
 }

--- a/MediaBrowser.Common/Configuration/IConfigurationManager.cs
+++ b/MediaBrowser.Common/Configuration/IConfigurationManager.cs
@@ -61,6 +61,12 @@ namespace MediaBrowser.Common.Configuration
         object GetConfiguration(string key);
 
         /// <summary>
+        /// Gets the array of coniguration stores.
+        /// </summary>
+        /// <returns>Array of ConfigurationStore.</returns>
+        ConfigurationStore[] GetConfigurationStores();
+
+        /// <summary>
         /// Gets the type of the configuration.
         /// </summary>
         /// <param name="key">The key.</param>


### PR DESCRIPTION
**Changes**
- Parameterize request body (so it is visible to Swashbuckle)
- Manually add types accepted by configurations to OpenAPI documentation.

Areas that could use some feedback:
- The controller method is no longer async - is this a problem? Is there a better way to accomplish this? I'm a Java EE developer by day, so the C#/dotnet style of handling this is a bit foreign to me. I'm happy to implement suggestions.
- The manual addition of the types to OpenAPI seems a bit shady, but even with @crobibero's suggestion of using Swashbuckle's polymorphism/inheritance features I can't seem to find a solution that allows me to specify an interface as the parameter type for the request body. This step seems to be a prerequisite to actually utilizing the polymorphism/inheritance features mentioned.

**Issues**
Fixes #7536 
