### PR TITLE
Secure API

### DIFF
--- a/Jellyfin.Api/Controllers/ClientLogController.cs
+++ b/Jellyfin.Api/Controllers/ClientLogController.cs
@@ -38,12 +38,10 @@ public class ClientLogController : BaseJellyfinApiController
     /// Upload a document.
     /// </summary>
     /// <response code="200">Document saved.</response>
-    /// <response code="403">Event logging disabled.</response>
     /// <response code="413">Upload size too large.</response>
     /// <returns>Create response.</returns>
     [HttpPost("Document")]
     [ProducesResponseType(typeof(ClientLogDocumentResponseDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status413PayloadTooLarge)]
     [AcceptsFile(MediaTypeNames.Text.Plain)]
     [RequestSizeLimit(MaxDocumentSize)]

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -89,7 +89,6 @@ public class ImageController : BaseJellyfinApiController
     /// </summary>
     /// <param name="userId">User Id.</param>
     /// <response code="204">Image updated.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <response code="404">Item not found.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("UserImage")]
@@ -97,7 +96,6 @@ public class ImageController : BaseJellyfinApiController
     [AcceptsImageFile]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> PostUserImage(
         [FromQuery] Guid? userId)
@@ -147,7 +145,6 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="userId">User Id.</param>
     /// <param name="imageType">(Unused) Image type.</param>
     /// <response code="204">Image updated.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Users/{userId}/Images/{imageType}")]
     [Authorize]
@@ -156,8 +153,6 @@ public class ImageController : BaseJellyfinApiController
     [AcceptsImageFile]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "imageType", Justification = "Imported from ServiceStack")]
     public Task<ActionResult> PostUserImageLegacy(
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] ImageType imageType)
@@ -170,7 +165,6 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="imageType">(Unused) Image type.</param>
     /// <param name="index">(Unused) Image index.</param>
     /// <response code="204">Image updated.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Users/{userId}/Images/{imageType}/{index}")]
     [Authorize]
@@ -179,9 +173,6 @@ public class ImageController : BaseJellyfinApiController
     [AcceptsImageFile]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "imageType", Justification = "Imported from ServiceStack")]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "index", Justification = "Imported from ServiceStack")]
     public Task<ActionResult> PostUserImageByIndexLegacy(
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] ImageType imageType,
@@ -193,12 +184,10 @@ public class ImageController : BaseJellyfinApiController
     /// </summary>
     /// <param name="userId">User Id.</param>
     /// <response code="204">Image deleted.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete("UserImage")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult> DeleteUserImage(
         [FromQuery] Guid? userId)
     {
@@ -239,16 +228,12 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="imageType">(Unused) Image type.</param>
     /// <param name="index">(Unused) Image index.</param>
     /// <response code="204">Image deleted.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete("Users/{userId}/Images/{imageType}")]
     [Authorize]
     [Obsolete("Kept for backwards compatibility")]
     [ApiExplorerSettings(IgnoreApi = true)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "imageType", Justification = "Imported from ServiceStack")]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "index", Justification = "Imported from ServiceStack")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public Task<ActionResult> DeleteUserImageLegacy(
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] ImageType imageType,
@@ -262,16 +247,12 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="imageType">(Unused) Image type.</param>
     /// <param name="index">(Unused) Image index.</param>
     /// <response code="204">Image deleted.</response>
-    /// <response code="403">User does not have permission to delete the image.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete("Users/{userId}/Images/{imageType}/{index}")]
     [Authorize]
     [Obsolete("Kept for backwards compatibility")]
     [ApiExplorerSettings(IgnoreApi = true)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "imageType", Justification = "Imported from ServiceStack")]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "index", Justification = "Imported from ServiceStack")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public Task<ActionResult> DeleteUserImageByIndexLegacy(
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] ImageType imageType,
@@ -348,7 +329,6 @@ public class ImageController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "index", Justification = "Imported from ServiceStack")]
     public async Task<ActionResult> SetItemImage(
         [FromRoute, Required] Guid itemId,
         [FromRoute, Required] ImageType imageType)
