### PR TITLE
Parse episode extras

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2670,8 +2670,8 @@ namespace Emby.Server.Implementations.Library
                         }
                     }
 
-                    // if owner is Episode, only suffix type matches will be allowed, episode name must match exactly
-                    if (owner is not Episode || (prefix is not null && prefix.Equals(ownerVideoInfo.Name, StringComparison.OrdinalIgnoreCase)))
+                    // if owner is Episode, only suffix type matches will be allowed, episode file name must match exactly
+                    if (owner is not Episode || (prefix is not null && prefix.Equals(Path.GetFileNameWithoutExtension(ownerVideoInfo.Path), StringComparison.OrdinalIgnoreCase)))
                     {
                         var extra = GetExtra(current, extraType.Value);
                         if (extra is not null)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2664,10 +2664,24 @@ namespace Emby.Server.Implementations.Library
                                 seriesName = season.SeriesName;
                             }
 
-                            if (seriesName is not null && seriesName.Equals(episodeInfo?.SeriesName, StringComparison.OrdinalIgnoreCase))
+                            if (seriesName is not null && episodeInfo?.SeriesName is not null)
                             {
-                                // don't attach episode extras to series or season
-                                continue;
+                                // trim series names like episodepathparser does
+                                seriesName = seriesName
+                                    .Trim()
+                                    .Trim('_', '.', '-')
+                                    .Trim();
+
+                                var episodeInfoSeriesName = episodeInfo.SeriesName
+                                    .Trim()
+                                    .Trim('_', '.', '-')
+                                    .Trim();
+
+                                if (seriesName.Equals(episodeInfoSeriesName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    // don't attach episode extras to series or season
+                                    continue;
+                                }
                             }
                         }
                     }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -47,12 +47,12 @@ using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Season = MediaBrowser.Controller.Entities.TV.Season;
-using Series = MediaBrowser.Controller.Entities.TV.Series;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using EpisodeInfo = Emby.Naming.TV.EpisodeInfo;
 using Genre = MediaBrowser.Controller.Entities.Genre;
 using Person = MediaBrowser.Controller.Entities.Person;
+using Season = MediaBrowser.Controller.Entities.TV.Season;
+using Series = MediaBrowser.Controller.Entities.TV.Series;
 using VideoResolver = Emby.Naming.Video.VideoResolver;
 
 namespace Emby.Server.Implementations.Library
@@ -2643,26 +2643,28 @@ namespace Emby.Server.Implementations.Library
                     // if owner is dir, don't own episode extras
                     // test if extra filename is formatted like an episode
                     int? dashIndex = current.Name?.LastIndexOf('-');
-                    String prefix = null;
+                    string prefix = null;
                     if (dashIndex is int dashIndexValue)
                     {
                         if (dashIndexValue >= 0)
                         {
                             prefix = current.Name.Substring(0, dashIndexValue); // possible episode name
-                            String path = current.FullName;
+                            string path = current.FullName;
                             path = string.Concat(path.AsSpan(0, path.LastIndexOf('-')), current.Extension);
                             var episodeInfo = resolver.Resolve(path, false);
 
-                            String SeriesName = null;
+                            string seriesName = null;
                             if (owner is Series series)
                             {
-                                SeriesName = series.Name;
+                                seriesName = series.Name;
                             }
+
                             if (owner is Season season)
                             {
-                                SeriesName = season.SeriesName;
+                                seriesName = season.SeriesName;
                             }
-                            if (SeriesName is not null && SeriesName.Equals(episodeInfo?.SeriesName, StringComparison.OrdinalIgnoreCase))
+
+                            if (seriesName is not null && seriesName.Equals(episodeInfo?.SeriesName, StringComparison.OrdinalIgnoreCase))
                             {
                                 // don't attach episode extras to series or season
                                 continue;
@@ -2679,7 +2681,6 @@ namespace Emby.Server.Implementations.Library
                             yield return extra;
                         }
                     }
-
                 }
             }
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -47,6 +47,8 @@ using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Season = MediaBrowser.Controller.Entities.TV.Season;
+using Series = MediaBrowser.Controller.Entities.TV.Series;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using EpisodeInfo = Emby.Naming.TV.EpisodeInfo;
 using Genre = MediaBrowser.Controller.Entities.Genre;
