### PR TITLE
Fix EqualsAny condition check for int and double

### DIFF
--- a/MediaBrowser.Model/Dlna/ConditionProcessor.cs
+++ b/MediaBrowser.Model/Dlna/ConditionProcessor.cs
@@ -136,12 +136,26 @@ namespace MediaBrowser.Model.Dlna
                 return !condition.IsRequired;
             }
 
+            var conditionType = condition.Condition;
+            if (condition.Condition == ProfileConditionType.EqualsAny)
+            {
+                foreach (var singleConditionString in condition.Value.AsSpan().Split('|'))
+                {
+                    if (int.TryParse(singleConditionString, NumberStyles.Any, CultureInfo.InvariantCulture, out int conditionValue)
+                        && conditionValue.Equals(currentValue))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             if (int.TryParse(condition.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var expected))
             {
-                switch (condition.Condition)
+                switch (conditionType)
                 {
                     case ProfileConditionType.Equals:
-                    case ProfileConditionType.EqualsAny:
                         return currentValue.Value.Equals(expected);
                     case ProfileConditionType.GreaterThanEqual:
                         return currentValue.Value >= expected;
@@ -212,9 +226,24 @@ namespace MediaBrowser.Model.Dlna
                 return !condition.IsRequired;
             }
 
+            var conditionType = condition.Condition;
+            if (condition.Condition == ProfileConditionType.EqualsAny)
+            {
+                foreach (var singleConditionString in condition.Value.AsSpan().Split('|'))
+                {
+                    if (double.TryParse(singleConditionString, NumberStyles.Any, CultureInfo.InvariantCulture, out double conditionValue)
+                        && conditionValue.Equals(currentValue))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             if (double.TryParse(condition.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var expected))
             {
-                switch (condition.Condition)
+                switch (conditionType)
                 {
                     case ProfileConditionType.Equals:
                         return currentValue.Value.Equals(expected);

--- a/MediaBrowser.Model/Dlna/ConditionProcessor.cs
+++ b/MediaBrowser.Model/Dlna/ConditionProcessor.cs
@@ -141,7 +141,7 @@ namespace MediaBrowser.Model.Dlna
             {
                 foreach (var singleConditionString in condition.Value.AsSpan().Split('|'))
                 {
-                    if (int.TryParse(singleConditionString, NumberStyles.Any, CultureInfo.InvariantCulture, out int conditionValue)
+                    if (int.TryParse(singleConditionString, NumberStyles.Integer, CultureInfo.InvariantCulture, out int conditionValue)
                         && conditionValue.Equals(currentValue))
                     {
                         return true;
@@ -151,7 +151,7 @@ namespace MediaBrowser.Model.Dlna
                 return false;
             }
 
-            if (int.TryParse(condition.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var expected))
+            if (int.TryParse(condition.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var expected))
             {
                 switch (conditionType)
                 {
@@ -231,7 +231,7 @@ namespace MediaBrowser.Model.Dlna
             {
                 foreach (var singleConditionString in condition.Value.AsSpan().Split('|'))
                 {
-                    if (double.TryParse(singleConditionString, NumberStyles.Any, CultureInfo.InvariantCulture, out double conditionValue)
+                    if (double.TryParse(singleConditionString, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double conditionValue)
                         && conditionValue.Equals(currentValue))
                     {
                         return true;
@@ -241,7 +241,7 @@ namespace MediaBrowser.Model.Dlna
                 return false;
             }
 
-            if (double.TryParse(condition.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var expected))
+            if (double.TryParse(condition.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var expected))
             {
                 switch (conditionType)
                 {


### PR DESCRIPTION
Currently `EqualsAny` is not implemented for `double` and the implementation for `int` does not work as it should (see #9350)

**Changes**
Split the conditional string value, parse the substrings into a int/double and check if one of them is equal to the current value.

**Issues**
Fixes #9350