### PR TITLE
Update embedded image names to match docs

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/EmbeddedImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/EmbeddedImageProvider.cs
@@ -31,13 +31,14 @@ namespace MediaBrowser.Providers.MediaInfo
             "poster",
             "folder",
             "cover",
-            "default"
+            "default",
+            "movie",
+            "show"
         };
 
         private static readonly string[] _backdropImageFileNames =
         {
             "backdrop",
-            "fanart",
             "background",
             "art"
         };


### PR DESCRIPTION
Realized I never added `EmbeddedImageProvider` to [the docs](https://jellyfin.org/docs/general/server/media/movies.html#images), then when I did so I noticed I'd missed the type-specific image names ("movie" and "show") that are listed there. Seemed easier to add support for them to the code than explain an exception for them in the docs.

**Changes**
 - Add missing documented image filenames to `EmbeddedImageProvider`
 - Remove redundant "fanart" name (picked up by "art" since the matcher uses `String.Contains`)