### PR TITLE
Save TVChannel Height if set

### DIFF
--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -246,6 +246,11 @@ public class ItemUpdateController : BaseJellyfinApiController
             episode.AirsBeforeSeasonNumber = request.AirsBeforeSeasonNumber;
         }
 
+        if (request.Height is not null && item is LiveTvChannel channel)
+        {
+            channel.Height = request.Height.Value;
+        }
+
         item.Tags = request.Tags;
 
         if (request.Taglines is not null)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Saves a height value if set for `LiveTVChannel` items. This allows an admin to specify the video height(ex. 480, 720, 1080) for channels when it is not automatically provided. This will then determine if the channel `isHD` or not.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Useful in conjunction with #8768