### PR TITLE
Calculate output audio bitrate from output channel count

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1693,14 +1693,25 @@ namespace Jellyfin.Api.Controllers
 
                 audioTranscodeParams += "-acodec " + audioCodec;
 
-                if (state.OutputAudioBitrate.HasValue)
+                var audioBitrate = state.OutputAudioBitrate;
+                var audioChannels = state.OutputAudioChannels;
+
+                if (audioBitrate.HasValue)
                 {
-                    audioTranscodeParams += " -ab " + state.OutputAudioBitrate.Value.ToString(CultureInfo.InvariantCulture);
+                    string vbrParam;
+                    if (_encodingOptions.EnableAudioVbr && (vbrParam = _encodingHelper.GetAudioVbrModeParam(state.OutputAudioCodec, audioBitrate.Value / audioChannels ?? 2)) != null)
+                    {
+                        audioTranscodeParams += vbrParam;
+                    }
+                    else
+                    {
+                        audioTranscodeParams += " -ab " + audioBitrate.Value.ToString(CultureInfo.InvariantCulture);
+                    }
                 }
 
-                if (state.OutputAudioChannels.HasValue)
+                if (audioChannels.HasValue)
                 {
-                    audioTranscodeParams += " -ac " + state.OutputAudioChannels.Value.ToString(CultureInfo.InvariantCulture);
+                    audioTranscodeParams += " -ac " + audioChannels.Value.ToString(CultureInfo.InvariantCulture);
                 }
 
                 if (state.OutputAudioSampleRate.HasValue)
@@ -1748,7 +1759,15 @@ namespace Jellyfin.Api.Controllers
 
             if (bitrate.HasValue)
             {
-                args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+                string vbrParam;
+                if (_encodingOptions.EnableAudioVbr && (vbrParam = _encodingHelper.GetAudioVbrModeParam(state.OutputAudioCodec, bitrate.Value / channels ?? 2)) != null)
+                {
+                    args += vbrParam;
+                }
+                else
+                {
+                    args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+                }
             }
 
             if (state.OutputAudioSampleRate.HasValue)

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -217,7 +217,7 @@ namespace Jellyfin.Api.Helpers
                         sdrVideoUrl += "&AllowVideoStreamCopy=false";
 
                         var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
-                        var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream) ?? 0;
+                        var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream, state.OutputAudioChannels) ?? 0;
                         var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
 
                         AppendPlaylist(builder, state, sdrVideoUrl, sdrTotalBitrate, subtitleGroup);

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -184,11 +184,11 @@ namespace Jellyfin.Api.Helpers
 
             state.OutputContainer = (containerInternal ?? string.Empty).TrimStart('.');
 
-            state.OutputAudioBitrate = encodingHelper.GetAudioBitrateParam(streamingRequest.AudioBitRate, streamingRequest.AudioCodec, state.AudioStream);
-
             state.OutputAudioCodec = streamingRequest.AudioCodec;
 
             state.OutputAudioChannels = encodingHelper.GetNumAudioChannelsParam(state, state.AudioStream, state.OutputAudioCodec);
+
+            state.OutputAudioBitrate = encodingHelper.GetAudioBitrateParam(streamingRequest.AudioBitRate, streamingRequest.AudioCodec, state.AudioStream, state.OutputAudioChannels);
 
             if (state.VideoRequest != null)
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2044,50 +2044,48 @@ namespace MediaBrowser.Controller.MediaEncoding
             return Convert.ToInt32(scaleFactor * bitrate);
         }
 
-        public int? GetAudioBitrateParam(BaseEncodingJobOptions request, MediaStream audioStream)
+        public int? GetAudioBitrateParam(BaseEncodingJobOptions request, MediaStream audioStream, int? outputAudioChannels)
         {
-            return GetAudioBitrateParam(request.AudioBitRate, request.AudioCodec, audioStream);
+            return GetAudioBitrateParam(request.AudioBitRate, request.AudioCodec, audioStream, outputAudioChannels);
         }
 
