### PR TITLE
Authentication API deprecations

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -157,7 +157,6 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="userId">The user id.</param>
         /// <param name="pw">The password as plain text.</param>
-        /// <param name="password">The password sha1-hash.</param>
         /// <response code="200">User authenticated.</response>
         /// <response code="403">Sha1-hashed password only is not allowed.</response>
         /// <response code="404">User not found.</response>
@@ -166,21 +165,16 @@ namespace Jellyfin.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Obsolete("Authenticate with username instead")]
         public async Task<ActionResult<AuthenticationResult>> AuthenticateUser(
             [FromRoute, Required] Guid userId,
-            [FromQuery, Required] string pw,
-            [FromQuery] string? password)
+            [FromQuery, Required] string pw)
         {
             var user = _userManager.GetUserById(userId);
 
             if (user is null)
             {
                 return NotFound("User not found");
-            }
-
-            if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(pw))
-            {
-                return StatusCode(StatusCodes.Status403Forbidden, "Only sha1 password is not allowed.");
             }
 
             AuthenticateUserByName request = new AuthenticateUserByName

--- a/Jellyfin.Api/Models/UserDtos/AuthenticateUserByName.cs
+++ b/Jellyfin.Api/Models/UserDtos/AuthenticateUserByName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Jellyfin.Api.Models.UserDtos
+﻿namespace Jellyfin.Api.Models.UserDtos
 {
     /// <summary>
     /// The authenticate user by name request body.
@@ -16,11 +14,5 @@ namespace Jellyfin.Api.Models.UserDtos
         /// Gets or sets the plain text password.
         /// </summary>
         public string? Pw { get; set; }
-
-        /// <summary>
-        /// Gets or sets the sha1-hashed password.
-        /// </summary>
-        [Obsolete("Send password using pw field")]
-        public string? Password { get; set; }
     }
 }


### PR DESCRIPTION
**Changes**
- Remove deprecated Password field from AuthenticateUserByName
  Was deprecated in 10.8 (5b0dc21c644af074095b760b2e42c516ce07c0d6) and since it's a request property it should be safe to remove in 10.9
- Deprecate user id based authentication endpoint
  It receives the plaintext password via an query parameter instead of request body which is dumb and a security risk. Also, we don't need an endpoint to login with userid. If a client knows the user id it should know the username too. I've removed the password property already because it isn't used and won't throw any errors when it is still send.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
