### PR TITLE
Added CleanupCollection task

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -112,7 +112,8 @@ namespace Emby.Server.Implementations.Collections
             return Path.Combine(_appPaths.DataPath, "collections");
         }
 
-        private Task<Folder?> GetCollectionsFolder(bool createIfNeeded)
+        /// <inheritdoc />
+        public Task<Folder?> GetCollectionsFolder(bool createIfNeeded)
         {
             return EnsureLibraryFolder(GetCollectionsFolderPath(), createIfNeeded);
         }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Collections;
+using MediaBrowser.Controller.Collections;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks;
+
+/// <summary>
+/// Deletes Path references from collections that no longer exists.
+/// </summary>
+public class CleanupCollectionPathsTask : IScheduledTask
+{
+    private readonly ILocalizationManager _localization;
+    private readonly ICollectionManager _collectionManager;
+    private readonly ILogger<CleanupCollectionPathsTask> _logger;
+    private readonly IProviderManager _providerManager;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CleanupCollectionPathsTask"/> class.
+    /// </summary>
+    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="collectionManager">Instance of the <see cref="ICollectionManager"/> interface.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="providerManager">The provider manager.</param>
+    /// <param name="fileSystem">The filesystem.</param>
+    public CleanupCollectionPathsTask(
+        ILocalizationManager localization,
+        ICollectionManager collectionManager,
+        ILogger<CleanupCollectionPathsTask> logger,
+        IProviderManager providerManager,
+        IFileSystem fileSystem)
+    {
+        _localization = localization;
+        _collectionManager = collectionManager;
+        _logger = logger;
+        _providerManager = providerManager;
+        _fileSystem = fileSystem;
+    }
+
+    /// <inheritdoc />
+    public string Name => _localization.GetLocalizedString("TaskCleanCollections");
+
+    /// <inheritdoc />
+    public string Key => "CleanCollections";
+
+    /// <inheritdoc />
+    public string Description => _localization.GetLocalizedString("TaskCleanCollectionsDescription");
+
+    /// <inheritdoc />
+    public string Category => _localization.GetLocalizedString("TasksMaintenanceCategory");
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var collectionsFolder = await _collectionManager.GetCollectionsFolder(true).ConfigureAwait(false);
+        if (collectionsFolder is null)
+        {
+            _logger.LogInformation("There is no collection folder to be found.");
+            return;
+        }
+
+        var collections = collectionsFolder.Children.OfType<BoxSet>()
+            .ToArray();
+        _logger.LogTrace("Found {CollectionLength} Boxsets.", collections.Length);
+        for (var index = 0; index < collections.Length; index++)
+        {
+            var collection = collections[index];
+            _logger.LogTrace("Check Boxset {CollectionName}.", collection.Name);
+            var itemsToRemove = new List<LinkedChild>();
+            foreach (var collectionLinkedChild in collection.LinkedChildren.ToArray())
+            {
+                if (!File.Exists(collectionLinkedChild.Path))
+                {
+                    _logger.LogInformation("Item in boxset {0} cannot be found at {1}.", collection.Name, collectionLinkedChild.Path);
+                    itemsToRemove.Add(collectionLinkedChild);
+                }
+            }
+
+            if (itemsToRemove.Any())
+            {
+                _logger.LogTrace("Update Boxset {CollectionName}.", collection.Name);
+                collection.LinkedChildren = collection.LinkedChildren.Except(itemsToRemove).ToArray();
+                await collection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _providerManager.QueueRefresh(
+                    collection.Id,
+                    new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                    {
+                        ForceSave = true
+                    },
+                    RefreshPriority.High);
+            }
+
+            progress.Report(100D / collections.Length * (index + 1));
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        return new[] { new TaskTriggerInfo() { Type = TaskTriggerInfo.TriggerStartup } };
+        // return Enumerable.Empty<TaskTriggerInfo>();
+    }
+}

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -72,7 +72,7 @@ public class CleanupCollectionPathsTask : IScheduledTask
         }
 
         var collections = collectionsFolder.Children.OfType<BoxSet>().ToArray();
