### PR TITLE
Fix QuickConnect operation names

### DIFF
--- a/Jellyfin.Api/Controllers/QuickConnectController.cs
+++ b/Jellyfin.Api/Controllers/QuickConnectController.cs
@@ -39,7 +39,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>Whether Quick Connect is enabled on the server or not.</returns>
         [HttpGet("Enabled")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<bool> GetEnabled()
+        public ActionResult<bool> GetQuickConnectEnabled()
         {
             return _quickConnect.IsEnabled;
         }
@@ -52,7 +52,7 @@ namespace Jellyfin.Api.Controllers
         /// <returns>A <see cref="QuickConnectResult"/> with a secret and code for future use or an error message.</returns>
         [HttpGet("Initiate")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult<QuickConnectResult>> Initiate()
+        public async Task<ActionResult<QuickConnectResult>> InitiateQuickConnect()
         {
             try
             {
@@ -75,7 +75,7 @@ namespace Jellyfin.Api.Controllers
         [HttpGet("Connect")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public ActionResult<QuickConnectResult> Connect([FromQuery, Required] string secret)
+        public ActionResult<QuickConnectResult> GetQuickConnectState([FromQuery, Required] string secret)
         {
             try
             {
@@ -102,7 +102,7 @@ namespace Jellyfin.Api.Controllers
         [Authorize(Policy = Policies.DefaultAuthorization)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<bool>> Authorize([FromQuery, Required] string code)
+        public async Task<ActionResult<bool>> AuthorizeQuickConnect([FromQuery, Required] string code)
         {
             var userId = ClaimHelpers.GetUserId(Request.HttpContext.User);
             if (!userId.HasValue)


### PR DESCRIPTION
Operation names should be unique for the generated OpenAPI document, they should also be somewhat descriptive of their function. Adding the "QuickConnect" name to all QC related operations fixes that.

This change only impacts the names of generated API functions in SDK's/apiclients, it does not break the API in any way.

**Changes**
- Fix QuickConnect operation names

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
