### PR TITLE
Disable splash screen image by default

### DIFF
--- a/MediaBrowser.Model/Branding/BrandingOptions.cs
+++ b/MediaBrowser.Model/Branding/BrandingOptions.cs
@@ -23,7 +23,7 @@ public class BrandingOptions
     /// <summary>
     /// Gets or sets a value indicating whether to enable the splashscreen.
     /// </summary>
-    public bool SplashscreenEnabled { get; set; } = true;
+    public bool SplashscreenEnabled { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the splashscreen location on disk.


### PR DESCRIPTION
**Changes**
Disables the splash screen image by default due to privacy concerns with the generated image exposing library contents.

**Issues**
Concerns reported via email and Reddit
