### PR TITLE
refactor: admin users must have a non-empty password

### DIFF
--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -131,6 +131,10 @@ public class StartupController : BaseJellyfinApiController
     public async Task<ActionResult> UpdateStartupUser([FromBody] StartupUserDto startupUserDto)
     {
         var user = _userManager.Users.First();
+        if (string.IsNullOrWhiteSpace(startupUserDto.Password))
+        {
+            return BadRequest("Password must not be empty");
+        }
 
         if (startupUserDto.Name is not null)
         {

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -278,6 +278,10 @@ namespace Jellyfin.Server.Implementations.Users
         public async Task ChangePassword(User user, string newPassword)
         {
             ArgumentNullException.ThrowIfNull(user);
+            if (user.HasPermission(PermissionKind.IsAdministrator) && string.IsNullOrWhiteSpace(newPassword))
+            {
+                throw new ArgumentException("Admin user passwords must not be empty", nameof(newPassword));
+            }
 
             await GetAuthenticationProvider(user).ChangePassword(user, newPassword).ConfigureAwait(false);
             await UpdateUserAsync(user).ConfigureAwait(false);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
It's annoying if your setup is strictly on LAN, but for the greater good, admin users must have a non-empty password
