### PR TITLE
Fix the broken transcoding throttler

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -285,7 +285,7 @@ namespace Jellyfin.Api.Controllers
             // Due to CTS.Token calling ThrowIfDisposed (https://github.com/dotnet/runtime/issues/29970) we have to "cache" the token
             // since it gets disposed when ffmpeg exits
             var cancellationToken = cancellationTokenSource.Token;
-            using var state = await StreamingHelpers.GetStreamingState(
+            var state = await StreamingHelpers.GetStreamingState(
                     streamingRequest,
                     Request,
                     _authContext,
@@ -1432,7 +1432,7 @@ namespace Jellyfin.Api.Controllers
             var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            using var state = await StreamingHelpers.GetStreamingState(
+            var state = await StreamingHelpers.GetStreamingState(
                     streamingRequest,
                     Request,
                     _authContext,

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -427,7 +427,7 @@ namespace Jellyfin.Api.Controllers
                 StreamOptions = streamOptions
             };
 
-            using var state = await StreamingHelpers.GetStreamingState(
+            var state = await StreamingHelpers.GetStreamingState(
                     streamingRequest,
                     Request,
                     _authContext,

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -654,8 +654,8 @@ namespace Jellyfin.Api.Helpers
         {
             if (EnableThrottling(state))
             {
-                transcodingJob.TranscodingThrottler = state.TranscodingThrottler = new TranscodingThrottler(transcodingJob, new Logger<TranscodingThrottler>(new LoggerFactory()), _serverConfigurationManager, _fileSystem);
-                state.TranscodingThrottler.Start();
+                transcodingJob.TranscodingThrottler = new TranscodingThrottler(transcodingJob, new Logger<TranscodingThrottler>(new LoggerFactory()), _serverConfigurationManager, _fileSystem);
+                transcodingJob.TranscodingThrottler.Start();
             }
         }
 

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -663,18 +663,11 @@ namespace Jellyfin.Api.Helpers
         {
             var encodingOptions = _serverConfigurationManager.GetEncodingOptions();
 
-            // enable throttling when NOT using hardware acceleration
-            if (string.IsNullOrEmpty(encodingOptions.HardwareAccelerationType))
-            {
-                return state.InputProtocol == MediaProtocol.File &&
-                       state.RunTimeTicks.HasValue &&
-                       state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks &&
-                       state.IsInputVideo &&
-                       state.VideoType == VideoType.VideoFile &&
-                       !EncodingHelper.IsCopyCodec(state.OutputVideoCodec);
-            }
-
-            return false;
+            return state.InputProtocol == MediaProtocol.File &&
+                   state.RunTimeTicks.HasValue &&
+                   state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks &&
+                   state.IsInputVideo &&
+                   state.VideoType == VideoType.VideoFile;
         }
 
         /// <summary>

--- a/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
@@ -48,11 +48,6 @@ namespace Jellyfin.Api.Models.StreamingDtos
         }
 
         /// <summary>
-        /// Gets or sets the transcoding throttler.
-        /// </summary>
-        public TranscodingThrottler? TranscodingThrottler { get; set; }
-
-        /// <summary>
         /// Gets the video request.
         /// </summary>
         public VideoRequestDto? VideoRequest => Request as VideoRequestDto;
@@ -191,11 +186,8 @@ namespace Jellyfin.Api.Models.StreamingDtos
                 {
                     _mediaSourceManager.CloseLiveStream(MediaSource.LiveStreamId).GetAwaiter().GetResult();
                 }
-
-                TranscodingThrottler?.Dispose();
             }
 
-            TranscodingThrottler = null;
             TranscodingJob = null;
 
             _disposed = true;

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -111,7 +111,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                         percent = 100.0 * currentMs / totalMs;
 
-                        transcodingPosition = val;
+                        transcodingPosition = TimeSpan.FromMilliseconds(currentMs);
                     }
                 }
                 else if (part.StartsWith("size=", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
We still need to modify ffmpeg itself for better implementation in the future.
Or utilize the `realtime` filter to limit the transcoding speed.

**Changes**
- Fix the broken transcoding throttler
- Re-enable it for HWA (tested on Intel/AMD/Nvidia)

**Issues**
HLS and progressive StreamStates are always disposed prematurely.