### PR TITLE
Don't throw exception if program.Title is null

### DIFF
--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -165,7 +165,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                 HasImage = !string.IsNullOrEmpty(program.Icon?.Source),
                 OfficialRating = string.IsNullOrEmpty(program.Rating?.Value) ? null : program.Rating.Value,
                 CommunityRating = program.StarRating,
-                SeriesId = program.Episode == null ? null : program.Title.GetMD5().ToString("N", CultureInfo.InvariantCulture)
+                SeriesId = program.Episode == null ? null : program.Title?.GetMD5().ToString("N", CultureInfo.InvariantCulture)
             };
 
             if (string.IsNullOrWhiteSpace(program.ProgramId))


### PR DESCRIPTION
Fixes exceptions generated from this (invalid) xml

```
<programme channel="3297" start="20221104130000 -0400" stop="20221105235959 -0400">
<category lang="en">sports</category>
<episode-num system="original-air-date">2022-11-04 13:00:00</episode-num>
<icon height="" src="https://domain.tld/image.png" width=""/>
<credits/>
<video/>
<date/>
</programme>
```