### PR TITLE
Add more codecs requiring ffmpeg strict -2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@
  - [cvium](https://github.com/cvium)
  - [dannymichel](https://github.com/dannymichel)
  - [DaveChild](https://github.com/DaveChild)
+ - [DavidFair](https://github.com/DavidFair)
  - [Delgan](https://github.com/Delgan)
  - [dcrdev](https://github.com/dcrdev)
  - [dhartung](https://github.com/dhartung)

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1712,12 +1712,13 @@ namespace Jellyfin.Api.Controllers
                 return audioTranscodeParams;
             }
 
-            // dts, flac and opus are experimental in mp4 muxer
+            // dts, flac, opus and truehd are experimental in mp4 muxer
             var strictArgs = string.Empty;
 
             if (string.Equals(state.ActualOutputAudioCodec, "flac", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(state.ActualOutputAudioCodec, "dts", StringComparison.OrdinalIgnoreCase))
+                || string.Equals(state.ActualOutputAudioCodec, "dts", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(state.ActualOutputAudioCodec, "truehd", StringComparison.OrdinalIgnoreCase))
             {
                 strictArgs = " -strict -2";
             }

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1712,11 +1712,12 @@ namespace Jellyfin.Api.Controllers
                 return audioTranscodeParams;
             }
 
-            // flac and opus are experimental in mp4 muxer
+            // dts, flac and opus are experimental in mp4 muxer
             var strictArgs = string.Empty;
 
             if (string.Equals(state.ActualOutputAudioCodec, "flac", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))
+                || string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(state.ActualOutputAudioCodec, "dts", StringComparison.OrdinalIgnoreCase))
             {
                 strictArgs = " -strict -2";
             }


### PR DESCRIPTION
Backports #9029 and adds truehd additionally in a separate commit.

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/2396
