### PR TITLE
Fix Live TV hardware decoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4397,7 +4397,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             // HWA decoders can handle both video files and video folders.
-            var videoType = mediaSource.VideoType;
+            var videoType = state.VideoType;
             if (videoType != VideoType.VideoFile
                 && videoType != VideoType.Iso
                 && videoType != VideoType.Dvd


### PR DESCRIPTION
**Changes**
- Fix Live TV hardware decoding

**Issues**
- HW decoder is disabled for Live TV, only HW encoder is allowed, which results in higher CPU usage.
- https://www.reddit.com/r/jellyfin/comments/11i2lno/live_tv_transcoding_instead_of_direct_streaming/