### PR TITLE
Add config option to disable dummy chapter generation

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -243,16 +243,10 @@ namespace MediaBrowser.Model.Configuration
         public bool AllowClientLogUpload { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the dummy chapters duration in seconds.
+        /// Gets or sets the dummy chapter duration in seconds, use 0 (zero) or less to disable generation alltogether.
         /// </summary>
         /// <value>The dummy chapters duration.</value>
-        public int DummyChapterDuration { get; set; } = 300;
-
-        /// <summary>
-        /// Gets or sets the dummy chapter count.
-        /// </summary>
-        /// <value>The dummy chapter count.</value>
-        public int DummyChapterCount { get; set; } = 100;
+        public int DummyChapterDuration { get; set; } = 0;
 
         /// <summary>
         /// Gets or sets the chapter image resolution.

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -240,7 +240,7 @@ namespace MediaBrowser.Providers.MediaInfo
             if (options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh ||
                 options.MetadataRefreshMode == MetadataRefreshMode.Default)
             {
-                if (chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
+                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
                 {
                     chapters = CreateDummyChapters(video);
                 }
@@ -524,39 +524,39 @@ namespace MediaBrowser.Providers.MediaInfo
         private ChapterInfo[] CreateDummyChapters(Video video)
         {
             var runtime = video.RunTimeTicks ?? 0;
-            long dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
 
-            if (runtime < 0)
+            // Only process files with a runtime higher than 0 and lower than 12h. The latter are likely corrupted.
+            if (runtime < 0 || runtime > TimeSpan.FromHours(12).Ticks)
             {
                 throw new ArgumentException(
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "{0} has invalid runtime of {1}",
+                        "{0} has an invalid runtime of {1} minutes",
                         video.Name,
-                        runtime));
+                        TimeSpan.FromTicks(runtime).Minutes));
             }
 
-            if (runtime < dummyChapterDuration)
+            long dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
+            if (runtime > dummyChapterDuration)
             {
-                return Array.Empty<ChapterInfo>();
-            }
+                int chapterCount = (int)(runtime / dummyChapterDuration);
+                var chapters = new ChapterInfo[chapterCount];
 
-            // Limit the chapters just in case there's some incorrect metadata here
-            int chapterCount = (int)Math.Min(runtime / dummyChapterDuration, _config.Configuration.DummyChapterCount);
-            var chapters = new ChapterInfo[chapterCount];
-
-            long currentChapterTicks = 0;
-            for (int i = 0; i < chapterCount; i++)
-            {
-                chapters[i] = new ChapterInfo
+                long currentChapterTicks = 0;
+                for (int i = 0; i < chapterCount; i++)
                 {
-                    StartPositionTicks = currentChapterTicks
-                };
+                    chapters[i] = new ChapterInfo
+                    {
+                        StartPositionTicks = currentChapterTicks
+                    };
 
-                currentChapterTicks += dummyChapterDuration;
+                    currentChapterTicks += dummyChapterDuration;
+                }
+
+                return chapters;
             }
 
-            return chapters;
+            return Array.Empty<ChapterInfo>();
         }
     }
 }


### PR DESCRIPTION
Some people don't want dummy chapters.
This makes dummy chapter generation configurable and disables it by default.
It additionally remove the dummy chapter count setting. Either you want dummy chapters or you don't.