### PR TITLE
Make IgnoreDts configurable for M3U tuner

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3UTunerHost.cs
@@ -196,7 +196,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 IsInfiniteStream = true,
                 IsRemote = isRemote,
 
-                IgnoreDts = true,
+                IgnoreDts = info.IgnoreDts,
                 SupportsDirectPlay = supportsDirectPlay,
                 SupportsDirectStream = supportsDirectStream,
 

--- a/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
+++ b/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
@@ -8,6 +8,7 @@ namespace MediaBrowser.Model.LiveTv
         public TunerHostInfo()
         {
             AllowHWTranscoding = true;
+            IgnoreDts = true;
         }
 
         public string Id { get; set; }
@@ -31,5 +32,7 @@ namespace MediaBrowser.Model.LiveTv
         public int TunerCount { get; set; }
 
         public string UserAgent { get; set; }
+
+        public bool IgnoreDts { get; set; }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Added IgnoreDts to TunerHostInfo
- Added IgnoreDts checkbox to M3U tuner configuration page: https://github.com/jellyfin/jellyfin-web/pull/3696

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin/issues/7267
Closes https://github.com/jellyfin/jellyfin/pull/7779 and https://github.com/jellyfin/jellyfin/pull/7776
