### PR TITLE
Fix the disordered color in Dolby Vision remuxing on Safari

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1773,13 +1773,23 @@ namespace Jellyfin.Api.Controllers
 
             var args = "-codec:v:0 " + codec;
 
-            // Prefer hvc1 to hev1.
             if (string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codec, "h265", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codec, "hevc", StringComparison.OrdinalIgnoreCase))
             {
-                args += " -tag:v:0 hvc1";
+                if (EncodingHelper.IsCopyCodec(codec)
+                    && (string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))
+                {
+                    // Prefer dvh1 to dvhe
+                    args += " -tag:v:0 dvh1";
+                }
+                else
+                {
+                    // Prefer hvc1 to hev1
+                    args += " -tag:v:0 hvc1";
+                }
             }
 
             // if  (state.EnableMpegtsM2TsMode)


### PR DESCRIPTION
**Changes**
- Fix the disordered color in Dolby Vision remuxing on Safari

https://github.com/jellyfin/jellyfin-ffmpeg/pull/144
If the patched `jellyfin-ffmpeg` is not used, it will automatically fall back to `hev1`.

<img src="https://user-images.githubusercontent.com/14953024/167303794-95b04881-e087-4eed-8500-19c714b4fffa.jpeg" width = "400" align=center /> <img src="https://user-images.githubusercontent.com/14953024/167303798-d93db44b-b87f-4d60-be22-9a2746e38ce3.jpeg" width = "400" align=center />