### PR TITLE
Fall back to using "logo" attrib if "tvg-logo" is mssing in M3U-tuner

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
@@ -122,9 +122,13 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
             var attributes = ParseExtInf(extInf, out string remaining);
             extInf = remaining;
 
-            if (attributes.TryGetValue("tvg-logo", out string value))
+            if (attributes.TryGetValue("tvg-logo", out string tvgLogo))
             {
-                channel.ImageUrl = value;
+                channel.ImageUrl = tvgLogo;
+            }
+            else if (attributes.TryGetValue("logo", out string logo))
+            {
+                channel.ImageUrl = logo;
             }
 
             if (attributes.TryGetValue("group-title", out string groupTitle))


### PR DESCRIPTION
**Changes**
If attribute "tvg-logo" is not found when m3u is parsed, look for attribut "logo" instead.
**Issues**
Jellyfin uses only "tvg-logo" attribute from m3u for live tv channel icons. In conjunction with tvhead headend this wont work as tvheadend uses "logo" attribute. This PR adds looking for "logo" as fall back, so following examples will both work:
#EXTINF:-1 tvg-logo="http://tvheadendserver:9981/imagecache/8"
#EXTINF:-1 logo="http://tvheadendserver:9981/imagecache/8"
-> See https://features.jellyfin.org/posts/2065/livetv-m3u-tuner-fallback-for-channellogo