### PR TITLE
Add libssl3 as an alternative dependency for Ubuntu 22.04 LTS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: at,
          libsqlite3-0,
          libfontconfig1,
          libfreetype6,
-         libssl1.1
+         libssl1.1 | libssl3
 Recommends: jellyfin-web, sudo
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin server backend and API.


### PR DESCRIPTION
**Changes**
Ubuntu 22.04 has intentionally moved to [`libssl3`](https://packages.ubuntu.com/jammy/libssl3): https://discourse.ubuntu.com/t/openssl-3-0-transition-plans/24453

IIRC dotnet6 should support libssl3.

**Issues**
Should fixes:
https://www.reddit.com/r/jellyfin/comments/u8y3pj/jellyfin_fails_to_start_with_ubuntu_2204_lts/
https://www.reddit.com/r/jellyfin/comments/ua0d30/unable_to_install_jellyfin_from_the_ubuntu_repo/
