### PR TITLE
Fix 'replace missing metadata' for music

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -250,8 +250,8 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
 
                     _libraryManager.UpdatePeople(audio, people);
-                    audio.Artists = audio.Artists != null ? audio.Artists : performers;
-                    audio.AlbumArtists = audio.AlbumArtists != null ? audio.AlbumArtists : albumArtists;
+                    audio.Artists ??= performers;
+                    audio.AlbumArtists ??= albumArtists;
                 }
 
                 audio.Name = string.IsNullOrEmpty(audio.Name) ? tags.Title : audio.Name;

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -255,9 +255,9 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
 
                 audio.Name = string.IsNullOrEmpty(audio.Name) ? tags.Title : audio.Name;
-                audio.Album = audio.Album != null ? audio.Album : tags.Album;
-                audio.IndexNumber = audio.IndexNumber != null ? audio.IndexNumber : Convert.ToInt32(tags.Track);
-                audio.ParentIndexNumber = audio.ParentIndexNumber != null ? audio.ParentIndexNumber : Convert.ToInt32(tags.Disc);
+                audio.Album ??= tags.Album;
+                audio.IndexNumber ??= Convert.ToInt32(tags.Track);
+                audio.ParentIndexNumber ??= Convert.ToInt32(tags.Disc);
 
                 if (tags.Year != 0)
                 {

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -271,27 +271,27 @@ namespace MediaBrowser.Providers.MediaInfo
                     audio.Genres = tags.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 }
 
-                if (!audio.ProviderIds.TryGetValue("MusicBrainzArtist", out var artistValue) || artistValue == null)
+                if (!audio.TryGetProviderId("MusicBrainzArtist", out var artistValue) || string.IsNullOrEmpty(artistValue))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzArtist, tags.MusicBrainzArtistId);
                 }
 
-                if (!audio.ProviderIds.TryGetValue("MusicBrainzAlbumArtist", out var albumArtistValue) || albumArtistValue == null)
+                if (!audio.TryGetProviderId("MusicBrainzAlbumArtist", out var albumArtistValue) || string.IsNullOrEmpty(albumArtistValue))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, tags.MusicBrainzReleaseArtistId);
                 }
 
-                if (!audio.ProviderIds.TryGetValue("MusicBrainzAlbum", out var albumValue) || albumValue == null)
+                if (!audio.TryGetProviderId("MusicBrainzAlbum", out var albumValue) || string.IsNullOrEmpty(albumValue))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, tags.MusicBrainzReleaseId);
                 }
 
-                if (!audio.ProviderIds.TryGetValue("MusicBrainzReleaseGroup", out var releaseGroupValue) || releaseGroupValue == null)
+                if (!audio.TryGetProviderId("MusicBrainzReleaseGroup", out var releaseGroupValue) || string.IsNullOrEmpty(releaseGroupValue))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, tags.MusicBrainzReleaseGroupId);
                 }
 
-                if (!audio.ProviderIds.TryGetValue("MusicBrainzTrack", out var trackValue) || trackValue == null)
+                if (!audio.TryGetProviderId("MusicBrainzTrack", out var trackValue) || string.IsNullOrEmpty(trackValue))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzTrack, tags.MusicBrainzTrackId);
                 }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -250,18 +250,13 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
 
                     _libraryManager.UpdatePeople(audio, people);
-                    // audio.Artists = performers;
                     audio.Artists = audio.Artists != null ? audio.Artists : performers;
-                    // audio.AlbumArtists = albumArtists;
                     audio.AlbumArtists = audio.AlbumArtists != null ? audio.AlbumArtists : albumArtists;
                 }
 
-                audio.Name = string.IsNullOrEmpty(audio.Name.ToString()) ? tags.Title : audio.Name;
-                // audio.Album = tags.Album;
+                audio.Name = string.IsNullOrEmpty(audio.Name) ? tags.Title : audio.Name;
                 audio.Album = audio.Album != null ? audio.Album : tags.Album;
-                // audio.IndexNumber = Convert.ToInt32(tags.Track);
                 audio.IndexNumber = audio.IndexNumber != null ? audio.IndexNumber : Convert.ToInt32(tags.Track);
-                // audio.ParentIndexNumber = Convert.ToInt32(tags.Disc);
                 audio.ParentIndexNumber = audio.ParentIndexNumber != null ? audio.ParentIndexNumber : Convert.ToInt32(tags.Disc);
 
                 if (tags.Year != 0)

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -271,27 +271,27 @@ namespace MediaBrowser.Providers.MediaInfo
                     audio.Genres = tags.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 }
 
-                if (!audio.TryGetProviderId("MusicBrainzArtist", out var artistValue) || string.IsNullOrEmpty(artistValue))
+                if (!audio.TryGetProviderId("MusicBrainzArtist", out _))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzArtist, tags.MusicBrainzArtistId);
                 }
 
