### PR TITLE
Add uniqueid tag to nfo

### DIFF
--- a/MediaBrowser.Model/Entities/MetadataProvider.cs
+++ b/MediaBrowser.Model/Entities/MetadataProvider.cs
@@ -84,6 +84,11 @@ namespace MediaBrowser.Model.Entities
         /// <summary>
         /// The TvMaze provider.
         /// </summary>
-        TvMaze = 19
+        TvMaze = 19,
+
+        /// <summary>
+        /// The Jellyfin provider.
+        /// </summary>
+        Jellyfin = 20
     }
 }

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -94,6 +94,8 @@ namespace MediaBrowser.XbmcMetadata.Savers
             "musicbrainzreleasegroupid",
             "tvdbid",
             "collectionitem",
+            "jellyfinid",
+            "uniqueid",
 
             "isuserfavorite",
             "userrating",
@@ -292,6 +294,11 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
+        protected virtual MetadataProvider? GetDefaultProvider()
+        {
+            return null;
+        }
+
         protected abstract void WriteCustomElements(BaseItem item, XmlWriter writer);
 
         public static void AddMediaInfo<T>(T item, XmlWriter writer)
@@ -437,6 +444,17 @@ namespace MediaBrowser.XbmcMetadata.Savers
         {
             var writtenProviderIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            var defaultProvider = GetDefaultProvider();
+
+            if (defaultProvider != null)
+            {
+                var defaultProviderId = item.GetProviderId((MetadataProvider)defaultProvider);
+                if (!string.IsNullOrEmpty(defaultProviderId))
+                {
+                    writer.WriteElementString("id", defaultProviderId);
+                }
+            }
+
             var overview = (item.Overview ?? string.Empty)
                 .StripHtml()
                 .Replace("&quot;", "'", StringComparison.Ordinal);
@@ -542,46 +560,17 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 writer.WriteElementString("aspectratio", hasAspectRatio.AspectRatio);
             }
 
-            var tmdbCollection = item.GetProviderId(MetadataProvider.TmdbCollection);
+            AddProviderId(writer, item, MetadataProvider.TmdbCollection, writtenProviderIds, "collectionnumber");
 
-            if (!string.IsNullOrEmpty(tmdbCollection))
+            var imdbTagName = "imdbid";
+            if (item is Series)
             {
-                writer.WriteElementString("collectionnumber", tmdbCollection);
-                writtenProviderIds.Add(MetadataProvider.TmdbCollection.ToString());
+                imdbTagName = "imdb_id";
             }
 
-            var imdb = item.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdb))
-            {
-                if (item is Series)
-                {
-                    writer.WriteElementString("imdb_id", imdb);
-                }
-                else
-                {
-                    writer.WriteElementString("imdbid", imdb);
-                }
-
-                writtenProviderIds.Add(MetadataProvider.Imdb.ToString());
-            }
-
-            // Series xml saver already saves this
-            if (item is not Series)
-            {
-                var tvdb = item.GetProviderId(MetadataProvider.Tvdb);
-                if (!string.IsNullOrEmpty(tvdb))
-                {
-                    writer.WriteElementString("tvdbid", tvdb);
-                    writtenProviderIds.Add(MetadataProvider.Tvdb.ToString());
-                }
-            }
-
-            var tmdb = item.GetProviderId(MetadataProvider.Tmdb);
-            if (!string.IsNullOrEmpty(tmdb))
-            {
-                writer.WriteElementString("tmdbid", tmdb);
-                writtenProviderIds.Add(MetadataProvider.Tmdb.ToString());
-            }
+            AddProviderIdAndUniqueId(writer, item, MetadataProvider.Imdb, writtenProviderIds, false, imdbTagName);
+            AddProviderIdAndUniqueId(writer, item, MetadataProvider.Tvdb, writtenProviderIds);
+            AddProviderIdAndUniqueId(writer, item, MetadataProvider.Tmdb, writtenProviderIds);
 
             if (!string.IsNullOrEmpty(item.PreferredMetadataLanguage))
             {
@@ -685,68 +674,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 }
             }
 
