### PR TITLE
Fix support for rtsp streams over tcp

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4970,7 +4970,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.InputProtocol == MediaProtocol.Rtsp)
             {
-                inputModifier += " -rtsp_transport tcp -rtsp_transport udp -rtsp_flags prefer_tcp";
+                inputModifier += " -rtsp_transport tcp+udp -rtsp_flags prefer_tcp";
             }
 
             if (!string.IsNullOrEmpty(state.InputAudioSync))


### PR DESCRIPTION
**Changes**
Fixes the ffmpeg parameters for rtsp over tcp streams. The previous parameters caused udp streams to be the only ones supported. 

Related ffmpeg mailing list post: https://lists.ffmpeg.org/pipermail/ffmpeg-user/2017-January/034958.html

**Issues**
Fixes #7630 
