### PR TITLE
Added handling of streams of type "data"

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -869,7 +869,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
             else
             {
-                _logger.LogError("Codec Type unknown. The stream will be ignored. Warning: Subsequential streams will have a wrong stream specifier!");
+                _logger.LogError("Codec Type {CodecType} unknown. The stream (index: {Index}) will be ignored. Warning: Subsequential streams will have a wrong stream specifier!", streamInfo.CodecType, streamInfo.Index);
                 return null;
             }
 

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -863,8 +863,13 @@ namespace MediaBrowser.MediaEncoding.Probing
                     }
                 }
             }
+            else if (string.Equals(streamInfo.CodecType, "data", StringComparison.OrdinalIgnoreCase))
+            {
+                stream.Type = MediaStreamType.Data;
+            }
             else
             {
+                _logger.LogError("Codec Type unknown. The stream will be ignored. Warning: Subsequential streams will have a wrong stream specifier!");
                 return null;
             }
 

--- a/MediaBrowser.Model/Entities/MediaStreamType.cs
+++ b/MediaBrowser.Model/Entities/MediaStreamType.cs
@@ -23,6 +23,11 @@ namespace MediaBrowser.Model.Entities
         /// <summary>
         /// The embedded image.
         /// </summary>
-        EmbeddedImage
+        EmbeddedImage,
+
+        /// <summary>
+        /// The data.
+        /// </summary>
+        Data
     }
 }


### PR DESCRIPTION
**Problem:**
Streams with CodecType "data" (like "epg" streams in DVB recordings) get ignored. This results in wrong stream specifiers for all subsequential streams. See isue #8284.

**Solution:**
This fix correctly handles "data" streams by setting a newly defined MediaStreamType for such stream. At the moment "data"streams are not processed any further.

