### PR TITLE
Modified await statement to remove compiler warning while awaiting on the file stream to be created.

### DIFF
--- a/MediaBrowser.Controller/ClientEvent/ClientEventLogger.cs
+++ b/MediaBrowser.Controller/ClientEvent/ClientEventLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -23,8 +23,12 @@ namespace MediaBrowser.Controller.ClientEvent
         {
             var fileName = $"upload_{clientName}_{clientVersion}_{DateTime.UtcNow:yyyyMMddHHmmss}_{Guid.NewGuid():N}.log";
             var logFilePath = Path.Combine(_applicationPaths.LogDirectoryPath, fileName);
-            await using var fileStream = new FileStream(logFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
-            await fileContents.CopyToAsync(fileStream).ConfigureAwait(false);
+            FileStream fileStream;
+            await using (fileStream = new FileStream(logFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                await fileContents.CopyToAsync(fileStream).ConfigureAwait(false);
+            }
+
             return fileName;
         }
     }


### PR DESCRIPTION
Working on compiler warning for this line of code. 

**Changes**
The changes to how the file stream is declared and added some brackets for the using.

The using will still be in the main context, while the flush will happen outside. 