### PR TITLE
Add parsing for dates with spaces

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -318,7 +318,7 @@ namespace Emby.Naming.Common
                 new EpisodeExpression(@"[\._ -]()[Ee][Pp]_?([0-9]+)([^\\/]*)$"),
                 // <!-- foo.E01., foo.e01. -->
                 new EpisodeExpression(@"[^\\/]*?()\.?[Ee]([0-9]+)\.([^\\/]*)$"),
-                new EpisodeExpression(@"(?<year>[0-9]{4})[\.\-_ ](?<month>[0-9]{2})[\.\-_ ](?<day>[0-9]{2})", true)
+                new EpisodeExpression(@"(?<year>[0-9]{4})[._ -](?<month>[0-9]{2})[._ -](?<day>[0-9]{2})", true)
                 {
                     DateTimeFormats = new[]
                     {
@@ -328,7 +328,7 @@ namespace Emby.Naming.Common
                         "yyyy MM dd"
                     }
                 },
-                new EpisodeExpression(@"(?<day>[0-9]{2})[\.\-_ ](?<month>[0-9]{2})[\.\-_ ](?<year>[0-9]{4})", true)
+                new EpisodeExpression(@"(?<day>[0-9]{2})[._ -](?<month>[0-9]{2})[._ -](?<year>[0-9]{4})", true)
                 {
                     DateTimeFormats = new[]
                     {

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -318,7 +318,7 @@ namespace Emby.Naming.Common
                 new EpisodeExpression(@"[\._ -]()[Ee][Pp]_?([0-9]+)([^\\/]*)$"),
                 // <!-- foo.E01., foo.e01. -->
                 new EpisodeExpression(@"[^\\/]*?()\.?[Ee]([0-9]+)\.([^\\/]*)$"),
-                new EpisodeExpression("(?<year>[0-9]{4})[\\.-_ ](?<month>[0-9]{2})[\\.-_ ](?<day>[0-9]{2})", true)
+                new EpisodeExpression(@"(?<year>[0-9]{4})[\.\-_ ](?<month>[0-9]{2})[\.\-_ ](?<day>[0-9]{2})", true)
                 {
                     DateTimeFormats = new[]
                     {
@@ -328,7 +328,7 @@ namespace Emby.Naming.Common
                         "yyyy MM dd"
                     }
                 },
-                new EpisodeExpression(@"(?<day>[0-9]{2})[.-_ ](?<month>[0-9]{2})[.-_ ](?<year>[0-9]{4})", true)
+                new EpisodeExpression(@"(?<day>[0-9]{2})[\.\-_ ](?<month>[0-9]{2})[\.\-_ ](?<year>[0-9]{4})", true)
                 {
                     DateTimeFormats = new[]
                     {

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -318,22 +318,24 @@ namespace Emby.Naming.Common
                 new EpisodeExpression(@"[\._ -]()[Ee][Pp]_?([0-9]+)([^\\/]*)$"),
                 // <!-- foo.E01., foo.e01. -->
                 new EpisodeExpression(@"[^\\/]*?()\.?[Ee]([0-9]+)\.([^\\/]*)$"),
-                new EpisodeExpression("(?<year>[0-9]{4})[\\.-](?<month>[0-9]{2})[\\.-](?<day>[0-9]{2})", true)
+                new EpisodeExpression("(?<year>[0-9]{4})[\\.-_ ](?<month>[0-9]{2})[\\.-_ ](?<day>[0-9]{2})", true)
                 {
                     DateTimeFormats = new[]
                     {
                         "yyyy.MM.dd",
                         "yyyy-MM-dd",
-                        "yyyy_MM_dd"
+                        "yyyy_MM_dd",
+                        "yyyy MM dd"
                     }
                 },
-                new EpisodeExpression(@"(?<day>[0-9]{2})[.-](?<month>[0-9]{2})[.-](?<year>[0-9]{4})", true)
+                new EpisodeExpression(@"(?<day>[0-9]{2})[.-_ ](?<month>[0-9]{2})[.-_ ](?<year>[0-9]{4})", true)
                 {
                     DateTimeFormats = new[]
                     {
                         "dd.MM.yyyy",
                         "dd-MM-yyyy",
-                        "dd_MM_yyyy"
+                        "dd_MM_yyyy",
+                        "dd MM yyyy"
                     }
                 },
 

--- a/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/DailyEpisodeTests.cs
@@ -13,6 +13,7 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData(@"/server/anything_1996-11-14.mp4", "anything", 1996, 11, 14)]
         [InlineData(@"/server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv", "james.corden", 2017, 04, 20)]
         [InlineData(@"/server/ABC News 2018_03_24_19_00_00.mkv", "ABC News", 2018, 03, 24)]
+        [InlineData(@"/server/Jeopardy 2023 07 14 HDTV x264 AC3.mkv", "Jeopardy", 2023, 07, 14)]
         // TODO: [InlineData(@"/server/anything_14.11.1996.mp4", "anything", 1996, 11, 14)]
         // TODO: [InlineData(@"/server/A Daily Show - (2015-01-15) - Episode Name - [720p].mkv", "A Daily Show", 2015, 01, 15)]
         // TODO: [InlineData(@"/server/Last Man Standing_KTLADT_2018_05_25_01_28_00.wtv", "Last Man Standing", 2018, 05, 25)]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
I've encountered titles with the date formatted using spaces between the numbers recently ("2023 07 28"). This adds that as a date format.

**Issues**
None
