### PR TITLE
Source SQLite cache_size from an Environment Variable

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -11,14 +11,15 @@ namespace Emby.Server.Implementations
         /// <summary>
         /// Gets a new copy of the default configuration options.
         /// </summary>
-        public static Dictionary<string, string?> DefaultConfiguration => new Dictionary<string, string?>
+        public static Dictionary<string, string?> DefaultConfiguration => new()
         {
             { HostWebClientKey, bool.TrueString },
             { DefaultRedirectKey, "web/" },
             { FfmpegProbeSizeKey, "1G" },
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
-            { BindToUnixSocketKey, bool.FalseString }
+            { BindToUnixSocketKey, bool.FalseString },
+            { SqliteCacheSizeKey, "20000" }
         };
     }
 }

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -25,6 +25,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Persistence;
@@ -34,6 +35,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.LiveTv;
 using MediaBrowser.Model.Querying;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SQLitePCL.pretty;
 
@@ -319,13 +321,15 @@ namespace Emby.Server.Implementations.Data
         /// <param name="logger">Instance of the <see cref="ILogger{SqliteItemRepository}"/> interface.</param>
         /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
         /// <param name="imageProcessor">Instance of the <see cref="IImageProcessor"/> interface.</param>
+        /// <param name="configuration">Instance of the <see cref="IConfiguration"/> interface.</param>
         /// <exception cref="ArgumentNullException">config is null.</exception>
         public SqliteItemRepository(
             IServerConfigurationManager config,
             IServerApplicationHost appHost,
             ILogger<SqliteItemRepository> logger,
             ILocalizationManager localization,
-            IImageProcessor imageProcessor)
+            IImageProcessor imageProcessor,
+            IConfiguration configuration)
             : base(logger)
         {
             _config = config;
@@ -337,11 +341,13 @@ namespace Emby.Server.Implementations.Data
             _jsonOptions = JsonDefaults.Options;
 
             DbFilePath = Path.Combine(_config.ApplicationPaths.DataPath, "library.db");
+
+            CacheSize = configuration.GetSqliteCacheSize();
             ReadConnectionsCount = Environment.ProcessorCount * 2;
         }
 
         /// <inheritdoc />
-        protected override int? CacheSize => 20000;
+        protected override int? CacheSize { get; }
 
         /// <inheritdoc />
         protected override TempStoreMode TempStore => TempStoreMode.Memory;

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -60,6 +60,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string UnixSocketPermissionsKey = "kestrel:socketPermissions";
 
         /// <summary>
+        /// The cache size of the SQL database, see cache_size.
+        /// </summary>
+        public const string SqliteCacheSizeKey = "sqlite:cacheSize";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>
@@ -115,5 +120,13 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The unix socket permissions.</returns>
         public static string? GetUnixSocketPermissions(this IConfiguration configuration)
             => configuration[UnixSocketPermissionsKey];
+
+        /// <summary>
+        /// Gets the cache_size from the <see cref="IConfiguration" />.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns>The sqlite cache size.</returns>
+        public static int? GetSqliteCacheSize(this IConfiguration configuration)
+            => configuration.GetValue<int?>(SqliteCacheSizeKey);
     }
 }


### PR DESCRIPTION
**Changes**

This pr adds support for an operator to modify the [`cache_size` PRAGMA option](https://www.sqlite.org/pragma.html#pragma_cache_size) dynamically. This allows an operator to increase the `cache_size` (currently hardcoded to about 82MiB) to troubleshoot performance or to decrease this if they are running in a memory constrained environment (the SQLite default value is about 2MiB).

I would propose this option as officially unsupported by Jellyfin project for now - e.g. "Here be dragons".

**Issues**

Resolves #9646.