### PR TITLE
Correct LocalTrailerCount in API

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1094,7 +1094,7 @@ namespace Emby.Server.Implementations.Dto
             {
                 if (item is IHasTrailers hasTrailers)
                 {
-                    dto.LocalTrailerCount = (item as IHasTrailers).LocalTrailers.Count;
+                    dto.LocalTrailerCount = hasTrailers.LocalTrailers.Count;
                 }
                 else
                 {

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1094,7 +1094,7 @@ namespace Emby.Server.Implementations.Dto
             {
                 if (item is IHasTrailers hasTrailers)
                 {
-                    dto.LocalTrailerCount = hasTrailers.GetTrailerCount();
+                    dto.LocalTrailerCount = (item as IHasTrailers).LocalTrailers.Count;
                 }
                 else
                 {


### PR DESCRIPTION
In 10.8, the `LocalTrailerCount` property is showing the count of local and remote trailers combined.

**Changes**
Ensure `LocalTrailerCount` contains count of local trailers only.
