### PR TITLE
Save modified userData after parsing an nfo

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -266,11 +266,6 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
             var nfoConfiguration = _config.GetNfoConfiguration();
             UserItemData? userData = null;
-            if (!string.IsNullOrWhiteSpace(nfoConfiguration.UserId))
-            {
-                var user = _userManager.GetUserById(Guid.Parse(nfoConfiguration.UserId));
-                userData = _userDataManager.GetUserData(user, item);
-            }
 
             switch (reader.Name)
             {
@@ -370,9 +365,12 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     {
                         var val = reader.ReadElementContentAsBoolean();
 
-                        if (userData is not null)
+                        if (!string.IsNullOrWhiteSpace(nfoConfiguration.UserId))
                         {
+                            var user = _userManager.GetUserById(Guid.Parse(nfoConfiguration.UserId));
+                            userData = _userDataManager.GetUserData(user, item);
                             userData.Played = val;
+                            _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
                         }
 
                         break;
@@ -381,11 +379,14 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 case "playcount":
                     {
                         var val = reader.ReadElementContentAsString();
-                        if (!string.IsNullOrWhiteSpace(val) && userData is not null)
+                        if (!string.IsNullOrWhiteSpace(val) && !string.IsNullOrWhiteSpace(nfoConfiguration.UserId))
                         {
                             if (int.TryParse(val, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
                             {
+                                var user = _userManager.GetUserById(Guid.Parse(nfoConfiguration.UserId));
+                                userData = _userDataManager.GetUserData(user, item);
                                 userData.PlayCount = count;
+                                _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
                             }
                         }
 
@@ -395,12 +396,15 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 case "lastplayed":
                     {
                         var val = reader.ReadElementContentAsString();
-                        if (!string.IsNullOrWhiteSpace(val) && userData is not null)
+                        if (!string.IsNullOrWhiteSpace(val) && !string.IsNullOrWhiteSpace(nfoConfiguration.UserId))
                         {
                             if (DateTime.TryParse(val, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var added))
                             {
+                                var user = _userManager.GetUserById(Guid.Parse(nfoConfiguration.UserId));
+                                userData = _userDataManager.GetUserData(user, item);
                                 userData.LastPlayedDate = added;
-                            }
+                                _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
+                           }
                             else
                             {
                                 Logger.LogWarning("Invalid lastplayed value found: {Value}", val);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
The user data object wasn't saved when modified after parsing an nfo, which made the watched, playcount and lastplayed tags functionally useless.  
I had to duplicate a few lines and move them in the switch in order to avoid trying to save new userData for every tag, but that shouldn't be a problem.  
Since it seems odd that this issue wasn't noticed for more than one year and the relevant tests were passing, this warrants a look by someone more experienced with the codebase, but that fixes #8415 for me.
I'm also not sure about the proper use of the "none" cancellation token sent during the data save, but I don't think there's an issue with not being able to cancel the save...

**Issues**
Fixes #8415