### PR TITLE
Fix similar parental rating calculation

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2401,13 +2401,17 @@ namespace Emby.Server.Implementations.Data
                 var builder = new StringBuilder();
                 builder.Append('(');
 
-                if (string.IsNullOrEmpty(item.OfficialRating))
+                if (string.IsNullOrEmpty(item.InheritedParentalRatingValue))
                 {
-                    builder.Append("(OfficialRating is null * 10)");
+                    builder.Append("(InheritedParentalRatingValue is null * 10)");
                 }
                 else
                 {
-                    builder.Append("(OfficialRating=@ItemOfficialRating * 10)");
+                    builder.Append(
+                        @"(SELECT CASE WHEN InheritedParentalRatingValue is null
+                                THEN 0
+                                ELSE 10.0 / (1.0 + ABS(InheritedParentalRatingValue - @InheritedParentalRatingValue))
+                                END)");
                 }
 
                 if (item.ProductionYear.HasValue)
@@ -2520,6 +2524,11 @@ namespace Emby.Server.Implementations.Data
             if (commandText.Contains("@SimilarItemId", StringComparison.OrdinalIgnoreCase))
             {
                 statement.TryBind("@SimilarItemId", item.Id);
+            }
+
+            if (commandText.Contains("@InheritedParentalRatingValue", StringComparison.OrdinalIgnoreCase))
+            {
+                statement.TryBind("@InheritedParentalRatingValue", item.InheritedParentalRatingValue);
             }
         }
 


### PR DESCRIPTION
**Changes**
In the current master branch, movie similarity matches on identical parental rating strings. But this means `CA-G` and `G` are considered different, despite [us.csv](https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/Localization/Ratings/us.csv) and [ca.csv](https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/Localization/Ratings/ca.csv) defining them both as `1`. The proposed fix matches on numeric parental rating and additionally provides a more gradual rating drop-off.

**Issues**
No known issues have been filed against this bug, but I suspect that's because item similarity is opaque to the end-user.