### PR TITLE
Fix French parental rating system

### DIFF
--- a/Emby.Server.Implementations/Localization/Ratings/fr.csv
+++ b/Emby.Server.Implementations/Localization/Ratings/fr.csv
@@ -1,5 +1,6 @@
 Public Averti,0
 Tous Publics,0
+TP,0
 U,0
 0+,0
 6+,6


### PR DESCRIPTION
**Changes**
I've added "TP" as a rating (French equivalent of U) meaning "Tous publics".

**Issues**
Some "universal" public movies are classified "U", and some are "TP" (meaning the same thing) in French UI. Without "TP" in this file, if you add a parental control, "TP" movies are not available.