-        public int? GetAudioBitrateParam(int? audioBitRate, string audioCodec, MediaStream audioStream)
+        public int? GetAudioBitrateParam(int? audioBitRate, string audioCodec, MediaStream audioStream, int? outputAudioChannels)
         {
             if (audioStream == null)
             {
                 return null;
             }
 
-            if (audioBitRate.HasValue && string.IsNullOrEmpty(audioCodec))
+            var inputChannels = audioStream.Channels ?? 0;
+            var outputChannels = outputAudioChannels ?? 0;
+
+            if (audioBitRate.HasValue && (string.IsNullOrEmpty(audioCodec)
+                || string.Equals(audioCodec, "aac", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "mp3", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "opus", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "vorbis", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "ac3", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "eac3", StringComparison.OrdinalIgnoreCase)))
             {
-                return Math.Min(384000, audioBitRate.Value);
+                return (inputChannels, outputChannels) switch
+                {
+                    ( >= 6, >= 6 or 0) => Math.Min(640000, audioBitRate.Value),
+                    ( > 0, > 0) => Math.Min(outputChannels * 128000, audioBitRate.Value),
+                    ( > 0, _) => Math.Min(inputChannels * 128000, audioBitRate.Value),
+                    (_, _) => Math.Min(384000, audioBitRate.Value)
+                };
             }
 
-            if (audioBitRate.HasValue && !string.IsNullOrEmpty(audioCodec))
+            if (audioBitRate.HasValue && (string.Equals(audioCodec, "flac", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(audioCodec, "alac", StringComparison.OrdinalIgnoreCase)))
             {
-                if (string.Equals(audioCodec, "aac", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "mp3", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "opus", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "vorbis", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "ac3", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "eac3", StringComparison.OrdinalIgnoreCase))
+                if ((audioStream.Channels ?? 0) >= 6)
                 {
-                    if ((audioStream.Channels ?? 0) >= 6)
-                    {
-                        return Math.Min(640000, audioBitRate.Value);
-                    }
-
-                    return Math.Min(384000, audioBitRate.Value);
+                    return Math.Min(3584000, audioBitRate.Value);
                 }
 
-                if (string.Equals(audioCodec, "flac", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(audioCodec, "alac", StringComparison.OrdinalIgnoreCase))
-                {
-                    if ((audioStream.Channels ?? 0) >= 6)
-                    {
-                        return Math.Min(3584000, audioBitRate.Value);
-                    }
+                return Math.Min(1536000, audioBitRate.Value);
 
-                    return Math.Min(1536000, audioBitRate.Value);
-                }
             }
 
             // Empty bitrate area is not allow on iOS

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -10,6 +10,7 @@ namespace MediaBrowser.Model.Configuration
         public EncodingOptions()
         {
             EnableFallbackFont = false;
+            EnableAudioVbr = false;
             DownMixAudioBoost = 2;
             MaxMuxingQueueSize = 2048;
             EnableThrottling = false;
@@ -52,6 +53,8 @@ namespace MediaBrowser.Model.Configuration
         public string FallbackFontPath { get; set; }
 
         public bool EnableFallbackFont { get; set; }
+
+        public bool EnableAudioVbr { get; set; }
 
         public double DownMixAudioBoost { get; set; }
 


### PR DESCRIPTION
384kbps is unnecessarily high for stereo output with our encoders and sending data over network is expensive. This commit introduces logic for calculating output bitrate based on output channel count, like this:
```csharp
(inputChannels, outputChannels) switch
{
    ( >= 6, >= 6 or 0) => Math.Min(640000, audioBitRate.Value),
    ( > 0, > 0) => Math.Min(outputChannels * 128000, audioBitRate.Value),
    ( > 0, _) => Math.Min(inputChannels * 128000, audioBitRate.Value),
    (_, _) => Math.Min(384000, audioBitRate.Value)
}
```

That means transcoded stereo output in hls is going to be **at most** 256kbps, mono 128kbps, surround 640kbps, etc.

This is a relatively small change I hope could get to users before the next major version, therefore this PR is for 10.8.z.
