### PR TITLE
Allow non-ASCII in downloaded filenames

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -637,22 +637,10 @@ namespace Jellyfin.Api.Controllers
                 await LogDownloadAsync(item, user).ConfigureAwait(false);
             }
 
-            var path = item.Path;
+            // Quotes are valid in linux. They'll possibly cause issues here.
+            var filename = Path.GetFileName(item.Path)?.Replace("\"", string.Empty, StringComparison.Ordinal);
 
-            // Quotes are valid in linux. They'll possibly cause issues here
-            var filename = (Path.GetFileName(path) ?? string.Empty).Replace("\"", string.Empty, StringComparison.Ordinal);
-            if (!string.IsNullOrWhiteSpace(filename))
-            {
-                // Kestrel doesn't support non-ASCII characters in headers
-                if (Regex.IsMatch(filename, @"[^\p{IsBasicLatin}]"))
-                {
-                    // Manually encoding non-ASCII characters, following https://tools.ietf.org/html/rfc5987#section-3.2.2
-                    filename = WebUtility.UrlEncode(filename);
-                }
-            }
-
-            // TODO determine non-ASCII validity.
-            return PhysicalFile(path, MimeTypes.GetMimeType(path), filename, true);
+            return PhysicalFile(item.Path, MimeTypes.GetMimeType(item.Path), filename, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Kestrel now supports non-ASCII characters in headers so we no longer need to urlencode the filenames. I've tested the filename 白蛇2：青蛇劫起 (2021).avi on a Mac and it works fine.

**Changes**
* Remove urlencoding

**Issues**
Fixes #8657
