### PR TITLE
DVR: Add options to disable NFO and image saving

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1814,21 +1814,27 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     program.AddGenre("News");
                 }
 
-                if (timer.IsProgramSeries)
+                if (GetConfiguration().SaveRecordingNFO)
                 {
-                    await SaveSeriesNfoAsync(timer, seriesPath).ConfigureAwait(false);
-                    await SaveVideoNfoAsync(timer, recordingPath, program, false).ConfigureAwait(false);
-                }
-                else if (!timer.IsMovie || timer.IsSports || timer.IsNews)
-                {
-                    await SaveVideoNfoAsync(timer, recordingPath, program, true).ConfigureAwait(false);
-                }
-                else
-                {
-                    await SaveVideoNfoAsync(timer, recordingPath, program, false).ConfigureAwait(false);
+                    if (timer.IsProgramSeries)
+                    {
+                        await SaveSeriesNfoAsync(timer, seriesPath).ConfigureAwait(false);
+                        await SaveVideoNfoAsync(timer, recordingPath, program, false).ConfigureAwait(false);
+                    }
+                    else if (!timer.IsMovie || timer.IsSports || timer.IsNews)
+                    {
+                        await SaveVideoNfoAsync(timer, recordingPath, program, true).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await SaveVideoNfoAsync(timer, recordingPath, program, false).ConfigureAwait(false);
+                    }
                 }
 
-                await SaveRecordingImages(recordingPath, program).ConfigureAwait(false);
+                if (GetConfiguration().SaveRecordingImages)
+                {
+                    await SaveRecordingImages(recordingPath, program).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1814,7 +1814,9 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     program.AddGenre("News");
                 }
 
-                if (GetConfiguration().SaveRecordingNFO)
+                var config = GetConfiguration();
+
+                if (config.SaveRecordingNFO)
                 {
                     if (timer.IsProgramSeries)
                     {
@@ -1831,7 +1833,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     }
                 }
 
-                if (GetConfiguration().SaveRecordingImages)
+                if (config.SaveRecordingImages)
                 {
                     await SaveRecordingImages(recordingPath, program).ConfigureAwait(false);
                 }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -320,7 +320,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
             if (!IsLocked)
             {
-                if (SourceType == SourceType.Library)
+                if (SourceType == SourceType.Library || SourceType == SourceType.LiveTV)
                 {
                     try
                     {

--- a/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
@@ -40,5 +40,9 @@ namespace MediaBrowser.Model.LiveTv
         public string RecordingPostProcessor { get; set; }
 
         public string RecordingPostProcessorArguments { get; set; }
+
+        public bool SaveRecordingNFO { get; set; } = true;
+
+        public bool SaveRecordingImages { get; set; } = true;
     }
 }


### PR DESCRIPTION
- SaveRecordingNFO and SaveRecordingImages default to true. Maintains current behavior.
- Episode.FillMissingEpisodeNumbersFromPath for live tv so external metadata can be pulled when recording starts.

Fixes #5178