### PR TITLE
Fixed RTL text not beeing rendered properly on Lib images

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,6 +67,8 @@
     <PackageVersion Include="SharpFuzz" Version="2.0.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
     <PackageVersion Include="SkiaSharp.Svg" Version="1.60.0" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
     <PackageVersion Include="SkiaSharp" Version="2.88.3" />
     <PackageVersion Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
     <PackageVersion Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />

--- a/src/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/src/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="SkiaSharp.Svg" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -155,7 +155,7 @@ public partial class StripCollageBuilder
 
         if (IsRtlTextRegex().IsMatch(libraryName))
         {
-            canvas.DrawShapedText(libraryName, 250, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
+            canvas.DrawShapedText(libraryName, width / 2f, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
         }
         else
         {

--- a/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -23,7 +23,7 @@ public partial class StripCollageBuilder
         _skiaEncoder = skiaEncoder;
     }
 
-    [GeneratedRegex(@"\s{IsArabic}|\s{IsArmenian}|\s{IsHebrew}|\s{IsSyriac}|\s{IsThaana}", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\p{IsArabic}|\p{IsArmenian}|\p{IsHebrew}|\p{IsSyriac}|\p{IsThaana}")]
     private static partial Regex IsRtlTextRegex();
 
     /// <summary>

--- a/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -23,7 +23,7 @@ public partial class StripCollageBuilder
         _skiaEncoder = skiaEncoder;
     }
 
-    [GeneratedRegex("(/s{IsArabic}||/s{IsArmenian}||/s{IsHebrew}||/s{IsSyriac}||/s{IsThaana})+", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\s{IsArabic}|\s{IsArmenian}|\s{IsHebrew}|\s{IsSyriac}|\s{IsThaana}", RegexOptions.IgnoreCase)]
     private static partial Regex IsRtlTextRegex();
 
     /// <summary>

--- a/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using SkiaSharp;
+using SkiaSharp.HarfBuzz;
 
 namespace Jellyfin.Drawing.Skia;
 
 /// <summary>
 /// Used to build collages of multiple images arranged in vertical strips.
 /// </summary>
-public class StripCollageBuilder
+public partial class StripCollageBuilder
 {
     private readonly SkiaEncoder _skiaEncoder;
 
@@ -21,6 +22,9 @@ public class StripCollageBuilder
     {
         _skiaEncoder = skiaEncoder;
     }
+
+    [GeneratedRegex("(/s{IsArabic}||/s{IsArmenian}||/s{IsHebrew}||/s{IsSyriac}||/s{IsThaana})+", RegexOptions.IgnoreCase)]
+    private static partial Regex IsRtlTextRegex();
 
     /// <summary>
     /// Check which format an image has been encoded with using its filename extension.
@@ -144,7 +148,19 @@ public class StripCollageBuilder
             textPaint.TextSize = 0.9f * width * textPaint.TextSize / textWidth;
         }
 
-        canvas.DrawText(libraryName, width / 2f, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
+        if (string.IsNullOrWhiteSpace(libraryName))
+        {
+            return bitmap;
+        }
+
+        if (IsRtlTextRegex().IsMatch(libraryName))
+        {
+            canvas.DrawShapedText(libraryName, 250, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
+        }
+        else
+        {
+            canvas.DrawText(libraryName, width / 2f, (height / 2f) + (textPaint.FontMetrics.XHeight / 2), textPaint);
+        }
 
         return bitmap;
     }


### PR DESCRIPTION
Building upon the work of #8050 and discussion in chat, using several character groups to evaluate if the text drawn on library images should be handled LTR or RTL

**Changes**
- Added RTL detection for following text cultures: 
  - Arabic
  - Armenian
  - Hebrew
  - Syriac
  - Thaana

**Issues**
#9610 
