### PR TITLE
Fix AV1 playback in LiveTV

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1651,7 +1651,7 @@ public class DynamicHlsController : BaseJellyfinApiController
             _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer),
             threads,
             mapArgs,
-            GetVideoArguments(state, startNumber, isEventPlaylist),
+            GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer),
             GetAudioArguments(state),
             maxMuxingQueueSize,
             state.SegmentLength.ToString(CultureInfo.InvariantCulture),
@@ -1814,8 +1814,9 @@ public class DynamicHlsController : BaseJellyfinApiController
     /// <param name="state">The <see cref="StreamState"/>.</param>
     /// <param name="startNumber">The first number in the hls sequence.</param>
     /// <param name="isEventPlaylist">Whether the playlist is EVENT or VOD.</param>
+    /// <param name="segmentContainer">The segment container.</param>
     /// <returns>The command line arguments for video transcoding.</returns>
-    private string GetVideoArguments(StreamState state, int startNumber, bool isEventPlaylist)
+    private string GetVideoArguments(StreamState state, int startNumber, bool isEventPlaylist, string segmentContainer)
     {
         if (state.VideoStream is null)
         {
@@ -1907,7 +1908,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         }
 
         // TODO why was this not enabled for VOD?
-        if (isEventPlaylist)
+        if (isEventPlaylist && string.Equals(segmentContainer, "ts", StringComparison.OrdinalIgnoreCase))
         {
             args += " -flags -global_header";
         }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1216,6 +1216,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             int bitrate = state.OutputVideoBitrate.Value;
 
+            // Bit rate under 1000k is not allowed in h264_qsv
+            if (string.Equals(videoCodec, "h264_qsv", StringComparison.OrdinalIgnoreCase))
+            {
+                bitrate = Math.Max(bitrate, 1000);
+            }
+
             // Currently use the same buffer size for all encoders
             int bufsize = bitrate * 2;
 


### PR DESCRIPTION
**Changes**
- Fix AV1 playback in LiveTV
- Fix transcoding when the bitrate is too low

**Issues**
- [h264_qsv @ 000001df5372ddc0] Error initializing the encoder: invalid video parameters (-15)