### PR TITLE
Fix null parental rating comparison

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2378,7 +2378,7 @@ namespace Emby.Server.Implementations.Data
                 else
                 {
                     builder.Append(
-                        @"(SELECT CASE WHEN InheritedParentalRatingValue=0
+                        @"(SELECT CASE WHEN COALESCE(InheritedParentalRatingValue, 0)=0
                                 THEN 0
                                 ELSE 10.0 / (1.0 + ABS(InheritedParentalRatingValue - @InheritedParentalRatingValue))
                                 END)");


### PR DESCRIPTION
In some instances, InheritedParentalRatingValue is null, which results in a guaranteed similarity score of null.

The side effect this causes is that the "More like this" section is entirely random for movies with a null InheritedParentalRatingValue.