### PR TITLE
Fix pre-existing chapter images not being deleted

### DIFF
--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -63,7 +63,7 @@ namespace Emby.Server.Implementations.MediaEncoder
         /// Determines whether [is eligible for chapter image extraction] [the specified video].
         /// </summary>
         /// <param name="video">The video.</param>
-        /// <param name="libraryOptions"></param>
+        /// <param name="libraryOptions">The library options for the video.</param>
         /// <returns><c>true</c> if [is eligible for chapter image extraction] [the specified video]; otherwise, <c>false</c>.</returns>
         private bool IsEligibleForChapterImageExtraction(Video video, LibraryOptions libraryOptions)
         {

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -15,6 +15,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
@@ -62,23 +63,16 @@ namespace Emby.Server.Implementations.MediaEncoder
         /// Determines whether [is eligible for chapter image extraction] [the specified video].
         /// </summary>
         /// <param name="video">The video.</param>
+        /// <param name="libraryOptions"></param>
         /// <returns><c>true</c> if [is eligible for chapter image extraction] [the specified video]; otherwise, <c>false</c>.</returns>
-        private bool IsEligibleForChapterImageExtraction(Video video)
+        private bool IsEligibleForChapterImageExtraction(Video video, LibraryOptions libraryOptions)
         {
             if (video.IsPlaceHolder)
             {
                 return false;
             }
 
-            var libraryOptions = _libraryManager.GetLibraryOptions(video);
-            if (libraryOptions is not null)
-            {
-                if (!libraryOptions.EnableChapterImageExtraction)
-                {
-                    return false;
-                }
-            }
-            else
+            if (libraryOptions is null || !libraryOptions.EnableChapterImageExtraction)
             {
                 return false;
             }
@@ -99,7 +93,9 @@ namespace Emby.Server.Implementations.MediaEncoder
 
         public async Task<bool> RefreshChapterImages(Video video, IDirectoryService directoryService, IReadOnlyList<ChapterInfo> chapters, bool extractImages, bool saveChapters, CancellationToken cancellationToken)
         {
-            if (!IsEligibleForChapterImageExtraction(video))
+            var libraryOptions = _libraryManager.GetLibraryOptions(video);
+
+            if (!IsEligibleForChapterImageExtraction(video, libraryOptions))
             {
                 extractImages = false;
             }
@@ -177,6 +173,12 @@ namespace Emby.Server.Implementations.MediaEncoder
                 {
                     chapter.ImagePath = path;
                     chapter.ImageDateModified = _fileSystem.GetLastWriteTimeUtc(path);
+                    changesMade = true;
+                }
+                else if (libraryOptions?.EnableChapterImageExtraction != true)
+                {
+                    // We have an image for the current chapter but the user has disabled chapter image extraction -> delete this chapter's image
+                    chapter.ImagePath = null;
                     changesMade = true;
                 }
             }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
@@ -100,7 +100,6 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
                     EnableImages = false
                 },
                 SourceTypes = new SourceType[] { SourceType.Library },
-                HasChapterImages = false,
                 IsVirtualItem = false
             })
                 .OfType<Video>()


### PR DESCRIPTION
**Changes**
Change `ChapterImagesTask` to query for videos with _and_ without pre-existing chapter images, rather than just those _without_ them. This makes sure that videos with pre-existing chapter images are sent downstream where they will be deleted if the client has disabled the "Enable chapter image extraction" setting in the dashboard.

**Issues**
Fixes #9102 
