### PR TITLE
Brighter VPP tone-mapping on Intel

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -125,6 +125,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                    && _mediaEncoder.SupportsFilter("scale_vaapi")
                    && _mediaEncoder.SupportsFilter("deinterlace_vaapi")
                    && _mediaEncoder.SupportsFilter("tonemap_vaapi")
+                   && _mediaEncoder.SupportsFilter("procamp_vaapi")
                    && _mediaEncoder.SupportsFilterWithOption(FilterOptionType.OverlayVaapiFrameSync)
                    && _mediaEncoder.SupportsFilter("hwupload_vaapi");
         }
@@ -2704,7 +2705,18 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var args = "tonemap_{0}=format={1}:p=bt709:t=bt709:m=bt709";
 
-            if (!hwTonemapSuffix.Contains("vaapi", StringComparison.OrdinalIgnoreCase))
+            if (hwTonemapSuffix.Contains("vaapi", StringComparison.OrdinalIgnoreCase))
+            {
+                args += ",procamp_vaapi=b={2}:c={3}:extra_hw_frames=16";
+                return string.Format(
+                        CultureInfo.InvariantCulture,
+                        args,
+                        hwTonemapSuffix,
+                        videoFormat ?? "nv12",
+                        options.VppTonemappingBrightness,
+                        options.VppTonemappingContrast);
+            }
+            else
             {
                 args += ":tonemap={2}:peak={3}:desat={4}";
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -100,6 +100,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "scale_vaapi",
             "deinterlace_vaapi",
             "tonemap_vaapi",
+            "procamp_vaapi",
             "overlay_vaapi",
             "hwupload_vaapi"
         };

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -26,6 +26,8 @@ namespace MediaBrowser.Model.Configuration
             TonemappingThreshold = 0.8;
             TonemappingPeak = 100;
             TonemappingParam = 0;
+            VppTonemappingBrightness = 0;
+            VppTonemappingContrast = 1.2;
             H264Crf = 23;
             H265Crf = 28;
             DeinterlaceDoubleRate = false;
@@ -88,6 +90,10 @@ namespace MediaBrowser.Model.Configuration
         public double TonemappingPeak { get; set; }
 
         public double TonemappingParam { get; set; }
+
+        public double VppTonemappingBrightness { get; set; }
+
+        public double VppTonemappingContrast { get; set; }
 
         public int H264Crf { get; set; }
 


### PR DESCRIPTION
**Web**
https://github.com/jellyfin/jellyfin-web/pull/3714

**Changes**
- Brighter VPP tone-mapping on Intel
- Add two extra options for VPP TM: brightness and contrast

**Issues**
Fixes: https://github.com/jellyfin/jellyfin/issues/6624
