### PR TITLE
Restore old interface for IBaseItemManager interface

### DIFF
--- a/MediaBrowser.Controller/BaseItemManager/BaseItemManager.cs
+++ b/MediaBrowser.Controller/BaseItemManager/BaseItemManager.cs
@@ -60,6 +60,14 @@ namespace MediaBrowser.Controller.BaseItemManager
         }
 
         /// <inheritdoc />
+        public bool IsMetadataFetcherEnabled(BaseItem baseItem, LibraryOptions libraryOptions, string name)
+        {
+            // just upcall into the by-TypeOptions version using the logic the old path would have used
+            TypeOptions? libraryTypeOptions = libraryOptions?.GetTypeOptions(baseItem.GetType().Name);
+            return this.IsMetadataFetcherEnabled(baseItem, libraryTypeOptions, name);
+        }
+
+        /// <inheritdoc />
         public bool IsImageFetcherEnabled(BaseItem baseItem, TypeOptions? libraryTypeOptions, string name)
         {
             if (baseItem is Channel)
@@ -82,6 +90,14 @@ namespace MediaBrowser.Controller.BaseItemManager
             var itemConfig = _serverConfigurationManager.Configuration.MetadataOptions.FirstOrDefault(i => string.Equals(i.ItemType, baseItem.GetType().Name, StringComparison.OrdinalIgnoreCase));
 
             return itemConfig is null || !itemConfig.DisabledImageFetchers.Contains(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <inheritdoc />
+        public bool IsImageFetcherEnabled(BaseItem baseItem, LibraryOptions libraryOptions, string name)
+        {
+            // just upcall into the by-TypeOptions version using the logic the old path would have used
+            TypeOptions? libraryTypeOptions = libraryOptions?.GetTypeOptions(baseItem.GetType().Name);
+            return this.IsImageFetcherEnabled(baseItem, libraryTypeOptions, name);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/BaseItemManager/IBaseItemManager.cs
+++ b/MediaBrowser.Controller/BaseItemManager/IBaseItemManager.cs
@@ -15,6 +15,28 @@ namespace MediaBrowser.Controller.BaseItemManager
         SemaphoreSlim MetadataRefreshThrottler { get; }
 
         /// <summary>
+        /// Is metadata fetcher enabled based on the library type options.
+        /// </summary>
+        /// <param name="baseItem">The base item.</param>
+        /// <param name="libraryOptions">The library options for <c>baseItem</c> from the library (if defined).</param>
+        /// <param name="name">The metadata fetcher name.</param>
+        /// <returns><c>true</c> if metadata fetcher is enabled, else false.</returns>
+        ///
+        /// This is still here for backward compatibility with old plugins, assume we're going to use new method.
+        bool IsMetadataFetcherEnabled(BaseItem baseItem, LibraryOptions libraryOptions, string name);
+
+        /// <summary>
+        /// Is image fetcher enabled based on the library type options.
+        /// </summary>
+        /// <param name="baseItem">The base item.</param>
+        /// <param name="libraryOptions">The library options for <c>baseItem</c> from the library (if defined).</param>
+        /// <param name="name">The image fetcher name.</param>
+        /// <returns><c>true</c> if image fetcher is enabled, else false.</returns>
+        ///
+        /// This is still here for backward compatibility with old plugins, assume we're going to use new method.
+        bool IsImageFetcherEnabled(BaseItem baseItem, LibraryOptions libraryOptions, string name);
+
+        /// <summary>
         /// Is metadata fetcher enabled.
         /// </summary>
         /// <param name="baseItem">The base item.</param>


### PR DESCRIPTION
The changes made in PR #7039 break Metadata plug-ins that may not have yet been recompiled. Added the original methods back and made the base implementation mirror what the old code was doing to prevent the old plug-ins from throwing `MissingMethodExceptions`
