### PR TITLE
Fix format normalizer for multiple input formats

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1,5 +1,4 @@
 #nullable disable
-#pragma warning disable CS1591
 
 using System;
 using System.Collections.Generic;
@@ -20,6 +19,9 @@ using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.MediaEncoding.Probing
 {
+    /// <summary>
+    /// Class responsible for normalizing FFprobe output.
+    /// </summary>
     public class ProbeResultNormalizer
     {
         // When extracting subtitles, the maximum length to consider (to avoid invalid filenames)
@@ -36,6 +38,11 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private string[] _splitWhiteList;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProbeResultNormalizer"/> class.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{ProbeResultNormalizer}"/> for use with the <see cref="ProbeResultNormalizer"/> instance.</param>
+        /// <param name="localization">The <see cref="ILocalizationManager"/> for use with the <see cref="ProbeResultNormalizer"/> instance.</param>
         public ProbeResultNormalizer(ILogger logger, ILocalizationManager localization)
         {
             _logger = logger;
@@ -73,6 +80,15 @@ namespace MediaBrowser.MediaEncoding.Probing
             "Smith/Kotzen",
         };
 
+        /// <summary>
+        /// Transforms a FFprobe response into its <see cref="MediaInfo"/> equivalent.
+        /// </summary>
+        /// <param name="data">The <see cref="InternalMediaInfoResult"/>.</param>
+        /// <param name="videoType">The <see cref="VideoType"/>.</param>
+        /// <param name="isAudio">A boolean indicating whether the media is audio.</param>
+        /// <param name="path">Path to media file.</param>
+        /// <param name="protocol">Path media protocol.</param>
+        /// <returns>The <see cref="MediaInfo"/>.</returns>
         public MediaInfo GetMediaInfo(InternalMediaInfoResult data, VideoType? videoType, bool isAudio, string path, MediaProtocol protocol)
         {
             var info = new MediaInfo
@@ -252,25 +268,30 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            // Handle MPEG-1 container
-            if (string.Equals(format, "mpegvideo", StringComparison.OrdinalIgnoreCase))
+            // Input can be a list of multiple, comma-delimited formats - each of them needs to be checked
+            var splitFormat = format.Split(',');
+            for (var i = 0; i < splitFormat.Length; i++)
             {
-                return "mpeg";
+                // Handle MPEG-1 container
+                if (string.Equals(splitFormat[i], "mpegvideo", StringComparison.OrdinalIgnoreCase))
+                {
+                    splitFormat[i] = "mpeg";
+                }
+
+                // Handle MPEG-2 container
+                else if (string.Equals(splitFormat[i], "mpeg", StringComparison.OrdinalIgnoreCase))
+                {
+                    splitFormat[i] = "ts";
+                }
+
+                // Handle matroska container
+                else if (string.Equals(splitFormat[i], "matroska", StringComparison.OrdinalIgnoreCase))
+                {
+                    splitFormat[i] = "mkv";
+                }
             }
 
-            // Handle MPEG-2 container
-            if (string.Equals(format, "mpeg", StringComparison.OrdinalIgnoreCase))
-            {
-                return "ts";
-            }
-
-            // Handle matroska container
-            if (string.Equals(format, "matroska", StringComparison.OrdinalIgnoreCase))
-            {
-                return "mkv";
-            }
-
-            return format;
+            return string.Join(',', splitFormat);
         }
 
         private int? GetEstimatedAudioBitrate(string codec, int? channels)


### PR DESCRIPTION
Seems like FFprobe can return a list of formats.

**Changes**
* Split format input before running normalization and run normalization on all input formats

**Issues**
Fixes #10046