### PR TITLE
Don't add additional entries if HEVC encoding is disabled

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Models.StreamingDtos;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Configuration;
@@ -202,8 +203,11 @@ namespace Jellyfin.Api.Helpers
 
             if (state.VideoStream != null && state.VideoRequest != null)
             {
+                var encodingOptions = _serverConfigurationManager.GetEncodingOptions();
+
                 // Provide SDR HEVC entrance for backward compatibility.
-                if (EncodingHelper.IsCopyCodec(state.OutputVideoCodec)
+                if (encodingOptions.AllowHevcEncoding
+                    && EncodingHelper.IsCopyCodec(state.OutputVideoCodec)
                     && !string.IsNullOrEmpty(state.VideoStream.VideoRange)
                     && string.Equals(state.VideoStream.VideoRange, "HDR", StringComparison.OrdinalIgnoreCase)
                     && string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
**Changes**
Don't add additional entries (_for HEVC_) if HEVC encoding is disabled.

**Issues**
Fixes #5576 (https://github.com/jellyfin/jellyfin/issues/5576#issuecomment-1373901085)
Fixes https://github.com/jellyfin/jellyfin/issues/8043
Fixes https://github.com/jellyfin/jellyfin-webos/issues/105
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/163
