### PR TITLE
Fix operation name in SearchController and correct nullability for SearchHint

### DIFF
--- a/Jellyfin.Api/Controllers/SearchController.cs
+++ b/Jellyfin.Api/Controllers/SearchController.cs
@@ -79,7 +79,7 @@ namespace Jellyfin.Api.Controllers
         [HttpGet]
         [Description("Gets search hints based on a search term")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<SearchHintResult> Get(
+        public ActionResult<SearchHintResult> GetSearchHints(
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
             [FromQuery] Guid? userId,
@@ -140,7 +140,7 @@ namespace Jellyfin.Api.Controllers
                 IndexNumber = item.IndexNumber,
                 ParentIndexNumber = item.ParentIndexNumber,
                 Id = item.Id,
-                Type = item.GetClientTypeName(),
+                Type = item.GetBaseItemKind(),
                 MediaType = item.MediaType,
                 MatchedTerm = hintInfo.MatchedTerm,
                 RunTimeTicks = item.RunTimeTicks,
@@ -149,8 +149,10 @@ namespace Jellyfin.Api.Controllers
                 EndDate = item.EndDate
             };
 
-            // legacy
+#pragma warning disable CS0618
+            // Kept for compatibility with older clients
             result.ItemId = result.Id;
+#pragma warning restore CS0618
 
             if (item.IsFolder)
             {

--- a/MediaBrowser.Model/Search/SearchHint.cs
+++ b/MediaBrowser.Model/Search/SearchHint.cs
@@ -1,8 +1,6 @@
-#nullable disable
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
+using Jellyfin.Data.Enums;
 
 namespace MediaBrowser.Model.Search
 {
@@ -12,11 +10,27 @@ namespace MediaBrowser.Model.Search
     public class SearchHint
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="SearchHint" /> class.
+        /// </summary>
+        public SearchHint()
+        {
+            Name = string.Empty;
+            MatchedTerm = string.Empty;
+            MediaType = string.Empty;
+            Artists = Array.Empty<string>();
+        }
+
+        /// <summary>
         /// Gets or sets the item id.
         /// </summary>
         /// <value>The item id.</value>
+        [Obsolete("Use Id instead")]
         public Guid ItemId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the item id.
+        /// </summary>
+        /// <value>The item id.</value>
         public Guid Id { get; set; }
 
         /// <summary>
@@ -53,38 +67,42 @@ namespace MediaBrowser.Model.Search
         /// Gets or sets the image tag.
         /// </summary>
         /// <value>The image tag.</value>
-        public string PrimaryImageTag { get; set; }
+        public string? PrimaryImageTag { get; set; }
 
         /// <summary>
         /// Gets or sets the thumb image tag.
         /// </summary>
         /// <value>The thumb image tag.</value>
-        public string ThumbImageTag { get; set; }
+        public string? ThumbImageTag { get; set; }
 
         /// <summary>
         /// Gets or sets the thumb image item identifier.
         /// </summary>
         /// <value>The thumb image item identifier.</value>
-        public string ThumbImageItemId { get; set; }
+        public string? ThumbImageItemId { get; set; }
 
         /// <summary>
         /// Gets or sets the backdrop image tag.
         /// </summary>
         /// <value>The backdrop image tag.</value>
-        public string BackdropImageTag { get; set; }
+        public string? BackdropImageTag { get; set; }
 
         /// <summary>
         /// Gets or sets the backdrop image item identifier.
         /// </summary>
         /// <value>The backdrop image item identifier.</value>
-        public string BackdropImageItemId { get; set; }
+        public string? BackdropImageItemId { get; set; }
 
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
         /// <value>The type.</value>
-        public string Type { get; set; }
+        public BaseItemKind Type { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is folder.
+        /// </summary>
+        /// <value><c>true</c> if this instance is folder; otherwise, <c>false</c>.</value>
         public bool? IsFolder { get; set; }
 
         /// <summary>
@@ -99,31 +117,47 @@ namespace MediaBrowser.Model.Search
         /// <value>The type of the media.</value>
         public string MediaType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the start date.
+        /// </summary>
+        /// <value>The start date.</value>
         public DateTime? StartDate { get; set; }
 
+        /// <summary>
+        /// Gets or sets the end date.
+        /// </summary>
+        /// <value>The end date.</value>
         public DateTime? EndDate { get; set; }
 
         /// <summary>
         /// Gets or sets the series.
         /// </summary>
         /// <value>The series.</value>
-        public string Series { get; set; }
+        public string? Series { get; set; }
 
-        public string Status { get; set; }
+        /// <summary>
+        /// Gets or sets the status.
+        /// </summary>
+        /// <value>The status.</value>
+        public string? Status { get; set; }
 
         /// <summary>
         /// Gets or sets the album.
         /// </summary>
         /// <value>The album.</value>
-        public string Album { get; set; }
+        public string? Album { get; set; }
 
-        public Guid AlbumId { get; set; }
+        /// <summary>
+        /// Gets or sets the album id.
+        /// </summary>
+        /// <value>The album id.</value>
+        public Guid? AlbumId { get; set; }
 
         /// <summary>
         /// Gets or sets the album artist.
         /// </summary>
         /// <value>The album artist.</value>
-        public string AlbumArtist { get; set; }
+        public string? AlbumArtist { get; set; }
 
         /// <summary>
         /// Gets or sets the artists.
@@ -147,13 +181,13 @@ namespace MediaBrowser.Model.Search
         /// Gets or sets the channel identifier.
         /// </summary>
         /// <value>The channel identifier.</value>
-        public Guid ChannelId { get; set; }
+        public Guid? ChannelId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the channel.
         /// </summary>
         /// <value>The name of the channel.</value>
-        public string ChannelName { get; set; }
+        public string? ChannelName { get; set; }
 
         /// <summary>
         /// Gets or sets the primary image aspect ratio.


### PR DESCRIPTION
_Untested, I don't have a proper test environment_

**Changes**
- Fix operation name in SearchController
  Operation names should be unique across the application. The search thingy used `get` as name which is not that unique of a name
- Correct nullability for SearchHint
  - Basically looked at the nullability of BaseItemDto (which all info is copied from) and what's conditionally set in the controller to determine nullability
- Use BaseItemKind enum in SearchHint
  - GetClientTypeName returns basically the same but as a string

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
