### PR TITLE
Add control over multiple codec streaming to the device profile

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -411,6 +411,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
+        /// <param name="enableMultipleCodecStreaming">Enable multiple codec streaming.</param>
         /// <response code="200">Video stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the playlist file.</returns>
         [HttpGet("Videos/{itemId}/master.m3u8")]
@@ -468,7 +469,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? videoStreamIndex,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions,
-            [FromQuery] bool enableAdaptiveBitrateStreaming = true)
+            [FromQuery] bool enableAdaptiveBitrateStreaming = true,
+            [FromQuery] bool enableMultipleCodecStreaming = true)
         {
             var streamingRequest = new HlsVideoRequestDto
             {
@@ -522,10 +524,11 @@ namespace Jellyfin.Api.Controllers
                 VideoStreamIndex = videoStreamIndex,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions,
-                EnableAdaptiveBitrateStreaming = enableAdaptiveBitrateStreaming
+                EnableAdaptiveBitrateStreaming = enableAdaptiveBitrateStreaming,
+                EnableMultipleCodecStreaming = enableMultipleCodecStreaming
             };
 
-            return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType, streamingRequest, enableAdaptiveBitrateStreaming).ConfigureAwait(false);
+            return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType, streamingRequest, enableAdaptiveBitrateStreaming, enableMultipleCodecStreaming).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -581,6 +584,7 @@ namespace Jellyfin.Api.Controllers
         /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
         /// <param name="streamOptions">Optional. The streaming options.</param>
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
+        /// <param name="enableMultipleCodecStreaming">Enable multiple codec streaming.</param>
         /// <response code="200">Audio stream returned.</response>
         /// <returns>A <see cref="FileResult"/> containing the playlist file.</returns>
         [HttpGet("Audio/{itemId}/master.m3u8")]
@@ -637,7 +641,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? videoStreamIndex,
             [FromQuery] EncodingContext? context,
             [FromQuery] Dictionary<string, string> streamOptions,
-            [FromQuery] bool enableAdaptiveBitrateStreaming = true)
+            [FromQuery] bool enableAdaptiveBitrateStreaming = true,
+            [FromQuery] bool enableMultipleCodecStreaming = true)
         {
             var streamingRequest = new HlsAudioRequestDto
             {
@@ -689,10 +694,11 @@ namespace Jellyfin.Api.Controllers
                 VideoStreamIndex = videoStreamIndex,
                 Context = context ?? EncodingContext.Streaming,
                 StreamOptions = streamOptions,
-                EnableAdaptiveBitrateStreaming = enableAdaptiveBitrateStreaming
+                EnableAdaptiveBitrateStreaming = enableAdaptiveBitrateStreaming,
+                EnableMultipleCodecStreaming = enableMultipleCodecStreaming
             };
 
-            return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType, streamingRequest, enableAdaptiveBitrateStreaming).ConfigureAwait(false);
+            return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType, streamingRequest, enableAdaptiveBitrateStreaming, enableMultipleCodecStreaming).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -233,10 +233,11 @@ namespace Jellyfin.Api.Controllers
                     TranscodeReasons = mediaSource.TranscodeReasons == 0 ? null : mediaSource.TranscodeReasons.ToString(),
                     Context = EncodingContext.Static,
                     StreamOptions = new Dictionary<string, string>(),
-                    EnableAdaptiveBitrateStreaming = true
+                    EnableAdaptiveBitrateStreaming = true,
+                    EnableMultipleCodecStreaming = true
                 };
 
-                return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType.Hls, dynamicHlsRequestDto, true)
+                return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType.Hls, dynamicHlsRequestDto, true, true)
                     .ConfigureAwait(false);
             }
 

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -97,11 +97,13 @@ namespace Jellyfin.Api.Helpers
         /// <param name="transcodingJobType">Transcoding job type.</param>
         /// <param name="streamingRequest">Streaming request dto.</param>
         /// <param name="enableAdaptiveBitrateStreaming">Enable adaptive bitrate streaming.</param>
+        /// <param name="enableMultipleCodecStreaming">Enable multiple codec streaming.</param>
         /// <returns>A <see cref="Task"/> containing the resulting <see cref="ActionResult"/>.</returns>
         public async Task<ActionResult> GetMasterHlsPlaylist(
             TranscodingJobType transcodingJobType,
             StreamingRequestDto streamingRequest,
-            bool enableAdaptiveBitrateStreaming)
+            bool enableAdaptiveBitrateStreaming,
+            bool enableMultipleCodecStreaming)
         {
             var isHeadRequest = _httpContextAccessor.HttpContext?.Request.Method == WebRequestMethods.Http.Head;
             // CTS lifecycle is managed internally.
@@ -110,6 +112,7 @@ namespace Jellyfin.Api.Helpers
                 streamingRequest,
                 isHeadRequest,
                 enableAdaptiveBitrateStreaming,
+                enableMultipleCodecStreaming,
                 transcodingJobType,
                 cancellationTokenSource).ConfigureAwait(false);
         }
@@ -118,6 +121,7 @@ namespace Jellyfin.Api.Helpers
             StreamingRequestDto streamingRequest,
             bool isHeadRequest,
             bool enableAdaptiveBitrateStreaming,
