### PR TITLE
Specify required movflags when encoding M4A audio

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,6 +58,7 @@
  - [HelloWorld017](https://github.com/HelloWorld017)
  - [ikomhoog](https://github.com/ikomhoog)
  - [jftuga](https://github.com/jftuga)
+ - [jmshrv](https://github.com/jmshrv)
  - [joern-h](https://github.com/joern-h)
  - [joshuaboniface](https://github.com/joshuaboniface)
  - [JustAMan](https://github.com/JustAMan)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5788,7 +5788,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Copy the movflags from GetProgressiveVideoFullCommandLine
             // See #9248 and the associated PR for why this is needed
-            var mp4ContainerNames = new HashSet<String> {
+            var mp4ContainerNames = new HashSet<String>
+            {
                 "mp4",
                 "m4a",
                 "m4p",

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5788,7 +5788,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Copy the movflags from GetProgressiveVideoFullCommandLine
             // See #9248 and the associated PR for why this is needed
-            var mp4ContainerNames = new HashSet<String>
+            var mp4ContainerNames = new HashSet<string>
             {
                 "mp4",
                 "m4a",

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5787,7 +5787,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             // Copy the movflags from GetProgressiveVideoFullCommandLine
-            // See # for explanation on why this is needed
+            // See #9248 and the associated PR for why this is needed
             var mp4ContainerNames = new HashSet<String> {
                 "mp4",
                 "m4a",

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5786,6 +5786,22 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
             }
 
+            // Copy the movflags from GetProgressiveVideoFullCommandLine
+            // See # for explanation on why this is needed
+            var mp4ContainerNames = new HashSet<String> {
+                "mp4",
+                "m4a",
+                "m4p",
+                "m4b",
+                "m4r",
+                "m4v",
+            };
+
+            if (mp4ContainerNames.Contains(state.OutputContainer.ToLower()))
+            {
+                audioTranscodeParams.Add("-movflags frag_keyframe+empty_moov+delay_moov");
+            }
+
             var threads = GetNumberOfThreads(state, encodingOptions, null);
 
             var inputModifier = GetInputModifier(state, encodingOptions, null);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -61,6 +61,16 @@ namespace MediaBrowser.Controller.MediaEncoding
             "Main10"
         };
 
+        private static readonly HashSet<string> _mp4ContainerNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "mp4",
+            "m4a",
+            "m4p",
+            "m4b",
+            "m4r",
+            "m4v",
+        };
+
         public EncodingHelper(
             IApplicationPaths appPaths,
             IMediaEncoder mediaEncoder,
@@ -5788,17 +5798,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Copy the movflags from GetProgressiveVideoFullCommandLine
             // See #9248 and the associated PR for why this is needed
-            var mp4ContainerNames = new HashSet<string>
-            {
-                "mp4",
-                "m4a",
-                "m4p",
-                "m4b",
-                "m4r",
-                "m4v",
-            };
-
-            if (mp4ContainerNames.Contains(state.OutputContainer.ToLower()))
+            if (_mp4ContainerNames.Contains(state.OutputContainer))
             {
                 audioTranscodeParams.Add("-movflags empty_moov+delay_moov");
             }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5581,7 +5581,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 && state.BaseRequest.Context == EncodingContext.Streaming)
             {
                 // Comparison: https://github.com/jansmolders86/mediacenterjs/blob/master/lib/transcoding/desktop.js
-                format = " -f mp4 -movflags empty_moov+delay_moov";
+                format = " -f mp4 -movflags frag_keyframe+empty_moov+delay_moov";
             }
 
             var threads = GetNumberOfThreads(state, encodingOptions, videoCodec);
@@ -5800,7 +5800,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (mp4ContainerNames.Contains(state.OutputContainer.ToLower()))
             {
-                audioTranscodeParams.Add("-movflags frag_keyframe+empty_moov+delay_moov");
+                audioTranscodeParams.Add("-movflags empty_moov+delay_moov");
             }
 
             var threads = GetNumberOfThreads(state, encodingOptions, null);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5581,7 +5581,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 && state.BaseRequest.Context == EncodingContext.Streaming)
             {
                 // Comparison: https://github.com/jansmolders86/mediacenterjs/blob/master/lib/transcoding/desktop.js
-                format = " -f mp4 -movflags frag_keyframe+empty_moov+delay_moov";
+                format = " -f mp4 -movflags empty_moov+delay_moov";
             }
 
             var threads = GetNumberOfThreads(state, encodingOptions, videoCodec);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
When the output container is [any valid MP4 extension](https://en.wikipedia.org/wiki/MP4_file_format#Filename_extensions), specify the same movflags that are also used in `GetProgressiveVideoAudioArguments`. I'm not 100% sure on the specifics, but this correctly returns an identical file to the one created in `/config/transcodes`.

(same as in the issue, `test` is what is returned from the API, `jellyfin` is what Jellyfin creates in `/config/transcodes`.

```
james@JamesPC-Linux ~/D/JellyfinExamples> sha256sum test-moov-fix.m4a jellyfin-moov-fix.m4a 
56059204973c1b52a3b1516ced84c52cd9a1204a4ef12352328a2ec77071ca64  test-moov-fix.m4a
56059204973c1b52a3b1516ced84c52cd9a1204a4ef12352328a2ec77071ca64  jellyfin-moov-fix.m4a
```

As expected, `test-moov-fix.m4a` can now be played correctly.

It may be worth using this implementation in `GetProgressiveVideoAudioArguments`, as it looks like requesting a `.m4v` file would not add the required flags.

Also, I've actually followed the [contributing guidelines](https://jellyfin.org/docs/general/contributing/development/) this time :upside_down_face: 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #9248