### PR TITLE
Increased (really) subtitle extraction timeout to 30 min (10.8.z back-port)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,6 +157,7 @@
  - [jonas-resch](https://github.com/jonas-resch)
  - [vgambier](https://github.com/vgambier)
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
+ - [RealGreenDragon](https://github.com/RealGreenDragon)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -605,7 +605,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     throw;
                 }
 
-                var ranToCompletion = await process.WaitForExitAsync(TimeSpan.FromMinutes(5)).ConfigureAwait(false);
+                var ranToCompletion = await process.WaitForExitAsync(TimeSpan.FromMinutes(30)).ConfigureAwait(false);
 
                 if (!ranToCompletion)
                 {


### PR DESCRIPTION
**Changes**
Back-port PR #8259 changes in 10.8.z branch.
Such changes are not a new feature, but in effect a fix of the original PR #7153 (already included in 10.8.z branch), whose declared goal was really fulfilled only with my PR #8259 (already merged in master).

**Issues**
Addresses #6672
Complete PR #7153
Back-port PR #8259
