### PR TITLE
Allow direct play even if no audio stream is available

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -436,9 +436,9 @@ namespace MediaBrowser.Model.Dlna
                 {
                     containerSupported = true;
 
-                    videoSupported = videoStream != null && profile.SupportsVideoCodec(videoStream.Codec);
+                    videoSupported = videoStream == null || profile.SupportsVideoCodec(videoStream.Codec);
 
-                    audioSupported = audioStream != null && profile.SupportsAudioCodec(audioStream.Codec);
+                    audioSupported = audioStream == null || profile.SupportsAudioCodec(audioStream.Codec);
 
                     if (videoSupported && audioSupported)
                     {
@@ -447,18 +447,17 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
-            var list = new List<TranscodeReason>();
             if (!containerSupported)
             {
                 reasons |= TranscodeReason.ContainerNotSupported;
             }
 
-            if (videoStream != null && !videoSupported)
+            if (!videoSupported)
             {
                 reasons |= TranscodeReason.VideoCodecNotSupported;
             }
 
-            if (audioStream != null && !audioSupported)
+            if (!audioSupported)
             {
                 reasons |= TranscodeReason.AudioCodecNotSupported;
             }
@@ -1182,14 +1181,18 @@ namespace MediaBrowser.Model.Dlna
                     }
 
                     // Check audio codec
-                    var selectedAudioStream = candidateAudioStreams.FirstOrDefault(audioStream => directPlayProfile.SupportsAudioCodec(audioStream.Codec));
-                    if (selectedAudioStream == null)
+                    MediaStream selectedAudioStream = null;
+                    if (candidateAudioStreams.Any())
                     {
-                        directPlayProfileReasons |= TranscodeReason.AudioCodecNotSupported;
-                    }
-                    else
-                    {
-                        audioCodecProfileReasons = audioStreamMatches.GetValueOrDefault(selectedAudioStream);
+                        selectedAudioStream = candidateAudioStreams.FirstOrDefault(audioStream => directPlayProfile.SupportsAudioCodec(audioStream.Codec));
+                        if (selectedAudioStream == null)
+                        {
+                            directPlayProfileReasons |= TranscodeReason.AudioCodecNotSupported;
+                        }
+                        else
+                        {
+                            audioCodecProfileReasons = audioStreamMatches.GetValueOrDefault(selectedAudioStream);
+                        }
                     }
 
                     var failureReasons = directPlayProfileReasons | containerProfileReasons | subtitleProfileReasons;

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -589,20 +589,18 @@ namespace MediaBrowser.Model.Dlna
             }
 
             // Collect candidate audio streams
-            IEnumerable<MediaStream> candidateAudioStreams = audioStream == null ? Array.Empty<MediaStream>() : new[] { audioStream };
+            ICollection<MediaStream> candidateAudioStreams = audioStream == null ? Array.Empty<MediaStream>() : new[] { audioStream };
             if (!options.AudioStreamIndex.HasValue || options.AudioStreamIndex < 0)
             {
                 if (audioStream?.IsDefault == true)
                 {
-                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.IsDefault);
+                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.IsDefault).ToArray();
                 }
                 else
                 {
-                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.Language == audioStream?.Language);
+                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.Language == audioStream?.Language).ToArray();
                 }
             }
-
-            candidateAudioStreams = candidateAudioStreams.ToArray();
 
             var videoStream = item.VideoStream;
 
@@ -1059,7 +1057,7 @@ namespace MediaBrowser.Model.Dlna
             MediaSourceInfo mediaSource,
             MediaStream videoStream,
             MediaStream audioStream,
-            IEnumerable<MediaStream> candidateAudioStreams,
+            ICollection<MediaStream> candidateAudioStreams,
             MediaStream subtitleStream,
             bool isEligibleForDirectPlay,
             bool isEligibleForDirectStream)


### PR DESCRIPTION
If a video doesn't have an audio stream, it cannot direct play right now, since no supported audio stream can is available (`FirstOrDefault` always returns `null` on empty collections).
This commit ensures that any audio stream is available before matching the device profiles.

**Changes**
* Wraps the audio stream check in a `.Any()` if clause to ensure at least one audio stream is available.
* The unused variable `list` is removed.
* `videoSupported` and `audioSupported` checks optimized to return faster – `null` streams are always “supported”.

**Issues**
* [jellyfin/jellyfin-android#28](https://github.com/jellyfin/jellyfin-android/issues/28#issuecomment-1221328279)
