### PR TITLE
Mock configuration to get SqliteCacheSizeKey during test

### DIFF
--- a/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteItemRepositoryTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteItemRepositoryTests.cs
@@ -6,6 +6,7 @@ using Emby.Server.Implementations.Data;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 
@@ -27,8 +28,18 @@ namespace Jellyfin.Server.Implementations.Tests.Data
             appHost.Setup(x => x.ReverseVirtualPath(It.IsAny<string>()))
                 .Returns((string x) => x.Replace(MetaDataPath, VirtualMetaDataPath, StringComparison.Ordinal));
 
+            var configSection = new Mock<IConfigurationSection>();
+            configSection
+                .SetupGet(x => x[It.Is<string>(s => s == MediaBrowser.Controller.Extensions.ConfigurationExtensions.SqliteCacheSizeKey)])
+                .Returns("0");
+            var config = new Mock<IConfiguration>();
+            config
+                .Setup(x => x.GetSection(It.Is<string>(s => s == MediaBrowser.Controller.Extensions.ConfigurationExtensions.SqliteCacheSizeKey)))
+                .Returns(configSection.Object);
+
             _fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
             _fixture.Inject(appHost);
+            _fixture.Inject(config);
             _sqliteItemRepository = _fixture.Create<SqliteItemRepository>();
         }
 


### PR DESCRIPTION
Fix breaking test from https://github.com/jellyfin/jellyfin/pull/9666