### PR TITLE
Don't cancel DVR recordings when adjusting settings

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2201,7 +2201,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
         }
 
-        private void SearchForDuplicateShowIds(List<TimerInfo> timers)
+        private void SearchForDuplicateShowIds(IEnumerable<TimerInfo> timers)
         {
             var groups = timers.ToLookup(i => i.ShowId ?? string.Empty).ToList();
 
@@ -2322,7 +2322,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 }
             }
 
-            SearchForDuplicateShowIds(enabledTimersForSeries.Distinct().ToList());
+            SearchForDuplicateShowIds(enabledTimersForSeries.Distinct());
 
             if (deleteInvalidTimers)
             {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2282,39 +2282,13 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
                     if (updateTimerSettings)
                     {
-                        // Only update if not currently active - test both new timer and existing in case Id's are different
-                        // Id's could be different if the timer was created manually prior to series timer creation
-                        if (!_activeRecordings.TryGetValue(timer.Id, out _) && !_activeRecordings.TryGetValue(existingTimer.Id, out _))
-                        {
-                            UpdateExistingTimerWithNewMetadata(existingTimer, timer);
-
-                            // Needed by ShouldCancelTimerForSeriesTimer
-                            timer.IsManual = existingTimer.IsManual;
-
-                            if (ShouldCancelTimerForSeriesTimer(seriesTimer, timer))
-                            {
-                                existingTimer.Status = RecordingStatus.Cancelled;
-                            }
-                            else if (!existingTimer.IsManual)
-                            {
-                                existingTimer.Status = RecordingStatus.New;
-                            }
-
-                            if (existingTimer.Status != RecordingStatus.Cancelled)
-                            {
-                                enabledTimersForSeries.Add(existingTimer);
-                            }
-
-                            existingTimer.KeepUntil = seriesTimer.KeepUntil;
-                            existingTimer.IsPostPaddingRequired = seriesTimer.IsPostPaddingRequired;
-                            existingTimer.IsPrePaddingRequired = seriesTimer.IsPrePaddingRequired;
-                            existingTimer.PostPaddingSeconds = seriesTimer.PostPaddingSeconds;
-                            existingTimer.PrePaddingSeconds = seriesTimer.PrePaddingSeconds;
-                            existingTimer.Priority = seriesTimer.Priority;
-                            existingTimer.SeriesTimerId = seriesTimer.Id;
-
-                            _timerProvider.Update(existingTimer);
-                        }
+                        existingTimer.KeepUntil = seriesTimer.KeepUntil;
+                        existingTimer.IsPostPaddingRequired = seriesTimer.IsPostPaddingRequired;
+                        existingTimer.IsPrePaddingRequired = seriesTimer.IsPrePaddingRequired;
+                        existingTimer.PostPaddingSeconds = seriesTimer.PostPaddingSeconds;
+                        existingTimer.PrePaddingSeconds = seriesTimer.PrePaddingSeconds;
+                        existingTimer.Priority = seriesTimer.Priority;
+                        existingTimer.SeriesTimerId = seriesTimer.Id;
                     }
 
                     existingTimer.SeriesTimerId = seriesTimer.Id;
@@ -2322,7 +2296,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 }
             }
 
-            SearchForDuplicateShowIds(enabledTimersForSeries.Distinct());
+            SearchForDuplicateShowIds(enabledTimersForSeries);
 
             if (deleteInvalidTimers)
             {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2322,7 +2322,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 }
             }
 
-            SearchForDuplicateShowIds(enabledTimersForSeries);
+            SearchForDuplicateShowIds(enabledTimersForSeries.Distinct().ToList());
 
             if (deleteInvalidTimers)
             {


### PR DESCRIPTION
Timers are getting added twice to the enabled list. This results in the second copy of the timer being detected as a duplicate of the showID and cancelled. Since both timers in the list are the same object, the original record is cancelled as a duplicate. 

I'm not sure exactly why it gets added twice in the first place, so I thought the easiest thing to do was to remove the duplicate timers (not duplicate shows)

Fixes #3523 