### PR TITLE
Explicitly setting DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update \
  && chmod 777 /cache /config /media \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-# ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -49,7 +49,7 @@ RUN apt-get update \
  && chmod 777 /cache /config /media \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-# ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
  && chmod 777 /cache /config /media \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-# ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
# Context

https://github.com/jellyfin/jellyfin/pull/6629 implicitly disabled DOTNET_SYSTEM_GLOBALIZATION_INVARIANT in docker images. However, by only commenting out `=1` and not explicitly setting `=0`, there exists at least one side effect of this.

## Detected side effect

1. Using the [Jellyfin Docker image](https://hub.docker.com/layers/jellyfin/jellyfin/20221223.2-unstable/images/sha256-bd807f9aa0a0251bd537f30ae5973a9a7d80d1284529e62d59826098bc46f217?context=explore)
2. Install `dotnet-script` and generate a script with the following code from [StringExtensions.cs](https://github.com/jellyfin/jellyfin/blob/master/src/Jellyfin.Extensions/StringExtensions.cs#L22):
```C#
using System;
using System.Globalization;
using System.Text;
using System.Text.RegularExpressions;

static readonly Regex _nonConformingUnicode = new Regex("([\ud800-\udbff](?![\udc00-\udfff]))|((?<![\ud800-\udbff])[\udc00-\udfff])|(\ufffd)");

public static string RemoveDiacritics(this string text)
{
    string withDiactritics = _nonConformingUnicode
	.Replace(text, string.Empty)
	.Normalize(NormalizationForm.FormD);

    var withoutDiactritics = new StringBuilder();
    foreach (char c in withDiactritics)
    {
	UnicodeCategory uc = CharUnicodeInfo.GetUnicodeCategory(c);
	if (uc != UnicodeCategory.NonSpacingMark)
	{
	    withoutDiactritics.Append(c);
	}
    }

    return withoutDiactritics.ToString().Normalize(NormalizationForm.FormC);
}

Console.WriteLine(RemoveDiacritics("é"));
```
3. Run this script both with and without `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`:
```
# DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0 /root/.dotnet/tools/dotnet-script helloworld.csx 
e
# DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 /root/.dotnet/tools/dotnet-script helloworld.csx 
é
```

# Changes

Explicitly setting `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0`

# Fixes

This change ensures that the unit tests we see in https://github.com/jellyfin/jellyfin/blob/master/tests/Jellyfin.Extensions.Tests/StringExtensionsTests.cs#L12 actually behave the same way in deployed Docker images. Otherwise the `CleanName` field in library.db contains accents, resulting in false negative searches for titles that actually contain diacritics.