### PR TITLE
Fixes for FFProbe Keyframe extraction

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@
  - [dmitrylyzo](https://github.com/dmitrylyzo)
  - [DMouse10462](https://github.com/DMouse10462)
  - [DrPandemic](https://github.com/DrPandemic)
+ - [eglia](https://github.com/eglia)
  - [EraYaN](https://github.com/EraYaN)
  - [escabe](https://github.com/escabe)
  - [excelite](https://github.com/excelite)

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -11,7 +11,7 @@ namespace Jellyfin.MediaEncoding.Keyframes.FfProbe;
 /// </summary>
 public static class FfProbeKeyframeExtractor
 {
-    private const string DefaultArguments = "-v error -skip_frame nokey -show_entries format=duration -show_entries stream=duration -show_entries packet=pts_time,flags -select_streams v -of csv \"{0}\"";
+    private const string DefaultArguments = "-fflags +genpts -v error -skip_frame nokey -show_entries format=duration -show_entries stream=duration -show_entries packet=pts_time,flags -select_streams v -of csv \"{0}\"";
 
     /// <summary>
     /// Extracts the keyframes using the ffprobe executable at the specified path.

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -65,9 +65,11 @@ public static class FfProbeKeyframeExtractor
                 if (rest.EndsWith(",K_"))
                 {
                     // Trim the flags from the packet line. Example line: packet,7169.079000,K_
-                    var keyframe = double.Parse(rest[..^3], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
-                    // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
-                    keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));
+                    if (double.TryParse(rest[..^3], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
+                    {
+                      // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
+                      keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));
+                    }
                 }
             }
             else if (lineType.Equals("stream", StringComparison.OrdinalIgnoreCase))

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -64,11 +64,11 @@ public static class FfProbeKeyframeExtractor
             {
                 // Split time and flags from the packet line. Example line: packet,7169.079000,K_
                 var secondComma = rest.IndexOf(',');
-                var pts_time = rest[..secondComma];
+                var ptsTime = rest[..secondComma];
                 var flags = rest[(secondComma + 1)..];
                 if (flags.StartsWith("K_"))
                 {
-                    if (double.TryParse(pts_time, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
+                    if (double.TryParse(ptsTime, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
                     {
                       // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
                       keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -62,10 +62,13 @@ public static class FfProbeKeyframeExtractor
             var rest = line[(firstComma + 1)..];
             if (lineType.Equals("packet", StringComparison.OrdinalIgnoreCase))
             {
-                if (rest.EndsWith(",K_"))
+                // Split time and flags from the packet line. Example line: packet,7169.079000,K_
+                var secondComma = rest.IndexOf(',');
+                var pts_time = rest[..secondComma];
+                var flags = rest[(secondComma + 1)..];
+                if (flags.StartsWith("K_"))
                 {
-                    // Trim the flags from the packet line. Example line: packet,7169.079000,K_
-                    if (double.TryParse(rest[..^3], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
+                    if (double.TryParse(pts_time, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
                     {
                       // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
                       keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));


### PR DESCRIPTION
**Changes**

- Add TryParse to the ffprobe keyframe extraction to allow for unexpected values in the ffprobe output.
Some (or all, I haven't checked them all) of my mp4 files produce the following output:
```
packet,N/A,K_
packet,0.000000,K_
packet,0.041708,__
```

- Add the genpts flag to generate the timestamps for files which show N/A for everything.
- Allow additional flags after "K_". Some of my files (LiveTV recordings in ts files) have the following output:
```
packet,52786.322778,K_side_data,

packet,52786.302778,__side_data,

```

**Issues**
N/A
