### PR TITLE
Fix subtitle selection behaviour

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -56,15 +56,17 @@ namespace Emby.Server.Implementations.Library
             }
             else if (mode == SubtitlePlaybackMode.Smart)
             {
-                // Respect forced flag.
-                stream = sortedStreams.FirstOrDefault(x => x.IsForced);
-
                 // Only attempt to load subtitles if the audio language is not one of the user's preferred subtitle languages.
                 // If no subtitles of preferred language available, use default behaviour.
                 if (!preferredLanguages.Contains(audioTrackLanguage, StringComparison.OrdinalIgnoreCase))
                 {
                     stream = sortedStreams.FirstOrDefault(x => preferredLanguages.Contains(x.Language, StringComparison.OrdinalIgnoreCase)) ??
                         sortedStreams.FirstOrDefault(x => x.IsExternal || x.IsForced || x.IsDefault);
+                }
+                else
+                {
+                    // Respect forced flag.
+                    stream = sortedStreams.FirstOrDefault(x => x.IsForced);
                 }
             }
             else if (mode == SubtitlePlaybackMode.Always)

--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -71,8 +71,8 @@ namespace Emby.Server.Implementations.Library
             }
             else if (mode == SubtitlePlaybackMode.Always)
             {
-                // Always load subtitles of the user's preferred subtitle language if possible, otherwise default behaviour.
-                stream = sortedStreams.FirstOrDefault(x => preferredLanguages.Contains(x.Language, StringComparison.OrdinalIgnoreCase)) ??
+                // Always load (full/non-forced) subtitles of the user's preferred subtitle language if possible, otherwise default behaviour.
+                stream = sortedStreams.FirstOrDefault(x => !x.IsForced && preferredLanguages.Contains(x.Language, StringComparison.OrdinalIgnoreCase)) ??
                     sortedStreams.FirstOrDefault(x => x.IsExternal || x.IsForced || x.IsDefault);
             }
             else if (mode == SubtitlePlaybackMode.OnlyForced)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Aligned the behaviour of the subtitle selection logic with the descriptions that are given on the front end. Currently the behaviour is not as the user would expect.

- "Default" should account for language preference when there are multiple options of equal priority, and should play subtitle tracks according to external, forced or default flag priority.
- "Smart" should respect forced tracks, then only attempt to play other subtitles if the user's subtitle language preference does not match the audio track language. If subtitles in the preferred language are not present then fall back on default behaviour.
- "Always Play" should always attempt to play subtitles matching the user's language preference, and fall back on default behaviour otherwise.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #8251 