### PR TITLE
Re-enable Remote Direct Stream

### DIFF
--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -6,6 +6,7 @@ using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.Models.StreamingDtos;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Dlna;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,15 +21,19 @@ namespace Jellyfin.Api.Controllers
     {
         private readonly AudioHelper _audioHelper;
 
+        private readonly IAuthorizationContext _authContext;
+
         private readonly TranscodingJobType _transcodingJobType = TranscodingJobType.Progressive;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioController"/> class.
         /// </summary>
         /// <param name="audioHelper">Instance of <see cref="AudioHelper"/>.</param>
-        public AudioController(AudioHelper audioHelper)
+        /// <param name="authContext">Instance of the <see cref="IAuthorizationContext"/> interface.</param>
+        public AudioController(AudioHelper audioHelper, IAuthorizationContext authContext)
         {
             _audioHelper = audioHelper;
+            _authContext = authContext;
         }
 
         /// <summary>
@@ -42,6 +47,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="deviceProfileId">Optional. The dlna device profile id to utilize.</param>
         /// <param name="playSessionId">The play session id.</param>
         /// <param name="segmentContainer">The segment container.</param>
+        /// <param name="segmentUri">Optional. URI of the segment if static stream is pointing at a playlist file.</param>
+        /// <param name="segmentToken">Optional. segment token for static stream.</param>
         /// <param name="segmentLength">The segment length.</param>
         /// <param name="minSegments">The minimum number of segments.</param>
         /// <param name="mediaSourceId">The media version id, if playing an alternate version.</param>
@@ -98,6 +105,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? deviceProfileId,
             [FromQuery] string? playSessionId,
             [FromQuery] string? segmentContainer,
+            [FromQuery] string? segmentUri,
+            [FromQuery] string? segmentToken,
             [FromQuery] int? segmentLength,
             [FromQuery] int? minSegments,
             [FromQuery] string? mediaSourceId,
@@ -150,6 +159,8 @@ namespace Jellyfin.Api.Controllers
                 DeviceProfileId = deviceProfileId,
                 PlaySessionId = playSessionId,
                 SegmentContainer = segmentContainer,
+                SegmentUri = segmentUri,
+                SegmentToken = segmentToken,
                 SegmentLength = segmentLength,
                 MinSegments = minSegments,
                 MediaSourceId = mediaSourceId,
@@ -193,7 +204,7 @@ namespace Jellyfin.Api.Controllers
                 StreamOptions = streamOptions
             };
 
-            return await _audioHelper.GetAudioStream(_transcodingJobType, streamingRequest).ConfigureAwait(false);
+            return await _audioHelper.GetAudioStream(Request, _transcodingJobType, streamingRequest).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -207,6 +218,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="deviceProfileId">Optional. The dlna device profile id to utilize.</param>
         /// <param name="playSessionId">The play session id.</param>
         /// <param name="segmentContainer">The segment container.</param>
+        /// <param name="segmentUri">Optional. URI of the segment if static stream is pointing at a playlist file.</param>
+        /// <param name="segmentToken">Optional. segment token for static stream.</param>
         /// <param name="segmentLength">The segment lenght.</param>
         /// <param name="minSegments">The minimum number of segments.</param>
         /// <param name="mediaSourceId">The media version id, if playing an alternate version.</param>
@@ -263,6 +276,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? deviceProfileId,
             [FromQuery] string? playSessionId,
             [FromQuery] string? segmentContainer,
+            [FromQuery] string? segmentUri,
+            [FromQuery] string? segmentToken,
             [FromQuery] int? segmentLength,
             [FromQuery] int? minSegments,
             [FromQuery] string? mediaSourceId,
@@ -315,6 +330,8 @@ namespace Jellyfin.Api.Controllers
                 DeviceProfileId = deviceProfileId,
                 PlaySessionId = playSessionId,
                 SegmentContainer = segmentContainer,
+                SegmentUri = segmentUri,
+                SegmentToken = segmentToken,
                 SegmentLength = segmentLength,
                 MinSegments = minSegments,
                 MediaSourceId = mediaSourceId,
@@ -358,7 +375,7 @@ namespace Jellyfin.Api.Controllers
                 StreamOptions = streamOptions
             };
 
-            return await _audioHelper.GetAudioStream(_transcodingJobType, streamingRequest).ConfigureAwait(false);
+            return await _audioHelper.GetAudioStream(Request, _transcodingJobType, streamingRequest).ConfigureAwait(false);
         }
     }
 }

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -259,7 +259,7 @@ namespace Jellyfin.Api.Controllers
                 Context = EncodingContext.Static
             };
 
