### PR TITLE
Add support for avif and webp for photos

### DIFF
--- a/Emby.Photos/PhotoProvider.cs
+++ b/Emby.Photos/PhotoProvider.cs
@@ -27,7 +27,7 @@ namespace Emby.Photos
         private readonly IImageProcessor _imageProcessor;
 
         // These are causing taglib to hang
-        private readonly string[] _includeExtensions = new string[] { ".jpg", ".jpeg", ".png", ".tiff", ".cr2" };
+        private readonly string[] _includeExtensions = new string[] { ".jpg", ".jpeg", ".png", ".tiff", ".cr2", ".webp", ".avif" };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PhotoProvider" /> class.


### PR DESCRIPTION
Add support for avif and webp for the Photo libraries.

**Changes**
Added the two extensions in `Emby.Photos/PhotoProvider.cs`
