### PR TITLE
Update API delete item logic

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -336,8 +336,16 @@ namespace Jellyfin.Api.Controllers
             var item = _libraryManager.GetItemById(itemId);
             var auth = await _authContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
             var user = auth.User;
+            var authToken = auth.IsAuthenticated;
 
-            if (!item.CanDelete(user))
+            if (user != null)
+            {
+                if (!item.CanDelete(user))
+                {
+                    return Unauthorized("Unauthorized access");
+                }
+            }
+            else if (!authToken)
             {
                 return Unauthorized("Unauthorized access");
             }
@@ -373,16 +381,25 @@ namespace Jellyfin.Api.Controllers
                 var item = _libraryManager.GetItemById(i);
                 var auth = await _authContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
                 var user = auth.User;
+                var authToken = auth.IsAuthenticated;
 
-                if (!item.CanDelete(user))
+                if (user != null)
                 {
-                    if (ids.Length > 1)
+                    if (!item.CanDelete(user))
                     {
-                        return Unauthorized("Unauthorized access");
+                        if (ids.Length > 1)
+                        {
+                            return Unauthorized("Unauthorized access");
+                        }
                     }
 
                     continue;
                 }
+                else if (!authToken)
+                {
+                    return Unauthorized("Unauthorized access");
+                }
+
 
                 _libraryManager.DeleteItem(
                     item,


### PR DESCRIPTION
Issue 7610 reported an error when using the delete item API.
It seems that there was not enough logic to handle when the user
variable returned null but the API token was authorized.

Added a new boolean that holds the API token authentication status.
If the user variable returns null from GetAuthorizationInfo then we
check to see if the API key is authenticated. If neither of these
conditions return true then Unauthorized() is returned.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
API Delete item logic has been updated to include an additional condition that checks if the API token is valid.
The original logic only checked for a valid user, and if the user returned null then it error-ed.

**Issues**
Fixes #7610
