### PR TITLE
Implement a Modular Home screen and User facing plugin pages

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -30,6 +30,7 @@ using Emby.Server.Implementations.Cryptography;
 using Emby.Server.Implementations.Data;
 using Emby.Server.Implementations.Devices;
 using Emby.Server.Implementations.Dto;
+using Emby.Server.Implementations.HomeScreen;
 using Emby.Server.Implementations.HttpServer.Security;
 using Emby.Server.Implementations.IO;
 using Emby.Server.Implementations.Library;
@@ -599,6 +600,10 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<ISubtitleManager, SubtitleManager>();
 
             serviceCollection.AddSingleton<IProviderManager, ProviderManager>();
+
+            serviceCollection.AddSingleton<IHomeScreenManager, HomeScreenManager>();
+
+            serviceCollection.AddSingleton<IPluginPagesManager, PluginPagesManager>();
 
             // TODO: Refactor to eliminate the circular dependency here so that Lazy<T> isn't required
             serviceCollection.AddTransient(provider => new Lazy<ILiveTvManager>(provider.GetRequiredService<ILiveTvManager>));

--- a/Emby.Server.Implementations/HomeScreen/HomeScreenManager.cs
+++ b/Emby.Server.Implementations/HomeScreen/HomeScreenManager.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.HomeScreen.Sections;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Emby.Server.Implementations.HomeScreen
+{
+    public class HomeScreenManager : IHomeScreenManager
+    {
+        private Dictionary<string, IHomeScreenSection> m_delegates = new Dictionary<string, IHomeScreenSection>();
+        private Dictionary<Guid, bool> m_userFeatureEnabledStates = new Dictionary<Guid, bool>();
+
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IApplicationPaths _applicationPaths;
+
+        public HomeScreenManager(IServiceProvider serviceProvider, IApplicationPaths applicationPaths)
+        {
+            _serviceProvider = serviceProvider;
+            _applicationPaths = applicationPaths;
+
+            string userFeatureEnabledPath = Path.Combine(_applicationPaths.CachePath, "userFeatureEnabled.json");
+            if (File.Exists(userFeatureEnabledPath))
+            {
+                m_userFeatureEnabledStates = JsonConvert.DeserializeObject<Dictionary<Guid, bool>>(File.ReadAllText(userFeatureEnabledPath));
+            }
+
+            RegisterResultsDelegate<MyMediaSection>();
+            RegisterResultsDelegate<ContinueWatchingSection>();
+            RegisterResultsDelegate<NextUpSection>();
+            RegisterResultsDelegate<LatestMoviesSection>();
+            RegisterResultsDelegate<LatestShowsSection>();
+        }
+
+        public IEnumerable<IHomeScreenSection> GetSectionTypes()
+        {
+            return m_delegates.Values;
+        }
+
+        public QueryResult<BaseItemDto> InvokeResultsDelegate(string key, HomeScreenSectionPayload payload)
+        {
+            if (m_delegates.ContainsKey(key))
+            {
+                return m_delegates[key].GetResults(payload);
+            }
+
+            return new QueryResult<BaseItemDto>(Array.Empty<BaseItemDto>());
+        }
+
+        public void RegisterResultsDelegate<T>() where T : IHomeScreenSection
+        {
+            T handler = ActivatorUtilities.CreateInstance<T>(_serviceProvider);
+
+            if (!m_delegates.ContainsKey(handler.Section))
+            {
+                m_delegates.Add(handler.Section, handler);
+            }
+            else
+            {
+                throw new Exception($"Section type '{handler.Section}' has already been registered to type '{m_delegates[handler.Section].GetType().FullName}'.");
+            }
+        }
+
+        public bool GetUserFeatureEnabled(Guid userId)
+        {
+            if (m_userFeatureEnabledStates.ContainsKey(userId))
+            {
+                return m_userFeatureEnabledStates[userId];
+            }
+
+            m_userFeatureEnabledStates.Add(userId, false);
+
+            return false;
+        }
+
+        public void SetUserFeatureEnabled(Guid userId, bool enabled)
+        {
+            if (!m_userFeatureEnabledStates.ContainsKey(userId))
+            {
+                m_userFeatureEnabledStates.Add(userId, enabled);
+            }
+
+            m_userFeatureEnabledStates[userId] = enabled;
+
+            string userFeatureEnabledPath = Path.Combine(_applicationPaths.CachePath, "userFeatureEnabled.json");
+            File.WriteAllText(userFeatureEnabledPath, JObject.FromObject(m_userFeatureEnabledStates).ToString(Newtonsoft.Json.Formatting.Indented));
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
@@ -16,7 +16,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
     /// <summary>
-    /// Continue Watching Section
+    /// Continue Watching Section.
     /// </summary>
     public class ContinueWatchingSection : IHomeScreenSection
     {

--- a/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
@@ -15,17 +15,25 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
+    /// <summary>
+    /// Continue Watching Section
+    /// </summary>
     public class ContinueWatchingSection : IHomeScreenSection
     {
-        public string Section => "ContinueWatching";
+        /// <inheritdoc/>
+        public string? Section => "ContinueWatching";
 
-        public string DisplayText { get; set; } = "Continue Watching";
+        /// <inheritdoc/>
+        public string? DisplayText { get; set; } = "Continue Watching";
 
-        public int Limit => 1;
+        /// <inheritdoc/>
+        public int? Limit => 1;
 
-        public string Route => null;
+        /// <inheritdoc/>
+        public string? Route => null;
 
-        public string AdditionalData { get; set; } = null;
+        /// <inheritdoc/>
+        public string? AdditionalData { get; set; } = null;
 
         private readonly IUserViewManager _userViewManager;
         private readonly IUserManager _userManager;
@@ -33,6 +41,14 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
         private readonly ILibraryManager _libraryManager;
         private readonly ISessionManager _sessionManager;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
+        /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>
+        /// <param name="dtoService">Instance of <see href="IDtoService" /> interface.</param>
+        /// <param name="libraryManager">Instance of <see href="ILibraryManager" /> interface.</param>
+        /// <param name="sessionManager">Instance of <see href="ISessionManager" /> interface.</param>
         public ContinueWatchingSection(IUserViewManager userViewManager,
             IUserManager userManager,
             IDtoService dtoService,
@@ -46,6 +62,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
             _sessionManager = sessionManager;
         }
 
+        /// <inheritdoc/>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
         {
             var user = _userManager.GetUserById(payload.UserId);

--- a/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/ContinueWatchingSection.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.HomeScreen.Sections
+{
+    public class ContinueWatchingSection : IHomeScreenSection
+    {
+        public string Section => "ContinueWatching";
+
+        public string DisplayText { get; set; } = "Continue Watching";
+
+        public int Limit => 1;
+
+        public string Route => null;
+
+        public string AdditionalData { get; set; } = null;
+
+        private readonly IUserViewManager _userViewManager;
+        private readonly IUserManager _userManager;
+        private readonly IDtoService _dtoService;
+        private readonly ILibraryManager _libraryManager;
+        private readonly ISessionManager _sessionManager;
+
+        public ContinueWatchingSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            IDtoService dtoService,
+            ILibraryManager libraryManager,
+            ISessionManager sessionManager)
+        {
+            _userViewManager = userViewManager;
+            _userManager = userManager;
+            _dtoService = dtoService;
+            _libraryManager = libraryManager;
+            _sessionManager = sessionManager;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
+        {
+            var user = _userManager.GetUserById(payload.UserId);
+            var dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.BasicSyncInfo
+                },
+                ImageTypeLimit = 1,
+                ImageTypes = new List<ImageType>
+                {
+                    ImageType.Primary,
+                    ImageType.Backdrop,
+                    ImageType.Thumb
+                }
+            };
+
+            var ancestorIds = Array.Empty<Guid>();
+
+            var excludeFolderIds = user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes);
+            if (excludeFolderIds.Length > 0)
+            {
+                ancestorIds = _libraryManager.GetUserRootFolder().GetChildren(user, true)
+                    .Where(i => i is Folder)
+                    .Where(i => !excludeFolderIds.Contains(i.Id))
+                    .Select(i => i.Id)
+                    .ToArray();
+            }
+
+            var itemsResult = _libraryManager.GetItemsResult(new InternalItemsQuery(user)
+            {
+                OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending) },
+                IsResumable = true,
+                Limit = 12,
+                Recursive = true,
+                DtoOptions = dtoOptions,
+                MediaTypes = new string[]
+                {
+                    "Video"
+                },
+                IsVirtualItem = false,
+                CollapseBoxSetItems = false,
+                EnableTotalRecordCount = false,
+                AncestorIds = ancestorIds
+            });
+
+            var returnItems = _dtoService.GetBaseItemDtos(itemsResult.Items, dtoOptions, user);
+
+            return new QueryResult<BaseItemDto>(
+                null,
+                itemsResult.TotalRecordCount,
+                returnItems);
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
@@ -15,7 +15,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
     /// <summary>
-    /// Latest Movies Section
+    /// Latest Movies Section.
     /// </summary>
     public class LatestMoviesSection : IHomeScreenSection
     {
@@ -39,7 +39,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
         private readonly IDtoService _dtoService;
 
         /// <summary>
-        /// Constructor
+        /// Constructor.
         /// </summary>
         /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
         /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
@@ -14,22 +14,36 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
+    /// <summary>
+    /// Latest Movies Section
+    /// </summary>
     public class LatestMoviesSection : IHomeScreenSection
     {
-        public string Section => "LatestMovies";
+        /// <inheritdoc/>
+        public string? Section => "LatestMovies";
 
-        public string DisplayText { get; set; } = "Latest Movies";
+        /// <inheritdoc/>
+        public string? DisplayText { get; set; } = "Latest Movies";
 
-        public int Limit => 1;
+        /// <inheritdoc/>
+        public int? Limit => 1;
 
-        public string Route => "movies";
+        /// <inheritdoc/>
+        public string? Route => "movies";
 
-        public string AdditionalData { get; set; } = "movies";
+        /// <inheritdoc/>
+        public string? AdditionalData { get; set; } = "movies";
 
         private readonly IUserViewManager _userViewManager;
         private readonly IUserManager _userManager;
         private readonly IDtoService _dtoService;
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
+        /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>
+        /// <param name="dtoService">Instance of <see href="IDtoService" /> interface.</param>
         public LatestMoviesSection(IUserViewManager userViewManager,
             IUserManager userManager,
             IDtoService dtoService)
@@ -39,6 +53,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
             _dtoService = dtoService;
         }
 
+        /// <inheritdoc/>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
         {
             var user = _userManager.GetUserById(payload.UserId);

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestMoviesSection.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.HomeScreen.Sections
+{
+    public class LatestMoviesSection : IHomeScreenSection
+    {
+        public string Section => "LatestMovies";
+
+        public string DisplayText { get; set; } = "Latest Movies";
+
+        public int Limit => 1;
+
+        public string Route => "movies";
+
+        public string AdditionalData { get; set; } = "movies";
+
+        private readonly IUserViewManager _userViewManager;
+        private readonly IUserManager _userManager;
+        private readonly IDtoService _dtoService;
+
+        public LatestMoviesSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            IDtoService dtoService)
+        {
+            _userViewManager = userViewManager;
+            _userManager = userManager;
+            _dtoService = dtoService;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
+        {
+            var user = _userManager.GetUserById(payload.UserId);
+
+            var dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.BasicSyncInfo,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Backdrop,
+                ImageType.Thumb
+            };
+
+            MyMediaSection myMedia = new MyMediaSection(_userViewManager, _userManager, _dtoService);
+            QueryResult<BaseItemDto> media = myMedia.GetResults(payload);
+
+            Guid parentId = media.Items.FirstOrDefault(x => x.Name == payload.AdditionalData)?.Id ?? Guid.Empty;
+
+            var list = _userViewManager.GetLatestItems(
+                new LatestItemsQuery
+                {
+                    GroupItems = false,
+                    Limit = 16,
+                    ParentId = parentId,
+                    UserId = payload.UserId,
+                    IncludeItemTypes = new BaseItemKind[]
+                    {
+                        BaseItemKind.Movie
+                    }
+                },
+                dtoOptions);
+
+            var dtos = list.Select(i =>
+            {
+                var item = i.Item2[0];
+                var childCount = 0;
+
+                if (i.Item1 != null && (i.Item2.Count > 1 || i.Item1 is MusicAlbum))
+                {
+                    item = i.Item1;
+                    childCount = i.Item2.Count;
+                }
+
+                var dto = _dtoService.GetBaseItemDto(item, dtoOptions, user);
+
+                dto.ChildCount = childCount;
+
+                return dto;
+            });
+
+            return new QueryResult<BaseItemDto>(dtos.ToList());
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.HomeScreen.Sections
+{
+    public class LatestShowsSection : IHomeScreenSection
+    {
+        public string Section => "LatestShows";
+
+        public string DisplayText { get; set; } = "Latest Shows";
+
+        public int Limit => 1;
+
+        public string Route => "tvshows";
+
+        public string AdditionalData { get; set; } = "tvshows";
+
+        private readonly IUserViewManager _userViewManager;
+        private readonly IUserManager _userManager;
+        private readonly IDtoService _dtoService;
+
+        public LatestShowsSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            IDtoService dtoService)
+        {
+            _userViewManager = userViewManager;
+            _userManager = userManager;
+            _dtoService = dtoService;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
+        {
+            var user = _userManager.GetUserById(payload.UserId);
+
+            var dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.BasicSyncInfo,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Backdrop,
+                ImageType.Thumb
+            };
+
+            MyMediaSection myMedia = new MyMediaSection(_userViewManager, _userManager, _dtoService);
+            QueryResult<BaseItemDto> media = myMedia.GetResults(payload);
+
+            Guid parentId = media.Items.FirstOrDefault(x => x.CollectionType == payload.AdditionalData)?.Id ?? Guid.Empty;
+
+            var list = _userViewManager.GetLatestItems(
+                new LatestItemsQuery
+                {
+                    GroupItems = true,
+                    Limit = 16,
+                    ParentId = parentId,
+                    UserId = payload.UserId,
+                    IsPlayed = false,
+                    IncludeItemTypes = Array.Empty<BaseItemKind>()
+                },
+                dtoOptions);
+
+            var dtos = list.Select(i =>
+            {
+                var item = i.Item2[0];
+                var childCount = 0;
+
+                if (i.Item1 != null && (i.Item2.Count > 1 || i.Item1 is MusicAlbum))
+                {
+                    item = i.Item1;
+                    childCount = i.Item2.Count;
+                }
+
+                var dto = _dtoService.GetBaseItemDto(item, dtoOptions, user);
+
+                dto.ChildCount = childCount;
+
+                return dto;
+            });
+
+            return new QueryResult<BaseItemDto>(dtos.ToList());
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
@@ -15,7 +15,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
     /// <summary>
-    /// Latest Shows Section
+    /// Latest Shows Section.
     /// </summary>
     public class LatestShowsSection : IHomeScreenSection
     {

--- a/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/LatestShowsSection.cs
@@ -14,22 +14,36 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
+    /// <summary>
+    /// Latest Shows Section
+    /// </summary>
     public class LatestShowsSection : IHomeScreenSection
     {
-        public string Section => "LatestShows";
+        /// <inheritdoc/>
+        public string? Section => "LatestShows";
 
-        public string DisplayText { get; set; } = "Latest Shows";
+        /// <inheritdoc/>
+        public string? DisplayText { get; set; } = "Latest Shows";
 
-        public int Limit => 1;
+        /// <inheritdoc/>
+        public int? Limit => 1;
 
-        public string Route => "tvshows";
+        /// <inheritdoc/>
+        public string? Route => "tvshows";
 
-        public string AdditionalData { get; set; } = "tvshows";
+        /// <inheritdoc/>
+        public string? AdditionalData { get; set; } = "tvshows";
 
         private readonly IUserViewManager _userViewManager;
         private readonly IUserManager _userManager;
         private readonly IDtoService _dtoService;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
+        /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>
+        /// <param name="dtoService">Instance of <see href="IDtoService" /> interface.</param>
         public LatestShowsSection(IUserViewManager userViewManager,
             IUserManager userManager,
             IDtoService dtoService)
@@ -39,6 +53,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
             _dtoService = dtoService;
         }
 
+        /// <inheritdoc/>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
         {
             var user = _userManager.GetUserById(payload.UserId);

--- a/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.HomeScreen.Sections
+{
+    public class MyMediaSection : IHomeScreenSection
+    {
+        public string Section => "MyMedia";
+
+        public string DisplayText { get; set; } = "My Media";
+
+        public int Limit => 1;
+
+        public string Route => null;
+
+        public string AdditionalData { get; set; } = null;
+
+        private readonly IUserViewManager _userViewManager;
+        private readonly IUserManager _userManager;
+        private readonly IDtoService _dtoService;
+
+        public MyMediaSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            IDtoService dtoService)
+        {
+            _userViewManager = userViewManager;
+            _userManager = userManager;
+            _dtoService = dtoService;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
+        {
+            var query = new UserViewQuery
+            {
+                UserId = payload.UserId,
+                IncludeHidden = false
+            };
+
+            var folders = _userViewManager.GetUserViews(query);
+
+            var dtoOptions = new DtoOptions();
+            var f = new List<ItemFields>
+            {
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.DisplayPreferencesId
+            };
+
+            dtoOptions.Fields = f.ToArray();
+
+            var user = _userManager.GetUserById(payload.UserId);
+
+            var dtos = folders.Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user))
+                .ToArray();
+
+            return new QueryResult<BaseItemDto>(dtos);
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
@@ -11,22 +11,36 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
+    /// <summary>
+    /// My Media Section
+    /// </summary>
     public class MyMediaSection : IHomeScreenSection
     {
-        public string Section => "MyMedia";
+        /// <inheritdoc/>
+        public string? Section => "MyMedia";
 
-        public string DisplayText { get; set; } = "My Media";
+        /// <inheritdoc/>
+        public string? DisplayText { get; set; } = "My Media";
 
-        public int Limit => 1;
+        /// <inheritdoc/>
+        public int? Limit => 1;
 
-        public string Route => null;
+        /// <inheritdoc/>
+        public string? Route => null;
 
-        public string AdditionalData { get; set; } = null;
+        /// <inheritdoc/>
+        public string? AdditionalData { get; set; } = null;
 
         private readonly IUserViewManager _userViewManager;
         private readonly IUserManager _userManager;
         private readonly IDtoService _dtoService;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
+        /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>
+        /// <param name="dtoService">Instance of <see href="IDtoService" /> interface.</param>
         public MyMediaSection(IUserViewManager userViewManager,
             IUserManager userManager,
             IDtoService dtoService)
@@ -36,6 +50,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
             _dtoService = dtoService;
         }
 
+        /// <inheritdoc/>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
         {
             var query = new UserViewQuery

--- a/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/MyMediaSection.cs
@@ -12,7 +12,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
     /// <summary>
-    /// My Media Section
+    /// My Media Section.
     /// </summary>
     public class MyMediaSection : IHomeScreenSection
     {

--- a/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
@@ -17,7 +17,7 @@ using MediaBrowser.Model.Querying;
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
     /// <summary>
-    /// Next Up Section
+    /// Next Up Section.
     /// </summary>
     public class NextUpSection : IHomeScreenSection
     {
@@ -44,7 +44,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
         private readonly ITVSeriesManager _tvSeriesManager;
 
         /// <summary>
-        /// Constructor
+        /// Constructor.
         /// </summary>
         /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
         /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>

--- a/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.TV;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.HomeScreen.Sections
+{
+    public class NextUpSection : IHomeScreenSection
+    {
+        public string Section => "NextUp";
+
+        public string DisplayText { get; set; } = "Next Up";
+
+        public int Limit => 1;
+
+        public string Route => "nextup";
+
+        public string AdditionalData { get; set; } = null;
+
+        private readonly IUserViewManager _userViewManager;
+        private readonly IUserManager _userManager;
+        private readonly IDtoService _dtoService;
+        private readonly ILibraryManager _libraryManager;
+        private readonly ISessionManager _sessionManager;
+        private readonly ITVSeriesManager _tvSeriesManager;
+
+        public NextUpSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            IDtoService dtoService,
+            ILibraryManager libraryManager,
+            ISessionManager sessionManager,
+            ITVSeriesManager tvSeriesManager)
+        {
+            _userViewManager = userViewManager;
+            _userManager = userManager;
+            _dtoService = dtoService;
+            _libraryManager = libraryManager;
+            _sessionManager = sessionManager;
+            _tvSeriesManager = tvSeriesManager;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
+        {
+            List<ItemFields> fields = new List<ItemFields>
+            {
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.DateCreated,
+                ItemFields.BasicSyncInfo,
+                ItemFields.Path,
+                ItemFields.MediaSourceCount
+            };
+
+            var options = new DtoOptions { Fields = fields };
+            options.ImageTypeLimit = 1;
+            options.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Backdrop,
+                ImageType.Banner,
+                ImageType.Thumb
+            };
+
+            var result = _tvSeriesManager.GetNextUp(
+                new NextUpQuery
+                {
+                    Limit = 24,
+                    SeriesId = null,
+                    StartIndex = null,
+                    UserId = payload.UserId,
+                    EnableTotalRecordCount = false,
+                    DisableFirstEpisode = true,
+                    NextUpDateCutoff = DateTime.MinValue,
+                    EnableRewatching = true
+                },
+                options);
+
+            var user = _userManager.GetUserById(payload.UserId);
+
+            var returnItems = _dtoService.GetBaseItemDtos(result.Items, options, user);
+
+            return new QueryResult<BaseItemDto>(
+                null,
+                result.TotalRecordCount,
+                returnItems);
+        }
+    }
+}

--- a/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
+++ b/Emby.Server.Implementations/HomeScreen/Sections/NextUpSection.cs
@@ -16,17 +16,25 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.HomeScreen.Sections
 {
+    /// <summary>
+    /// Next Up Section
+    /// </summary>
     public class NextUpSection : IHomeScreenSection
     {
-        public string Section => "NextUp";
+        /// <inheritdoc/>
+        public string? Section => "NextUp";
 
-        public string DisplayText { get; set; } = "Next Up";
+        /// <inheritdoc/>
+        public string? DisplayText { get; set; } = "Next Up";
 
-        public int Limit => 1;
+        /// <inheritdoc/>
+        public int? Limit => 1;
 
-        public string Route => "nextup";
+        /// <inheritdoc/>
+        public string? Route => "nextup";
 
-        public string AdditionalData { get; set; } = null;
+        /// <inheritdoc/>
+        public string? AdditionalData { get; set; } = null;
 
         private readonly IUserViewManager _userViewManager;
         private readonly IUserManager _userManager;
@@ -35,6 +43,15 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
         private readonly ISessionManager _sessionManager;
         private readonly ITVSeriesManager _tvSeriesManager;
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="userViewManager">Instance of <see href="IUserViewManager" /> interface.</param>
+        /// <param name="userManager">Instance of <see href="IUserManager" /> interface.</param>
+        /// <param name="dtoService">Instance of <see href="IDtoService" /> interface.</param>
+        /// <param name="libraryManager">Instance of <see href="ILibraryManager" /> interface.</param>
+        /// <param name="sessionManager">Instance of <see href="ISessionManager" /> interface.</param>
+        /// <param name="tvSeriesManager">Instance of <see href="ITVSeriesManager" /> interface.</param>
         public NextUpSection(IUserViewManager userViewManager,
             IUserManager userManager,
             IDtoService dtoService,
@@ -50,6 +67,7 @@ namespace Emby.Server.Implementations.HomeScreen.Sections
             _tvSeriesManager = tvSeriesManager;
         }
 
+        /// <inheritdoc/>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload)
         {
             List<ItemFields> fields = new List<ItemFields>

--- a/Emby.Server.Implementations/Plugins/PluginPagesManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginPagesManager.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Plugins;
+
+namespace Emby.Server.Implementations.Plugins
+{
+    public class PluginPagesManager : IPluginPagesManager
+    {
+        private List<PluginPage> m_pluginPages = new List<PluginPage>();
+
+        public IEnumerable<PluginPage> GetPages()
+        {
+            return m_pluginPages;
+        }
+
+        public void RegisterPluginPage(PluginPage page)
+        {
+            if (m_pluginPages.Any(x => x.Id == page.Id))
+            {
+                // The page is already added
+                // TODO: Log error
+                return;
+            }
+
+            m_pluginPages.Add(page);
+        }
+    }
+}

--- a/Emby.Server.Implementations/Plugins/PluginPagesManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginPagesManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,15 +7,18 @@ using MediaBrowser.Controller.Plugins;
 
 namespace Emby.Server.Implementations.Plugins
 {
+    /// <inheritdoc/>
     public class PluginPagesManager : IPluginPagesManager
     {
         private List<PluginPage> m_pluginPages = new List<PluginPage>();
 
+        /// <inheritdoc/>
         public IEnumerable<PluginPage> GetPages()
         {
             return m_pluginPages;
         }
 
+        /// <inheritdoc/>
         public void RegisterPluginPage(PluginPage page)
         {
             if (m_pluginPages.Any(x => x.Id == page.Id))

--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -32,6 +32,7 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="displayPreferencesManager">Instance of <see cref="IDisplayPreferencesManager"/> interface.</param>
         /// <param name="logger">Instance of <see cref="ILogger{DisplayPreferencesController}"/> interface.</param>
+        /// <param name="homeScreenManager">Instance of <see cref="IHomeScreenManager" /> interface.</param>
         public DisplayPreferencesController(IDisplayPreferencesManager displayPreferencesManager, ILogger<DisplayPreferencesController> logger, IHomeScreenManager homeScreenManager)
         {
             _displayPreferencesManager = displayPreferencesManager;

--- a/Jellyfin.Api/Controllers/HomeScreenController.cs
+++ b/Jellyfin.Api/Controllers/HomeScreenController.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Extensions;
+using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Library;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Api.Controllers
+{
+    public class HomeScreenSections
+    {
+        // TODO: Create a proper BaseItem for HomeScreenSections
+        public static BaseItemDto MyMedia { get; private set; } = new BaseItemDto
+        {
+            Name = "MyMedia",
+            OriginalTitle = "My Media"
+        };
+
+        public static BaseItemDto ContinueWatching { get; private set; } = new BaseItemDto
+        {
+            Name = "ContinueWatching",
+            OriginalTitle = "Continue Watching"
+        };
+
+        public static BaseItemDto NextUp { get; private set; } = new BaseItemDto
+        {
+            Name = "NextUp",
+            OriginalTitle = "Next Up",
+            SortName = "nextup"
+        };
+
+        public static BaseItemDto LatestMovies { get; private set; } = new BaseItemDto
+        {
+            Name = "LatestMovies",
+            OriginalTitle = "Latest Movies",
+            Overview = "movies"
+        };
+
+        public static BaseItemDto LatestShows { get; private set; } = new BaseItemDto
+        {
+            Name = "LatestShows",
+            OriginalTitle = "Latest Shows",
+            Overview = "tvshows"
+        };
+    }
+
+    [Authorize(Policy = Policies.DefaultAuthorization)]
+    public class HomeScreenController : BaseJellyfinApiController
+    {
+        private readonly IUserManager _userManager;
+        private readonly IUserViewManager _userViewManager;
+        private readonly ILibraryManager _libraryManager;
+        private readonly IDtoService _dtoService;
+        private readonly ISessionManager _sessionManager;
+        private readonly IHomeScreenManager _homeScreenManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TvShowsController"/> class.
+        /// </summary>
+        /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+        /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
+        public HomeScreenController(
+            IUserManager userManager,
+            IUserViewManager userViewManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService,
+            ISessionManager sessionManager,
+            IHomeScreenManager homeScreenManager)
+        {
+            _userManager = userManager;
+            _userViewManager = userViewManager;
+            _libraryManager = libraryManager;
+            _dtoService = dtoService;
+            _sessionManager = sessionManager;
+            _homeScreenManager = homeScreenManager;
+        }
+
+        [HttpGet("Sections")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<QueryResult<BaseItemDto>> GetHomeScreenSections(
+            [FromQuery] Guid? userId)
+        {
+            List<BaseItemDto> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsBaseItem()).ToList();
+
+            return new QueryResult<BaseItemDto>(
+                0,
+                sections.Count,
+                sections);
+        }
+
+        [HttpGet("Section/{sectionType}")]
+        public QueryResult<BaseItemDto> GetSectionContent(
+            [FromRoute] string sectionType,
+            [FromQuery, Required] Guid userId,
+            [FromQuery] string? additionalData)
+        {
+            HomeScreenSectionPayload payload = new HomeScreenSectionPayload
+            {
+                UserId = userId,
+                AdditionalData = additionalData
+            };
+
+            return _homeScreenManager.InvokeResultsDelegate(sectionType, payload);
+        }
+    }
+}

--- a/Jellyfin.Api/Controllers/HomeScreenController.cs
+++ b/Jellyfin.Api/Controllers/HomeScreenController.cs
@@ -96,7 +96,9 @@ namespace Jellyfin.Api.Controllers
         public ActionResult<QueryResult<HomeScreenSectionInfo>> GetHomeScreenSections(
             [FromQuery] Guid? userId)
         {
-            List<HomeScreenSectionInfo> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsInfo()).ToList();
+            ModularHomeUserSettings settings = _homeScreenManager.GetUserSettings(userId ?? Guid.Empty);
+
+            List<HomeScreenSectionInfo> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsInfo()).Where(x => settings.EnabledSections.Contains(x.Section)).ToList();
 
             return new QueryResult<HomeScreenSectionInfo>(
                 0,

--- a/Jellyfin.Api/Controllers/HomeScreenController.cs
+++ b/Jellyfin.Api/Controllers/HomeScreenController.cs
@@ -93,12 +93,12 @@ namespace Jellyfin.Api.Controllers
 
         [HttpGet("Sections")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<QueryResult<BaseItemDto>> GetHomeScreenSections(
+        public ActionResult<QueryResult<HomeScreenSectionInfo>> GetHomeScreenSections(
             [FromQuery] Guid? userId)
         {
-            List<BaseItemDto> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsBaseItem()).ToList();
+            List<HomeScreenSectionInfo> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsInfo()).ToList();
 
-            return new QueryResult<BaseItemDto>(
+            return new QueryResult<HomeScreenSectionInfo>(
                 0,
                 sections.Count,
                 sections);

--- a/Jellyfin.Api/Controllers/HomeScreenController.cs
+++ b/Jellyfin.Api/Controllers/HomeScreenController.cs
@@ -22,43 +22,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Api.Controllers
 {
-    public class HomeScreenSections
-    {
-        // TODO: Create a proper BaseItem for HomeScreenSections
-        public static BaseItemDto MyMedia { get; private set; } = new BaseItemDto
-        {
-            Name = "MyMedia",
-            OriginalTitle = "My Media"
-        };
-
-        public static BaseItemDto ContinueWatching { get; private set; } = new BaseItemDto
-        {
-            Name = "ContinueWatching",
-            OriginalTitle = "Continue Watching"
-        };
-
-        public static BaseItemDto NextUp { get; private set; } = new BaseItemDto
-        {
-            Name = "NextUp",
-            OriginalTitle = "Next Up",
-            SortName = "nextup"
-        };
-
-        public static BaseItemDto LatestMovies { get; private set; } = new BaseItemDto
-        {
-            Name = "LatestMovies",
-            OriginalTitle = "Latest Movies",
-            Overview = "movies"
-        };
-
-        public static BaseItemDto LatestShows { get; private set; } = new BaseItemDto
-        {
-            Name = "LatestShows",
-            OriginalTitle = "Latest Shows",
-            Overview = "tvshows"
-        };
-    }
-
+    /// <summary>
+    /// API controller for the Modular Home Screen.
+    /// </summary>
     [Authorize(Policy = Policies.DefaultAuthorization)]
     public class HomeScreenController : BaseJellyfinApiController
     {
@@ -73,8 +39,11 @@ namespace Jellyfin.Api.Controllers
         /// Initializes a new instance of the <see cref="TvShowsController"/> class.
         /// </summary>
         /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+        /// <param name="userViewManager">Instance of the <see cref="IUserViewManager"/> interface.</param>
         /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
+        /// <param name="sessionManager">Instance of the <see cref="ISessionManager"/> interface.</param>
+        /// <param name="homeScreenManager">Instance of the <see cref="IHomeScreenManager"/> interface.</param>
         public HomeScreenController(
             IUserManager userManager,
             IUserViewManager userViewManager,
@@ -91,14 +60,19 @@ namespace Jellyfin.Api.Controllers
             _homeScreenManager = homeScreenManager;
         }
 
+        /// <summary>
+        /// Get what home screen sections the user has enabled.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <returns></returns>
         [HttpGet("Sections")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<QueryResult<HomeScreenSectionInfo>> GetHomeScreenSections(
             [FromQuery] Guid? userId)
         {
-            ModularHomeUserSettings settings = _homeScreenManager.GetUserSettings(userId ?? Guid.Empty);
+            ModularHomeUserSettings? settings = _homeScreenManager.GetUserSettings(userId ?? Guid.Empty);
 
-            List<HomeScreenSectionInfo> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsInfo()).Where(x => settings.EnabledSections.Contains(x.Section)).ToList();
+            List<HomeScreenSectionInfo> sections = _homeScreenManager.GetSectionTypes().Select(x => x.AsInfo()).Where(x => settings?.EnabledSections.Contains(x.Section ?? "") ?? false).ToList();
 
             return new QueryResult<HomeScreenSectionInfo>(
                 0,
@@ -106,6 +80,13 @@ namespace Jellyfin.Api.Controllers
                 sections);
         }
 
+        /// <summary>
+        /// Get the content for the home screen section based on <paramref name="sectionType"/>.
+        /// </summary>
+        /// <param name="sectionType">The section type.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="additionalData">Any additional data this section is showing.</param>
+        /// <returns></returns>
         [HttpGet("Section/{sectionType}")]
         public QueryResult<BaseItemDto> GetSectionContent(
             [FromRoute] string sectionType,

--- a/Jellyfin.Api/Controllers/PluginPagesController.cs
+++ b/Jellyfin.Api/Controllers/PluginPagesController.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Api.Controllers
+{
+    [Authorize(Policy = Policies.DefaultAuthorization)]
+    public class PluginPagesController : BaseJellyfinApiController
+    {
+        private readonly IPluginPagesManager _pluginPagesManager;
+
+        public PluginPagesController(IPluginPagesManager pluginPagesManager) : base()
+        {
+            _pluginPagesManager = pluginPagesManager;
+        }
+
+        [HttpGet("User")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<QueryResult<PluginPage>> GetHomeScreenSections()
+        {
+            List<PluginPage> pages = _pluginPagesManager.GetPages().ToList();
+
+            return new QueryResult<PluginPage>(
+                0,
+                pages.Count,
+                pages);
+        }
+
+    }
+}

--- a/Jellyfin.Api/Controllers/PluginPagesController.cs
+++ b/Jellyfin.Api/Controllers/PluginPagesController.cs
@@ -30,9 +30,9 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Get pages this plugin serves for users
+        /// Get pages this plugin serves for users.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Array of <see cref="PluginPage"/>.</returns>
         [HttpGet("User")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<QueryResult<PluginPage>> GetPluginPages()

--- a/Jellyfin.Api/Controllers/PluginPagesController.cs
+++ b/Jellyfin.Api/Controllers/PluginPagesController.cs
@@ -12,19 +12,30 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Api.Controllers
 {
+    /// <summary>
+    /// Plugin Pages API controller.
+    /// </summary>
     [Authorize(Policy = Policies.DefaultAuthorization)]
     public class PluginPagesController : BaseJellyfinApiController
     {
         private readonly IPluginPagesManager _pluginPagesManager;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="pluginPagesManager">Instance of <see href="IPluginPagesManager" /> interface.</param>
         public PluginPagesController(IPluginPagesManager pluginPagesManager) : base()
         {
             _pluginPagesManager = pluginPagesManager;
         }
 
+        /// <summary>
+        /// Get pages this plugin serves for users
+        /// </summary>
+        /// <returns></returns>
         [HttpGet("User")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<QueryResult<PluginPage>> GetHomeScreenSections()
+        public ActionResult<QueryResult<PluginPage>> GetPluginPages()
         {
             List<PluginPage> pages = _pluginPagesManager.GetPages().ToList();
 

--- a/MediaBrowser.Controller/Library/IHomeScreenManager.cs
+++ b/MediaBrowser.Controller/Library/IHomeScreenManager.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+
+namespace MediaBrowser.Controller.Library
+{
+    public interface IHomeScreenManager
+    {
+        public delegate QueryResult<BaseItemDto> GetResultsDelegate(HomeScreenSectionPayload payload);
+
+        void RegisterResultsDelegate<T>() where T : IHomeScreenSection;
+
+        IEnumerable<IHomeScreenSection> GetSectionTypes();
+
+        QueryResult<BaseItemDto> InvokeResultsDelegate(string key, HomeScreenSectionPayload payload);
+
+        bool GetUserFeatureEnabled(Guid userId);
+
+        void SetUserFeatureEnabled(Guid userId, bool enabled);
+    }
+
+    public interface IHomeScreenSection
+    {
+        public string Section { get; }
+
+        public string DisplayText { get; set; }
+
+        public int Limit { get; }
+
+        public string Route { get; }
+
+        public string AdditionalData { get; set; }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload);
+    }
+
+    public class HomeScreenSectionInfo
+    {
+        public string Section { get; set; }
+
+        public string DisplayText { get; set; }
+
+        public int Limit { get; set; }
+
+        public string Route { get; set; }
+
+        public string AdditionalData { get; set; }
+
+    }
+
+    public static class HomeScreenSectionExtensions
+    {
+
+        public static BaseItemDto AsBaseItem(this IHomeScreenSection section)
+        {
+#pragma warning disable CA1305 // Specify IFormatProvider
+            return new BaseItemDto
+            {
+                Name = section.Section,
+                OriginalTitle = section.DisplayText,
+                ChannelNumber = section.Limit.ToString(),
+                SortName = section.Route,
+                Overview = section.AdditionalData
+            };
+#pragma warning restore CA1305 // Specify IFormatProvider
+        }
+    }
+}

--- a/MediaBrowser.Controller/Library/IHomeScreenManager.cs
+++ b/MediaBrowser.Controller/Library/IHomeScreenManager.cs
@@ -8,63 +8,157 @@ using MediaBrowser.Model.Querying;
 
 namespace MediaBrowser.Controller.Library
 {
+    /// <summary>
+    /// IHomeScreenManager interface.
+    /// </summary>
     public interface IHomeScreenManager
     {
-        public delegate QueryResult<BaseItemDto> GetResultsDelegate(HomeScreenSectionPayload payload);
-
+        /// <summary>
+        /// Register a home screen section with the <see cref="IHomeScreenManager"/>.
+        /// </summary>
+        /// <typeparam name="T">A class that implements <see cref="IHomeScreenSection"/>.</typeparam>
         void RegisterResultsDelegate<T>() where T : IHomeScreenSection;
 
+        /// <summary>
+        /// Get the registered <see cref="IHomeScreenSection"/> instances.
+        /// </summary>
+        /// <returns>Array of <see cref="IHomeScreenSection"/></returns>
         IEnumerable<IHomeScreenSection> GetSectionTypes();
 
+        /// <summary>
+        /// Get the results for a particular section type.
+        /// </summary>
+        /// <param name="key">The section type identifier.</param>
+        /// <param name="payload">The payload to pass to the section to adjust its results.</param>
+        /// <returns>Array of results.</returns>
         QueryResult<BaseItemDto> InvokeResultsDelegate(string key, HomeScreenSectionPayload payload);
 
+        /// <summary>
+        /// Gets whether the user has the Modular Home feature enabled.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <returns>Enabled state</returns>
         bool GetUserFeatureEnabled(Guid userId);
 
+        /// <summary>
+        /// Sets the state for whether the user has the Modular Home feature enabled or not.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="enabled">Is the feature enabled or not?</param>
         void SetUserFeatureEnabled(Guid userId, bool enabled);
 
-        ModularHomeUserSettings GetUserSettings(Guid userId);
+        /// <summary>
+        /// Get the user's Modular Home settings for which sections are enabled.
+        /// </summary>
+        /// <param name="userId">The user.</param>
+        /// <returns>The user's settings.</returns>
+        ModularHomeUserSettings? GetUserSettings(Guid userId);
 
+        /// <summary>
+        /// Updates the user's Modular Home settings.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="userSettings">The settings for the user.</param>
+        /// <returns></returns>
         bool UpdateUserSettings(Guid userId, ModularHomeUserSettings userSettings);
     }
 
+    /// <summary>
+    /// Interface describing a Home Screen section for Modular Home.
+    /// </summary>
     public interface IHomeScreenSection
     {
-        public string Section { get; }
+        /// <summary>
+        /// Section identifier.
+        /// </summary>
+        public string? Section { get; }
 
-        public string DisplayText { get; set; }
+        /// <summary>
+        /// Text to display on frontend.
+        /// </summary>
+        public string? DisplayText { get; set; }
 
-        public int Limit { get; }
+        /// <summary>
+        /// Limit of the number of these sections a single user can see at once. (Usually 1)
+        /// </summary>
+        public int? Limit { get; }
 
-        public string Route { get; }
+        /// <summary>
+        /// If set, will tell the frontend where the header for this section should navigate to.
+        /// </summary>
+        public string? Route { get; }
 
-        public string AdditionalData { get; set; }
+        /// <summary>
+        /// Any additional data the section uses.
+        /// </summary>
+        public string? AdditionalData { get; set; }
 
+        /// <summary>
+        /// Get the results for the section.
+        /// </summary>
+        /// <param name="payload">The data for the section to determine what results to provider.</param>
+        /// <returns>Array of results.</returns>
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload);
     }
 
+    /// <summary>
+    /// Model for <see cref="IHomeScreenSection"/> used for getting section info.
+    /// </summary>
     public class HomeScreenSectionInfo
     {
-        public string Section { get; set; }
+        /// <summary>
+        /// Section ID
+        /// </summary>
+        public string? Section { get; set; }
 
-        public string DisplayText { get; set; }
+        /// <summary>
+        /// DisplayText
+        /// </summary>
+        public string? DisplayText { get; set; }
 
-        public int Limit { get; set; }
+        /// <summary>
+        /// Display Limit
+        /// </summary>
+        public int Limit { get; set; } = 1;
 
-        public string Route { get; set; }
+        /// <summary>
+        /// URL to navigation to
+        /// </summary>
+        public string? Route { get; set; }
 
-        public string AdditionalData { get; set; }
+        /// <summary>
+        /// Any additional data.
+        /// </summary>
+        public string? AdditionalData { get; set; }
 
     }
 
+    /// <summary>
+    /// UserSettings model for Modular Home.
+    /// </summary>
     public class ModularHomeUserSettings
     {
+        /// <summary>
+        /// The UserID.
+        /// </summary>
         public Guid UserId { get; set; }
+
+        /// <summary>
+        /// What sections are enabled.
+        /// </summary>
         public List<string> EnabledSections { get; set; } = new List<string>();
     }
 
+    /// <summary>
+    /// Extensions for <see cref="IHomeScreenSection"/>.
+    /// </summary>
     public static class HomeScreenSectionExtensions
     {
-
+        /// <summary>
+        /// Converts the <see cref="IHomeScreenSection"/> to a <see cref="HomeScreenSectionInfo"/>.
+        /// </summary>
+        /// <param name="section"><see cref="IHomeScreenSection"/> instance to convert.</param>
+        /// <returns>Converted <see cref="HomeScreenSectionInfo"/>.</returns>
         public static HomeScreenSectionInfo AsInfo(this IHomeScreenSection section)
         {
             return new HomeScreenSectionInfo
@@ -73,7 +167,7 @@ namespace MediaBrowser.Controller.Library
                 DisplayText = section.DisplayText,
                 AdditionalData = section.AdditionalData,
                 Route = section.Route,
-                Limit = section.Limit
+                Limit = section.Limit ?? 1
             };
         }
     }

--- a/MediaBrowser.Controller/Library/IHomeScreenManager.cs
+++ b/MediaBrowser.Controller/Library/IHomeScreenManager.cs
@@ -21,6 +21,10 @@ namespace MediaBrowser.Controller.Library
         bool GetUserFeatureEnabled(Guid userId);
 
         void SetUserFeatureEnabled(Guid userId, bool enabled);
+
+        ModularHomeUserSettings GetUserSettings(Guid userId);
+
+        bool UpdateUserSettings(Guid userId, ModularHomeUserSettings userSettings);
     }
 
     public interface IHomeScreenSection
@@ -50,6 +54,12 @@ namespace MediaBrowser.Controller.Library
 
         public string AdditionalData { get; set; }
 
+    }
+
+    public class ModularHomeUserSettings
+    {
+        public Guid UserId { get; set; }
+        public List<string> EnabledSections { get; set; } = new List<string>();
     }
 
     public static class HomeScreenSectionExtensions

--- a/MediaBrowser.Controller/Library/IHomeScreenManager.cs
+++ b/MediaBrowser.Controller/Library/IHomeScreenManager.cs
@@ -55,18 +55,16 @@ namespace MediaBrowser.Controller.Library
     public static class HomeScreenSectionExtensions
     {
 
-        public static BaseItemDto AsBaseItem(this IHomeScreenSection section)
+        public static HomeScreenSectionInfo AsInfo(this IHomeScreenSection section)
         {
-#pragma warning disable CA1305 // Specify IFormatProvider
-            return new BaseItemDto
+            return new HomeScreenSectionInfo
             {
-                Name = section.Section,
-                OriginalTitle = section.DisplayText,
-                ChannelNumber = section.Limit.ToString(),
-                SortName = section.Route,
-                Overview = section.AdditionalData
+                Section = section.Section,
+                DisplayText = section.DisplayText,
+                AdditionalData = section.AdditionalData,
+                Route = section.Route,
+                Limit = section.Limit
             };
-#pragma warning restore CA1305 // Specify IFormatProvider
         }
     }
 }

--- a/MediaBrowser.Controller/Library/IHomeScreenManager.cs
+++ b/MediaBrowser.Controller/Library/IHomeScreenManager.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Controller.Library
         /// <summary>
         /// Get the registered <see cref="IHomeScreenSection"/> instances.
         /// </summary>
-        /// <returns>Array of <see cref="IHomeScreenSection"/></returns>
+        /// <returns>Array of <see cref="IHomeScreenSection"/>.</returns>
         IEnumerable<IHomeScreenSection> GetSectionTypes();
 
         /// <summary>
@@ -37,14 +37,14 @@ namespace MediaBrowser.Controller.Library
         /// Gets whether the user has the Modular Home feature enabled.
         /// </summary>
         /// <param name="userId">The user ID.</param>
-        /// <returns>Enabled state</returns>
+        /// <returns>Enabled state.</returns>
         bool GetUserFeatureEnabled(Guid userId);
 
         /// <summary>
         /// Sets the state for whether the user has the Modular Home feature enabled or not.
         /// </summary>
         /// <param name="userId">The user ID.</param>
-        /// <param name="enabled">Is the feature enabled or not?</param>
+        /// <param name="enabled">Is the feature enabled or not.</param>
         void SetUserFeatureEnabled(Guid userId, bool enabled);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace MediaBrowser.Controller.Library
         public string? DisplayText { get; set; }
 
         /// <summary>
-        /// Limit of the number of these sections a single user can see at once. (Usually 1)
+        /// Limit of the number of these sections a single user can see at once. (Usually 1).
         /// </summary>
         public int? Limit { get; }
 
@@ -107,22 +107,22 @@ namespace MediaBrowser.Controller.Library
     public class HomeScreenSectionInfo
     {
         /// <summary>
-        /// Section ID
+        /// Section ID.
         /// </summary>
         public string? Section { get; set; }
 
         /// <summary>
-        /// DisplayText
+        /// DisplayText.
         /// </summary>
         public string? DisplayText { get; set; }
 
         /// <summary>
-        /// Display Limit
+        /// Display Limit.
         /// </summary>
         public int Limit { get; set; } = 1;
 
         /// <summary>
-        /// URL to navigation to
+        /// URL to navigation to.
         /// </summary>
         public string? Route { get; set; }
 

--- a/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
+++ b/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace MediaBrowser.Controller.Plugins
 {
     /// <summary>
-    /// Interface for PluginPagesManager
+    /// Interface for PluginPagesManager.
     /// </summary>
     public interface IPluginPagesManager
     {

--- a/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
+++ b/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.Plugins
+{
+    public interface IPluginPagesManager
+    {
+        void RegisterPluginPage(PluginPage page);
+
+        IEnumerable<PluginPage> GetPages();
+    }
+
+    public class PluginPage
+    {
+        public string Id { get; set; }
+
+        public string Url { get; set; }
+
+        public string DisplayText { get; set; }
+
+        public string Icon { get; set; }
+    }
+}

--- a/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
+++ b/MediaBrowser.Controller/Plugins/IPluginPagesManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,21 +6,48 @@ using System.Threading.Tasks;
 
 namespace MediaBrowser.Controller.Plugins
 {
+    /// <summary>
+    /// Interface for PluginPagesManager
+    /// </summary>
     public interface IPluginPagesManager
     {
+        /// <summary>
+        /// Register an instance of a <see cref="PluginPage"/>.
+        /// </summary>
+        /// <param name="page">The page to register.</param>
         void RegisterPluginPage(PluginPage page);
 
+        /// <summary>
+        /// Get a list of the registered pages.
+        /// </summary>
+        /// <returns>Array of <see cref="PluginPage"/>.</returns>
         IEnumerable<PluginPage> GetPages();
     }
 
+    /// <summary>
+    /// Description for a page a Plugin is providing to the frontend.
+    /// Used to populate the hamburger menu with options.
+    /// </summary>
     public class PluginPage
     {
-        public string Id { get; set; }
+        /// <summary>
+        /// The ID of the page.
+        /// </summary>
+        public string? Id { get; set; }
 
-        public string Url { get; set; }
+        /// <summary>
+        /// The URL to the HTML the plugin is serving.
+        /// </summary>
+        public string? Url { get; set; }
 
-        public string DisplayText { get; set; }
+        /// <summary>
+        /// What the display text should be.
+        /// </summary>
+        public string? DisplayText { get; set; }
 
-        public string Icon { get; set; }
+        /// <summary>
+        /// What material icon should be displayed in the menu.
+        /// </summary>
+        public string? Icon { get; set; }
     }
 }

--- a/MediaBrowser.Model/Dto/HomeScreenSectionPayload.cs
+++ b/MediaBrowser.Model/Dto/HomeScreenSectionPayload.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+
+namespace MediaBrowser.Model.Dto
+{
+    public class HomeScreenSectionPayload
+    {
+        public Guid UserId { get; set; }
+
+        public string? AdditionalData { get; set; }
+    }
+}

--- a/MediaBrowser.Model/Dto/HomeScreenSectionPayload.cs
+++ b/MediaBrowser.Model/Dto/HomeScreenSectionPayload.cs
@@ -9,10 +9,20 @@ using MediaBrowser.Model.Querying;
 
 namespace MediaBrowser.Model.Dto
 {
+    /// <summary>
+    /// Payload created by provided data from the frontend to determine how to deal with how a home screen section should display.
+    /// </summary>
     public class HomeScreenSectionPayload
     {
+        /// <summary>
+        /// The UserId that's requesting the section data.
+        /// </summary>
         public Guid UserId { get; set; }
 
+        /// <summary>
+        /// Additional data is used to make the specific request more dynamic. It could be GetLatestMedia (tvshows/movies) or suggestions based on a genre.
+        /// There is no limit to what this value could be.
+        /// </summary>
         public string? AdditionalData { get; set; }
     }
 }

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -49,8 +49,12 @@
 
   <ItemGroup>
     <None Remove="Plugins\AudioDb\Configuration\config.html" />
+    <None Remove="Plugins\ModularHome\Config\settings.html" />
+    <None Remove="Plugins\ModularHome\Config\settings.js" />
     <EmbeddedResource Include="Plugins\AudioDb\Configuration\config.html" />
     <None Remove="Plugins\Omdb\Configuration\config.html" />
+    <EmbeddedResource Include="Plugins\ModularHome\Config\settings.html" />
+    <EmbeddedResource Include="Plugins\ModularHome\Config\settings.js" />
     <EmbeddedResource Include="Plugins\Omdb\Configuration\config.html" />
     <None Remove="Plugins\MusicBrainz\Configuration\config.html" />
     <EmbeddedResource Include="Plugins\MusicBrainz\Configuration\config.html" />

--- a/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
@@ -49,7 +49,7 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
         /// <summary>
         /// Get the section types that are registered in Modular Home.
         /// </summary>
-        /// <returns>Array of <see cref="HomeScreenSectionInfo"/></returns>
+        /// <returns>Array of <see cref="HomeScreenSectionInfo"/>.</returns>
         [HttpGet("Sections")]
         public QueryResult<HomeScreenSectionInfo> GetSectionTypes()
         {
@@ -79,7 +79,7 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
         /// Get the user settings for Modular Home.
         /// </summary>
         /// <param name="userId">The user ID.</param>
-        /// <returns><see cref="ModularHomeUserSettings"/></returns>
+        /// <returns><see cref="ModularHomeUserSettings"/>.</returns>
         [HttpGet("UserSettings")]
         public ActionResult<ModularHomeUserSettings> GetUserSettings([FromQuery] Guid userId)
         {
@@ -92,8 +92,8 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
         /// <summary>
         /// Update the user settings for Modular Home.
         /// </summary>
-        /// <param name="obj">Instance of <see cref="ModularHomeUserSettings" /></param>
-        /// <returns>Status</returns>
+        /// <param name="obj">Instance of <see cref="ModularHomeUserSettings" />.</param>
+        /// <returns>Status.</returns>
         [HttpPost("UserSettings")]
         public ActionResult UpdateSettings([FromBody] ModularHomeUserSettings obj)
         {

--- a/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
@@ -58,6 +58,19 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
             return new QueryResult<HomeScreenSectionInfo>(null, items.Count, items);
         }
 
+        [HttpGet("UserSettings")]
+        public ActionResult<ModularHomeUserSettings> GetUserSettings([FromQuery] Guid userId)
+        {
+            return _homeScreenManager.GetUserSettings(userId);
+        }
+
+        [HttpPost("UserSettings")]
+        public ActionResult UpdateSettings([FromBody] ModularHomeUserSettings obj)
+        {
+            _homeScreenManager.UpdateUserSettings(obj.UserId, obj);
+
+            return Ok();
+        }
         // TODO: Add support for saving the section types being enabled/disabled.
 
         private ActionResult ServeView(string viewName)

--- a/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Providers.Plugins.ModularHome.Api
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class ModularHomeViewsController : ControllerBase
+    {
+        private readonly ILogger<ModularHomeViewsController> _logger;
+        private readonly IHomeScreenManager _homeScreenManager;
+
+        public ModularHomeViewsController(ILogger<ModularHomeViewsController> logger, IHomeScreenManager homeScreenManager)
+        {
+            _logger = logger;
+            _homeScreenManager = homeScreenManager;
+        }
+
+        [HttpGet("{viewName}")]
+        public ActionResult GetView([FromRoute] string viewName)
+        {
+            return ServeView(viewName);
+        }
+
+        [HttpGet("Sections")]
+        public QueryResult<HomeScreenSectionInfo> GetSectionTypes()
+        {
+            // Todo add reading whether the section is enabled or disabled by the user.
+            List<HomeScreenSectionInfo> items = new List<HomeScreenSectionInfo>();
+
+            IEnumerable<IHomeScreenSection> sections = _homeScreenManager.GetSectionTypes();
+
+            foreach (IHomeScreenSection section in sections)
+            {
+                HomeScreenSectionInfo item = new HomeScreenSectionInfo
+                {
+                    Section = section.Section,
+                    DisplayText = section.DisplayText,
+                    AdditionalData = section.AdditionalData,
+                    Route = section.Route,
+                    Limit = section.Limit
+                };
+
+                items.Add(item);
+            }
+
+            return new QueryResult<HomeScreenSectionInfo>(null, items.Count, items);
+        }
+
+        // TODO: Add support for saving the section types being enabled/disabled.
+
+        private ActionResult ServeView(string viewName)
+        {
+            if (Plugin.Instance == null)
+            {
+                return BadRequest("No plugin instance found");
+            }
+
+            IEnumerable<PluginPageInfo> pages = Plugin.Instance.GetViews();
+
+            if (pages == null)
+            {
+                return NotFound("Pages is null or empty");
+            }
+
+            var view = pages.FirstOrDefault(pageInfo => pageInfo.Name == viewName, null);
+
+            if (view == null)
+            {
+                return NotFound("No matching view found");
+            }
+
+            Stream? stream = Plugin.Instance.GetType().Assembly.GetManifestResourceStream(view.EmbeddedResourcePath);
+
+            if (stream == null)
+            {
+                _logger.LogError("Failed to get resource {Resource}", view.EmbeddedResourcePath);
+                return NotFound();
+            }
+
+            return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath));
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Api/ModularHomeViewsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,6 +14,9 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.Plugins.ModularHome.Api
 {
+    /// <summary>
+    /// API controller for Modular Home plugin.
+    /// </summary>
     [ApiController]
     [Route("[controller]")]
     public class ModularHomeViewsController : ControllerBase
@@ -21,18 +24,32 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
         private readonly ILogger<ModularHomeViewsController> _logger;
         private readonly IHomeScreenManager _homeScreenManager;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="logger">Instance of <see cref="ILogger"/> interface.</param>
+        /// <param name="homeScreenManager">Instance of <see cref="IHomeScreenManager"/> interface.</param>
         public ModularHomeViewsController(ILogger<ModularHomeViewsController> logger, IHomeScreenManager homeScreenManager)
         {
             _logger = logger;
             _homeScreenManager = homeScreenManager;
         }
 
+        /// <summary>
+        /// Get the view for the plugin.
+        /// </summary>
+        /// <param name="viewName">The view identifier.</param>
+        /// <returns>View.</returns>
         [HttpGet("{viewName}")]
         public ActionResult GetView([FromRoute] string viewName)
         {
             return ServeView(viewName);
         }
 
+        /// <summary>
+        /// Get the section types that are registered in Modular Home.
+        /// </summary>
+        /// <returns>Array of <see cref="HomeScreenSectionInfo"/></returns>
         [HttpGet("Sections")]
         public QueryResult<HomeScreenSectionInfo> GetSectionTypes()
         {
@@ -49,7 +66,7 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
                     DisplayText = section.DisplayText,
                     AdditionalData = section.AdditionalData,
                     Route = section.Route,
-                    Limit = section.Limit
+                    Limit = section.Limit ?? 1
                 };
 
                 items.Add(item);
@@ -58,12 +75,25 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
             return new QueryResult<HomeScreenSectionInfo>(null, items.Count, items);
         }
 
+        /// <summary>
+        /// Get the user settings for Modular Home.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <returns><see cref="ModularHomeUserSettings"/></returns>
         [HttpGet("UserSettings")]
         public ActionResult<ModularHomeUserSettings> GetUserSettings([FromQuery] Guid userId)
         {
-            return _homeScreenManager.GetUserSettings(userId);
+            return _homeScreenManager.GetUserSettings(userId) ?? new ModularHomeUserSettings
+            {
+                UserId = userId
+            };
         }
 
+        /// <summary>
+        /// Update the user settings for Modular Home.
+        /// </summary>
+        /// <param name="obj">Instance of <see cref="ModularHomeUserSettings" /></param>
+        /// <returns>Status</returns>
         [HttpPost("UserSettings")]
         public ActionResult UpdateSettings([FromBody] ModularHomeUserSettings obj)
         {
@@ -71,7 +101,6 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
 
             return Ok();
         }
-        // TODO: Add support for saving the section types being enabled/disabled.
 
         private ActionResult ServeView(string viewName)
         {
@@ -87,7 +116,7 @@ namespace MediaBrowser.Providers.Plugins.ModularHome.Api
                 return NotFound("Pages is null or empty");
             }
 
-            var view = pages.FirstOrDefault(pageInfo => pageInfo.Name == viewName, null);
+            var view = pages.FirstOrDefault(pageInfo => pageInfo?.Name == viewName, null);
 
             if (view == null)
             {

--- a/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.html
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.html
@@ -1,0 +1,22 @@
+<script defer>
+    import("/ModularHomeViews/settings.js").then((renderer) => {
+        const view = document.querySelector("#config-page");
+
+        renderer.default(view);
+    });
+</script>
+<form id="config-page" class="configForm" style="margin: 0 auto;">
+    <div class="verticalSection verticalSection-extrabottompadding">
+        <h2 class="sectionTitle">Modular Home  - Settings:</h2>
+
+        <div class="verticalSection verticalSection-extrabottompadding">
+            <label class="checkboxContainer">
+                <input is="emby-checkbox" type="checkbox" id="modularHomeEnabled" />
+                <span>Enable "Modular Home". This will change your home screen into a more dynamic screen with options from other plugins to be able to contribute into what you see and are recommended.</span>
+            </label>
+        </div>
+    </div>
+    <button is="emby-button" type="submit" class="raised button-submit block btnSave">
+        <span>Save</span>
+    </button>
+</form>

--- a/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.html
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.html
@@ -15,6 +15,13 @@
                 <span>Enable "Modular Home". This will change your home screen into a more dynamic screen with options from other plugins to be able to contribute into what you see and are recommended.</span>
             </label>
         </div>
+
+        <div class="verticalSection verticalSection-extrabottompadding">
+            <h3>Enabled Sections</h3>
+            <div id="enabledSections">
+            </div>
+        </div>
+
     </div>
     <button is="emby-button" type="submit" class="raised button-submit block btnSave">
         <span>Save</span>

--- a/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.js
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.js
@@ -5,6 +5,45 @@ const config = {
             document.querySelector('#modularHomeEnabled').checked = userSettings.CustomPrefs['useModularHome'] === 'true';
         });
 
+        ApiClient.fetch({
+            url: '/ModularHomeViews/UserSettings?userId=' + ApiClient.getCurrentUserId(),
+            type: 'GET',
+            dataType: 'json',
+            headers: {
+                accept: 'application/json'
+            }
+        }).then(function (settings) {
+            ApiClient.fetch({
+                url: '/ModularHomeViews/Sections',
+                type: 'GET',
+                dataType: 'json',
+                headers: {
+                    accept: 'application/json'
+                }
+            }).then(function (response) {
+                if (response.TotalRecordCount > 0) {
+
+                    let html = '';
+                    for (let i = 0; i < response.TotalRecordCount; ++i) {
+                        let section = response.Items[i];
+
+                        let checked = false;
+                        if (settings.EnabledSections.includes(section.Section)) {
+                            checked = true;
+                        }
+
+                        html += '<label class="checkboxContainer">';
+                        html += '<input is="emby-checkbox" type="checkbox" class="sectionEnabledCheckbox" data-section="' + section.Section + '" ' + (checked ? 'checked' : '') + ' />';
+                        html += '<span>' + section.DisplayText + '</span>';
+                        html += '</label>';
+                    }
+
+                    let elem = document.querySelector('#enabledSections');
+                    elem.innerHTML = html;
+                }
+            });
+        });
+
         document.querySelector('.configForm')
             .addEventListener('submit', function (e) {
                 ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
@@ -12,6 +51,28 @@ const config = {
 
                     ApiClient.updateDisplayPreferences('usersettings', userSettings, ApiClient.getCurrentUserId(), 'emby');
                 });
+
+                let data = {
+                    UserId: ApiClient.getCurrentUserId(),
+                    EnabledSections: []
+                };
+
+                let checkboxes = document.querySelectorAll('.sectionEnabledCheckbox');
+
+                checkboxes.forEach(function (checkbox) {
+                    let sectionId = checkbox.getAttribute('data-section');
+
+                    if (checkbox.checked) {
+                        data.EnabledSections.push(sectionId);
+                    }
+                });
+
+                ApiClient.ajax({
+                    url: '/ModularHomeViews/UserSettings',
+                    type: 'POST',
+                    data: JSON.stringify(data),
+                    contentType: 'application/json'
+                })
 
                 e.preventDefault();
                 return false;

--- a/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.js
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Config/settings.js
@@ -1,0 +1,25 @@
+
+const config = {
+    setup: (view) => {
+        ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
+            document.querySelector('#modularHomeEnabled').checked = userSettings.CustomPrefs['useModularHome'] === 'true';
+        });
+
+        document.querySelector('.configForm')
+            .addEventListener('submit', function (e) {
+                ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
+                    userSettings.CustomPrefs['useModularHome'] = document.querySelector('#modularHomeEnabled').checked ? 'true' : 'false';
+
+                    ApiClient.updateDisplayPreferences('usersettings', userSettings, ApiClient.getCurrentUserId(), 'emby');
+                });
+
+                e.preventDefault();
+                return false;
+            });
+    }
+}
+
+
+export default function (view) {
+    config.setup(view);
+}

--- a/MediaBrowser.Providers/Plugins/ModularHome/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Configuration/PluginConfiguration.cs
@@ -8,6 +8,9 @@ using MediaBrowser.Model.Plugins;
 
 namespace MediaBrowser.Providers.Plugins.ModularHome.Configuration
 {
+    /// <summary>
+    /// PluginConfiguration for Modular Home.
+    /// </summary>
     public class PluginConfiguration : BasePluginConfiguration
     {
         /// <summary>

--- a/MediaBrowser.Providers/Plugins/ModularHome/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Configuration/PluginConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using MediaBrowser.Model.Plugins;
+
+namespace MediaBrowser.Providers.Plugins.ModularHome.Configuration
+{
+    public class PluginConfiguration : BasePluginConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
+        /// </summary>
+        public PluginConfiguration()
+        {
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json.Linq;
 namespace MediaBrowser.Providers.Plugins.ModularHome
 {
     /// <summary>
-    /// Modular Home Plugin
+    /// Modular Home Plugin.
     /// </summary>
     public class Plugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     {
@@ -69,7 +69,7 @@ namespace MediaBrowser.Providers.Plugins.ModularHome
         /// <summary>
         /// Get the views that the plugin serves.
         /// </summary>
-        /// <returns>Array of <see cref="PluginPageInfo"/></returns>
+        /// <returns>Array of <see cref="PluginPageInfo"/>.</returns>
         public IEnumerable<PluginPageInfo> GetViews()
         {
             return new[]

--- a/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Providers.Plugins.ModularHome.Configuration;
+using Newtonsoft.Json.Linq;
+
+namespace MediaBrowser.Providers.Plugins.ModularHome
+{
+    public class Plugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
+    {
+        public static Plugin Instance { get; private set; }
+
+        public override Guid Id => Guid.Parse("eb1cd147-f300-4860-a087-c85a07d6ab94");
+
+        public override string Name => "ModularHome";
+
+        public override string Description => "Enables functionality to have a more dynamic home screen, sections can be added by other plugins and each user can configure what does and doesn't appear on their homescreen.";
+
+        public override string ConfigurationFileName => "Jellyfin.Plugin.ModularHome.xml";
+
+        private const string ConfigFile = "config.json";
+
+        private readonly IPluginPagesManager _pluginPagesManager;
+
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, IPluginPagesManager pluginPagesManager)
+            : base(applicationPaths, xmlSerializer)
+        {
+            Instance = this;
+
+            _pluginPagesManager = pluginPagesManager;
+
+            _pluginPagesManager.RegisterPluginPage(new PluginPage
+            {
+                Id = "ModularHome",
+                DisplayText = "Modular Home",
+                Url = "/ModularHomeViews/settings",
+                Icon = "ballot"
+            });
+        }
+
+        public IEnumerable<PluginPageInfo> GetPages()
+        {
+            return Array.Empty<PluginPageInfo>();
+        }
+
+        public IEnumerable<PluginPageInfo> GetViews()
+        {
+            return new[]
+            {
+                new PluginPageInfo
+                {
+                    Name = "settings",
+                    EmbeddedResourcePath = $"{GetType().Namespace}.Config.settings.html"
+                },
+                new PluginPageInfo
+                {
+                    Name = "settings.js",
+                    EmbeddedResourcePath = $"{GetType().Namespace}.Config.settings.js"
+                },
+            };
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/ModularHome/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,22 +14,36 @@ using Newtonsoft.Json.Linq;
 
 namespace MediaBrowser.Providers.Plugins.ModularHome
 {
+    /// <summary>
+    /// Modular Home Plugin
+    /// </summary>
     public class Plugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     {
-        public static Plugin Instance { get; private set; }
+        /// <summary>
+        /// Static Instance of this.
+        /// </summary>
+        public static Plugin? Instance { get; private set; }
 
+        /// <inheritdoc/>
         public override Guid Id => Guid.Parse("eb1cd147-f300-4860-a087-c85a07d6ab94");
 
+        /// <inheritdoc/>
         public override string Name => "ModularHome";
 
+        /// <inheritdoc/>
         public override string Description => "Enables functionality to have a more dynamic home screen, sections can be added by other plugins and each user can configure what does and doesn't appear on their homescreen.";
 
+        /// <inheritdoc/>
         public override string ConfigurationFileName => "Jellyfin.Plugin.ModularHome.xml";
-
-        private const string ConfigFile = "config.json";
 
         private readonly IPluginPagesManager _pluginPagesManager;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="applicationPaths">Instance of <see cref="IApplicationPaths"/> interface.</param>
+        /// <param name="xmlSerializer">Instance of <see cref="IXmlSerializer"/> interface.</param>
+        /// <param name="pluginPagesManager">Instance of <see cref="IPluginPagesManager"/> interface.</param>
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, IPluginPagesManager pluginPagesManager)
             : base(applicationPaths, xmlSerializer)
         {
@@ -46,11 +60,16 @@ namespace MediaBrowser.Providers.Plugins.ModularHome
             });
         }
 
+        /// <inheritdoc/>
         public IEnumerable<PluginPageInfo> GetPages()
         {
             return Array.Empty<PluginPageInfo>();
         }
 
+        /// <summary>
+        /// Get the views that the plugin serves.
+        /// </summary>
+        /// <returns>Array of <see cref="PluginPageInfo"/></returns>
         public IEnumerable<PluginPageInfo> GetViews()
         {
             return new[]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Add support to have a modular (extensible) home screen that can be modified by the user and added to by plugins.
- Add support for plugins to serve pages that any user (not just admins) can see.
- The support is hidden behind a user preference and the old home screen layout is left untouched.

**Known Issues**
- Currently only 5 of the home screen sections have been ported into the new system: My Media, Continue Watching, Next Up, Latest Movies and Latest Shows. The other types will need to be added in due course.
- Settings are limited and currently use a json file for storing the settings rather than the database.

**Linked PRs**
https://github.com/jellyfin/jellyfin-web/pull/3740
https://github.com/jellyfin/jellyfin-apiclient-javascript/pull/422