### PR TITLE
Add SeriesStatus.Unreleased

### DIFF
--- a/MediaBrowser.Model/Entities/SeriesStatus.cs
+++ b/MediaBrowser.Model/Entities/SeriesStatus.cs
@@ -1,18 +1,23 @@
 namespace MediaBrowser.Model.Entities
 {
     /// <summary>
-    /// Enum SeriesStatus.
+    /// The status of a series.
     /// </summary>
     public enum SeriesStatus
     {
         /// <summary>
-        /// The continuing.
+        /// The continuing status. This indicates that a series is currently releasing.
         /// </summary>
         Continuing,
 
         /// <summary>
-        /// The ended.
+        /// The ended status. This indicates that a series has completed and is no longer being released.
         /// </summary>
-        Ended
+        Ended,
+
+        /// <summary>
+        /// The unreleased status. This indicates that a series has not been released yet.
+        /// </summary>
+        Unreleased
     }
 }


### PR DESCRIPTION
**Changes**

Add new "Unreleased" status to SeriesStatus enum. To be used for series that have not started releasing yet. This PR does not change any of the core providers to make use of this new enum member.

Also make the descriptions slightly more useful.

**Rationale**

Currently we only have a continuing and ended state. But it's not uncommon to have the directories for new series made before they start releasing. For that particular case there is no way to indicate this "unreleased" state. With jellyfin-web (and possibly other clients) having a filter for series state it makes sense to put unreleased series in their own grouping.

**To consider**

Different providers have different states. Some examples:

- TheMovieDatabase: `Rumored, Planned, In Production, Post Production, Released, Canceled`
- AniList: `FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS`

We might want to add some of these as well, like cancelled or hiatus. This PR focusses on the unreleased state only though.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
