### PR TITLE
Add tests for preferred audio language selection

### DIFF
--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
@@ -16,15 +16,31 @@ public class MediaStreamSelectorTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void GetDefaultAudioStreamIndex_WithoutDefault_NotNull(bool preferDefaultTrack)
+    [InlineData(new string[0], false, 1)]
+    [InlineData(new string[0], true, 1)]
+    [InlineData(new[] { "eng" }, false, 2)]
+    [InlineData(new[] { "eng" }, true, 1)]
+    [InlineData(new[] { "eng", "fre" }, false, 2)]
+    [InlineData(new[] { "fre", "eng" }, false, 1)]
+    [InlineData(new[] { "eng", "fre" }, true, 1)]
+    public void GetDefaultAudioStreamIndex_PreferredLanguage_SelectsCorrect(string[] preferredLanguages, bool preferDefaultTrack, int expectedIndex)
     {
-        var streams = new[]
+        var streams = new MediaStream[]
         {
-            new MediaStream()
+            new()
+            {
+                Index = 1,
+                Language = "fre",
+                IsDefault = true
+            },
+            new()
+            {
+                Index = 2,
+                Language = "eng",
+                IsDefault = false
+            }
         };
 
-        Assert.NotNull(MediaStreamSelector.GetDefaultAudioStreamIndex(streams, Array.Empty<string>(), preferDefaultTrack));
+        Assert.Equal(expectedIndex, MediaStreamSelector.GetDefaultAudioStreamIndex(streams, preferredLanguages, preferDefaultTrack));
     }
 }


### PR DESCRIPTION
I wrote tests a while back trying to reproduce #6935

Everything worked as expected and the issue has now been closed for being stale, but the tests might as well be checked in for improved coverage.

**Changes**
- Add tests for preferred audio language stream selection
