### PR TITLE
Remove warnings from Emby.Dlna.csproj

### DIFF
--- a/Emby.Dlna/Common/ServiceAction.cs
+++ b/Emby.Dlna/Common/ServiceAction.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Emby.Dlna.Common
 {
@@ -12,7 +13,6 @@ namespace Emby.Dlna.Common
         /// </summary>
         public ServiceAction()
         {
-            ArgumentList = new List<Argument>();
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Emby.Dlna.Common
         /// <summary>
         /// Gets the ArgumentList.
         /// </summary>
-        public List<Argument> ArgumentList { get; }
+        public Collection<Argument> ArgumentList { get; } = new Collection<Argument>();
 
         /// <inheritdoc />
         public override string ToString() => Name;

--- a/Emby.Dlna/PlayTo/DeviceInfo.cs
+++ b/Emby.Dlna/PlayTo/DeviceInfo.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS1591
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Emby.Dlna.Common;
 using MediaBrowser.Model.Dlna;
 
@@ -10,7 +11,6 @@ namespace Emby.Dlna.PlayTo
 {
     public class DeviceInfo
     {
-        private readonly List<DeviceService> _services = new List<DeviceService>();
         private string _baseUrl = string.Empty;
 
         public DeviceInfo()
@@ -46,7 +46,7 @@ namespace Emby.Dlna.PlayTo
 
         public DeviceIcon Icon { get; set; }
 
-        public List<DeviceService> Services => _services;
+        public Collection<DeviceService> Services { get; }
 
         public DeviceIdentification ToDeviceIdentification()
         {

--- a/Emby.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/Emby.Dlna/PlayTo/DlnaHttpClient.cs
@@ -46,7 +46,7 @@ namespace Emby.Dlna.PlayTo
         {
             using var response = await _httpClientFactory.CreateClient(NamedClient.Dlna).SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 return await XDocument.LoadAsync(

--- a/Emby.Dlna/PlayTo/TransportCommands.cs
+++ b/Emby.Dlna/PlayTo/TransportCommands.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
@@ -14,9 +15,9 @@ namespace Emby.Dlna.PlayTo
     {
         private const string CommandBase = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">" + "<SOAP-ENV:Body>" + "<m:{0} xmlns:m=\"{1}\">" + "{2}" + "</m:{0}>" + "</SOAP-ENV:Body></SOAP-ENV:Envelope>";
 
-        public List<StateVariable> StateVariables { get; } = new List<StateVariable>();
+        public Collection<StateVariable> StateVariables { get; } = new Collection<StateVariable>();
 
-        public List<ServiceAction> ServiceActions { get; } = new List<ServiceAction>();
+        public Collection<ServiceAction> ServiceActions { get; } = new Collection<ServiceAction>();
 
         public static TransportCommands Create(XDocument document)
         {

--- a/Emby.Dlna/PlayTo/TransportState.cs
+++ b/Emby.Dlna/PlayTo/TransportState.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable CA1707
 
 namespace Emby.Dlna.PlayTo
 {


### PR DESCRIPTION
BugFix PR to remove warnings from the Emby.Dlna project.

**Changes**
- Changed read only lists to read only collections.
- Disabled warning about `_` in enum value.
- Removed await from await using. Not 100% sure about this one.
  - https://stackoverflow.com/questions/70886713/how-do-i-get-the-await-using-syntax-correct
  - https://github.com/dotnet/csharplang/discussions/2661
  - Seems like this is a language issue with await using + ConfigureAwait.

**Issues**
#2149 
Removing warnings from sln
