### PR TITLE
Add advanced options for Intel QSV encoders

### DIFF
--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -44,7 +44,19 @@ public class EncodingOptions
         EnableEnhancedNvdecDecoder = true;
         PreferSystemNativeHwDecoder = true;
         EnableIntelLowPowerH264HwEncoder = false;
+        EnableIntelLookAheadH264 = false;
+        IntelLookAheadDepthH264 = 60;
+        EnableIntelExtBrcH264 = false;
+        EnableIntelBPyramidH264 = false;
+        EnableIntelAdaptiveIBFramesH264 = false;
+        EnableIntelTrellisH264 = false;
         EnableIntelLowPowerHevcHwEncoder = false;
+        EnableIntelLookAheadHevc = false;
+        IntelLookAheadDepthHevc = 60;
+        EnableIntelExtBrcHevc = false;
+        EnableIntelBPyramidHevc = false;
+        EnableIntelAdaptiveIBFramesHevc = false;
+        EnableIntelTrellisHevc = false;
         EnableHardwareEncoding = true;
         AllowHevcEncoding = false;
         EnableSubtitleExtraction = true;
@@ -223,9 +235,69 @@ public class EncodingOptions
     public bool EnableIntelLowPowerH264HwEncoder { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether LookAhead should be used for Intel H264 encoder.
+    /// </summary>
+    public bool EnableIntelLookAheadH264 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the number of frames that should be used for LookAhead with Intel H264 encoder.
+    /// </summary>
+    public int IntelLookAheadDepthH264 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether ExtBrc should be used for Intel H264 encoder.
+    /// </summary>
+    public bool EnableIntelExtBrcH264 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether B-Pyramid should be used for Intel H264 encoder.
+    /// </summary>
+    public bool EnableIntelBPyramidH264 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Adaptive I/B frames should be used for Intel H264 encoder.
+    /// </summary>
+    public bool EnableIntelAdaptiveIBFramesH264 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Trellis quantization should be used for Intel H264 encoder.
+    /// </summary>
+    public bool EnableIntelTrellisH264 { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the Intel HEVC low-power hardware encoder should be used.
     /// </summary>
     public bool EnableIntelLowPowerHevcHwEncoder { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether LookAhead should be used for Intel HEVC encoder.
+    /// </summary>
+    public bool EnableIntelLookAheadHevc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the number of frames that should be used for LookAhead with Intel HEVC encoder.
+    /// </summary>
+    public int IntelLookAheadDepthHevc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether ExtBrc should be used for Intel HEVC encoder.
+    /// </summary>
+    public bool EnableIntelExtBrcHevc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether B-Pyramid should be used for Intel HEVC encoder.
+    /// </summary>
+    public bool EnableIntelBPyramidHevc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Adaptive I/B frames should be used for Intel HEVC encoder.
+    /// </summary>
+    public bool EnableIntelAdaptiveIBFramesHevc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Trellis quantization should be used for Intel HEVC encoder.
+    /// </summary>
+    public bool EnableIntelTrellisHevc { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether hardware encoding is enabled.


### PR DESCRIPTION
In my testing, enabling LookAhead and ExtBRC increases VMAF score by ~3 in low-bitrate scenarios (89 vs 92 for 1080p at 3Mbit) and Trellis by further ~0.2. The improvement largely depends on the content and I didn't find any sample that would suffer. 

Please note the actual parameters QSV applies internally for an encoding session depend on various factors, such as GPU generation, driver version and other supplied parameters, such as `preset` and `low_power`. For instance, LookAhead didn't seem to have an effect for me on a Gen9 GPU when combined with `low_power`.

More info on that here: https://github.com/intel/media-delivery/blob/master/doc/quality.rst

**Changes**
- Add options for LookAhead, ExtBrc, B-Pyramid, Adaptive I/B frames and Trellis
- Add extra_hw_frames to input if LookAhead is enabled
- Add calculation of the number of extra_hw_frames in filters (increased by LookAheadDepth) - still needs testing which ones actually need to be increased
