### PR TITLE
Fix(api): /Items without user

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -239,14 +239,13 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] bool? enableImages = true)
     {
         var isApiKey = User.GetIsApiKey();
-        // if api key is used (auth.IsApiKey == true), then `user` will be null throughout this method
+        // if api key is used (auth.IsApiKey == true), then `user` will be an admin
         userId = RequestHelpers.GetUserId(User, userId);
         var user = !isApiKey && !userId.Value.Equals(default)
             ? _userManager.GetUserById(userId.Value) ?? throw new ResourceNotFoundException()
-            : null;
+            : _userManager.GetUserAdmin();
 
-        // beyond this point, we're either using an api key or we have a valid user
-        if (!isApiKey && user is null)
+        if (user is null)
         {
             return BadRequest("userId is required");
         }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -106,6 +106,20 @@ namespace Jellyfin.Server.Implementations.Users
         public IEnumerable<Guid> UsersIds => _users.Keys;
 
         /// <inheritdoc/>
+        public User? GetUserAdmin()
+        {
+            foreach (var (guid, user) in _users)
+            {
+                if (user.HasPermission(PermissionKind.IsAdministrator))
+                {
+                    return user;
+                }
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
         public User? GetUserById(Guid id)
         {
             if (id.Equals(default))

--- a/MediaBrowser.Controller/Library/IUserManager.cs
+++ b/MediaBrowser.Controller/Library/IUserManager.cs
@@ -40,6 +40,12 @@ namespace MediaBrowser.Controller.Library
         Task InitializeAsync();
 
         /// <summary>
+        /// Gets an admin user for api's where the user is unknown but required. Requires initial user setup.
+        /// </summary>
+        /// <returns>The user or <c>null</c> if initial setup is not completed.</returns>
+        User? GetUserAdmin();
+
+        /// <summary>
         /// Gets a user by Id.
         /// </summary>
         /// <param name="id">The id.</param>


### PR DESCRIPTION
REST API endpoint '/Items' requires userId query.

**Changes**
- `UserManager` provides with `getUserAdmin()` an admin account as fallback for specific edge cases like this. The "admin" might not have the full view to all items (possible?)
- Other solution: Refactor Items handling with optional user. However Jellyfin is all about users, so i don't think it's worth.
- Other solution: Create an apiKey user which is hidden for clients

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Closes: #9708
