### PR TITLE
Fix MusicBrainz default server

### DIFF
--- a/MediaBrowser.Providers/Plugins/MusicBrainz/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/Configuration/PluginConfiguration.cs
@@ -8,7 +8,7 @@ namespace MediaBrowser.Providers.Plugins.MusicBrainz.Configuration;
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
-    private const string DefaultServer = "musicbrainz.org";
+    private const string DefaultServer = "https://musicbrainz.org";
 
     private const double DefaultRateLimit = 1.0;
 


### PR DESCRIPTION
I forgot to add back the protocol here too which broke URL generation for external IDs. This should fix it.