### PR TITLE
Add auto-generated asyncapi docs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <!-- Run "dotnet list package (dash,dash)outdated" to see the latest versions of each package.-->
-
   <ItemGroup Label="Package Dependencies">
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.0" />
@@ -56,6 +54,7 @@
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
     <PackageVersion Include="prometheus-net" Version="8.0.0" />
+    <PackageVersion Include="Saunter" Version="0.11.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Mono.Nat" />
     <PackageReference Include="prometheus-net.DotNetRuntime" />
+    <PackageReference Include="Saunter" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" />
     <PackageReference Include="DotNet.Glob" />
   </ItemGroup>

--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -9,15 +9,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Controller.Net;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Session;
+using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
+using Saunter.Attributes;
 
 namespace Emby.Server.Implementations.HttpServer
 {
     /// <summary>
     /// Class WebSocketConnection.
     /// </summary>
+    [AsyncApi]
+    [Channel(nameof(WebSocketConnection), Servers = new[] { "websocket" })]
+    [SubscribeOperation(typeof(WebSocketMessage<>))]
     public class WebSocketConnection : IWebSocketConnection
     {
         /// <summary>
@@ -92,6 +99,12 @@ namespace Emby.Server.Implementations.HttpServer
         /// <param name="message">The message.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Task.</returns>
+        [Message(typeof(WebSocketMessage<int>))]
+        [Message(typeof(WebSocketMessage<string>))]
+        [Message(typeof(WebSocketMessage<GeneralCommand>))]
+        [Message(typeof(WebSocketMessage<ActivityLogEntry[]>))]
+        [Message(typeof(WebSocketMessage<TaskInfo[]>))]
+        [Message(typeof(WebSocketMessage<SessionInfo[]>))]
         public Task SendAsync<T>(WebSocketMessage<T> message, CancellationToken cancellationToken)
         {
             var json = JsonSerializer.SerializeToUtf8Bytes(message, _jsonOptions);

--- a/Jellyfin.Server/Properties/launchSettings.json
+++ b/Jellyfin.Server/Properties/launchSettings.json
@@ -1,29 +1,39 @@
 {
-  "profiles": {
-    "Jellyfin.Server": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:8096",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Jellyfin.Server (nowebclient)": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "commandLineArgs": "--nowebclient"
-    },
-    "Jellyfin.Server (API Docs)": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "api-docs/swagger",
-      "applicationUrl": "http://localhost:8096",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "commandLineArgs": "--nowebclient"
+    "profiles": {
+        "Jellyfin.Server": {
+            "commandName": "Project",
+            "launchBrowser": true,
+            "applicationUrl": "http://localhost:8096",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        "Jellyfin.Server (nowebclient)": {
+            "commandName": "Project",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "commandLineArgs": "--nowebclient"
+        },
+        "Jellyfin.Server (API Docs)": {
+            "commandName": "Project",
+            "launchBrowser": true,
+            "launchUrl": "api-docs/swagger",
+            "applicationUrl": "http://localhost:8096",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "commandLineArgs": "--nowebclient"
+        },
+        "Jellyfin.Server (AsyncAPI Docs)": {
+            "commandName": "Project",
+            "launchBrowser": true,
+            "launchUrl": "api-docs/asyncapi",
+            "applicationUrl": "http://localhost:8096",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "commandLineArgs": "--nowebclient"
+        }
     }
-  }
 }

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Prometheus;
+using Saunter;
 
 namespace Jellyfin.Server
 {
@@ -67,6 +68,7 @@ namespace Jellyfin.Server
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
             services.AddJellyfinDbContext();
             services.AddJellyfinApiSwagger();
+            services.AddAsyncApi();
 
             // configure custom legacy authentication
             services.AddCustomAuthentication();
@@ -209,6 +211,9 @@ namespace Jellyfin.Server
                     }
 
                     endpoints.MapHealthChecks("/health");
+
+                    endpoints.MapAsyncApiDocuments();
+                    endpoints.MapAsyncApiUi();
                 });
             });
         }


### PR DESCRIPTION
**Changes**
Adds generation of Websocket documentation.
Viewable at `/api-docs/asyncapi`

**Issues**
None, but requested by client devs

I'm not 100% happy with the generated docs but that may just be a limitation of how our websocket is implemented.

Current spec: [asyncapi.json.txt](https://github.com/jellyfin/jellyfin/files/10974824/asyncapi.json.txt)

