### PR TITLE
Fix DVD folder playback

### DIFF
--- a/DvdLib/BigEndianBinaryReader.cs
+++ b/DvdLib/BigEndianBinaryReader.cs
@@ -1,0 +1,38 @@
+using System.Buffers.Binary;
+using System.IO;
+
+namespace DvdLib;
+
+/// <summary>
+/// A reader for big endian binary data.
+/// </summary>
+public class BigEndianBinaryReader : BinaryReader
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BigEndianBinaryReader"/> class.
+    /// </summary>
+    /// <param name="input">The input data stream.</param>
+    /// <returns>The <see cref="BigEndianBinaryReader"/>.</returns>
+    public BigEndianBinaryReader(Stream input)
+        : base(input)
+    {
+    }
+
+    /// <summary>
+    /// Reads a unsigned 16 bit integer from the binary data stream.
+    /// </summary>
+    /// <returns>The read unsigned 16 bit integer.</returns>
+    public override ushort ReadUInt16()
+    {
+        return BinaryPrimitives.ReadUInt16BigEndian(base.ReadBytes(2));
+    }
+
+    /// <summary>
+    /// Reads a unsigned 32 bit integer from the binary data stream.
+    /// </summary>
+    /// <returns>The read unsigned 32 bit integer.</returns>
+    public override uint ReadUInt32()
+    {
+        return BinaryPrimitives.ReadUInt32BigEndian(base.ReadBytes(4));
+    }
+}

--- a/DvdLib/DvdLib.csproj
+++ b/DvdLib/DvdLib.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- ProjectGuid is only included as a requirement for SonarQube analysis -->
+  <PropertyGroup>
+    <ProjectGuid>{713F42B5-878E-499D-A878-E4C652B1D5E8}</ProjectGuid>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedVersion.cs" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AnalysisMode>AllDisabledByDefault</AnalysisMode>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/DvdLib/Enums/BlockMode.cs
+++ b/DvdLib/Enums/BlockMode.cs
@@ -1,0 +1,27 @@
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The block mode.
+/// </summary>
+public enum BlockMode
+{
+    /// <summary>
+    /// Not in a block.
+    /// </summary>
+    NotInBlock = 0,
+
+    /// <summary>
+    /// First cell.
+    /// </summary>
+    FirstCell = 1,
+
+    /// <summary>
+    /// In a block.
+    /// </summary>
+    InBlock = 2,
+
+    /// <summary>
+    /// Last cell.
+    /// </summary>
+    LastCell = 3,
+}

--- a/DvdLib/Enums/BlockMode.cs
+++ b/DvdLib/Enums/BlockMode.cs
@@ -23,5 +23,5 @@ public enum BlockMode
     /// <summary>
     /// Last cell.
     /// </summary>
-    LastCell = 3,
+    LastCell = 3
 }

--- a/DvdLib/Enums/BlockType.cs
+++ b/DvdLib/Enums/BlockType.cs
@@ -13,5 +13,5 @@ public enum BlockType
     /// <summary>
     /// Angle.
     /// </summary>
-    Angle = 1,
+    Angle = 1
 }

--- a/DvdLib/Enums/BlockType.cs
+++ b/DvdLib/Enums/BlockType.cs
@@ -1,0 +1,17 @@
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The block type.
+/// </summary>
+public enum BlockType
+{
+    /// <summary>
+    /// Normal.
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Angle.
+    /// </summary>
+    Angle = 1,
+}

--- a/DvdLib/Enums/CellType.cs
+++ b/DvdLib/Enums/CellType.cs
@@ -1,0 +1,27 @@
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The cell type.
+/// </summary>
+public enum CellType
+{
+    /// <summary>
+    /// Normal.
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// First of angle block.
+    /// </summary>
+    AngleFirst = 1,
+
+    /// <summary>
+    /// Middle of angle block.
+    /// </summary>
+    AngleMiddle = 2,
+
+    /// <summary>
+    /// Last of angle block.
+    /// </summary>
+    AngleEnd = 3
+}

--- a/DvdLib/Enums/Commands.cs
+++ b/DvdLib/Enums/Commands.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The command.
+/// </summary>
+[Flags]
+public enum Command
+{
+    /// <summary>
+    /// None.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// None.
+    /// </summary>
+    Exists = 1,
+
+    /// <summary>
+    /// Only in pre/post.
+    /// </summary>
+    Button = 2,
+
+    /// <summary>
+    /// Only in cell.
+    /// </summary>
+    PrePost = 4,
+
+    /// <summary>
+    /// Only in Button.
+    /// </summary>
+    Cell = 8,
+}

--- a/DvdLib/Enums/PlaybackMode.cs
+++ b/DvdLib/Enums/PlaybackMode.cs
@@ -1,0 +1,17 @@
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The playback mode.
+/// </summary>
+public enum PlaybackMode
+{
+    /// <summary>
+    /// Normal.
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Still after each VOB.
+    /// </summary>
+    StillAfterEachVOBU = 1,
+}

--- a/DvdLib/Enums/PlaybackMode.cs
+++ b/DvdLib/Enums/PlaybackMode.cs
@@ -11,7 +11,7 @@ public enum PlaybackMode
     Normal = 0,
 
     /// <summary>
-    /// Still after each VOB.
+    /// Still after each VOBU.
     /// </summary>
-    StillAfterEachVOBU = 1,
+    StillAfterEachVOBU = 1
 }

--- a/DvdLib/Enums/ProgramPlaybackMode.cs
+++ b/DvdLib/Enums/ProgramPlaybackMode.cs
@@ -1,0 +1,22 @@
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The program playback mode.
+/// </summary>
+public enum ProgramPlaybackMode
+{
+    /// <summary>
+    /// Sequential.
+    /// </summary>
+    Sequential,
+
+    /// <summary>
+    /// Random.
+    /// </summary>
+    Random,
+
+    /// <summary>
+    /// Shuffle.
+    /// </summary>
+    Shuffle
+}

--- a/DvdLib/Enums/UserOperation.cs
+++ b/DvdLib/Enums/UserOperation.cs
@@ -14,14 +14,14 @@ public enum UserOperation
     None = 0,
 
     /// <summary>
-    /// Title or time play.
+    /// Time play or search.
     /// </summary>
-    TitleOrTimePlay = 1,
+    TimePlayOrSearch = 1,
 
     /// <summary>
