### PR TITLE
Add scheduled task to extract subtitles

### DIFF
--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -122,5 +122,7 @@
     "TaskOptimizeDatabase": "Optimize database",
     "TaskOptimizeDatabaseDescription": "Compacts database and truncates free space. Running this task after scanning the library or doing other changes that imply database modifications might improve performance.",
     "TaskKeyframeExtractor": "Keyframe Extractor",
-    "TaskKeyframeExtractorDescription": "Extracts keyframes from video files to create more precise HLS playlists. This task may run for a long time."
+    "TaskKeyframeExtractorDescription": "Extracts keyframes from video files to create more precise HLS playlists. This task may run for a long time.",
+    "TaskExtractSubtitles": "Extract subtitles",
+    "TaskExtractSubtitlesDescription": "Extracts subtitles from video files for immediate access in web player. This task may run for a long time."
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
@@ -101,7 +101,7 @@ public class ExtractSubtitlesTask : IScheduledTask
                     var format = stream.Codec;
 
                     // SubtitleEncoder has readers only for these formats, everything else converted to SRT.
-                    if (!_supportedFormats.Contains(format, StringComparer.OrdinalIgnoreCase))
+                    if (!_supportedFormats.Contains(format, StringComparison.OrdinalIgnoreCase))
                     {
                         format = SubtitleFormat.SRT;
                     }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Tasks;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks;
+
+/// <summary>
+/// Scheduled task to extract embedded subtitles for immediate access in web player.
+/// </summary>
+public class ExtractSubtitlesTask : IScheduledTask
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly ISubtitleEncoder _subtitleEncoder;
+    private readonly ILocalizationManager _localization;
+    private static readonly BaseItemKind[] _itemTypes = { BaseItemKind.Episode, BaseItemKind.Movie };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtractSubtitlesTask" /> class.
+    /// </summary>
+    /// <param name="libraryManager">Instance of <see cref="ILibraryManager"/> interface.</param>
+    /// /// <param name="subtitleEncoder">Instance of <see cref="ISubtitleEncoder"/> interface.</param>
+    /// <param name="localization">Instance of <see cref="ILocalizationManager"/> interface.</param>
+    public ExtractSubtitlesTask(
+        ILibraryManager libraryManager,
+        ISubtitleEncoder subtitleEncoder,
+        ILocalizationManager localization)
+    {
+        _libraryManager = libraryManager;
+        _subtitleEncoder = subtitleEncoder;
+        _localization = localization;
+    }
+
+    /// <inheritdoc />
+    public string Key => "ExtractSubtitles";
+
+    /// <inheritdoc />
+    public string Name => _localization.GetLocalizedString("TaskExtractSubtitles");
+
+    /// <inheritdoc />
+    public string Description => _localization.GetLocalizedString("TaskExtractSubtitlesDescription");
+
+    /// <inheritdoc />
+    public string Category => _localization.GetLocalizedString("TasksLibraryCategory");
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => Enumerable.Empty<TaskTriggerInfo>();
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var query = new InternalItemsQuery
+        {
+            Recursive = true,
+            HasSubtitles = true,
+            IsVirtualItem = false,
+            IncludeItemTypes = _itemTypes,
+            DtoOptions = new DtoOptions(false),
+            MediaTypes = new[] { MediaType.Video },
+            SourceTypes = new[] { SourceType.Library },
+        };
+
+        var completedVideos = 0;
+        var videos = _libraryManager.GetItemList(query);
+
+        foreach (var video in videos)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var streams = video.GetMediaStreams()
+                .Where(stream => stream.IsTextSubtitleStream
+                                 && stream.SupportsExternalStream
+                                 && !stream.IsExternal);
+            foreach (var stream in streams)
+            {
+                var index = stream.Index;
+                var format = stream.Codec;
+                var mediaSourceId = video.Id.ToString("N", CultureInfo.InvariantCulture);
+
+                // SubtitleEncoder has readers only for this formats, everything else converted to SRT.
+                if (!string.Equals(format, "ass", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(format, "ssa", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(format, "srt", StringComparison.OrdinalIgnoreCase))
+                {
+                    format = "srt";
+                }
+
+                await _subtitleEncoder.GetSubtitles(video, mediaSourceId, index, format, 0, 0, false, cancellationToken).ConfigureAwait(false);
+            }
+
+            completedVideos++;
+            double percent = (double)completedVideos / videos.Count;
+            progress.Report(100 * percent);
+        }
+
+        progress.Report(100);
+    }
+}

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ExtractSubtitlesTask.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Tasks;
 
 namespace Emby.Server.Implementations.ScheduledTasks.Tasks;
@@ -24,6 +25,7 @@ public class ExtractSubtitlesTask : IScheduledTask
     private readonly ISubtitleEncoder _subtitleEncoder;
     private readonly ILocalizationManager _localization;
     private static readonly BaseItemKind[] _itemTypes = { BaseItemKind.Episode, BaseItemKind.Movie };
+    private static readonly List<string> _supportedFormats = new() { SubtitleFormat.SRT, SubtitleFormat.ASS, SubtitleFormat.SSA };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExtractSubtitlesTask" /> class.
@@ -88,9 +90,7 @@ public class ExtractSubtitlesTask : IScheduledTask
                 var mediaSourceId = video.Id.ToString("N", CultureInfo.InvariantCulture);
 
                 // SubtitleEncoder has readers only for this formats, everything else converted to SRT.
-                if (!string.Equals(format, "ass", StringComparison.OrdinalIgnoreCase)
-                    && !string.Equals(format, "ssa", StringComparison.OrdinalIgnoreCase)
-                    && !string.Equals(format, "srt", StringComparison.OrdinalIgnoreCase))
+                if (!_supportedFormats.Contains(format, StringComparer.OrdinalIgnoreCase))
                 {
                     format = "srt";
                 }


### PR DESCRIPTION
"Fetching additional data" is really annoying to see when you're ready for movie with popcorn :)

There is already workaround from @iwalton3 [jellyfin_extract_sub.py](https://gist.github.com/iwalton3/f60f4741f561a742e6f8689a621c9824), but it requires python, cron and all that hassle.

So this is basically the same idea: extract all embedded subtitles in background beforehand.
There is no default trigger since task can be resource consuming and probably not for everyone.

**Changes**

* Add scheduled task to extract subtitles

**Issues**

Addresses #6672

And feature requests:
* [Automatic extraction of subtitles](https://features.jellyfin.org/posts/288/automatic-extraction-of-subtitles)
* [Subtitle improvements](https://features.jellyfin.org/posts/722/subtitle-improvements)