### PR TITLE
DVR: Prefer HD channels then earliest showing when handling duplicate showings.

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2193,7 +2193,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
         private void HandleDuplicateShowIds(List<TimerInfo> timers)
         {
             // sort showings by HD channels first, then by startDate, record earliest showing possible
-            foreach (var timer in timers.OrderByDescending(t => this._liveTvManager.GetLiveTvChannel(t, this).IsHD).ThenBy(t => t.StartDate).Skip(1))
+            foreach (var timer in timers.OrderByDescending(t => _liveTvManager.GetLiveTvChannel(t, this).IsHD).ThenBy(t => t.StartDate).Skip(1))
             {
                 // TODO: Get smarter, prefer HD, etc
 

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2195,8 +2195,6 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             // sort showings by HD channels first, then by startDate, record earliest showing possible
             foreach (var timer in timers.OrderByDescending(t => _liveTvManager.GetLiveTvChannel(t, this).IsHD).ThenBy(t => t.StartDate).Skip(1))
             {
-                // TODO: Get smarter, prefer HD, etc
-
                 timer.Status = RecordingStatus.Cancelled;
                 _timerProvider.Update(timer);
             }

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -2192,7 +2192,8 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
         private void HandleDuplicateShowIds(List<TimerInfo> timers)
         {
-            foreach (var timer in timers.Skip(1))
+            // sort showings by HD channels first, then by startDate, record earliest showing possible
+            foreach (var timer in timers.OrderByDescending(t => this._liveTvManager.GetLiveTvChannel(t, this).IsHD).ThenBy(t => t.StartDate).Skip(1))
             {
                 // TODO: Get smarter, prefer HD, etc
 

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/TimerManager.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/TimerManager.cs
@@ -122,11 +122,28 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
             if (_timers.TryAdd(item.Id, timer))
             {
-                Logger.LogInformation(
-                    "Creating recording timer for {Id}, {Name}. Timer will fire in {Minutes} minutes",
+                if (item.IsSeries)
+                {
+                    Logger.LogInformation(
+                    "Creating recording timer for {Id}, {Name} {SeasonNumber}x{EpisodeNumber:D2} on channel {ChannelId}. Timer will fire in {Minutes} minutes at {StartDate}",
                     item.Id,
                     item.Name,
-                    dueTime.TotalMinutes.ToString(CultureInfo.InvariantCulture));
+                    item.SeasonNumber,
+                    item.EpisodeNumber,
+                    item.ChannelId,
+                    dueTime.TotalMinutes.ToString(CultureInfo.InvariantCulture),
+                    item.StartDate);
+                }
+                else
+                {
+                    Logger.LogInformation(
+                    "Creating recording timer for {Id}, {Name} on channel {ChannelId}. Timer will fire in {Minutes} minutes at {StartDate}",
+                    item.Id,
+                    item.Name,
+                    item.ChannelId,
+                    dueTime.TotalMinutes.ToString(CultureInfo.InvariantCulture),
+                    item.StartDate);
+                }
             }
             else
             {


### PR DESCRIPTION
Current behavior of the scheduler is undefined when handling duplicate showings. Order of timers is unknown. This PR sorts duplicate showings first by HD channels, then by earliest showing. Under the current behavior, my DVR could sometimes wait over a week to record a later episode for no discernable reason. 

Logs more details when scheduling DVR timers.
