### PR TITLE
Fixed probesize argument passing to FFmpeg

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -238,3 +238,4 @@
  - [Jakob Kukla](https://github.com/jakobkukla)
  - [Utku Özdemir](https://github.com/utkuozdemir)
  - [JPUC1143](https://github.com/Jpuc1143/)
+ - [0x25CBFC4F](https://github.com/0x25CBFC4F)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5678,7 +5678,6 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Apply -analyzeduration as per the environment variable,
             // otherwise ffmpeg will break on certain files due to default value is 0.
-            // The default value of -probesize is more than enough, so leave it as is.
             var ffmpegAnalyzeDuration = _config.GetFFmpegAnalyzeDuration() ?? string.Empty;
 
             if (state.MediaSource.AnalyzeDurationMs > 0)
@@ -5693,6 +5692,22 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (!string.IsNullOrEmpty(analyzeDurationArgument))
             {
                 inputModifier += " " + analyzeDurationArgument;
+            }
+
+            inputModifier = inputModifier.Trim();
+
+            // Apply -probesize if configured
+            var probeSizeArgument = string.Empty;
+            var ffmpegProbeSize = _config.GetFFmpegProbeSize();
+
+            if (!string.IsNullOrEmpty(ffmpegProbeSize))
+            {
+                probeSizeArgument = $"-probesize {probeSizeArgument}";
+            }
+
+            if (!string.IsNullOrEmpty(probeSizeArgument))
+            {
+                inputModifier += $" {probeSizeArgument}";
             }
 
             inputModifier = inputModifier.Trim();


### PR DESCRIPTION
While setting up Jellyfish myself I stumbled into issue described in #9984 (related issue is #1713)
Server knows about FFmpeg's probesize variable but it is unused. This PR fixes that.

I should mention that documentation [explicitly states](https://github.com/jellyfin/jellyfin.org/blob/13b92c4e903fd64148dfd6a73fc5059d8eb3f10a/docs/general/administration/configuration.md?plain=1#L105) that this variable exists so I think this is expected behavior.

**Changes**
- I added a code block to `EncodingHelper.GetInputModifier` that passes `probesize` argument to FFmpeg.
- Added myself to CONTRIBUTORS.md

**Issues**
Fixes #9984
