### PR TITLE
Fix dual-stack socket issues with VPNs on OS supporting IPv6 by allowing user to disable IPv6 in network config.

### DIFF
--- a/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -601,6 +601,11 @@ namespace Jellyfin.Networking.Manager
         {
             NetworkConfiguration config = (NetworkConfiguration)configuration ?? throw new ArgumentNullException(nameof(configuration));
 
+            // Disable IPv6 on dual-stack socket, name resolution, ping, etc...
+            // useful to workaround dual-stack socket issues when the OS reports support of IPv6, but some other
+            // underlying infrastructure element (typically VPN) doesn't function well with IPv6 request
+            AppContext.SetSwitch("System.Net.DisableIPv6", !config.EnableIPV6);
+
             IsIP4Enabled = Socket.OSSupportsIPv4 && config.EnableIPV4;
             IsIP6Enabled = Socket.OSSupportsIPv6 && config.EnableIPV6;
 


### PR DESCRIPTION
Fix dual-stack socket issues with VPNs on OS supporting IPv6 by allowing user to disable IPv6 in network config.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Use 'EnableIPV6' config from network settings to disable IPV6 appwide with app context "System.Net.DisableIPv6"

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #8054