### PR TITLE
Update Jellyfin.XmlTv to 10.8.0

### DIFF
--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="DiscUtils.Udf" Version="0.16.13" />
-    <PackageReference Include="Jellyfin.XmlTv" Version="10.6.2" />
+    <PackageReference Include="Jellyfin.XmlTv" Version="10.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />


### PR DESCRIPTION
**Changes**
- Update dependency Jellyfin.XmlTv to version 10.8.0

Pulls in jellyfin/Jellyfin.XmlTv#9 so the element following a category element won't be skipped.