### PR TITLE
Implement check to hide all libraries when user has no access

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1503,6 +1503,12 @@ namespace Emby.Server.Implementations.Library
                 });
 
                 query.TopParentIds = userViews.SelectMany(i => GetTopParentIdsForQuery(i, user)).ToArray();
+
+                // Prevent searching in all libraries due to empty filter
+                if (query.TopParentIds.Length == 0)
+                {
+                    query.TopParentIds = new[] { Guid.NewGuid() };
+                }
             }
         }
 


### PR DESCRIPTION
**Changes**
Implement the same check used at other `GetTopParentIdsForQuery` call sites so a user without any library access cannot bypass it by searching for media

**Issues**
Fixes [#1946](https://github.com/jellyfin/jellyfin/issues/1946)
