### PR TITLE
Fix album art extraction for multi-disc music albums

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -166,6 +166,7 @@
  - [RealGreenDragon](https://github.com/RealGreenDragon)
  - [ipitio](https://github.com/ipitio)
  - [TheTyrius](https://github.com/TheTyrius)
+ - [tallbl0nde](https://github.com/tallbl0nde)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
@@ -31,6 +31,7 @@ namespace Emby.Server.Implementations.Images
             return _libraryManager.GetItemList(new InternalItemsQuery
             {
                 Parent = item,
+                Recursive = true,
                 DtoOptions = new DtoOptions(true),
                 ImageTypes = new ImageType[] { ImageType.Primary },
                 OrderBy = new (string, SortOrder)[]


### PR DESCRIPTION
**Changes**
Sets the `Recursive` flag to `true` within the query made in `BaseFolderImageProvider.GetItemsWithImages()` in order to search for audio files in an album (that contain images within their metadata) more than one level deep.

In my case I store *all* music with the following structure (even for single disc albums):
```
Music/
  Artist/
    Album/
      Disc 1/
        01 - Track 1.flac
        ...
```

Running `Refresh all metadata` on my music library after making this change gets all the album art to be displayed for each album.

I feel cheeky for adding my name to the contributors for a single-line change but I'm planning to make more contributions in the future 😉

**Issues**
There's no exact issue that I could find, however #9359 seems to be relevant (although it outlines more issues).
