### PR TITLE
Fix high single thread usage in throttler

### DIFF
--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -654,7 +654,7 @@ namespace Jellyfin.Api.Helpers
         {
             if (EnableThrottling(state))
             {
-                transcodingJob.TranscodingThrottler = new TranscodingThrottler(transcodingJob, new Logger<TranscodingThrottler>(new LoggerFactory()), _serverConfigurationManager, _fileSystem);
+                transcodingJob.TranscodingThrottler = new TranscodingThrottler(transcodingJob, new Logger<TranscodingThrottler>(new LoggerFactory()), _serverConfigurationManager, _fileSystem, _mediaEncoder);
                 transcodingJob.TranscodingThrottler.Start();
             }
         }

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -38,6 +38,12 @@ namespace MediaBrowser.Controller.MediaEncoding
         Version EncoderVersion { get; }
 
         /// <summary>
+        /// Whether p key pausing is supported.
+        /// </summary>
+        /// <value><c>true</c> if p key pausing is supported, <c>false</c> otherwise.</value>
+        bool IsPkeyPauseSupported { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the configured Vaapi device is from AMD(radeonsi/r600 Mesa driver).
         /// </summary>
         /// <value><c>true</c> if the Vaapi device is an AMD(radeonsi/r600 Mesa driver) GPU, <c>false</c> otherwise.</value>

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -153,7 +153,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-version", false);
+                output = GetProcessOutput(_encoderPath, "-version", false, null);
             }
             catch (Exception ex)
             {
@@ -234,7 +234,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-version", false);
+                output = GetProcessOutput(_encoderPath, "-version", false, null);
             }
             catch (Exception ex)
             {
@@ -341,7 +341,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             try
             {
-                var output = GetProcessOutput(_encoderPath, "-v verbose -hide_banner -init_hw_device vaapi=va:" + renderNodePath, true);
+                var output = GetProcessOutput(_encoderPath, "-v verbose -hide_banner -init_hw_device vaapi=va:" + renderNodePath, true, null);
                 return output.Contains(driverName, StringComparison.Ordinal);
             }
             catch (Exception ex)
@@ -356,7 +356,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string? output = null;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-hwaccels", false);
+                output = GetProcessOutput(_encoderPath, "-hwaccels", false, null);
             }
             catch (Exception ex)
             {
@@ -384,7 +384,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-h filter=" + filter, false);
+                output = GetProcessOutput(_encoderPath, "-h filter=" + filter, false, null);
             }
             catch (Exception ex)
             {
@@ -402,13 +402,34 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return false;
         }
 
+        public bool CheckSupportedRuntimeKey(string keyDesc)
+        {
+            if (string.IsNullOrEmpty(keyDesc))
+            {
+                return false;
+            }
+
+            string output;
+            try
+            {
+                output = GetProcessOutput(_encoderPath, "-hide_banner -f lavfi -i nullsrc=s=1x1:d=500 -f null -", true, "?");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking supported runtime key");
+                return false;
+            }
+
+            return output.Contains(keyDesc, StringComparison.Ordinal);
+        }
+
         private IEnumerable<string> GetCodecs(Codec codec)
         {
             string codecstr = codec == Codec.Encoder ? "encoders" : "decoders";
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-" + codecstr, false);
+                output = GetProcessOutput(_encoderPath, "-" + codecstr, false, null);
             }
             catch (Exception ex)
             {
@@ -439,7 +460,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-filters", false);
+                output = GetProcessOutput(_encoderPath, "-filters", false, null);
             }
             catch (Exception ex)
             {
@@ -477,7 +498,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return dict;
         }
 
-        private string GetProcessOutput(string path, string arguments, bool readStdErr)
+        private string GetProcessOutput(string path, string arguments, bool readStdErr, string? testKey)
         {
             using (var process = new Process()
             {
@@ -487,6 +508,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     UseShellExecute = false,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     ErrorDialog = false,
+                    RedirectStandardInput = !string.IsNullOrEmpty(testKey),
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 }
@@ -495,6 +517,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _logger.LogDebug("Running {Path} {Arguments}", path, arguments);
 
                 process.Start();
+
+                if (!string.IsNullOrEmpty(testKey))
+                {
+                    process.StandardInput.Write(testKey);
+                }
 
                 return readStdErr ? process.StandardError.ReadToEnd() : process.StandardOutput.ReadToEnd();
             }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -67,6 +67,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private List<string> _filters = new List<string>();
         private IDictionary<int, bool> _filtersWithOption = new Dictionary<int, bool>();
 
+        private bool _isPkeyPauseSupported = false;
+
         private bool _isVaapiDeviceAmd = false;
         private bool _isVaapiDeviceInteliHD = false;
         private bool _isVaapiDeviceInteli965 = false;
@@ -99,6 +101,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string ProbePath => _ffprobePath;
 
         public Version EncoderVersion => _ffmpegVersion;
+
+        public bool IsPkeyPauseSupported => _isPkeyPauseSupported;
 
         public bool IsVaapiDeviceAmd => _isVaapiDeviceAmd;
 
@@ -153,6 +157,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 SetMediaEncoderVersion(validator);
 
                 _threads = EncodingHelper.GetNumberOfThreads(null, options, null);
+
+                _isPkeyPauseSupported = validator.CheckSupportedRuntimeKey("p      pause transcoding");
 
                 // Check the Vaapi device vendor
                 if (OperatingSystem.IsLinux()


### PR DESCRIPTION
**Changes**
- Fix high single thread usage in throttler (this requires [jellyfin-ffmpeg >= 5.0.1-8](https://github.com/jellyfin/jellyfin-ffmpeg/pull/165))


> free single core usage from [c]. And it has a faster resume speed than other methods. vf_realtime filter has also been considered but it doesn't support remux. [p] to pause, [u] or any other key to resume.