### PR TITLE
Add permissions for collection management

### DIFF
--- a/Jellyfin.Api/Auth/UserPermissionPolicy/UserPermissionHandler.cs
+++ b/Jellyfin.Api/Auth/UserPermissionPolicy/UserPermissionHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Jellyfin.Api.Auth.DownloadPolicy;
 using Jellyfin.Api.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Library;
@@ -8,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 namespace Jellyfin.Api.Auth.UserPermissionPolicy
 {
     /// <summary>
-    /// Download authorization handler.
+    /// User permission authorization handler.
     /// </summary>
     public class UserPermissionHandler : AuthorizationHandler<UserPermissionRequirement>
     {

--- a/Jellyfin.Api/Auth/UserPermissionPolicy/UserPermissionRequirement.cs
+++ b/Jellyfin.Api/Auth/UserPermissionPolicy/UserPermissionRequirement.cs
@@ -1,7 +1,7 @@
 ﻿using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Data.Enums;
 
-namespace Jellyfin.Api.Auth.DownloadPolicy
+namespace Jellyfin.Api.Auth.UserPermissionPolicy
 {
     /// <summary>
     /// The user permission requirement.

--- a/Jellyfin.Api/Constants/Policies.cs
+++ b/Jellyfin.Api/Constants/Policies.cs
@@ -69,4 +69,9 @@ public static class Policies
     /// Policy name for accessing a SyncPlay group.
     /// </summary>
     public const string SyncPlayIsInGroup = "SyncPlayIsInGroup";
+
+    /// <summary>
+    /// Policy name for accessing collection management.
+    /// </summary>
+    public const string CollectionManagement = "CollectionManagement";
 }

--- a/Jellyfin.Api/Controllers/CollectionController.cs
+++ b/Jellyfin.Api/Controllers/CollectionController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.ModelBinders;
 using MediaBrowser.Controller.Collections;
@@ -16,7 +17,7 @@ namespace Jellyfin.Api.Controllers;
 /// The collection controller.
 /// </summary>
 [Route("Collections")]
-[Authorize]
+[Authorize(Policy = Policies.CollectionManagement)]
 public class CollectionController : BaseJellyfinApiController
 {
     private readonly ICollectionManager _collectionManager;

--- a/Jellyfin.Data/Entities/User.cs
+++ b/Jellyfin.Data/Entities/User.cs
@@ -508,6 +508,7 @@ namespace Jellyfin.Data.Entities
             Permissions.Add(new Permission(PermissionKind.EnableVideoPlaybackTranscoding, true));
             Permissions.Add(new Permission(PermissionKind.ForceRemoteSourceTranscoding, false));
             Permissions.Add(new Permission(PermissionKind.EnableRemoteControlOfOtherUsers, false));
+            Permissions.Add(new Permission(PermissionKind.EnableCollectionManagement, false));
         }
 
         /// <summary>

--- a/Jellyfin.Data/Enums/PermissionKind.cs
+++ b/Jellyfin.Data/Enums/PermissionKind.cs
@@ -108,6 +108,11 @@ namespace Jellyfin.Data.Enums
         /// <summary>
         /// Whether the server should force transcoding on remote connections for the user.
         /// </summary>
-        ForceRemoteSourceTranscoding = 20
+        ForceRemoteSourceTranscoding = 20,
+
+        /// <summary>
+        /// Whether the user can create, modify and delete collections.
+        /// </summary>
+        EnableCollectionManagement = 21
     }
 }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -369,6 +369,7 @@ namespace Jellyfin.Server.Implementations.Users
                     EnablePlaybackRemuxing = user.HasPermission(PermissionKind.EnablePlaybackRemuxing),
                     ForceRemoteSourceTranscoding = user.HasPermission(PermissionKind.ForceRemoteSourceTranscoding),
                     EnablePublicSharing = user.HasPermission(PermissionKind.EnablePublicSharing),
+                    EnableCollectionManagement = user.HasPermission(PermissionKind.EnableCollectionManagement),
                     AccessSchedules = user.AccessSchedules.ToArray(),
                     BlockedTags = user.GetPreference(PreferenceKind.BlockedTags),
                     AllowedTags = user.GetPreference(PreferenceKind.AllowedTags),
