### PR TITLE
Fix intel dx11-ocl interop taking too long to initialize on windows

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4503,7 +4503,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                     if (isD3d11Supported && isCodecAvailable)
                     {
-                        return " -hwaccel d3d11va" + (outputHwSurface ? " -hwaccel_output_format d3d11" : string.Empty) + (isAv1 ? " -c:v av1" : string.Empty);
+                        // set -threads 3 to intel d3d11va decoder explicitly. Lower threads may result in dead lock.
+                        // on newer devices such as Xe, the larger the init_pool_size, the longer the initialization time for opencl to derive from d3d11.
+                        return " -hwaccel d3d11va" + (outputHwSurface ? " -hwaccel_output_format d3d11" : string.Empty) + " -threads 3" + (isAv1 ? " -c:v av1" : string.Empty);
                     }
                 }
                 else


### PR DESCRIPTION
**Changes**
- Fix intel dx11-ocl interop taking too long to initialize on windows

**Issues**
Without this, QSV+OpenCL filtering takes 10s or longer to initialize. With this, it will be reduced to 1~3s.
Newer iGPU such as Xe graphics is affected.