### PR TITLE
Add back library scan from library manager

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2454,6 +2454,12 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <inheritdoc />
+        public void QueueLibraryScan()
+        {
+            _taskManager.QueueScheduledTask<RefreshMediaLibraryTask>();
+        }
+
+        /// <inheritdoc />
         public int? GetSeasonNumberFromPath(string path)
             => SeasonPathParser.Parse(path, true, true).SeasonNumber;
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -570,5 +570,13 @@ namespace MediaBrowser.Controller.Library
         Task RunMetadataSavers(BaseItem item, ItemUpdateType updateReason);
 
         BaseItem GetParentItem(Guid? parentId, Guid? userId);
+
+        /// <summary>
+        /// Queue a library scan.
+        /// </summary>
+        /// <remarks>
+        /// This exists so plugins can trigger a library scan.
+        /// </remarks>
+        void QueueLibraryScan();
     }
 }


### PR DESCRIPTION
This was removed in https://github.com/jellyfin/jellyfin/pull/7326 but I think it should exist