### PR TITLE
feat: macOS arm64 build support

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -13,5 +13,6 @@ packages:
   - centos.amd64
   - linux.amd64
   - windows.amd64
-  - macos
+  - macos.amd64
+  - macos.arm64
   - portable

--- a/deployment/Dockerfile.macos.amd64
+++ b/deployment/Dockerfile.macos.amd64
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
+# Docker build arguments
+ARG SOURCE_DIR=/jellyfin
+ARG ARTIFACT_DIR=/dist
+# Docker run environment
+ENV SOURCE_DIR=/jellyfin
+ENV ARTIFACT_DIR=/dist
+ENV DEB_BUILD_OPTIONS=noddebs
+ENV ARCH=amd64
+ENV IS_DOCKER=YES
+
+# Prepare Debian build environment
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    debhelper gnupg devscripts \
+    mmv libcurl4-openssl-dev libfontconfig1-dev \
+    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+
+# Link to docker-build script
+RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.amd64 /build.sh
+
+VOLUME ${SOURCE_DIR}/
+
+VOLUME ${ARTIFACT_DIR}/
+
+ENTRYPOINT ["/build.sh"]

--- a/deployment/Dockerfile.macos.arm64
+++ b/deployment/Dockerfile.macos.arm64
@@ -17,7 +17,7 @@ RUN apt-get update -yqq \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
 
 # Link to docker-build script
-RUN ln -sf ${SOURCE_DIR}/deployment/build.macos /build.sh
+RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.arm64 /build.sh
 
 VOLUME ${SOURCE_DIR}/
 

--- a/deployment/build.macos.amd64
+++ b/deployment/build.macos.amd64
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#= macOS 10.13+ amd64 .tar.gz
+
+set -o errexit
+set -o xtrace
+
+# Move to source directory
+pushd ${SOURCE_DIR}
+
+# Get version
+if [[ ${IS_UNSTABLE} == 'yes' ]]; then
+    version="${BUILD_ID}"
+else
+    version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
+fi
+
+# Build archives
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-x64 --output dist/jellyfin-server_${version}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
+tar -czf jellyfin-server_${version}_macos-amd64.tar.gz -C dist jellyfin-server_${version}
+rm -rf dist/jellyfin-server_${version}
+
+# Move the artifacts out
+mkdir -p ${ARTIFACT_DIR}/
+mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+
+if [[ ${IS_DOCKER} == YES ]]; then
+    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+fi
+
+popd

--- a/deployment/build.macos.arm64
+++ b/deployment/build.macos.arm64
@@ -17,7 +17,7 @@ fi
 
 # Build archives
 dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-arm64 --output dist/jellyfin-server_${version}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
-tar -czf jellyfin-server_${version}_macos-amd64.tar.gz -C dist jellyfin-server_${version}
+tar -czf jellyfin-server_${version}_macos-arm64.tar.gz -C dist jellyfin-server_${version}
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out

--- a/deployment/build.macos.arm64
+++ b/deployment/build.macos.arm64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#= MacOS 10.13+ .tar.gz
+#= macOS 11.0+ arm64 .tar.gz
 
 set -o errexit
 set -o xtrace
@@ -16,7 +16,7 @@ else
 fi
 
 # Build archives
-dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-x64 --output dist/jellyfin-server_${version}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
+dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime osx-arm64 --output dist/jellyfin-server_${version}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
 tar -czf jellyfin-server_${version}_macos-amd64.tar.gz -C dist jellyfin-server_${version}
 rm -rf dist/jellyfin-server_${version}
 


### PR DESCRIPTION
Signed-off-by: gnattu <gnattuoc@me.com>

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This add building support for macOS arm64 target which is pretty stable now on dotnet 6. One thing to note is that the old build script is renamed from `build.macos` to `build.macos.amd64`, I did not find direct use of these scripts other than the build script itself, if it breaks anything please let me know.

Already tested with a ubuntu 22.04 amd64 buiding host using docker crossbuild. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
