### PR TITLE
Sort external files when scanning

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -175,12 +175,12 @@ namespace MediaBrowser.Providers.MediaInfo
                 return Array.Empty<ExternalPathParserResult>();
             }
 
-            var files = directoryService.GetFilePaths(folder, clearCache).ToList();
+            var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
             files.Remove(video.Path);
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))
             {
-                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
+                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache, true));
             }
 
             if (!files.Any())


### PR DESCRIPTION
This is mostly useful in order to have a deterministic display in the UI and your subtitles follow a clear naming scheme. I would for instance like to show preferred subtitle formats first in the list, which is enabled by this and a simple additional tag in the name just after the title.

**Changes**
Just turns on sorting for the two methods that get the actual external file names.
