### PR TITLE
Adding "creation_time" as a tag lookup for FFProbe for premiere date

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -144,7 +144,8 @@ namespace MediaBrowser.MediaEncoding.Probing
                 FFProbeHelpers.GetDictionaryDateTime(tags, "retail date") ??
                 FFProbeHelpers.GetDictionaryDateTime(tags, "retail_date") ??
                 FFProbeHelpers.GetDictionaryDateTime(tags, "date_released") ??
-                FFProbeHelpers.GetDictionaryDateTime(tags, "date");
+                FFProbeHelpers.GetDictionaryDateTime(tags, "date") ??
+                FFProbeHelpers.GetDictionaryDateTime(tags, "creation_time");
 
             // Set common metadata for music (audio) and music videos (video)
             info.Album = tags.GetValueOrDefault("album");


### PR DESCRIPTION
I found that my home videos are not getting a PremiereDate from the server despite ffprobeshowing one. Here is the output of ffprobe:

Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'ellie_eating.MP4':
  Metadata:
    major_brand     : XAVC
    minor_version   : 16785407
    compatible_brands: XAVCmp42iso2
    creation_time   : 2020-08-01T00:06:51.000000Z
  Duration: 00:00:33.54, start: 0.000000, bitrate: 50032 kb/s
  Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709), 1920x1080 [SAR 1:1 DAR 16:9], 47904 kb/s, 29.97 fps, 29.97 tbr, 30k tbn, 59.94 tbc (default)
    Metadata:
      creation_time   : 2020-08-01T00:06:51.000000Z
      handler_name    : Video Media Handler
      vendor_id       : [0][0][0][0]
      encoder         : AVC Coding
  Stream #0:1(und): Audio: pcm_s16be (twos / 0x736F7774), 48000 Hz, 2 channels, s16, 1536 kb/s (default)
    Metadata:
      creation_time   : 2020-08-01T00:06:51.000000Z
      handler_name    : Sound Media Handler
      vendor_id       : [0][0][0][0]
  Stream #0:2(und): Data: none (rtmd / 0x646D7472), 245 kb/s (default)
    Metadata:
      creation_time   : 2020-08-01T00:06:51.000000Z
      handler_name    : Timed Metadata Media Handler
      timecode        : 12:45:05:19

Here is the info found from ffprobe in the server:

![image](https://user-images.githubusercontent.com/804057/206766084-8e57a9fd-eeaf-465a-bfd9-527637ea230e.png)

And here is the file vs the info: 
![image](https://user-images.githubusercontent.com/804057/206361762-a23e2b0f-93c7-4068-95fb-b04b0a5c541b.png)


If PremiereData isn't the correct field please let me know. DateCreated from the server seems to be tied to the file creation date, not the ffprobe data.
