### PR TITLE
Don't auto-update if plugin is pending restart

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -715,6 +715,7 @@ namespace Emby.Server.Implementations.Plugins
             {
                 // This value is memory only - so that the web will show restart required.
                 plugin.Manifest.Status = PluginStatus.Restart;
+                plugin.Manifest.AutoUpdate = false;
                 return;
             }
 
@@ -729,6 +730,7 @@ namespace Emby.Server.Implementations.Plugins
 
             // This value is memory only - so that the web will show restart required.
             plugin.Manifest.Status = PluginStatus.Restart;
+            plugin.Manifest.AutoUpdate = false;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/8681

The update task already ignores plugins marked as Disabled, but when initially disabling a plugin it's status is set to Restart.

Alternatively we could ignore plugins with a status of Restart when checking for updates