### PR TITLE
Use nfo provided remote images on initial scan

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -685,7 +685,8 @@ namespace MediaBrowser.Providers.Manager
                         {
                             try
                             {
-                                if (!options.IsReplacingImage(remoteImage.Type))
+                                if (item.ImageInfos.Any(x => x.Type == remoteImage.Type)
+                                    && !options.IsReplacingImage(remoteImage.Type))
                                 {
                                     continue;
                                 }


### PR DESCRIPTION
**Changes**
If there are no images to begin with, we are not replacing anything. So if there are no images of this ImageType, then don't skip over this image.

**Issues**
Fixes #8993 

I did also test that #7836 does not appear again.
