### PR TITLE
Fix image searching to prioritize explicit language match if searching in English

### DIFF
--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -24,24 +24,27 @@ namespace MediaBrowser.Model.Extensions
                 requestedLanguage = "en";
             }
 
-            var isRequestedLanguageEn = string.Equals(requestedLanguage, "en", StringComparison.OrdinalIgnoreCase);
-
             return remoteImageInfos.OrderByDescending(i =>
                 {
+                    // Image priority ordering:
+                    //  - Images that match the requested language
+                    //  - Images with no language
+                    //  - TODO: Images that match the original language
+                    //  - Images in English
+                    //  - Images that don't match the requested language
+
                     if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
                     {
-                        return 3;
+                        return 4;
                     }
 
                     if (string.IsNullOrEmpty(i.Language))
                     {
-                        // Assume empty image language is likely to be English.
-                        return isRequestedLanguageEn ? 3 : 2;
+                        return 3;
                     }
 
-                    if (!isRequestedLanguageEn && string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
                     {
-                        // Prioritize English over non-requested languages.
                         return 2;
                     }
 


### PR DESCRIPTION
**Context**
In the current master branch of Jellyfin, image ordering with a non-English requested language orders like so:

1. Images that match the requested language
2. English images _or_ images with no language
3. All other images

Whereas image ordering with English as the requested language orders like so:

1. Images matching your requested language _or_ images with no language
2. All other images


**Changes**

This change proposes a consistent ordering of images irrespective of the specific requested language:

1. Images that match the requested language
2. Images with no language
3. English images
4. All other images
