### PR TITLE
Prevent 400 error when using navigation buttons.

### DIFF
--- a/MediaBrowser.Model/Session/GeneralCommand.cs
+++ b/MediaBrowser.Model/Session/GeneralCommand.cs
@@ -14,9 +14,9 @@ public class GeneralCommand
     }
 
     [JsonConstructor]
-    public GeneralCommand(Dictionary<string, string> arguments)
+    public GeneralCommand(Dictionary<string, string>? arguments)
     {
-        Arguments = arguments;
+        Arguments = arguments ?? new Dictionary<string, string>();
     }
 
     public GeneralCommandType Name { get; set; }


### PR DESCRIPTION
**Changes**
 - Fix navigation buttons in web app. (API call in `jellyfin-web` currently returns a 400 error.)

This fix can be back-ported to the 10.8.x stable version and I have verified it works as such.