### PR TITLE
Catch external streams exceptions

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioResolver.cs
@@ -4,6 +4,7 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -15,16 +16,19 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioResolver"/> class for external audio file processing.
         /// </summary>
+        /// <param name="logger">The logger.</param>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         public AudioResolver(
+            ILogger<AudioResolver> logger,
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
             IFileSystem fileSystem,
             NamingOptions namingOptions)
             : base(
+                logger,
                 localizationManager,
                 mediaEncoder,
                 fileSystem,

--- a/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeProvider.cs
@@ -47,7 +47,6 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly Task<ItemUpdateType> _cachedTask = Task.FromResult(ItemUpdateType.None);
 
         public FFProbeProvider(
-            ILogger<FFProbeProvider> logger,
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
             IItemRepository itemRepo,
@@ -59,11 +58,12 @@ namespace MediaBrowser.Providers.MediaInfo
             IChapterManager chapterManager,
             ILibraryManager libraryManager,
             IFileSystem fileSystem,
+            ILoggerFactory loggerFactory,
             NamingOptions namingOptions)
         {
-            _logger = logger;
-            _audioResolver = new AudioResolver(localization, mediaEncoder, fileSystem, namingOptions);
-            _subtitleResolver = new SubtitleResolver(localization, mediaEncoder, fileSystem, namingOptions);
+            _logger = loggerFactory.CreateLogger<FFProbeProvider>();
+            _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
+            _subtitleResolver = new SubtitleResolver(loggerFactory.CreateLogger<SubtitleResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _videoProber = new FFProbeVideoInfo(
                 _logger,
                 mediaSourceManager,

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -15,6 +15,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -33,6 +34,7 @@ namespace MediaBrowser.Providers.MediaInfo
         /// </summary>
         private readonly IMediaEncoder _mediaEncoder;
 
+        private readonly ILogger _logger;
         private readonly IFileSystem _fileSystem;
 
         /// <summary>
@@ -48,18 +50,21 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaInfoResolver"/> class.
         /// </summary>
+        /// <param name="logger">The logger.</param>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         /// <param name="type">The <see cref="DlnaProfileType"/> of the parsed file.</param>
         protected MediaInfoResolver(
+            ILogger logger,
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
             IFileSystem fileSystem,
             NamingOptions namingOptions,
             DlnaProfileType type)
         {
+            _logger = logger;
             _mediaEncoder = mediaEncoder;
             _fileSystem = fileSystem;
             _namingOptions = namingOptions;
@@ -133,8 +138,10 @@ namespace MediaBrowser.Providers.MediaInfo
                             }
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        _logger.LogError(ex, "Error getting external streams from {Path}", pathInfo.Path);
+
                         continue;
                     }
                 }

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -101,34 +101,41 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 if (!pathInfo.Path.AsSpan().EndsWith(".strm", StringComparison.OrdinalIgnoreCase))
                 {
-                    var mediaInfo = await GetMediaInfo(pathInfo.Path, _type, cancellationToken).ConfigureAwait(false);
-
-                    if (mediaInfo.MediaStreams.Count == 1)
+                    try
                     {
-                        MediaStream mediaStream = mediaInfo.MediaStreams[0];
+                        var mediaInfo = await GetMediaInfo(pathInfo.Path, _type, cancellationToken).ConfigureAwait(false);
 
-                        if ((mediaStream.Type == MediaStreamType.Audio && _type == DlnaProfileType.Audio)
-                            || (mediaStream.Type == MediaStreamType.Subtitle && _type == DlnaProfileType.Subtitle))
+                        if (mediaInfo.MediaStreams.Count == 1)
                         {
-                            mediaStream.Index = startIndex++;
-                            mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
-                            mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
+                            MediaStream mediaStream = mediaInfo.MediaStreams[0];
 
-                            mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
-                        }
-                    }
-                    else
-                    {
-                        foreach (MediaStream mediaStream in mediaInfo.MediaStreams)
-                        {
                             if ((mediaStream.Type == MediaStreamType.Audio && _type == DlnaProfileType.Audio)
                                 || (mediaStream.Type == MediaStreamType.Subtitle && _type == DlnaProfileType.Subtitle))
                             {
                                 mediaStream.Index = startIndex++;
+                                mediaStream.IsDefault = pathInfo.IsDefault || mediaStream.IsDefault;
+                                mediaStream.IsForced = pathInfo.IsForced || mediaStream.IsForced;
 
                                 mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
                             }
                         }
+                        else
+                        {
+                            foreach (MediaStream mediaStream in mediaInfo.MediaStreams)
+                            {
+                                if ((mediaStream.Type == MediaStreamType.Audio && _type == DlnaProfileType.Audio)
+                                    || (mediaStream.Type == MediaStreamType.Subtitle && _type == DlnaProfileType.Subtitle))
+                                {
+                                    mediaStream.Index = startIndex++;
+
+                                    mediaStreams.Add(MergeMetadata(mediaStream, pathInfo));
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        continue;
                     }
                 }
             }

--- a/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleResolver.cs
@@ -4,6 +4,7 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -15,16 +16,19 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <summary>
         /// Initializes a new instance of the <see cref="SubtitleResolver"/> class for external subtitle file processing.
         /// </summary>
+        /// <param name="logger">The logger.</param>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="mediaEncoder">The media encoder.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="namingOptions">The <see cref="NamingOptions"/> object containing FileExtensions, MediaDefaultFlags, MediaForcedFlags and MediaFlagDelimiters.</param>
         public SubtitleResolver(
+            ILogger<SubtitleResolver> logger,
             ILocalizationManager localizationManager,
             IMediaEncoder mediaEncoder,
             IFileSystem fileSystem,
             NamingOptions namingOptions)
             : base(
+                logger,
                 localizationManager,
                 mediaEncoder,
                 fileSystem,

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioResolverTests.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -55,7 +56,7 @@ public class AudioResolverTests
         fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
             .Returns(true);
 
-        _audioResolver = new AudioResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
+        _audioResolver = new AudioResolver(Mock.Of<ILogger<AudioResolver>>(), localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
     [Theory]

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -70,7 +71,7 @@ public class MediaInfoResolverTests
         fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
-        _subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
+        _subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), _localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
     [Fact]
@@ -201,7 +202,7 @@ public class MediaInfoResolverTests
         var mediaEncoder = Mock.Of<IMediaEncoder>(MockBehavior.Strict);
         var fileSystem = Mock.Of<IFileSystem>();
 
-        var subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder, fileSystem, new NamingOptions());
+        var subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), _localizationManager, mediaEncoder, fileSystem, new NamingOptions());
 
         var streams = await subtitleResolver.GetExternalStreamsAsync(video, 0, directoryService.Object, false, CancellationToken.None);
 
@@ -306,7 +307,7 @@ public class MediaInfoResolverTests
         fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
-        var subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
+        var subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), _localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
 
         var directoryService = GetDirectoryServiceForExternalFile(file);
         var streams = await subtitleResolver.GetExternalStreamsAsync(video, 0, directoryService, false, CancellationToken.None);
@@ -381,7 +382,7 @@ public class MediaInfoResolverTests
         fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MetadataDirectoryRegex)))
             .Returns(true);
 
-        var subtitleResolver = new SubtitleResolver(_localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
+        var subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), _localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
 
         int startIndex = 1;
         var streams = await subtitleResolver.GetExternalStreamsAsync(video, startIndex, directoryService.Object, false, CancellationToken.None);

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleResolverTests.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -55,7 +56,7 @@ public class SubtitleResolverTests
         fileSystem.Setup(fs => fs.DirectoryExists(It.IsRegex(MediaInfoResolverTests.MetadataDirectoryRegex)))
             .Returns(true);
 
-        _subtitleResolver = new SubtitleResolver(localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
+        _subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
     [Theory]


### PR DESCRIPTION
**Changes**
- Catch external streams exceptions (invalid or empty external streams will break the main video stream)

**Issues**
Closes #7710
