### PR TITLE
Use Token for SchedulesDirect Images and Image Index

### DIFF
--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -165,12 +165,12 @@ namespace Emby.Server.Implementations.LiveTv.Listings
 
                         const double DesiredAspect = 2.0 / 3;
 
-                        programEntry.PrimaryImage = GetProgramImage(ApiUrl, imagesWithText, DesiredAspect) ??
-                                                    GetProgramImage(ApiUrl, allImages, DesiredAspect);
+                        programEntry.PrimaryImage = GetProgramImage(ApiUrl, imagesWithText, DesiredAspect, token) ??
+                                                    GetProgramImage(ApiUrl, allImages, DesiredAspect, token);
 
                         const double WideAspect = 16.0 / 9;
 
-                        programEntry.ThumbImage = GetProgramImage(ApiUrl, imagesWithText, WideAspect);
+                        programEntry.ThumbImage = GetProgramImage(ApiUrl, imagesWithText, WideAspect, token);
 
                         // Don't supply the same image twice
                         if (string.Equals(programEntry.PrimaryImage, programEntry.ThumbImage, StringComparison.Ordinal))
@@ -178,7 +178,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                             programEntry.ThumbImage = null;
                         }
 
-                        programEntry.BackdropImage = GetProgramImage(ApiUrl, imagesWithoutText, WideAspect);
+                        programEntry.BackdropImage = GetProgramImage(ApiUrl, imagesWithoutText, WideAspect, token);
 
                         // programEntry.bannerImage = GetProgramImage(ApiUrl, data, "Banner", false) ??
                         //    GetProgramImage(ApiUrl, data, "Banner-L1", false) ??
@@ -399,7 +399,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             return info;
         }
 
-        private static string GetProgramImage(string apiUrl, IEnumerable<ImageDataDto> images, double desiredAspect)
+        private static string GetProgramImage(string apiUrl, IEnumerable<ImageDataDto> images, double desiredAspect, string token)
         {
             var match = images
                 .OrderBy(i => Math.Abs(desiredAspect - GetAspectRatio(i)))
@@ -423,7 +423,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             }
             else
             {
-                return apiUrl + "/image/" + uri;
+                return apiUrl + "/image/" + uri + "?token=" + token;
             }
         }
 

--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -457,6 +457,8 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             IReadOnlyList<string> programIds,
             CancellationToken cancellationToken)
         {
+            var token = await GetToken(info, cancellationToken).ConfigureAwait(false);
+
             if (programIds.Count == 0)
             {
                 return Array.Empty<ShowImagesDto>();
@@ -478,6 +480,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             {
                 Content = new StringContent(str.ToString(), Encoding.UTF8, MediaTypeNames.Application.Json)
             };
+            message.Headers.TryAddWithoutValidation("token", token);
 
             try
             {


### PR DESCRIPTION
I have not worked on the server in a long time. Please provide guidance on how I can improve this solution.

**Changes**
As per the API changes on October 1st (and possibly earlier), SchedulesDirect requires the token to be used to get the available image artwork index, and for image requests. This is part of an effort by them to curb abuse of the program artwork from their data provider.

References:
https://www.schedulesdirect.org/news/056/SD-JSON-images-now-require-tokens

**Issues**
Likely fixes #7528, may be related to #8502.

**Followup**
As per the [changes to the API page](https://github.com/SchedulesDirect/JSON-Service/wiki/API-20141201/_compare/b66fb95c6d167c968fc11311ac5e02cbb28b883a...b1bbfbcec39846623476a0f8b96d1f0d501bef7f), the token can either be provided as a header, or as a query parameter. I didn't know how to add it as a header for the image downloads themselves, so I added it as a query.