### PR TITLE
IAsyncDisposable is one big pitfall

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -545,12 +545,14 @@ namespace Jellyfin.Server
             const string ResourcePath = "Jellyfin.Server.Resources.Configuration.logging.json";
             Stream resource = typeof(Program).Assembly.GetManifestResourceStream(ResourcePath)
                 ?? throw new InvalidOperationException($"Invalid resource path: '{ResourcePath}'");
-            Stream dst = new FileStream(configPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
             await using (resource.ConfigureAwait(false))
-            await using (dst.ConfigureAwait(false))
             {
-                // Copy the resource contents to the expected file path for the config file
-                await resource.CopyToAsync(dst).ConfigureAwait(false);
+                Stream dst = new FileStream(configPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+                await using (dst.ConfigureAwait(false))
+                {
+                    // Copy the resource contents to the expected file path for the config file
+                    await resource.CopyToAsync(dst).ConfigureAwait(false);
+                }
             }
         }
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -681,11 +681,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             if (!string.Equals(text, newText, StringComparison.Ordinal))
             {
                 var fileStream = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
-                var writer = new StreamWriter(fileStream, encoding);
                 await using (fileStream.ConfigureAwait(false))
-                await using (writer.ConfigureAwait(false))
                 {
-                    await writer.WriteAsync(newText.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    var writer = new StreamWriter(fileStream, encoding);
+                    await using (writer.ConfigureAwait(false))
+                    {
+                        await writer.WriteAsync(newText.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#unacceptable-pattern

Regex used:
```
await using \(.+\)
\W+await using
```

