### PR TITLE
Feature: Provide service for File Transformation

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -27,7 +27,9 @@ using Jellyfin.Networking.Configuration;
 using Jellyfin.Server.Configuration;
 using Jellyfin.Server.Filters;
 using Jellyfin.Server.Formatters;
+using Jellyfin.Server.Infrastructure.FileTransformation;
 using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.FileTransformation;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Session;
 using Microsoft.AspNetCore.Authentication;
@@ -260,6 +262,18 @@ namespace Jellyfin.Server.Extensions
             }
 
             return mvcBuilder.AddControllersAsServices();
+        }
+
+        /// <summary>
+        /// Adds the File Transformation services to the service collection.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <returns>The updated service collection.</returns>
+        public static IServiceCollection AddJellyfinFileTransformation(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.AddSingleton<WebFileTransformationService>()
+                .AddSingleton<IWebFileTransformationReadService>(s => s.GetRequiredService<WebFileTransformationService>())
+                .AddSingleton<IWebFileTransformationWriteService>(s => s.GetRequiredService<WebFileTransformationService>());
         }
 
         /// <summary>

--- a/Jellyfin.Server/Infrastructure/FileTransformation/PhysicalTransformedFileProvider.cs
+++ b/Jellyfin.Server/Infrastructure/FileTransformation/PhysicalTransformedFileProvider.cs
@@ -1,0 +1,64 @@
+using System.Buffers;
+using System.IO;
+using MediaBrowser.Controller.FileTransformation;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Embedded;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
+
+namespace Jellyfin.Server.Infrastructure.FileTransformation;
+
+/// <summary>
+/// Provides file contents modified by <see cref="IWebFileTransformationReadService"/>.
+/// </summary>
+public class PhysicalTransformedFileProvider : IFileProvider
+{
+    private readonly PhysicalFileProvider _parentProvider;
+    private readonly IWebFileTransformationReadService _webFileTransformationService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PhysicalTransformedFileProvider"/> class based on the set parent provider.
+    /// </summary>
+    /// <param name="parentProvider">The parent provider.</param>
+    /// <param name="webFileTransformationService">The <see cref="IWebFileTransformationReadService"/>.</param>
+    public PhysicalTransformedFileProvider(
+        PhysicalFileProvider parentProvider,
+        IWebFileTransformationReadService webFileTransformationService)
+    {
+        _parentProvider = parentProvider;
+        _webFileTransformationService = webFileTransformationService;
+    }
+
+    /// <inheritdoc />
+    public IDirectoryContents GetDirectoryContents(string subpath)
+    {
+        return _parentProvider.GetDirectoryContents(subpath);
+    }
+
+    /// <inheritdoc />
+    public IFileInfo GetFileInfo(string subpath)
+    {
+        var iFileInfo = _parentProvider.GetFileInfo(subpath);
+        if (iFileInfo is not PhysicalFileInfo { Exists: true } physicalFileInfo
+            || !_webFileTransformationService.NeedsTransformation(subpath))
+        {
+            return iFileInfo;
+        }
+
+        using var sourceStream = physicalFileInfo.CreateReadStream();
+        var transformedStream = new MemoryStream();
+        sourceStream.CopyTo(transformedStream);
+        transformedStream.Seek(0, SeekOrigin.Begin);
+
+        _webFileTransformationService.RunTransformation(subpath, transformedStream);
+        transformedStream.Seek(0, SeekOrigin.Begin);
+
+        return new TransformableFileInfo(physicalFileInfo, transformedStream);
+    }
+
+    /// <inheritdoc />
+    public IChangeToken Watch(string filter)
+    {
+        return _parentProvider.Watch(filter);
+    }
+}

--- a/Jellyfin.Server/Infrastructure/FileTransformation/TransformableFileInfo.cs
+++ b/Jellyfin.Server/Infrastructure/FileTransformation/TransformableFileInfo.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+
+namespace Jellyfin.Server.Infrastructure.FileTransformation;
+
+internal class TransformableFileInfo : IFileInfo
+{
+    private readonly PhysicalFileInfo _baseInfo;
+    private readonly Stream _transformedStream;
+
+    public TransformableFileInfo(PhysicalFileInfo baseInfo, Stream transformedStream)
+    {
+        _baseInfo = baseInfo;
+        _transformedStream = transformedStream;
+    }
+
+    public bool Exists => _baseInfo.Exists;
+
+    public bool IsDirectory => _baseInfo.IsDirectory;
+
+    public DateTimeOffset LastModified => _baseInfo.LastModified;
+
+    public long Length => _transformedStream.Length;
+
+    public string Name => _baseInfo.Name;
+
+    public string? PhysicalPath => _baseInfo.PhysicalPath;
+
+    public Stream CreateReadStream()
+    {
+        return _transformedStream;
+    }
+}

