### PR TITLE
Minor search update - full word titles matches first

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2456,6 +2456,8 @@ namespace Emby.Server.Implementations.Data
                 builder.Append('(');
 
                 builder.Append("((CleanName like @SearchTermStartsWith or (OriginalTitle not null and OriginalTitle like @SearchTermStartsWith)) * 10)");
+                builder.Append("+ ((CleanName = @SearchTermStartsWith COLLATE NOCASE or (OriginalTitle not null and OriginalTitle = @SearchTermStartsWith COLLATE NOCASE)) * 10)");
+
 
                 if (query.SearchTerm.Length > 1)
                 {
@@ -3152,6 +3154,11 @@ namespace Emby.Server.Implementations.Data
             if (string.Equals(name, ItemSortBy.SimilarityScore, StringComparison.OrdinalIgnoreCase))
             {
                 return ItemSortBy.SimilarityScore;
+            }
+
+            if (string.Equals(name, ItemSortBy.SearchScore, StringComparison.OrdinalIgnoreCase))
+            {
+                return ItemSortBy.SearchScore;
             }
 
             // Unknown SortBy, just sort by the SortName.

--- a/MediaBrowser.Model/Querying/ItemSortBy.cs
+++ b/MediaBrowser.Model/Querying/ItemSortBy.cs
@@ -154,5 +154,10 @@ namespace MediaBrowser.Model.Querying
         /// The similarity score.
         /// </summary>
         public const string SimilarityScore = "SimilarityScore";
+
+        /// <summary>
+        /// The search score.
+        /// </summary>
+        public const string SearchScore = "SearchScore";
     }
 }


### PR DESCRIPTION
Update to search - prioritise titles that match completely e.g.

search string "thing" will bring back title Thing first e.g.

Thing
Thing!
Thing Thing

**Changes**
Added additonal +10 search score for exact match with case insensitive.  Added sort by SearchScore DESC ( was previously ORDER BY SortName DESC, SortName ASC)

**Issues**

n/a