-            return await _audioHelper.GetAudioStream(TranscodingJobType.Progressive, audioStreamingDto).ConfigureAwait(false);
+            return await _audioHelper.GetAudioStream(Request, TranscodingJobType.Progressive, audioStreamingDto).ConfigureAwait(false);
         }
 
         private DeviceProfile GetDeviceProfile(

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -267,6 +267,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="deviceProfileId">Optional. The dlna device profile id to utilize.</param>
         /// <param name="playSessionId">The play session id.</param>
         /// <param name="segmentContainer">The segment container.</param>
+        /// <param name="segmentUri">Optional. URI of the segment if static stream is pointing at a playlist file.</param>
+        /// <param name="segmentToken">Optional. segment token for static stream.</param>
         /// <param name="segmentLength">The segment length.</param>
         /// <param name="minSegments">The minimum number of segments.</param>
         /// <param name="mediaSourceId">The media version id, if playing an alternate version.</param>
@@ -325,6 +327,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? deviceProfileId,
             [FromQuery] string? playSessionId,
             [FromQuery] string? segmentContainer,
+            [FromQuery] string? segmentUri,
+            [FromQuery] string? segmentToken,
             [FromQuery] int? segmentLength,
             [FromQuery] int? minSegments,
             [FromQuery] string? mediaSourceId,
@@ -382,6 +386,8 @@ namespace Jellyfin.Api.Controllers
                 DeviceProfileId = deviceProfileId,
                 PlaySessionId = playSessionId,
                 SegmentContainer = segmentContainer,
+                SegmentUri = segmentUri,
+                SegmentToken = segmentToken,
                 SegmentLength = segmentLength,
                 MinSegments = minSegments,
                 MediaSourceId = mediaSourceId,
@@ -465,7 +471,8 @@ namespace Jellyfin.Api.Controllers
                 StreamingHelpers.AddDlnaHeaders(state, Response.Headers, true, state.Request.StartTimeTicks, Request, _dlnaManager);
 
                 var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, HttpContext).ConfigureAwait(false);
+                var authInfo = await _authContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
+                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, HttpContext, authInfo.Token).ConfigureAwait(false);
             }
 
             if (@static.HasValue && @static.Value && state.InputProtocol != MediaProtocol.File)
@@ -521,6 +528,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="deviceProfileId">Optional. The dlna device profile id to utilize.</param>
         /// <param name="playSessionId">The play session id.</param>
         /// <param name="segmentContainer">The segment container.</param>
+        /// <param name="segmentUri">Optional. URI of the segment if static stream is pointing at a playlist file.</param>
+        /// <param name="segmentToken">Optional. segment token for static stream.</param>
         /// <param name="segmentLength">The segment length.</param>
         /// <param name="minSegments">The minimum number of segments.</param>
         /// <param name="mediaSourceId">The media version id, if playing an alternate version.</param>
@@ -579,6 +588,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] string? deviceProfileId,
             [FromQuery] string? playSessionId,
             [FromQuery] string? segmentContainer,
+            [FromQuery] string? segmentUri,
+            [FromQuery] string? segmentToken,
             [FromQuery] int? segmentLength,
             [FromQuery] int? minSegments,
             [FromQuery] string? mediaSourceId,
@@ -632,6 +643,8 @@ namespace Jellyfin.Api.Controllers
                 deviceProfileId,
                 playSessionId,
                 segmentContainer,
+                segmentUri,
+                segmentToken,
                 segmentLength,
                 minSegments,
                 mediaSourceId,

--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -83,10 +83,12 @@ namespace Jellyfin.Api.Helpers
         /// <summary>
         /// Get audio stream.
         /// </summary>
+        /// <param name="request">HTTP request.</param>
         /// <param name="transcodingJobType">Transcoding job type.</param>
         /// <param name="streamingRequest">Streaming controller.Request dto.</param>
         /// <returns>A <see cref="Task"/> containing the resulting <see cref="ActionResult"/>.</returns>
         public async Task<ActionResult> GetAudioStream(
+            HttpRequest request,
             TranscodingJobType transcodingJobType,
             StreamingRequestDto streamingRequest)
         {
@@ -138,7 +140,8 @@ namespace Jellyfin.Api.Helpers
                 StreamingHelpers.AddDlnaHeaders(state, _httpContextAccessor.HttpContext.Response.Headers, true, streamingRequest.StartTimeTicks, _httpContextAccessor.HttpContext.Request, _dlnaManager);
 
                 var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, _httpContextAccessor.HttpContext).ConfigureAwait(false);
+                var authInfo = await _authContext.GetAuthorizationInfo(request).ConfigureAwait(false);
+                return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, _httpContextAccessor.HttpContext, authInfo.Token).ConfigureAwait(false);
             }
 
             if (streamingRequest.Static && state.InputProtocol != MediaProtocol.File)

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -239,12 +239,6 @@ namespace Jellyfin.Api.Helpers
 
             options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
 
-            if (!options.ForceDirectStream)
-            {
-                // direct-stream http streaming is currently broken
-                options.EnableDirectStream = false;
-            }
-
             // Beginning of Playback Determination
             var streamInfo = string.Equals(item.MediaType, MediaType.Audio, StringComparison.OrdinalIgnoreCase)
                 ? streamBuilder.BuildAudioItem(options)

--- a/Jellyfin.Api/Models/StreamingDtos/StreamingRequestDto.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamingRequestDto.cs
@@ -33,6 +33,16 @@ namespace Jellyfin.Api.Models.StreamingDtos
         public string? SegmentContainer { get; set; }
 
         /// <summary>
