### PR TITLE
Add a small Bash script to launch Jellyfin, instead of a symlink.

### DIFF
--- a/fedora/jellyfin-selinux-launcher.sh
+++ b/fedora/jellyfin-selinux-launcher.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/lib64/jellyfin/jellyfin ${@}

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -14,6 +14,7 @@ License:        GPLv2
 URL:            https://jellyfin.org
 # Jellyfin Server tarball created by `make -f .copr/Makefile srpm`, real URL ends with `v%%{version}.tar.gz`
 Source0:        jellyfin-server-%{version}.tar.gz
+Source10:       jellyfin-selinux-launcher.sh
 Source11:       jellyfin.service
 Source12:       jellyfin.env
 Source13:       jellyfin.override.conf
@@ -73,7 +74,7 @@ dotnet publish --configuration Release --self-contained --runtime %{dotnet_runti
 # Jellyfin files
 %{__mkdir} -p %{buildroot}%{_libdir}/jellyfin %{buildroot}%{_bindir}
 %{__cp} -r Jellyfin.Server/bin/Release/net7.0/%{dotnet_runtime}/publish/* %{buildroot}%{_libdir}/jellyfin
-ln -srf %{_libdir}/jellyfin/jellyfin %{buildroot}%{_bindir}/jellyfin
+%{__install} -D %{SOURCE10} %{buildroot}%{_bindir}/jellyfin
 
 # Jellyfin config
 %{__install} -D Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/jellyfin/logging.json
@@ -106,6 +107,7 @@ ln -srf %{_libdir}/jellyfin/jellyfin %{buildroot}%{_bindir}/jellyfin
 %attr(755,root,root) %{_libdir}/jellyfin/createdump
 %attr(755,root,root) %{_libdir}/jellyfin/jellyfin
 %{_libdir}/jellyfin/*
+%attr(755,root,root) %{_bindir}/jellyfin
 
 # Jellyfin config
 %config(noreplace) %attr(644,jellyfin,jellyfin) %{_sysconfdir}/jellyfin/logging.json


### PR DESCRIPTION
Fix the Jellyfin launcher on SELinux-enabled systems. Replace /usr/bin/jellyfin symlink with a 2-line shell script, which itself calls the target of the symlink.
  - The symlink causes a problem with SELinux because it understands symlinks.
  - This shell script automatically inherits the correct SELinux context.

**Changes**
- Add 2-line shell script that calls the Jellyfin executable
- Update Fedora spec file to use new launcher script.

**Issues**
Fixes [Issue 8114](https://github.com/jellyfin/jellyfin/issues/8114)