### PR TITLE
Increase stale bot operations per run

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -19,6 +19,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-close: 21
           days-before-pr-close: -1
+          operations-per-run: 75
           exempt-issue-labels: regression,security,roadmap,future,feature,enhancement,confirmed
           stale-issue-label: stale
           stale-issue-message: |-


### PR DESCRIPTION
Stalebot currently does not work as intended, apparently we need to increase its operation contingent.

**Changes**
Increase stalebot `operations-per-run` from 30 to 75
