### PR TITLE
Fix client supported image formats

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -28,7 +28,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Jellyfin.Api.Controllers
@@ -2038,13 +2037,8 @@ namespace Jellyfin.Api.Controllers
             }
 
             var acceptParam = Request.Query[HeaderNames.Accept];
-            if (StringValues.IsNullOrEmpty(acceptParam))
-            {
-                return Array.Empty<ImageFormat>();
-            }
 
-            // Can't be null, checked above
-            var supportsWebP = SupportsFormat(supportedFormats, acceptParam!, ImageFormat.Webp, false);
+            var supportsWebP = SupportsFormat(supportedFormats, acceptParam, ImageFormat.Webp, false);
 
             if (!supportsWebP)
             {
@@ -2066,8 +2060,7 @@ namespace Jellyfin.Api.Controllers
             formats.Add(ImageFormat.Jpg);
             formats.Add(ImageFormat.Png);
 
-            // Can't be null, checked above
-            if (SupportsFormat(supportedFormats, acceptParam!, ImageFormat.Gif, true))
+            if (SupportsFormat(supportedFormats, acceptParam, ImageFormat.Gif, true))
             {
                 formats.Add(ImageFormat.Gif);
             }
@@ -2075,7 +2068,7 @@ namespace Jellyfin.Api.Controllers
             return formats.ToArray();
         }
 
-        private bool SupportsFormat(IReadOnlyCollection<string> requestAcceptTypes, string acceptParam, ImageFormat format, bool acceptAll)
+        private bool SupportsFormat(IReadOnlyCollection<string> requestAcceptTypes, string? acceptParam, ImageFormat format, bool acceptAll)
         {
             if (requestAcceptTypes.Contains(format.GetMimeType()))
             {


### PR DESCRIPTION
I recently noticed on the Android TV app that logos for TV shows with transparent backgrounds now had black backgrounds instead. I traced this to `GetClientSupportedFormats` short circuiting if the Accept header was missing.

These changes remove the short-circuit so that at least the jpg and png formats get added by default. Some code is adjusted so that it handles a missing Accept header.