### PR TITLE
Implement hardware filters for videotoolbox, use Apple AAC encoder when available

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -546,6 +546,11 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(codec, "aac", StringComparison.OrdinalIgnoreCase))
             {
+                // Use Apple's aac encoder if available as it provides best audio quality
+                if (_mediaEncoder.SupportsEncoder("aac_at"))
+                {
+                    return "aac_at";
+                }
                 // Use libfdk_aac for better audio quality if using custom build of FFmpeg which has fdk_aac support
                 if (_mediaEncoder.SupportsEncoder("libfdk_aac"))
                 {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4457,6 +4457,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             var swFilterChain = GetSwVidFilterChain(state, options, vidEncoder);
+
+            if (!options.EnableHardwareEncoding)
+            {
+                return swFilterChain;
+            }
+
             if (_mediaEncoder.EncoderVersion.CompareTo(new Version("5.0.0")) < 0)
             {
                 // All features used here requires ffmpeg 5.0 or later, fallback to software filters if using an old ffmpeg

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4476,16 +4476,15 @@ namespace MediaBrowser.Controller.MediaEncoding
             var newfilters = new List<string>();
             var noOverlay = swFilterChain.OverlayFilters.Count == 0;
 
+            // ffmpeg cannot use videotoolbox to scale
+            var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, inW, inH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
+            newfilters.Add(swScaleFilter);
+
             // hwupload on videotoolbox encoders can automatically convert AVFrame into its CVPixelBuffer equivalent
             // videotoolbox will automatically convert the CVPixelBuffer to a pixel format the encoder supports, so we don't have to set a pixel format explicitly here
             // This will reduce CPU usage significantly on UHD videos with 10 bit colors because we bypassed the ffmpeg pixel format conversion
             newfilters.Add("hwupload");
             var mainFilters = noOverlay ? newfilters : swFilterChain.MainFilters;
-            var overlayFilters = noOverlay ? swFilterChain.OverlayFilters : newfilters;
-
-            // ffmpeg cannot use videotoolbox to scale
-            var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, inW, inH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
-            mainFilters.Add(swScaleFilter);
 
             if (doDeintH2645)
             {
@@ -4493,7 +4492,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 mainFilters.Add(deintFilter);
             }
 
-            return (mainFilters, swFilterChain.SubFilters, overlayFilters);
+            return (mainFilters, swFilterChain.SubFilters, swFilterChain.OverlayFilters);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4484,14 +4484,14 @@ namespace MediaBrowser.Controller.MediaEncoding
             // videotoolbox will automatically convert the CVPixelBuffer to a pixel format the encoder supports, so we don't have to set a pixel format explicitly here
             // This will reduce CPU usage significantly on UHD videos with 10 bit colors because we bypassed the ffmpeg pixel format conversion
             newfilters.Add("hwupload");
-            var mainFilters = noOverlay ? newfilters : swFilterChain.MainFilters;
 
             if (doDeintH2645)
             {
                 var deintFilter = GetHwDeinterlaceFilter(state, options, "videotoolbox");
-                mainFilters.Add(deintFilter);
+                newfilters.Add(deintFilter);
             }
 
+            var mainFilters = noOverlay ? newfilters : swFilterChain.MainFilters;
             return (mainFilters, swFilterChain.SubFilters, swFilterChain.OverlayFilters);
         }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4475,6 +4475,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var threeDFormat = state.MediaSource.Video3DFormat;
             var newfilters = new List<string>();
             var noOverlay = swFilterChain.OverlayFilters.Count == 0;
+            var supportsHwDeint = _mediaEncoder.SupportsFilter("yadif_videotoolbox");
 
             // ffmpeg cannot use videotoolbox to scale
             var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, inW, inH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
@@ -4487,7 +4488,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (doDeintH2645)
             {
-                var deintFilter = GetHwDeinterlaceFilter(state, options, "videotoolbox");
+                var deintFilter = supportsHwDeint ? GetHwDeinterlaceFilter(state, options, "videotoolbox") : GetSwDeinterlaceFilter(state, options);
                 newfilters.Add(deintFilter);
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -551,6 +551,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     return "aac_at";
                 }
+
                 // Use libfdk_aac for better audio quality if using custom build of FFmpeg which has fdk_aac support
                 if (_mediaEncoder.SupportsEncoder("libfdk_aac"))
                 {

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -56,6 +56,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "libvpx",
             "libvpx-vp9",
             "aac",
+            "aac_at",
             "libfdk_aac",
             "ac3",
             "libmp3lame",

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -108,6 +108,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "libplacebo",
             "scale_vulkan",
             "overlay_vulkan"
+            "hwupload_vaapi",
+            // videotoolbox
+            "yadif_videotoolbox"
         };
 
         private static readonly IReadOnlyDictionary<int, string[]> _filterOptionsDict = new Dictionary<int, string[]>

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -107,7 +107,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // vulkan
             "libplacebo",
             "scale_vulkan",
-            "overlay_vulkan"
+            "overlay_vulkan",
             "hwupload_vaapi",
             // videotoolbox
             "yadif_videotoolbox"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
This PR implements the hardware filters for videotoolbox introduced in ffmpeg 5.0, this will reduce CPU usage on macOS host

This PR also prefers Apple's AAC encoder in the coreaudio framework when available, because it provides even better quality than fdk_aac.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
