### PR TITLE
Fix auth endpoints using api key

### DIFF
--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
@@ -46,6 +46,13 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
                 return Task.CompletedTask;
             }
 
+            if (isApiKey)
+            {
+                // Api keys are unrestricted.
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+
             var isInLocalNetwork = _httpContextAccessor.HttpContext is not null
                                    && _networkManager.IsInLocalNetwork(_httpContextAccessor.HttpContext.GetNormalizedRemoteIp());
             var user = _userManager.GetUserById(userId);
@@ -62,7 +69,7 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
             }
 
             // Admins can do everything
-            if (isApiKey || context.User.IsInRole(UserRoles.Administrator))
+            if (context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;

--- a/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
@@ -1,9 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
 using Jellyfin.Server.Implementations.Security;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
@@ -46,6 +50,32 @@ namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
                 userRole);
 
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task ShouldSucceedOnApiKey()
+        {
+            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
+
+            _httpContextAccessor
+                .Setup(h => h.HttpContext!.Connection.RemoteIpAddress)
+                .Returns(new IPAddress(0));
+
+            _userManagerMock
+                .Setup(u => u.GetUserById(It.IsAny<Guid>()))
+                .Returns<User>(null);
+
+            var claims = new[]
+            {
+                new Claim(InternalClaimTypes.IsApiKey, bool.TrueString)
+            };
+
+            var identity = new ClaimsIdentity(claims, string.Empty);
+            var principal = new ClaimsPrincipal(identity);
+            var context = new AuthorizationHandlerContext(_requirements, principal, null);
 
             await _sut.HandleAsync(context);
             Assert.True(context.HasSucceeded);


### PR DESCRIPTION
### Changes:
Api keys aren't tied to a user so succeed the requirement before checking for user permissions.

Fixes the following exception:
```
[20:13:22] [ERR] [143] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /Library/VirtualFolders.
System.ArgumentException: Guid can't be empty (Parameter 'id')
   at Jellyfin.Server.Implementations.Users.UserManager.GetUserById(Guid id)
   at Jellyfin.Api.Auth.DefaultAuthorizationPolicy.DefaultAuthorizationHandler.HandleRequirementAsync(AuthorizationHandlerContext context, DefaultAuthorizationRequirement requirement)
   at Microsoft.AspNetCore.Authorization.AuthorizationHandler`1.HandleAsync(AuthorizationHandlerContext context)
   at Microsoft.AspNetCore.Authorization.DefaultAuthorizationService.AuthorizeAsync(ClaimsPrincipal user, Object resource, IEnumerable`1 requirements)
   at Microsoft.AspNetCore.Authorization.Policy.PolicyEvaluator.AuthorizeAsync(AuthorizationPolicy policy, AuthenticateResult authenticationResult, HttpContext context, Object resource)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext)
   at Jellyfin.Api.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Jellyfin.Api.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context, IServerConfigurationManager serverConfigurationManager)
   at Jellyfin.Api.Middleware.ExceptionMiddleware.Invoke(HttpContext context)
```