### PR TITLE
Remove one session per device id limitation

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1519,24 +1519,9 @@ namespace Emby.Server.Implementations.Session
                     DeviceId = deviceId
                 }).ConfigureAwait(false)).Items;
 
-            foreach (var auth in allExistingForDevice)
-            {
-                if (existing is null || !string.Equals(auth.AccessToken, existing.AccessToken, StringComparison.Ordinal))
-                {
-                    try
-                    {
-                        await Logout(auth).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error while logging out.");
-                    }
-                }
-            }
-
             if (existing is not null)
             {
-                _logger.LogInformation("Reissuing access token: {Token}", existing.AccessToken);
+                _logger.LogInformation("Reusing existing access token: {Token}", existing.AccessToken);
                 return existing.AccessToken;
             }
 

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1513,12 +1513,6 @@ namespace Emby.Server.Implementations.Session
                     Limit = 1
                 }).ConfigureAwait(false)).Items.FirstOrDefault();
 
-            var allExistingForDevice = (await _deviceManager.GetDevices(
-                new DeviceQuery
-                {
-                    DeviceId = deviceId
-                }).ConfigureAwait(false)).Items;
-
             if (existing is not null)
             {
                 _logger.LogInformation("Reusing existing access token: {Token}", existing.AccessToken);


### PR DESCRIPTION
**Changes**
Removes the limitation of only allowing one active auth token per device id. This removes the need for clients to implement hacks to enable users to switch logins without entering a password every time.

**Issues**
It's been mentioned in chat many times, but I don't see an issue or discussion for this :eyes: 
