### PR TITLE
fix #9983 MigrateNetworkConfiguration error

### DIFF
--- a/Jellyfin.Server/Migrations/MigrationRunner.cs
+++ b/Jellyfin.Server/Migrations/MigrationRunner.cs
@@ -93,7 +93,7 @@ namespace Jellyfin.Server.Migrations
 
         private static void HandleStartupWizardCondition(IEnumerable<IMigrationRoutine> migrations, MigrationOptions migrationOptions, bool isStartWizardCompleted, ILogger logger)
         {
-            if (isStartWizardCompleted || migrationOptions.Applied.Count != 0)
+            if (isStartWizardCompleted)
             {
                 return;
             }
@@ -106,6 +106,8 @@ namespace Jellyfin.Server.Migrations
 
         private static void PerformMigrations(IMigrationRoutine[] migrations, MigrationOptions migrationOptions, Action<MigrationOptions> saveConfiguration, ILogger logger)
         {
+            // save already applied migrations, and skip them thereafter
+            saveConfiguration(migrationOptions);
             var appliedMigrationIds = migrationOptions.Applied.Select(m => m.Id).ToHashSet();
 
             for (var i = 0; i < migrations.Length; i++)


### PR DESCRIPTION
fix #9983: [Issue]: Starting freshly installed Jellyfin server for the second time fails with MigrateNetworkConfiguration error

**Changes**
migration.xml now is written also when  migrations are skipped during a fresh install of Jellyfin server

**Issues**
fixes #9983
