### PR TITLE
Only disable the global_header for AMD HEVC encoder

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1457,8 +1457,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 args += keyFrameArg + gopArg;
             }
 
-            // global_header produced by AMD VA-API encoder causes non-playable fMP4 on iOS
-            if (codec.Contains("vaapi", StringComparison.OrdinalIgnoreCase)
+            // global_header produced by AMD HEVC VA-API encoder causes non-playable fMP4 on iOS
+            if (string.Equals(codec, "hevc_vaapi", StringComparison.OrdinalIgnoreCase)
                 && _mediaEncoder.IsVaapiDeviceAmd)
             {
                 args += " -flags:v -global_header";


### PR DESCRIPTION
**Changes**
- Only disable the `global_header` for AMD HEVC encoder

**Issues**
- Fixes VA-API AV1 encoder on AMD https://github.com/jellyfin/jellyfin-ffmpeg/issues/264#issuecomment-1640566294
