### PR TITLE
Clear TranscodingInfo if play method changed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -770,6 +770,11 @@ namespace Emby.Server.Implementations.Session
 
             await UpdateNowPlayingItem(session, info, libraryItem, !isAutomated).ConfigureAwait(false);
 
+            if (!string.IsNullOrEmpty(session.DeviceId) && info.PlayMethod != PlayMethod.Transcode)
+            {
+                ClearTranscodingInfo(session.DeviceId);
+            }
+
             var users = GetUsers(session);
 
             // only update saved user data on actual check-ins, not automated ones


### PR DESCRIPTION
Copy-paste from https://github.com/jellyfin/jellyfin/blob/ff4f624850bc7d5024feaee93ffe52c07c27d172/Emby.Server.Implementations/Session/SessionManager.cs#L676-L679

**Changes**
Clear `TranscodingInfo` if method changed

**Issues**
`TranscodingInfo` in the session isn't cleared when switching from `Transcoding` to `DirectPlay`.
