### PR TITLE
Add escape hatch for Series merging

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -184,6 +184,11 @@ namespace MediaBrowser.Controller.Entities.TV
                 list.Insert(0, key);
             }
 
+            if (this.TryGetProviderId(MetadataProvider.Custom, out key))
+            {
+                list.Insert(0, key);
+            }
+
             return list;
         }
 

--- a/MediaBrowser.Model/Entities/MetadataProvider.cs
+++ b/MediaBrowser.Model/Entities/MetadataProvider.cs
@@ -8,6 +8,12 @@ namespace MediaBrowser.Model.Entities
     public enum MetadataProvider
     {
         /// <summary>
+        /// This metadata provider is for users and/or plugins to override the
+        /// default merging behaviour.
+        /// </summary>
+        Custom = 0,
+
+        /// <summary>
         /// The imdb.
         /// </summary>
         Imdb = 2,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This is an universal solution for plugins to override how series are merged.
The reason to override is so we can set the same provider id on multiple items without merging them, while using another id for merging them. Having an (optional) provider id not tied to any online database allows plugins to use their own rules for merging series.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Follow up PR for #7497 
