### PR TITLE
fix: accessing Standard* of a Process requires manually disposing them afterwards

### DIFF
--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -620,7 +620,7 @@ public class TranscodingJobHelper : IDisposable
         state.TranscodingJob = transcodingJob;
 
         // Important - don't await the log task or we won't be able to kill FFmpeg when the user stops playback
-        _ = new JobLogger(_logger).StartStreamingLog(state, process.StandardError.BaseStream, logStream);
+        _ = new JobLogger(_logger).StartStreamingLog(state, process.StandardError, logStream);
 
         // Wait for the file to exist before proceeding
         var ffmpegTargetFile = state.WaitForPath ?? outputPath;

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -20,12 +20,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             _logger = logger;
         }
 
-        public async Task StartStreamingLog(EncodingJobInfo state, Stream source, Stream target)
+        public async Task StartStreamingLog(EncodingJobInfo state, StreamReader reader, Stream target)
         {
             try
             {
                 using (target)
-                using (var reader = new StreamReader(source))
+                using (reader)
                 {
                     while (!reader.EndOfStream && reader.BaseStream.CanRead)
                     {

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -572,24 +572,14 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                 process.Start();
 
-                if (!string.IsNullOrEmpty(testKey))
+                if (redirectStandardIn)
                 {
-                    process.StandardInput.Write(testKey);
+                    using var writer = process.StandardInput;
+                    writer.Write(testKey);
                 }
 
-                var reader = readStdErr ? process.StandardError : process.StandardOutput;
-                try
-                {
-                    return reader.ReadToEnd();
-                }
-                finally
-                {
-                    reader.Dispose();
-                    if (redirectStandardIn)
-                    {
-                        process.StandardInput.Dispose();
-                    }
-                }
+                using var reader = readStdErr ? process.StandardError : process.StandardOutput;
+                return reader.ReadToEnd();
             }
         }
     }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1033,6 +1033,14 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                 try
                 {
+                    process.StandardOutput.Dispose();
+                }
+                catch
+                {
+                }
+
+                try
+                {
                     process.Dispose();
                 }
                 catch

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -511,7 +511,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             using (var processWrapper = new ProcessWrapper(process, this))
             {
                 StartProcess(processWrapper);
-                await process.StandardOutput.BaseStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+                using var reader = process.StandardOutput;
+                await reader.BaseStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 InternalMediaInfoResult result;
                 try
@@ -1029,14 +1030,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 lock (_mediaEncoder._runningProcessesLock)
                 {
                     _mediaEncoder._runningProcesses.Remove(this);
-                }
-
-                try
-                {
-                    process.StandardOutput.Dispose();
-                }
-                catch
-                {
                 }
 
                 try

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -130,7 +130,8 @@ namespace MediaBrowser.Providers.MediaInfo
                         throw;
                     }
 
-                    output = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+                    using var reader = process.StandardError;
+                    output = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
                     cancellationToken.ThrowIfCancellationRequested();
                     MatchCollection split = LUFSRegex().Matches(output);
 

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -68,51 +68,54 @@ public static class FfProbeKeyframeExtractor
         double streamDuration = 0;
         double formatDuration = 0;
 
-        while (!reader.EndOfStream)
+        using (reader)
         {
-            var line = reader.ReadLine().AsSpan();
-            if (line.IsEmpty)
+            while (!reader.EndOfStream)
             {
-                continue;
-            }
-
-            var firstComma = line.IndexOf(',');
-            var lineType = line[..firstComma];
-            var rest = line[(firstComma + 1)..];
-            if (lineType.Equals("packet", StringComparison.OrdinalIgnoreCase))
-            {
-                // Split time and flags from the packet line. Example line: packet,7169.079000,K_
-                var secondComma = rest.IndexOf(',');
-                var ptsTime = rest[..secondComma];
-                var flags = rest[(secondComma + 1)..];
-                if (flags.StartsWith("K_"))
+                var line = reader.ReadLine().AsSpan();
+                if (line.IsEmpty)
                 {
-                    if (double.TryParse(ptsTime, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
+                    continue;
+                }
+
+                var firstComma = line.IndexOf(',');
+                var lineType = line[..firstComma];
+                var rest = line[(firstComma + 1)..];
+                if (lineType.Equals("packet", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Split time and flags from the packet line. Example line: packet,7169.079000,K_
+                    var secondComma = rest.IndexOf(',');
+                    var ptsTime = rest[..secondComma];
+                    var flags = rest[(secondComma + 1)..];
+                    if (flags.StartsWith("K_"))
                     {
-                      // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
-                      keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));
+                        if (double.TryParse(ptsTime, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var keyframe))
+                        {
+                            // Have to manually convert to ticks to avoid rounding errors as TimeSpan is only precise down to 1 ms when converting double.
+                            keyframes.Add(Convert.ToInt64(keyframe * TimeSpan.TicksPerSecond));
+                        }
+                    }
+                }
+                else if (lineType.Equals("stream", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (double.TryParse(rest, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var streamDurationResult))
+                    {
+                        streamDuration = streamDurationResult;
+                    }
+                }
+                else if (lineType.Equals("format", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (double.TryParse(rest, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var formatDurationResult))
+                    {
+                        formatDuration = formatDurationResult;
                     }
                 }
             }
-            else if (lineType.Equals("stream", StringComparison.OrdinalIgnoreCase))
-            {
-                if (double.TryParse(rest, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var streamDurationResult))
-                {
-                    streamDuration = streamDurationResult;
-                }
-            }
-            else if (lineType.Equals("format", StringComparison.OrdinalIgnoreCase))
-            {
-                if (double.TryParse(rest, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var formatDurationResult))
-                {
-                    formatDuration = formatDurationResult;
-                }
-            }
+
+            // Prefer the stream duration as it should be more accurate
+            var duration = streamDuration > 0 ? streamDuration : formatDuration;
+
+            return new KeyframeData(TimeSpan.FromSeconds(duration).Ticks, keyframes);
         }
-
-        // Prefer the stream duration as it should be more accurate
-        var duration = streamDuration > 0 ? streamDuration : formatDuration;
-
-        return new KeyframeData(TimeSpan.FromSeconds(duration).Ticks, keyframes);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Seems like we must dispose the streamreaders manually to avoid (temporarily) leaking SafeFileHandles: https://source.dot.net/#System.Diagnostics.Process/System/Diagnostics/Process.cs,894