### PR TITLE
Add missing format providers (fix CA1305 errors)

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -178,7 +178,7 @@ namespace Jellyfin.Api.Controllers
 
             foreach (var key in displayPreferences.CustomPrefs.Keys.Where(key => key.StartsWith("homesection", StringComparison.OrdinalIgnoreCase)))
             {
-                var order = int.Parse(key.AsSpan().Slice("homesection".Length));
+                var order = int.Parse(key.AsSpan().Slice("homesection".Length), NumberStyles.Any, CultureInfo.InvariantCulture);
                 if (!Enum.TryParse<HomeSectionType>(displayPreferences.CustomPrefs[key], true, out var type))
                 {
                     type = order < 8 ? defaults[order] : HomeSectionType.None;

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -351,7 +351,7 @@ namespace Jellyfin.Api.Helpers
             try
             {
                 // Parses npt times in the format of '10:19:25.7'
-                return TimeSpan.Parse(value).Ticks;
+                return TimeSpan.Parse(value, CultureInfo.InvariantCulture).Ticks;
             }
             catch
             {

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -612,11 +613,14 @@ namespace Jellyfin.Server
             catch (Exception ex)
             {
                 Log.Logger = new LoggerConfiguration()
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}")
+                    .WriteTo.Console(
+                        outputTemplate: "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}",
+                        formatProvider: CultureInfo.InvariantCulture)
                     .WriteTo.Async(x => x.File(
                         Path.Combine(appPaths.LogDirectoryPath, "log_.log"),
                         rollingInterval: RollingInterval.Day,
                         outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message}{NewLine}{Exception}",
+                        formatProvider: CultureInfo.InvariantCulture,
                         encoding: Encoding.UTF8))
                     .Enrich.FromLogContext()
                     .Enrich.WithThreadId()


### PR DESCRIPTION
This resolves the following compilation errors (originally encountered whilst trying to build for Arch Linux using an [AUR package](https://aur.archlinux.org/packages/jellyfin), but can be reproduced using the repo's own build script with the dpkg check commented out):

> Jellyfin.Api/Controllers/DisplayPreferencesController.cs(181,29): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Jellyfin.Api/Jellyfin.Api.csproj]
> Jellyfin.Api/Helpers/StreamingHelpers.cs(354,24): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Jellyfin.Api/Jellyfin.Api.csproj]
> Jellyfin.Server/Program.cs(614,30): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Jellyfin.Server/Jellyfin.Server.csproj]
> Jellyfin.Server/Program.cs(616,41): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Jellyfin.Server/Jellyfin.Server.csproj]

I've used `CultureInfo.InvariantCulture` as that seems to be used everywhere else, though I'm not familiar enough with the codebase to know if a better formatter would be more appropriate in these cases.