### PR TITLE
fix: respect the image refresh options when parsing remote images from NFO

### DIFF
--- a/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
+++ b/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
@@ -34,8 +34,8 @@ namespace MediaBrowser.Controller.Providers
 
         public bool IsReplacingImage(ImageType type)
         {
-            return ImageRefreshMode == MetadataRefreshMode.FullRefresh &&
-                   (ReplaceAllImages || ReplaceImages.Contains(type));
+            return ImageRefreshMode == MetadataRefreshMode.FullRefresh
+                   && (ReplaceAllImages || ReplaceImages.Contains(type));
         }
     }
 }

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -655,8 +655,6 @@ namespace MediaBrowser.Providers.Manager
             };
             temp.Item.Path = item.Path;
 
-            var userDataList = new List<UserItemData>();
-
             // If replacing all metadata, run internet providers first
             if (options.ReplaceAllMetadata)
             {
@@ -670,7 +668,7 @@ namespace MediaBrowser.Providers.Manager
 
             var hasLocalMetadata = false;
 
-            foreach (var provider in providers.OfType<ILocalMetadataProvider<TItemType>>().ToList())
+            foreach (var provider in providers.OfType<ILocalMetadataProvider<TItemType>>())
             {
                 var providerName = provider.GetType().Name;
                 Logger.LogDebug("Running {Provider} for {Item}", providerName, logName);
@@ -687,6 +685,11 @@ namespace MediaBrowser.Providers.Manager
                         {
                             try
                             {
+                                if (!options.IsReplacingImage(remoteImage.Type))
+                                {
+                                    continue;
+                                }
+
                                 await ProviderManager.SaveImage(item, remoteImage.Url, remoteImage.Type, null, cancellationToken).ConfigureAwait(false);
                                 refreshResult.UpdateType |= ItemUpdateType.ImageUpdate;
                             }
@@ -699,11 +702,6 @@ namespace MediaBrowser.Providers.Manager
                         if (imageService.MergeImages(item, localItem.Images))
                         {
                             refreshResult.UpdateType |= ItemUpdateType.ImageUpdate;
-                        }
-
-                        if (localItem.UserDataList != null)
-                        {
-                            userDataList.AddRange(localItem.UserDataList);
                         }
 
                         MergeData(localItem, temp, Array.Empty<MetadataField>(), !options.ReplaceAllMetadata, true);
@@ -764,14 +762,10 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            // var isUnidentified = failedProviderCount > 0 && successfulProviderCount == 0;
-
             foreach (var provider in customProviders.Where(i => i is not IPreRefreshProvider))
             {
                 await RunCustomProvider(provider, item, logName, options, refreshResult, cancellationToken).ConfigureAwait(false);
             }
-
-            // ImportUserData(item, userDataList, cancellationToken);
 
             return refreshResult;
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Skip the image saving if `IsReplacingImage` is false. Also removed some unused code, which may or may not be re-introduced by #5884

**Issues**
Fixes #7836
