### PR TITLE
Resolving Warning related to ProviderIds

### DIFF
--- a/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
+++ b/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
@@ -25,7 +25,7 @@ namespace MediaBrowser.Controller.Collections
 
         public bool IsLocked { get; set; }
 
-        // private implementation of ProviderIds property from interface to allow setter access
+        // Private implementation of ProviderIds property from interface to allow setter access
         Dictionary<string, string> IHasProviderIds.ProviderIds
         {
             get => _providerIds;

--- a/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
+++ b/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
@@ -8,11 +8,13 @@ using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Controller.Collections
 {
-    public class CollectionCreationOptions : IHasProviderIds
+    public sealed class CollectionCreationOptions : IHasProviderIds
     {
+        private Dictionary<string, string> _providerIds;
+
         public CollectionCreationOptions()
         {
-            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _providerIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             ItemIdList = Array.Empty<string>();
             UserIds = Array.Empty<Guid>();
         }
@@ -23,7 +25,14 @@ namespace MediaBrowser.Controller.Collections
 
         public bool IsLocked { get; set; }
 
-        public Dictionary<string, string> ProviderIds { get; set; }
+        // private implementation of ProviderIds property from interface to allow setter access
+        Dictionary<string, string> IHasProviderIds.ProviderIds
+        {
+            get => _providerIds;
+            set => _providerIds = value;
+        }
+
+        public Dictionary<string, string> ProviderIds { get => _providerIds; }
 
         public IReadOnlyList<string> ItemIdList { get; set; }
 


### PR DESCRIPTION



**Changes**
Warning related to ProviderIds being initialized in the constructor and having its collection reference changed externally.
Changed the ProviderIds property while maintaining the interface's set implementation.

**Issues**
Compiler warning.
