### PR TITLE
Calculate output audio bitrate from output channel count

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1685,9 +1685,20 @@ public class DynamicHlsController : BaseJellyfinApiController
 
             audioTranscodeParams += "-acodec " + audioCodec;
 
-            if (state.OutputAudioBitrate.HasValue)
+            var audioBitrate = state.OutputAudioBitrate;
+            var audioChannels = state.OutputAudioChannels;
+
+            if (audioBitrate.HasValue)
             {
-                audioTranscodeParams += " -ab " + state.OutputAudioBitrate.Value.ToString(CultureInfo.InvariantCulture);
+                string vbrParam;
+                if (_encodingOptions.EnableAudioVbr && (vbrParam = _encodingHelper.GetAudioVbrModeParam(audioCodec, audioBitrate.Value / audioChannels ?? 2)) != null)
+                {
+                    audioTranscodeParams += vbrParam;
+                }
+                else
+                {
+                    audioTranscodeParams += " -ab " + audioBitrate.Value.ToString(CultureInfo.InvariantCulture);
+                }
             }
 
             if (state.OutputAudioChannels.HasValue)
@@ -1747,7 +1758,15 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         if (bitrate.HasValue)
         {
-            args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+            string vbrParam;
+            if (_encodingOptions.EnableAudioVbr && (vbrParam = _encodingHelper.GetAudioVbrModeParam(audioCodec, bitrate.Value / channels ?? 2)) != null)
+            {
+                args += vbrParam;
+            }
+            else
+            {
+                args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+            }
         }
 
         if (state.OutputAudioSampleRate.HasValue)

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -222,9 +222,9 @@ public class DynamicHlsHelper
                     var sdrVideoUrl = ReplaceProfile(playlistUrl, "hevc", string.Join(',', requestedVideoProfiles), "main");
                     sdrVideoUrl += "&AllowVideoStreamCopy=false";
 
-                        var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
-                        var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream, state.OutputAudioChannels) ?? 0;
-                        var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
+                    var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
+                    var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream, state.OutputAudioChannels) ?? 0;
+                    var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
 
                     var sdrPlaylist = AppendPlaylist(builder, state, sdrVideoUrl, sdrTotalBitrate, subtitleGroup);
 

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -222,9 +222,9 @@ public class DynamicHlsHelper
                     var sdrVideoUrl = ReplaceProfile(playlistUrl, "hevc", string.Join(',', requestedVideoProfiles), "main");
                     sdrVideoUrl += "&AllowVideoStreamCopy=false";
 
-                    var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
-                    var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream) ?? 0;
-                    var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
+                        var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
+                        var sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream, state.OutputAudioChannels) ?? 0;
+                        var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
 
                     var sdrPlaylist = AppendPlaylist(builder, state, sdrVideoUrl, sdrTotalBitrate, subtitleGroup);
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2187,6 +2187,47 @@ namespace MediaBrowser.Controller.MediaEncoding
             return 128000;
         }
 
+        public string GetAudioVbrModeParam(string encoder, int bitratePerChannel)
+        {
+            if (encoder == "libfdk_aac")
+            {
+                return " -vbr:a " + (bitratePerChannel switch
+                {
+                    < 32000 => "1",
+                    < 48000 => "2",
+                    < 64000 => "3",
+                    < 96000 => "4",
+                    _ => "5"
+                });
+            }
+
+            if (encoder == "libmp3lame")
+            {
+                return " -qscale:a " + (bitratePerChannel switch
+                {
+                    < 48000 => "8",
+                    < 64000 => "6",
+                    < 88000 => "4",
+                    < 112000 => "2",
+                    _ => "0"
+                });
+            }
+
+            if (encoder == "libvorbis")
+            {
+                return " -qscale:a " + (bitratePerChannel switch
+                {
+                    < 40000 => "0",
+                    < 56000 => "2",
+                    < 80000 => "4",
+                    < 112000 => "6",
+                    _ => "8"
+                });
+            }
+
+            return null;
+        }
+
         public string GetAudioFilterParam(EncodingJobInfo state, EncodingOptions encodingOptions)
         {
             var channels = state.OutputAudioChannels;
@@ -5833,7 +5874,15 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (bitrate.HasValue)
             {
-                args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+                string vbrParam;
+                if (encodingOptions.EnableAudioVbr && (vbrParam = GetAudioVbrModeParam(codec, bitrate.Value / channels ?? 2)) != null)
+                {
+                    args += vbrParam;
+                }
+                else
+                {
+                    args += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+                }
             }
 
             if (state.OutputAudioSampleRate.HasValue)
@@ -5851,13 +5900,22 @@ namespace MediaBrowser.Controller.MediaEncoding
             var audioTranscodeParams = new List<string>();
 
             var bitrate = state.OutputAudioBitrate;
+            var channels = state.OutputAudioChannels;
 
             if (bitrate.HasValue)
             {
-                audioTranscodeParams.Add("-ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture));
+                string vbrParam;
+                if (encodingOptions.EnableAudioVbr && (vbrParam = GetAudioVbrModeParam(GetAudioEncoder(state), bitrate.Value / channels ?? 2)) != null)
+                {
+                    audioTranscodeParams.Add(vbrParam);
+                }
+                else
+                {
+                    audioTranscodeParams.Add("-ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture));
+                }
             }
 
-            if (state.OutputAudioChannels.HasValue)
+            if (channels.HasValue)
             {
                 audioTranscodeParams.Add("-ac " + state.OutputAudioChannels.Value.ToString(CultureInfo.InvariantCulture));
             }

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -14,6 +14,7 @@ public class EncodingOptions
     public EncodingOptions()
     {
         EnableFallbackFont = false;
+        EnableAudioVbr = false;
         DownMixAudioBoost = 2;
         DownMixStereoAlgorithm = DownMixStereoAlgorithms.None;
         MaxMuxingQueueSize = 2048;
@@ -69,6 +70,11 @@ public class EncodingOptions
     /// Gets or sets a value indicating whether to use the fallback font.
     /// </summary>
     public bool EnableFallbackFont { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether variable-bitrate audio encoding is enabled.
+    /// </summary>
+    public bool EnableAudioVbr { get; set; }
 
     /// <summary>
     /// Gets or sets the audio boost applied when downmixing audio.


### PR DESCRIPTION
384kbps is unnecessarily high for stereo output with our encoders and sending data over network is expensive. This commit introduces logic for calculating output bitrate based on output channel count, like this:
```csharp
(inputChannels, outputChannels) switch
{
    ( >= 6, >= 6 or 0) => Math.Min(640000, audioBitRate.Value),
    ( > 0, > 0) => Math.Min(outputChannels * 128000, audioBitRate.Value),
    ( > 0, _) => Math.Min(inputChannels * 128000, audioBitRate.Value),
    (_, _) => Math.Min(384000, audioBitRate.Value)
}
```

That means transcoded stereo output in hls is going to be **at most** 256kbps, mono 128kbps, surround 640kbps, etc.

The second commit adds VBR mode calculation from the output bitrate based on expected upper-bound average bitrate for high-quality audio. This is user-configurable and disabled by default.

Continued from https://github.com/jellyfin/jellyfin/pull/8113
