### PR TITLE
LiveTV fixes

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -5440,6 +5440,9 @@ AND Type = @InternalPersonType)");
 
             list.AddRange(inheritedTags.Select(i => (6, i)));
 
+            // Remove all invalid values.
+            list.RemoveAll(i => string.IsNullOrEmpty(i.Item2));
+
             return list;
         }
 

--- a/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/XmlTvListingsProvider.cs
@@ -137,32 +137,33 @@ namespace Emby.Server.Implementations.LiveTv.Listings
 
         private static ProgramInfo GetProgramInfo(XmlTvProgram program, ListingsProviderInfo info)
         {
-            string episodeTitle = program.Episode?.Title;
+            string episodeTitle = program.Episode.Title;
+            var programCategories = program.Categories.Where(c => !string.IsNullOrWhiteSpace(c)).ToList();
 
             var programInfo = new ProgramInfo
             {
                 ChannelId = program.ChannelId,
                 EndDate = program.EndDate.UtcDateTime,
-                EpisodeNumber = program.Episode?.Episode,
+                EpisodeNumber = program.Episode.Episode,
                 EpisodeTitle = episodeTitle,
-                Genres = program.Categories,
+                Genres = programCategories,
                 StartDate = program.StartDate.UtcDateTime,
                 Name = program.Title,
                 Overview = program.Description,
                 ProductionYear = program.CopyrightDate?.Year,
-                SeasonNumber = program.Episode?.Series,
-                IsSeries = program.Episode is not null,
+                SeasonNumber = program.Episode.Series,
+                IsSeries = program.Episode.Series is not null,
                 IsRepeat = program.IsPreviouslyShown && !program.IsNew,
                 IsPremiere = program.Premiere is not null,
-                IsKids = program.Categories.Any(c => info.KidsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
-                IsMovie = program.Categories.Any(c => info.MovieCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
-                IsNews = program.Categories.Any(c => info.NewsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
-                IsSports = program.Categories.Any(c => info.SportsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
+                IsKids = programCategories.Any(c => info.KidsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
+                IsMovie = programCategories.Any(c => info.MovieCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
+                IsNews = programCategories.Any(c => info.NewsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
+                IsSports = programCategories.Any(c => info.SportsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
                 ImageUrl = string.IsNullOrEmpty(program.Icon?.Source) ? null : program.Icon.Source,
                 HasImage = !string.IsNullOrEmpty(program.Icon?.Source),
                 OfficialRating = string.IsNullOrEmpty(program.Rating?.Value) ? null : program.Rating.Value,
                 CommunityRating = program.StarRating,
-                SeriesId = program.Episode is null ? null : program.Title?.GetMD5().ToString("N", CultureInfo.InvariantCulture)
+                SeriesId = program.Episode.Episode is null ? null : program.Title?.GetMD5().ToString("N", CultureInfo.InvariantCulture)
             };
 
             if (string.IsNullOrWhiteSpace(program.ProgramId))
@@ -243,7 +244,7 @@ namespace Emby.Server.Implementations.LiveTv.Listings
             {
                 Id = c.Id,
                 Name = c.DisplayName,
-                ImageUrl = string.IsNullOrEmpty(c.Icon.Source) ? null : c.Icon.Source,
+                ImageUrl = string.IsNullOrEmpty(c.Icon?.Source) ? null : c.Icon.Source,
                 Number = string.IsNullOrWhiteSpace(c.Number) ? c.Id : c.Number
             }).ToList();
         }

--- a/tests/Jellyfin.Server.Implementations.Tests/LiveTv/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/LiveTv/Listings/XmlTvListingsProviderTests.cs
@@ -67,4 +67,23 @@ public class XmlTvListingsProviderTests
         Assert.Equal("https://domain.tld/image.png", program.ImageUrl);
         Assert.Equal("3297", program.ChannelId);
     }
+
+    [Theory]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/emptycategory.xml")]
+    [InlineData("https://example.com/emptycategory.xml")]
+    public async Task GetProgramsAsync_EmptyCategories_Success(string path)
+    {
+        var info = new ListingsProviderInfo()
+        {
+            Path = path
+        };
+
+        var startDate = new DateTime(2022, 11, 4);
+        var programs = await _xmlTvListingsProvider.GetProgramsAsync(info, "3297", startDate, startDate.AddDays(1), CancellationToken.None);
+        var programsList = programs.ToList();
+        Assert.Single(programsList);
+        var program = programsList[0];
+        Assert.DoesNotContain(program.Genres, g => string.Equals(g, string.Empty, StringComparison.Ordinal));
+        Assert.Equal("3297", program.ChannelId);
+    }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Test Data/LiveTv/Listings/XmlTv/emptycategory.xml
+++ b/tests/Jellyfin.Server.Implementations.Tests/Test Data/LiveTv/Listings/XmlTv/emptycategory.xml
@@ -1,0 +1,6 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 -0400" stop="20221105235959 -0400">
+    <category lang="en" />
+    <category lang="en">sports</category>
+  </programme>
+</tv>


### PR DESCRIPTION
- Filter out empty categories
- Filter out empty item values

The following exception is thrown in `InsertItemValues` if `values` contains an empty string.
```
[2023-02-11 07:13:16.900 -07:00] [ERR] [22] Emby.Server.Implementations.LiveTv.LiveTvManager: Error getting programs for channel "ABC EAST"
Constraint: SQLitePCL.pretty.SQLiteException: NOT NULL constraint failed: ItemValues.Type
   at SQLitePCL.pretty.SQLiteException.Throw(Int32 rc, Int32 extended, String msg)
   at SQLitePCL.pretty.SQLiteException.CheckOk(sqlite3 db, Int32 rc)
   at SQLitePCL.pretty.SQLiteException.CheckOk(sqlite3_stmt stmt, Int32 rc)
   at SQLitePCL.pretty.StatementImpl.MoveNext()
   at Emby.Server.Implementations.Data.SqliteItemRepository.InsertItemValues(Byte[] idBlob, List`1 values, IDatabaseConnection db) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 5511
   at Emby.Server.Implementations.Data.SqliteItemRepository.UpdateItemValues(Guid itemId, List`1 values, IDatabaseConnection db) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 5462
   at Emby.Server.Implementations.Data.SqliteItemRepository.SaveItemsInTransaction(IDatabaseConnection db, IEnumerable`1 tuples) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 655
   at Emby.Server.Implementations.Data.SqliteItemRepository.<>c__DisplayClass34_0.<SaveItems>b__0(IDatabaseConnection db) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 617
   at SQLitePCL.pretty.DatabaseConnection.<>c__DisplayClass20_0.<RunInTransaction>b__0(IDatabaseConnection db)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction[T](IDatabaseConnection This, Func`2 f, TransactionMode mode)
   at SQLitePCL.pretty.DatabaseConnection.RunInTransaction(IDatabaseConnection This, Action`1 action, TransactionMode mode)
   at Emby.Server.Implementations.Data.ManagedConnection.RunInTransaction(Action`1 action, TransactionMode mode) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\ManagedConnection.cs:line 51
   at Emby.Server.Implementations.Data.SqliteItemRepository.SaveItems(IEnumerable`1 items, CancellationToken cancellationToken) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Data\SqliteItemRepository.cs:line 614
   at Emby.Server.Implementations.Library.LibraryManager.CreateItems(IReadOnlyList`1 items, BaseItem parent, CancellationToken cancellationToken) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 1770
   at Emby.Server.Implementations.LiveTv.LiveTvManager.RefreshChannelsInternal(ILiveTvService service, IProgress`1 progress, CancellationToken cancellationToken) in C:\Users\Cody\Documents\Code\jellyfin\Emby.Server.Implementations\LiveTv\LiveTvManager.cs:line 1210
```