@@ -2614,11 +2616,12 @@ namespace Emby.Server.Implementations.Library
                 yield break;
             }
 
+            var resolver = new EpisodeResolver(_namingOptions);
             var count = fileSystemChildren.Count;
             for (var i = 0; i < count; i++)
             {
                 var current = fileSystemChildren[i];
-                if (current.IsDirectory && _namingOptions.AllExtrasTypesFolderNames.ContainsKey(current.Name))
+                if (!owner.IsInMixedFolder && current.IsDirectory && _namingOptions.AllExtrasTypesFolderNames.ContainsKey(current.Name))
                 {
                     var filesInSubFolder = _fileSystem.GetFiles(current.FullName, null, false, false);
                     foreach (var file in filesInSubFolder)
@@ -2637,11 +2640,46 @@ namespace Emby.Server.Implementations.Library
                 }
                 else if (!current.IsDirectory && _extraResolver.TryGetExtraTypeForOwner(current.FullName, ownerVideoInfo, out var extraType))
                 {
-                    var extra = GetExtra(current, extraType.Value);
-                    if (extra is not null)
+                    // if owner is dir, don't own episode extras
+                    // test if extra filename is formatted like an episode
+                    int? dashIndex = current.Name?.LastIndexOf('-');
+                    String prefix = null;
+                    if (dashIndex is int dashIndexValue)
                     {
-                        yield return extra;
+                        if (dashIndexValue >= 0)
+                        {
+                            prefix = current.Name.Substring(0, dashIndexValue); // possible episode name
+                            String path = current.FullName;
+                            path = string.Concat(path.AsSpan(0, path.LastIndexOf('-')), current.Extension);
+                            var episodeInfo = resolver.Resolve(path, false);
+
+                            String SeriesName = null;
+                            if (owner is Series series)
+                            {
+                                SeriesName = series.Name;
+                            }
+                            if (owner is Season season)
+                            {
+                                SeriesName = season.SeriesName;
+                            }
+                            if (SeriesName is not null && SeriesName.Equals(episodeInfo?.SeriesName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                // don't attach episode extras to series or season
+                                continue;
+                            }
+                        }
                     }
+
+                    // if owner is Episode, only suffix type matches will be allowed, episode name must match exactly
+                    if (owner is not Episode || (prefix is not null && prefix.Equals(ownerVideoInfo.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        var extra = GetExtra(current, extraType.Value);
+                        if (extra is not null)
+                        {
+                            yield return extra;
+                        }
+                    }
+
                 }
             }
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2649,6 +2649,7 @@ namespace Emby.Server.Implementations.Library
                         if (dashIndexValue >= 0)
                         {
                             prefix = current.Name.Substring(0, dashIndexValue); // possible episode name
+                            prefix = ParseName(prefix).Name; // clean name - remove all things in brackets etc
                             string path = current.FullName;
                             path = string.Concat(path.AsSpan(0, path.LastIndexOf('-')), current.Extension);
                             var episodeInfo = resolver.Resolve(path, false);
@@ -2686,8 +2687,8 @@ namespace Emby.Server.Implementations.Library
                         }
                     }
 
-                    // if owner is Episode, only suffix type matches will be allowed, episode file name must match exactly
-                    if (owner is not Episode || (prefix is not null && prefix.Equals(Path.GetFileNameWithoutExtension(ownerVideoInfo.Path), StringComparison.OrdinalIgnoreCase)))
+                    // if owner is Episode, only suffix type matches will be allowed, episode file cleaned name must match
+                    if (owner is not Episode || (prefix is not null && prefix.Equals(ownerVideoInfo.Name, StringComparison.OrdinalIgnoreCase)))
                     {
                         var extra = GetExtra(current, extraType.Value);
                         if (extra is not null)

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -279,8 +279,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 ExtraFiles = leftOver
             };
 
-            var isInMixedFolder = resolverResult.Count > 1 || parent?.IsTopParent == true;
-
             foreach (var video in resolverResult)
             {
                 var firstVideo = video.Files[0];
@@ -296,7 +294,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 var videoItem = new T
                 {
                     Path = path,
-                    IsInMixedFolder = isInMixedFolder,
                     ProductionYear = video.Year,
                     Name = parseName ? video.Name : firstVideo.Name,
                     AdditionalParts = additionalParts,
@@ -310,6 +307,13 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
             }
 
             result.ExtraFiles.AddRange(files.Where(i => !ContainsFile(resolverResult, i)));
+
+            //calculate if in mixed folder after extra files have been removed from count
+            var isInMixedFolder = result.Items.Count > 1 || parent?.IsTopParent == true;
+            foreach (var item in result.Items)
+            {
+                item.IsInMixedFolder = isInMixedFolder;
+            }
 
             return result;
         }

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -308,7 +308,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
 
             result.ExtraFiles.AddRange(files.Where(i => !ContainsFile(resolverResult, i)));
 
-            //calculate if in mixed folder after extra files have been removed from count
+            // calculate if in mixed folder after extra files have been removed from count
             var isInMixedFolder = result.Items.Count > 1 || parent?.IsTopParent == true;
             foreach (var item in result.Items)
             {

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
@@ -1344,7 +1345,7 @@ namespace MediaBrowser.Controller.Entities
         /// <returns><c>true</c> if any items have changed, else <c>false</c>.</returns>
         protected virtual async Task<bool> RefreshedOwnedItems(MetadataRefreshOptions options, IReadOnlyList<FileSystemMetadata> fileSystemChildren, CancellationToken cancellationToken)
         {
-            if (!IsFileProtocol || !SupportsOwnedItems || IsInMixedFolder || this is ICollectionFolder or UserRootFolder or AggregateFolder || this.GetType() == typeof(Folder))
+            if (!IsFileProtocol || !SupportsOwnedItems || (IsInMixedFolder && this is not Episode) || this is ICollectionFolder or UserRootFolder or AggregateFolder || this.GetType() == typeof(Folder))
             {
                 return false;
             }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -44,7 +44,7 @@ namespace MediaBrowser.Controller.Entities.TV
         public int? IndexNumberEnd { get; set; }
 
         [JsonIgnore]
-        protected override bool SupportsOwnedItems => IsStacked || MediaSourceCount > 1;
+        protected override bool SupportsOwnedItems => true;
 
         [JsonIgnore]
         public override bool SupportsInheritedParentImages => true;

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -311,6 +311,7 @@ public class FindExtrasTests
         {
             "/series/Dexter/Season 1/Dexter - S01E01.mkv",
             "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01 [WEBDL-1080p AVC][AAC 2.0][YouTube]-deleted.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
@@ -348,8 +349,10 @@ public class FindExtrasTests
         var owner = new Season { Name = "Season 1", SeriesName = "Dexter", Path = "/series/Dexter/Season 1" };
         var paths = new List<string>
         {
-            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
-            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter 1x01 [Bluray-1080p x264][AC3 5.1][-reward] - Northwest Passage.mkv",
+            "/series/Dexter/Season 1/Dexter 1x01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter 1x01 [WEBDL-1080p AVC][AAC 2.0][YouTube]-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter 1x01 [WEBDL-1080p AVC][AAC 2.0][YouTube][-MrC] - Log Lady Introduction 1-extra.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
             "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
@@ -483,5 +486,32 @@ public class FindExtrasTests
         Assert.Equal(typeof(Video), extras[1].GetType());
         Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[1].Path);
         Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv", extras[2].Path);
+    }
+
+    [Fact]
+    public void FindExtras_EpisodeWithExtras_CleanNameTest()
+    {
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01[Bluray-1080p x264][AC3 5.1].mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01 [WEBDL-1080p AVC][AAC 2.0][YouTube]-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01[Bluray-1080p x264][AC3 5.1] - Some crazy deleted scene -deleted.mkv"
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var owner = new Episode { Name = "Dexter - S01E01", Path = "/series/Dexter/Season 1/Dexter - S01E01[Bluray-1080p x264][AC3 5.1].mkv", IsInMixedFolder = true };
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.DeletedScene, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E01 [WEBDL-1080p AVC][AAC 2.0][YouTube]-deleted.mkv", extras[0].Path);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -442,11 +442,12 @@ public class FindExtrasTests
         extras = _libraryManager.FindExtras(folderOwner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
 
         Assert.Equal(3, extras.Count);
-        Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
-        Assert.Equal(typeof(Video), extras[0].GetType());
-        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[0].Path);
-        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv", extras[1].Path);
-        Assert.Equal(ExtraType.DeletedScene, extras[2].ExtraType);
-        Assert.Equal("/series/Dexter/Dexter - S03E05/Deleted Scenes/Meet Friends.mkv", extras[2].Path);
+        // directory type extras are found before suffix type
+        Assert.Equal(ExtraType.DeletedScene, extras[0].ExtraType);
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Deleted Scenes/Meet Friends.mkv", extras[0].Path);
+        Assert.Equal(ExtraType.Featurette, extras[1].ExtraType);
+        Assert.Equal(typeof(Video), extras[1].GetType());
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[1].Path);
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv", extras[2].Path);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -399,6 +399,7 @@ public class FindExtrasTests
             "/series/Dexter/Dexter - S02E05-clip.mkv",
             "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
             "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv",
         };
 
         var files = paths.Select(p => new FileSystemMetadata
@@ -439,9 +440,10 @@ public class FindExtrasTests
         Folder folderOwner = new Folder { Name = "Dexter - S03E05", Path = "/series/Dexter/Dexter - S03E05", IsInMixedFolder = true };
         extras = _libraryManager.FindExtras(folderOwner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
 
-        Assert.Single(extras);
+        Assert.Equal(2, extras.Count);
         Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
         Assert.Equal(typeof(Video), extras[0].GetType());
         Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv", extras[1].Path);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -400,6 +400,7 @@ public class FindExtrasTests
             "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
             "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
             "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv",
+            "/series/Dexter/Dexter - S03E05/Deleted Scenes/Meet Friends.mkv",
         };
 
         var files = paths.Select(p => new FileSystemMetadata
@@ -437,13 +438,15 @@ public class FindExtrasTests
         Assert.Equal("/series/Dexter/Dexter - S02E05-clip.mkv", extras[0].Path);
 
         // episode folder with special feature subfolders are not supported yet, but it should be considered as not mixed, but current is marked as mixed
-        Folder folderOwner = new Folder { Name = "Dexter - S03E05", Path = "/series/Dexter/Dexter - S03E05", IsInMixedFolder = true };
+        Folder folderOwner = new Folder { Name = "Dexter - S03E05", Path = "/series/Dexter/Dexter - S03E05", IsInMixedFolder = false };
         extras = _libraryManager.FindExtras(folderOwner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
 
-        Assert.Equal(2, extras.Count);
+        Assert.Equal(3, extras.Count);
         Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
         Assert.Equal(typeof(Video), extras[0].GetType());
         Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[0].Path);
         Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette2.mkv", extras[1].Path);
+        Assert.Equal(ExtraType.DeletedScene, extras[2].ExtraType);
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Deleted Scenes/Meet Friends.mkv", extras[2].Path);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -302,4 +302,146 @@ public class FindExtrasTests
         Assert.Equal("/series/Dexter/trailer.mkv", extras[0].Path);
         Assert.Equal("/series/Dexter/trailers/trailer2.mkv", extras[1].Path);
     }
+
+    [Fact]
+    public void FindExtras_SeriesWithExtras_FindsCorrectExtras()
+    {
+        var owner = new Series { Name = "Dexter", Path = "/series/Dexter" };
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.BehindTheScenes, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("Funny-behindthescenes", extras[0].FileNameWithoutExtension);
+        Assert.Equal("/series/Dexter/Funny-behindthescenes.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/interviews/The Director.mkv", extras[1].Path);
+    }
+
+    [Fact]
+    public void FindExtras_SeasonWithExtras_FindsCorrectExtras()
+    {
+        var owner = new Season { Name = "Season 1", SeriesName = "Dexter", Path = "/series/Dexter/Season 1" };
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.BehindTheScenes, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("It's a begining-behindthescenes", extras[0].FileNameWithoutExtension);
+        Assert.Equal("/series/Dexter/Season 1/It's a begining-behindthescenes.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/Season 1/interviews/The Cast.mkv", extras[1].Path);
+    }
+
+    [Fact]
+    public void FindExtras_EpisodeWithExtras_FindsCorrectExtras()
+    {
+        var paths = new List<string>
+        {
+            "/series/Dexter/Season 1/Dexter - S01E01.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv",
+            "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv",
+            "/series/Dexter/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/Dexter/Season 1/interviews/The Cast.mkv",
+            "/series/Dexter/Funny-behindthescenes.mkv",
+            "/series/Dexter/interviews/The Director.mkv",
+            "/series/Dexter/Dexter - S02E05.mkv",
+            "/series/Dexter/Dexter - S02E05-clip.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth.mkv",
+            "/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var owner = new Episode { Name = "Dexter - S01E01", Path = "/series/Dexter/Season 1/Dexter - S01E01.mkv", IsInMixedFolder = true };
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.DeletedScene, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E01-deleted.mkv", extras[0].Path);
+
+        owner = new Episode { Name = "Dexter - S01E02 - Second Epi", Path = "/series/Dexter/Season 1/Dexter - S01E02 - Second Epi.mkv", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.Interview, extras[0].ExtraType);
+        Assert.Equal(ExtraType.Scene, extras[1].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-interview.mkv", extras[0].Path);
+        Assert.Equal("/series/Dexter/Season 1/Dexter - S01E02 - Second Epi-scene.mkv", extras[1].Path);
+
+        owner = new Episode { Name = "Dexter - S02E05", Path = "/series/Dexter/Dexter - S02E05.mkv", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Dexter - S02E05-clip.mkv", extras[0].Path);
+
+        // episode folder with special feature subfolders are not supported yet, but it should be considered as not mixed, but current is marked as mixed
+        Folder folderOwner = new Folder { Name = "Dexter - S03E05", Path = "/series/Dexter/Dexter - S03E05", IsInMixedFolder = true };
+        extras = _libraryManager.FindExtras(folderOwner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Single(extras);
+        Assert.Equal(ExtraType.Clip, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("/series/Dexter/Dexter - S03E05/Dexter - S03E05 - Fifth-featurette.mkv", extras[0].Path);
+    }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/FindExtrasTests.cs
@@ -382,6 +382,40 @@ public class FindExtrasTests
     }
 
     [Fact]
+    public void FindExtras_SeasonWithExtras_FindsCorrectExtras2()
+    {
+        // Series name directory has special characters stripped that episodes do not
+        var owner = new Season { Name = "Season 1", SeriesName = "The Venture Bros.", Path = "/series/The Venture Bros/Season 1" };
+        var paths = new List<string>
+        {
+            "/series/The Venture Bros/Season 1/The Venture Bros. S01E01.mkv",
+            "/series/The Venture Bros/Season 1/The Venture Bros. S01E01-deleted.mkv",
+            "/series/The Venture Bros/Season 1/The Venture Bros. - S01E02 - Second Epi.mkv",
+            "/series/The Venture Bros/Season 1/The Venture Bros. - S01E02 - Second Epi-interview.mkv",
+            "/series/The Venture Bros/Season 1/The Venture Bros. - S01E02 - Second Epi-scene.mkv",
+            "/series/The Venture Bros/Season 1/It's a begining-behindthescenes.mkv",
+            "/series/The Venture Bros/Season 1/interviews/The Cast.mkv",
+        };
+
+        var files = paths.Select(p => new FileSystemMetadata
+        {
+            FullName = p,
+            Name = Path.GetFileName(p),
+            Extension = Path.GetExtension(p),
+            IsDirectory = string.IsNullOrEmpty(Path.GetExtension(p))
+        }).ToList();
+
+        var extras = _libraryManager.FindExtras(owner, files, new DirectoryService(_fileSystemMock.Object)).OrderBy(e => e.ExtraType).ToList();
+
+        Assert.Equal(2, extras.Count);
+        Assert.Equal(ExtraType.BehindTheScenes, extras[0].ExtraType);
+        Assert.Equal(typeof(Video), extras[0].GetType());
+        Assert.Equal("It's a begining-behindthescenes", extras[0].FileNameWithoutExtension);
+        Assert.Equal("/series/The Venture Bros/Season 1/It's a begining-behindthescenes.mkv", extras[0].Path);
+        Assert.Equal("/series/The Venture Bros/Season 1/interviews/The Cast.mkv", extras[1].Path);
+    }
+
+    [Fact]
     public void FindExtras_EpisodeWithExtras_FindsCorrectExtras()
     {
         var paths = new List<string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Subfolder and suffix style extras support for episodes. Includes unit tests for series, season and episode level extras.

Feature parity with [plex ](https://support.plex.tv/articles/local-files-for-tv-show-trailers-and-extras/).

Edit: upon further testing, JF does support -clip2 style suffixes.