### PR TITLE
 Combine Title and Overview for multi-episodes files for the TMDB provider

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -167,6 +167,7 @@
  - [ipitio](https://github.com/ipitio)
  - [TheTyrius](https://github.com/TheTyrius)
  - [tallbl0nde](https://github.com/tallbl0nde)
+ - [scampower3](https://github.com/scampower3)
 
 # Emby Contributors
 

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -139,8 +139,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
                 for (int i = 1; i < result.Count; i++)
                 {
-                    name.Append(" / " + result[i].Name);
-                    overview.Append(" / " + result[i].Overview);
+                    name.Append(" / ").Append(result[i].Name);
+                    overview.Append(" / ").Append(result[i].Overview);
                 }
 
                 episodeResult.Name = name.ToString();

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -14,7 +14,6 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
-using MediaBrowser.Providers.Music;
 using TMDbLib.Objects.TvShows;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -121,7 +121,18 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
                 if (result is not null)
                 {
-                    episodeResult = result[0];
+                    // Forces a deep copy of the first TvEpisode, so we don't modify the original because it's cached
+                    episodeResult = new TvEpisode()
+                    {
+                        Name = result[0].Name,
+                        Overview = result[0].Overview,
+                        AirDate = result[0].AirDate,
+                        VoteAverage = result[0].VoteAverage,
+                        ExternalIds = result[0].ExternalIds,
+                        Videos = result[0].Videos,
+                        Credits = result[0].Credits
+                    };
+
                     if (result.Count > 1)
                     {
                         var name = new StringBuilder(episodeResult.Name);


### PR DESCRIPTION
Now multi-episodes file show all episodes titles and overviews instead of only just the first episode's title and overview.

**Changes**

- Checks if there is an IndexNumberEnd. If it exist, do multiple request for all episodes between IndexNumber and IndexNumber end. Concats the name and overviews with a " / " delimiting each other.

**Issues**
Partially fixes  #2980
