### PR TITLE
Change: Add TinyMediaManager compatibility for german parental rating

### DIFF
--- a/Emby.Server.Implementations/Localization/Ratings/de.csv
+++ b/Emby.Server.Implementations/Localization/Ratings/de.csv
@@ -1,12 +1,17 @@
 Educational,0
 Infoprogramm,0
 FSK-0,0
+FSK 0,0
 0,0
 FSK-6,6
+FSK 6,6
 6,6
 FSK-12,12
+FSK 12,12
 12,12
 FSK-16,16
+FSK 16,16
 16,16
 FSK-18,18
+FSK 18,18
 18,18

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -100,7 +100,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             await localizationManager.LoadAll();
             var ratings = localizationManager.GetParentalRatings().ToList();
 
-            Assert.Equal(19, ratings.Count);
+            Assert.Equal(24, ratings.Count);
 
             var fsk = ratings.FirstOrDefault(x => x.Name.Equals("FSK-12", StringComparison.Ordinal));
             Assert.NotNull(fsk);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This PR adds the format which gets written by
 the tool TinyMediaManager which can be used to
 manage large media databases comfortably.

TMM writes wither multiple Codes and/or space
 divided german FSK codes, but can't be configured
 to only use the number or the slash delimited variant.

After this change the parental control for Libraries
 managed with TMM and presented/loaded into Jellyfin
 should work again.