### PR TITLE
Use EventManager for AuthenticationSuccess, AuthenticationFailure

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -95,12 +95,6 @@ namespace Emby.Server.Implementations.Session
             _deviceManager.DeviceOptionsUpdated += OnDeviceManagerDeviceOptionsUpdated;
         }
 
-        /// <inheritdoc />
-        public event EventHandler<GenericEventArgs<AuthenticationRequest>> AuthenticationFailed;
-
-        /// <inheritdoc />
-        public event EventHandler<GenericEventArgs<AuthenticationResult>> AuthenticationSucceeded;
-
         /// <summary>
         /// Occurs when playback has started.
         /// </summary>
@@ -1468,7 +1462,7 @@ namespace Emby.Server.Implementations.Session
 
             if (user is null)
             {
-                AuthenticationFailed?.Invoke(this, new GenericEventArgs<AuthenticationRequest>(request));
+                await _eventManager.PublishAsync(new GenericEventArgs<AuthenticationRequest>(request)).ConfigureAwait(false);
                 throw new AuthenticationException("Invalid username or password entered.");
             }
 
@@ -1504,8 +1498,7 @@ namespace Emby.Server.Implementations.Session
                 ServerId = _appHost.SystemId
             };
 
-            AuthenticationSucceeded?.Invoke(this, new GenericEventArgs<AuthenticationResult>(returnResult));
-
+            await _eventManager.PublishAsync(new GenericEventArgs<AuthenticationResult>(returnResult)).ConfigureAwait(false);
             return returnResult;
         }
 

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -157,7 +157,7 @@ namespace Jellyfin.Server.Implementations.Users
                 await UpdateUserInternalAsync(dbContext, user).ConfigureAwait(false);
             }
 
-            var eventArgs = new GenericEventArgs<User>(user);
+            var eventArgs = new UserUpdatedEventArgs(user);
             await _eventManager.PublishAsync(eventArgs).ConfigureAwait(false);
             OnUserUpdated?.Invoke(this, eventArgs);
         }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -157,7 +157,9 @@ namespace Jellyfin.Server.Implementations.Users
                 await UpdateUserInternalAsync(dbContext, user).ConfigureAwait(false);
             }
 
-            OnUserUpdated?.Invoke(this, new GenericEventArgs<User>(user));
+            var eventArgs = new GenericEventArgs<User>(user);
+            await _eventManager.PublishAsync(eventArgs).ConfigureAwait(false);
+            OnUserUpdated?.Invoke(this, eventArgs);
         }
 
         /// <inheritdoc/>

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -58,16 +58,6 @@ namespace MediaBrowser.Controller.Session
         event EventHandler<SessionEventArgs> CapabilitiesChanged;
 
         /// <summary>
-        /// Occurs when [authentication failed].
-        /// </summary>
-        event EventHandler<GenericEventArgs<AuthenticationRequest>> AuthenticationFailed;
-
-        /// <summary>
-        /// Occurs when [authentication succeeded].
-        /// </summary>
-        event EventHandler<GenericEventArgs<AuthenticationResult>> AuthenticationSucceeded;
-
-        /// <summary>
         /// Gets the sessions.
         /// </summary>
         /// <value>The sessions.</value>


### PR DESCRIPTION
The following events aren't currently firing:

 - [x] Authentication Success
 - [x] Authentication Failure
 - [ ] Plugin installed
 - [ ] Pending restart
 - [x] User updated

Pending restart requires more work, plugin installed _should_ be working but haven't investigated. 