### PR TITLE
Fix malformed VA-API ffmpeg arguments

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -728,14 +728,14 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (_mediaEncoder.IsVaapiDeviceInteliHD)
                 {
-                    args.Append(GetVaapiDeviceArgs(null, "iHD", null, VaapiAlias));
+                    args.Append(GetVaapiDeviceArgs(options.VaapiDevice, "iHD", null, VaapiAlias));
                 }
                 else if (_mediaEncoder.IsVaapiDeviceInteli965)
                 {
                     // Only override i965 since it has lower priority than iHD in libva lookup.
                     Environment.SetEnvironmentVariable("LIBVA_DRIVER_NAME", "i965");
                     Environment.SetEnvironmentVariable("LIBVA_DRIVER_NAME_JELLYFIN", "i965");
-                    args.Append(GetVaapiDeviceArgs(null, "i965", null, VaapiAlias));
+                    args.Append(GetVaapiDeviceArgs(options.VaapiDevice, "i965", null, VaapiAlias));
                 }
                 else
                 {


### PR DESCRIPTION
**Changes**
This PR passes the `options.VaapiDevice` setting to all `GetVaapiDeviceArgs` and lets it evaluate whether that setting is null and the default value should be used.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Potentially addresses:

* #8235 
* #8117
* #5993 
* Probably more ... this seems like a pretty ... popular error?

**In detail**

Looking through the Jellyfin general and Transcode logs I could see commands looking like `/usr/lib/jellyfin-ffmpeg/ffmpeg -analyzeduration 200M -init_hw_device vaapi=va:,driver=iHD` which would result in the error below.

```plaintext
Failed to set value 'vaapi=va:,driver=iHD' for option 'init_hw_device': Generic error in an external library
```

As far as I can tell is simply telling us we've made an invalid invocation of `-init_hw_device`. :shrug: Reading from different bug threads, I'm not sure if this isolated to within running from the Docker image, or this is expected to be a valid call in certain situations. Regardless, manually running completing this command with `-init_hw_device vaapi=va:/dev/dri/actuallyAValueValidForMySystem,driver=iHD` would allow the transcodes to succeed. _(My actual Kubernetes deployment mapped that GPU to `/dev/dri/renderD129`, a non-default value.)_

Looking at the code, I'm under the impression that this change should be safe since `GetVaapiDeviceArgs` checks if the value passed is `null` by using `??` and assigns the default of `/dev/dri/renderD128` if `null` is passed ... but I'm getting a feeling I could be causing a regression here.

This PR could certainly use wiser eyes than mine.

---

You can find an OCI image matching c7bbc005f1113b6548381cc785c73e803a32d38a at `ghcr.io/avanier/jellyfin:10.8.4-vaapi-fix`. This image is working correctly for me on kernel `5.4.0`.