-        _logger.LogTrace("Found {CollectionLength} Boxsets", collections.Length);
+        _logger.LogDebug("Found {CollectionLength} Boxsets", collections.Length);
 
         for (var index = 0; index < collections.Length; index++)
         {

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -79,7 +79,7 @@ public class CleanupCollectionPathsTask : IScheduledTask
             var collection = collections[index];
             _logger.LogDebug("Check Boxset {CollectionName}", collection.Name);
             var itemsToRemove = new List<LinkedChild>();
-            foreach (var collectionLinkedChild in collection.LinkedChildren.ToArray())
+            foreach (var collectionLinkedChild in collection.LinkedChildren)
             {
                 if (!File.Exists(collectionLinkedChild.Path))
                 {

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -74,7 +74,7 @@ public class CleanupCollectionPathsTask : IScheduledTask
 
         var collections = collectionsFolder.Children.OfType<BoxSet>().ToArray();
         _logger.LogTrace("Found {CollectionLength} Boxsets.", collections.Length);
-        
+
         for (var index = 0; index < collections.Length; index++)
         {
             var collection = collections[index];

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Emby.Server.Implementations.Collections;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -68,30 +67,30 @@ public class CleanupCollectionPathsTask : IScheduledTask
         var collectionsFolder = await _collectionManager.GetCollectionsFolder(false).ConfigureAwait(false);
         if (collectionsFolder is null)
         {
-            _logger.LogInformation("There is no collection folder to be found.");
+            _logger.LogDebug("There is no collection folder to be found");
             return;
         }
 
         var collections = collectionsFolder.Children.OfType<BoxSet>().ToArray();
-        _logger.LogTrace("Found {CollectionLength} Boxsets.", collections.Length);
+        _logger.LogTrace("Found {CollectionLength} Boxsets", collections.Length);
 
         for (var index = 0; index < collections.Length; index++)
         {
             var collection = collections[index];
-            _logger.LogTrace("Check Boxset {CollectionName}.", collection.Name);
+            _logger.LogDebug("Check Boxset {CollectionName}", collection.Name);
             var itemsToRemove = new List<LinkedChild>();
             foreach (var collectionLinkedChild in collection.LinkedChildren.ToArray())
             {
                 if (!File.Exists(collectionLinkedChild.Path))
                 {
-                    _logger.LogInformation("Item in boxset {CollectionName} cannot be found at {ItemPath}.", collection.Name, collectionLinkedChild.Path);
+                    _logger.LogInformation("Item in boxset {CollectionName} cannot be found at {ItemPath}", collection.Name, collectionLinkedChild.Path);
                     itemsToRemove.Add(collectionLinkedChild);
                 }
             }
 
             if (itemsToRemove.Any())
             {
-                _logger.LogTrace("Update Boxset {CollectionName}.", collection.Name);
+                _logger.LogDebug("Update Boxset {CollectionName}", collection.Name);
                 collection.LinkedChildren = collection.LinkedChildren.Except(itemsToRemove).ToArray();
                 await collection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
                     .ConfigureAwait(false);

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -74,11 +74,12 @@ public class CleanupCollectionPathsTask : IScheduledTask
         var collections = collectionsFolder.Children.OfType<BoxSet>().ToArray();
         _logger.LogDebug("Found {CollectionLength} Boxsets", collections.Length);
 
+        var itemsToRemove = new List<LinkedChild>();
         for (var index = 0; index < collections.Length; index++)
         {
             var collection = collections[index];
             _logger.LogDebug("Check Boxset {CollectionName}", collection.Name);
-            var itemsToRemove = new List<LinkedChild>();
+
             foreach (var collectionLinkedChild in collection.LinkedChildren)
             {
                 if (!File.Exists(collectionLinkedChild.Path))
@@ -102,6 +103,8 @@ public class CleanupCollectionPathsTask : IScheduledTask
                         ForceSave = true
                     },
                     RefreshPriority.High);
+
+                itemsToRemove.Clear();
             }
 
             progress.Report(100D / collections.Length * (index + 1));

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -88,7 +88,7 @@ public class CleanupCollectionPathsTask : IScheduledTask
                 }
             }
 
-            if (itemsToRemove.Any())
+            if (itemsToRemove.Count != 0)
             {
                 _logger.LogDebug("Update Boxset {CollectionName}", collection.Name);
                 collection.LinkedChildren = collection.LinkedChildren.Except(itemsToRemove).ToArray();

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionPathsTask.cs
@@ -65,16 +65,16 @@ public class CleanupCollectionPathsTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var collectionsFolder = await _collectionManager.GetCollectionsFolder(true).ConfigureAwait(false);
+        var collectionsFolder = await _collectionManager.GetCollectionsFolder(false).ConfigureAwait(false);
         if (collectionsFolder is null)
         {
             _logger.LogInformation("There is no collection folder to be found.");
             return;
         }
 
-        var collections = collectionsFolder.Children.OfType<BoxSet>()
-            .ToArray();
+        var collections = collectionsFolder.Children.OfType<BoxSet>().ToArray();
         _logger.LogTrace("Found {CollectionLength} Boxsets.", collections.Length);
+        
         for (var index = 0; index < collections.Length; index++)
         {
             var collection = collections[index];
@@ -84,7 +84,7 @@ public class CleanupCollectionPathsTask : IScheduledTask
             {
                 if (!File.Exists(collectionLinkedChild.Path))
                 {
-                    _logger.LogInformation("Item in boxset {0} cannot be found at {1}.", collection.Name, collectionLinkedChild.Path);
+                    _logger.LogInformation("Item in boxset {CollectionName} cannot be found at {ItemPath}.", collection.Name, collectionLinkedChild.Path);
                     itemsToRemove.Add(collectionLinkedChild);
                 }
             }
@@ -113,6 +113,5 @@ public class CleanupCollectionPathsTask : IScheduledTask
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
         return new[] { new TaskTriggerInfo() { Type = TaskTriggerInfo.TriggerStartup } };
-        // return Enumerable.Empty<TaskTriggerInfo>();
     }
 }

--- a/MediaBrowser.Controller/Collections/ICollectionManager.cs
+++ b/MediaBrowser.Controller/Collections/ICollectionManager.cs
@@ -56,5 +56,12 @@ namespace MediaBrowser.Controller.Collections
         /// <param name="user">The user.</param>
         /// <returns>IEnumerable{BaseItem}.</returns>
         IEnumerable<BaseItem> CollapseItemsWithinBoxSets(IEnumerable<BaseItem> items, User user);
+
+        /// <summary>
+        /// Gets the folder where collections are stored.
+        /// </summary>
+        /// <param name="createIfNeeded">Will create the collection folder on the storage if set to true.</param>
+        /// <returns>The folder instance referencing the collection storage.</returns>
+        Task<Folder?> GetCollectionsFolder(bool createIfNeeded);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Added Task to run at startup to cleanup collection items that are not longer physical present.
Updated interface of ICollectionManager to get reference to the Boxsets location to prevent duplicate magic strings.

**Issues**
#1907 
