### PR TITLE
Fix file stacking

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -141,8 +141,7 @@ namespace Emby.Naming.Common
             VideoFileStackingRules = new[]
             {
                 new FileStackRule(@"^(?<filename>.*?)(?:(?<=[\]\)\}])|[ _.-]+)[\(\[]?(?<parttype>cd|dvd|part|pt|dis[ck])[ _.-]*(?<number>[0-9]+)[\)\]]?(?:\.[^.]+)?$", true),
-                new FileStackRule(@"^(?<filename>.*?)(?:(?<=[\]\)\}])|[ _.-]+)[\(\[]?(?<parttype>cd|dvd|part|pt|dis[ck])[ _.-]*(?<number>[a-d])[\)\]]?(?:\.[^.]+)?$", false),
-                new FileStackRule(@"^(?<filename>.*?)(?:(?<=[\]\)\}])|[ _.-]?)(?<number>[a-d])(?:\.[^.]+)?$", false)
+                new FileStackRule(@"^(?<filename>.*?)(?:(?<=[\]\)\}])|[ _.-]+)[\(\[]?(?<parttype>cd|dvd|part|pt|dis[ck])[ _.-]*(?<number>[a-d])[\)\]]?(?:\.[^.]+)?$", false)
             };
 
             CleanDateTimes = new[]

--- a/tests/Jellyfin.Naming.Tests/Video/StackTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/StackTests.cs
@@ -236,7 +236,7 @@ namespace Jellyfin.Naming.Tests.Video
         }
 
         [Fact]
-        public void TestFalsePositive()
+        public void TestMissingParttype()
         {
             var files = new[]
             {
@@ -248,9 +248,8 @@ namespace Jellyfin.Naming.Tests.Video
 
             var result = StackResolver.ResolveFiles(files, _namingOptions).ToList();
 
-            Assert.Single(result);
-
-            TestStackInfo(result[0], "300", 3);
+            // There should be no stack, because all files should be treated as separate movies
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -297,11 +296,11 @@ namespace Jellyfin.Naming.Tests.Video
 
             var result = StackResolver.ResolveFiles(files, _namingOptions).ToList();
 
-            Assert.Equal(3, result.Count);
+            // Only 'Bad Boys (2006)' and '300 (2006)' should be in the stack
+            Assert.Equal(2, result.Count);
 
             TestStackInfo(result[0], "300 (2006)", 4);
-            TestStackInfo(result[1], "300", 3);
-            TestStackInfo(result[2], "Bad Boys (2006)", 4);
+            TestStackInfo(result[1], "Bad Boys (2006)", 4);
         }
 
         [Fact]

--- a/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
@@ -332,7 +332,7 @@ namespace Jellyfin.Naming.Tests.Video
                 files.Select(i => VideoResolver.Resolve(i, false, _namingOptions)).OfType<VideoFileInfo>().ToList(),
                 _namingOptions).ToList();
 
-            // The result should contain to individual movies
+            // The result should contain two individual movies
             // Version grouping should not work here, because the files are not in a directory with the name 'Four Sisters and a Wedding'
             Assert.Equal(2, result.Count);
         }

--- a/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
@@ -332,7 +332,9 @@ namespace Jellyfin.Naming.Tests.Video
                 files.Select(i => VideoResolver.Resolve(i, false, _namingOptions)).OfType<VideoFileInfo>().ToList(),
                 _namingOptions).ToList();
 
-            Assert.Single(result);
+            // The result should contain to individual movies
+            // Version grouping should not work here, because the files are not in a directory with the name 'Four Sisters and a Wedding'
+            Assert.Equal(2, result.Count);
         }
 
         [Fact]


### PR DESCRIPTION
As discussed with @Shadowghost in #8004, there is a stacking rule (`VideoFileStackingRules`) in the file `Emby.Naming/Common/NamingOptions.cs` that makes no sense. It leads to a behavior that is not documented.

For example the files

- `300a.mkv`,
- `300b.mkv` and
- `300c.mkv`

will be treated as parts of the same movie. But according to the Shows documentation (https://jellyfin.org/docs/general/server/media/shows/#episodes-split-across-multiple-parts) _- don't know why this isn't also documented in the movie section -_ a `<parttype>` is required.
So normally the files should to be named like this:

- `300 parta.mkv`,
- `300 partb.mkv` and
- `300 partc.mkv`

I removed the corresponding rule and adjusted the affected test cases. Now the above naming (`300a`, ...) does no longer work. Instead the files have to be named like `300 parta`, etc. as it is documented.

