### PR TITLE
Properly dispose prepared statements

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -166,18 +166,6 @@ namespace Emby.Server.Implementations.Data
         public IStatement PrepareStatement(IDatabaseConnection connection, string sql)
             => connection.PrepareStatement(sql);
 
-        public IStatement[] PrepareAll(IDatabaseConnection connection, IReadOnlyList<string> sql)
-        {
-            int len = sql.Count;
-            IStatement[] statements = new IStatement[len];
-            for (int i = 0; i < len; i++)
-            {
-                statements[i] = connection.PrepareStatement(sql[i]);
-            }
-
-            return statements;
-        }
-
         protected bool TableExists(ManagedConnection connection, string name)
         {
             return connection.RunInTransaction(


### PR DESCRIPTION
Makes sure all prepared statements get properly disposed.
Also don't allocate 2 arrays to do `PrepareAll` when they can be prepared individually.