### PR TITLE
Fix unexpected remuxing of direct playable media

### DIFF
--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -239,6 +239,13 @@ namespace Jellyfin.Api.Helpers
 
             options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
 
+            // If the user doesn't have access to transcoding, then ignore the bitrate limit
+            if ((item is Video && !user.HasPermission(PermissionKind.EnableVideoPlaybackTranscoding))
+                || (item is Audio && !user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding)))
+            {
+                options.MaxBitrate = null;
+            }
+
             if (!options.ForceDirectStream)
             {
                 // direct-stream http streaming is currently broken

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -237,13 +237,13 @@ namespace Jellyfin.Api.Helpers
                     user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding));
             }
 
-            options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
-
-            // If the user doesn't have access to transcoding, then ignore the bitrate limit
+            // If the user doesn't have access to transcoding or has disabled it, then ignore the bitrate limit of the client
             if (!mediaSource.SupportsTranscoding)
             {
-                options.MaxBitrate = null;
+                maxBitrate = null;
             }
+
+            options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
 
             if (!options.ForceDirectStream)
             {

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -240,8 +240,7 @@ namespace Jellyfin.Api.Helpers
             options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
 
             // If the user doesn't have access to transcoding, then ignore the bitrate limit
-            if ((item is Video && !user.HasPermission(PermissionKind.EnableVideoPlaybackTranscoding))
-                || (item is Audio && !user.HasPermission(PermissionKind.EnableAudioPlaybackTranscoding)))
+            if (!mediaSource.SupportsTranscoding)
             {
                 options.MaxBitrate = null;
             }


### PR DESCRIPTION
_Alternative to https://github.com/jellyfin/jellyfin-web/pull/3670_

**Changes**
Reset the maximum bitrate if the corresponding transcoding type is blocked for the user.

**Issues**
If the user has set a maximum bitrate and transcoding is blocked after that, direct playable video is never (if its bitrate exeeds the specified one) played direct because of this limit - it is remuxed.

**Steps To Reproduce**
1. With allowed transcoding, set the maximum bitrate in `Settings/Playback` to have the direct playable video transcoded.
2. Block transcoding.
3. Refresh page / relogin.
4. Start video.
5. Remuxing is used instead of DirectPlay. (_No DirectPlay because bitrate is exceeded_)
And there is no way to change this.
