### PR TITLE
Add support for "Digital Media" album splits

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -175,6 +175,7 @@ namespace Emby.Naming.Common
             AlbumStackingPrefixes = new[]
             {
                 "cd",
+                "digital media",
                 "disc",
                 "disk",
                 "vol",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
"Digital Media" is a common 'disk'-splitting prefix, more so with recent 'digital' music releases as physical cds/disks aren't used. In particular, it is part of Lidarr's `{Medium Format}` tag for automatic archive sorting. So it would be good to see this reflected into Jellyfin. I'm not familiar with the code-base, or whether a ' ' character is valid within this context.
