### PR TITLE
Add option to specify user id on user creation

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CA1307
+#pragma warning disable CA1307
 
 using System;
 using System.Collections.Concurrent;
@@ -172,7 +172,7 @@ namespace Jellyfin.Server.Implementations.Users
             }
         }
 
-        internal async Task<User> CreateUserInternalAsync(string name, JellyfinDb dbContext)
+        internal async Task<User> CreateUserInternalAsyncWithGuid(string name, JellyfinDb dbContext, Guid id)
         {
             // TODO: Remove after user item data is migrated.
             var max = await dbContext.Users.AsQueryable().AnyAsync().ConfigureAwait(false)
@@ -187,6 +187,11 @@ namespace Jellyfin.Server.Implementations.Users
                 InternalId = max + 1
             };
 
+            if (!id.Equals(default))
+            {
+                user.Id = id;
+            }
+
             user.AddDefaultPermissions();
             user.AddDefaultPreferences();
 
@@ -195,8 +200,19 @@ namespace Jellyfin.Server.Implementations.Users
             return user;
         }
 
+        internal async Task<User> CreateUserInternalAsync(string name, JellyfinDb dbContext)
+        {
+            return await CreateUserInternalAsyncWithGuid(name, dbContext, Guid.Empty).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         public async Task<User> CreateUserAsync(string name)
+        {
+            return await CreateUserAsync(name, Guid.Empty).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<User> CreateUserAsync(string name, Guid id)
         {
             ThrowIfInvalidUsername(name);
 
@@ -212,7 +228,7 @@ namespace Jellyfin.Server.Implementations.Users
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                newUser = await CreateUserInternalAsync(name, dbContext).ConfigureAwait(false);
+                newUser = await CreateUserInternalAsyncWithGuid(name, dbContext, id).ConfigureAwait(false);
 
                 dbContext.Users.Add(newUser);
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);

--- a/MediaBrowser.Controller/Library/IUserManager.cs
+++ b/MediaBrowser.Controller/Library/IUserManager.cs
@@ -76,6 +76,16 @@ namespace MediaBrowser.Controller.Library
         Task UpdateUserAsync(User user);
 
         /// <summary>
+        /// Creates a user with the specified name and ID.
+        /// </summary>
+        /// <param name="name">The name of the new user.</param>
+        /// <param name="id">Optional: The id of the new user. May be empty.</param>
+        /// <returns>The created user.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> already exists.</exception>
+        Task<User> CreateUserAsync(string name, Guid id);
+
+        /// <summary>
         /// Creates a user with the specified name.
         /// </summary>
         /// <param name="name">The name of the new user.</param>


### PR DESCRIPTION
The issue being solved here is that custom user management plugins (such as [this ](https://github.com/GermanCoding/jellyfin-server-sync) one) cannot set a Guid when adding a new user - it is always choosen at random. Normally this is good behaviour, but for plugins trying to synchronize data this is problematic.

I did not find a good way to change the user id (shortly) after creation, so I propose to make it configurable (for plugins) instead. Implementations not requiring a specific ID can still operate as-is, API compatibility is maintained.