### PR TITLE
Add delay_moov flag for progressive mp4 transcoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5569,7 +5569,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 && state.BaseRequest.Context == EncodingContext.Streaming)
             {
                 // Comparison: https://github.com/jansmolders86/mediacenterjs/blob/master/lib/transcoding/desktop.js
-                format = " -f mp4 -movflags frag_keyframe+empty_moov";
+                format = " -f mp4 -movflags frag_keyframe+empty_moov+delay_moov";
             }
 
             var threads = GetNumberOfThreads(state, encodingOptions, videoCodec);


### PR DESCRIPTION
**Changes**
Adds the `delay_moov` flag to the progressive mp4 transcoding options to fix an issue where some files fail to transcode currently

**Issues**
N/A
