### PR TITLE
Escape the path to pass as a command line argument

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1662,8 +1662,8 @@ namespace Jellyfin.Api.Controllers
                 startNumber.ToString(CultureInfo.InvariantCulture),
                 baseUrlParam,
                 isEventPlaylist ? "event" : "vod",
-                outputTsArg,
-                outputPath).Trim();
+                outputTsArg.Replace("\"", "\\\"", StringComparison.Ordinal),
+                outputPath.Replace("\"", "\\\"", StringComparison.Ordinal)).Trim();
         }
 
         /// <summary>

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -21,6 +21,7 @@ using MediaBrowser.Controller.Dlna;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
+using MediaBrowser.MediaEncoding.Encoder;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.IO;
@@ -1662,8 +1663,8 @@ namespace Jellyfin.Api.Controllers
                 startNumber.ToString(CultureInfo.InvariantCulture),
                 baseUrlParam,
                 isEventPlaylist ? "event" : "vod",
-                outputTsArg.Replace("\"", "\\\"", StringComparison.Ordinal),
-                outputPath.Replace("\"", "\\\"", StringComparison.Ordinal)).Trim();
+                EncodingUtils.NormalizePath(outputTsArg),
+                EncodingUtils.NormalizePath(outputPath)).Trim();
         }
 
         /// <summary>

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Emby.Dlna\Emby.Dlna.csproj" />
     <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
+    <ProjectReference Include="..\MediaBrowser.MediaEncoding\MediaBrowser.MediaEncoding.csproj" />
     <ProjectReference Include="..\src\Jellyfin.MediaEncoding.Hls\Jellyfin.MediaEncoding.Hls.csproj" />
   </ItemGroup>
 

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.MediaEncoding.Encoder;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
@@ -320,7 +321,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
                 "-dump_attachment:{1} \"{2}\" -i {0} -t 0 -f null null",
                 inputPath,
                 attachmentStreamIndex,
-                outputPath.Replace("\"", "\\\"", StringComparison.Ordinal));
+                EncodingUtils.NormalizePath(outputPath));
 
             int exitCode;
 

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -317,10 +317,10 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
             var processArgs = string.Format(
                 CultureInfo.InvariantCulture,
-                "-dump_attachment:{1} {2} -i {0} -t 0 -f null null",
+                "-dump_attachment:{1} \"{2}\" -i {0} -t 0 -f null null",
                 inputPath,
                 attachmentStreamIndex,
-                outputPath);
+                outputPath.Replace("\"", "\\\"", StringComparison.Ordinal));
 
             int exitCode;
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
@@ -56,7 +56,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>System.String.</returns>
-        private static string NormalizePath(string path)
+        public static string NormalizePath(string path)
         {
             // Quotes are valid path characters in linux and they need to be escaped here with a leading \
             return path.Replace("\"", "\\\"", StringComparison.Ordinal);


### PR DESCRIPTION
**Changes**
Escape the path to pass as a command line argument.

**Issues**
1. Transcoding doesn't work when `datadir` contains quotes in the path.
2. Attachment extraction doesn't work when `datadir` contains spaces in the path.

~_It would be better to extract these `Replace`s into a function. Where?_~
Use `MediaBrowser.MediaEncoding.NormalizePath` (https://github.com/jellyfin/jellyfin/pull/9178#issuecomment-1404675829)

Tested with datadir `jellyfin "test` on Ubuntu 20.04.