### PR TITLE
Parse episode extras

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
@@ -1362,7 +1363,7 @@ namespace MediaBrowser.Controller.Entities
         /// <returns><c>true</c> if any items have changed, else <c>false</c>.</returns>
         protected virtual async Task<bool> RefreshedOwnedItems(MetadataRefreshOptions options, IReadOnlyList<FileSystemMetadata> fileSystemChildren, CancellationToken cancellationToken)
         {
-            if (!IsFileProtocol || !SupportsOwnedItems || IsInMixedFolder || this is ICollectionFolder or UserRootFolder or AggregateFolder || this.GetType() == typeof(Folder))
+            if (!IsFileProtocol || !SupportsOwnedItems || (IsInMixedFolder && this is not Episode) || this is ICollectionFolder or UserRootFolder or AggregateFolder || this.GetType() == typeof(Folder))
             {
                 return false;
             }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -44,7 +44,7 @@ namespace MediaBrowser.Controller.Entities.TV
         public int? IndexNumberEnd { get; set; }
 
         [JsonIgnore]
-        protected override bool SupportsOwnedItems => IsStacked || MediaSourceCount > 1;
+        protected override bool SupportsOwnedItems => true;
 
         [JsonIgnore]
         public override bool SupportsInheritedParentImages => true;

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -302,4 +302,146 @@ public class FindExtrasTests
         Assert.Equal("/series/Dexter/trailer.mkv", extras[0].Path);
         Assert.Equal("/series/Dexter/trailers/trailer2.mkv", extras[1].Path);
     }
+
+    [Fact]
+    public void FindExtras_SeriesWithExtras_FindsCorrectExtras()
+    {
+        var owner = new Series { Name = "Dexter", Path = "/series/Dexter" };
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.BehindTheScenes, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("Funny-behindthescenes", extras[0].FileNameWithoutExtension);
+        Assert.Equal("/series/Dexter/Funny-behindthescenes.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/interviews/The Director.mkv", extras[1].Path);
+    }
+
+    [Fact]
+    public void FindExtras_SeasonWithExtras_FindsCorrectExtras()
+    {
+        var owner = new Season { Name = "Season 1", SeriesName = "Dexter", Path = "/series/Dexter/Season 1" };
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.BehindTheScenes, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("It's a begining-behindthescenes", extras[0].FileNameWithoutExtension);
+        Assert.Equal("/series/Dexter/Season 1/It's a begining-behindthescenes.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/Season 1/interviews/The Cast.mkv", extras[1].Path);
+    }
+
+    [Fact]
+    public void FindExtras_EpisodeWithExtras_FindsCorrectExtras()
+    {
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var owner = new Episode { Name = "Dexter - S01E01", Path = "/series/Dexter/Season 1/Dexter - S01E01.mkv", IsInMixedFolder = true };
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.DeletedScene, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv", extras[0].Path);
+
+        owner = new Episode { Name = "Dexter - S01E02 - Second Epi", Path = "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.Interview, extras[0].ExtraType);
+        Assert.Equal(ExtraType.Scene, extras[1].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv", extras[1].Path);
+
+        owner = new Episode { Name = "Dexter - S02E05", Path = "/series/Dexter/Dexter - S02E05.mkv", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Dexter - S02E05-clip.mkv", extras[0].Path);
+
+        // episode folder with special feature subfolders are not supported yet, but it should be considered as not mixed, but current is marked as mixed
+        Folder folderOwner = new Folder { Name = "Dexter - S03E05", Path = "/series/Dexter/Dexter - S03E05", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(folderOwner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[0].Path);
+    }
 }


### PR DESCRIPTION
Only suffix style is supported for episodes. Includes unit tests for series, season and episode level extras.

Mostly feature parity with [plex ](https://support.plex.tv/articles/local-files-for-tv-show-trailers-and-extras/) except for multiple episode extras of the same type.