### PR TITLE
Fix extra type differentiation

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -512,13 +512,13 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
-                    ExtraType.Clip,
+                    ExtraType.Short,
                     ExtraRuleType.DirectoryName,
                     "shorts",
                     MediaType.Video),
 
                 new ExtraRule(
-                    ExtraType.Clip,
+                    ExtraType.Featurette,
                     ExtraRuleType.DirectoryName,
                     "featurettes",
                     MediaType.Video),
@@ -533,6 +533,12 @@ namespace Emby.Naming.Common
                     ExtraType.Unknown,
                     ExtraRuleType.DirectoryName,
                     "other",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Clip,
+                    ExtraRuleType.DirectoryName,
+                    "clips",
                     MediaType.Video),
 
                 new ExtraRule(
@@ -638,13 +644,13 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
-                    ExtraType.Clip,
+                    ExtraType.Featurette,
                     ExtraRuleType.Suffix,
                     "-featurette",
                     MediaType.Video),
 
                 new ExtraRule(
-                    ExtraType.Clip,
+                    ExtraType.Short,
                     ExtraRuleType.Suffix,
                     "-short",
                     MediaType.Video),

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -75,7 +75,9 @@ namespace MediaBrowser.Controller.Entities
             Model.Entities.ExtraType.DeletedScene,
             Model.Entities.ExtraType.Interview,
             Model.Entities.ExtraType.Sample,
-            Model.Entities.ExtraType.Scene
+            Model.Entities.ExtraType.Scene,
+            Model.Entities.ExtraType.Featurette,
+            Model.Entities.ExtraType.Short
         };
 
         private string _sortName;

--- a/MediaBrowser.Model/Entities/ExtraType.cs
+++ b/MediaBrowser.Model/Entities/ExtraType.cs
@@ -13,6 +13,8 @@ namespace MediaBrowser.Model.Entities
         Scene = 6,
         Sample = 7,
         ThemeSong = 8,
-        ThemeVideo = 9
+        ThemeVideo = 9,
+        Featurette = 10,
+        Short = 11
     }
 }

--- a/tests/Jellyfin.Naming.Tests/Video/ExtraTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/ExtraTests.cs
@@ -51,8 +51,9 @@ namespace Jellyfin.Naming.Tests.Video
         [InlineData(ExtraType.Interview, "interviews")]
         [InlineData(ExtraType.Scene, "scenes")]
         [InlineData(ExtraType.Sample, "samples")]
-        [InlineData(ExtraType.Clip, "shorts")]
-        [InlineData(ExtraType.Clip, "featurettes")]
+        [InlineData(ExtraType.Short, "shorts")]
+        [InlineData(ExtraType.Featurette, "featurettes")]
+        [InlineData(ExtraType.Clip, "clips")]
         [InlineData(ExtraType.ThemeVideo, "backdrops")]
         [InlineData(ExtraType.Unknown, "extras")]
         public void TestDirectories(ExtraType type, string dirName)


### PR DESCRIPTION
Change extra parsing rules for Featurettes and Shorts so they don't both get classed as ExtraType.Clip.

Fix test broken by these changes.

**Changes**
Change parsing rules for extras labeled "short" and "featurette." Both were previously classed as type "Clip" 
Add two new Extra types (short, featurette)
Add parsing rule to allow "clip" extras in folder form. Now accommodates all supported extra types in either suffix or folder form.


**Issues**
Fixes [#4114](https://github.com/jellyfin/jellyfin-web/issues/4114)

**Other**
PR for user facing portion: [4115](https://github.com/jellyfin/jellyfin-web/pull/4115)
