### PR TITLE
fix: kill ffprobe if keyframe parsing fails

### DIFF
--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -38,9 +38,28 @@ public static class FfProbeKeyframeExtractor
             EnableRaisingEvents = true
         };
 
-        process.Start();
+        try
+        {
+            process.Start();
 
-        return ParseStream(process.StandardOutput);
+            return ParseStream(process.StandardOutput);
+        }
+        catch (Exception)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+            }
+            catch
+            {
+                // We do not care if this fails
+            }
+
+            throw;
+        }
     }
 
     internal static KeyframeData ParseStream(StreamReader reader)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Kill the ffprobe process if the parsing crashes

**Issues**
Partially fixes https://github.com/jellyfin/jellyfin/issues/8513
