### PR TITLE
Rework Fedora build

### DIFF
--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:36
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -9,7 +9,7 @@ ENV IS_DOCKER=YES
 
 # Prepare Fedora environment
 RUN dnf update -yq \
-  && dnf install -yq @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd wget
+  && dnf install -yq @buildsys-build rpmdevtools git dnf-plugins-core libcurl-devel fontconfig-devel freetype-devel openssl-devel glibc-devel libicu-devel systemd wget make
 
 # Install DotNET SDK
 RUN wget -q https://download.visualstudio.microsoft.com/download/pr/dc930bff-ef3d-4f6f-8799-6eb60390f5b4/1efee2a8ea0180c94aff8f15eb3af981/dotnet-sdk-6.0.300-linux-x64.tar.gz -O dotnet-sdk.tar.gz \

--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -7,16 +7,11 @@ SRPM    := jellyfin-$(subst -,~,$(VERSION))-$(RELEASE)$(shell rpm --eval %dist).
 TARBALL :=$(NAME)-$(subst -,~,$(VERSION)).tar.gz
 
 epel-7-x86_64_repos := https://packages.microsoft.com/rhel/7/prod/
-epel-8-x86_64_repos := https://download.copr.fedorainfracloud.org/results/@dotnet-sig/dotnet-preview/$(TARGET)/
 
 fed_ver := $(shell rpm -E %fedora)
 # fallback when not running on Fedora
 fed_ver ?= 36
 TARGET  ?= fedora-$(fed_ver)-x86_64
-
-ifeq ($(findstring fedora,$(TARGET)),fedora)
-$(TARGET)_repos     := https://download.copr.fedorainfracloud.org/results/@dotnet-sig/dotnet-preview/$(TARGET)/
-endif
 
 outdir  ?= $(PWD)/$(DIR)/
 

--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -8,13 +8,17 @@ TARBALL :=$(NAME)-$(subst -,~,$(VERSION)).tar.gz
 
 epel-7-x86_64_repos := https://packages.microsoft.com/rhel/7/prod/
 epel-8-x86_64_repos := https://download.copr.fedorainfracloud.org/results/@dotnet-sig/dotnet-preview/$(TARGET)/
-fedora_repos        := https://download.copr.fedorainfracloud.org/results/@dotnet-sig/dotnet-preview/$(TARGET)/
-fedora-34-x86_64_repos := $(fedora_repos)
-fedora-35-x86_64_repos := $(fedora_repos)
-fedora-34-x86_64_repos := $(fedora_repos)
+
+fed_ver := $(shell rpm -E %fedora)
+# fallback when not running on Fedora
+fed_ver ?= 36
+TARGET  ?= fedora-$(fed_ver)-x86_64
+
+ifeq ($(findstring fedora,$(TARGET)),fedora)
+$(TARGET)_repos     := https://download.copr.fedorainfracloud.org/results/@dotnet-sig/dotnet-preview/$(TARGET)/
+endif
 
 outdir  ?= $(PWD)/$(DIR)/
-TARGET  ?= fedora-35-x86_64
 
 srpm: $(DIR)/$(SRPM)
 tarball: $(DIR)/$(TARBALL)

--- a/fedora/jellyfin.env
+++ b/fedora/jellyfin.env
@@ -21,7 +21,7 @@ JELLYFIN_LOG_DIR="/var/log/jellyfin"
 JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 
 # web client path, installed by the jellyfin-web package
-JELLYFIN_WEB_OPT="--webdir=/usr/share/jellyfin-web"
+# JELLYFIN_WEB_OPT="--webdir=/usr/share/jellyfin-web"
 
 # In-App service control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/libexec/jellyfin/restart.sh"

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -10,7 +10,7 @@ Name:           jellyfin
 Version:        10.8.0
 Release:        1%{?dist}
 Summary:        The Free Software Media System
-License:        GPLv3
+License:        GPLv2
 URL:            https://jellyfin.org
 # Jellyfin Server tarball created by `make -f .copr/Makefile srpm`, real URL ends with `v%%{version}.tar.gz`
 Source0:        jellyfin-server-%{version}.tar.gz

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -62,6 +62,7 @@ the Jellyfin server to bind to ports 80 and/or 443 for example.
 %prep
 %autosetup -n jellyfin-server-%{version} -b 0
 
