### PR TITLE
Augment search to consider tags

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2462,6 +2462,7 @@ namespace Emby.Server.Implementations.Data
                 if (query.SearchTerm.Length > 1)
                 {
                     builder.Append("+ ((CleanName like @SearchTermContains or (OriginalTitle not null and OriginalTitle like @SearchTermContains)) * 10)");
+                    builder.Append("+ ((Tags not null and Tags like @SearchTermContains) * 5)");
                 }
 
                 builder.Append(") as SearchScore");


### PR DESCRIPTION
**Changes**
This minor change permits users to search for items via tags.

**Issues**

* https://github.com/jellyfin/jellyfin/issues/7691
* https://features.jellyfin.org/posts/276/search-by-tag-genre
* https://features.jellyfin.org/posts/635/search-by-tag
* https://www.reddit.com/r/jellyfin/comments/paqi3t/is_there_a_way_of_searching_by_tag/
* https://www.reddit.com/r/jellyfin/comments/xp94po/am_i_doing_something_wrong_i_cannot_search_with/

**Commentary**

Seems to be a frequently requested feature. I considered searching with a join on the `ItemValues` table, but figured this direct approach would likely be sufficient.