### PR TITLE
Implement full text search

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -154,6 +154,8 @@ namespace Emby.Server.Implementations.Data
 
             WriteConnection.Execute("PRAGMA temp_store=" + (int)TempStore);
 
+            WriteConnection.Execute("PRAGMA recursive_triggers = ON");
+
             // Configuration and pragmas can affect VACUUM so it needs to be last.
             WriteConnection.Execute("VACUUM");
 

--- a/Emby.Server.Implementations/Library/SearchEngine.cs
+++ b/Emby.Server.Implementations/Library/SearchEngine.cs
@@ -73,9 +73,7 @@ namespace Emby.Server.Implementations.Library
         {
             var searchTerm = query.SearchTerm;
 
-            ArgumentException.ThrowIfNullOrEmpty(searchTerm);
-
-            searchTerm = searchTerm.Trim().RemoveDiacritics();
+            ArgumentException.ThrowIfNullOrEmpty(searchTerm.Value);
 
             var excludeItemTypes = query.ExcludeItemTypes.ToList();
             var includeItemTypes = (query.IncludeItemTypes ?? Array.Empty<BaseItemKind>()).ToList();
@@ -146,6 +144,7 @@ namespace Emby.Server.Implementations.Library
             var searchQuery = new InternalItemsQuery(user)
             {
                 SearchTerm = searchTerm,
+                SearchType = query.SearchType,
                 ExcludeItemTypes = excludeItemTypes.ToArray(),
                 IncludeItemTypes = includeItemTypes.ToArray(),
                 Limit = query.Limit,

--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -5,6 +5,7 @@ using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -52,7 +53,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="minCommunityRating">Optional filter by minimum community rating.</param>
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">Optional. Search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="excludeItemTypes">Optional. If specified, results will be filtered out based on item type. This allows multiple, comma delimited.</param>
@@ -89,7 +91,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] double? minCommunityRating,
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
@@ -153,7 +156,8 @@ namespace Jellyfin.Api.Controllers
                 Years = years,
                 MinCommunityRating = minCommunityRating,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = searchTerm ?? new SearchTermDto(),
+                SearchType = searchType,
                 EnableTotalRecordCount = enableTotalRecordCount,
                 OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder)
             };
@@ -255,7 +259,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="minCommunityRating">Optional filter by minimum community rating.</param>
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">Optional. Search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="excludeItemTypes">Optional. If specified, results will be filtered out based on item type. This allows multiple, comma delimited.</param>
@@ -292,7 +297,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] double? minCommunityRating,
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
@@ -356,7 +362,8 @@ namespace Jellyfin.Api.Controllers
                 Years = years,
                 MinCommunityRating = minCommunityRating,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = searchTerm ?? new SearchTermDto(),
+                SearchType = searchType,
                 EnableTotalRecordCount = enableTotalRecordCount,
                 OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder)
             };

--- a/Jellyfin.Api/Controllers/GenresController.cs
+++ b/Jellyfin.Api/Controllers/GenresController.cs
@@ -5,6 +5,7 @@ using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -51,7 +52,8 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">The search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="excludeItemTypes">Optional. If specified, results will be filtered out based on item type. This allows multiple, comma delimited.</param>
@@ -74,7 +76,8 @@ namespace Jellyfin.Api.Controllers
         public ActionResult<QueryResult<BaseItemDto>> GetGenres(
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
@@ -112,7 +115,8 @@ namespace Jellyfin.Api.Controllers
                 NameStartsWith = nameStartsWith,
                 NameStartsWithOrGreater = nameStartsWithOrGreater,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = searchTerm ?? new SearchTermDto(),
+                SearchType = searchType,
                 EnableTotalRecordCount = enableTotalRecordCount,
                 OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder)
             };

--- a/Jellyfin.Api/Controllers/MusicGenresController.cs
+++ b/Jellyfin.Api/Controllers/MusicGenresController.cs
@@ -5,6 +5,7 @@ using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -51,7 +52,8 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">The search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="excludeItemTypes">Optional. If specified, results will be filtered out based on item type. This allows multiple, comma delimited.</param>
@@ -74,7 +76,8 @@ namespace Jellyfin.Api.Controllers
         public ActionResult<QueryResult<BaseItemDto>> GetMusicGenres(
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
@@ -112,7 +115,8 @@ namespace Jellyfin.Api.Controllers
                 NameStartsWith = nameStartsWith,
                 NameStartsWithOrGreater = nameStartsWithOrGreater,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = searchTerm ?? new SearchTermDto(),
+                SearchType = searchType,
                 EnableTotalRecordCount = enableTotalRecordCount,
                 OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder)
             };

--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -47,7 +48,7 @@ namespace Jellyfin.Api.Controllers
         /// Gets all persons.
         /// </summary>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">The search term.</param>
+        /// <param name="searchTerm">Optional. The search term.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="filters">Optional. Specify additional filters to apply.</param>
         /// <param name="isFavorite">Optional filter by items that are marked as favorite, or not. userId is required.</param>

