### PR TITLE
fix copy&paste error for requestedRangeTypes preventing stream copy

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1713,6 +1713,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Can't stream copy if we're burning in subtitles
             if (request.SubtitleStreamIndex.HasValue
+                && request.SubtitleStreamIndex.Value >= 0
                 && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode)
             {
                 return false;
@@ -1760,7 +1761,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             var requestedRangeTypes = state.GetRequestedRangeTypes(videoStream.Codec);
-            if (requestedProfiles.Length > 0)
+            if (requestedRangeTypes.Length > 0)
             {
                 if (string.IsNullOrEmpty(videoStream.VideoRangeType))
                 {


### PR DESCRIPTION
**Changes**
- fix copy&paste error for `requestedRangeTypes` preventing stream copy
- fix invalid _(-1)_ SubtitleStreamIndex preventing stream copy

Negative/invalid SubtitleStreamIndex values should also be ignored and allow stream copy.

fixes #8070 
fixes #7880 _(probably)_