@@ -391,7 +371,6 @@ public class ImageController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "index", Justification = "Imported from ServiceStack")]
     public async Task<ActionResult> SetItemImageByIndex(
         [FromRoute, Required] Guid itemId,
         [FromRoute, Required] ImageType imageType,
@@ -1789,13 +1768,11 @@ public class ImageController : BaseJellyfinApiController
     /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
     /// <response code="204">Successfully uploaded new splashscreen.</response>
     /// <response code="400">Error reading MimeType from uploaded image.</response>
-    /// <response code="403">User does not have permission to upload splashscreen..</response>
     /// <exception cref="ArgumentException">Error reading the image format.</exception>
     [HttpPost("Branding/Splashscreen")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [AcceptsImageFile]
     public async Task<ActionResult> UploadCustomSplashscreen()
     {
@@ -1827,7 +1804,6 @@ public class ImageController : BaseJellyfinApiController
     /// </summary>
     /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
     /// <response code="204">Successfully deleted the custom splashscreen.</response>
-    /// <response code="403">User does not have permission to delete splashscreen..</response>
     [HttpDelete("Branding/Splashscreen")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -348,13 +348,11 @@ public class LibraryController : BaseJellyfinApiController
     /// </summary>
     /// <param name="itemId">The item id.</param>
     /// <response code="204">Item deleted.</response>
-    /// <response code="401">Unauthorized access.</response>
     /// <response code="404">Item not found.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete("Items/{itemId}")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult DeleteItem(Guid itemId)
     {
@@ -393,12 +391,10 @@ public class LibraryController : BaseJellyfinApiController
     /// </summary>
     /// <param name="ids">The item ids.</param>
     /// <response code="204">Items deleted.</response>
-    /// <response code="401">Unauthorized access.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete("Items")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult DeleteItems([FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] ids)
     {

--- a/Jellyfin.Api/Controllers/QuickConnectController.cs
+++ b/Jellyfin.Api/Controllers/QuickConnectController.cs
@@ -48,7 +48,6 @@ public class QuickConnectController : BaseJellyfinApiController
     /// Initiate a new quick connect request.
     /// </summary>
     /// <response code="200">Quick connect request successfully created.</response>
-    /// <response code="401">Quick connect is not active on this server.</response>
     /// <returns>A <see cref="QuickConnectResult"/> with a secret and code for future use or an error message.</returns>
     [HttpPost("Initiate")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -107,12 +106,10 @@ public class QuickConnectController : BaseJellyfinApiController
     /// <param name="code">Quick connect code to authorize.</param>
     /// <param name="userId">The user the authorize. Access to the requested user is required.</param>
     /// <response code="200">Quick connect result authorized successfully.</response>
-    /// <response code="403">Unknown user id.</response>
     /// <returns>Boolean indicating if the authorization was successful.</returns>
     [HttpPost("Authorize")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<bool>> AuthorizeQuickConnect([FromQuery, Required] string code, [FromQuery] Guid? userId = null)
     {
         userId = RequestHelpers.GetUserId(User, userId);

--- a/Jellyfin.Api/Controllers/SystemController.cs
+++ b/Jellyfin.Api/Controllers/SystemController.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using Jellyfin.Api.Attributes;
-using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
@@ -62,12 +61,10 @@ public class SystemController : BaseJellyfinApiController
     /// Gets information about the server.
     /// </summary>
     /// <response code="200">Information retrieved.</response>
-    /// <response code="403">User does not have permission to retrieve information.</response>
     /// <returns>A <see cref="SystemInfo"/> with info about the system.</returns>
     [HttpGet("Info")]
     [Authorize(Policy = Policies.FirstTimeSetupOrIgnoreParentalControl)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public ActionResult<SystemInfo> GetSystemInfo()
         => _systemManager.GetSystemInfo(Request);
 
@@ -96,12 +93,10 @@ public class SystemController : BaseJellyfinApiController
     /// Restarts the application.
     /// </summary>
     /// <response code="204">Server restarted.</response>
-    /// <response code="403">User does not have permission to restart server.</response>
     /// <returns>No content. Server restarted.</returns>
     [HttpPost("Restart")]
     [Authorize(Policy = Policies.LocalAccessOrRequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public ActionResult RestartApplication()
     {
         _systemManager.Restart();
@@ -112,12 +107,10 @@ public class SystemController : BaseJellyfinApiController
     /// Shuts down the application.
     /// </summary>
     /// <response code="204">Server shut down.</response>
-    /// <response code="403">User does not have permission to shutdown server.</response>
     /// <returns>No content. Server shut down.</returns>
     [HttpPost("Shutdown")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public ActionResult ShutdownApplication()
     {
         _systemManager.Shutdown();
@@ -128,12 +121,10 @@ public class SystemController : BaseJellyfinApiController
     /// Gets a list of available server log files.
     /// </summary>
     /// <response code="200">Information retrieved.</response>
-    /// <response code="403">User does not have permission to get server logs.</response>
     /// <returns>An array of <see cref="LogFile"/> with the available log files.</returns>
     [HttpGet("Logs")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public ActionResult<LogFile[]> GetServerLogs()
     {
         IEnumerable<FileSystemMetadata> files;
@@ -167,12 +158,10 @@ public class SystemController : BaseJellyfinApiController
     /// Gets information about the request endpoint.
     /// </summary>
     /// <response code="200">Information retrieved.</response>
-    /// <response code="403">User does not have permission to get endpoint information.</response>
     /// <returns><see cref="EndPointInfo"/> with information about the endpoint.</returns>
     [HttpGet("Endpoint")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public ActionResult<EndPointInfo> GetEndpointInfo()
     {
         return new EndPointInfo
@@ -187,13 +176,11 @@ public class SystemController : BaseJellyfinApiController
     /// </summary>
     /// <param name="name">The name of the log file to get.</param>
     /// <response code="200">Log file retrieved.</response>
-    /// <response code="403">User does not have permission to get log files.</response>
     /// <response code="404">Could not find a log file with the name.</response>
     /// <returns>The log file.</returns>
     [HttpGet("Logs/Log")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesFile(MediaTypeNames.Text.Plain)]
     public ActionResult GetLogFile([FromQuery, Required] string name)

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -171,12 +171,10 @@ public class UserController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="pw">The password as plain text.</param>
     /// <response code="200">User authenticated.</response>
-    /// <response code="403">Sha1-hashed password only is not allowed.</response>
     /// <response code="404">User not found.</response>
     /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationResult"/>.</returns>
     [HttpPost("{userId}/Authenticate")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ApiExplorerSettings(IgnoreApi = true)]
     [Obsolete("Authenticate with username instead")]
@@ -261,13 +259,11 @@ public class UserController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="request">The <see cref="UpdateUserPassword"/> request.</param>
     /// <response code="204">Password successfully reset.</response>
-    /// <response code="403">User is not allowed to update the password.</response>
     /// <response code="404">User not found.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success or a <see cref="ForbidResult"/> or a <see cref="NotFoundResult"/> on failure.</returns>
     [HttpPost("Password")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> UpdateUserPassword(
         [FromQuery] Guid? userId,
@@ -343,7 +339,6 @@ public class UserController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="request">The <see cref="UpdateUserEasyPassword"/> request.</param>
     /// <response code="204">Password successfully reset.</response>
-    /// <response code="403">User is not allowed to update the password.</response>
     /// <response code="404">User not found.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success or a <see cref="ForbidResult"/> or a <see cref="NotFoundResult"/> on failure.</returns>
     [HttpPost("{userId}/EasyPassword")]
@@ -351,7 +346,6 @@ public class UserController : BaseJellyfinApiController
     [ApiExplorerSettings(IgnoreApi = true)]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult UpdateUserEasyPassword(
         [FromRoute, Required] Guid userId,
@@ -367,13 +361,11 @@ public class UserController : BaseJellyfinApiController
     /// <param name="updateUser">The updated user model.</param>
     /// <response code="204">User updated.</response>
     /// <response code="400">User information was not supplied.</response>
-    /// <response code="403">User update forbidden.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success or a <see cref="BadRequestResult"/> or a <see cref="ForbidResult"/> on failure.</returns>
     [HttpPost]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult> UpdateUser(
         [FromQuery] Guid? userId,
         [FromBody, Required] UserDto updateUser)
@@ -428,13 +420,11 @@ public class UserController : BaseJellyfinApiController
     /// <param name="newPolicy">The new user policy.</param>
     /// <response code="204">User policy updated.</response>
     /// <response code="400">User policy was not supplied.</response>
-    /// <response code="403">User policy update forbidden.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success or a <see cref="BadRequestResult"/> or a <see cref="ForbidResult"/> on failure..</returns>
     [HttpPost("{userId}/Policy")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult> UpdateUserPolicy(
         [FromRoute, Required] Guid userId,
         [FromBody, Required] UserPolicy newPolicy)
@@ -483,12 +473,10 @@ public class UserController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="userConfig">The new user configuration.</param>
     /// <response code="204">User configuration updated.</response>
-    /// <response code="403">User configuration update forbidden.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
     [HttpPost("Configuration")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult> UpdateUserConfiguration(
         [FromQuery] Guid? userId,
         [FromBody, Required] UserConfiguration userConfig)
@@ -516,14 +504,12 @@ public class UserController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="userConfig">The new user configuration.</param>
     /// <response code="204">User configuration updated.</response>
-    /// <response code="403">User configuration update forbidden.</response>
     /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
     [HttpPost("{userId}/Configuration")]
     [Authorize]
     [Obsolete("Kept for backwards compatibility")]
     [ApiExplorerSettings(IgnoreApi = true)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public Task<ActionResult> UpdateUserConfigurationLegacy(
         [FromRoute, Required] Guid userId,
         [FromBody, Required] UserConfiguration userConfig)


### PR DESCRIPTION
The goal of this pull request is to secure the API by requiring authentication header or API key request parameter where applicable.
Additionally, proper response codes are added to endpoints if either auth failed or access is forbidden.

Endpoints which should be accessible without auth:
* Global system information
* Public user list
* Image endpoints (otherwise embedding is not possible)
* DLNA endpoints (only from local network) excluding playback endpoints (DLNA controller should return URIs with API key request parameter included)

All other endpoints should require auth by either header or request parameter while deprecating request parameter where possible.

**(Planned) Changes**
- [ ] Migrate API to file scoped namespaces
- [ ] Enforce auth on applicable endpoints
- [x] Add proper responses to endpoints
- [ ] Mark request parameter auth as deprecated where applicable

**Issues**
*To be filled when finished*