-    /// Chapter search or play.
+    /// PTT play or search.
     /// </summary>
-    ChapterSearchOrPlay = 2,
+    PTTPlayOrSearch = 2,
 
     /// <summary>
     /// Title play.
@@ -39,14 +39,14 @@ public enum UserOperation
     GoUp = 16,
 
     /// <summary>
-    /// Time or chapter search.
+    /// Time or PTT search.
     /// </summary>
-    TimeOrChapterSearch = 32,
+    TimeOrPTTSearch = 32,
 
     /// <summary>
-    /// Previous or top program search.
+    /// Top or previous program search.
     /// </summary>
-    PrevOrTopProgramSearch = 64,
+    TopOrPrevProgramSearch = 64,
 
     /// <summary>
     /// Next program search.
@@ -136,5 +136,5 @@ public enum UserOperation
     /// <summary>
     /// Video presentation mode change.
     /// </summary>
-    VideoPresentationModeChange = 16777216,
+    VideoPresentationModeChange = 16777216
 }

--- a/DvdLib/Enums/UserOperation.cs
+++ b/DvdLib/Enums/UserOperation.cs
@@ -1,0 +1,140 @@
+using System;
+
+namespace DvdLib.Enums;
+
+/// <summary>
+/// The User Operation Flags (Uops).
+/// </summary>
+[Flags]
+public enum UserOperation
+{
+    /// <summary>
+    /// None.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Title or time play.
+    /// </summary>
+    TitleOrTimePlay = 1,
+
+    /// <summary>
+    /// Chapter search or play.
+    /// </summary>
+    ChapterSearchOrPlay = 2,
+
+    /// <summary>
+    /// Title play.
+    /// </summary>
+    TitlePlay = 4,
+
+    /// <summary>
+    /// Stop.
+    /// </summary>
+    Stop = 8,
+
+    /// <summary>
+    /// Go up.
+    /// </summary>
+    GoUp = 16,
+
+    /// <summary>
+    /// Time or chapter search.
+    /// </summary>
+    TimeOrChapterSearch = 32,
+
+    /// <summary>
+    /// Previous or top program search.
+    /// </summary>
+    PrevOrTopProgramSearch = 64,
+
+    /// <summary>
+    /// Next program search.
+    /// </summary>
+    NextProgramSearch = 128,
+
+    /// <summary>
+    /// Forward scan.
+    /// </summary>
+    ForwardScan = 256,
+
+    /// <summary>
+    /// Backward scan.
+    /// </summary>
+    BackwardScan = 512,
+
+    /// <summary>
+    /// Menu call - Title.
+    /// </summary>
+    MenuCallTitle = 1024,
+
+    /// <summary>
+    /// Menu call - Root.
+    /// </summary>
+    MenuCallRoot = 2048,
+
+    /// <summary>
+    /// Menu call - Subpicture.
+    /// </summary>
+    MenuCallSubpicture = 4096,
+
+    /// <summary>
+    ///Menu call -  Audio menu.
+    /// </summary>
+    MenuCallAudio = 8192,
+
+    /// <summary>
+    /// Menu call - Angle menu.
+    /// </summary>
+    MenuCallAngle = 16384,
+
+    /// <summary>
+    /// Menu call - Chapter.
+    /// </summary>
+    MenuCallChapter = 32768,
+
+    /// <summary>
+    /// Resume.
+    /// </summary>
+    Resume = 65536,
+
+    /// <summary>
+    /// Button select or activate.
+    /// </summary>
+    ButtonSelectOrActivate = 131072,
+
+    /// <summary>
+    /// Still off.
+    /// </summary>
+    StillOff = 262144,
+
+    /// <summary>
+    /// Pause on.
+    /// </summary>
+    PauseOn = 524288,
+
+    /// <summary>
+    /// Audio stream change.
+    /// </summary>
+    AudioStreamChange = 1048576,
+
+    /// <summary>
+    /// Subpicture stream change.
+    /// </summary>
+    SubpictureStreamChange = 2097152,
+
+    /// <summary>
+    /// Angle change.
+    /// </summary>
+    AngleChange = 4194304,
+
+    /// <summary>
+    /// Karaoke audio mix change.
+    /// </summary>
+    KaraokeAudioMixChange = 8388608,
+
+    /// <summary>
+    /// Video presentation mode change.
+    /// </summary>
+    VideoPresentationModeChange = 16777216,
+}

--- a/DvdLib/Ifo/Cell.cs
+++ b/DvdLib/Ifo/Cell.cs
@@ -1,0 +1,29 @@
+using System.IO;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A cell.
+/// </summary>
+public class Cell
+{
+    /// <summary>
+    /// The cell playback information.
+    /// </summary>
+    public CellPlaybackInfo PlaybackInfo { get; private set; }
+
+    /// <summary>
+    /// The cell position information.
+    /// </summary>
+    public CellPositionInfo PositionInfo { get; private set; }
+
+    internal void ParsePlayback(BinaryReader br)
+    {
+        PlaybackInfo = new CellPlaybackInfo(br);
+    }
+
+    internal void ParsePosition(BinaryReader br)
+    {
+        PositionInfo = new CellPositionInfo(br);
+    }
+}

