### PR TITLE
Enable OMDB plot for non-English languages as fallback

### DIFF
--- a/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
@@ -408,10 +408,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
                 }
             }
 
-            if (isEnglishRequested)
-            {
-                item.Overview = result.Plot;
-            }
+            item.Overview = result.Plot;
 
             if (!Plugin.Instance.Configuration.CastAndCrew)
             {


### PR DESCRIPTION
**Changes**
Re-enables OMDb plot data for non-english languages. This was used as a fallback if there was no localised plot in 10.7.z.

Simpler fix of #8633

**Issues**
Fixes #8064
