### PR TITLE
Make userId truly optional in UniversalAudioController

### DIFF
--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -117,7 +117,13 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] bool enableRedirection = true)
         {
             var deviceProfile = GetDeviceProfile(container, transcodingContainer, audioCodec, transcodingProtocol, breakOnNonKeyFrames, transcodingAudioChannels, maxAudioSampleRate, maxAudioBitDepth, maxAudioChannels);
-            (await _authorizationContext.GetAuthorizationInfo(Request).ConfigureAwait(false)).DeviceId = deviceId;
+            var authorizationInfo = await _authorizationContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
+            authorizationInfo.DeviceId = deviceId;
+
+            if (!userId.HasValue || userId.Equals(Guid.Empty))
+            {
+                userId = authorizationInfo.UserId;
+            }
 
             var authInfo = await _authorizationContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
 

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -120,7 +120,7 @@ namespace Jellyfin.Api.Controllers
             var authorizationInfo = await _authorizationContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
             authorizationInfo.DeviceId = deviceId;
 
-            if (!userId.HasValue || userId.Equals(Guid.Empty))
+            if (!userId.HasValue || userId.Value.Equals(Guid.Empty))
             {
                 userId = authorizationInfo.UserId;
             }


### PR DESCRIPTION
**Changes**

Use the userId from the authorizationInfo when the request doesn't have one. This makes the parameter actually optional (right now you get a bad request when there is no user id...)

**Issues**

```
System.ArgumentException: Guid can't be empty (Parameter 'id')
   at Jellyfin.Server.Implementations.Users.UserManager.GetUserById(Guid id)
   at Jellyfin.Api.Helpers.MediaInfoHelper.SetDeviceSpecificData(BaseItem item, MediaSourceInfo mediaSource, DeviceProfile profile, AuthorizationInfo auth, Nullable`1 maxBitrate, Int64 startTimeTicks, String mediaSourceId, Nullable`1 audioStreamIndex, Nullable`1 subtitleStreamIndex, Nullable`1 maxAudioChannels, String playSessionId, Guid userId, Boolean enableDirectPlay, Boolean enableDirectStream, Boolean enableTranscoding, Boolean allowVideoStreamCopy, Boolean allowAudioStreamCopy, IPAddress ipAddress)
   at Jellyfin.Api.Controllers.UniversalAudioController.GetUniversalAudioStream(Guid itemId, String[] container, String mediaSourceId, String deviceId, Nullable`1 userId, String audioCodec, Nullable`1 maxAudioChannels, Nullable`1 transcodingAudioChannels, Nullable`1 maxStreamingBitrate, Nullable`1 audioBitRate, Nullable`1 startTimeTicks, String transcodingContainer, String transcodingProtocol, Nullable`1 maxAudioSampleRate, Nullable`1 maxAudioBitDepth, Nullable`1 enableRemoteMedia, Boolean breakOnNonKeyFrames, Boolean enableRedirection)
   at lambda_method1331(Closure , Object )
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
```