### PR TITLE
Add merge conflict comment

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -19,6 +19,7 @@ jobs:
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request_target'}}
         with:
           dirtyLabel: 'merge conflict'
+          commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'
           repoToken: ${{ secrets.JF_BOT_TOKEN }}
 
   project:


### PR DESCRIPTION
**Changes**
Adds a comment when a PR is labeled with a merge conflict for visibility

**Issues**
Related to point 2 in this meta discussion: https://github.com/jellyfin/jellyfin-meta/discussions/40
