### PR TITLE
Add ability to upload (and save) SDH subtitles

### DIFF
--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -416,6 +416,7 @@ public class SubtitleController : BaseJellyfinApiController
                     Format = body.Format,
                     Language = body.Language,
                     IsForced = body.IsForced,
+                    IsHearingImpaired = body.IsHearingImpaired,
                     Stream = memoryStream
                 }).ConfigureAwait(false);
             _providerManager.QueueRefresh(video.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.High);

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -90,7 +90,7 @@ public class SubtitleController : BaseJellyfinApiController
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult<Task> DeleteSubtitle(
+    public async Task<ActionResult> DeleteSubtitle(
         [FromRoute, Required] Guid itemId,
         [FromRoute, Required] int index)
     {
@@ -101,7 +101,7 @@ public class SubtitleController : BaseJellyfinApiController
             return NotFound();
         }
 
-        _subtitleManager.DeleteSubtitles(item, index);
+        await _subtitleManager.DeleteSubtitles(item, index).ConfigureAwait(false);
         return NoContent();
     }
 

--- a/Jellyfin.Api/Models/SubtitleDtos/UploadSubtitleDto.cs
+++ b/Jellyfin.Api/Models/SubtitleDtos/UploadSubtitleDto.cs
@@ -26,6 +26,12 @@ public class UploadSubtitleDto
     public bool IsForced { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the subtitle is for hearing impaired.
+    /// </summary>
+    [Required]
+    public bool IsHearingImpaired { get; set; }
+
+    /// <summary>
     /// Gets or sets the subtitle data.
     /// </summary>
     [Required]

--- a/MediaBrowser.Controller/Subtitles/SubtitleResponse.cs
+++ b/MediaBrowser.Controller/Subtitles/SubtitleResponse.cs
@@ -14,6 +14,8 @@ namespace MediaBrowser.Controller.Subtitles
 
         public bool IsForced { get; set; }
 
+        public bool IsHearingImpaired { get; set; }
+
         public Stream Stream { get; set; }
     }
 }

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -200,6 +200,11 @@ namespace MediaBrowser.Providers.Subtitles
                     saveFileName += ".forced";
                 }
 
+                if (response.IsHearingImpaired)
+                {
+                    saveFileName += ".sdh";
+                }
+
                 saveFileName += "." + response.Format.ToLowerInvariant();
 
                 if (saveInMediaFolder)


### PR DESCRIPTION
**Changes**
Added `IsHearingImpaired` flag to both `UploadSubtitleDto` and `SubtitleResponse` which then adds a `.sdh` suffix to filename when saving (This should work with opensubtitles (pr soon™️))

Also made subtitle deletion async, this fixes a bug on the frontend where after deleting a subtitle it would refresh the subtitle list before the deletion was actually finished. This resulted in user seeing the deleted sub track, attempting to delete it again would actually delete the subtitle track below it since they are ID-based

**Issues**
None

UI: https://github.com/jellyfin/jellyfin-web/pull/4728
