### PR TITLE
Add "Allowed Tags" to Parental Controls

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -231,3 +231,4 @@
  - [Matthew Jones](https://github.com/matthew-jones-uk)
  - [Jakob Kukla](https://github.com/jakobkukla)
  - [Utku Özdemir](https://github.com/utkuozdemir)
+ - [JPUC1143](https://github.com/Jpuc1143/)

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4477,6 +4477,24 @@ namespace Emby.Server.Implementations.Data
                 }
             }
 
+            if (query.IncludeInheritedTags.Length > 0)
+            {
+                var paramName = "@IncludeInheritedTags";
+                if (statement is null)
+                {
+                    int index = 0;
+                    string includedTags = string.Join(',', query.IncludeInheritedTags.Select(_ => paramName + index++));
+                    whereClauses.Add("((select CleanValue from ItemValues where ItemId=Guid and Type=6 and cleanvalue in (" + includedTags + ")) is not null)");
+                }
+                else
+                {
+                    for (int index = 0; index < query.IncludeInheritedTags.Length; index++)
+                    {
+                        statement.TryBind(paramName + index, GetCleanValue(query.IncludeInheritedTags[index]));
+                    }
+                }
+            }
+
             if (query.SeriesStatuses.Length > 0)
             {
                 var statuses = new List<string>();

--- a/Jellyfin.Data/Enums/PreferenceKind.cs
+++ b/Jellyfin.Data/Enums/PreferenceKind.cs
@@ -63,6 +63,11 @@ namespace Jellyfin.Data.Enums
         /// <summary>
         /// A list of ordered views.
         /// </summary>
-        OrderedViews = 11
+        OrderedViews = 11,
+
+        /// <summary>
+        /// A list of allowed tags.
+        /// </summary>
+        AllowedTags = 12
     }
 }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -371,6 +371,7 @@ namespace Jellyfin.Server.Implementations.Users
                     EnablePublicSharing = user.HasPermission(PermissionKind.EnablePublicSharing),
                     AccessSchedules = user.AccessSchedules.ToArray(),
                     BlockedTags = user.GetPreference(PreferenceKind.BlockedTags),
+                    AllowedTags = user.GetPreference(PreferenceKind.AllowedTags),
                     EnabledChannels = user.GetPreferenceValues<Guid>(PreferenceKind.EnabledChannels),
                     EnabledDevices = user.GetPreference(PreferenceKind.EnabledDevices),
                     EnabledFolders = user.GetPreferenceValues<Guid>(PreferenceKind.EnabledFolders),
@@ -696,6 +697,7 @@ namespace Jellyfin.Server.Implementations.Users
                 // TODO: fix this at some point
                 user.SetPreference(PreferenceKind.BlockUnratedItems, policy.BlockUnratedItems ?? Array.Empty<UnratedItem>());
                 user.SetPreference(PreferenceKind.BlockedTags, policy.BlockedTags);
+                user.SetPreference(PreferenceKind.AllowedTags, policy.AllowedTags);
                 user.SetPreference(PreferenceKind.EnabledChannels, policy.EnabledChannels);
                 user.SetPreference(PreferenceKind.EnabledDevices, policy.EnabledDevices);
                 user.SetPreference(PreferenceKind.EnabledFolders, policy.EnabledFolders);

--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -170,6 +170,7 @@ namespace Jellyfin.Server.Migrations.Routines
                     }
 
                     user.SetPreference(PreferenceKind.BlockedTags, policy.BlockedTags);
+                    user.SetPreference(PreferenceKind.AllowedTags, policy.AllowedTags);
                     user.SetPreference(PreferenceKind.EnabledChannels, policy.EnabledChannels);
                     user.SetPreference(PreferenceKind.EnabledDevices, policy.EnabledDevices);
                     user.SetPreference(PreferenceKind.EnabledFolders, policy.EnabledFolders);

--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -170,7 +170,6 @@ namespace Jellyfin.Server.Migrations.Routines
                     }
 
                     user.SetPreference(PreferenceKind.BlockedTags, policy.BlockedTags);
-                    user.SetPreference(PreferenceKind.AllowedTags, policy.AllowedTags);
                     user.SetPreference(PreferenceKind.EnabledChannels, policy.EnabledChannels);
                     user.SetPreference(PreferenceKind.EnabledDevices, policy.EnabledDevices);
                     user.SetPreference(PreferenceKind.EnabledFolders, policy.EnabledFolders);

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1607,6 +1607,11 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
+            if (user.GetPreference(PreferenceKind.AllowedTags).Any() && !user.GetPreference(PreferenceKind.AllowedTags).Any(i => Tags.Contains(i, StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1607,7 +1607,8 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
-            if (user.GetPreference(PreferenceKind.AllowedTags).Any() && !user.GetPreference(PreferenceKind.AllowedTags).Any(i => Tags.Contains(i, StringComparison.OrdinalIgnoreCase)))
+            var allowedTagsPreference = user.GetPreference(PreferenceKind.AllowedTags);
+            if (allowedTagsPreference.Any() && !allowedTagsPreference.Any(i => Tags.Contains(i, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -26,6 +26,7 @@ namespace MediaBrowser.Controller.Entities
             EnableTotalRecordCount = true;
             ExcludeArtistIds = Array.Empty<Guid>();
             ExcludeInheritedTags = Array.Empty<string>();
+            IncludeInheritedTags = Array.Empty<string>();
             ExcludeItemIds = Array.Empty<Guid>();
             ExcludeItemTypes = Array.Empty<BaseItemKind>();
             ExcludeTags = Array.Empty<string>();
@@ -94,6 +95,8 @@ namespace MediaBrowser.Controller.Entities
         public string[] ExcludeTags { get; set; }
 
         public string[] ExcludeInheritedTags { get; set; }
+
+        public string[] IncludeInheritedTags { get; set; }
 
         public IReadOnlyList<string> Genres { get; set; }
 
@@ -368,6 +371,7 @@ namespace MediaBrowser.Controller.Entities
             }
 
             ExcludeInheritedTags = user.GetPreference(PreferenceKind.BlockedTags);
+            IncludeInheritedTags = user.GetPreference(PreferenceKind.AllowedTags);
 
             User = user;
         }

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -35,6 +35,7 @@ namespace MediaBrowser.Model.Users
             EnableSharedDeviceControl = true;
 
             BlockedTags = Array.Empty<string>();
+            AllowedTags = Array.Empty<string>();
             BlockUnratedItems = Array.Empty<UnratedItem>();
 
             EnableUserPreferenceAccess = true;
@@ -85,6 +86,8 @@ namespace MediaBrowser.Model.Users
         public int? MaxParentalRating { get; set; }
 
         public string[] BlockedTags { get; set; }
+
+        public string[] AllowedTags { get; set; }
 
         public bool EnableUserPreferenceAccess { get; set; }
 


### PR DESCRIPTION
**Changes**
Parental Controls  can now block all the media that do not have a specified tag, similar to the already existing "Block items with tags" but with a whitelist instead. By default, as long as no tags are configured for the whitelist, no shows will be blocked.

**Issues**
Implements #928