--- a/Jellyfin.Api/Controllers/SearchController.cs
+++ b/Jellyfin.Api/Controllers/SearchController.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Drawing;
@@ -59,7 +60,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
         /// <param name="userId">Optional. Supply a user id to search within a user's library or omit to search all.</param>
-        /// <param name="searchTerm">The search term to filter on.</param>
+        /// <param name="searchTerm">Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="includeItemTypes">If specified, only results with the specified item types are returned. This allows multiple, comma delimited.</param>
         /// <param name="excludeItemTypes">If specified, results with these item types are filtered out. This allows multiple, comma delimited.</param>
         /// <param name="mediaTypes">If specified, only results with the specified media types are returned. This allows multiple, comma delimited.</param>
@@ -83,7 +85,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
             [FromQuery] Guid? userId,
-            [FromQuery, Required] string searchTerm,
+            [FromQuery, Required] SearchTermDto searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] includeItemTypes,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] mediaTypes,
@@ -103,6 +106,7 @@ namespace Jellyfin.Api.Controllers
             {
                 Limit = limit,
                 SearchTerm = searchTerm,
+                SearchType = searchType,
                 IncludeArtists = includeArtists,
                 IncludeGenres = includeGenres,
                 IncludeMedia = includeMedia,

--- a/Jellyfin.Api/Controllers/StudiosController.cs
+++ b/Jellyfin.Api/Controllers/StudiosController.cs
@@ -4,6 +4,7 @@ using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -49,7 +50,8 @@ namespace Jellyfin.Api.Controllers
         /// </summary>
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
-        /// <param name="searchTerm">Optional. Search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
         /// <param name="excludeItemTypes">Optional. If specified, results will be filtered out based on item type. This allows multiple, comma delimited.</param>
@@ -71,7 +73,8 @@ namespace Jellyfin.Api.Controllers
         public ActionResult<QueryResult<BaseItemDto>> GetStudios(
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] BaseItemKind[] excludeItemTypes,
@@ -108,7 +111,8 @@ namespace Jellyfin.Api.Controllers
                 NameStartsWith = nameStartsWith,
                 NameStartsWithOrGreater = nameStartsWithOrGreater,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = searchTerm ?? new SearchTermDto(),
+                SearchType = searchType,
                 EnableTotalRecordCount = enableTotalRecordCount
             };
 

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -67,7 +68,8 @@ namespace Jellyfin.Api.Controllers
         /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
         /// <param name="limit">Optional. The maximum number of records to return.</param>
         /// <param name="recursive">When searching within folders, this determines whether or not the search will be recursive. true/false.</param>
-        /// <param name="searchTerm">Optional. Filter based on a search term.</param>
+        /// <param name="searchTerm">Optional. Filter based on a full text search using this search term.</param>
+        /// <param name="searchType">Optional. Set the type of full text search to do. Defaults to "Prefix".</param>
         /// <param name="sortOrder">Sort Order - Ascending, Descending.</param>
         /// <param name="parentId">Specify this to localize the search to a specific item or folder. Omit to use the root.</param>
         /// <param name="fields">Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimited. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines.</param>
@@ -155,7 +157,8 @@ namespace Jellyfin.Api.Controllers
             [FromQuery] int? startIndex,
             [FromQuery] int? limit,
             [FromQuery] bool? recursive,
