### PR TITLE
Augment tag searching to consider individual ItemValues instead of the delimited tags field

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2461,7 +2461,9 @@ namespace Emby.Server.Implementations.Data
                 if (query.SearchTerm.Length > 1)
                 {
                     builder.Append("+ ((CleanName like @SearchTermContains or (OriginalTitle not null and OriginalTitle like @SearchTermContains)) * 10)");
-                    builder.Append("+ ((Tags not null and Tags like @SearchTermContains) * 5)");
+                    builder.Append("+ (SELECT COUNT(1) * 1 from ItemValues where ItemId=Guid and CleanValue like @SearchTermContains)");
+                    builder.Append("+ (SELECT COUNT(1) * 2 from ItemValues where ItemId=Guid and CleanValue like @SearchTermStartsWith)");
+                    builder.Append("+ (SELECT COUNT(1) * 10 from ItemValues where ItemId=Guid and CleanValue like @SearchTermEquals)");
                 }
 
                 builder.Append(") as SearchScore");
@@ -2491,6 +2493,11 @@ namespace Emby.Server.Implementations.Data
             if (commandText.Contains("@SearchTermContains", StringComparison.OrdinalIgnoreCase))
             {
                 statement.TryBind("@SearchTermContains", "%" + searchTerm + "%");
+            }
+
+            if (commandText.Contains("@SearchTermEquals", StringComparison.OrdinalIgnoreCase))
+            {
+                statement.TryBind("@SearchTermEquals", searchTerm);
             }
         }
 


### PR DESCRIPTION
**Changes**
This change improves tag searching. Previously, `(Tags not null and Tags like @SearchTermContains)` searched against the composed `tag1|tag2|tag3` value. That approach had no good way of differentiating between `str1` and `prefix...str1...suffix` which might have entirely different meaning (e.g. searching `cia` would turn up content from `artifiCIAl intelligence`).

This PR provides bias towards startswith and equals, additionally biasing content with multiple matching tags.