### PR TITLE
Don't ignore DTS in M3UTuner to avoid missing audio

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3UTunerHost.cs
@@ -196,7 +196,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 IsInfiniteStream = true,
                 IsRemote = isRemote,
 
-                IgnoreDts = true,
+                IgnoreDts = false,
                 SupportsDirectPlay = supportsDirectPlay,
                 SupportsDirectStream = supportsDirectStream,
 


### PR DESCRIPTION
Tested locally on win10 using the m3u8 file attached to the bug.
The offending channels now have audio in live TV and recordings.

**Changes**
Set IgnoreDTS to false

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/7267
