### PR TITLE
Fallback only to the current time when marking item as watched

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1863,7 +1863,7 @@ namespace MediaBrowser.Controller.Entities
                 data.PlaybackPositionTicks = 0;
             }
 
-            data.LastPlayedDate = datePlayed ?? data.LastPlayedDate ?? DateTime.UtcNow;
+            data.LastPlayedDate = datePlayed ?? DateTime.UtcNow;
             data.Played = true;
 
             UserDataManager.SaveUserData(user.Id, this, data, UserDataSaveReason.TogglePlayed, CancellationToken.None);


### PR DESCRIPTION
**Changes**
Marking an item without providing `datePlayed` parameter now fallbacks only to the current server time instead of media's `lastPlayedDate`.

**Issues**
ex. Fixes [#8492](https://github.com/jellyfin/jellyfin/issues/8492)
