### PR TITLE
HDHomeRun - Fix incorrect starting offset of buffer span in CheckTunerAvailability.

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunManager.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunManager.cs
@@ -67,7 +67,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
 
                 int receivedBytes = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-                return VerifyReturnValueOfGetSet(buffer.AsSpan(receivedBytes), "none");
+                return VerifyReturnValueOfGetSet(buffer.AsSpan(0, receivedBytes), "none");
             }
             finally
             {


### PR DESCRIPTION
CheckTunerAvailability creates a span from a buffer to pass to the validation function. It appears to be incorrectly using the length as the starting index which is causing the tuner initialization to fail. Fixing this resolved the issue I was having with my HDHR3-US.

Please let me if you would like any additional  changes  or testing done.

Fixes #7154 