### PR TITLE
Remove mount and unmount permissions for jellyfin group from sudoers

### DIFF
--- a/debian/conf/jellyfin-sudoers
+++ b/debian/conf/jellyfin-sudoers
@@ -30,8 +30,4 @@ Defaults!RESTARTSERVER_INITD !requiretty
 Defaults!STARTSERVER_INITD !requiretty
 Defaults!STOPSERVER_INITD !requiretty
 
-#Allow the server to mount iso images
-jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-jellyfin ALL=(ALL) NOPASSWD: /bin/umount
-
 Defaults:jellyfin !requiretty

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -18,14 +18,6 @@ $ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-re
 $ sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
 ```
 
-## ISO mounting
-
-To allow Jellyfin to mount/umount ISO files uncomment these two lines in `/etc/sudoers.d/jellyfin-sudoers`
-```
-# %jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-# %jellyfin ALL=(ALL) NOPASSWD: /bin/umount
-```
-
 ## Building with dotnet
 
 Jellyfin is build with `--self-contained` so no dotnet required for runtime.

--- a/fedora/jellyfin.sudoers
+++ b/fedora/jellyfin.sudoers
@@ -11,8 +11,4 @@ Defaults!RESTARTSERVER_SYSTEMD !requiretty
 Defaults!STARTSERVER_SYSTEMD !requiretty
 Defaults!STOPSERVER_SYSTEMD !requiretty
 
-# Allow the server to mount iso images
-jellyfin ALL=(ALL) NOPASSWD: /bin/mount
-jellyfin ALL=(ALL) NOPASSWD: /bin/umount
-
 Defaults:jellyfin !requiretty


### PR DESCRIPTION
Fixes #8037

We no longer mount ISOs nor do we support plugins mounting them. All playback and probing related handling is done by ffmpeg or other tools directly accessing the ISO without the OS being involved.