### PR TITLE
Add option to include resumable items in next up requests

### DIFF
--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -68,7 +68,8 @@ public class TvShowsController : BaseJellyfinApiController
     /// <param name="nextUpDateCutoff">Optional. Starting date of shows to show in Next Up section.</param>
     /// <param name="enableTotalRecordCount">Whether to enable the total records count. Defaults to true.</param>
     /// <param name="disableFirstEpisode">Whether to disable sending the first episode in a series as next up.</param>
-    /// <param name="enableRewatching">Whether to include watched episode in next up results.</param>
+    /// <param name="enableResumable">Whether to include resumable episodes in next up results.</param>
+    /// <param name="enableRewatching">Whether to include watched episodes in next up results.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the next up episodes.</returns>
     [HttpGet("NextUp")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -86,6 +87,7 @@ public class TvShowsController : BaseJellyfinApiController
         [FromQuery] DateTime? nextUpDateCutoff,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool disableFirstEpisode = false,
+        [FromQuery] bool enableResumable = true,
         [FromQuery] bool enableRewatching = false)
     {
         userId = RequestHelpers.GetUserId(User, userId);
@@ -104,6 +106,7 @@ public class TvShowsController : BaseJellyfinApiController
                 EnableTotalRecordCount = enableTotalRecordCount,
                 DisableFirstEpisode = disableFirstEpisode,
                 NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue,
+                EnableResumable = enableResumable,
                 EnableRewatching = enableRewatching
             },
             options);

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -14,6 +14,7 @@ namespace MediaBrowser.Model.Querying
             EnableTotalRecordCount = true;
             DisableFirstEpisode = false;
             NextUpDateCutoff = DateTime.MinValue;
+            EnableResumable = false;
             EnableRewatching = false;
         }
 
@@ -82,6 +83,11 @@ namespace MediaBrowser.Model.Querying
         /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
         /// </summary>
         public DateTime NextUpDateCutoff { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include resumable episodes as next up.
+        /// </summary>
+        public bool EnableResumable { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether getting rewatching next up list.


### PR DESCRIPTION
**Changes**
Adds an option to enable resumable items to be included in next up requests. This defaults to true to enable the original behavior of finding the next episode of a series that should be played.

Clients will probably want to add the new request parameter to prevent the duplication on the home screen between next up and continue watching. ~~Once this is merged I plan to add a new home screen section type that uses this to present a single row for next up + continue watching (as has been requested [here](https://features.jellyfin.org/posts/1055/give-the-option-to-combine-next-up-and-continue-watching)).~~ Actually this still won't fully meet the needs for a combined up next + continue watching home screen section since it does not include movies. :thinking: 

PR that introduced the initial breakage: https://github.com/jellyfin/jellyfin/pull/4628

**Issues**
N/A
