### PR TITLE
Fix `.ignore` files not being honored in `extras` directories

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -164,6 +164,7 @@
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [RealGreenDragon](https://github.com/RealGreenDragon)
  - [ipitio](https://github.com/ipitio)
+ - [Tim Gels](https://github.com/TimGels)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2626,7 +2626,13 @@ namespace Emby.Server.Implementations.Library
                 var current = fileSystemChildren[i];
                 if (current.IsDirectory && _namingOptions.AllExtrasTypesFolderNames.ContainsKey(current.Name))
                 {
-                    var filesInSubFolder = _fileSystem.GetFiles(current.FullName, null, false, false);
+                    var filesInSubFolder = _fileSystem.GetFiles(current.FullName, null, false, false).ToList();
+
+                    if (filesInSubFolder.Any(e => e.Name.Equals(".ignore", StringComparison.Ordinal)))
+                    {
+                        continue;
+                    }
+
                     foreach (var file in filesInSubFolder)
                     {
                         if (!_extraResolver.TryGetExtraTypeForOwner(file.FullName, ownerVideoInfo, out var extraType))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added a patch to fix `.ignore` files not working in `extras` folders. This is done by skipping the resolving of the current extra directory files, if it contains a `.ignore` file.

Ideally, we would make use of the ignore file check inside the `ResolvePath` method that folders like season folders also go through. But due to some limitations, like limited access to some needed information from inside the FindExtras method, this couldn't be done easily without the need of a big refactor.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #9571 
