### PR TITLE
Fix the probing of m4a metadata with missing composer

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -223,30 +223,39 @@ namespace MediaBrowser.Providers.MediaInfo
                     var albumArtists = tags.AlbumArtists;
                     foreach (var albumArtist in albumArtists)
                     {
-                        PeopleHelper.AddPerson(people, new PersonInfo
+                        if (!string.IsNullOrEmpty(albumArtist))
                         {
-                            Name = albumArtist,
-                            Type = PersonKind.AlbumArtist
-                        });
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = albumArtist,
+                                Type = PersonKind.AlbumArtist
+                            });
+                        }
                     }
 
                     var performers = tags.Performers;
                     foreach (var performer in performers)
                     {
-                        PeopleHelper.AddPerson(people, new PersonInfo
+                        if (!string.IsNullOrEmpty(performer))
                         {
-                            Name = performer,
-                            Type = PersonKind.Artist
-                        });
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = performer,
+                                Type = PersonKind.Artist
+                            });
+                        }
                     }
 
                     foreach (var composer in tags.Composers)
                     {
-                        PeopleHelper.AddPerson(people, new PersonInfo
+                        if (!string.IsNullOrEmpty(composer))
                         {
-                            Name = composer,
-                            Type = PersonKind.Composer
-                        });
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = composer,
+                                Type = PersonKind.Composer
+                            });
+                        }
                     }
 
                     _libraryManager.UpdatePeople(audio, people);


### PR DESCRIPTION
**Changes**
The composer is not set in some of my m4a files. For some reason TagLibSharp returns the composer as an empty string in this case. This causes an exception in PeopleHelper.AddPerson, and thus probing fails.

IMHO we can simply ignore empty values.

**Issues**
Fixes: #10061
