### PR TITLE
Fix the DG2 HDR TM tearing issue on Windows

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1415,7 +1415,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                     param += " -preset 7";
                 }
 
-                param += " -look_ahead 0";
+                // Only h264_qsv has look_ahead option
+                if (string.Equals(videoEncoder, "h264_qsv", StringComparison.OrdinalIgnoreCase))
+                {
+                    param += " -look_ahead 0";
+                }
             }
             else if (string.Equals(videoEncoder, "h264_nvenc", StringComparison.OrdinalIgnoreCase) // h264 (h264_nvenc)
                      || string.Equals(videoEncoder, "hevc_nvenc", StringComparison.OrdinalIgnoreCase)) // hevc (hevc_nvenc)
@@ -1453,7 +1457,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         break;
 
                     default:
-                        param += " -preset p4";
+                        param += " -preset p1";
                         break;
                 }
             }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3404,6 +3404,12 @@ namespace MediaBrowser.Controller.MediaEncoding
                         // map from d3d11va to qsv.
                         mainFilters.Add("hwmap=derive_device=qsv");
                     }
+                    else
+                    {
+                        // Insert a qsv scaler to sync the decoder surface,
+                        // msdk will passthrough this internally.
+                        mainFilters.Add("hwmap=derive_device=qsv,scale_qsv");
+                    }
                 }
 
                 // hw deint


### PR DESCRIPTION
**Changes**
- Fix the DG2 HDR TM tearing issue on Windows
- Fix some encoding presets

**Issues**
Intel DG2/A380 on Windows may produces tearing and artifacts when mapping from D3D11VA to OpenCL.
