### PR TITLE
Require userId for NextUp endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -72,7 +72,7 @@ public class TvShowsController : BaseJellyfinApiController
     [HttpGet("NextUp")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<QueryResult<BaseItemDto>> GetNextUp(
-        [FromQuery] Guid? userId,
+        [FromQuery, Required] Guid userId,
         [FromQuery] int? startIndex,
         [FromQuery] int? limit,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
@@ -98,7 +98,7 @@ public class TvShowsController : BaseJellyfinApiController
                 ParentId = parentId,
                 SeriesId = seriesId,
                 StartIndex = startIndex,
-                UserId = userId ?? Guid.Empty,
+                UserId = userId,
                 EnableTotalRecordCount = enableTotalRecordCount,
                 DisableFirstEpisode = disableFirstEpisode,
                 NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue,
@@ -106,9 +106,9 @@ public class TvShowsController : BaseJellyfinApiController
             },
             options);
 
-        var user = userId is null || userId.Value.Equals(default)
+        var user = userId.Equals(default)
             ? null
-            : _userManager.GetUserById(userId.Value);
+            : _userManager.GetUserById(userId);
 
         var returnItems = _dtoService.GetBaseItemDtos(result.Items, options, user);
 


### PR DESCRIPTION
```
[18:35:14] [ERR] [58] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /Shows/NextUp.
System.ArgumentException: Guid can't be empty (Parameter 'id')
   at Jellyfin.Server.Implementations.Users.UserManager.GetUserById(Guid id) in /home/bond/dev/jellyfin/Jellyfin.Server.Implementations/Users/UserManager.cs:line 113
   at Emby.Server.Implementations.TV.TVSeriesManager.GetNextUp(NextUpQuery query, DtoOptions options) in /home/bond/dev/jellyfin/Emby.Server.Implementations/TV/TVSeriesManager.cs:line 38
   at Jellyfin.Api.Controllers.TvShowsController.GetNextUp(Nullable`1 userId, Nullable`1 startIndex, Nullable`1 limit, ItemFields[] fields, Nullable`1 seriesId, Nullable`1 parentId, Nullable`1 enableImages, Nullable`1 imageTypeLimit, ImageType[] enableImageTypes, Nullable`1 enableUserData, Nullable`1 nextUpDateCutoff, Boolean enableTotalRecordCount, Boolean disableFirstEpisode, Boolean enableRewatching) in /home/bond/dev/jellyfin/Jellyfin.Api/Controllers/TvShowsController.cs:line 94
   at lambda_method957(Closure, Object, Object[])
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeActionMethodAsync()
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeNextActionFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Jellyfin.Api.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/ServerStartupMessageMiddleware.cs:line 49
   at Jellyfin.Api.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/WebSocketHandlerMiddleware.cs:line 38
   at Jellyfin.Api.Middleware.IpBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/IpBasedAccessValidationMiddleware.cs:line 48
   at Jellyfin.Api.Middleware.LanFilteringMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/LanFilteringMiddleware.cs:line 48
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/QueryStringDecodingMiddleware.cs:line 37
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/RobotsRedirectionMiddleware.cs:line 45
   at Jellyfin.Api.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/LegacyEmbyRouteRewriteMiddleware.cs:line 52
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Jellyfin.Api.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context, IServerConfigurationManager serverConfigurationManager) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/ResponseTimeMiddleware.cs:line 67
   at Jellyfin.Api.Middleware.ExceptionMiddleware.Invoke(HttpContext context) in /home/bond/dev/jellyfin/Jellyfin.Api/Middleware/ExceptionMiddleware.cs:line 101

```