### PR TITLE
Fix stream mapping if no external stream exists

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5486,6 +5486,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             var index = 0;
             var length = mediaStreams.Count;
 
+            if (mediaStreams.All(i => !i.IsExternal))
+            {
+                return streamToFind.Index;
+            }
+
             for (var i = 0; i < length; i++)
             {
                 var currentMediaStream = mediaStreams[i];

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -184,9 +184,15 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (mediaInfo != null)
             {
+                var keepOriginalIndex = startIndex == 0 && mediaInfo.MediaStreams.Count > 0;
+
                 foreach (var mediaStream in mediaInfo.MediaStreams)
                 {
-                    mediaStream.Index = startIndex++;
+                    if (!keepOriginalIndex)
+                    {
+                        mediaStream.Index = startIndex++;
+                    }
+
                     mediaStreams.Add(mediaStream);
                 }
 
@@ -228,11 +234,17 @@ namespace MediaBrowser.Providers.MediaInfo
             else
             {
                 var currentMediaStreams = video.GetMediaStreams();
+                var keepOriginalIndex = startIndex == 0 && currentMediaStreams.Count > 0;
+
                 foreach (var mediaStream in currentMediaStreams)
                 {
                     if (!mediaStream.IsExternal)
                     {
-                        mediaStream.Index = startIndex++;
+                        if (!keepOriginalIndex)
+                        {
+                            mediaStream.Index = startIndex++;
+                        }
+
                         mediaStreams.Add(mediaStream);
                     }
                 }


### PR DESCRIPTION
**Changes**
- Fix stream mapping if no external stream exists

**Issues**
Should fixes: #8015 #8016

> // Add external streams before adding the streams from the file to preserve stream IDs on remote videos

Remote video stream do not always start at 0:0, data stream start at 0:0 is possible.