--- a/Jellyfin.Server/Infrastructure/FileTransformation/TransformableFileInfo.cs
+++ b/Jellyfin.Server/Infrastructure/FileTransformation/TransformableFileInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;
@@ -26,7 +26,7 @@ internal class TransformableFileInfo : IFileInfo
 
     public string Name => _baseInfo.Name;
 
-    public string? PhysicalPath => _baseInfo.PhysicalPath;
+    public string? PhysicalPath => null;
 
     public Stream CreateReadStream()
     {

--- a/Jellyfin.Server/Infrastructure/FileTransformation/WebFileTransformationService.cs
+++ b/Jellyfin.Server/Infrastructure/FileTransformation/WebFileTransformationService.cs
@@ -21,10 +21,15 @@ public class WebFileTransformationService : IWebFileTransformationReadService, I
         _fileTransformations = new Dictionary<string, ICollection<TransformFile>>();
     }
 
+    private string NormalizePath(string path)
+    {
+        return path.TrimStart('/');
+    }
+
     /// <inheritdoc />
     public bool NeedsTransformation(string path)
     {
-        return _fileTransformations.ContainsKey(path);
+        return _fileTransformations.ContainsKey(NormalizePath(path));
     }
 
     /// <inheritdoc />
@@ -35,6 +40,7 @@ public class WebFileTransformationService : IWebFileTransformationReadService, I
             throw new ArgumentNullException(nameof(stream));
         }
 
+        path = NormalizePath(path);
         var pipeline = _fileTransformations[path];
         foreach (var action in pipeline)
         {
@@ -56,6 +62,7 @@ public class WebFileTransformationService : IWebFileTransformationReadService, I
             throw new ArgumentNullException(nameof(transformation));
         }
 
