### PR TITLE
Combine Title and Overview for multi-episodes files for NFO file

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -92,9 +92,38 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     {
                         reader.MoveToContent();
 
-                        if (reader.ReadToDescendant("episode") && int.TryParse(reader.ReadElementContentAsString(), out var num))
+                        while (!reader.EOF && reader.ReadState == ReadState.Interactive)
                         {
-                            item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            if (reader.NodeType == XmlNodeType.Element)
+                            {
+                                switch (reader.Name)
+                                {
+                                    case "name":
+                                    case "title":
+                                    case "localtitle":
+                                        item.Item.Name = item.Item.Name + " / " + reader.ReadElementContentAsString();
+                                        break;
+                                    case "episode":
+                                        {
+                                            if (int.TryParse(reader.ReadElementContentAsString(), out var num))
+                                            {
+                                                item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
+                                            }
+
+                                            break;
+                                        }
+
+                                    case "biography":
+                                    case "plot":
+                                    case "review":
+                                        item.Item.Overview = item.Item.Overview + " / " + reader.ReadElementContentAsString();
+                                        break;
+                                }
+                            }
+
+                            reader.Read();
                         }
                     }
                 }

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -107,7 +107,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                     case "name":
                                     case "title":
                                     case "localtitle":
-                                        name.Append(" / " + reader.ReadElementContentAsString());
+                                        name.Append(" / ").Append(reader.ReadElementContentAsString());
                                         break;
                                     case "episode":
                                         {
@@ -122,7 +122,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                     case "biography":
                                     case "plot":
                                     case "review":
-                                        overview.Append(" / " + reader.ReadElementContentAsString());
+                                        overview.Append(" / ").Append(reader.ReadElementContentAsString());
                                         break;
                                 }
                             }

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Xml;
 using MediaBrowser.Common.Configuration;
@@ -81,7 +82,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 }
 
                 // Extract the last episode number from nfo
+                // Retrieves all title and plot tags from the rest of the nfo and concatenates them with the first episode
                 // This is needed because XBMC metadata uses multiple episodedetails blocks instead of episodenumberend tag
+                var name = new StringBuilder(item.Item.Name);
+                var overview = new StringBuilder(item.Item.Overview);
                 while ((index = xmlFile.IndexOf(srch, StringComparison.OrdinalIgnoreCase)) != -1)
                 {
                     xml = xmlFile.Substring(0, index + srch.Length);
@@ -103,7 +107,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                     case "name":
                                     case "title":
                                     case "localtitle":
-                                        item.Item.Name = item.Item.Name + " / " + reader.ReadElementContentAsString();
+                                        name.Append(" / " + reader.ReadElementContentAsString());
                                         break;
                                     case "episode":
                                         {
@@ -118,7 +122,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                                     case "biography":
                                     case "plot":
                                     case "review":
-                                        item.Item.Overview = item.Item.Overview + " / " + reader.ReadElementContentAsString();
+                                        overview.Append(" / " + reader.ReadElementContentAsString());
                                         break;
                                 }
                             }
@@ -127,6 +131,9 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         }
                     }
                 }
+
+                item.Item.Name = name.ToString();
+                item.Item.Overview = overview.ToString();
             }
             catch (XmlException)
             {

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -208,6 +208,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         break;
                     }
 
+                case "displayafterseason":
                 case "airsafter_season":
                     {
                         var val = reader.ReadElementContentAsString();

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using Jellyfin.Data.Enums;
@@ -114,11 +114,11 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             _parser.Fetch(result, "Test Data/Rising.nfo", CancellationToken.None);
 
             var item = result.Item;
-            Assert.Equal("Rising (1)", item.Name);
+            Assert.Equal("Rising (1) / Rising (2)", item.Name);
             Assert.Equal(1, item.IndexNumber);
             Assert.Equal(2, item.IndexNumberEnd);
             Assert.Equal(1, item.ParentIndexNumber);
-            Assert.Equal("A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy.", item.Overview);
+            Assert.Equal("A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy. / Sheppard tries to convince Weir to mount a rescue mission to free Colonel Sumner, Teyla, and the others captured by the Wraith.", item.Overview);
             Assert.Equal(new DateTime(2004, 7, 16), item.PremiereDate);
             Assert.Equal(2004, item.ProductionYear);
         }


### PR DESCRIPTION
Now multi-episodes file show all episodes titles and overviews instead of only just the first episode's title and overview.

**Changes**

- Iterates through each episodedetails block. Grabs the title and plot and concats them together with a " / " delimiting each other.

**Issues**
Partially fixes #2980
