### PR TITLE
Fix debian/ubuntu arm64 build error,runtime argument missing

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,10 @@ ifeq ($(HOST_ARCH),arm64)
     # Building ARM
     DOTNETRUNTIME := debian-arm64
 endif
+ifeq ($(HOST_ARCH),aarch64)
+    # Building ARM
+    DOTNETRUNTIME := debian-arm64
+endif
 
 export DH_VERBOSE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
I tried to compile on Rock 5B, but it`s fail

 log:
```bash
make[1]: Entering directory '/root/jellyfin'
dotnet publish -maxcpucount:1 --configuration Release --output='/root/jellyfin/usr/lib/jellyfin/bin' --self-contained --runtime  \
        -p:DebugSymbols=false -p:DebugType=none Jellyfin.Server
Required argument missing for option: --runtime
```

I checked the build script and found that it used arch to obtain the architecture. However, on the Armbian system, he returned aarch64 instead of the existing arm64 in the script, which resulted in the runtime missing parameters
```bash
root@rock-5b:~/jellyfin# arch
aarch64
root@rock-5b:~/jellyfin# neofetch
                                 root@rock-5b
                                 ------------
      █ █ █ █ █ █ █ █ █ █ █      OS: Armbian (23.08.0-trunk) aarch64
     ███████████████████████     Host: Radxa ROCK 5B
   ▄▄██                   ██▄▄   Kernel: 5.10.160-legacy-rk35xx
   ▄▄██    ███████████    ██▄▄   Uptime: 2 hours, 27 mins
   ▄▄██   ██         ██   ██▄▄   Packages: 1444 (dpkg)
   ▄▄██   ██         ██   ██▄▄   Shell: bash 5.1.16
   ▄▄██   ██         ██   ██▄▄   Terminal: /dev/pts/0
   ▄▄██   █████████████   ██▄▄   CPU: (8) @ 1.800GHz
   ▄▄██   ██         ██   ██▄▄   Memory: 1695MiB / 7688MiB
   ▄▄██   ██         ██   ██▄▄
   ▄▄██   ██         ██   ██▄▄
   ▄▄██                   ██▄▄
     ███████████████████████
      █ █ █ █ █ █ █ █ █ █ █


```

**Changes**
I added the judgment for aarch64 in the debian/rules file
