### PR TITLE
Remove MPEG4 hwaccel from AMF

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4684,11 +4684,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     return GetHwaccelType(state, options, "vc1", bitDepth, hwSurface);
                 }
-
-                if (string.Equals("mpeg4", videoStream.Codec, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetHwaccelType(state, options, "mpeg4", bitDepth, hwSurface);
-                }
             }
 
             if (is8_10bitSwFormatsAmf)


### PR DESCRIPTION
**Web**
- https://github.com/jellyfin/jellyfin-web/pull/3701

**Changes**
- Remove MPEG4 hwaccel from AMF, which is not supported by ffmpeg

**Issues**
Fixes: #7922
