### PR TITLE
Use the correct trancode path

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -37,6 +37,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         private readonly IMediaEncoder _mediaEncoder;
         private readonly ISubtitleEncoder _subtitleEncoder;
         private readonly IConfiguration _config;
+        private readonly IConfigurationManager _configurationManager;
 
         // i915 hang was fixed by linux 6.2 (3f882f2)
         private readonly Version _minKerneli915Hang = new Version(5, 18);
@@ -112,12 +113,14 @@ namespace MediaBrowser.Controller.MediaEncoding
             IApplicationPaths appPaths,
             IMediaEncoder mediaEncoder,
             ISubtitleEncoder subtitleEncoder,
-            IConfiguration config)
+            IConfiguration config,
+            IConfigurationManager configurationManager)
         {
             _appPaths = appPaths;
             _mediaEncoder = mediaEncoder;
             _subtitleEncoder = subtitleEncoder;
             _config = config;
+            _configurationManager = configurationManager;
         }
 
         [GeneratedRegex(@"\s+")]
@@ -1058,7 +1061,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
             {
-                var tmpConcatPath = Path.Join(options.TranscodingTempPath, state.MediaSource.Id + ".concat");
+                var tmpConcatPath = Path.Join(_configurationManager.GetTranscodePath(), state.MediaSource.Id + ".concat");
                 _mediaEncoder.GenerateConcatConfig(state.MediaSource, tmpConcatPath);
                 arg.Append(" -f concat -safe 0 -i ")
                     .Append(tmpConcatPath);


### PR DESCRIPTION
`EncodingOptions.TranscodingTempPath` can be empty (and is by default), the correct way to get the trancode path is
`EncodingConfigurationExtensions.GetTranscodePath` which falls back to `$CACHEPATH/transcodes` when `EncodingOptions.TranscodingTempPath` is null or empty.