### PR TITLE
Fix the brightness of VPP tonemap and add the tonemap mode

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -43,6 +43,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         private readonly Version _minFFmpegImplictHwaccel = new Version(6, 0);
         private readonly Version _minFFmpegHwaUnsafeOutput = new Version(6, 0);
+        private readonly Version _minFFmpegOclCuTonemapMode = new Version(5, 1, 3);
 
         private static readonly string[] _videoProfilesH264 = new[]
         {
@@ -2816,7 +2817,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             return string.Empty;
         }
 
-        public static string GetHwTonemapFilter(EncodingOptions options, string hwTonemapSuffix, string videoFormat)
+        public string GetHwTonemapFilter(EncodingOptions options, string hwTonemapSuffix, string videoFormat)
         {
             if (string.IsNullOrEmpty(hwTonemapSuffix))
             {
@@ -2827,7 +2828,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (hwTonemapSuffix.Contains("vaapi", StringComparison.OrdinalIgnoreCase))
             {
-                args += ",procamp_vaapi=b={2}:c={3}:extra_hw_frames=16";
+                args = "procamp_vaapi=b={2}:c={3}," + args + ":extra_hw_frames=32";
+
                 return string.Format(
                         CultureInfo.InvariantCulture,
                         args,
@@ -2840,14 +2842,24 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 args += ":tonemap={2}:peak={3}:desat={4}";
 
-                if (options.TonemappingParam != 0)
+                if (string.Equals(options.TonemappingMode, "max", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(options.TonemappingMode, "rgb", StringComparison.OrdinalIgnoreCase))
                 {
-                    args += ":param={5}";
+                    if (_mediaEncoder.EncoderVersion >= _minFFmpegOclCuTonemapMode)
+                    {
+                        args += ":tonemap_mode={5}";
+                    }
                 }
 
-                if (!string.Equals(options.TonemappingRange, "auto", StringComparison.OrdinalIgnoreCase))
+                if (options.TonemappingParam != 0)
                 {
-                    args += ":range={6}";
+                    args += ":param={6}";
+                }
+
+                if (string.Equals(options.TonemappingRange, "tv", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(options.TonemappingRange, "pc", StringComparison.OrdinalIgnoreCase))
+                {
+                    args += ":range={7}";
                 }
             }
 
@@ -2859,6 +2871,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     options.TonemappingAlgorithm,
                     options.TonemappingPeak,
                     options.TonemappingDesat,
+                    options.TonemappingMode,
                     options.TonemappingParam,
                     options.TonemappingRange);
         }

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -21,13 +21,13 @@ namespace MediaBrowser.Model.Configuration
             EnableTonemapping = false;
             EnableVppTonemapping = false;
             TonemappingAlgorithm = "bt2390";
+            TonemappingMode = "auto";
             TonemappingRange = "auto";
             TonemappingDesat = 0;
-            TonemappingThreshold = 0.8;
             TonemappingPeak = 100;
             TonemappingParam = 0;
-            VppTonemappingBrightness = 0;
-            VppTonemappingContrast = 1.2;
+            VppTonemappingBrightness = 16;
+            VppTonemappingContrast = 1;
             H264Crf = 23;
             H265Crf = 28;
             DeinterlaceDoubleRate = false;
@@ -82,11 +82,11 @@ namespace MediaBrowser.Model.Configuration
 
         public string TonemappingAlgorithm { get; set; }
 
+        public string TonemappingMode { get; set; }
+
         public string TonemappingRange { get; set; }
 
         public double TonemappingDesat { get; set; }
-
-        public double TonemappingThreshold { get; set; }
 
         public double TonemappingPeak { get; set; }
 


### PR DESCRIPTION
**Web changes**
- https://github.com/jellyfin/jellyfin-web/pull/4492

**Changes**
- Fix the brightness of VPP tonemap
- Add the tonemap mode option RGB (requires jellyfin-ffmpeg 5.1.3+)
- Drop the deprecated `Threshold` option

**Issues**
- The VPP tonemap crushes the details of dark areas (right)
![vpptm](https://user-images.githubusercontent.com/14953024/232028772-de7109b2-5ec2-4f95-a2b9-e690632a9b02.png)

- The default tonemap mode MAX may causes the brightest areas [blown out to white](https://www.reddit.com/r/jellyfin/comments/120vc05/cant_get_tone_mapping_looking_right/) (left)
![image](https://user-images.githubusercontent.com/14953024/232029560-308252cd-40a9-4e9a-baf8-9eb35a94c013.png)