### PR TITLE
Migrate to IHost

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.2" />
     <PackageReference Include="prometheus-net" Version="7.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -185,11 +185,7 @@ namespace Jellyfin.Server
             try
             {
                 var host = Host.CreateDefaultBuilder()
-                    .ConfigureServices(services =>
-                    {
-                        // NOTE: Called first to ensure app host configuration is fully initialized
-                        appHost.Init(services);
-                    })
+                    .ConfigureServices(services => appHost.Init(services))
                     .ConfigureWebHostDefaults(webHostBuilder => webHostBuilder.ConfigureWebHostBuilder(appHost, startupConfig, appPaths))
                     .ConfigureAppConfiguration(config => config.ConfigureAppConfiguration(options, appPaths, startupConfig))
                     .UseSerilog()

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -204,7 +204,7 @@ namespace Jellyfin.Server
                     endpoints.MapControllers();
                     if (_serverConfigurationManager.Configuration.EnableMetrics)
                     {
-                        endpoints.MapMetrics("/metrics");
+                        endpoints.MapMetrics();
                     }
 
                     endpoints.MapHealthChecks("/health");

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -35,20 +35,17 @@ namespace Jellyfin.Server
     /// </summary>
     public class Startup
     {
-        private readonly IServerConfigurationManager _serverConfigurationManager;
         private readonly IServerApplicationHost _serverApplicationHost;
+        private readonly IServerConfigurationManager _serverConfigurationManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup" /> class.
         /// </summary>
-        /// <param name="serverConfigurationManager">The server configuration manager.</param>
-        /// <param name="serverApplicationHost">The server application host.</param>
-        public Startup(
-            IServerConfigurationManager serverConfigurationManager,
-            IServerApplicationHost serverApplicationHost)
+        /// <param name="appHost">The server application host.</param>
+        public Startup(CoreAppHost appHost)
         {
-            _serverConfigurationManager = serverConfigurationManager;
-            _serverApplicationHost = serverApplicationHost;
+            _serverApplicationHost = appHost;
+            _serverConfigurationManager = appHost.ConfigurationManager;
         }
 
         /// <summary>
@@ -87,8 +84,7 @@ namespace Jellyfin.Server
                 RequestHeaderEncodingSelector = (_, _) => Encoding.UTF8
             };
 
-            services
-                .AddHttpClient(NamedClient.Default, c =>
+            services.AddHttpClient(NamedClient.Default, c =>
                 {
                     c.DefaultRequestHeaders.UserAgent.Add(productHeader);
                     c.DefaultRequestHeaders.Accept.Add(acceptJsonHeader);

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -78,11 +79,17 @@ namespace Jellyfin.Server.Integration.Tests
                 commandLineOpts,
                 startupConfig);
             _disposableComponents.Add(appHost);
-            var serviceCollection = new ServiceCollection();
-            appHost.Init(serviceCollection);
 
-            // Configure the web host builder
-            Program.ConfigureWebHostBuilder(builder, appHost, startupConfig, appPaths);
+            builder.ConfigureServices(services => appHost.Init(services))
+                .ConfigureWebHostBuilder(appHost, startupConfig, appPaths)
+                .ConfigureAppConfiguration((context, builder) =>
+                {
+                    builder
+                        .SetBasePath(appPaths.ConfigurationDirectoryPath)
+                        .AddInMemoryCollection(ConfigurationOptions.DefaultConfiguration)
+                        .AddEnvironmentVariables("JELLYFIN_")
+                        .AddInMemoryCollection(commandLineOpts.ConvertToConfig());
+                });
         }
 
         /// <inheritdoc/>

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -82,7 +82,7 @@ namespace Jellyfin.Server.Integration.Tests
             appHost.Init(serviceCollection);
 
             // Configure the web host builder
-            Program.ConfigureWebHostBuilder(builder, appHost, serviceCollection, commandLineOpts, startupConfig, appPaths);
+            Program.ConfigureWebHostBuilder(builder, appHost, startupConfig, appPaths);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Redo of #7347

Using `IHost` and `IHostBuilder` is the [recommended](https://learn.microsoft.com/en-us/aspnet/core/migration/22-to-30?tabs=visual-studio#hostbuilder-replaces-webhostbuilder) way to configure the application host.

When using `IHost`, it is no longer possible to use DI in Startup.cs, except for `IConfiguration`, `IHostEnvironment`, and `IWebEnvironment`, so startup initialization is now done manually

This should decrease the startup time of Jellyfin since the ServiceProvider is no longer created twice, but I haven't measured it.