### PR TITLE
Close streams with no sessions on playback and session events

### DIFF
--- a/Emby.Server.Implementations/Library/ExclusiveLiveStream.cs
+++ b/Emby.Server.Implementations/Library/ExclusiveLiveStream.cs
@@ -37,6 +37,8 @@ namespace Emby.Server.Implementations.Library
 
         public string UniqueId { get; }
 
+        public bool AllowCleanup { get; set; }
+
         public Task Close()
         {
             return _closeFn();

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1263,6 +1263,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                             ItemId = channelItem.Id,
                             OpenToken = mediaStreamInfo.OpenToken
                         },
+                        false,
                         CancellationToken.None).ConfigureAwait(false);
 
                     mediaStreamInfo = liveStreamResponse.Item1.MediaSource;

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/LiveStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/LiveStream.cs
@@ -73,6 +73,8 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
 
         public DateTime DateOpened { get; protected set; }
 
+        public bool AllowCleanup { get; set; }
+
         protected void SetTempFilePath(string extension)
         {
             TempFilePath = Path.Combine(_configurationManager.GetTranscodePath(), UniqueId + "." + extension);

--- a/MediaBrowser.Controller/Library/ILiveStream.cs
+++ b/MediaBrowser.Controller/Library/ILiveStream.cs
@@ -23,6 +23,8 @@ namespace MediaBrowser.Controller.Library
 
         string UniqueId { get; }
 
+        bool AllowCleanup { get; set; }
+
         Task Open(CancellationToken openCancellationToken);
 
         Task Close();

--- a/MediaBrowser.Controller/Library/IMediaSourceManager.cs
+++ b/MediaBrowser.Controller/Library/IMediaSourceManager.cs
@@ -90,7 +90,7 @@ namespace MediaBrowser.Controller.Library
         /// <returns>Task&lt;MediaSourceInfo&gt;.</returns>
         Task<LiveStreamResponse> OpenLiveStream(LiveStreamRequest request, CancellationToken cancellationToken);
 
-        Task<Tuple<LiveStreamResponse, IDirectStreamProvider>> OpenLiveStreamInternal(LiveStreamRequest request, CancellationToken cancellationToken);
+        Task<Tuple<LiveStreamResponse, IDirectStreamProvider>> OpenLiveStreamInternal(LiveStreamRequest request, bool allowCleanup, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the live stream.
@@ -132,5 +132,7 @@ namespace MediaBrowser.Controller.Library
         void SetDefaultAudioAndSubtitleStreamIndexes(BaseItem item, MediaSourceInfo source, User user);
 
         Task AddMediaInfoWithProbe(MediaSourceInfo mediaSource, bool isAudio, string cacheKey, bool addProbeDelay, bool isLiveStream, CancellationToken cancellationToken);
+
+        List<KeyValuePair<string, ILiveStream>> GetOpenStreams();
     }
 }


### PR DESCRIPTION
Some of the Jellyfin clients (such as Android Mobile) do not seem to unsubscribe from Live Streams after they are closed. This can result in streams remaining open on the server indefinitely, which causes issues with M3UTuners that have a fixed number of active streams allowed. The server should be responsible for cleaning up after any irresponsible clients, or connection failures in this case.

**Changes**
Adds a new function to SessionManager to close any streams that are not currently "claimed" by a session. Adds behavior to trigger this cleanup on events that would require it such as playback stopping or sessions ending. Also allows the cleanup to be toggled for the case of Live TV Recording, which does not need to be cleaned up.

**Issues**
Fixes #9690
