### PR TITLE
Remove firewalld spec and target Fedora 37

### DIFF
--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:37
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/fedora/jellyfin-firewalld.xml
+++ b/fedora/jellyfin-firewalld.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Jellyfin</short>
-  <description>The Free Software Media System.</description>
-  <port protocol="tcp" port="8096"/>
-  <port protocol="tcp" port="8920"/>
-  <port protocol="udp" port="1900"/>
-  <port protocol="udp" port="7359"/>
-</service>

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -19,8 +19,7 @@ Source12:       jellyfin.env
 Source13:       jellyfin.sudoers
 Source14:       restart.sh
 Source15:       jellyfin.override.conf
-Source16:       jellyfin-firewalld.xml
-Source17:       jellyfin-server-lowports.conf
+Source16:       jellyfin-server-lowports.conf
 
 %{?systemd_requires}
 BuildRequires:  systemd
@@ -83,7 +82,6 @@ ln -srf %{_libdir}/jellyfin/jellyfin %{buildroot}%{_bindir}/jellyfin
 %{__install} -D %{SOURCE12} %{buildroot}%{_sysconfdir}/sysconfig/jellyfin
 
 # system config
-%{__install} -D %{SOURCE16} %{buildroot}%{_prefix}/lib/firewalld/services/jellyfin.xml
 %{__install} -D %{SOURCE13} %{buildroot}%{_sysconfdir}/sudoers.d/jellyfin-sudoers
 %{__install} -D %{SOURCE15} %{buildroot}%{_sysconfdir}/systemd/system/jellyfin.service.d/override.conf
 %{__install} -D %{SOURCE11} %{buildroot}%{_unitdir}/jellyfin.service
@@ -117,7 +115,6 @@ ln -srf %{_libdir}/jellyfin/jellyfin %{buildroot}%{_bindir}/jellyfin
 %config %{_sysconfdir}/sysconfig/jellyfin
 
 # system config
-%{_prefix}/lib/firewalld/services/jellyfin.xml
 %{_unitdir}/jellyfin.service
 %config(noreplace) %attr(600,root,root) %{_sysconfdir}/sudoers.d/jellyfin-sudoers
 %config(noreplace) %{_sysconfdir}/systemd/system/jellyfin.service.d/override.conf


### PR DESCRIPTION
Fedora 37 ships with this firewalld configuration by default, and thus our package conflicts with it.

For older releases, it should be added manually (and I don't believe those upgrading would have it removed) but I expect given Fedora's release schedule that most everyone will upgrade soon.

At the same time, upgrade the build Dockerfile to target 37 to ensure consistency.