-            var externalId = item.GetProviderId(MetadataProvider.AudioDbArtist);
+            AddProviderId(writer, item, MetadataProvider.AudioDbArtist, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.AudioDbAlbum, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.Zap2It, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.MusicBrainzAlbum, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.MusicBrainzAlbumArtist, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.MusicBrainzArtist, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.MusicBrainzReleaseGroup, writtenProviderIds);
+            AddProviderId(writer, item, MetadataProvider.TvRage, writtenProviderIds);
 
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("audiodbartistid", externalId);
-                writtenProviderIds.Add(MetadataProvider.AudioDbArtist.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.AudioDbAlbum);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("audiodbalbumid", externalId);
-                writtenProviderIds.Add(MetadataProvider.AudioDbAlbum.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.Zap2It);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("zap2itid", externalId);
-                writtenProviderIds.Add(MetadataProvider.Zap2It.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.MusicBrainzAlbum);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("musicbrainzalbumid", externalId);
-                writtenProviderIds.Add(MetadataProvider.MusicBrainzAlbum.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.MusicBrainzAlbumArtist);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("musicbrainzalbumartistid", externalId);
-                writtenProviderIds.Add(MetadataProvider.MusicBrainzAlbumArtist.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.MusicBrainzArtist);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("musicbrainzartistid", externalId);
-                writtenProviderIds.Add(MetadataProvider.MusicBrainzArtist.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.MusicBrainzReleaseGroup);
-
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("musicbrainzreleasegroupid", externalId);
-                writtenProviderIds.Add(MetadataProvider.MusicBrainzReleaseGroup.ToString());
-            }
-
-            externalId = item.GetProviderId(MetadataProvider.TvRage);
-            if (!string.IsNullOrEmpty(externalId))
-            {
-                writer.WriteElementString("tvrageid", externalId);
-                writtenProviderIds.Add(MetadataProvider.TvRage.ToString());
-            }
+            AddProviderIdAndUniqueId(writer, item, MetadataProvider.Jellyfin, writtenProviderIds, true, null, item.Id.ToString("N", CultureInfo.InvariantCulture));
 
             if (item.ProviderIds is not null)
             {
@@ -762,7 +699,10 @@ namespace MediaBrowser.XbmcMetadata.Savers
                             XmlConvert.VerifyName(tagName);
                             Logger.LogDebug("Saving custom provider tagname {0}", tagName);
 
-                            writer.WriteElementString(GetTagForProviderKey(providerKey), providerId);
+                            writer.WriteElementString(tagName, providerId);
+
+                            var typeName = GetUniqueIdTypeForProviderKey(providerKey);
+                            AddUniqueId(writer, item, typeName, providerId, IsDefaultProvider(providerKey));
                         }
                         catch (ArgumentException)
                         {
@@ -789,6 +729,56 @@ namespace MediaBrowser.XbmcMetadata.Savers
             {
                 AddCollectionItems(folder, writer);
             }
+        }
+
+        private void AddProviderIdAndUniqueId(XmlWriter writer, BaseItem item, MetadataProvider provider, HashSet<string> writtenProviderIds, bool isDefault = false, string? tagName = null, string? externalId = null)
+        {
+            AddProviderIdImpl(writer, item, provider, writtenProviderIds, true, isDefault, tagName, externalId);
+        }
+
+        private void AddProviderId(XmlWriter writer, BaseItem item, MetadataProvider provider, HashSet<string> writtenProviderIds, string? tagName = null, string? externalId = null)
+        {
+            AddProviderIdImpl(writer, item, provider, writtenProviderIds, false, false, tagName, externalId);
+        }
+
+        private void AddProviderIdImpl(XmlWriter writer, BaseItem item, MetadataProvider provider, HashSet<string> writtenProviderIds, bool addUniqueId, bool isDefault, string? tagName = null, string? externalId = null)
+        {
+            if (string.IsNullOrEmpty(externalId))
+            {
+                externalId = item.GetProviderId(provider);
+            }
+
+            if (!string.IsNullOrEmpty(externalId))
+            {
+                var providerKey = provider.ToString();
+
+                if (tagName is null)
+                {
+                    tagName = GetTagForProviderKey(providerKey);
+                }
+
+                writer.WriteElementString(tagName, externalId);
+                writtenProviderIds.Add(providerKey);
+
+                if (addUniqueId)
+                {
+                    AddUniqueId(writer, item, GetUniqueIdTypeForProviderKey(providerKey), externalId, isDefault);
+                }
+            }
+        }
+
+        private void AddUniqueId(XmlWriter writer, BaseItem item, string providerTypeName, string externalId, bool isDefault)
+        {
+            writer.WriteStartElement("uniqueid");
+            writer.WriteAttributeString("type", providerTypeName);
+
+            if (isDefault)
+            {
+                writer.WriteAttributeString("default", "true");
+            }
+
+            writer.WriteString(externalId);
+            writer.WriteEndElement();
         }
 
         private void AddCollectionItems(Folder item, XmlWriter writer)
