### PR TITLE
Add extras with "Other" as a label

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -530,6 +530,12 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
+                    ExtraType.Unknown,
+                    ExtraRuleType.DirectoryName,
+                    "other",
+                    MediaType.Video),
+
+                new ExtraRule(
                     ExtraType.Trailer,
                     ExtraRuleType.Filename,
                     "trailer",
@@ -647,6 +653,12 @@ namespace Emby.Naming.Common
                     ExtraType.Unknown,
                     ExtraRuleType.Suffix,
                     "-extra",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Unknown,
+                    ExtraRuleType.Suffix,
+                    "-other",
                     MediaType.Video)
             };
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Adds support for extras in a directory called "Other", or with the suffix "-other". This brings in behaviour that more closely matches Plex in "[Local Files for Movie Trailers and Extras](https://support.plex.tv/articles/local-files-for-trailers-and-extras/)".

**Issues**
Resolves a comment from a user post on Reddit: [Migrate from Plex to Jellyfin and specific naming](https://www.reddit.com/r/jellyfin/comments/vgtber/migrate_from_plex_to_jellyfin_and_specific_naming/)
