### PR TITLE
Remove conditional skia inclusion

### DIFF
--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="BlurHashSharp" Version="1.2.0" />
     <PackageReference Include="BlurHashSharp.SkiaSharp" Version="1.2.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin/pull/7792 breaks building linux builds on any OS that is not linux.