### PR TITLE
Fix regression in DlnaHttpClient

### DIFF
--- a/Emby.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/Emby.Dlna/PlayTo/DlnaHttpClient.cs
@@ -66,13 +66,15 @@ namespace Emby.Dlna.PlayTo
             }
         }
 
-        public Task<XDocument?> GetDataAsync(string url, CancellationToken cancellationToken)
+        public async Task<XDocument?> GetDataAsync(string url, CancellationToken cancellationToken)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            return SendRequestAsync(request, cancellationToken);
+
+            // Have to await here instead of returning the Task directly, otherwise request would be disposed too soon
+            return await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<XDocument?> SendCommandAsync(
+        public async Task<XDocument?> SendCommandAsync(
             string baseUrl,
             DeviceService service,
             string command,
@@ -99,7 +101,8 @@ namespace Emby.Dlna.PlayTo
                 request.Headers.TryAddWithoutValidation("contentFeatures.dlna.org", header);
             }
 
-            return SendRequestAsync(request, cancellationToken);
+            // Have to await here instead of returning the Task directly, otherwise request would be disposed too soon
+            return await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
```
[18:53:50] [ERR] [25] Emby.Dlna.Main.DlnaEntryPoint: Error updating device info for 192.168.1.21 - Sonos Connect:Amp Berging
System.Net.Http.HttpRequestException: An error occurred while sending the request.
 ---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.Http.StringContent'.
   at System.Net.Http.HttpContent.CheckDisposed()
   at System.Net.Http.HttpContent.CopyToAsync(Stream stream, TransportContext context, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnection.SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.DecompressionHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at Microsoft.Extensions.Http.Logging.LoggingHttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at Microsoft.Extensions.Http.Logging.LoggingScopeHttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Emby.Dlna.PlayTo.DlnaHttpClient.SendRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken) in /home/loma/dev/jellyfin/Emby.Dlna/PlayTo/DlnaHttpClient.cs:line 47
   at Emby.Dlna.PlayTo.Device.GetTransportInfo(TransportCommands avCommands, CancellationToken cancellationToken) in /home/loma/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 705
   at Emby.Dlna.PlayTo.Device.TimerCallback(Object sender) in /home/loma/dev/jellyfin/Emby.Dlna/PlayTo/Device.cs:line 521
```
Regression from #7433