+
 %build
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export PATH=$PATH:/usr/local/bin
@@ -71,47 +72,62 @@ dotnet publish --configuration Release --self-contained --runtime %{dotnet_runti
 
 
 %install
-%{__mkdir} -p %{buildroot}%{_libdir}/%{name} %{buildroot}%{_bindir}
-%{__cp} -r Jellyfin.Server/bin/Release/net6.0/%{dotnet_runtime}/publish/* %{buildroot}%{_libdir}/%{name}
+# Jellyfin files
+%{__mkdir} -p %{buildroot}%{_libdir}/jellyfin %{buildroot}%{_bindir}
+%{__cp} -r Jellyfin.Server/bin/Release/net6.0/%{dotnet_runtime}/publish/* %{buildroot}%{_libdir}/jellyfin
+ln -srf %{_libdir}/jellyfin/jellyfin %{buildroot}%{_bindir}/jellyfin
+%{__install} -D %{SOURCE14} %{buildroot}%{_libexecdir}/jellyfin/restart.sh
 
-%{__install} -D -m 0644 %{SOURCE15} %{buildroot}%{_sysconfdir}/systemd/system/jellyfin.service.d/override.conf
-%{__install} -D -m 0644 %{SOURCE17} %{buildroot}%{_unitdir}/jellyfin.service.d/jellyfin-server-lowports.conf
-%{__install} -D -m 0644 Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/jellyfin/logging.json
-%{__mkdir} -p %{buildroot}%{_bindir}
-tee %{buildroot}%{_bindir}/jellyfin << EOF
-#!/bin/sh
-exec %{_libdir}/jellyfin/jellyfin \${@}
-EOF
+# Jellyfin config
+%{__install} -D Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/jellyfin/logging.json
+%{__install} -D %{SOURCE12} %{buildroot}%{_sysconfdir}/sysconfig/jellyfin
+
+# system config
+%{__install} -D %{SOURCE16} %{buildroot}%{_prefix}/lib/firewalld/services/jellyfin.xml
+%{__install} -D %{SOURCE13} %{buildroot}%{_sysconfdir}/sudoers.d/jellyfin-sudoers
+%{__install} -D %{SOURCE15} %{buildroot}%{_sysconfdir}/systemd/system/jellyfin.service.d/override.conf
+%{__install} -D %{SOURCE11} %{buildroot}%{_unitdir}/jellyfin.service
+
+# empty directories
 %{__mkdir} -p %{buildroot}%{_sharedstatedir}/jellyfin
 %{__mkdir} -p %{buildroot}%{_sysconfdir}/jellyfin
-%{__mkdir} -p %{buildroot}%{_var}/log/jellyfin
 %{__mkdir} -p %{buildroot}%{_var}/cache/jellyfin
+%{__mkdir} -p %{buildroot}%{_var}/log/jellyfin
 
-%{__install} -D -m 0644 %{SOURCE11} %{buildroot}%{_unitdir}/jellyfin.service
-%{__install} -D -m 0644 %{SOURCE12} %{buildroot}%{_sysconfdir}/sysconfig/jellyfin
-%{__install} -D -m 0600 %{SOURCE13} %{buildroot}%{_sysconfdir}/sudoers.d/jellyfin-sudoers
-%{__install} -D -m 0755 %{SOURCE14} %{buildroot}%{_libexecdir}/jellyfin/restart.sh
-%{__install} -D -m 0644 %{SOURCE16} %{buildroot}%{_prefix}/lib/firewalld/services/jellyfin.xml
+# jellyfin-server-lowports subpackage
+%{__install} -D -m 0644 %{SOURCE17} %{buildroot}%{_unitdir}/jellyfin.service.d/jellyfin-server-lowports.conf
+
 
 %files
 # empty as this is just a meta-package
 
 %files server
-%attr(755,root,root) %{_bindir}/jellyfin
-%{_libdir}/jellyfin/*
+%defattr(644,root,root,755)
+
+# Jellyfin files
+%{_bindir}/jellyfin
 # Needs 755 else only root can run it since binary build by dotnet is 722
+%attr(755,root,root) %{_libdir}/jellyfin/createdump
 %attr(755,root,root) %{_libdir}/jellyfin/jellyfin
-%{_unitdir}/jellyfin.service
-%{_libexecdir}/jellyfin/restart.sh
-%{_prefix}/lib/firewalld/services/jellyfin.xml
-%attr(755,jellyfin,jellyfin) %dir %{_sysconfdir}/jellyfin
+%{_libdir}/jellyfin/*
+%attr(755,root,root) %{_libexecdir}/jellyfin/restart.sh
+
+# Jellyfin config
+%config(noreplace) %attr(644,jellyfin,jellyfin) %{_sysconfdir}/jellyfin/logging.json
 %config %{_sysconfdir}/sysconfig/jellyfin
+
+# system config
+%{_prefix}/lib/firewalld/services/jellyfin.xml
+%{_unitdir}/jellyfin.service
 %config(noreplace) %attr(600,root,root) %{_sysconfdir}/sudoers.d/jellyfin-sudoers
 %config(noreplace) %{_sysconfdir}/systemd/system/jellyfin.service.d/override.conf
-%config(noreplace) %attr(644,jellyfin,jellyfin) %{_sysconfdir}/jellyfin/logging.json
+
+# empty directories
 %attr(750,jellyfin,jellyfin) %dir %{_sharedstatedir}/jellyfin
-%attr(-,jellyfin,jellyfin) %dir %{_var}/log/jellyfin
+%attr(755,jellyfin,jellyfin) %dir %{_sysconfdir}/jellyfin
 %attr(750,jellyfin,jellyfin) %dir %{_var}/cache/jellyfin
+%attr(-,  jellyfin,jellyfin) %dir %{_var}/log/jellyfin
+
 %license LICENSE
 
 

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -30,6 +30,12 @@ BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, 
 BuildRequires:  dotnet-runtime-6.0, dotnet-sdk-6.0
 Requires: %{name}-server = %{version}-%{release}, %{name}-web = %{version}-%{release}
 
+# Temporary (hopefully?) fix for https://github.com/jellyfin/jellyfin/issues/7471
+%if 0%{?fedora} >= 36
+%global __requires_exclude ^liblttng-ust\\.so\\.0.*$
+%endif
+
+
 %description
 Jellyfin is a free software media system that puts you in control of managing and streaming your media.
 
@@ -107,6 +113,7 @@ EOF
 %attr(-,jellyfin,jellyfin) %dir %{_var}/log/jellyfin
 %attr(750,jellyfin,jellyfin) %dir %{_var}/cache/jellyfin
 %license LICENSE
+
 
 %files server-lowports
 %{_unitdir}/jellyfin.service.d/jellyfin-server-lowports.conf


### PR DESCRIPTION
# Changes
* Rewrite Fedora `Makefile` so we don't need to constantly update with every new Fedora release. This is especially useful when Fedora and Jellyfin release cycles don't line up. Version selection is as follows:
  1. TARGET environment variable, which is currently used already
  2. Currently running Fedora version
  3. Hardcoded Fallback version that can be updated occasionally
* Use ~~`latest`~~ `36` Fedora image in Fedora Docker builds
  * ~~Same reasoning as the Makefile, we don't need to constantly update ourselves when a base image tag can do that for us. The Fedora base image is maintained by the Fedora project (and from my understanding mostly automated), so we don't need to worry about this not being updated anytime soon.~~
  * ~~`latest` always points to the current *released* Fedora version. So while F36 is currently in beta, `latest` still points to F35.~~
  * changed to `36` as requested in review
* Remove additional dotnet-preview repo from Makefile
  * Repo doesn't seem maintained, and maintainers actively discourage the usage in production in its description
  * Considering this, we should build with stable .NET releases, which Fedora and RHEL 8+ repos already provide
* Use Fedora-version-specific runtime-identifier for `dotnet publish`
  * This has no actual effect right now judging by the [RID
        catalog](https://github.com/dotnet/docs/blob/3efd59151a7421172658a6fbcf88a0bd5fa7a92d/docs/core/rid-catalog.md), so this is just future proofing.
* Remove AutoReqProv
  * There's rarely a reason to use this feature, this is not one of them
  * In the [proposal of this feature](https://fedoraproject.org/wiki/AutoReqProv_(draft)#Usage) it is stated that this is not to be used on packages with binaries in /usr/bin and others, which is the case in this package.
  * also didn't seem to work since we were still having dependency issues with implicit dependencies anyway
* Removed `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` as it is unused in .NET SDK
  * see dotnet/sdk#9945
  * it's already merged for removal in future versions
* Filter dependency to fix F36 build
  * Filter for F36+ since we don't know when (if ever) this issue will befixed (it's up to .NET SDK). If it's ever fixed we can adjust or remove this condition.
  * built on F34, F35, F36, and EPEL7 targets to confirm it only affects the F36 RPM. Can't test EPEL 8 (see below).
* general housecleaning in the spec file
  * Replaced shell script used to start JF with a symlink, since it didn't do anything else.
  * Sorted installs by category/path to make it easier to maintain the spec.
  * Defined `%defattr` in file section so we don't need to set it on a by-file level. This also helps with the messed up default file permissions `dotnet publish` produces.
  * Removed some duplicate attribute definitions in `%install` and `%files` sections. They are now all in the `%files` section because of `%defattr` being specified and overriding them otherwise.

## Minor adjustments:
* Move building process `dotnet publish` to `%build` section
  * Also removed `--output` from this due to an outstanding bug on SDK's side. This also separates building and installing as intended
* define LICENSE as `%license`, which automatically puts it in a standardised directory







## Tests done
:heavy_check_mark: `make rpms`
:heavy_check_mark: `TARGET=fedora-123 make rpms`
:heavy_check_mark: `TARGET=gibberish make rpms`
:heavy_check_mark: `TARGET=epel-7-x86_64 make rpms`
:x: `TARGET=epel-8-x86_64 make rpms` - `mock-core-configs`  doesn't come with a `.cfg` for this, but this is an issue with the current version already. Not sure what the correct replacement is, `rhel+epel-8`?

# Related Issues
* fixes #7471
* fixes #7504 
* fixes jellyfin/jellyfin-web#2059
* companion PR to jellyfin/jellyfin-web#3571





---

# Just for reference, these are pretty much solved:

**Open questions/potential changes**
@brianjmurrell sorry to ping you like this but it seems you did a lot of work on the Fedora builds already, so possibly you're best addressed with these
1. Should we possibly use rawhide as a fallback instead? Otherwise we will still have to update the fallback periodically. Rawhide might be the better option here.
2. Do we really need a fallback at all? The Azure pipelines are passing the environment variable from what I can tell, if building locally it will likely be on Fedora anyway. And if it's not Fedora it's probably going to be RHEL (or compatibles) where any of the released Fedoras or Rawhide are not going to be useful either.
3. Currently we're not dealing with RHEL-clones (Alma, CentOS, Rocky) at all, should we?
5. When passing unhandled targets (Centos, Alma, Rocky, SuSE(?)), there's no repo passed to `--addrepo` at all. Should we just error out and cancel the build?

Only tangentially related, but are the added repos even needed anymore? At least on F36 the required Dotnet packages are already in the Fedora repos:
```
% rpm -E %fedora
36

% dnf search dotnet-sdk              
Last metadata expiration check: 14:04:24 ago on Sat 16 Apr 2022 23:14:07 CEST.
===================== Name Matched: dotnet-sdk ======================
dotnet-sdk-3.1.x86_64 : .NET Core 3.1 Software Development Kit
dotnet-sdk-3.1-source-built-artifacts.x86_64 : Internal package for
     ...: building .NET Core 3.1 Software Development Kit
dotnet-sdk-6.0.x86_64 : .NET 6.0 Software Development Kit
dotnet-sdk-6.0-source-built-artifacts.x86_64 : Internal package for
     ...: building .NET 6.0 Software Development Kit

% dnf search dotnet-runtime
Last metadata expiration check: 14:04:47 ago on Sat 16 Apr 2022 23:14:07 CEST.
=================== Name Matched: dotnet-runtime ====================
dotnet-runtime-3.1.x86_64 : NET Core 3.1 runtime
dotnet-runtime-6.0.x86_64 : NET 6.0 runtime
```

Also one important note and also a reason for this being a draft: this does *not* solve the issue described in #7471.
While the RPM builds just fine, it cannot be installed on F36 due to said missing dependency:
```
% sudo dnf install ./jellyfin-10.8.0\~beta2-1.fc36.x86_64.rpm ./jellyfin-server-10.8.0\~beta2-1.fc36.x86_64.rpm ./jellyfin-web-10.8.0\~beta2-1.fc36.noarch.rpm
Last metadata expiration check: 2:04:57 ago on Mon 18 Apr 2022 02:28:42 CEST.
Error: 
 Problem 1: conflicting requests
  - nothing provides liblttng-ust.so.0()(64bit) needed by jellyfin-server-10.8.0~beta2-1.fc36.x86_64
 Problem 2: package jellyfin-10.8.0~beta2-1.fc36.x86_64 requires jellyfin-server = 10.8.0~beta2-1.fc36, but none of the providers can be installed
  - conflicting requests
  - nothing provides liblttng-ust.so.0()(64bit) needed by jellyfin-server-10.8.0~beta2-1.fc36.x86_64
(try to add '--skip-broken' to skip uninstallable packages)
```

Still need to find a solution to that.