### PR TITLE
Fix backdrop image fetching to prioritize non-language images

### DIFF
--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -313,7 +313,8 @@ namespace MediaBrowser.Providers.Manager
                 }
 
                 minWidth = savedOptions.GetMinWidth(ImageType.Backdrop);
-                await DownloadMultiImages(item, ImageType.Backdrop, refreshOptions, backdropLimit, provider, result, list, minWidth, cancellationToken).ConfigureAwait(false);
+                var listWithNoLangFirst = list.Where(i => string.IsNullOrEmpty(i.Language)).Concat(list.Where(i => !string.IsNullOrEmpty(i.Language)));
+                await DownloadMultiImages(item, ImageType.Backdrop, refreshOptions, backdropLimit, provider, result, listWithNoLangFirst, minWidth, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -313,7 +313,7 @@ namespace MediaBrowser.Providers.Manager
                 }
 
                 minWidth = savedOptions.GetMinWidth(ImageType.Backdrop);
-                var listWithNoLangFirst = list.Where(i => string.IsNullOrEmpty(i.Language)).Concat(list.Where(i => !string.IsNullOrEmpty(i.Language)));
+                var listWithNoLangFirst = list.OrderByDescending(i => string.IsNullOrEmpty(i.Language));
                 await DownloadMultiImages(item, ImageType.Backdrop, refreshOptions, backdropLimit, provider, result, listWithNoLangFirst, minWidth, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
# Context
#8946 accidentally introduced a side effect of all backdrop images preferring the explicit language of the library. The purpose of backdrop images should actually deprioritize language.

We could additionally modify `OrderByLanguageDescending`, but how this gets used with both manual image searches and during metadata refresh makes it a little slippery to refactor properly. The proposed solution here is fairly simple and gets us the behaviour we're looking for.

# Changes
Image sorting prioritizes non-language images for backdrop metadata refreshes.
