### PR TITLE
Remove unnecesary socket workaround

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -339,12 +339,6 @@ namespace Jellyfin.Server
                     {
                         var socketPath = GetUnixSocketPath(startupConfig, appPaths);
 
-                        // Workaround for https://github.com/aspnet/AspNetCore/issues/14134
-                        if (File.Exists(socketPath))
-                        {
-                            File.Delete(socketPath);
-                        }
-
                         options.ListenUnixSocket(socketPath);
                         _logger.LogInformation("Kestrel listening to unix socket {SocketPath}", socketPath);
                     }


### PR DESCRIPTION
**Changes**
Removes code working around [ASP.NET Core #14134](https://github.com/aspnet/AspNetCore/issues/14134) not cleaning up unix socket files, as this has been fixed as of .NET 6