### PR TITLE
Search for external files in subfolders

### DIFF
--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -62,14 +62,17 @@ namespace MediaBrowser.Controller.Providers
         public IReadOnlyList<string> GetFilePaths(string path)
             => GetFilePaths(path, false);
 
-        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false)
+        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false, bool recursive = false)
         {
             if (clearCache)
             {
                 _filePathCache.TryRemove(path, out _);
             }
 
-            var filePaths = _filePathCache.GetOrAdd(path, static (p, fileSystem) => fileSystem.GetFilePaths(p).ToList(), _fileSystem);
+            var filePaths = _filePathCache.GetOrAdd(
+                path,
+                static (p, options) => options.fileSystem.GetFilePaths(p, options.recursive).ToList(),
+                (fileSystem: _fileSystem, recursive));
 
             if (sort)
             {

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -15,6 +15,6 @@ namespace MediaBrowser.Controller.Providers
 
         IReadOnlyList<string> GetFilePaths(string path);
 
-        IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);
+        IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false, bool recursive = false);
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -175,7 +175,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 return Array.Empty<ExternalPathParserResult>();
             }
 
-            var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
+            var files = directoryService.GetFilePaths(folder, clearCache, sort: true, recursive: true).ToList();
             files.Remove(video.Path);
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -123,13 +123,13 @@ public class MediaInfoResolverTests
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
         // any path other than test target exists and provides an empty listing
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         _subtitleResolver.GetExternalFiles(video.Object, directoryService.Object, false);
 
         directoryService.Verify(
-            ds => ds.GetFilePaths(It.IsRegex(pathNotFoundRegex), It.IsAny<bool>(), It.IsAny<bool>()),
+            ds => ds.GetFilePaths(It.IsRegex(pathNotFoundRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()),
             Times.Never);
     }
 
@@ -196,7 +196,7 @@ public class MediaInfoResolverTests
         };
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         var mediaEncoder = Mock.Of<IMediaEncoder>(MockBehavior.Strict);
@@ -351,9 +351,9 @@ public class MediaInfoResolverTests
         }
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(files);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         List<MediaStream> GenerateMediaStreams()
@@ -423,16 +423,16 @@ public class MediaInfoResolverTests
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
         if (useMetadataDirectory)
         {
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(Array.Empty<string>());
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(new[] { MetadataDirectoryPath + "/" + file });
         }
         else
         {
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(new[] { VideoDirectoryPath + "/" + file });
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(Array.Empty<string>());
         }
 


### PR DESCRIPTION
It would be really nice to search for external files in sub directories. This would be especially handy in the case of anime.
Let me give a real example:

```
Attack on Titans
| Season 4
     | Eng Sub
          | [Crunchyroll]
               | 01.ass
               | 02.ass
     | Rus Sound
          | [StudioBand]
               | 01.mka
               | 02.mka
     | Rus Sub
          | [Crunchyroll]
               | 01.ass
               | 02.ass
          | [Firegorn Team]
               | Forced
                   | 01.ass
                   | 02.ass
               | Full
                   | 01.ass
                   | 02.ass
          | [SovetRomantica]
               | 01.ass
               | 02.ass
     | 01.mkv
     | 02.mkv
```

**Changes**
Just search for external files recursively.
I am absolutely not sure if this is the best solution and how much it will affect performance.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
