### PR TITLE
Add new settings MarkResumableItemUnplayedOnPlay and UpdateLastPlayedAndPlayCountOnPlayCompletion

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -212,6 +212,15 @@ namespace Emby.Server.Implementations.Library
             };
         }
 
+        private void SetPlayed(UserItemData data)
+        {
+            data.Played = true;
+            if (_config.Configuration.UpdateLastPlayedAndPlayCountOnPlayCompletion)
+            {
+                data.LastPlayedDate = DateTime.UtcNow;
+            }
+        }
+
         /// <inheritdoc />
         public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks)
         {
@@ -236,7 +245,8 @@ namespace Emby.Server.Implementations.Library
                 {
                     // mark as completed close to the end
                     positionTicks = 0;
-                    data.Played = playedToCompletion = true;
+                    playedToCompletion = true;
+                    SetPlayed(data);
                 }
                 else
                 {
@@ -245,7 +255,8 @@ namespace Emby.Server.Implementations.Library
                     if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
                     {
                         positionTicks = 0;
-                        data.Played = playedToCompletion = true;
+                        playedToCompletion = true;
+                        SetPlayed(data);
                     }
                 }
             }
@@ -263,14 +274,16 @@ namespace Emby.Server.Implementations.Library
                 {
                     // mark as completed close to the end
                     positionTicks = 0;
-                    data.Played = playedToCompletion = true;
+                    playedToCompletion = true;
+                    SetPlayed(data);
                 }
             }
             else if (!hasRuntime)
             {
                 // If we don't know the runtime we'll just have to assume it was fully played
-                data.Played = playedToCompletion = true;
                 positionTicks = 0;
+                playedToCompletion = true;
+                SetPlayed(data);
             }
 
             if (!item.SupportsPlayedStatus)

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -128,6 +128,18 @@ namespace MediaBrowser.Model.Configuration
         public string[] SortRemoveWords { get; set; } = new[] { "the", "a", "an" };
 
         /// <summary>
+        /// Gets or sets a value indicating whether to mark a resumable item being played as unplayed when the play starts.
+        /// </summary>
+        /// <value><c>true</c> if this resumable item should be marked unplayed; otherwise, <c>false</c> item play state will not change when play starts.</value>
+        public bool MarkResumableItemUnplayedOnPlay { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to set LastPlayed time and increment playcount only when played to completion, or on every play start.
+        /// </summary>
+        /// <value><c>true</c> if playcount and lastplayed update on play completion; otherwise, <c>false</c> playcount and lastplayed update on play start.</value>
+        public bool UpdateLastPlayedAndPlayCountOnPlayCompletion { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the minimum percentage of an item that must be played in order for playstate to be updated.
         /// </summary>
         /// <value>The min resume PCT.</value>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
New playback settings

- MarkResumableItemUnplayedOnPlay : Allows disabling of default behavior to mark an item as unplayed when playback starts
- UpdateLastPlayedAndPlayCountOnPlayCompletion: Enable to increment play count and update last played date when item is played to completion, instead of default updating on playback start.

These changes only affect items that support resumable ticks.

Defaults preserve existing JF behaviors.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7535