### PR TITLE
Rescue malformed Xml response in DLNA PlayTo

### DIFF
--- a/Emby.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/Emby.Dlna/PlayTo/DlnaHttpClient.cs
@@ -17,7 +17,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Dlna.PlayTo
 {
-    public class DlnaHttpClient
+    /// <summary>
+    /// Http client for Dlna PlayTo function.
+    /// </summary>
+    public partial class DlnaHttpClient
     {
         private readonly ILogger _logger;
         private readonly IHttpClientFactory _httpClientFactory;
@@ -62,8 +65,7 @@ namespace Emby.Dlna.PlayTo
                 var xmlString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
                 // find and replace unescaped ampersands (&)
-                Regex regex = new Regex(@"(&(?![a-z]*;))");
-                xmlString = regex.Replace(xmlString, @"&amp;");
+                xmlString = EscapeAmpersandRegex().Replace(xmlString, "&amp;");
 
                 try
                 {
@@ -77,10 +79,7 @@ namespace Emby.Dlna.PlayTo
                 catch (XmlException ex)
                 {
                     _logger.LogError(ex, "Failed to parse response");
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        _logger.LogDebug("Malformed response: {Content}\n", xmlString);
-                    }
+                    _logger.LogDebug("Malformed response: {Content}\n", xmlString);
 
                     return null;
                 }
@@ -125,5 +124,12 @@ namespace Emby.Dlna.PlayTo
             // Have to await here instead of returning the Task directly, otherwise request would be disposed too soon
             return await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Compile-time generated regular expression for escaping ampersands.
+        /// </summary>
+        /// <returns>Compiled regular expression.</returns>
+        [GeneratedRegex("(&(?![a-z]*;))")]
+        private static partial Regex EscapeAmpersandRegex();
     }
 }


### PR DESCRIPTION
Not all devices (TVs/Receivers/Tuners) appear to provide well-formed Xml responses when using the 'remote control' / 'PlayTo' functionality. Currently, in such cases Jellyfin becomes unable to provide remote control or song progress, behaving like nothing happened (while the remote device starts playing), and throws an exception in the log. 
In this PR, when the XmlException is caught, it tries to escape unescaped & characters and then retries to read the Xml. If the Xml is now correct, Jellyfin will operate normally - if it is still not correct it will log the XmlException after all.

**Changes**
Add regex expression to the exception handler in DlnaHttpClient's SendRequestAsync function. Adding it there avoids interrupting the normal flow, but provides a rescue scenario for communicating with ill-behaving equipment.
Regex currently fixes unescaped ampersands, other corrections could easily be added.

**Issues**
Described in #9521. I'm not sure it fixes the original Bose issue, but does correct the behaviour with my amplifier.