+        /// Gets or sets the segment URI.
+        /// </summary>
+        public string? SegmentUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the segment token for static stream.
+        /// </summary>
+        public string? SegmentToken { get; set; }
+
+        /// <summary>
         /// Gets or sets the segment length.
         /// </summary>
         public int? SegmentLength { get; set; }

--- a/tests/Jellyfin.Api.Tests/Helpers/FileStreamResponseHelpersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/FileStreamResponseHelpersTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Jellyfin.Api.Helpers;
+using Jellyfin.Api.Models.StreamingDtos;
+using Jellyfin.Data.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Helpers
+{
+    public static class FileStreamResponseHelpersTests
+    {
+        [Fact]
+        public static async void ProcessPlaylist_Success()
+        {
+            FileStreamResponseHelpers.SegmentUriHmacKey = "someKey";
+            var inputPlaylist = @"#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-KEY:METHOD=AES-128,URI=""http://media.example.com/key"",IV=someIV
+#EXT-X-MAP:URI=""/init.mp4""
+# Some comment
+
+#EXTINF:9.009,
+first.ts
+#EXTINF:9.009,
+//media.example.com/second.ts
+#EXTINF:3.003,
+https://media.example.com/third.ts";
+            var expectedOutput = @"#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-KEY:METHOD=""AES-128"",URI=""/Videos/someItemId/stream?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=http%3A%2F%2Fmedia.example.com%2Fkey&segmentToken=8RYTjz61eGPNqNJm4c7ebrqxJxi6XsXQ9fdpI6R0eLk%3D"",IV=""someIV""
+#EXT-X-MAP:URI=""/Videos/someItemId/stream.mp4?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=%2Finit.mp4&segmentToken=EFzS%2Fdnu2VjC7IkwQce0YEJiQPDYGujVHQjGxLRf2xo%3D""
+# Some comment
+
+#EXTINF:9.009,
+/Videos/someItemId/stream.ts?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=first.ts&segmentToken=4SQyEq01QE77FCYwCZk1MVL2XpzfneVeem7%2FMUkK3zo%3D
+#EXTINF:9.009,
+/Videos/someItemId/stream.ts?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=%2F%2Fmedia.example.com%2Fsecond.ts&segmentToken=JIyCHnuYGfiwKMPZ3DzxONI9oDyZIIbJNkarh2tYAkg%3D
+#EXTINF:3.003,
+/Videos/someItemId/stream.ts?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=https%3A%2F%2Fmedia.example.com%2Fthird.ts&segmentToken=m4TCMYK0lXtEzNZAfQkYErEK8gAaAoZcqeXIy5qnpDc%3D";
+            var result = await FileStreamResponseHelpers.ProcessPlaylist("someItemId", "someMediaSourceId", "someAccessToken", inputPlaylist);
+            Assert.Equal(expectedOutput, result.Content);
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Helpers/FileStreamResponseHelpersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/FileStreamResponseHelpersTests.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using Jellyfin.Api.Helpers;
-using Jellyfin.Api.Models.StreamingDtos;
-using Jellyfin.Data.Enums;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Moq;
 using Xunit;
 
 namespace Jellyfin.Api.Tests.Helpers
@@ -14,7 +6,7 @@ namespace Jellyfin.Api.Tests.Helpers
     public static class FileStreamResponseHelpersTests
     {
         [Fact]
-        public static async void ProcessPlaylist_Success()
+        public static async void RewriteUrisInM3UPlaylist_Success()
         {
             FileStreamResponseHelpers.SegmentUriHmacKey = "someKey";
             var inputPlaylist = @"#EXTM3U
@@ -41,7 +33,7 @@ https://media.example.com/third.ts";
 /Videos/someItemId/stream.ts?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=%2F%2Fmedia.example.com%2Fsecond.ts&segmentToken=JIyCHnuYGfiwKMPZ3DzxONI9oDyZIIbJNkarh2tYAkg%3D
 #EXTINF:3.003,
 /Videos/someItemId/stream.ts?static=true&mediaSourceId=someMediaSourceId&api_key=someAccessToken&segmentUri=https%3A%2F%2Fmedia.example.com%2Fthird.ts&segmentToken=m4TCMYK0lXtEzNZAfQkYErEK8gAaAoZcqeXIy5qnpDc%3D";
-            var result = await FileStreamResponseHelpers.ProcessPlaylist("someItemId", "someMediaSourceId", "someAccessToken", inputPlaylist);
+            var result = await FileStreamResponseHelpers.RewriteUrisInM3UPlaylist("someItemId", "someMediaSourceId", "someAccessToken", inputPlaylist);
             Assert.Equal(expectedOutput, result.Content);
         }
     }


### PR DESCRIPTION
Add partial content support to Static Remote Stream

**Changes**
This change adds partial content support to Static Remote Stream by allowing Range-related HTTP headers to be passed through.

**Issues**
https://github.com/jellyfin/jellyfin/issues/8145