@@ -685,6 +686,7 @@ namespace Jellyfin.Server.Implementations.Users
                 user.SetPermission(PermissionKind.EnableAllFolders, policy.EnableAllFolders);
                 user.SetPermission(PermissionKind.EnableRemoteControlOfOtherUsers, policy.EnableRemoteControlOfOtherUsers);
                 user.SetPermission(PermissionKind.EnablePlaybackRemuxing, policy.EnablePlaybackRemuxing);
+                user.SetPermission(PermissionKind.EnableCollectionManagement, policy.EnableCollectionManagement);
                 user.SetPermission(PermissionKind.ForceRemoteSourceTranscoding, policy.ForceRemoteSourceTranscoding);
                 user.SetPermission(PermissionKind.EnablePublicSharing, policy.EnablePublicSharing);
 

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ using Emby.Server.Implementations;
 using Jellyfin.Api.Auth;
 using Jellyfin.Api.Auth.AnonymousLanAccessPolicy;
 using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
-using Jellyfin.Api.Auth.DownloadPolicy;
 using Jellyfin.Api.Auth.FirstTimeSetupPolicy;
 using Jellyfin.Api.Auth.SyncPlayAccessPolicy;
 using Jellyfin.Api.Auth.UserPermissionPolicy;
@@ -75,6 +74,7 @@ namespace Jellyfin.Server.Extensions
                 options.AddPolicy(Policies.SyncPlayCreateGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.CreateGroup));
                 options.AddPolicy(Policies.SyncPlayJoinGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.JoinGroup));
                 options.AddPolicy(Policies.SyncPlayIsInGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.IsInGroup));
+                options.AddPolicy(Policies.CollectionManagement, new UserPermissionRequirement(PermissionKind.EnableCollectionManagement));
                 options.AddPolicy(Policies.AnonymousLanAccessPolicy, new AnonymousLanAccessRequirement());
                 options.AddPolicy(
                     Policies.RequiresElevation,

--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -163,6 +163,7 @@ namespace Jellyfin.Server.Migrations.Routines
                     user.SetPermission(PermissionKind.EnablePlaybackRemuxing, policy.EnablePlaybackRemuxing);
                     user.SetPermission(PermissionKind.ForceRemoteSourceTranscoding, policy.ForceRemoteSourceTranscoding);
                     user.SetPermission(PermissionKind.EnablePublicSharing, policy.EnablePublicSharing);
+                    user.SetPermission(PermissionKind.EnableCollectionManagement, policy.EnableCollectionManagement);
 
                     foreach (var policyAccessSchedule in policy.AccessSchedules)
                     {

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -104,7 +104,7 @@ namespace MediaBrowser.Controller.Entities.Movies
 
         public override bool IsAuthorizedToDelete(User user, List<Folder> allCollectionFolders)
         {
-            return true;
+            return user.HasPermission(PermissionKind.IsAdministrator) || user.HasPermission(PermissionKind.EnableCollectionManagement);
         }
 
         public override bool IsSaveLocalMetadataEnabled()

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -13,6 +13,7 @@ namespace MediaBrowser.Model.Users
         public UserPolicy()
         {
             IsHidden = true;
+            EnableCollectionManagement = false;
 
             EnableContentDeletion = false;
             EnableContentDeletionFromFolders = Array.Empty<string>();
@@ -72,6 +73,12 @@ namespace MediaBrowser.Model.Users
         /// </summary>
         /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
         public bool IsHidden { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance can manage collections.
+        /// </summary>
+        /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
+        public bool EnableCollectionManagement { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance is disabled.


### PR DESCRIPTION
**Changes**
* Adds a permission to manage collections (add, remove and delete)
* Enforce permission on the collection endpoints

Will require changes to jellyfin-web (https://github.com/jellyfin/jellyfin-web/pull/4199) to take the new permission into account when displaying the elements in the item dropdown and collection screens. Additionally requires a setting in jellyfin-web to be available to set it.

**Issues**
Fixes #7179