### PR TITLE
Add support for more remote subtitle info

### DIFF
--- a/MediaBrowser.Model/Providers/RemoteSubtitleInfo.cs
+++ b/MediaBrowser.Model/Providers/RemoteSubtitleInfo.cs
@@ -25,8 +25,18 @@ namespace MediaBrowser.Model.Providers
 
         public float? CommunityRating { get; set; }
 
+        public float? FrameRate { get; set; }
+
         public int? DownloadCount { get; set; }
 
         public bool? IsHashMatch { get; set; }
+
+        public bool? AiTranslated { get; set; }
+
+        public bool? MachineTranslated { get; set; }
+
+        public bool? Forced { get; set; }
+
+        public bool? HearingImpaired { get; set; }
     }
 }


### PR DESCRIPTION
**Changes**
Added `Forced`, `HearingImpaired`, `MachineTranslated`, `AiTranslated` and `FrameRate` properties to RemoteSubtitleInfo, all this info is provided by opensubtitles but we don't display it

UI in https://github.com/jellyfin/jellyfin-web/pull/4727

**Issues**
Fixes: https://github.com/jellyfin/jellyfin/issues/10027
