### PR TITLE
Fix the PNG image decoding issue in Skia

### DIFF
--- a/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="BlurHashSharp" Version="1.2.0" />
     <PackageReference Include="BlurHashSharp.SkiaSharp" Version="1.2.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1-preview.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.1-preview.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Changes**
Fix the PNG image decoding issue in Skia by upgrading to 2.88.1-preview.1

**Issues**
Regression was introduced in 2.88.0: https://github.com/mono/SkiaSharp/issues/2095
