### PR TITLE
#7626 Added handling for common FormatExceptions with Skia loading sv…

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1879,7 +1879,7 @@ namespace Emby.Server.Implementations.Library
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Cannot get image dimensions for {ImagePath}", image.Path);
-                    size = new ImageDimensions(0, 0);
+                    size = default;
                     image.Width = 0;
                     image.Height = 0;
                 }

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -130,7 +130,7 @@ public class SkiaEncoder : IImageEncoder
                 // this exception is known to be thrown on vector images that define custom styles
                 // skia svg is not able to parse that and as the repository is quite stale and has not received updates we just catch them
                 _logger.LogDebug(skiaColorException, "There was a issue loading the requested svg file");
-                return new ImageDimensions(0, 0);
+                return default;
             }
         }
 
@@ -142,10 +142,10 @@ public class SkiaEncoder : IImageEncoder
                 return new ImageDimensions(info.Width, info.Height);
             case SKCodecResult.Unimplemented:
                 _logger.LogDebug("Image format not supported: {FilePath}", path);
-                return new ImageDimensions(0, 0);
+                return default;
             default:
                 _logger.LogError("Unable to determine image dimensions for {FilePath}: {SkCodecResult}", path, result);
-                return new ImageDimensions(0, 0);
+                return default;
         }
     }
 

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -120,8 +120,18 @@ public class SkiaEncoder : IImageEncoder
         if (extension.Equals(".svg", StringComparison.OrdinalIgnoreCase))
         {
             var svg = new SKSvg();
-            svg.Load(path);
-            return new ImageDimensions(Convert.ToInt32(svg.Picture.CullRect.Width), Convert.ToInt32(svg.Picture.CullRect.Height));
+            try
+            {
+                svg.Load(path);
+                return new ImageDimensions(Convert.ToInt32(svg.Picture.CullRect.Width), Convert.ToInt32(svg.Picture.CullRect.Height));
+            }
+            catch (FormatException skiaColorException)
+            {
+                // this exception is known to be thrown on vector images that define custom styles
+                // skia svg is not able to parse that and as the repository is quite stale and has not received updates we just catch them
+                _logger.LogDebug(skiaColorException, "There was a issue loading the requested svg file");
+                return new ImageDimensions(0, 0);
+            }
         }
 
         using var codec = SKCodec.Create(path, out SKCodecResult result);


### PR DESCRIPTION
Handles the skia svg errors that will throw when skia loads an svg file that defines an element with style like this:

```
<g id="surface1">
<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" ...
```

gracefully as this is unlikely to be fixed by the upstream repro.
This should reduce the log bloat for users with effected files.

**Changes**
Added try-catch and debug logging for effected code.

**Issues**
Mitigates changes done from PR #7946 for Bug #7626
