### PR TITLE
feat: Return early if client requests segments just for buffering

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1458,6 +1458,10 @@ public class DynamicHlsController : BaseJellyfinApiController
             _logger.LogDebug("returning {0} [it exists, try 1]", segmentPath);
             return await GetSegmentResult(state, playlistPath, segmentPath, segmentExtension, segmentId, job, cancellationToken).ConfigureAwait(false);
         }
+        else if (HttpContext.Request.Headers.ContainsKey("X-Buffer-Only"))
+        {
+            return new StatusCodeResult(412);
+        }
 
         var transcodingLock = _transcodingJobHelper.GetTranscodingLock(playlistPath);
         await transcodingLock.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -85,6 +85,7 @@ public static class FileStreamResponseHelpers
         httpContext.Response.Headers[HeaderNames.AcceptRanges] = "none";
 
         var contentType = state.GetMimeType(outputPath);
+        bool bufferOnly = httpContext.Request.Headers.ContainsKey("X-Buffer-Only");
 
         // Headers only
         if (isHeadRequest)
@@ -100,6 +101,11 @@ public static class FileStreamResponseHelpers
             TranscodingJobDto? job;
             if (!File.Exists(outputPath))
             {
+                if (bufferOnly)
+                {
+                    return new StatusCodeResult(412);
+                }
+
                 job = await transcodingJobHelper.StartFfMpeg(state, outputPath, ffmpegCommandLineArguments, httpContext.Request, transcodingJobType, cancellationTokenSource).ConfigureAwait(false);
             }
             else


### PR DESCRIPTION
As described in mentioned feature request, it would be great if Jellyfin would make use of multiple connections for streaming. Server basically supports this out-of-the-box and it's mostly up for the clients to make use of it. Yet, for transcoding scenario, client doesn't know how far it can do the actual buffering, without worrying about order in which those segments are pulled (like with 20 connections for example), before server tries to restart the transcoding from new timestamp.

Idea here is to make use of some header, which I propose here to be **X-Buffer-Only** to indicate that client requests given segment just for the sake of buffering and it's not intended as **seek** operation by user for that matter. So, if given segment is just not yet ready, it will return **412** status code, as precondition is not yet met. That will indicate to simply try again in a while.

Everything works as before for clients that will not use this flag.

**Changes**
Added logic to make use of optional **X-Buffer-Only** requested by the client, to not treat requested segments ahead of play-time as **seek** operation by the client. Instead it will return **412** status code if segment is not ready yet. Transcoding throttle will be unpaused if client is eager for more buffer.

**Issues**
Feature [2171](https://features.jellyfin.org/posts/2171/better-internet-streaming-using-multiple-parallel-connections-or-threads)
