### PR TITLE
Fix recursive children lookup of folders

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@
  - [DMouse10462](https://github.com/DMouse10462)
  - [DrPandemic](https://github.com/DrPandemic)
  - [eglia](https://github.com/eglia)
+ - [EgorBakanov](https://github.com/EgorBakanov)
  - [EraYaN](https://github.com/EraYaN)
  - [escabe](https://github.com/escabe)
  - [excelite](https://github.com/excelite)


### PR DESCRIPTION
Currently it is impossible to play/shuffle collection unless it directly contains audio tracks or video because albums/collections/etc. are not consider direct children.

**Changes**
- Add recursive lookup for linked children
- Prevent infinite recursive lookup

**Issues**
Fixes #6193
Fixes #7226

**Related reddit posts**
* [Help! Can't play a music collection](https://www.reddit.com/r/jellyfin/comments/vpvnxd/help_cant_play_a_music_collection/)
* [Error on Play or Shuffle Music Collection](https://www.reddit.com/r/jellyfin/comments/s6ltkw/error_on_play_or_shuffle_music_collection/)
* ['Playback Error' when playing Collection/Playlist](https://www.reddit.com/r/jellyfin/comments/qoxc9o/playback_error_when_playing_collectionplaylist/)
* [Problem with playing a collection with just Tv shows in it.](https://www.reddit.com/r/jellyfin/comments/obwkjd/problem_with_playing_a_collection_with_just_tv/)