### PR TITLE
Exclude streams with mismatched types in external files

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -106,19 +106,28 @@ namespace MediaBrowser.Providers.MediaInfo
                     if (mediaInfo.MediaStreams.Count == 1)
                     {
                         MediaStream mediaStream = mediaInfo.MediaStreams[0];
-                        mediaStream.Index = startIndex++;
-                        mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
-                        mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
 
-                        mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                        if ((mediaStream.Type == MediaStreamType.Audio && _type == DlnaProfileType.Audio)
+                            || (mediaStream.Type == MediaStreamType.Subtitle && _type == DlnaProfileType.Subtitle))
+                        {
+                            mediaStream.Index = startIndex++;
+                            mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
+                            mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
+
+                            mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                        }
                     }
                     else
                     {
                         foreach (MediaStream mediaStream in mediaInfo.MediaStreams)
                         {
-                            mediaStream.Index = startIndex++;
+                            if ((mediaStream.Type == MediaStreamType.Audio && _type == DlnaProfileType.Audio)
+                                || (mediaStream.Type == MediaStreamType.Subtitle && _type == DlnaProfileType.Subtitle))
+                            {
+                                mediaStream.Index = startIndex++;
 
-                            mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                                mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                            }
                         }
                     }
                 }
@@ -221,13 +230,6 @@ namespace MediaBrowser.Providers.MediaInfo
             mediaStream.IsExternal = true;
             mediaStream.Title = string.IsNullOrEmpty(mediaStream.Title) ? (string.IsNullOrEmpty(pathInfo.Title) ? null : pathInfo.Title) : mediaStream.Title;
             mediaStream.Language = string.IsNullOrEmpty(mediaStream.Language) ? (string.IsNullOrEmpty(pathInfo.Language) ? null : pathInfo.Language) : mediaStream.Language;
-
-            mediaStream.Type = _type switch
-            {
-                DlnaProfileType.Audio => MediaStreamType.Audio,
-                DlnaProfileType.Subtitle => MediaStreamType.Subtitle,
-                _ => mediaStream.Type
-            };
 
             return mediaStream;
         }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
@@ -43,6 +43,9 @@ public class AudioResolverTests
                 MediaStreams = new List<MediaStream>
                 {
                     new()
+                    {
+                        Type = MediaStreamType.Audio
+                    }
                 }
             }));
 

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -359,7 +359,10 @@ public class MediaInfoResolverTests
             var mediaStreams = new List<MediaStream>();
             for (int i = 0; i < streamCount; i++)
             {
-                mediaStreams.Add(new());
+                mediaStreams.Add(new()
+                {
+                    Type = MediaStreamType.Subtitle
+                });
             }
 
             return mediaStreams;

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -43,6 +43,9 @@ public class SubtitleResolverTests
                 MediaStreams = new List<MediaStream>
                 {
                     new()
+                    {
+                        Type = MediaStreamType.Subtitle
+                    }
                 }
             }));
 


### PR DESCRIPTION
**Changes**
- Exclude streams with mismatched types in external files

**Issues**
![image](https://user-images.githubusercontent.com/14953024/170559202-87ac670d-00d6-442f-8ce5-39b53278757b.png)

PGS subtitles in Mka container were incorrectly marked as audio.
They should exist in Mks, so exclude them during scanning.