### PR TITLE
Prefer unplayed items when sorting randomly

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -236,3 +236,5 @@
  - [Jakob Kukla](https://github.com/jakobkukla)
  - [Utku Özdemir](https://github.com/utkuozdemir)
  - [JPUC1143](https://github.com/Jpuc1143/)
+ - [DavidMikeSimon](https://github.com/DavidMikeSimon)
+

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2150,6 +2150,7 @@ namespace Emby.Server.Implementations.Data
                     || sortingFields.Contains(ItemSortBy.PlayCount)
                     || sortingFields.Contains(ItemSortBy.DatePlayed)
                     || sortingFields.Contains(ItemSortBy.SeriesDatePlayed)
+                    || sortingFields.Contains(ItemSortBy.Random) // Needed because random sorting uses IsPlayed
                     || query.IsFavoriteOrLiked.HasValue
                     || query.IsFavorite.HasValue
                     || query.IsResumable.HasValue
@@ -2946,7 +2947,7 @@ namespace Emby.Server.Implementations.Data
                 if (hasSimilar)
                 {
                     prepend.Add(("SimilarityScore", SortOrder.Descending));
-                    prepend.Add((ItemSortBy.Random, SortOrder.Ascending));
+                    prepend.Add((ItemSortBy.SortName, SortOrder.Ascending));
                 }
 
                 var arr = new (string, SortOrder)[prepend.Count + orderBy.Count];
@@ -2982,7 +2983,8 @@ namespace Emby.Server.Implementations.Data
 
             if (string.Equals(name, ItemSortBy.Random, StringComparison.OrdinalIgnoreCase))
             {
-                return "RANDOM()";
+                // Prefer unplayed items
+                return "((ABS(RANDOM()) % 65536) + (Select Case When played Then 65536 Else 0 End))";
             }
 
             if (string.Equals(name, ItemSortBy.DatePlayed, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
**Changes**
This PR adjusts the "Random" sorting strategy to prefer unplayed items over played items, as a simple way of addressing [feature request 717](https://features.jellyfin.org/posts/717/shuffle-weight-recently-played-media-should-be-less-likely-to-be-next).

The idea here is that when a user hits the "Shuffle" button in any given context (e.g. a show, a library, a collection), they are probably not interested in seeing items that they have recently already played via shuffle. Tying the priority to the "Played" flag gives the user some control over this behavior, e.g. if they want to "reset" their shuffle exclusion, they can mark a folder as unplayed.

**Looking for feedback and suggestions**
I'm definitely open to suggestions about this approach and implementation! In particular, I notice that besides the `ORDER BY RANDOM()` strategy implemented in `SqliteItemRepository`, there are two other possible ways for items to be shuffled: `RandomComparer` and `ShuffleExtensions`. I'm unsure about whether these need to be adjusted as well, and I was unable to figure how they could get invoked from front-end actions.

**Issues**
https://features.jellyfin.org/posts/717/shuffle-weight-recently-played-media-should-be-less-likely-to-be-next