### PR TITLE
Add option to allow extras to use embedded titles

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1999,38 +1999,35 @@ namespace Emby.Server.Implementations.Library
 
         public List<Folder> GetCollectionFolders(BaseItem item)
         {
-            while (item is not null)
-            {
-                var parent = item.GetParent();
-
-                if (parent is null || parent is AggregateFolder)
-                {
-                    break;
-                }
-
-                item = parent;
-            }
-
-            if (item is null)
-            {
-                return new List<Folder>();
-            }
-
-            return GetCollectionFoldersInternal(item, GetUserRootFolder().Children.OfType<Folder>());
+            return GetCollectionFolders(item, GetUserRootFolder().Children.OfType<Folder>());
         }
 
-        public List<Folder> GetCollectionFolders(BaseItem item, List<Folder> allUserRootChildren)
+        public List<Folder> GetCollectionFolders(BaseItem item, IEnumerable<Folder> allUserRootChildren)
         {
             while (item is not null)
             {
                 var parent = item.GetParent();
 
-                if (parent is null || parent is AggregateFolder)
+                if (parent is AggregateFolder)
                 {
                     break;
                 }
 
-                item = parent;
+                if (parent is null)
+                {
+                    var owner = item.GetOwner();
+
+                    if (owner is null)
+                    {
+                        break;
+                    }
+
+                    item = owner;
+                }
+                else
+                {
+                    item = parent;
+                }
             }
 
             if (item is null)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2451,6 +2451,11 @@ namespace MediaBrowser.Controller.Entities
                 return Task.FromResult(true);
             }
 
+            if (video.OwnerId.Equals(default))
+            {
+                video.OwnerId = this.Id;
+            }
+
             return RefreshMetadataForOwnedItem(video, copyTitleMetadata, newOptions, cancellationToken);
         }
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -429,10 +429,16 @@ namespace MediaBrowser.Controller.Library
         /// Gets the collection folders.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <returns>IEnumerable&lt;Folder&gt;.</returns>
+        /// <returns>The folders that contain the item.</returns>
         List<Folder> GetCollectionFolders(BaseItem item);
 
-        List<Folder> GetCollectionFolders(BaseItem item, List<Folder> allUserRootChildren);
+        /// <summary>
+        /// Gets the collection folders.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="allUserRootChildren">The root folders to consider.</param>
+        /// <returns>The folders that contain the item.</returns>
+        List<Folder> GetCollectionFolders(BaseItem item, IEnumerable<Folder> allUserRootChildren);
 
         LibraryOptions GetLibraryOptions(BaseItem item);
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -45,6 +45,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableEmbeddedTitles { get; set; }
 
+        public bool EnableEmbeddedExtrasTitles { get; set; }
+
         public bool EnableEmbeddedEpisodeInfos { get; set; }
 
         public int AutomaticRefreshIntervalDays { get; set; }

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -484,8 +484,8 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 if (!string.IsNullOrWhiteSpace(data.Name) && libraryOptions.EnableEmbeddedTitles)
                 {
-                    // Don't use the embedded name for extras because it will often be the same name as the movie
-                    if (!video.ExtraType.HasValue)
+                    // Separate option to use the embedded name for extras because it will often be the same name as the movie
+                    if (!video.ExtraType.HasValue || libraryOptions.EnableEmbeddedExtrasTitles)
                     {
                         video.Name = data.Name;
                     }


### PR DESCRIPTION
I took the time to embed titles in my extras (including characters not valid for use in filenames) and was annoyed when Jellyfin ignored the embedded value. Finally got around to adding an option to enable it.

**Changes**
- Fix library search for owned items to look to their parent (so extras can use the options of the library their parent belongs to)
- Add an option to allow video extras to prefer their embedded title over the file name

**Issues**
Option exposed by jellyfin/jellyfin-web#3652
