### PR TITLE
Don't refresh playlists on album refresh

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -12,7 +12,6 @@ using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -12,6 +12,7 @@ using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
@@ -169,8 +170,8 @@ namespace MediaBrowser.Controller.Entities.Audio
 
             var childUpdateType = ItemUpdateType.None;
 
-            // Refresh songs
-            foreach (var item in items)
+            // Refresh songs only and not m3u files in album folder
+            foreach (var item in items.OfType<Audio>())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
**Changes**
Change music album refresh to not refresh child playlists

Note: playlists created in Jellyfin containing songs from an album are not included in `items` and are not being refreshed. So this change should not affect custom playlists

**Issues**
Fixes #3088 