### PR TITLE
Fix NRE in DisposeAsyncCore

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -1184,10 +1184,13 @@ namespace Emby.Server.Implementations
                 }
             }
 
-            // used for closing websockets
-            foreach (var session in _sessionManager.Sessions)
+            if (_sessionManager != null)
             {
-                await session.DisposeAsync().ConfigureAwait(false);
+                // used for closing websockets
+                foreach (var session in _sessionManager.Sessions)
+                {
+                    await session.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Fixes NRE in DisposeAsyncCore when _sessionManager is null (appears to be possible, happens when a broken plugin prevents startup)

```
An unhandled exception of type 'System.NullReferenceException' occurred in System.Private.CoreLib.dll: 'Object reference not set to an instance of an object.'
   at Emby.Server.Implementations.ApplicationHost.<DisposeAsyncCore>d__126.MoveNext() in /home/mbr/Desktop/projects/jellfyin/new-develop/jellyfin/Emby.Server.Implementations/ApplicationHost.cs:line 1190
   at Emby.Server.Implementations.ApplicationHost.<DisposeAsync>d__125.MoveNext() in /home/mbr/Desktop/projects/jellfyin/new-develop/jellyfin/Emby.Server.Implementations/ApplicationHost.cs:line 1152
   at Jellyfin.Server.Program.<StartServer>d__11.MoveNext() in /home/mbr/Desktop/projects/jellfyin/new-develop/jellyfin/Jellyfin.Server/Program.cs:line 260
   at Jellyfin.Server.Program.<StartApp>d__10.MoveNext() in /home/mbr/Desktop/projects/jellfyin/new-develop/jellyfin/Jellyfin.Server/Program.cs:line 177
   at Jellyfin.Server.Program.<Main>(String[] args)
```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None
