### PR TITLE
Refactor GetDownload into LibraryManager.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -114,7 +114,7 @@
  - [Smith00101010](https://github.com/Smith00101010)
  - [sorinyo2004](https://github.com/sorinyo2004)
  - [sparky8251](https://github.com/sparky8251)
- - [spookbits](https://github.com/spookbits)
+ - [spooksbit](https://github.com/spooksbit)
  - [ssenart](https://github.com/ssenart)
  - [stanionascu](https://github.com/stanionascu)
  - [stevehayles](https://github.com/stevehayles)

--- a/Jellyfin.Server.Implementations/Events/Consumers/Library/ItemDownloadLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Library/ItemDownloadLogger.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Threading.Tasks;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Activity;
+using MediaBrowser.Model.Globalization;
+
+namespace Jellyfin.Server.Implementations.Events.Consumers.Library
+{
+    /// <summary>
+    /// Creates an entry in the activity log whenever a library item is downloaded.
+    /// </summary>
+    public class ItemDownloadLogger : IEventConsumer<ItemDownloadEventArgs>
+    {
+        private readonly IActivityManager _activityManager;
+        private readonly ILocalizationManager _localizationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemDownloadLogger"/> class.
+        /// </summary>
+        /// <param name="activityManager">The activity manager.</param>
+        /// <param name="localizationManager">The localization manager.</param>
+        public ItemDownloadLogger(IActivityManager activityManager, ILocalizationManager localizationManager)
+        {
+            _activityManager = activityManager;
+            _localizationManager = localizationManager;
+        }
+
+        /// <inheritdoc/>
+        public async Task OnEvent(ItemDownloadEventArgs eventArgs)
+        {
+            await _activityManager.CreateAsync(new ActivityLog(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        _localizationManager.GetLocalizedString("UserDownloadingItemWithValues"),
+                        eventArgs.AuthInfo.User.Username,
+                        eventArgs.Item.Name),
+                    "UserDownloadingContent",
+                    eventArgs.AuthInfo.UserId)
+            {
+                ShortOverview = string.Format(CultureInfo.InvariantCulture, _localizationManager.GetLocalizedString("AppDeviceValues"), eventArgs.AuthInfo.Client, eventArgs.AuthInfo.Device),
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/Jellyfin.Server.Implementations/Events/EventingServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Events/EventingServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Jellyfin.Data.Events;
+using Jellyfin.Data.Events;
 using Jellyfin.Data.Events.System;
 using Jellyfin.Data.Events.Users;
 using Jellyfin.Server.Implementations.Events.Consumers.Library;
@@ -33,6 +33,7 @@ namespace Jellyfin.Server.Implementations.Events
         {
             // Library consumers
             collection.AddScoped<IEventConsumer<SubtitleDownloadFailureEventArgs>, SubtitleDownloadFailureLogger>();
+            collection.AddScoped<IEventConsumer<ItemDownloadEventArgs>, ItemDownloadLogger>();
 
             // Security consumers
             collection.AddScoped<IEventConsumer<GenericEventArgs<AuthenticationRequest>>, AuthenticationFailedLogger>();

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -11,6 +11,7 @@ using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Resolvers;
 using MediaBrowser.Controller.Sorting;
@@ -570,5 +571,7 @@ namespace MediaBrowser.Controller.Library
         Task RunMetadataSavers(BaseItem item, ItemUpdateType updateReason);
 
         BaseItem GetParentItem(Guid? parentId, Guid? userId);
+
+        Task<string> GetDownloadFile(BaseItem item, AuthorizationInfo auth);
     }
 }

--- a/MediaBrowser.Controller/Library/ItemDownloadEventArgs.cs
+++ b/MediaBrowser.Controller/Library/ItemDownloadEventArgs.cs
@@ -1,0 +1,24 @@
+#nullable disable
+
+using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Net;
+
+namespace MediaBrowser.Controller.Library
+{
+    /// <summary>
+    /// An event that occurs when an item is downloaded.
+    /// </summary>
+    public class ItemDownloadEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the Item that was downloaded.
+        /// </summary>
+        public BaseItem Item { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authorization info used to download the file.
+        /// </summary>
+        public AuthorizationInfo AuthInfo { get; set; }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Refactored `GetDownload` from `LibraryController` to `LibraryManager`.

This addresses #3122 where the `LibraryController` contained a direct reference to `ActivityLog` EF model class. Instead of creating a DTO class and refactoring `ActivityManager` to use a DTO, the logic was pulled into the service layer. The service layer now uses `EventManager` to publish `ItemDownloadEventArgs` to a newly created `IEventConsumer`, which will then create the `ActivityLog` records. The made the most sense since all other references to `ActivityLog` were also `IEventConsumer` logger-types.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Addresses #3122 