### PR TITLE
Revert dependency updates to Azure Pipelines

### DIFF
--- a/.ci/azure-pipelines-abi.yml
+++ b/.ci/azure-pipelines-abi.yml
@@ -35,14 +35,14 @@ jobs:
           packageType: sdk
           version: ${{ parameters.DotNetSdkVersion }}
 
-      - task: DotNetCoreCLI@2.210.0
+      - task: DotNetCoreCLI@2
         displayName: 'Install ABI CompatibilityChecker Tool'
         inputs:
           command: custom
           custom: tool
           arguments: 'update compatibilitychecker -g'
 
-      - task: DownloadPipelineArtifact@2.198.0
+      - task: DownloadPipelineArtifact@2
         displayName: 'Download New Assembly Build Artifact'
         inputs:
           source: 'current'
@@ -50,7 +50,7 @@ jobs:
           path: "$(System.ArtifactsDirectory)/new-artifacts"
           runVersion: "latest"
 
-      - task: CopyFiles@2.211.0
+      - task: CopyFiles@2
         displayName: 'Copy New Assembly Build Artifact'
         inputs:
           sourceFolder: $(System.ArtifactsDirectory)/new-artifacts
@@ -60,7 +60,7 @@ jobs:
           overWrite: true
           flattenFolders: true
 
-      - task: DownloadPipelineArtifact@2.198.0
+      - task: DownloadPipelineArtifact@2
         displayName: 'Download Reference Assembly Build Artifact'
         enabled: false
         inputs:
@@ -72,7 +72,7 @@ jobs:
           runVersion: "latestFromBranch"
           runBranch: "refs/heads/$(System.PullRequest.TargetBranch)"
 
-      - task: CopyFiles@2.211.0
+      - task: CopyFiles@2
         displayName: 'Copy Reference Assembly Build Artifact'
         enabled: false
         inputs:
@@ -83,7 +83,7 @@ jobs:
           overWrite: true
           flattenFolders: true
 
-      - task: DotNetCoreCLI@2.210.0
+      - task: DotNetCoreCLI@2
         displayName: 'Execute ABI Compatibility Check Tool'
         enabled: false
         inputs:

--- a/.ci/azure-pipelines-main.yml
+++ b/.ci/azure-pipelines-main.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: true
         persistCredentials: true
 
-      - task: DownloadPipelineArtifact@2.198.0
+      - task: DownloadPipelineArtifact@2
         displayName: 'Download Web Branch'
         condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion')
         inputs:
@@ -31,7 +31,7 @@ jobs:
           pipeline: 'Jellyfin Web'
           runBranch: variables['Build.SourceBranch']
 
-      - task: DownloadPipelineArtifact@2.198.0
+      - task: DownloadPipelineArtifact@2
         displayName: 'Download Web Target'
         condition: eq(variables['Build.Reason'], 'PullRequest')
         inputs:
@@ -42,7 +42,7 @@ jobs:
           pipeline: 'Jellyfin Web'
           runBranch: variables['System.PullRequest.TargetBranch']
 
-      - task: ExtractFiles@1.211.0
+      - task: ExtractFiles@1
         displayName: 'Extract Web Client'
         inputs:
           archiveFilePatterns: '$(Agent.TempDirectory)/*.zip'
@@ -55,7 +55,7 @@ jobs:
           packageType: sdk
           version: ${{ parameters.DotNetSdkVersion }}
 
-      - task: DotNetCoreCLI@2.210.0
+      - task: DotNetCoreCLI@2
         displayName: 'Publish Server'
         inputs:
           command: publish

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -69,7 +69,7 @@ jobs:
       runOptions: 'inline'
       inline: 'mkdir -p /srv/repository/incoming/azure/$(Build.BuildNumber)/$(BuildConfiguration)'
 
-  - task: CopyFilesOverSSH@0.212.0
+  - task: CopyFilesOverSSH@0
     displayName: 'Upload artifacts to repository server'
     inputs:
       sshEndpoint: repository
@@ -90,7 +90,7 @@ jobs:
     displayName: Set release version (stable)
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
-  - task: DownloadPipelineArtifact@2.198.0
+  - task: DownloadPipelineArtifact@2
     displayName: 'Download OpenAPI Spec'
     inputs:
       source: 'current'
@@ -105,7 +105,7 @@ jobs:
       runOptions: 'inline'
       inline: 'mkdir -p /srv/repository/incoming/azure/$(Build.BuildNumber)'
 
-  - task: CopyFilesOverSSH@0.212.0
+  - task: CopyFilesOverSSH@0
     displayName: 'Upload artifacts to repository server'
     inputs:
       sshEndpoint: repository
@@ -137,7 +137,7 @@ jobs:
     displayName: Set release version (stable)
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
-  - task: Docker@2.211.0
+  - task: Docker@2
     displayName: 'Push Unstable Image'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
     inputs:
@@ -150,7 +150,7 @@ jobs:
         unstable-$(Build.BuildNumber)-$(BuildConfiguration)
         unstable-$(BuildConfiguration)
 
-  - task: Docker@2.211.0
+  - task: Docker@2
     displayName: 'Push Stable Image'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
     inputs:
@@ -210,7 +210,7 @@ jobs:
       packageType: 'sdk'
       version: '6.0.x'
 
-  - task: DotNetCoreCLI@2.210.0
+  - task: DotNetCoreCLI@2
     displayName: 'Build Stable Nuget packages'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
     inputs:
@@ -225,7 +225,7 @@ jobs:
       custom: 'pack'
       arguments: -o $(Build.ArtifactStagingDirectory) -p:Version=$(JellyfinVersion)
 
-  - task: DotNetCoreCLI@2.210.0
+  - task: DotNetCoreCLI@2
     displayName: 'Build Unstable Nuget packages'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
     inputs:
@@ -256,7 +256,7 @@ jobs:
       publishFeedCredentials: 'NugetOrg'
       allowPackageConflicts: true # This ignores an error if the version already exists
 
-  - task: NuGetAuthenticate@0.203.0
+  - task: NuGetAuthenticate@0
     displayName: 'Authenticate to unstable Nuget feed'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 

--- a/.ci/azure-pipelines-test.yml
+++ b/.ci/azure-pipelines-test.yml
@@ -51,7 +51,7 @@ jobs:
           organization: 'jellyfin'
           projectKey: 'jellyfin_jellyfin'
 
-      - task: DotNetCoreCLI@2.210.0
+      - task: DotNetCoreCLI@2
         displayName: 'Run CLI Tests'
         inputs:
           command: "test"


### PR DESCRIPTION
These dependency updates broke the pipeline... so downgrade while we wait for the migration to GHA