### PR TITLE
Revert "Revert "Merge pull request #8298 from lomion0815/fix-data-stream""

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -863,8 +863,13 @@ namespace MediaBrowser.MediaEncoding.Probing
                     }
                 }
             }
+            else if (string.Equals(streamInfo.CodecType, "data", StringComparison.OrdinalIgnoreCase))
+            {
+                stream.Type = MediaStreamType.Data;
+            }
             else
             {
+                _logger.LogError("Codec Type {CodecType} unknown. The stream (index: {Index}) will be ignored. Warning: Subsequential streams will have a wrong stream specifier!", streamInfo.CodecType, streamInfo.Index);
                 return null;
             }
 

--- a/MediaBrowser.Model/Entities/MediaStreamType.cs
+++ b/MediaBrowser.Model/Entities/MediaStreamType.cs
@@ -23,6 +23,11 @@ namespace MediaBrowser.Model.Entities
         /// <summary>
         /// The embedded image.
         /// </summary>
-        EmbeddedImage
+        EmbeddedImage,
+
+        /// <summary>
+        /// The data.
+        /// </summary>
+        Data
     }
 }


### PR DESCRIPTION
Reverting the change wasn't necessary anymore and actually causes problems for users that have data streams because the database now contains an invalid value. Reverting the revert for 10.8.7.

In the future we should make sure no database/api changes are added to patch releases unless it's a critical bugfix so we don't end up ping-ponging like we did here.

Reverts jellyfin/jellyfin#8480