### PR TITLE
Add support for embedded lyrics to lyrics API

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -1361,10 +1361,6 @@ namespace Emby.Server.Implementations.Data
             {
                 return false;
             }
-            else if (type == typeof(Audio))
-            {
-                return false;
-            }
             else if (type == typeof(MusicAlbum))
             {
                 return false;
@@ -1391,7 +1387,7 @@ namespace Emby.Server.Implementations.Data
 
             BaseItem item = null;
 
-            if (TypeRequiresDeserialization(type))
+            if (TypeRequiresDeserialization(type) && reader[1].ToBlob() != null)
             {
                 try
                 {

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -147,7 +147,7 @@ namespace Emby.Server.Implementations.Dto
             }
             else if (item is Audio)
             {
-                dto.HasLyrics = _lyricManager.HasLyricFile(item);
+                dto.HasLyrics = _lyricManager.HasLyricFile(item) || !string.IsNullOrWhiteSpace(((Audio)item).EmbeddedLyrics);
             }
 
             if (item is IItemByName itemByName

--- a/MediaBrowser.Controller/Entities/Audio/Audio.cs
+++ b/MediaBrowser.Controller/Entities/Audio/Audio.cs
@@ -37,6 +37,8 @@ namespace MediaBrowser.Controller.Entities.Audio
         [JsonIgnore]
         public IReadOnlyList<string> AlbumArtists { get; set; }
 
+        public string EmbeddedLyrics { get; set; }
+
         [JsonIgnore]
         public override bool SupportsPlayedStatus => true;
 

--- a/MediaBrowser.Providers/Lyric/TxtLyricProvider.cs
+++ b/MediaBrowser.Providers/Lyric/TxtLyricProvider.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Lyrics;
 using MediaBrowser.Controller.Resolvers;
 
@@ -26,22 +28,33 @@ public class TxtLyricProvider : ILyricProvider
     public IReadOnlyCollection<string> SupportedMediaTypes { get; } = new[] { "lrc", "elrc", "txt" };
 
     /// <summary>
-    /// Opens lyric file for the requested item, and processes it for API return.
+    /// Retrieves the unsynchronized lyrics of the requested item from the lyric file or the embedded tags, and processes them for API return.
     /// </summary>
     /// <param name="item">The item to to process.</param>
     /// <returns>If provider can determine lyrics, returns a <see cref="LyricResponse"/>; otherwise, null.</returns>
     public async Task<LyricResponse?> GetLyrics(BaseItem item)
     {
         string? lyricFilePath = this.GetLyricFilePath(item.Path);
+        string[]? lyricTextLines = null;
 
         if (string.IsNullOrEmpty(lyricFilePath))
         {
-            return null;
+            if (item is Audio)
+            {
+                var audioItem = item as Audio;
+
+                if (audioItem != null && !string.IsNullOrEmpty(audioItem.EmbeddedLyrics))
+                {
+                    lyricTextLines = audioItem.EmbeddedLyrics.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                }
+            }
+        }
+        else
+        {
+            lyricTextLines = await File.ReadAllLinesAsync(lyricFilePath).ConfigureAwait(false);
         }
 
-        string[] lyricTextLines = await File.ReadAllLinesAsync(lyricFilePath).ConfigureAwait(false);
-
-        if (lyricTextLines.Length == 0)
+        if (lyricTextLines == null || lyricTextLines.Length == 0)
         {
             return null;
         }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -199,6 +199,11 @@ namespace MediaBrowser.Providers.MediaInfo
                     audio.PremiereDate = new DateTime(year, 01, 01);
                 }
 
+                if (!string.IsNullOrWhiteSpace(tags.Lyrics))
+                {
+                    audio.EmbeddedLyrics = tags.Lyrics;
+                }
+
                 if (!audio.LockedFields.Contains(MetadataField.Genres))
                 {
                     audio.Genres = tags.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();


### PR DESCRIPTION
**Changes**
This PR adds support for loading embedded lyrics from music files in LRC and TXT format. Previously these were only loaded from external files.

In order to store the lyrics I enabled the JSON serialization for items of type Audio. If there's a problem with this it would also be possible to add a database field for it or retrieve them when requested.