### PR TITLE
Backport HWA permissions fix (#9006) to 10.8.z

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -30,11 +30,11 @@ case "$1" in
       adduser --system --ingroup ${JELLYFIN_USER} --shell /bin/false ${JELLYFIN_USER} --no-create-home --home ${PROGRAMDATA} \
         --gecos "Jellyfin default user" > /dev/null 2>&1
     fi
-    # add jellyfin to the render group for hwa
+    # Add jellyfin to the render group for hwa
     if [[ ! -z "$(getent group ${RENDER_GROUP})" ]]; then
       usermod -aG ${RENDER_GROUP} ${JELLYFIN_USER} > /dev/null 2>&1
     fi
-    # add jellyfin to the video group for hwa
+    # Add jellyfin to the video group for hwa
     if [[ ! -z "$(getent group ${VIDEO_GROUP})" ]]; then
       usermod -aG ${VIDEO_GROUP} ${JELLYFIN_USER} > /dev/null 2>&1
     fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,6 +10,8 @@ if [[ -f $DEFAULT_FILE ]]; then
 fi
 
 JELLYFIN_USER=${JELLYFIN_USER:-jellyfin}
+RENDER_GROUP=${RENDER_GROUP:-render}
+VIDEO_GROUP=${VIDEO_GROUP:-video}
 
 # Data directories for program data (cache, db), configs, and logs
 PROGRAMDATA=${JELLYFIN_DATA_DIRECTORY-/var/lib/$NAME}
@@ -27,6 +29,14 @@ case "$1" in
     if [[ -z "$(getent passwd ${JELLYFIN_USER})"  ]]; then
       adduser --system --ingroup ${JELLYFIN_USER} --shell /bin/false ${JELLYFIN_USER} --no-create-home --home ${PROGRAMDATA} \
         --gecos "Jellyfin default user" > /dev/null 2>&1
+    fi
+    # add jellyfin to the render group for hwa
+    if [[ ! -z "$(getent group ${RENDER_GROUP})" ]]; then
+      usermod -aG ${RENDER_GROUP} ${JELLYFIN_USER} > /dev/null 2>&1
+    fi
+    # add jellyfin to the video group for hwa
+    if [[ ! -z "$(getent group ${VIDEO_GROUP})" ]]; then
+      usermod -aG ${VIDEO_GROUP} ${JELLYFIN_USER} > /dev/null 2>&1
     fi
     # ensure $PROGRAMDATA exists
     if [[ ! -d $PROGRAMDATA ]]; then

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -139,6 +139,9 @@ getent group jellyfin >/dev/null || groupadd -r jellyfin
 getent passwd jellyfin >/dev/null || \
     useradd -r -g jellyfin -d %{_sharedstatedir}/jellyfin -s /sbin/nologin \
     -c "Jellyfin default user" jellyfin
+# Add jellyfin to the render and video groups for hwa.
+[ ! -z "$(getent group render)" ] && usermod -aG render jellyfin >/dev/null 2>&1
+[ ! -z "$(getent group video)" ] && usermod -aG video jellyfin >/dev/null 2>&1
 exit 0
 
 %post server


### PR DESCRIPTION
**Changes**
- Backport HWA permissions fix (#9006) to 10.8.z

**Issues**
- Fixes the permission issue on VAAPI and QSV **when install on host**:
```
[AVHWDeviceContext @ 0x55b9b2a92200] No VA display found for any default device.
Device creation failed: -22.
Failed to set value 'vaapi=va:,driver=iHD,kernel_driver=i915' for option 'init_hw_device': Invalid argument
Error parsing global options: Invalid argument
```