### PR TITLE
Fix TranscodeReasons type in OpenAPI output

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -434,11 +434,15 @@ namespace Jellyfin.Server.Extensions
             options.MapType<TranscodeReason>(() =>
                 new OpenApiSchema
                 {
-                    Type = "string",
-                    Enum = Enum.GetNames<TranscodeReason>()
-                        .Select(e => new OpenApiString(e))
-                        .Cast<IOpenApiAny>()
-                        .ToArray()
+                    Type = "array",
+                    Items = new OpenApiSchema
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Id = nameof(TranscodeReason),
+                            Type = ReferenceType.Schema,
+                        }
+                    }
                 });
 
             // Swashbuckle doesn't use JsonOptions to describe responses, so we need to manually describe it.

--- a/Jellyfin.Server/Filters/AdditionalModelFilter.cs
+++ b/Jellyfin.Server/Filters/AdditionalModelFilter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Jellyfin.Extensions;
 using Jellyfin.Server.Migrations;
 using MediaBrowser.Common.Plugins;
@@ -8,6 +9,7 @@ using MediaBrowser.Model.ApiClient;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Session;
 using MediaBrowser.Model.SyncPlay;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -56,6 +58,15 @@ namespace Jellyfin.Server.Filters
 
                 context.SchemaGenerator.GenerateSchema(configuration.ConfigurationType, context.SchemaRepository);
             }
+
+            context.SchemaRepository.AddDefinition(nameof(TranscodeReason), new OpenApiSchema
+            {
+                Type = "string",
+                Enum = Enum.GetNames<TranscodeReason>()
+                    .Select(e => new OpenApiString(e))
+                    .Cast<IOpenApiAny>()
+                    .ToArray()
+            });
         }
     }
 }


### PR DESCRIPTION
**Changes**
- Change TranscodingInfo.TranscodeReasons to an array instead of string
- Move enum definition for TranscodeReasons to it's own schema

**Issues**

Fixes #8514 