### PR TITLE
Make LUFS property nullable in BaseItemDto

### DIFF
--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -783,7 +783,7 @@ namespace MediaBrowser.Model.Dto
         /// Gets or sets the LUFS value.
         /// </summary>
         /// <value>The LUFS Value.</value>
-        public float LUFS { get; set; }
+        public float? LUFS { get; set; }
 
         /// <summary>
         /// Gets or sets the current program.


### PR DESCRIPTION
This fixes a regression from #9222 where the LUFS field in the OpenAPI spec was not nullable. This will cause issues with the Kotlin SDK.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Make LUFS property nullable in BaseItemDto
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
