### PR TITLE
Added replaygain support for transcoded audio

### DIFF
--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -149,7 +149,7 @@ namespace Jellyfin.Api.Helpers
             StreamingHelpers.AddDlnaHeaders(state, _httpContextAccessor.HttpContext.Response.Headers, streamingRequest.Static || isTranscodeCached, streamingRequest.StartTimeTicks, _httpContextAccessor.HttpContext.Request, _dlnaManager);
 
             // Static stream
-            if (streamingRequest.Static)
+            if (streamingRequest.Static && !_serverConfigurationManager.GetEncodingOptions().EnableAlwaysAudioTranscode)
             {
                 var contentType = state.GetMimeType("." + state.OutputContainer, false) ?? state.GetMimeType(state.MediaPath);
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5785,6 +5785,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
             }
 
+            if(encodingOptions.EnableReplayGain){
+                audioTranscodeParams.Add("-af volume=replaygain=track ");
+            }
+
             var threads = GetNumberOfThreads(state, encodingOptions, null);
 
             var inputModifier = GetInputModifier(state, encodingOptions, null);

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -48,6 +48,8 @@ public class EncodingOptions
         EnableSubtitleExtraction = true;
         AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = new[] { "mkv" };
         HardwareDecodingCodecs = new string[] { "h264", "vc1" };
+        EnableReplayGain = false;
+        EnableAlwaysAudioTranscode = false;
     }
 
     /// <summary>
@@ -244,4 +246,14 @@ public class EncodingOptions
     /// Gets or sets the file extensions on-demand metadata based keyframe extraction is enabled for.
     /// </summary>
     public string[] AllowOnDemandMetadataBasedKeyframeExtractionForExtensions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether replaygain should be enabled for transcoded audio.
+    /// </summary>
+    public bool EnableReplayGain { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether audio transcode should always be enabled.
+    /// </summary>
+    public bool EnableAlwaysAudioTranscode { get; set; }
 }


### PR DESCRIPTION
Added replaygain support for transcoded audio. Because the audio has to be transcoded to enable replaygain, I have also added another option to force audio transcoding. 

Frontend settings here: https://github.com/jellyfin/jellyfin-web/pull/4294

**Changes**
Added replaygain support for transcoded audio
Added always transcode audio function

**Issues**
