### PR TITLE
Avoid shell expansion issues

### DIFF
--- a/fedora/jellyfin-selinux-launcher.sh
+++ b/fedora/jellyfin-selinux-launcher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /usr/lib64/jellyfin/jellyfin ${@}
+exec /usr/lib64/jellyfin/jellyfin "${@}"


### PR DESCRIPTION
**Changes**
Per https://www.shellcheck.net/wiki/SC2068:

Double quotes around $@ (and similarly, ${array[@]}) prevents globbing and word splitting of individual elements, while still expanding to multiple separate arguments.