### PR TITLE
Switch to FirstOrDefault extension

### DIFF
--- a/Jellyfin.Api/Controllers/SearchController.cs
+++ b/Jellyfin.Api/Controllers/SearchController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -187,7 +188,7 @@ namespace Jellyfin.Api.Controllers
                     result.AlbumArtist = album.AlbumArtist;
                     break;
                 case Audio song:
-                    result.AlbumArtist = song.AlbumArtists?[0];
+                    result.AlbumArtist = song.AlbumArtists?.FirstOrDefault();
                     result.Artists = song.Artists;
 
                     MusicAlbum musicAlbum = song.AlbumEntity;

--- a/src/Jellyfin.Extensions/ReadOnlyListExtension.cs
+++ b/src/Jellyfin.Extensions/ReadOnlyListExtension.cs
@@ -57,5 +57,21 @@ namespace Jellyfin.Extensions
 
             return -1;
         }
+
+        /// <summary>
+        /// Get the first or default item from a list.
+        /// </summary>
+        /// <param name="source">The source list.</param>
+        /// <typeparam name="T">The type of item.</typeparam>
+        /// <returns>The first item or default if list is empty.</returns>
+        public static T? FirstOrDefault<T>(this IReadOnlyList<T>? source)
+        {
+            if (source is null || source.Count == 0)
+            {
+                return default;
+            }
+
+            return source[0];
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/7883

Extension method was added because there is an analyzer to not use the Linq method