--- a/DvdLib/Ifo/CellPlaybackInfo.cs
+++ b/DvdLib/Ifo/CellPlaybackInfo.cs
@@ -1,0 +1,97 @@
+using DvdLib.Enums;
+using System.IO;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A cell's playback information.
+/// </summary>
+public class CellPlaybackInfo
+{
+    /// <summary>
+    /// The block mode.
+    /// </summary>
+    public readonly BlockMode Mode;
+
+    /// <summary>
+    /// The block type.
+    /// </summary>
+    public readonly BlockType Type;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="Cell" /> supports seamless playback.
+    /// </summary>
+    /// <value><c>true</c> if the cell supports it; otherwise, <c>false</c>.</value>
+    public readonly bool SeamlessPlay;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="Cell" /> is interleaved.
+    /// </summary>
+    /// <value><c>true</c> if the cell is interleaved; otherwise, <c>false</c>.</value>
+    public readonly bool Interleaved;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="Cell" /> supports seamless playback.
+    /// </summary>
+    /// <value><c>true</c> if the cell supports it; otherwise, <c>false</c>.</value>
+    public readonly bool STCDiscontinuity;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="Cell" /> supports seamless playback.
+    /// </summary>
+    /// <value><c>true</c> if the cell supports it; otherwise, <c>false</c>.</value>
+    public readonly bool SeamlessAngle;
+
+    /// <summary>
+    /// The playback mode.
+    /// </summary>
+    public readonly PlaybackMode PlaybackMode;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="Cell" /> is restricted.
+    /// </summary>
+    /// <value><c>true</c> if the cell is restricted; otherwise, <c>false</c>.</value>
+    public readonly bool Restricted;
+
+    /// <summary>
+    /// The still time.
+    /// </summary>
+    public readonly byte StillTime;
+
+    /// <summary>
+    /// The command number.
+    /// </summary>
+    public readonly byte CommandNumber;
+
+    /// <summary>
+    /// The playback time.
+    /// </summary>
+    public readonly DvdTime PlaybackTime;
+
+    /// <summary>
+    /// The first sector.
+    /// </summary>
+    public readonly uint FirstSector;
+
+    /// <summary>
+    /// The first ILV end sector.
+    /// </summary>
+    public readonly uint FirstILVUEndSector;
+
+    /// <summary>
+    /// The last VOB start sector.
+    /// </summary>
+    public readonly uint LastVOBUStartSector;
+
+    /// <summary>
+    /// The last sector.
+    /// </summary>
+    public readonly uint LastSector;
+
+    internal CellPlaybackInfo(BinaryReader br)
+    {
+        br.BaseStream.Seek(0x4, SeekOrigin.Current);
+        PlaybackTime = new DvdTime(br.ReadBytes(4));
+        br.BaseStream.Seek(0x10, SeekOrigin.Current);
+    }
+}

--- a/DvdLib/Ifo/CellPositionInfo.cs
+++ b/DvdLib/Ifo/CellPositionInfo.cs
@@ -19,8 +19,13 @@ public class CellPositionInfo
 
     internal CellPositionInfo(BinaryReader br)
     {
+        // Read VOB id
         VOBId = br.ReadUInt16();
+
+        // Skip reserved byte
         br.ReadByte();
+
+        // Read cell id
         CellId = br.ReadByte();
     }
 }

--- a/DvdLib/Ifo/CellPositionInfo.cs
+++ b/DvdLib/Ifo/CellPositionInfo.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// The cell position information.
+/// </summary>
+public class CellPositionInfo
+{
+    /// <summary>
+    /// The VOB id.
+    /// </summary>
+    public readonly ushort VOBId;
+
+    /// <summary>
+    /// The cell id.
+    /// </summary>
+    public readonly byte CellId;
+
+    internal CellPositionInfo(BinaryReader br)
+    {
+        VOBId = br.ReadUInt16();
+        br.ReadByte();
+        CellId = br.ReadByte();
+    }
+}