+            bool enableMultipleCodecStreaming,
             TranscodingJobType transcodingJobType,
             CancellationTokenSource cancellationTokenSource)
         {
@@ -200,7 +204,7 @@ namespace Jellyfin.Api.Helpers
 
             var basicPlaylist = AppendPlaylist(builder, state, playlistUrl, totalBitrate, subtitleGroup);
 
-            if (state.VideoStream != null && state.VideoRequest != null)
+            if (enableMultipleCodecStreaming && state.VideoStream != null && state.VideoRequest != null)
             {
                 // Provide SDR HEVC entrance for backward compatibility.
                 if (EncodingHelper.IsCopyCodec(state.OutputVideoCodec)

--- a/Jellyfin.Api/Models/StreamingDtos/HlsAudioRequestDto.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/HlsAudioRequestDto.cs
@@ -9,5 +9,10 @@
         /// Gets or sets a value indicating whether enable adaptive bitrate streaming.
         /// </summary>
         public bool EnableAdaptiveBitrateStreaming { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enable multiple codec streaming.
+        /// </summary>
+        public bool EnableMultipleCodecStreaming { get; set; }
     }
 }

--- a/Jellyfin.Api/Models/StreamingDtos/HlsVideoRequestDto.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/HlsVideoRequestDto.cs
@@ -9,5 +9,10 @@
         /// Gets or sets a value indicating whether enable adaptive bitrate streaming.
         /// </summary>
         public bool EnableAdaptiveBitrateStreaming { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enable multiple codec streaming.
+        /// </summary>
+        public bool EnableMultipleCodecStreaming { get; set; }
     }
 }

--- a/MediaBrowser.Model/Dlna/DeviceProfile.cs
+++ b/MediaBrowser.Model/Dlna/DeviceProfile.cs
@@ -81,6 +81,11 @@ namespace MediaBrowser.Model.Dlna
         public bool EnableAlbumArtInDidl { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether enable multiple codec streaming.
+        /// </summary>
+        public bool? EnableMultipleCodecStreaming { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether EnableSingleAlbumArtLimit.
         /// </summary>
         [DefaultValue(false)]

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -359,6 +359,11 @@ namespace MediaBrowser.Model.Dlna
 
                 var longBitrate = Math.Min(transcodingBitrate, playlistItem.AudioBitrate ?? transcodingBitrate);
                 playlistItem.AudioBitrate = longBitrate > int.MaxValue ? int.MaxValue : Convert.ToInt32(longBitrate);
+
+                if (options.Profile.EnableMultipleCodecStreaming.HasValue)
+                {
+                    playlistItem.EnableMultipleCodecStreaming = options.Profile.EnableMultipleCodecStreaming;
+                }
             }
 
             playlistItem.TranscodeReasons = transcodeReasons;
@@ -914,6 +919,11 @@ namespace MediaBrowser.Model.Dlna
                 // Don't use Math.Clamp as availableBitrateForVideo can be lower then 64k.
                 var currentValue = playlistItem.VideoBitrate ?? availableBitrateForVideo;
                 playlistItem.VideoBitrate = Math.Max(Math.Min(availableBitrateForVideo, currentValue), 64_000);
+            }
+
+            if (options.Profile.EnableMultipleCodecStreaming.HasValue)
+            {
+                playlistItem.EnableMultipleCodecStreaming = options.Profile.EnableMultipleCodecStreaming;
             }
 
             _logger.LogDebug(

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -580,6 +580,11 @@ namespace MediaBrowser.Model.Dlna
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether enable multiple codec streaming.
+        /// </summary>
+        public bool? EnableMultipleCodecStreaming { get; set; }
+
         public void SetOption(string qualifier, string name, string value)
         {
             if (string.IsNullOrEmpty(qualifier))
@@ -740,6 +745,8 @@ namespace MediaBrowser.Model.Dlna
             list.Add(new NameValuePair("LiveStreamId", liveStreamId ?? string.Empty));
 
             list.Add(new NameValuePair("SubtitleMethod", item.SubtitleStreamIndex.HasValue && item.SubtitleDeliveryMethod != SubtitleDeliveryMethod.External ? item.SubtitleDeliveryMethod.ToString() : string.Empty));
+
+            list.Add(new NameValuePair("EnableMultipleCodecStreaming", item.EnableMultipleCodecStreaming.HasValue ? item.EnableMultipleCodecStreaming.Value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant() : string.Empty));
 
             if (!item.IsDirectStream)
             {


### PR DESCRIPTION
Using this flag we can disable unnecessary (for some clients) [backward compatibility streams](https://github.com/jellyfin/jellyfin/blob/c795f17fa6ae9e4f68f23cb569a1129de8fd7635/Jellyfin.Api/Helpers/DynamicHlsHelper.cs#L198-L237).

In fact, [this block](https://github.com/jellyfin/jellyfin/blob/c795f17fa6ae9e4f68f23cb569a1129de8fd7635/Jellyfin.Api/Helpers/DynamicHlsHelper.cs#L198-L237) doesn't work.
All streams in the master playlist are bound to the same `PlaySessionId`.
The server starts the transcoding process after receiving a request (_middle bitrate or lower_) from the device.
After sufficient buffering, the device requests a higher bitrate.
Since the `PlaySessionId` is the same, it seems that the transcoding job doesn't restart with the new parameters.

_Adaptive bitrate streaming probably doesn't work either._

**Changes**
Add the `EnableMultipleCodecStreaming` flag to the device profile to control multiple codec streaming

**Issues**
https://github.com/jellyfin/jellyfin-tizen/issues/163
https://github.com/jellyfin/jellyfin/issues/5576
https://github.com/jellyfin/jellyfin-webos/issues/105
https://github.com/jellyfin/jellyfin-web/issues/1190
https://github.com/jellyfin/jellyfin-webos/issues/59

Web part: https://github.com/jellyfin/jellyfin-web/pull/4260