@@ -1026,5 +1016,31 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private string GetTagForProviderKey(string providerKey)
             => providerKey.ToLowerInvariant() + "id";
+
+        private string GetUniqueIdTypeForProviderKey(string providerKey)
+            => providerKey.ToLowerInvariant();
+
+        private bool IsDefaultProvider(string providerKey)
+        {
+            var defaultProvider = GetDefaultProvider();
+            if (defaultProvider != null)
+            {
+                var defaultProviderKey = defaultProvider.ToString();
+                return providerKey.Equals(defaultProviderKey, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        private bool IsDefaultProvider(MetadataProvider provider)
+        {
+            var defaultProvider = GetDefaultProvider();
+            if (defaultProvider != null)
+            {
+                return provider == defaultProvider;
+            }
+
+            return false;
+        }
     }
 }

--- a/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
@@ -6,6 +6,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
 using MediaBrowser.XbmcMetadata.Configuration;
 using Microsoft.Extensions.Logging;
@@ -48,6 +49,12 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <inheritdoc />
         public override bool IsEnabledFor(BaseItem item, ItemUpdateType updateType)
             => item.SupportsLocalMetadata && item is Episode && updateType >= MinimumUpdateType;
+
+         /// <inheritdoc />
+        protected override MetadataProvider? GetDefaultProvider()
+        {
+            return MetadataProvider.Tvdb;
+        }
 
         /// <inheritdoc />
         protected override void WriteCustomElements(BaseItem item, XmlWriter writer)

--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -90,16 +90,15 @@ namespace MediaBrowser.XbmcMetadata.Savers
             return false;
         }
 
+         /// <inheritdoc />
+        protected override MetadataProvider? GetDefaultProvider()
+        {
+            return MetadataProvider.Imdb;
+        }
+
         /// <inheritdoc />
         protected override void WriteCustomElements(BaseItem item, XmlWriter writer)
         {
-            var imdb = item.GetProviderId(MetadataProvider.Imdb);
-
-            if (!string.IsNullOrEmpty(imdb))
-            {
-                writer.WriteElementString("id", imdb);
-            }
-
             if (item is MusicVideo musicVideo)
             {
                 foreach (var artist in musicVideo.Artists)

--- a/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
@@ -49,6 +49,12 @@ namespace MediaBrowser.XbmcMetadata.Savers
         public override bool IsEnabledFor(BaseItem item, ItemUpdateType updateType)
             => item.SupportsLocalMetadata && item is Series && updateType >= MinimumUpdateType;
 
+         /// <inheritdoc />
+        protected override MetadataProvider? GetDefaultProvider()
+        {
+            return MetadataProvider.Tvdb;
+        }
+
         /// <inheritdoc />
         protected override void WriteCustomElements(BaseItem item, XmlWriter writer)
         {
@@ -58,8 +64,6 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
             if (!string.IsNullOrEmpty(tvdb))
             {
-                writer.WriteElementString("id", tvdb);
-
                 writer.WriteStartElement("episodeguide");
 
                 var language = item.GetPreferredMetadataLanguage();


### PR DESCRIPTION
This adds `<uniqueid>` to nfo files, which is required per Kodi's wiki, reference: [tv shows](https://kodi.wiki/view/NFO_files/TV_shows), [episodes](https://kodi.wiki/view/NFO_files/Episodes), [movies](https://kodi.wiki/view/NFO_files/Movies).

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
1) Adds `<uniqueid>` to nfo.
2) Adds jellyfin as a provider (and thus, a `uniqueid`) since it is a metadata provider. This change allows kodi plugins, sources, etc. to map kodi DB ids to jellyfin ids without having to do error prone title lookups.
3) Use DRY when adding provider ids.

