### PR TITLE
Move transcodes to be under CachePath

### DIFF
--- a/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
+++ b/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
@@ -32,7 +32,7 @@ namespace MediaBrowser.Common.Configuration
             var transcodingTempPath = configurationManager.GetEncodingOptions().TranscodingTempPath;
             if (string.IsNullOrEmpty(transcodingTempPath))
             {
-                transcodingTempPath = Path.Combine(configurationManager.CommonApplicationPaths.ProgramDataPath, "transcodes");
+                transcodingTempPath = Path.Combine(configurationManager.CommonApplicationPaths.CachePath, "transcodes");
             }
 
             // Make sure the directory exists


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Move transcodes to be under CachePath instead of ProgramDataPath.

Since transcodes are ephemeral (they're cleaned up periodically and recreated if they don't exist), they're more like cache data than program data. Systems can (and oftentimes do) have the cache directory on a different disk, use a different type of file system, or have a different backup policy for the cache path because it contains ephemeral data.

**Issues**
This PR doesn't exactly solve the following issues, but it is related to them, as it changes jellyfin to use a more appropriate path for these temporary files which makes it more likely that the system will be configured to handle this data more appropriately avoiding these issues:
https://github.com/jellyfin/jellyfin/issues/4893
https://github.com/jellyfin/jellyfin/issues/3929