### PR TITLE
Fix locked item metadata updates

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -334,6 +334,12 @@ namespace MediaBrowser.Providers.Manager
                 updateType |= UpdateCumulativeRunTimeTicks(item, children);
                 updateType |= UpdateDateLastMediaAdded(item, children);
 
+                // don't update user-changeable metadata for locked items
+                if (item.IsLocked)
+                {
+                    return updateType;
+                }
+
                 if (EnableUpdatingPremiereDateFromChildren)
                 {
                     updateType |= UpdatePremiereDate(item, children);

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -381,7 +381,7 @@ namespace MediaBrowser.Providers.Manager
                 if (!folder.RunTimeTicks.HasValue || folder.RunTimeTicks.Value != ticks)
                 {
                     folder.RunTimeTicks = ticks;
-                    return ItemUpdateType.MetadataEdit;
+                    return ItemUpdateType.MetadataImport;
                 }
             }
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -105,7 +105,10 @@ namespace MediaBrowser.Providers.MediaInfo
             audio.RunTimeTicks = mediaInfo.RunTimeTicks;
             audio.Size = mediaInfo.Size;
 
-            FetchDataFromTags(audio);
+            if (!audio.IsLocked)
+            {
+                FetchDataFromTags(audio);
+            }
 
             _itemRepo.SaveMediaStreams(audio.Id, mediaInfo.MediaStreams, cancellationToken);
         }

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -54,6 +54,12 @@ namespace MediaBrowser.Providers.Music
         {
             var updateType = base.UpdateMetadataFromChildren(item, children, isFullRefresh, currentUpdateType);
 
+            // don't update user-changeable metadata for locked items
+            if (item.IsLocked)
+            {
+                return updateType;
+            }
+
             if (isFullRefresh || currentUpdateType > ItemUpdateType.None)
             {
                 if (!item.LockedFields.Contains(MetadataField.Name))


### PR DESCRIPTION
**Changes**
- Fix a couple cases where metadata could be updated on locked items
- Change `ItemUpdateType` for `RunTimeTicks` updating to `MetadataImport` to be consistent with other file attribute updates

**Issues**
Fixes #8888
