### PR TITLE
Prevent host lookup on GetSmartUrl for HTTP requests

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1088,15 +1088,7 @@ namespace Emby.Server.Implementations
                 return GetLocalApiUrl(request.Host.Host, request.Scheme, requestPort);
             }
 
-            // Published server ends with a /
-            if (!string.IsNullOrEmpty(PublishedServerUrl))
-            {
-                // Published server ends with a '/', so we need to remove it.
-                return PublishedServerUrl.Trim('/');
-            }
-
-            string smart = NetManager.GetBindInterface(request, out var port);
-            return GetLocalApiUrl(smart.Trim('/'), request.Scheme, port);
+            return GetSmartApiUrl(request.HttpContext.Connection.RemoteIpAddress ?? IPAddress.Loopback);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Should fix the slowness reported in #8179 caused by #6486 for 10.8.
#8147 already fixes this for master by removing the host lookup feature.

**Changes**
Use the RemoteIpAddress of the HTTP request for getting the API URL.

**Issues**
Fixes #8179
