### PR TITLE
Fix nvenc preset order

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -160,6 +160,7 @@
  - [vgambier](https://github.com/vgambier)
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [RealGreenDragon](https://github.com/RealGreenDragon)
+ - [TheTyrius](https://github.com/TheTyrius)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1459,11 +1459,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                         param += " -preset p7";
                         break;
 
-                    case "slow":
+                    case "slower":
                         param += " -preset p6";
                         break;
 
-                    case "slower":
+                    case "slow":
                         param += " -preset p5";
                         break;
 
@@ -1496,8 +1496,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 switch (encodingOptions.EncoderPreset)
                 {
                     case "veryslow":
-                    case "slow":
                     case "slower":
+                    case "slow":
                         param += " -quality quality";
                         break;
 


### PR DESCRIPTION
**Changes**
Changed the ordering of the "slow" and "slower" presets in the transcoding helper, so they are aligned with the order in the settings dropdown.

Did the same to a switch-case where there is no change in behavior right now (but might prevent a bug like this in the future).

**Issues**
First raised in https://github.com/jellyfin/jellyfin/issues/9537 thanks nyanmisaka for giving it a look so incredibly quickly (and also for all the other work you do on Jellyfin)
