### PR TITLE
fix: set memorystream position after copying

### DIFF
--- a/Emby.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/Emby.Dlna/PlayTo/DlnaHttpClient.cs
@@ -57,6 +57,7 @@ namespace Emby.Dlna.PlayTo
             response.EnsureSuccessStatusCode();
             await using MemoryStream ms = new MemoryStream();
             await response.Content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+            ms.Position = 0;
             try
             {
                 return await XDocument.LoadAsync(


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Issues**
CopyToAsync doesn't rewind the stream