+        path = NormalizePath(path);
         if (!_fileTransformations.TryGetValue(path, out var pipeline))
         {
             pipeline = new List<TransformFile>();

--- a/Jellyfin.Server/Infrastructure/FileTransformation/WebFileTransformationService.cs
+++ b/Jellyfin.Server/Infrastructure/FileTransformation/WebFileTransformationService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.FileTransformation;
+
+namespace Jellyfin.Server.Infrastructure.FileTransformation;
+
+/// <summary>
+/// Provides methods for Writing and Reading file Transformations.
+/// </summary>
+public class WebFileTransformationService : IWebFileTransformationReadService, IWebFileTransformationWriteService
+{
+    private readonly IDictionary<string, ICollection<TransformFile>> _fileTransformations;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebFileTransformationService"/> class.
+    /// </summary>
+    public WebFileTransformationService()
+    {
+        _fileTransformations = new Dictionary<string, ICollection<TransformFile>>();
+    }
+
+    /// <inheritdoc />
+    public bool NeedsTransformation(string path)
+    {
+        return _fileTransformations.ContainsKey(path);
+    }
+
+    /// <inheritdoc />
+    public void RunTransformation(string path, Stream stream)
+    {
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        var pipeline = _fileTransformations[path];
+        foreach (var action in pipeline)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            action(path, stream);
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddTransformation(string path, TransformFile transformation)
+    {
+        if (path == null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        if (transformation == null)
+        {
+            throw new ArgumentNullException(nameof(transformation));
+        }
+
+        if (!_fileTransformations.TryGetValue(path, out var pipeline))
+        {
+            pipeline = new List<TransformFile>();
+            _fileTransformations[path] = pipeline;
+        }
+
+        pipeline.Add(transformation);
+    }
+}

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -12,11 +12,13 @@ using Jellyfin.Server.HealthChecks;
 using Jellyfin.Server.Implementations;
 using Jellyfin.Server.Implementations.Extensions;
 using Jellyfin.Server.Infrastructure;
+using Jellyfin.Server.Infrastructure.FileTransformation;
 using Jellyfin.Server.Middleware;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Extensions;
+using MediaBrowser.Controller.FileTransformation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -66,6 +68,7 @@ namespace Jellyfin.Server
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
             services.AddJellyfinDbContext();
             services.AddJellyfinApiSwagger();
+            services.AddJellyfinFileTransformation();
 
             // configure custom legacy authentication
             services.AddCustomAuthentication();
@@ -174,7 +177,9 @@ namespace Jellyfin.Server
                     extensionProvider.Mappings.Add(".mem", MediaTypeNames.Application.Octet);
                     mainApp.UseStaticFiles(new StaticFileOptions
                     {
-                        FileProvider = new PhysicalFileProvider(_serverConfigurationManager.ApplicationPaths.WebPath),
+                        FileProvider = new PhysicalTransformedFileProvider(
+                            new PhysicalFileProvider(_serverConfigurationManager.ApplicationPaths.WebPath),
+                            mainApp.ApplicationServices.GetRequiredService<IWebFileTransformationReadService>()),
                         RequestPath = "/web",
                         ContentTypeProvider = extensionProvider
                     });

--- a/MediaBrowser.Controller/FileTransformation/IWebFileTransformationReadService.cs
+++ b/MediaBrowser.Controller/FileTransformation/IWebFileTransformationReadService.cs
@@ -1,0 +1,23 @@
+using System.IO;
+
+namespace MediaBrowser.Controller.FileTransformation;
+
+/// <summary>
+/// Provides access to the Transformations setup by <see cref="IWebFileTransformationWriteService"/>.
+/// </summary>
+public interface IWebFileTransformationReadService
+{
+    /// <summary>
+    /// Checks if a given paths file needs transformation.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True if the file needs transformation, otherwise false.</returns>
+    bool NeedsTransformation(string path);
+
+    /// <summary>
+    /// Runs the Transformation pipeline on the Stream.
+    /// </summary>
+    /// <param name="path">The origin path where the file originates from.</param>
+    /// <param name="stream">The writable stream of that files contents.</param>
+    void RunTransformation(string path, Stream stream);
+}

--- a/MediaBrowser.Controller/FileTransformation/IWebFileTransformationWriteService.cs
+++ b/MediaBrowser.Controller/FileTransformation/IWebFileTransformationWriteService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.FileTransformation;
+
+/// <summary>
+/// Provides a method for transforming a file.
+/// </summary>
+/// <param name="path">The origin file path.</param>
+/// <param name="contents">The contents of the file.</param>
+public delegate void TransformFile(string path, Stream contents);
+
+/// <summary>
+/// Provides Plugins with the capability to transform Html, Javascript and Css files.
+/// </summary>
+public interface IWebFileTransformationWriteService
+{
+    /// <summary>
+    /// Adds a new Transformation to the Pipeline.
+    /// </summary>
+    /// <param name="path">The requested file path.</param>
+    /// <param name="transformation">The callback that will be invoked when the file is requested.</param>
+    void AddTransformation(string path, TransformFile transformation);
+}

--- a/tests/Jellyfin.Server.Integration.Tests/FileTransformingPlugin.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/FileTransformingPlugin.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.FileTransformation;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+
+namespace Jellyfin.Server.Integration.Tests;
+
+#pragma warning disable CS1591
+public class FileTransformingPlugin : BasePlugin<BasePluginConfiguration>
+{
+    private readonly IWebFileTransformationWriteService _fileTransformationWriteService;
+
+    public FileTransformingPlugin(
+        IApplicationPaths applicationPaths,
+        IXmlSerializer xmlSerializer,
+        IWebFileTransformationWriteService fileTransformationWriteService) : base(applicationPaths, xmlSerializer)
+    {
+        _fileTransformationWriteService = fileTransformationWriteService;
+        _fileTransformationWriteService.AddTransformation("index.html", TransformIndexHtml);
+    }
+
+    public override string Name => "File Transformation Plugin test.";
+
+    public override Guid Id => new Guid("649C546C-D66F-458D-80FF-0FE5FEFEEDA8");
+
+    private void TransformIndexHtml(string path, Stream contents)
+    {
+        using var textReader = new StreamReader(contents, null, true, -1, true);
+        var text = textReader.ReadToEnd();
+        var regex = Regex.Replace(text, "(<html>)", "<<$1>>");
+        contents.Seek(0, SeekOrigin.Begin);
+
+        using var textWriter = new StreamWriter(contents, null, -1, true);
+        textWriter.Write(regex);
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Transformation/TransformationTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Transformation/TransformationTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Emby.Server.Implementations;
+using MediaBrowser.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Transformation
+{
+    public class TransformationTests : IClassFixture<JellyfinApplicationFactory>
+    {
+        private readonly JellyfinApplicationFactory _factory;
+
+        public TransformationTests(JellyfinApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task GetIndexHtmlTransformed()
+        {
+            // prepare test data
+            var testIndexHtml = @"<html>
+</html>";
+            var client = _factory.CreateClient();
+
+            Assert.NotNull(_factory.AppPaths);
+            var testIndexPath = Path.Combine(_factory.AppPaths.WebPath, "index.html");
+            await File.WriteAllTextAsync(testIndexPath, testIndexHtml);
+
+            var response = await client.GetAsync("/web/index.html").ConfigureAwait(false);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            Assert.Contains("<<<html>>>", content, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
Added the `IWebFileTransformationWriteService` for plugins to add in-memory transformations to files provided under the /web prefix. Also added the `IWebFileTransformationReadService` for the newly created `WebFileTransformationService` to consume those changes.

This will allow plugin authors to no longer rely on modifying those files on disk or for the user to do that in the jellyfins web folder. Instead Plugin authors can just inject needed changes in memory in a structured way.
