### PR TITLE
Make the bitrate of the fallback stream the same as the original

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -211,19 +211,8 @@ public class DynamicHlsHelper
                     var sdrVideoUrl = ReplaceProfile(playlistUrl, "hevc", string.Join(',', requestedVideoProfiles), "main");
                     sdrVideoUrl += "&AllowVideoStreamCopy=false";
 
-                    var sdrOutputVideoBitrate = _encodingHelper.GetVideoBitrateParamValue(state.VideoRequest, state.VideoStream, state.OutputVideoCodec);
-                    var sdrOutputAudioBitrate = 0;
-                    if (EncodingHelper.LosslessAudioCodecs.Contains(state.VideoRequest.AudioCodec, StringComparison.OrdinalIgnoreCase))
-                    {
-                        sdrOutputAudioBitrate = state.AudioStream.BitRate ?? 0;
-                    }
-                    else
-                    {
-                        sdrOutputAudioBitrate = _encodingHelper.GetAudioBitrateParam(state.VideoRequest, state.AudioStream, state.OutputAudioChannels) ?? 0;
-                    }
-
-                    var sdrTotalBitrate = sdrOutputAudioBitrate + sdrOutputVideoBitrate;
-                    AppendPlaylist(builder, state, sdrVideoUrl, sdrTotalBitrate, subtitleGroup);
+                    // HACK: Use the same bitrate so that the client can choose by other attributes, such as color range.
+                    AppendPlaylist(builder, state, sdrVideoUrl, totalBitrate, subtitleGroup);
 
                     // Restore the video codec
                     state.OutputVideoCodec = "copy";


### PR DESCRIPTION
_Alternative to #10751_

In addition to #9092
If HEVC encoding is enabled, we may still encounter unnecessary transcoding issue.

:warning: This PR is a hack/trick. It works on my Tizen 4 TV and Tizen 5 emulator (with `AllowHevcEncoding` condition removed).
I am for removing the problematic block, since we have `VideoRange` and probably no longer need a fallback stream. But this requires testing the Apple devices that require this fallback stream.

**Changes**
Make the bitrate of the fallback stream the same as the original, so that the client can choose by other attributes, such as color range.

**Issues**
Possible unnecessary transcoding (+tone mapping) in the same way as described [here](https://github.com/jellyfin/jellyfin/pull/9016#issue-1521365292).
> All streams in the master playlist are bound to the same `PlaySessionId`.
The server starts the transcoding process after receiving a request (_middle bitrate or lower_) from the device.
After sufficient buffering, the device requests a higher bitrate.
Since the `PlaySessionId` is the same, it seems that the transcoding job doesn't restart with the new parameters.

Fixes #8043
Fixes https://github.com/jellyfin/jellyfin-webos/issues/105
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/163
Fixes https://github.com/jellyfin/jellyfin-webos/issues/59
Fixes https://github.com/jellyfin/jellyfin/issues/5576 (https://github.com/jellyfin/jellyfin/issues/5576#issuecomment-1373901085)
Fixes https://github.com/jellyfin/jellyfin-web/issues/1190