### PR TITLE
Add dts to list of audio codecs which require ffmpeg strict -2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@
  - [cvium](https://github.com/cvium)
  - [dannymichel](https://github.com/dannymichel)
  - [DaveChild](https://github.com/DaveChild)
+ - [DavidFair](https://github.com/DavidFair)
  - [Delgan](https://github.com/Delgan)
  - [dcrdev](https://github.com/dcrdev)
  - [dhartung](https://github.com/dhartung)

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1704,11 +1704,12 @@ namespace Jellyfin.Api.Controllers
                 return audioTranscodeParams;
             }
 
-            // flac and opus are experimental in mp4 muxer
+            // dts, flac and opus are experimental in mp4 muxer
             var strictArgs = string.Empty;
 
             if (string.Equals(state.ActualOutputAudioCodec, "flac", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))
+                || string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(state.ActualOutputAudioCodec, "dts", StringComparison.OrdinalIgnoreCase))
             {
                 strictArgs = " -strict -2";
             }


### PR DESCRIPTION
**Changes**
Adds dts to the list of audio codecs where ffmpeg will throw asking us to opt into experimental support. This is seen when the original content is based on dts and we don't acopy using ffmpeg.

Note: I haven't tested this locally, as my server is currently 200+ miles away from me with no way to remotely install a new version. Looking at my logs and the logs in the original this happens on DTS media that's transcoded, so it should be easy to test...

**Issues**
Fixes #8804 
