### PR TITLE
Don't overwrite NFO images

### DIFF
--- a/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
+++ b/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1819, CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Model.Entities;
 
@@ -23,7 +24,7 @@ namespace MediaBrowser.Controller.Providers
 
         public bool ReplaceAllImages { get; set; }
 
-        public ImageType[] ReplaceImages { get; set; }
+        public IEnumerable<ImageType> ReplaceImages { get; set; }
 
         public bool IsAutomated { get; set; }
 

--- a/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
+++ b/MediaBrowser.Controller/Providers/ImageRefreshOptions.cs
@@ -24,7 +24,7 @@ namespace MediaBrowser.Controller.Providers
 
         public bool ReplaceAllImages { get; set; }
 
-        public IEnumerable<ImageType> ReplaceImages { get; set; }
+        public IReadOnlyList<ImageType> ReplaceImages { get; set; }
 
         public bool IsAutomated { get; set; }
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -273,7 +273,7 @@ namespace MediaBrowser.Providers.Manager
                 }
 
                 if (!refreshOptions.ReplaceAllImages &&
-                    refreshOptions.ReplaceImages.Length == 0 &&
+                    !refreshOptions.ReplaceImages.Any() &&
                     ContainsImages(item, provider.GetSupportedImages(item).ToList(), savedOptions, backdropLimit))
                 {
                     return;

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -273,7 +273,7 @@ namespace MediaBrowser.Providers.Manager
                 }
 
                 if (!refreshOptions.ReplaceAllImages &&
-                    !refreshOptions.ReplaceImages.Any() &&
+                    refreshOptions.ReplaceImages.Count == 0 &&
                     ContainsImages(item, provider.GetSupportedImages(item).ToList(), savedOptions, backdropLimit))
                 {
                     return;

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -714,7 +714,7 @@ namespace MediaBrowser.Providers.Manager
                         if (localImagesFound)
                         {
                             options.ReplaceAllImages = false;
-                            options.ReplaceImages = replaceImages.ToArray();
+                            options.ReplaceImages = replaceImages;
                         }
 
                         if (imageService.MergeImages(item, localItem.Images))

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -26,6 +26,8 @@ namespace MediaBrowser.Providers.Manager
         where TItemType : BaseItem, IHasLookupInfo<TIdType>, new()
         where TIdType : ItemLookupInfo, new()
     {
+        private static readonly ImageType[] AllImageTypes = Enum.GetValues<ImageType>();
+
         protected MetadataService(IServerConfigurationManager serverConfigurationManager, ILogger<MetadataService<TItemType, TIdType>> logger, IProviderManager providerManager, IFileSystem fileSystem, ILibraryManager libraryManager)
         {
             ServerConfigurationManager = serverConfigurationManager;
@@ -672,7 +674,7 @@ namespace MediaBrowser.Providers.Manager
             }
 
             var hasLocalMetadata = false;
-            var replaceImages = Enum.GetValues<ImageType>().ToList();
+            var replaceImages = AllImageTypes.ToList();
             var localImagesFound = false;
 
             foreach (var provider in providers.OfType<ILocalMetadataProvider<TItemType>>())

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -704,7 +704,6 @@ namespace MediaBrowser.Providers.Manager
                                 // remove imagetype that has just been downloaded
                                 replaceImages.Remove(remoteImage.Type);
                                 localImagesFound = true;
-
                             }
                             catch (HttpRequestException ex)
                             {


### PR DESCRIPTION
Track what ImageTypes have been provided by local NFO. Remove those from the list of all ImageTypes so they will not be overwritten by subsequent providers.

Fixes #9000