--- a/DvdLib/Ifo/Chapter.cs
+++ b/DvdLib/Ifo/Chapter.cs
@@ -1,0 +1,36 @@
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A chapter.
+/// </summary>
+public class Chapter
+{
+    /// <summary>
+    /// The program chain number.
+    /// </summary>
+    public ushort ProgramChainNumber { get; private set; }
+
+    /// <summary>
+    /// The program number.
+    /// </summary>
+    public ushort ProgramNumber { get; private set; }
+
+    /// <summary>
+    /// The chapter number.
+    /// </summary>
+    public uint ChapterNumber { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Chapter"/> class.
+    /// </summary>
+    /// <param name="pgcNum">The program chain number.</param>
+    /// <param name="programNum">The program number.</param>
+    /// <param name="chapterNum">The chapter number.</param>
+    /// <returns>The <see cref="Chapter"/>.</returns>
+    public Chapter(ushort pgcNum, ushort programNum, uint chapterNum)
+    {
+        ProgramChainNumber = pgcNum;
+        ProgramNumber = programNum;
+        ChapterNumber = chapterNum;
+    }
+}

--- a/DvdLib/Ifo/Dvd.cs
+++ b/DvdLib/Ifo/Dvd.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A DVD.
+/// </summary>
+public class Dvd
+{
+    private readonly ushort _titleSetCount;
+    private ushort _titleCount;
+
+    /// <summary>
+    /// The list of titles.
+    /// </summary>
+    public readonly List<Title> Titles;
+
+
+    /// <summary>
+    /// The dictionary of valid VTS paths.
+    /// </summary>
+    public readonly Dictionary<ushort, string> VTSPaths = new Dictionary<ushort, string>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Dvd"/> class.
+    /// </summary>
+    /// <param name="path">The path to the DVD.</param>
+    /// <returns>The <see cref="Dvd"/>.</returns>
+    public Dvd(string path)
+    {
+        Titles = new List<Title>();
+        var allFiles = new DirectoryInfo(path).GetFiles(path, SearchOption.AllDirectories);
+
+        var vmgPath = allFiles.FirstOrDefault(i => string.Equals(i.Name, "VIDEO_TS.IFO", StringComparison.OrdinalIgnoreCase)) ??
+            allFiles.FirstOrDefault(i => string.Equals(i.Name, "VIDEO_TS.BUP", StringComparison.OrdinalIgnoreCase));
+
+        if (vmgPath == null)
+        {
+            foreach (var ifo in allFiles)
+            {
+                if (!string.Equals(ifo.Extension, ".ifo", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var nums = ifo.Name.Split('_', StringSplitOptions.RemoveEmptyEntries);
+                if (nums.Length >= 2 && ushort.TryParse(nums[1], out var ifoNumber))
+                {
+                    ReadVTS(ifoNumber, ifo.FullName);
+                }
+            }
+        }
+        else
+        {
+            using (var vmgFs = new FileStream(vmgPath.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                using (var vmgRead = new BigEndianBinaryReader(vmgFs))
+                {
+                    vmgFs.Seek(0x3E, SeekOrigin.Begin);
+                    _titleSetCount = vmgRead.ReadUInt16();
+
+                    // read address of TT_SRPT
+                    vmgFs.Seek(0xC4, SeekOrigin.Begin);
+                    uint ttSectorPtr = vmgRead.ReadUInt32();
+                    vmgFs.Seek(ttSectorPtr * 2048, SeekOrigin.Begin);
+                    ReadTT_SRPT(vmgRead);
+                }
+            }
+
+            for (ushort titleSetNum = 1; titleSetNum <= _titleSetCount; titleSetNum++)
+            {
+                ReadVTS(titleSetNum, allFiles);
+            }
+        }
+    }
+
+    private void ReadTT_SRPT(BinaryReader read)
+    {
+        _titleCount = read.ReadUInt16();
+        read.BaseStream.Seek(6, SeekOrigin.Current);
+        for (uint titleNum = 1; titleNum <= _titleCount; titleNum++)
+        {
+            var t = new Title(titleNum);
+            t.ParseTT_SRPT(read);
+            Titles.Add(t);
+        }
+    }
+
+    private void ReadVTS(ushort vtsNum, IReadOnlyList<FileInfo> allFiles)
+    {
+        var filename = string.Format(CultureInfo.InvariantCulture, "VTS_{0:00}_0.IFO", vtsNum);
+
+        var vtsPath = allFiles.FirstOrDefault(i => string.Equals(i.Name, filename, StringComparison.OrdinalIgnoreCase)) ??
+            allFiles.FirstOrDefault(i => string.Equals(i.Name, Path.ChangeExtension(filename, ".bup"), StringComparison.OrdinalIgnoreCase));
+
+        if (vtsPath == null)
+        {
+            throw new FileNotFoundException("Unable to find VTS IFO file");
+        }
+
+        ReadVTS(vtsNum, vtsPath.FullName);
+    }
+
+    private void ReadVTS(ushort vtsNum, string vtsPath)
+    {
+        VTSPaths[vtsNum] = vtsPath;
+
+        using (var vtsFs = new FileStream(vtsPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            using (var vtsRead = new BigEndianBinaryReader(vtsFs))
+            {
+                // Read VTS_PTT_SRPT
+                vtsFs.Seek(0xC8, SeekOrigin.Begin);
+                uint vtsPttSrptSecPtr = vtsRead.ReadUInt32();
+                uint baseAddr = (vtsPttSrptSecPtr * 2048);
+                vtsFs.Seek(baseAddr, SeekOrigin.Begin);
+
+                ushort numTitles = vtsRead.ReadUInt16();
+                vtsRead.ReadUInt16();
+                uint endaddr = vtsRead.ReadUInt32();
+                uint[] offsets = new uint[numTitles];
+                for (ushort titleNum = 0; titleNum < numTitles; titleNum++)
+                {
+                    offsets[titleNum] = vtsRead.ReadUInt32();
+                }
+
+                for (uint titleNum = 0; titleNum < numTitles; titleNum++)
+                {
+                    uint chapNum = 1;
+                    vtsFs.Seek(baseAddr + offsets[titleNum], SeekOrigin.Begin);
+                    var t = Titles.FirstOrDefault(vtst => vtst.IsVTSTitle(vtsNum, titleNum + 1));
+                    if (t == null)
+                    {
+                        continue;
+                    }
+
+                    do
+                    {
+                        t.Chapters.Add(new Chapter(vtsRead.ReadUInt16(), vtsRead.ReadUInt16(), chapNum));
+                        if (titleNum + 1 < numTitles && vtsFs.Position == (baseAddr + offsets[titleNum + 1]))
+                        {
+                            break;
+                        }
+
+                        chapNum++;
+                    }
+                    while (vtsFs.Position < (baseAddr + endaddr));
+                }
+
+                // Read VTS_PGCI
+                vtsFs.Seek(0xCC, SeekOrigin.Begin);
+                uint vtsPgciSecPtr = vtsRead.ReadUInt32();
+                vtsFs.Seek(vtsPgciSecPtr * 2048, SeekOrigin.Begin);
+
+                long startByte = vtsFs.Position;
+
+                ushort numPgcs = vtsRead.ReadUInt16();
+                vtsFs.Seek(6, SeekOrigin.Current);
+                for (ushort pgcNum = 1; pgcNum <= numPgcs; pgcNum++)
+                {
+                    byte pgcCat = vtsRead.ReadByte();
+                    bool entryPgc = (pgcCat & 0x80) != 0;
+                    uint titleNum = (uint)(pgcCat & 0x7F);
+
+                    vtsFs.Seek(3, SeekOrigin.Current);
+                    uint vtsPgcOffset = vtsRead.ReadUInt32();
+
+                    var t = Titles.FirstOrDefault(vtst => vtst.IsVTSTitle(vtsNum, titleNum));
+                    if (t != null)
+                    {
+                        t.AddPgc(vtsRead, startByte + vtsPgcOffset, entryPgc, pgcNum);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DvdLib/Ifo/Dvd.cs
+++ b/DvdLib/Ifo/Dvd.cs
@@ -33,7 +33,7 @@ public class Dvd
     public Dvd(string path)
     {
         Titles = new List<Title>();
-        var allFiles = new DirectoryInfo(path).GetFiles(path, SearchOption.AllDirectories);
+        var allFiles = new DirectoryInfo(path).GetFiles("*", SearchOption.AllDirectories);
 
         var vmgPath = allFiles.FirstOrDefault(i => string.Equals(i.Name, "VIDEO_TS.IFO", StringComparison.OrdinalIgnoreCase)) ??
             allFiles.FirstOrDefault(i => string.Equals(i.Name, "VIDEO_TS.BUP", StringComparison.OrdinalIgnoreCase));

--- a/DvdLib/Ifo/DvdTime.cs
+++ b/DvdLib/Ifo/DvdTime.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A classs holding information on DVD runtime and framerate.
+/// </summary>
+public class DvdTime
+{
+    /// <summary>
+    /// The hours.
+    /// </summary>
+    public readonly byte Hours;
+
+    /// <summary>
+    /// The minutes.
+    /// </summary>
+    public readonly byte Minutes;
+
+    /// <summary>
+    /// The seconds.
+    /// </summary>
+    public readonly byte Seconds;
+
+    /// <summary>
+    /// The total amount of frames.
+    /// </summary>
+    public readonly byte Frames;
+
+    /// <summary>
+    /// The frame rate.
+    /// </summary>
+    public readonly byte FrameRate;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DvdTime"/> class.
+    /// </summary>
+    /// <param name="data">The binary data.</param>
+    /// <returns>The <see cref="DvdTime"/>.</returns>
+    public DvdTime(byte[] data)
+    {
+        Hours = GetBCDValue(data[0]);
+        Minutes = GetBCDValue(data[1]);
+        Seconds = GetBCDValue(data[2]);
+        Frames = GetBCDValue((byte)(data[3] & 0x3F));
+
+        if ((data[3] & 0x80) != 0)
+        {
+            FrameRate = 30;
+        }
+        else if ((data[3] & 0x40) != 0)
+        {
+            FrameRate = 25;
+        }
+    }
+
+    private static byte GetBCDValue(byte data)
+    {
+        return (byte)((((data & 0xF0) >> 4) * 10) + (data & 0x0F));
+    }
+
+    /// <summary>
+    /// Converts <see cref="DvdTime"/> to <see cref="TimeSpan"/>.
+    /// </summary>
+    /// <param name="time">The <see cref="DvdTime"/>.</param>
+    /// <returns>The <see cref="TimeSpan"/>.</returns>
+    public static explicit operator TimeSpan(DvdTime time)
+    {
+        int ms = (int)(((1.0 / (double)time.FrameRate) * time.Frames) * 1000.0);
+        return new TimeSpan(0, time.Hours, time.Minutes, time.Seconds, ms);
+    }
+}

--- a/DvdLib/Ifo/Program.cs
+++ b/DvdLib/Ifo/Program.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A program.
+/// </summary>
+public class Program
+{
+    /// <summary>
+    /// The cells.
+    /// </summary>
+    public IReadOnlyList<Cell> Cells { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Program"/> class.
+    /// </summary>
+    /// <param name="cells">The list of cells.</param>
+    /// <returns>The <see cref="Title"/>.</returns>
+    public Program(List<Cell> cells)
+    {
+        Cells = cells;
+    }
+}

--- a/DvdLib/Ifo/ProgramChain.cs
+++ b/DvdLib/Ifo/ProgramChain.cs
@@ -98,8 +98,6 @@ public class ProgramChain
         _prevProgramNumber = br.ReadUInt16();
         _goupProgramNumber = br.ReadUInt16();
 
-        StillTime = br.ReadByte();
-
         byte pbMode = br.ReadByte();
         if (pbMode == 0)
         {
@@ -112,6 +110,7 @@ public class ProgramChain
 
         ProgramCount = (uint)(pbMode & 0x7F);
 
+        StillTime = br.ReadByte();
         Palette = br.ReadBytes(64);
         _commandTableOffset = br.ReadUInt16();
         _programMapOffset = br.ReadUInt16();

--- a/DvdLib/Ifo/ProgramChain.cs
+++ b/DvdLib/Ifo/ProgramChain.cs
@@ -1,0 +1,146 @@
+using DvdLib.Enums;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A program chain.
+/// </summary>
+public class ProgramChain
+{
+    private byte _programCount;
+    private byte _cellCount;
+    private ushort _nextProgramNumber;
+    private ushort _prevProgramNumber;
+    private ushort _goupProgramNumber;
+    private ushort _commandTableOffset;
+    private ushort _programMapOffset;
+    private ushort _cellPlaybackOffset;
+    private ushort _cellPositionOffset;
+
+    /// <summary>
+    /// The programs.
+    /// </summary>
+    public readonly List<Program> Programs;
+
+    /// <summary>
+    /// The cells.
+    /// </summary>
+    public readonly List<Cell> Cells;
+
+    /// <summary>
+    /// The playback time.
+    /// </summary>
+    public DvdTime PlaybackTime { get; private set; }
+
+    /// <summary>
+    /// The prohibited user operations.
+    /// </summary>
+    public UserOperation ProhibitedUserOperations { get; private set; }
+
+    /// <summary>
+    /// The audio stream control.
+    /// </summary>
+    public byte[] AudioStreamControl { get; private set; } // 8*2 entries
+
+    /// <summary>
+    /// The subpicture stream control.
+    /// </summary>
+    public byte[] SubpictureStreamControl { get; private set; } // 32*4 entries
+
+    /// <summary>
+    /// The playback mode.
+    /// </summary>
+    public ProgramPlaybackMode PlaybackMode { get; private set; }
+
+    /// <summary>
+    /// The program count.
+    /// </summary>
+    public uint ProgramCount { get; private set; }
+
+    /// <summary>
+    /// The still time.
+    /// </summary>
+    public byte StillTime { get; private set; }
+
+    /// <summary>
+    /// The color palette.
+    /// </summary>
+    public byte[] Palette { get; private set; } // 16*4 entries
+
+    /// <summary>
+    /// The video title set index.
+    /// </summary>
+    public readonly uint VideoTitleSetIndex;
+
+    internal ProgramChain(uint vtsPgcNum)
+    {
+        VideoTitleSetIndex = vtsPgcNum;
+        Cells = new List<Cell>();
+        Programs = new List<Program>();
+    }
+
+    internal void ParseHeader(BinaryReader br)
+    {
+        long startPos = br.BaseStream.Position;
+
+        br.ReadUInt16();
+        _programCount = br.ReadByte();
+        _cellCount = br.ReadByte();
+        PlaybackTime = new DvdTime(br.ReadBytes(4));
+        ProhibitedUserOperations = (UserOperation)br.ReadUInt32();
+        AudioStreamControl = br.ReadBytes(16);
+        SubpictureStreamControl = br.ReadBytes(128);
+
+        _nextProgramNumber = br.ReadUInt16();
+        _prevProgramNumber = br.ReadUInt16();
+        _goupProgramNumber = br.ReadUInt16();
+
+        StillTime = br.ReadByte();
+
+        byte pbMode = br.ReadByte();
+        if (pbMode == 0)
+        {
+            PlaybackMode = ProgramPlaybackMode.Sequential;
+        }
+        else
+        {
+            PlaybackMode = ((pbMode & 0x80) == 0) ? ProgramPlaybackMode.Random : ProgramPlaybackMode.Shuffle;
+        }
+
+        ProgramCount = (uint)(pbMode & 0x7F);
+
+        Palette = br.ReadBytes(64);
+        _commandTableOffset = br.ReadUInt16();
+        _programMapOffset = br.ReadUInt16();
+        _cellPlaybackOffset = br.ReadUInt16();
+        _cellPositionOffset = br.ReadUInt16();
+
+        // Read position info
+        br.BaseStream.Seek(startPos + _cellPositionOffset, SeekOrigin.Begin);
+        for (var cellNum = 0; cellNum < _cellCount; cellNum++)
+        {
+            var c = new Cell();
+            c.ParsePosition(br);
+            Cells.Add(c);
+        }
+
+        br.BaseStream.Seek(startPos + _cellPlaybackOffset, SeekOrigin.Begin);
+        for (int cellNum = 0; cellNum < _cellCount; cellNum++)
+        {
+            Cells[cellNum].ParsePlayback(br);
+        }
+
+        br.BaseStream.Seek(startPos + _programMapOffset, SeekOrigin.Begin);
+        var cellNumbers = new List<int>();
+        for (int progNum = 0; progNum < _programCount; progNum++) cellNumbers.Add(br.ReadByte() - 1);
+
+        for (int i = 0; i < cellNumbers.Count; i++)
+        {
+            int max = (i + 1 == cellNumbers.Count) ? _cellCount : cellNumbers[i + 1];
+            Programs.Add(new Program(Cells.Where((c, idx) => idx >= cellNumbers[i] && idx < max).ToList()));
+        }
+    }
+}

--- a/DvdLib/Ifo/Title.cs
+++ b/DvdLib/Ifo/Title.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A title.
+/// </summary>
+public class Title
+{
+    private ushort _parentalManagementMask;
+    private byte _titleNumberInVTS;
+    private uint _vtsStartSector; // relative to start of entire disk
+
+    /// <summary>
+    /// The title number.
+    /// </summary>
+    public uint TitleNumber { get; private set; }
+
+    /// <summary>
+    /// The angle count.
+    /// </summary>
+    public uint AngleCount { get; private set; }
+
+    /// <summary>
+    /// The chapter count.
+    /// </summary>
+    public ushort ChapterCount { get; private set; }
+
+    /// <summary>
+    /// The video title set number.
+    /// </summary>
+    public byte VideoTitleSetNumber { get; private set; }
+
+    /// <summary>
+    /// The entry program chain.
+    /// </summary>
+    public ProgramChain EntryProgramChain { get; private set; }
+
+    /// <summary>
+    /// The program chains.
+    /// </summary>
+    public readonly List<ProgramChain> ProgramChains;
+
+    /// <summary>
+    /// The chapters.
+    /// </summary>
+    public readonly List<Chapter> Chapters;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Title"/> class.
+    /// </summary>
+    /// <param name="titleNum">The title number.</param>
+    /// <returns>The <see cref="Title"/>.</returns>
+    public Title(uint titleNum)
+    {
+        ProgramChains = new List<ProgramChain>();
+        Chapters = new List<Chapter>();
+        Chapters = new List<Chapter>();
+        TitleNumber = titleNum;
+    }
+
+    /// <summary>
+    /// Checks if a title is a VTS title.
+    /// </summary>
+    /// <param name="vtsNum">The VTS number.</param>
+    /// <param name="vtsTitleNum">The VTS title number.</param>
+    /// <returns>Returns true if the title is VTS.</returns>
+    public bool IsVTSTitle(uint vtsNum, uint vtsTitleNum)
+    {
+        return (vtsNum == VideoTitleSetNumber && vtsTitleNum == _titleNumberInVTS);
+    }
+
+    internal void ParseTT_SRPT(BinaryReader br)
+    {
+        byte titleType = br.ReadByte();
+        // TODO parse Title Type
+
+        AngleCount = br.ReadByte();
+        ChapterCount = br.ReadUInt16();
+        _parentalManagementMask = br.ReadUInt16();
+        VideoTitleSetNumber = br.ReadByte();
+        _titleNumberInVTS = br.ReadByte();
+        _vtsStartSector = br.ReadUInt32();
+    }
+
+    internal void AddPgc(BinaryReader br, long startByte, bool entryPgc, uint pgcNum)
+    {
+        long curPos = br.BaseStream.Position;
+        br.BaseStream.Seek(startByte, SeekOrigin.Begin);
+
+        var pgc = new ProgramChain(pgcNum);
+        pgc.ParseHeader(br);
+        ProgramChains.Add(pgc);
+        if (entryPgc)
+        {
+            EntryProgramChain = pgc;
+        }
+
+        br.BaseStream.Seek(curPos, SeekOrigin.Begin);
+    }
+}

--- a/DvdLib/Ifo/Title.cs
+++ b/DvdLib/Ifo/Title.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -18,14 +19,19 @@ public class Title
     public uint TitleNumber { get; private set; }
 
     /// <summary>
+    /// The title number.
+    /// </summary>
+    public TitleType TitleType { get; private set; }
+
+    /// <summary>
     /// The angle count.
     /// </summary>
-    public uint AngleCount { get; private set; }
+    public uint NumberOfAngles { get; private set; }
 
     /// <summary>
     /// The chapter count.
     /// </summary>
-    public ushort ChapterCount { get; private set; }
+    public ushort NumberOfChapters { get; private set; }
 
     /// <summary>
     /// The video title set number.
@@ -51,13 +57,14 @@ public class Title
     /// Initializes a new instance of the <see cref="Title"/> class.
     /// </summary>
     /// <param name="titleNum">The title number.</param>
+    /// <param name="br">The binary reader.</param>
     /// <returns>The <see cref="Title"/>.</returns>
-    public Title(uint titleNum)
+    public Title(uint titleNum, BinaryReader br)
     {
+        TitleNumber = titleNum;
+        ParseTT_SRPT(br);
         ProgramChains = new List<ProgramChain>();
         Chapters = new List<Chapter>();
-        Chapters = new List<Chapter>();
-        TitleNumber = titleNum;
     }
 
     /// <summary>
@@ -71,20 +78,18 @@ public class Title
         return (vtsNum == VideoTitleSetNumber && vtsTitleNum == _titleNumberInVTS);
     }
 
-    internal void ParseTT_SRPT(BinaryReader br)
+    private void ParseTT_SRPT(BinaryReader br)
     {
-        byte titleType = br.ReadByte();
-        // TODO parse Title Type
-
-        AngleCount = br.ReadByte();
-        ChapterCount = br.ReadUInt16();
+        TitleType = new TitleType(br);
+        NumberOfAngles = br.ReadByte();
+        NumberOfChapters = br.ReadUInt16();
         _parentalManagementMask = br.ReadUInt16();
         VideoTitleSetNumber = br.ReadByte();
         _titleNumberInVTS = br.ReadByte();
         _vtsStartSector = br.ReadUInt32();
     }
 
-    internal void AddPgc(BinaryReader br, long startByte, bool entryPgc, uint pgcNum)
+    internal void AddProgramChains(BinaryReader br, long startByte, bool entryPgc, uint pgcNum)
     {
         long curPos = br.BaseStream.Position;
         br.BaseStream.Seek(startByte, SeekOrigin.Begin);

--- a/DvdLib/Ifo/TitleType.cs
+++ b/DvdLib/Ifo/TitleType.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using System.Collections;
+using DvdLib.Enums;
+
+namespace DvdLib.Ifo;
+
+/// <summary>
+/// A title type.
+/// </summary>
+public class TitleType
+{
+    /// <summary>
+    /// The first user operation.
+    /// </summary>
+    public readonly UserOperation Uop0 = UserOperation.None;
+
+    /// <summary>
+    /// The second user operation.
+    /// </summary>
+    public readonly UserOperation Uop1 = UserOperation.None;
+
+    /// <summary>
+    /// The jump/link/call commands.
+    /// </summary>
+    public readonly Command commands = Command.None;
+
+    /// <summary>
+    /// A value indicating whether this <see cref="TitleType" /> is sequential.
+    /// </summary>
+    /// <value><c>true</c> if sequential; otherwise, <c>false</c>.</value>
+    public bool Sequential;
+
+    internal TitleType(BinaryReader br)
+    {
+        var bitArray = new BitArray(new byte[] {br.ReadByte()});
+        if (bitArray[0])
+        {
+            Uop0 = UserOperation.TimePlayOrSearch;
+        }
+
+        if (bitArray[1])
+        {
+            Uop0 = UserOperation.PTTPlayOrSearch;
+        }
+
+        if (bitArray[2])
+        {
+            commands |= Command.Exists;
+        }
+
+        if (bitArray[3])
+        {
+            commands |= Command.Button;
+        }
+
+        if (bitArray[4])
+        {
+            commands |= Command.PrePost;
+        }
+
+        if (bitArray[5])
+        {
+            commands |= Command.Cell;
+        }
+
+        Sequential = !bitArray[6];
+    }
+}

--- a/DvdLib/Properties/AssemblyInfo.cs
+++ b/DvdLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DvdLib")]
+[assembly: AssemblyDescription("A library for reading DVD information.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Jellyfin Project")]
+[assembly: AssemblyProduct("Jellyfin Server")]
+[assembly: AssemblyCopyright("Copyright © 2022 Jellyfin Contributors. Code released under the GNU General Public License")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -525,7 +525,10 @@ public class TranscodingJobHelper : IDisposable
         if (state.SubtitleStream is not null && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode)
         {
             var attachmentPath = Path.Combine(_appPaths.CachePath, "attachments", state.MediaSource.Id);
-            await _attachmentExtractor.ExtractAllAttachments(state.MediaPath, state.MediaSource, attachmentPath, cancellationTokenSource.Token).ConfigureAwait(false);
+                if (state.VideoType != VideoType.Dvd)
+                {
+                await _attachmentExtractor.ExtractAllAttachments(state.MediaPath, state.MediaSource, attachmentPath, cancellationTokenSource.Token).ConfigureAwait(false);
+                }
 
             if (state.SubtitleStream.IsExternal && string.Equals(Path.GetExtension(state.SubtitleStream.Path), ".mks", StringComparison.OrdinalIgnoreCase))
             {

--- a/Jellyfin.sln
+++ b/Jellyfin.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jellyfin.Drawing", "src\Jel
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Emby.Photos", "Emby.Photos\Emby.Photos.csproj", "{89AB4548-770D-41FD-A891-8DAFF44F452C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DvdLib", "DvdLib\DvdLib.csproj", "{713F42B5-878E-499D-A878-E4C652B1D5E8}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Emby.Server.Implementations", "Emby.Server.Implementations\Emby.Server.Implementations.csproj", "{E383961B-9356-4D5D-8233-9A1079D03055}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RSSDP", "RSSDP\RSSDP.csproj", "{21002819-C39A-4D3E-BE83-2A276A77FB1F}"
@@ -135,6 +137,10 @@ Global
 		{89AB4548-770D-41FD-A891-8DAFF44F452C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89AB4548-770D-41FD-A891-8DAFF44F452C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89AB4548-770D-41FD-A891-8DAFF44F452C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{713F42B5-878E-499D-A878-E4C652B1D5E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{713F42B5-878E-499D-A878-E4C652B1D5E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{713F42B5-878E-499D-A878-E4C652B1D5E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{713F42B5-878E-499D-A878-E4C652B1D5E8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E383961B-9356-4D5D-8233-9A1079D03055}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E383961B-9356-4D5D-8233-9A1079D03055}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E383961B-9356-4D5D-8233-9A1079D03055}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -535,6 +535,11 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             var mediaPath = state.MediaPath ?? string.Empty;
 
+            if (state.MediaSource.VideoType == VideoType.Dvd)
+            {
+                return _mediaEncoder.GetInputArgument(_mediaEncoder.GetPrimaryPlaylistVobFiles(state.MediaPath, null).ToList(), state.MediaSource);
+            }
+
             return _mediaEncoder.GetInputArgument(mediaPath, state.MediaSource);
         }
 

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -154,6 +154,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         string GetInputArgument(string inputFile, MediaSourceInfo mediaSource);
 
         /// <summary>
+        /// Gets the input argument.
+        /// </summary>
+        /// <param name="inputFiles">The input files.</param>
+        /// <param name="mediaSource">The mediaSource.</param>
+        /// <returns>System.String.</returns>
+        string GetInputArgument(IReadOnlyList<string> inputFiles, MediaSourceInfo mediaSource);
+
+        /// <summary>
         /// Gets the input argument for an external subtitle file.
         /// </summary>
         /// <param name="inputFile">The input file.</param>

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -187,5 +187,13 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="path">The path.</param>
         /// <param name="pathType">The type of path.</param>
         void UpdateEncoderPath(string path, string pathType);
+
+        /// <summary>
+        /// Gets the primary playlist of .vob files.
+        /// </summary>
+        /// <param name="path">The to the .vob files.</param>
+        /// <param name="titleNumber">The title number to start with.</param>
+        /// <returns>A playlist.</returns>
+        IEnumerable<string> GetPrimaryPlaylistVobFiles(string path, uint? titleNumber);
     }
 }

--- a/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
@@ -1,35 +1,44 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using MediaBrowser.Model.MediaInfo;
 
 namespace MediaBrowser.MediaEncoding.Encoder
 {
     public static class EncodingUtils
     {
-        public static string GetInputArgument(string inputPrefix, string inputFile, MediaProtocol protocol)
+        public static string GetInputArgument(string inputPrefix, IReadOnlyList<string> inputFiles, MediaProtocol protocol)
         {
             if (protocol != MediaProtocol.File)
             {
-                return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", inputFile);
+                return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", inputFiles[0]);
             }
 
-            return GetConcatInputArgument(inputFile, inputPrefix);
+            return GetConcatInputArgument(inputFiles, inputPrefix);
         }
 
         /// <summary>
         /// Gets the concat input argument.
         /// </summary>
-        /// <param name="inputFile">The input file.</param>
+        /// <param name="inputFiles">The input files.</param>
         /// <param name="inputPrefix">The input prefix.</param>
         /// <returns>System.String.</returns>
-        private static string GetConcatInputArgument(string inputFile, string inputPrefix)
+        private static string GetConcatInputArgument(IReadOnlyList<string> inputFiles, string inputPrefix)
         {
             // Get all streams
             // If there's more than one we'll need to use the concat command
+            if (inputFiles.Count > 1)
+            {
+                var files = string.Join("|", inputFiles.Select(NormalizePath));
+
+                return string.Format(CultureInfo.InvariantCulture, "concat:\"{0}\"", files);
+            }
+
             // Determine the input path for video files
-            return GetFileInputArgument(inputFile, inputPrefix);
+            return GetFileInputArgument(inputFiles[0], inputPrefix);
         }
 
         /// <summary>

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -865,6 +865,85 @@ namespace MediaBrowser.MediaEncoding.Encoder
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc />
+        public IEnumerable<string> GetPrimaryPlaylistVobFiles(string path, uint? titleNumber)
+        {
+            // Minimum size 450 MB
+            const long MinPlayableSize = 471859200;
+
+            // Try to eliminate menus and intros by skipping all files at the front of the list that are less than the minimum size
+            // Once we reach a file that is at least the minimum, return all subsequent ones
+            var allVobs = _fileSystem.GetFiles(path, true)
+                .Where(file => string.Equals(file.Extension, ".vob", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(i => i.FullName)
+                .ToList();
+
+            // If we didn't find any satisfying the min length, just take them all
+            if (allVobs.Count == 0)
+            {
+                _logger.LogWarning("No vobs found in dvd structure.");
+                return Enumerable.Empty<string>();
+            }
+
+            if (titleNumber.HasValue)
+            {
+                var prefix = string.Format(
+                    CultureInfo.InvariantCulture,
+                    titleNumber.Value >= 10 ? "VTS_{0}_" : "VTS_0{0}_",
+                    titleNumber.Value);
+                var vobs = allVobs.Where(i => i.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+
+                if (vobs.Count > 0)
+                {
+                    var minSizeVobs = vobs
+                        .SkipWhile(f => f.Length < MinPlayableSize)
+                        .ToList();
+
+                    return minSizeVobs.Count == 0 ? vobs.Select(i => i.FullName) : minSizeVobs.Select(i => i.FullName);
+                }
+
+                _logger.LogWarning("Could not determine vob file list for {Path} using DvdLib. Will scan using file sizes.", path);
+            }
+
+            var files = allVobs
+                .SkipWhile(f => f.Length < MinPlayableSize)
+                .ToList();
+
+            // If we didn't find any satisfying the min length, just take them all
+            if (files.Count == 0)
+            {
+                _logger.LogWarning("Vob size filter resulted in zero matches. Taking all vobs.");
+                files = allVobs;
+            }
+
+            // Assuming they're named "vts_05_01", take all files whose second part matches that of the first file
+            if (files.Count > 0)
+            {
+                var parts = _fileSystem.GetFileNameWithoutExtension(files[0]).Split('_');
+
+                if (parts.Length == 3)
+                {
+                    var title = parts[1];
+
+                    files = files.TakeWhile(f =>
+                    {
+                        var fileParts = _fileSystem.GetFileNameWithoutExtension(f).Split('_');
+
+                        return fileParts.Length == 3 && string.Equals(title, fileParts[1], StringComparison.OrdinalIgnoreCase);
+                    }).ToList();
+
+                    // If this resulted in not getting any vobs, just take them all
+                    if (files.Count == 0)
+                    {
+                        _logger.LogWarning("Vob filename filter resulted in zero matches. Taking all vobs.");
+                        files = allVobs;
+                    }
+                }
+            }
+
+            return files.Select(i => i.FullName);
+        }
+
         public bool CanExtractSubtitles(string codec)
         {
             // TODO is there ever a case when a subtitle can't be extracted??

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
     <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />
+    <ProjectReference Include="..\DvdLib\DvdLib.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DvdLib.Ifo;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -96,13 +96,13 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
 
                     var tmpItem = new Video
-                        {
-                            Path = streamFileNames.First()
-                        };
+                    {
+                        Path = streamFileNames.First()
+                    };
 
                     mediaInfoResult = await GetMediaInfo(tmpItem, cancellationToken).ConfigureAwait(false);
                 }
-                else if (item.VideoType == VideoType.BluRay)
+                else
                 {
                     mediaInfoResult = await GetMediaInfo(item, cancellationToken).ConfigureAwait(false);
                 }
@@ -600,10 +600,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
         private long GetRuntime(Title title)
         {
-            return title.ProgramChains
-                    .Select(i => (TimeSpan)i.PlaybackTime)
-                    .Select(i => i.Ticks)
-                    .Sum();
+            return title.ProgramChains.Sum(i => ((TimeSpan)i.PlaybackTime).Ticks);
         }
     }
 }


### PR DESCRIPTION
After further testing my conclusion mentioned in #9068 it seems like DVD folder playback did initially work in 10.6.x but was broken since.

DVD ISO playback also does not work as well as I expected, so to support DVDs at all, I reverted the DVDLib removal part of #9068.
Additionally I checked the code of DVDLib, rearranged it, added documentation and extended and fixed the parsing based on information avalable at https://web.archive.org/web/20190514224954/http://stnsoft.com/DVD/index.html

As long as your local files are fine (especially the runtime within VOBs) this changes allow proper probing and playback of DVD folders.

I suggest deprecating DVD ISO playback support if this is merged due to its unreliability with ffmpeg. Out of security concerns I'm against reintroducing mount permissions to Jellyfin just for being able to mount DVD ISOs to run the folder based scanner and transcoder on them.

**Changes**
* Partially revert #9068

**Issues**
Fixes #7786
Fixes #7065
