### PR TITLE
fix: swap to `jellyfin-ffmpeg5`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
  && apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y \
    mesa-va-drivers \
-   jellyfin-ffmpeg \
+   jellyfin-ffmpeg5 \
    openssl \
    locales \
 # Intel VAAPI Tone mapping dependencies:


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Swaps to building the Dockerfile with `jellyfin-ffmpeg5`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->


**Landmines**
Not sure about the state of arm support of JF-FFMPEG but might be worth a quick look if we update this on the amd64 build :)