### PR TITLE
Increase journal_size_limit Defaults

### DIFF
--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -73,9 +73,10 @@ namespace Emby.Server.Implementations.Data
 
         /// <summary>
         /// Gets the journal size limit. <see href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit" />.
+        /// The default (-1) is overriden to prevent unconstrained WAL size, as reported by users.
         /// </summary>
         /// <value>The journal size limit.</value>
-        protected virtual int? JournalSizeLimit => 0;
+        protected virtual int? JournalSizeLimit => 134_217_728; // 128MiB
 
         /// <summary>
         /// Gets the page size.


### PR DESCRIPTION
**Changes**

Per the [documentation](https://www.sqlite.org/pragma.html#pragma_journal_size_limit) for `journal_size_limit`, when set to `0`, SQLite will "always truncate rollback journals and WAL files to their minimum size".

This pr changes Jelly's defaults from `0` to `134_217_728` (aka, 128MiB).

While I have no performance tests, a value of `0` seems problematic given we are currently using the `journal_mode = WAL` option (since one of the purposes of using WAL is to prevent needing to remove/truncate the journal after each operation).

**Issues**

Related: #9044
