### PR TITLE
fix: use a combination of ParentIndexNumber and IndexNumber to determine next up episodes

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -3541,10 +3541,11 @@ namespace Emby.Server.Implementations.Data
                 statement?.TryBind("@MinIndexNumber", query.MinIndexNumber.Value);
             }
 
-            if (query.MinParentIndexNumber.HasValue)
+            if (query.MinParentAndIndexNumber.HasValue)
             {
-                whereClauses.Add("ParentIndexNumber>=@MinParentIndexNumber");
-                statement?.TryBind("@MinParentIndexNumber", query.MinParentIndexNumber.Value);
+                whereClauses.Add("((ParentIndexNumber=@MinParentAndIndexNumberParent and IndexNumber>=@MinParentAndIndexNumberIndex) or ParentIndexNumber>@MinParentAndIndexNumberParent)");
+                statement?.TryBind("@MinParentAndIndexNumberParent", query.MinParentAndIndexNumber.Value.ParentIndexNumber);
+                statement?.TryBind("@MinParentAndIndexNumberIndex", query.MinParentAndIndexNumber.Value.IndexNumber);
             }
 
             if (query.MinDateCreated.HasValue)

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -205,7 +205,15 @@ namespace MediaBrowser.Controller.Entities
 
         public int? MinIndexNumber { get; set; }
 
-        public int? MinParentIndexNumber { get; set; }
+        /// <summary>
+        /// Gets or sets the minimum ParentIndexNumber and IndexNumber.
+        /// </summary>
+        /// <remarks>
+        /// It produces this where clause:
+        /// <para>(ParentIndexNumber = X and IndexNumber >= Y) or ParentIndexNumber > X.
+        /// </para>
+        /// </remarks>
+        public (int ParentIndexNumber, int IndexNumber)? MinParentAndIndexNumber { get; set; }
 
         public int? AiredDuringSeason { get; set; }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Using ParentIndexNumber and IndexNumber individually doesn't work when the next episode is in another season. This changes the query to look for higher episode numbers in the same season and episodes in higher seasons.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/8655