### PR TITLE
Add log point explaining why stream cant be shared

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/SharedHttpStream.cs
@@ -67,6 +67,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 || contentType.Contains("text/", StringComparison.OrdinalIgnoreCase))
             {
                 // Close the stream without any sharing features
+                Logger.LogInformation("Stream {Url} closed without sharing, response has content type {ContentType} and result code {ResultCode}-{ResultVerb}", url, contentType, (int)response.StatusCode, response.StatusCode);
                 response.Dispose();
                 return;
             }


### PR DESCRIPTION
This change addresses https://github.com/jellyfin/jellyfin/issues/8756.

I believe this extra log point will help others set up and fault find issues with live tv and recording.

It was not clear to me or the op of the issue that we where getting certain response codes. So this extra log point would have saved a lot of debugging.