### PR TITLE
set collection ProductionYear metadata to newest Movie instead of oldest

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -424,7 +424,7 @@ namespace MediaBrowser.Providers.Manager
                 return updateType;
             }
 
-            var date = children.Select(i => i.PremiereDate ?? DateTime.MaxValue).Min();
+            var date = children.Select(i => i.PremiereDate ?? DateTime.MinValue).Max();
 
             var originalPremiereDate = item.PremiereDate;
             var originalProductionYear = item.ProductionYear;
@@ -436,7 +436,7 @@ namespace MediaBrowser.Providers.Manager
             }
             else
             {
-                var year = children.Select(i => i.ProductionYear ?? 0).Min();
+                var year = children.Select(i => i.ProductionYear ?? 0).Max();
 
                 if (year > 0)
                 {


### PR DESCRIPTION
Set collection ProductionYear to newest Movie instead of oldest so
that collections show up in newer location during sorting.

Fixes #8079

Signed-off-by: Scott Branden <sbranden@gmail.com>

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
