### PR TITLE
Fix Docker healthcheck output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,4 +89,4 @@ ENTRYPOINT ["./jellyfin/jellyfin", \
     "--ffmpeg", "/usr/lib/jellyfin-ffmpeg/ffmpeg"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -78,4 +78,4 @@ ENTRYPOINT ["./jellyfin/jellyfin", \
     "--ffmpeg", "/usr/lib/jellyfin-ffmpeg/ffmpeg"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -72,4 +72,4 @@ ENTRYPOINT ["./jellyfin/jellyfin", \
     "--ffmpeg", "/usr/bin/ffmpeg"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1


### PR DESCRIPTION
The current Docker healthcheck command results in progress info being output, e.g.
```
$ docker inspect <jellyfin-container>
... snip ...
"Health": {
    "Status": "healthy",
    "FailingStreak": 0,
    "Log": [
        {
            "Start": "2022-10-10T00:01:53.361633357-07:00",
            "End": "2022-10-10T00:01:53.536249464-07:00",
            "ExitCode": 0,
            "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     7    0     7    0     0    194      0 --:--:-- --:--:-- --:--:--   194\nHealthy"
        },
... snip ...
```

Fix this by adding the `-f/--fail`, `-s/--silent`, `-S/--show-error` options to avoid progress output, but still show error messages if something goes wrong.