### PR TITLE
Fix to make sure that UDF streams are opened with Share.Read (#8276)

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/BaseVideoResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/BaseVideoResolver.cs
@@ -163,17 +163,15 @@ namespace Emby.Server.Implementations.Library.Resolvers
                     try
                     {
                         // use disc-utils, both DVDs and BDs use UDF filesystem
-                        using (var videoFileStream = File.Open(video.Path, FileMode.Open, FileAccess.Read))
-                        using (UdfReader udfReader = new UdfReader(videoFileStream))
+                        using var videoFileStream = File.Open(video.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        using UdfReader udfReader = new UdfReader(videoFileStream);
+                        if (udfReader.DirectoryExists("VIDEO_TS"))
                         {
-                            if (udfReader.DirectoryExists("VIDEO_TS"))
-                            {
-                                video.IsoType = IsoType.Dvd;
-                            }
-                            else if (udfReader.DirectoryExists("BDMV"))
-                            {
-                                video.IsoType = IsoType.BluRay;
-                            }
+                            video.IsoType = IsoType.Dvd;
+                        }
+                        else if (udfReader.DirectoryExists("BDMV"))
+                        {
+                            video.IsoType = IsoType.BluRay;
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Make sure that any subsequent requests to open the file for read will succeed. As per documentation, if this flag is not set, then any request to open the file for reading (by this process or another process) will fail until the file is closed.

**Changes**
Pass the flag FileShare.Read when opening the FileStream for UDF validation.

**Issues**
Fixes #8276
