### PR TITLE
Add and enforce playback permission on API

### DIFF
--- a/Jellyfin.Api/Auth/LocalAccessOrRequiresElevationPolicy/LocalAccessOrRequiresElevationHandler.cs
+++ b/Jellyfin.Api/Auth/LocalAccessOrRequiresElevationPolicy/LocalAccessOrRequiresElevationHandler.cs
@@ -34,20 +34,9 @@ namespace Jellyfin.Api.Auth.LocalAccessOrRequiresElevationPolicy
             var ip = _httpContextAccessor.HttpContext?.GetNormalizedRemoteIP();
 
             // Loopback will be on LAN, so we can accept null.
-            if (ip is null || _networkManager.IsInLocalNetwork(ip))
+            if (ip is null || _networkManager.IsInLocalNetwork(ip) || context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(requirement);
-
-                return Task.CompletedTask;
-            }
-
-            if (context.User.IsInRole(UserRoles.Administrator))
-            {
-                context.Succeed(requirement);
-            }
-            else
-            {
-                context.Fail();
             }
 
             return Task.CompletedTask;

--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -4,10 +4,11 @@ using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Helpers;
-using Jellyfin.Api.Models.StreamingDtos;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,6 +17,7 @@ namespace Jellyfin.Api.Controllers;
 /// <summary>
 /// The audio controller.
 /// </summary>
+[Authorize(Policy = Policies.Playback)]
 public class AudioController : BaseJellyfinApiController
 {
     private readonly AudioHelper _audioHelper;

--- a/Jellyfin.Api/Controllers/HlsSegmentController.cs
+++ b/Jellyfin.Api/Controllers/HlsSegmentController.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Helpers;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.MediaEncoding;
@@ -20,6 +21,7 @@ namespace Jellyfin.Api.Controllers;
 /// The hls segment controller.
 /// </summary>
 [Route("")]
+[Authorize(Policy = Policies.Playback)]
 public class HlsSegmentController : BaseJellyfinApiController
 {
     private readonly IFileSystem _fileSystem;

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -1156,6 +1156,7 @@ public class LiveTvController : BaseJellyfinApiController
     /// or a <see cref="NotFoundResult"/> if recording not found.
     /// </returns>
     [HttpGet("LiveRecordings/{recordingId}/stream")]
+    [Authorize(Policy = Policies.Playback)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesVideoFile]
@@ -1183,6 +1184,7 @@ public class LiveTvController : BaseJellyfinApiController
     /// or a <see cref="NotFoundResult"/> if stream not found.
     /// </returns>
     [HttpGet("LiveStreamFiles/{streamId}/stream.{container}")]
+    [Authorize(Policy = Policies.Playback)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesVideoFile]

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -8,6 +8,7 @@ using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Api.Models.StreamingDtos;
+using MediaBrowser.Common.Api;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
@@ -29,6 +30,7 @@ namespace Jellyfin.Api.Controllers;
 /// The universal audio controller.
 /// </summary>
 [Route("")]
+[Authorize(Policy = Policies.Playback)]
 public class UniversalAudioController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;
@@ -91,7 +93,6 @@ public class UniversalAudioController : BaseJellyfinApiController
     /// <returns>A <see cref="Task"/> containing the audio file.</returns>
     [HttpGet("Audio/{itemId}/universal")]
     [HttpHead("Audio/{itemId}/universal", Name = "HeadUniversalAudioStream")]
-    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status302Found)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
+++ b/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
@@ -10,6 +10,7 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// Attachments controller.
 /// </summary>
 [Route("Videos")]
+[Authorize]
 public class VideoAttachmentsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -311,6 +311,7 @@ public class VideosController : BaseJellyfinApiController
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream")]
     [HttpHead("{itemId}/stream", Name = "HeadVideoStream")]
+    [Authorize(Policy = Policies.Playback)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesVideoFile]
     public async Task<ActionResult> GetVideoStream(
@@ -552,6 +553,7 @@ public class VideosController : BaseJellyfinApiController
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream.{container}")]
     [HttpHead("{itemId}/stream.{container}", Name = "HeadVideoStreamByContainer")]
+    [Authorize(Policy = Policies.Playback)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesVideoFile]
     public Task<ActionResult> GetVideoStreamByContainer(

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -77,6 +77,7 @@ namespace Jellyfin.Server.Extensions
                 options.AddPolicy(Policies.LiveTvAccess, new UserPermissionRequirement(PermissionKind.EnableLiveTvAccess));
                 options.AddPolicy(Policies.LiveTvManagement, new UserPermissionRequirement(PermissionKind.EnableLiveTvManagement));
                 options.AddPolicy(Policies.LocalAccessOrRequiresElevation, new LocalAccessOrRequiresElevationRequirement());
+                options.AddPolicy(Policies.Playback, new UserPermissionRequirement(PermissionKind.EnableMediaPlayback));
                 options.AddPolicy(Policies.SyncPlayHasAccess, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.HasAccess));
                 options.AddPolicy(Policies.SyncPlayCreateGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.CreateGroup));
                 options.AddPolicy(Policies.SyncPlayJoinGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.JoinGroup));

--- a/MediaBrowser.Common/Api/Policies.cs
+++ b/MediaBrowser.Common/Api/Policies.cs
@@ -94,4 +94,9 @@ public static class Policies
     /// Policy name for accessing lyric management.
     /// </summary>
     public const string LyricManagement = "LyricManagement";
+
+    /// <summary>
+    /// Policy name for playback.
+    /// </summary>
+    public const string Playback = "Playback";
 }


### PR DESCRIPTION
Why is there a setting if it is never enforced anywhere...

**Changes**
* Add auth policy for media playback
* Enforce policy on all playback endpoints for non-LAN requests

**Issues**
Fixes #9872