### PR TITLE
Enable Quick Connect by default

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -79,7 +79,7 @@ namespace MediaBrowser.Model.Configuration
         /// <summary>
         /// Gets or sets a value indicating whether quick connect is available for use on this server.
         /// </summary>
-        public bool QuickConnectAvailable { get; set; } = false;
+        public bool QuickConnectAvailable { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether [enable case sensitive item ids].


### PR DESCRIPTION
Quick Connect is a safe way to authenticate new devices, and will be the default authentication method in the next Android TV app version (using a password will require an additional step). This PR enables the functionality by default. AFAIK this only affects new installations?

**Changes**
- Enable Quick Connect by default

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
