### PR TITLE
Add MusicBrainz server validation and fallback

### DIFF
--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Providers.Plugins.MusicBrainz;
 /// </summary>
 public class MusicBrainzAlbumProvider : IRemoteMetadataProvider<MusicAlbum, AlbumInfo>, IHasOrder, IDisposable
 {
-    private readonly ILogger _logger;
+    private readonly ILogger<MusicBrainzAlbumProvider> _logger;
     private readonly Query _musicBrainzQuery;
     private readonly string _musicBrainzDefaultUri = "https://musicbrainz.org";
 

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Providers.Plugins.MusicBrainz;
 /// </summary>
 public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, ArtistInfo>, IDisposable
 {
-    private readonly ILogger _logger;
+    private readonly ILogger<MusicBrainzArtistProvider> _logger;
     private readonly Query _musicBrainzQuery;
     private readonly string _musicBrainzDefaultUri = "https://musicbrainz.org";
 


### PR DESCRIPTION
Fixes one of the outstanding kinks of the new MusicBrainz plugin implementation. Makes this compatible with the config value used in 10.8.

**Changes**
* Validate server URI
* Properly set query options
* Fallback to official server if no valid URI is specified