### PR TITLE
fix: skip library folders that are inaccessible or empty

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.IO;
@@ -675,7 +676,15 @@ namespace Emby.Server.Implementations.IO
         /// <inheritdoc />
         public virtual IEnumerable<string> GetFileSystemEntryPaths(string path, bool recursive = false)
         {
-            return Directory.EnumerateFileSystemEntries(path, "*", GetEnumerationOptions(recursive));
+            try
+            {
+                return Directory.EnumerateFileSystemEntries(path, "*", GetEnumerationOptions(recursive));
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or DirectoryNotFoundException or SecurityException)
+            {
+                _logger.LogError(ex, "Failed to enumerate path {Path}", path);
+                return Enumerable.Empty<string>();
+            }
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -440,7 +440,6 @@ namespace MediaBrowser.Controller.Entities
                     }
                 }
 
-                // If any items were added or removed....
                 if (newItems.Count > 0)
                 {
                     LibraryManager.CreateItems(newItems, this, cancellationToken);

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -78,5 +78,10 @@ namespace MediaBrowser.Controller.Providers
 
             return filePaths;
         }
+
+        public bool IsAccessible(string path)
+        {
+            return _fileSystem.GetFileSystemEntryPaths(path).Any();
+        }
     }
 }

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -16,5 +16,7 @@ namespace MediaBrowser.Controller.Providers
         IReadOnlyList<string> GetFilePaths(string path);
 
         IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);
+
+        bool IsAccessible(string path);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Skip `Folder` where `IsTopParent == true` if the filesystem path is inaccessible or empty
- Don't remove anything when `IsRoot` is true (AggregateFolder and UserRootFolder will have this condition and they directly point to library folders)

I have only tested it on Windows with SMB mount and an empty folder. It needs to be tested more, especially Linux network shares, symlinks etc.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
