### PR TITLE
Track selector fix

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -13,11 +13,11 @@ namespace Emby.Server.Implementations.Library
     {
         public static int? GetDefaultAudioStreamIndex(IReadOnlyList<MediaStream> streams, IReadOnlyList<string> preferredLanguages, bool preferDefaultTrack)
         {
-            var sortedStreams = GetSortedStreams(streams, MediaStreamType.Audio, preferredLanguages);
+            var sortedStreams = GetSortedStreams(streams, MediaStreamType.Audio, preferredLanguages).ToList();
 
             if (preferDefaultTrack)
             {
-                var defaultStream = streams.FirstOrDefault(i => i.IsDefault);
+                var defaultStream = sortedStreams.FirstOrDefault(i => i.IsDefault);
 
                 if (defaultStream != null)
                 {

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
@@ -29,13 +29,21 @@ public class MediaStreamSelectorTests
         {
             new()
             {
+                Index = 0,
+                Type = MediaStreamType.Video,
+                IsDefault = true
+            },
+            new()
+            {
                 Index = 1,
+                Type = MediaStreamType.Audio,
                 Language = "fre",
                 IsDefault = true
             },
             new()
             {
                 Index = 2,
+                Type = MediaStreamType.Audio,
                 Language = "eng",
                 IsDefault = false
             }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaStreamSelectorTests.cs
@@ -16,15 +16,31 @@ public class MediaStreamSelectorTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void GetDefaultAudioStreamIndex_WithoutDefault_NotNull(bool preferDefaultTrack)
+    [InlineData(new string[0], false, 1)]
+    [InlineData(new string[0], true, 1)]
+    [InlineData(new[] { "eng" }, false, 2)]
+    [InlineData(new[] { "eng" }, true, 1)]
+    [InlineData(new[] { "eng", "fre" }, false, 2)]
+    [InlineData(new[] { "fre", "eng" }, false, 1)]
+    [InlineData(new[] { "eng", "fre" }, true, 1)]
+    public void GetDefaultAudioStreamIndex_PreferredLanguage_SelectsCorrect(string[] preferredLanguages, bool preferDefaultTrack, int expectedIndex)
     {
-        var streams = new[]
+        var streams = new MediaStream[]
         {
-            new MediaStream()
+            new()
+            {
+                Index = 1,
+                Language = "fre",
+                IsDefault = true
+            },
+            new()
+            {
+                Index = 2,
+                Language = "eng",
+                IsDefault = false
+            }
         };
 
-        Assert.NotNull(MediaStreamSelector.GetDefaultAudioStreamIndex(streams, Array.Empty<string>(), preferDefaultTrack));
+        Assert.Equal(expectedIndex, MediaStreamSelector.GetDefaultAudioStreamIndex(streams, preferredLanguages, preferDefaultTrack));
     }
 }


### PR DESCRIPTION
Cherry-pick of #7682 into 10.8.z, already merged to master so intentionally not tagged for backport.

**Changes**
- Fix default audio stream selection ignoring type

**Issues**
- Fixes #7752
