### PR TITLE
Remove libraspberrypi0 package from arm Dockerfile

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -38,8 +38,6 @@ RUN apt-get update \
  libssl-dev \
  libfontconfig1 \
  libfreetype6 \
- libomxil-bellagio0 \
- libomxil-bellagio-bin \
  vainfo \
  libva2 \
  locales \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -40,7 +40,6 @@ RUN apt-get update \
  libfreetype6 \
  libomxil-bellagio0 \
  libomxil-bellagio-bin \
- libraspberrypi0 \
  vainfo \
  libva2 \
  locales \


### PR DESCRIPTION
I believe this isn't needed anymore since https://github.com/jellyfin/jellyfin-ffmpeg/pull/77 got merged
