### PR TITLE
Use Guid type for UserConfiguration fields

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -326,10 +326,10 @@ namespace Jellyfin.Server.Implementations.Users
                     EnableNextEpisodeAutoPlay = user.EnableNextEpisodeAutoPlay,
                     RememberSubtitleSelections = user.RememberSubtitleSelections,
                     SubtitleLanguagePreference = user.SubtitleLanguagePreference ?? string.Empty,
-                    OrderedViews = user.GetPreference(PreferenceKind.OrderedViews),
-                    GroupedFolders = user.GetPreference(PreferenceKind.GroupedFolders),
-                    MyMediaExcludes = user.GetPreference(PreferenceKind.MyMediaExcludes),
-                    LatestItemsExcludes = user.GetPreference(PreferenceKind.LatestItemExcludes)
+                    OrderedViews = user.GetPreferenceValues<Guid>(PreferenceKind.OrderedViews),
+                    GroupedFolders = user.GetPreferenceValues<Guid>(PreferenceKind.GroupedFolders),
+                    MyMediaExcludes = user.GetPreferenceValues<Guid>(PreferenceKind.MyMediaExcludes),
+                    LatestItemsExcludes = user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes)
                 },
                 Policy = new UserPolicy
                 {

--- a/MediaBrowser.Model/Configuration/UserConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/UserConfiguration.cs
@@ -22,10 +22,10 @@ namespace MediaBrowser.Model.Configuration
             HidePlayedInLatest = true;
             PlayDefaultAudioTrack = true;
 
-            LatestItemsExcludes = Array.Empty<string>();
-            OrderedViews = Array.Empty<string>();
-            MyMediaExcludes = Array.Empty<string>();
-            GroupedFolders = Array.Empty<string>();
+            LatestItemsExcludes = Array.Empty<Guid>();
+            OrderedViews = Array.Empty<Guid>();
+            MyMediaExcludes = Array.Empty<Guid>();
+            GroupedFolders = Array.Empty<Guid>();
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool DisplayMissingEpisodes { get; set; }
 
-        public string[] GroupedFolders { get; set; }
+        public Guid[] GroupedFolders { get; set; }
 
         public SubtitlePlaybackMode SubtitleMode { get; set; }
 
@@ -56,11 +56,11 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableLocalPassword { get; set; }
 
-        public string[] OrderedViews { get; set; }
+        public Guid[] OrderedViews { get; set; }
 
-        public string[] LatestItemsExcludes { get; set; }
+        public Guid[] LatestItemsExcludes { get; set; }
 
-        public string[] MyMediaExcludes { get; set; }
+        public Guid[] MyMediaExcludes { get; set; }
 
         public bool HidePlayedInLatest { get; set; }
 


### PR DESCRIPTION
The OrderedViews, GroupedFolders, MyMediaExcludes, LatestItemsExcludes arrays only store BaseItemDto ids. The BaseItemDto id is a Guid.

**Changes**
- Use Guid type for UserConfiguration fields

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
