### PR TITLE
Backport the ffmpeg link fix (#8901) to 10.8.z

### DIFF
--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -8,7 +8,7 @@ set -o xtrace
 # Version variables
 NSSM_VERSION="nssm-2.24-101-g897c7ad"
 NSSM_URL="http://files.evilt.win/nssm/${NSSM_VERSION}.zip"
-FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg.zip";
+FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg-portable_win64.zip";
 
 # Move to source directory
 pushd ${SOURCE_DIR}


### PR DESCRIPTION
**Changes**
- Backport #8901 into 10.8.z in case it breaks the next publish.