### PR TITLE
Fix User Image not Reformatting Properly

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -160,6 +160,7 @@
  - [vgambier](https://github.com/vgambier)
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [RealGreenDragon](https://github.com/RealGreenDragon)
+ - [Neuheit](https://github.com/Neuheit)
 
 # Emby Contributors
 

--- a/Emby.Drawing/ImageProcessor.cs
+++ b/Emby.Drawing/ImageProcessor.cs
@@ -127,7 +127,7 @@ namespace Emby.Drawing
             ImageDimensions? originalImageSize = null;
             if (originalImage.Width > 0 && originalImage.Height > 0)
             {
-                originalImageSize = new ImageDimensions(originalImage.Width, originalImage.Height);
+                originalImageSize = GetImageDimensions(originalImagePath);
             }
 
             var mimeType = MimeTypes.GetMimeType(originalImagePath);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This PR ensures that the correct image dimensions are being used for the original image when determining whether to reformat it. Originally it would always create a copy `ImageDimensions` with identical width and height to the original image, which would lead to unpredictable behavior when determining whether to resize the image versus just serving the original image. This change corrects this by always getting the correct dimensions of the image.

**Issues**
Fixes #8544 
