### PR TITLE
chore: enable on demand keyframe extraction for mkv

### DIFF
--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -39,7 +39,7 @@ namespace MediaBrowser.Model.Configuration
             EnableHardwareEncoding = true;
             AllowHevcEncoding = false;
             EnableSubtitleExtraction = true;
-            AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = Array.Empty<string>();
+            AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = new[] { "mkv" };
             HardwareDecodingCodecs = new string[] { "h264", "vc1" };
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Enables on demand keyframe extraction for the mkv container. It's reasonably fast (completely metadata-based) and we'll get more feedback by enabling it by default