-                if (!audio.TryGetProviderId("MusicBrainzAlbumArtist", out var albumArtistValue) || string.IsNullOrEmpty(albumArtistValue))
+                if (!audio.TryGetProviderId("MusicBrainzAlbumArtist", out _))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, tags.MusicBrainzReleaseArtistId);
                 }
 
-                if (!audio.TryGetProviderId("MusicBrainzAlbum", out var albumValue) || string.IsNullOrEmpty(albumValue))
+                if (!audio.TryGetProviderId("MusicBrainzAlbum", out _))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, tags.MusicBrainzReleaseId);
                 }
 
-                if (!audio.TryGetProviderId("MusicBrainzReleaseGroup", out var releaseGroupValue) || string.IsNullOrEmpty(releaseGroupValue))
+                if (!audio.TryGetProviderId("MusicBrainzReleaseGroup", out _))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, tags.MusicBrainzReleaseGroupId);
                 }
 
-                if (!audio.TryGetProviderId("MusicBrainzTrack", out var trackValue) || string.IsNullOrEmpty(trackValue))
+                if (!audio.TryGetProviderId("MusicBrainzTrack", out _))
                 {
                     audio.SetProviderId(MetadataProvider.MusicBrainzTrack, tags.MusicBrainzTrackId);
                 }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -250,14 +250,19 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
 
                     _libraryManager.UpdatePeople(audio, people);
-                    audio.Artists = performers;
-                    audio.AlbumArtists = albumArtists;
+                    // audio.Artists = performers;
+                    audio.Artists = audio.Artists != null ? audio.Artists : performers;
+                    // audio.AlbumArtists = albumArtists;
+                    audio.AlbumArtists = audio.AlbumArtists != null ? audio.AlbumArtists : albumArtists;
                 }
 
-                audio.Name = tags.Title;
-                audio.Album = tags.Album;
-                audio.IndexNumber = Convert.ToInt32(tags.Track);
-                audio.ParentIndexNumber = Convert.ToInt32(tags.Disc);
+                audio.Name = string.IsNullOrEmpty(audio.Name.ToString()) ? tags.Title : audio.Name;
+                // audio.Album = tags.Album;
+                audio.Album = audio.Album != null ? audio.Album : tags.Album;
+                // audio.IndexNumber = Convert.ToInt32(tags.Track);
+                audio.IndexNumber = audio.IndexNumber != null ? audio.IndexNumber : Convert.ToInt32(tags.Track);
+                // audio.ParentIndexNumber = Convert.ToInt32(tags.Disc);
+                audio.ParentIndexNumber = audio.ParentIndexNumber != null ? audio.ParentIndexNumber : Convert.ToInt32(tags.Disc);
 
                 if (tags.Year != 0)
                 {
@@ -271,11 +276,30 @@ namespace MediaBrowser.Providers.MediaInfo
                     audio.Genres = tags.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 }
 
-                audio.SetProviderId(MetadataProvider.MusicBrainzArtist, tags.MusicBrainzArtistId);
-                audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, tags.MusicBrainzReleaseArtistId);
-                audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, tags.MusicBrainzReleaseId);
-                audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, tags.MusicBrainzReleaseGroupId);
-                audio.SetProviderId(MetadataProvider.MusicBrainzTrack, tags.MusicBrainzTrackId);
+                if (!audio.ProviderIds.TryGetValue("MusicBrainzArtist", out var artistValue) || artistValue == null)
+                {
+                    audio.SetProviderId(MetadataProvider.MusicBrainzArtist, tags.MusicBrainzArtistId);
+                }
+
+                if (!audio.ProviderIds.TryGetValue("MusicBrainzAlbumArtist", out var albumArtistValue) || albumArtistValue == null)
+                {
+                    audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, tags.MusicBrainzReleaseArtistId);
+                }
+
+                if (!audio.ProviderIds.TryGetValue("MusicBrainzAlbum", out var albumValue) || albumValue == null)
+                {
+                    audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, tags.MusicBrainzReleaseId);
+                }
+
+                if (!audio.ProviderIds.TryGetValue("MusicBrainzReleaseGroup", out var releaseGroupValue) || releaseGroupValue == null)
+                {
+                    audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, tags.MusicBrainzReleaseGroupId);
+                }
+
+                if (!audio.ProviderIds.TryGetValue("MusicBrainzTrack", out var trackValue) || trackValue == null)
+                {
+                    audio.SetProviderId(MetadataProvider.MusicBrainzTrack, tags.MusicBrainzTrackId);
+                }
             }
         }
     }


### PR DESCRIPTION
**Changes**
The code includes logic that ensures that manually entered data by the user in certain metadata fields is not modified during the process of searching and updating missing metadata

**Issues**
Fixes issue #9760 for music.
