### PR TITLE
feat: api Sessions/Simple, returns SimpleSessionInfo

### DIFF
--- a/MediaBrowser.Controller/Session/SimpleSessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SimpleSessionInfo.cs
@@ -24,7 +24,7 @@ public sealed class SimpleSessionInfo
     /// </summary>
     /// <value>The name of the device playing.</value>
     public string DeviceName { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the device id.
     /// </summary>

--- a/MediaBrowser.Controller/Session/SimpleSessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SimpleSessionInfo.cs
@@ -1,0 +1,39 @@
+#nullable disable
+using System;
+
+namespace MediaBrowser.Controller.Session;
+
+#pragma warning disable CS1591
+/// <summary>
+/// Class SimpleSessionInfo to display a subset of <see cref="SessionInfo"/>.
+/// </summary>
+public sealed class SimpleSessionInfo
+{
+    /// <summary>
+    /// Gets or sets UserName.
+    /// </summary>
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// Gets or sets content now playing.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets Device that is playing content.
+    /// </summary>
+    /// <value>The name of the device playing.</value>
+    public string DeviceName { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the device id.
+    /// </summary>
+    /// <value>The device id.</value>
+    public string DeviceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last activity date.
+    /// </summary>
+    /// <value>The last activity date.</value>
+    public DateTime LastActivityDate { get; set; }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -22,6 +22,16 @@ public class SessionControllerTests : IClassFixture<JellyfinApplicationFactory>
         client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
 
         using var response = await client.GetAsync($"Session/Sessions?userId={Guid.NewGuid()}").ConfigureAwait(false);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSimpleSession_NonExistentUserId_NotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
+
+        using var response = await client.GetAsync($"Session/Simple?userId={Guid.NewGuid()}").ConfigureAwait(false);
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added Server API endpoint `session/Simple`, which returns more simplified, flattened `SimpleSessionInfo` objects. 

Returning `SimpleSessionInfo` simplifies consuming the JF Rest API - it is much smaller (I am using interval 30sec)  and the flattened structure helps automations for me in HomeAssistant.


Open questions:

- [ ]  do we accept this addition to Sessions API
- [ ]  is the created `SimpleSessionInfo`  complete enough (I was thinking maybe add Bandwith or Quality information too)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
https://github.com/jellyfin/jellyfin/issues/9665
