### PR TITLE
fix: only use keyframes when remuxing video

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1414,7 +1414,8 @@ namespace Jellyfin.Api.Controllers
                 state.RunTimeTicks ?? 0,
                 state.Request.SegmentContainer ?? string.Empty,
                 "hls1/main/",
-                Request.QueryString.ToString());
+                Request.QueryString.ToString(),
+                EncodingHelper.IsCopyCodec(state.OutputVideoCodec));
             var playlist = _dynamicHlsPlaylistGenerator.CreateMainPlaylist(request);
 
             return new FileContentResult(Encoding.UTF8.GetBytes(playlist), MimeTypes.GetMimeType("playlist.m3u8"));

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
@@ -14,7 +14,8 @@ public class CreateMainPlaylistRequest
     /// <param name="segmentContainer">The desired segment container eg. "ts".</param>
     /// <param name="endpointPrefix">The URI prefix for the relative URL in the playlist.</param>
     /// <param name="queryString">The desired query string to append (must start with ?).</param>
-    public CreateMainPlaylistRequest(string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString)
+    /// <param name="isRemuxingVideo">Whether the video is being remuxed.</param>
+    public CreateMainPlaylistRequest(string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString, bool isRemuxingVideo)
     {
         FilePath = filePath;
         DesiredSegmentLengthMs = desiredSegmentLengthMs;
@@ -22,6 +23,7 @@ public class CreateMainPlaylistRequest
         SegmentContainer = segmentContainer;
         EndpointPrefix = endpointPrefix;
         QueryString = queryString;
+        IsRemuxingVideo = isRemuxingVideo;
     }
 
     /// <summary>
@@ -53,4 +55,9 @@ public class CreateMainPlaylistRequest
     /// Gets the query string.
     /// </summary>
     public string QueryString { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the video is being remuxed.
+    /// </summary>
+    public bool IsRemuxingVideo { get; }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
@@ -34,7 +34,8 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
     public string CreateMainPlaylist(CreateMainPlaylistRequest request)
     {
         IReadOnlyList<double> segments;
-        if (TryExtractKeyframes(request.FilePath, out var keyframeData))
+        // For video transcodes it is sufficient with equal length segments as ffmpeg will create new keyframes
+        if (request.IsRemuxingVideo && TryExtractKeyframes(request.FilePath, out var keyframeData))
         {
             segments = ComputeSegments(keyframeData, request.DesiredSegmentLengthMs);
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
The original keyframes were used for transcodes, but that is not valid.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/6957
