### PR TITLE
Pass referer parameter to ffmpeg

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -255,6 +255,21 @@ namespace MediaBrowser.Controller.MediaEncoding
             return string.Empty;
         }
 
+        /// <summary>
+        /// Gets the referer param.
+        /// </summary>
+        /// <param name="state">The state.</param>
+        /// <returns>System.String.</returns>
+        public string GetRefererParam(EncodingJobInfo state)
+        {
+            if (state.RemoteHttpHeaders.TryGetValue("Referer", out string referer))
+            {
+                return "-referer \"" + referer + "\"";
+            }
+
+            return string.Empty;
+        }
+
         public static string GetInputFormat(string container)
         {
             if (string.IsNullOrEmpty(container))
@@ -4958,6 +4973,15 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (!string.IsNullOrEmpty(userAgentParam))
             {
                 inputModifier += " " + userAgentParam;
+            }
+
+            inputModifier = inputModifier.Trim();
+
+            var refererParam = GetRefererParam(state);
+
+            if (!string.IsNullOrEmpty(refererParam))
+            {
+                inputModifier += " " + refererParam;
             }
 
             inputModifier = inputModifier.Trim();


### PR DESCRIPTION
Pass referer parameter to ffmpeg.

**Changes**
As of https://trac.ffmpeg.org/ticket/2179, ffmpeg supports referer parameter which injects Referer header to the HTTP request for remote content. Have EncodingHelper pass this in if it's included in RemoteHttpHeaders.

**Issues**
https://github.com/jellyfin/jellyfin/issues/8143
