### PR TITLE
Expand AMD VA-API Vulkan filtering support to Polaris/gfx8

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -891,6 +891,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
                 else if (_mediaEncoder.IsVaapiDeviceAmd)
                 {
+                    // Disable AMD EFC feature since it's still unstable in upstream Mesa.
+                    Environment.SetEnvironmentVariable("AMD_DEBUG", "noefc");
+
                     if (IsVulkanFullSupported()
                         && _mediaEncoder.IsVaapiDeviceSupportVulkanDrmInterop)
                     {

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -64,8 +64,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Gets a value indicating whether the configured Vaapi device supports vulkan drm format modifier.
         /// </summary>
-        /// <value><c>true</c> if the Vaapi device supports vulkan drm format modifier, <c>false</c> otherwise.</value>
-        bool IsVaapiDeviceSupportVulkanFmtModifier { get; }
+        /// <value><c>true</c> if the Vaapi device supports vulkan drm interop, <c>false</c> otherwise.</value>
+        bool IsVaapiDeviceSupportVulkanDrmInterop { get; }
 
         /// <summary>
         /// Whether given encoder codec is supported.

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -76,12 +76,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private bool _isVaapiDeviceAmd = false;
         private bool _isVaapiDeviceInteliHD = false;
         private bool _isVaapiDeviceInteli965 = false;
-        private bool _isVaapiDeviceSupportVulkanFmtModifier = false;
+        private bool _isVaapiDeviceSupportVulkanDrmInterop = false;
 
-        private static string[] _vulkanFmtModifierExts =
+        private static string[] _vulkanExternalMemoryDmaBufExts =
         {
-            "VK_KHR_sampler_ycbcr_conversion",
-            "VK_EXT_image_drm_format_modifier",
             "VK_KHR_external_memory_fd",
             "VK_EXT_external_memory_dma_buf",
             "VK_KHR_external_semaphore_fd",
@@ -140,7 +138,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public bool IsVaapiDeviceInteli965 => _isVaapiDeviceInteli965;
 
         /// <inheritdoc />
-        public bool IsVaapiDeviceSupportVulkanFmtModifier => _isVaapiDeviceSupportVulkanFmtModifier;
+        public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
@@ -204,7 +202,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     _isVaapiDeviceAmd = validator.CheckVaapiDeviceByDriverName("Mesa Gallium driver", options.VaapiDevice);
                     _isVaapiDeviceInteliHD = validator.CheckVaapiDeviceByDriverName("Intel iHD driver", options.VaapiDevice);
                     _isVaapiDeviceInteli965 = validator.CheckVaapiDeviceByDriverName("Intel i965 driver", options.VaapiDevice);
-                    _isVaapiDeviceSupportVulkanFmtModifier = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanFmtModifierExts);
+                    _isVaapiDeviceSupportVulkanDrmInterop = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanExternalMemoryDmaBufExts);
 
                     if (_isVaapiDeviceAmd)
                     {
@@ -219,9 +217,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
                         _logger.LogInformation("VAAPI device {RenderNodePath} is Intel GPU (i965)", options.VaapiDevice);
                     }
 
-                    if (_isVaapiDeviceSupportVulkanFmtModifier)
+                    if (_isVaapiDeviceSupportVulkanDrmInterop)
                     {
-                        _logger.LogInformation("VAAPI device {RenderNodePath} supports Vulkan DRM format modifier", options.VaapiDevice);
+                        _logger.LogInformation("VAAPI device {RenderNodePath} supports Vulkan DRM interop", options.VaapiDevice);
                     }
                 }
             }


### PR DESCRIPTION
**ROCm OpenCL runtime is not needed anymore when using HDR tone-mapping on Polaris/gfx8.**

This change requires [jellyfin-ffmpeg5 5.1.3-4](https://github.com/jellyfin/jellyfin-ffmpeg/pull/268) or [jellyfin-ffmpeg6 6.0-5](https://github.com/jellyfin/jellyfin-ffmpeg/pull/267) or newer versions.

**Changes**
- Expand AMD VA-API Vulkan filtering support to Polaris/gfx8
(Older cards don't benefit as much because they don't support 10-bit HEVC decoding)

**Issues**
- ROCm runtime is the biggest issue 😅
