### PR TITLE
Remove mp2 from video file extensions

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -48,7 +48,6 @@ namespace Emby.Naming.Common
                 ".mkv",
                 ".mk3d",
                 ".mov",
-                ".mp2",
                 ".mp4",
                 ".mpe",
                 ".mpeg",


### PR DESCRIPTION
`.mp2` is commonly used for MPEG-1 audio layer 2 audio files and I have never seen it used as a file extension for video.

## Related issues
* [Reddit](https://www.reddit.com/r/jellyfin/comments/u0dytw/1080beta1_might_be_handled_wrong/)