### PR TITLE
Fix audio codec not being used in UniversalAudio

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5762,7 +5762,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                 audioTranscodeParams.Add("-ac " + state.OutputAudioChannels.Value.ToString(CultureInfo.InvariantCulture));
             }
 
-            audioTranscodeParams.Add("-acodec " + state.OutputAudioCodec);
+            if (!string.IsNullOrEmpty(state.OutputAudioCodec))
+            {
+                audioTranscodeParams.Add("-acodec " + state.OutputAudioCodec);
+            }
 
             if (!string.Equals(state.OutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5762,6 +5762,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 audioTranscodeParams.Add("-ac " + state.OutputAudioChannels.Value.ToString(CultureInfo.InvariantCulture));
             }
 
+            audioTranscodeParams.Add("-acodec " + state.OutputAudioCodec);
+
             if (!string.Equals(state.OutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))
             {
                 // opus only supports specific sampling rates

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5764,7 +5764,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (!string.IsNullOrEmpty(state.OutputAudioCodec))
             {
-                audioTranscodeParams.Add("-acodec " + state.OutputAudioCodec);
+                audioTranscodeParams.Add("-acodec " + GetAudioEncoder(state));
             }
 
             if (!string.Equals(state.OutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR specifies the audio codec when creating the ffmpeg command line when streaming audio. Currently, Jellyfin doesn't specify this and therefore just falls back on whatever the default codec of the container is. For example, here is an ffmpeg log run from a call to `/Audio/{id}/universal?transcodingContainer=ogg&audioCodec=opus`. Note how Vorbis is used despite audioCodec being set to opus.

<details>

```
/Audio/0d811359188af113961e7d18b0085ca7/universal

{"Protocol":0,"Id":"0d811359188af113961e7d18b0085ca7","Path":"/media/Music/Casiopea/1982 - 4x4/01 - Mid-Manhattan.flac","EncoderPath":null,"EncoderProtocol":null,"Type":0,"Container":"flac","Size":31252924,"Name":"01 - Mid-Manhattan","IsRemote":false,"ETag":"5e9910bdcaf55a912ce4341f9a1e9d70","RunTimeTicks":2822000128,"ReadAtNativeFramerate":false,"IgnoreDts":false,"IgnoreIndex":false,"GenPtsInput":false,"SupportsTranscoding":true,"SupportsDirectStream":true,"SupportsDirectPlay":true,"IsInfiniteStream":false,"RequiresOpening":false,"OpenToken":null,"RequiresClosing":false,"LiveStreamId":null,"BufferMs":null,"RequiresLooping":false,"SupportsProbing":true,"VideoType":null,"IsoType":null,"Video3DFormat":null,"MediaStreams":[{"Codec":"flac","CodecTag":null,"Language":null,"ColorRange":null,"ColorSpace":null,"ColorTransfer":null,"ColorPrimaries":null,"DvVersionMajor":null,"DvVersionMinor":null,"DvProfile":null,"DvLevel":null,"RpuPresentFlag":null,"ElPresentFlag":null,"BlPresentFlag":null,"DvBlSignalCompatibilityId":null,"Comment":null,"TimeBase":"1/44100","CodecTimeBase":"1/44100","Title":null,"VideoRange":null,"VideoRangeType":null,"VideoDoViTitle":null,"LocalizedUndefined":null,"LocalizedDefault":null,"LocalizedForced":null,"LocalizedExternal":null,"DisplayTitle":"FLAC - Stereo","NalLengthSize":null,"IsInterlaced":false,"IsAVC":null,"ChannelLayout":"stereo","BitRate":885979,"BitDepth":16,"RefFrames":null,"PacketLength":null,"Channels":2,"SampleRate":44100,"IsDefault":false,"IsForced":false,"Height":null,"Width":null,"AverageFrameRate":null,"RealFrameRate":null,"Profile":null,"Type":0,"AspectRatio":null,"Index":0,"Score":null,"IsExternal":false,"DeliveryMethod":null,"DeliveryUrl":null,"IsExternalUrl":null,"IsTextSubtitleStream":false,"SupportsExternalStream":false,"Path":null,"PixelFormat":null,"Level":0,"IsAnamorphic":null}],"MediaAttachments":[],"Formats":[],"Bitrate":885979,"Timestamp":null,"RequiredHttpHeaders":{},"TranscodingUrl":null,"TranscodingSubProtocol":null,"TranscodingContainer":null,"AnalyzeDurationMs":null,"DefaultAudioStreamIndex":null,"DefaultSubtitleStreamIndex":null}

/usr/lib/jellyfin-ffmpeg/ffmpeg -analyzeduration 200M  -i file:"/media/Music/Casiopea/1982 - 4x4/01 - Mid-Manhattan.flac" -threads 0 -vn -ab 128000 -ac 2 -id3v2_version 3 -write_id3v1 1 -y "/config/transcodes/94889ed7de8e686dc7de7eddd19df672.ogg"


ffmpeg version 5.1.1-Jellyfin Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 10 (Debian 10.2.1-6)
  configuration: --prefix=/usr/lib/jellyfin-ffmpeg --target-os=linux --extra-libs=-lfftw3f --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-ptx-compression --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-static --enable-gmp --enable-gnutls --enable-chromaprint --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265 --enable-libzvbi --enable-libzimg --enable-libfdk-aac --arch=amd64 --enable-libshaderc --enable-libplacebo --enable-vulkan --enable-opencl --enable-vaapi --enable-amf --enable-libmfx --enable-ffnvcodec --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvdec --enable-nvenc
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
Input #0, flac, from 'file:/media/Music/Casiopea/1982 - 4x4/01 - Mid-Manhattan.flac':
  Metadata:
    ARTIST          : Casiopea
    TITLE           : Mid-Manhattan
    ALBUM           : 4x4
    DATE            : 1982
    track           : 01
    GENRE           : Fusion
    COMMENT         : EAC Flac 1.1.2 -5
  Duration: 00:04:42.20, start: 0.000000, bitrate: 885 kb/s
  Stream #0:0: Audio: flac, 44100 Hz, stereo, s16
Stream mapping:
  Stream #0:0 -> #0:0 (flac (native) -> vorbis (libvorbis))
Press [q] to stop, [?] for help
Output #0, ogg, to '/config/transcodes/94889ed7de8e686dc7de7eddd19df672.ogg':
  Metadata:
    ARTIST          : Casiopea
    TITLE           : Mid-Manhattan
    ALBUM           : 4x4
    DATE            : 1982
    track           : 01
    GENRE           : Fusion
    COMMENT         : EAC Flac 1.1.2 -5
    encoder         : Lavf59.27.100
  Stream #0:0: Audio: vorbis, 44100 Hz, stereo, fltp, 128 kb/s
    Metadata:
      encoder         : Lavc59.37.100 libvorbis
      ARTIST          : Casiopea
      TITLE           : Mid-Manhattan
      ALBUM           : 4x4
      DATE            : 1982
      TRACKNUMBER     : 01
      GENRE           : Fusion
      DESCRIPTION     : EAC Flac 1.1.2 -5
size=       4kB time=00:00:00.01 bitrate=2448.7kbits/s speed= 104x    
size=     183kB time=00:00:14.03 bitrate= 106.7kbits/s speed=27.9x    
size=     256kB time=00:00:28.34 bitrate=  74.0kbits/s speed=28.2x    
size=     512kB time=00:00:42.69 bitrate=  98.2kbits/s speed=28.3x    
size=     768kB time=00:00:56.87 bitrate= 110.6kbits/s speed=28.3x    
size=    1024kB time=00:01:11.22 bitrate= 117.8kbits/s speed=28.4x    
size=    1280kB time=00:01:25.60 bitrate= 122.5kbits/s speed=28.4x    
size=    1536kB time=00:01:40.01 bitrate= 125.8kbits/s speed=28.4x    
size=    1536kB time=00:01:54.18 bitrate= 110.2kbits/s speed=28.4x    
size=    1792kB time=00:02:08.24 bitrate= 114.5kbits/s speed=28.4x    
size=    2048kB time=00:02:22.43 bitrate= 117.8kbits/s speed=28.4x    
size=    2304kB time=00:02:36.78 bitrate= 120.4kbits/s speed=28.4x    
size=    2560kB time=00:02:51.18 bitrate= 122.5kbits/s speed=28.4x    
size=    2816kB time=00:03:05.34 bitrate= 124.5kbits/s speed=28.4x    
size=    3072kB time=00:03:19.71 bitrate= 126.0kbits/s speed=28.4x    
size=    3328kB time=00:03:34.11 bitrate= 127.3kbits/s speed=28.4x    
size=    3328kB time=00:03:47.96 bitrate= 119.6kbits/s speed=28.4x    
size=    3584kB time=00:04:01.92 bitrate= 121.4kbits/s speed=28.3x    
size=    3840kB time=00:04:15.92 bitrate= 122.9kbits/s speed=28.3x    
size=    4096kB time=00:04:30.06 bitrate= 124.2kbits/s speed=28.3x    
size=    4385kB time=00:04:42.19 bitrate= 127.3kbits/s speed=28.5x    
video:0kB audio:4340kB subtitle:0kB other streams:0kB global headers:4kB muxing overhead: 1.028162%
```

</details>

I haven't tested this PR yet since its 4am and I don't want to fight macOS right now, but I'll give it a go tomorrow.