-            [FromQuery] string? searchTerm,
+            [FromQuery] SearchTermDto? searchTerm,
+            [FromQuery] FullTextSearchType? searchType,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] SortOrder[] sortOrder,
             [FromQuery] Guid? parentId,
             [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
@@ -245,6 +248,7 @@ namespace Jellyfin.Api.Controllers
                     limit,
                     recursive,
                     searchTerm,
+                    searchType,
                     sortOrder,
                     parentId,
                     fields,

--- a/Jellyfin.Data/Dtos/SearchTermDto.cs
+++ b/Jellyfin.Data/Dtos/SearchTermDto.cs
@@ -1,0 +1,57 @@
+namespace Jellyfin.Data.Dtos;
+
+using System;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// A dto representing a sanitized search term.
+/// </summary>
+public class SearchTermDto : IParsable<SearchTermDto>
+{
+    // https://www.sqlite.org/fts5.html: 3.1. FTS5 Strings
+    private static Regex _fullTextSearchReplace = new Regex(@"[^\sa-zA-Z0-9_\u001a\u0080-\uffff]+");
+
+    /// <summary>
+    /// Gets the sanitized search term.
+    /// </summary>
+    public string? Value { get; init; }
+
+    private static string? SanitizeSearchTerm(string? searchTerm)
+    {
+        if (string.IsNullOrEmpty(searchTerm))
+        {
+            return searchTerm;
+        }
+
+        // Remove reserved characters
+        // ToLower() to turn reserved words "AND", "OR", and "NOT" into normal fts5 strings
+        return _fullTextSearchReplace.Replace(searchTerm, " ").Trim().ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Checks if the sanitized search term holds a value.
+    /// </summary>
+    /// <returns><b>True</b> if the sanitized search term is null or empty.</returns>
+    public bool IsNullOrEmpty()
+    {
+        return string.IsNullOrEmpty(Value);
+    }
+
+#pragma warning disable CS1591
+
+    public static SearchTermDto Parse(string s, IFormatProvider? provider)
+    {
+        if (!TryParse(s, provider, out var result))
+        {
+           throw new ArgumentException("Could not parse supplied value.", nameof(s));
+        }
+
+        return result;
+    }
+
+    public static bool TryParse(string? s, IFormatProvider? provider, out SearchTermDto result)
+    {
+        result = new SearchTermDto { Value = SanitizeSearchTerm(s) };
+        return true;
+    }
+}

--- a/Jellyfin.Data/Enums/FullTextSearchType.cs
+++ b/Jellyfin.Data/Enums/FullTextSearchType.cs
@@ -1,0 +1,24 @@
+namespace Jellyfin.Data.Enums;
+
+using System;
+
+/// <summary>
+/// Used to set the types of full text searching.
+/// </summary>
+public enum FullTextSearchType
+{
+    /// <summary>
+    /// Search by phrase.
+    /// </summary>
+    Phrase,
+
+    /// <summary>
+    /// Search by prefix.
+    /// </summary>
+    Prefix,
+
+    /// <summary>
+    /// Search by keyword.
+    /// </summary>
+    Keyword,
+}

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -42,6 +43,7 @@ namespace MediaBrowser.Controller.Entities
             PersonIds = Array.Empty<Guid>();
             PersonTypes = Array.Empty<string>();
             PresetViews = Array.Empty<string>();
+            SearchTerm = new SearchTermDto();
             SeriesStatuses = Array.Empty<SeriesStatus>();
             SourceTypes = Array.Empty<SourceType>();
             StudioIds = Array.Empty<Guid>();
@@ -351,7 +353,9 @@ namespace MediaBrowser.Controller.Entities
 
         public int? MinWidth { get; set; }
 
-        public string? SearchTerm { get; set; }
+        public SearchTermDto SearchTerm { get; set; }
+
+        public FullTextSearchType? SearchType { get; set; }
 
         public string? SeriesTimerId { get; set; }
 

--- a/MediaBrowser.Model/Querying/ItemSortBy.cs
+++ b/MediaBrowser.Model/Querying/ItemSortBy.cs
@@ -159,5 +159,10 @@ namespace MediaBrowser.Model.Querying
         /// The search score.
         /// </summary>
         public const string SearchScore = "SearchScore";
+
+        /// <summary>
+        /// The full text search rank.
+        /// </summary>
+        public const string Rank = "Rank";
     }
 }

--- a/MediaBrowser.Model/Search/SearchQuery.cs
+++ b/MediaBrowser.Model/Search/SearchQuery.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Enums;
 
 namespace MediaBrowser.Model.Search
@@ -16,6 +17,7 @@ namespace MediaBrowser.Model.Search
             IncludePeople = true;
             IncludeStudios = true;
 
+            SearchTerm = new SearchTermDto();
             MediaTypes = Array.Empty<string>();
             IncludeItemTypes = Array.Empty<BaseItemKind>();
             ExcludeItemTypes = Array.Empty<BaseItemKind>();
@@ -31,7 +33,13 @@ namespace MediaBrowser.Model.Search
         /// Gets or sets the search term.
         /// </summary>
         /// <value>The search term.</value>
-        public string SearchTerm { get; set; }
+        public SearchTermDto SearchTerm { get; set; }
+
+        /// <summary>
+        /// Gets or sets the search types.
+        /// </summary>
+        /// <value>The search types.</value>
+        public FullTextSearchType? SearchType { get; set; }
 
         /// <summary>
         /// Gets or sets the start index. Used for paging.


### PR DESCRIPTION
**Changes**
This implements a true full text search using sqlite's built in fts5 extension. Currently, jellyfin is trying to implement full text search by [doing some sql trickery](https://github.com/jellyfin/jellyfin/blob/fec23de427fe1c46e4ce1aaf31f1695c90232059/Emby.Server.Implementations/Data/SqliteItemRepository.cs#L2427), but it doesn't support things like keyword searches. For example, it doesn't support a search like `90 day what now`, which in a FTS would return `90 Day Fiancé - What Now! (2017)`.

This new implementation supports FTS with three different search types, of which one can be specified by the client: Phrase, Prefix, and Keyword. It defaults to Prefix, which makes it backwards compatible with the existing search. ~~In addition, this implementation is using the Porter tokenizer, which implements the [Porter stemming algorithm](https://tartarus.org/martin/PorterStemmer/)~~. (EDIT: I took out the Porter tokenizer. It can give confusing results.) The fts5 extension provides a rank for each search so the results are returned in rank order.

This should require no intervention on the user's part. On startup, the user's FTS index is seeded automatically if their index is empty. Real time FTS index updates are achieved using db triggers.

Two changes were made from the existing search

1) Tags are not included in the FTS index. It doesn't make sense to include it because a FTS plus tag search can be done as follows: `searchTerm=<search term>&tags=<tags>`.

2) `ProviderIds` is in the FTS index. This means a search like the following will return the item of interest (if it exists): `searchTerm=Tmdb%3D61575` or `searchTerm=Tmdb+61575`