### PR TITLE
Fix performance loss of QSV HDR tone-mapping on Windows

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3487,12 +3487,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                         // map from d3d11va to qsv.
                         mainFilters.Add("hwmap=derive_device=qsv");
                     }
-                    else
-                    {
-                        // Insert a qsv scaler to sync the decoder surface,
-                        // msdk will passthrough this internally.
-                        mainFilters.Add("hwmap=derive_device=qsv,scale_qsv");
-                    }
                 }
 
                 // hw deint
@@ -4653,10 +4647,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                     if (isD3d11Supported && isCodecAvailable)
                     {
-                        // set -threads 3 to intel d3d11va decoder explicitly. Lower threads may result in dead lock.
-                        // on newer devices such as Xe, the larger the init_pool_size, the longer the initialization time for opencl to derive from d3d11.
                         return " -hwaccel d3d11va" + (outputHwSurface ? " -hwaccel_output_format d3d11" : string.Empty)
-                            + (profileMismatch ? " -hwaccel_flags +allow_profile_mismatch" : string.Empty) + " -threads 3" + (isAv1 ? " -c:v av1" : string.Empty);
+                            + (profileMismatch ? " -hwaccel_flags +allow_profile_mismatch" : string.Empty) + " -threads 2" + (isAv1 ? " -c:v av1" : string.Empty);
                     }
                 }
                 else


### PR DESCRIPTION
**Changes**
- Fix performance loss of QSV HDR tone-mapping on Windows
(The VPP passthrough cannot completely avoid the problem, but brings visible performance loss.
jellyfin-ffmpeg 5.1.3-5, 6.0-6 or newer contains a potent fix than this one.)

**Issues**
- See also https://github.com/jellyfin/jellyfin-ffmpeg/pull/275

![image](https://github.com/jellyfin/jellyfin-ffmpeg/assets/14953024/7742cbd1-a367-44b9-950c-d35ed966460e)