### PR TITLE
API Sessions endpoint, added `nowPlaying` querystring param

### DIFF
--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -53,6 +53,7 @@ public class SessionController : BaseJellyfinApiController
     /// <param name="controllableByUserId">Filter by sessions that a given user is allowed to remote control.</param>
     /// <param name="deviceId">Filter by device Id.</param>
     /// <param name="activeWithinSeconds">Optional. Filter by sessions that were active in the last n seconds.</param>
+    /// <param name="nowPlaying">Optional. Filter by sessions that are currently playing content.</param>
     /// <response code="200">List of sessions returned.</response>
     /// <returns>An <see cref="IEnumerable{SessionInfo}"/> with the available sessions.</returns>
     [HttpGet("Sessions")]
@@ -61,7 +62,8 @@ public class SessionController : BaseJellyfinApiController
     public ActionResult<IEnumerable<SessionInfo>> GetSessions(
         [FromQuery] Guid? controllableByUserId,
         [FromQuery] string? deviceId,
-        [FromQuery] int? activeWithinSeconds)
+        [FromQuery] int? activeWithinSeconds,
+        [FromQuery] bool? nowPlaying)
     {
         var result = _sessionManager.Sessions;
 
@@ -108,6 +110,11 @@ public class SessionController : BaseJellyfinApiController
 
                 return true;
             });
+        }
+
+        if (nowPlaying.GetValueOrDefault())
+        {
+            result = result.Where(i => i.NowPlayingItem != null);
         }
 
         return Ok(result);

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -112,9 +112,11 @@ public class SessionController : BaseJellyfinApiController
             });
         }
 
-        if (nowPlaying.GetValueOrDefault())
+        if (nowPlaying.HasValue)
         {
-            result = result.Where(i => i.NowPlayingItem != null);
+            result = nowPlaying.Value
+                ? result.Where(i => i.NowPlayingItem != null)
+                : result.Where(i => i.NowPlayingItem == null);
         }
 
         return Ok(result);

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
@@ -25,15 +25,17 @@ public class SessionControllerTests : IClassFixture<JellyfinApplicationFactory>
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    [Fact]
-    public async Task GetSessions_NowPlaying_Ok()
+    [Theory]
+    [InlineData("?nowPlaying=false")]
+    [InlineData("?nowPlaying=true")]
+    [InlineData("")]
+    public async Task GetSessions_NowPlaying_Ok(string querystring)
     {
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
 
-        using var response = await client.GetAsync("Sessions?nowPlaying=true").ConfigureAwait(false);
+        using var response = await client.GetAsync($"Sessions{querystring}").ConfigureAwait(false);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("[]", await response.Content.ReadAsStringAsync());
     }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -23,5 +23,17 @@ public class SessionControllerTests : IClassFixture<JellyfinApplicationFactory>
 
         using var response = await client.GetAsync($"Session/Sessions?userId={Guid.NewGuid()}").ConfigureAwait(false);
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSessions_NowPlaying_Ok()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client).ConfigureAwait(false));
+
+        using var response = await client.GetAsync("Sessions?nowPlaying=true").ConfigureAwait(false);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("[]", await response.Content.ReadAsStringAsync());
     }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/SessionControllerTests.cs
@@ -26,9 +26,7 @@ public class SessionControllerTests : IClassFixture<JellyfinApplicationFactory>
     }
 
     [Theory]
-    [InlineData("?nowPlaying=false")]
     [InlineData("?nowPlaying=true")]
-    [InlineData("")]
     public async Task GetSessions_NowPlaying_Ok(string querystring)
     {
         var client = _factory.CreateClient();


### PR DESCRIPTION
Only return sessions that have an item currently playing, when using optional parameter 'nowPlaying' on the `Sessions` endpoint.

This was a suggested workaround for my issue #9665.


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Instead of adding extra endpoint,
querystringparam `nowPlaying` is added to `Sessions` endpoint,
to filter 'NowPlaying' sessions only.

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
https://github.com/jellyfin/jellyfin/issues/9665 
<!-- Tag any issues that this PR solves here.

ex. Fixes # -->
