### PR TITLE
Introduce Clearer Authentication Requests

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -152,53 +152,14 @@ namespace Jellyfin.Api.Controllers
         }
 
         /// <summary>
-        /// Authenticates a user.
-        /// </summary>
-        /// <param name="userId">The user id.</param>
-        /// <param name="pw">The password as plain text.</param>
-        /// <param name="password">The password sha1-hash.</param>
-        /// <response code="200">User authenticated.</response>
-        /// <response code="403">Sha1-hashed password only is not allowed.</response>
-        /// <response code="404">User not found.</response>
-        /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationResult"/>.</returns>
-        [HttpPost("{userId}/Authenticate")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<AuthenticationResult>> AuthenticateUser(
-            [FromRoute, Required] Guid userId,
-            [FromQuery, Required] string pw,
-            [FromQuery] string? password)
-        {
-            var user = _userManager.GetUserById(userId);
-
-            if (user == null)
-            {
-                return NotFound("User not found");
-            }
-
-            if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(pw))
-            {
-                return StatusCode(StatusCodes.Status403Forbidden, "Only sha1 password is not allowed.");
-            }
-
-            AuthenticateUserByName request = new AuthenticateUserByName
-            {
-                Username = user.Username,
-                Pw = pw
-            };
-            return await AuthenticateUserByName(request).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Authenticates a user by name.
         /// </summary>
-        /// <param name="request">The <see cref="AuthenticateUserByName"/> request.</param>
+        /// <param name="request">The <see cref="AuthenticateUserRequest"/> request.</param>
         /// <response code="200">User authenticated.</response>
         /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationRequest"/> with information about the new session.</returns>
-        [HttpPost("AuthenticateByName")]
+        [HttpPost("Authenticate")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult<AuthenticationResult>> AuthenticateUserByName([FromBody, Required] AuthenticateUserByName request)
+        public async Task<ActionResult<AuthenticationResult>> AuthenticateUserByName([FromBody, Required] AuthenticateUserRequest request)
         {
             var auth = await _authContext.GetAuthorizationInfo(Request).ConfigureAwait(false);
 
@@ -210,7 +171,7 @@ namespace Jellyfin.Api.Controllers
                     AppVersion = auth.Version,
                     DeviceId = auth.DeviceId,
                     DeviceName = auth.Device,
-                    Password = request.Pw,
+                    Password = request.Password,
                     RemoteEndPoint = HttpContext.GetNormalizedRemoteIp().ToString(),
                     Username = request.Username
                 }).ConfigureAwait(false);
@@ -227,13 +188,13 @@ namespace Jellyfin.Api.Controllers
         /// <summary>
         /// Authenticates a user with quick connect.
         /// </summary>
-        /// <param name="request">The <see cref="QuickConnectDto"/> request.</param>
+        /// <param name="request">The <see cref="QuickConnectRequest"/> request.</param>
         /// <response code="200">User authenticated.</response>
         /// <response code="400">Missing token.</response>
         /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationRequest"/> with information about the new session.</returns>
-        [HttpPost("AuthenticateWithQuickConnect")]
+        [HttpPost("Authenticate/QuickConnnect")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<AuthenticationResult> AuthenticateWithQuickConnect([FromBody, Required] QuickConnectDto request)
+        public ActionResult<AuthenticationResult> AuthenticateWithQuickConnect([FromBody, Required] QuickConnectRequest request)
         {
             try
             {

--- a/Jellyfin.Api/Models/UserDtos/AuthenticateUserRequest.cs
+++ b/Jellyfin.Api/Models/UserDtos/AuthenticateUserRequest.cs
@@ -5,7 +5,7 @@ namespace Jellyfin.Api.Models.UserDtos
     /// <summary>
     /// The authenticate user by name request body.
     /// </summary>
-    public class AuthenticateUserByName
+    public class AuthenticateUserRequest
     {
         /// <summary>
         /// Gets or sets the username.
@@ -15,12 +15,6 @@ namespace Jellyfin.Api.Models.UserDtos
         /// <summary>
         /// Gets or sets the plain text password.
         /// </summary>
-        public string? Pw { get; set; }
-
-        /// <summary>
-        /// Gets or sets the sha1-hashed password.
-        /// </summary>
-        [Obsolete("Send password using pw field")]
         public string? Password { get; set; }
     }
 }

--- a/Jellyfin.Api/Models/UserDtos/QuickConnectRequest.cs
+++ b/Jellyfin.Api/Models/UserDtos/QuickConnectRequest.cs
@@ -5,7 +5,7 @@ namespace Jellyfin.Api.Models.UserDtos
     /// <summary>
     /// The quick connect request body.
     /// </summary>
-    public class QuickConnectDto
+    public class QuickConnectRequest
     {
         /// <summary>
         /// Gets or sets the quick connect secret.

--- a/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
@@ -27,15 +27,15 @@ namespace Jellyfin.Server.Integration.Tests
             Assert.Equal(HttpStatusCode.NoContent, completeResponse.StatusCode);
 
             using var content = JsonContent.Create(
-                new AuthenticateUserByName()
+                new AuthenticateUserRequest()
                 {
                     Username = user!.Name,
-                    Pw = user.Password,
+                    Password = user.Password,
                 },
                 options: jsonOptions);
             content.Headers.Add("X-Emby-Authorization", DummyAuthHeader);
 
-            using var authResponse = await client.PostAsync("/Users/AuthenticateByName", content).ConfigureAwait(false);
+            using var authResponse = await client.PostAsync("/Users/Authenticate", content).ConfigureAwait(false);
             var auth = await JsonSerializer.DeserializeAsync<AuthenticationResultDto>(
                 await authResponse.Content.ReadAsStreamAsync().ConfigureAwait(false),
                 jsonOptions).ConfigureAwait(false);


### PR DESCRIPTION
🚧  in progress of deprecating old APIs and rewriting summary 🚧 

This PR simplifies the authentication requests, by:
1. Removing authentication by user ID
2. Removing obsolete parameter and `Pw -> Password`
3. Change paths to be more clear
4. Object name changes

## Why

I recently refactored the [Swift Jellyfin SDK](https://github.com/jellyfin/jellyfin-sdk-swift) and created a client object for some helpful usage. Part of this was wrapping the authentication request and through that I found this area to be somewhat messy, so I thought as part of my first contribution it would be easy since it was small.

## Justifications

> Removing authentication by user ID

Jellyfin-web does not use this endpoint and I looked through a few other clients and they don't as well. Removal of this consolidates the authentication requests. Additionally, if a client has a method of obtaining user IDs they should have a method of obtaining usernames as well. I also found this specific route to be odd.

> Removing obsolete parameter and `Pw -> Password`

This parameter was marked obsolete [early 2021](https://github.com/LePips/jellyfin/commit/5b0dc21c644af074095b760b2e42c516ce07c0d6). It's been over a year now and I strongly value a clearer name than holding onto obsolete implementations. I don't remove the obsolete property entirely from many other places, like `AuthenticationRequest`, in this PR.

> Change paths to be more clear

It's odd to use a small phrase in an API call. By a quick scan a lot of the server's other routes follow good noun/command conventions and these ones just stood out.

> Object name changes

This is just me not liking the `dto` convention. The contextual usage of these objects are for requests and also matches other object names like `AuthenticationRequest`.

---

This would be a breaking change for all authentication requests and is just a very small transition.

## Thoughts

From working with Jellyfin for over a year now and refactoring the Swift SDK I've started to have some thoughts about how we can make a cleaner API. There are ~408 total API calls in this project and I will never attempt to look at all of them. I'm playing a sort of whac-a-mole with the calls that I use directly/most often.

I'm not a Senior REST API developer so this is also a learning opportunity for me and I welcome all discussions either here or in the developer channels about this work here and in the future. This work can be part of minor 10.X updates or as a part of the beginning of a major 11.0 update.



