### PR TITLE
Run collect script on failures

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -168,6 +168,7 @@ jobs:
 - job: CollectArtifacts
   timeoutInMinutes: 20
   displayName: 'Collect Artifacts'
+  condition: succeededOrFailed()
   continueOnError: true
   dependsOn:
   - BuildPackage


### PR DESCRIPTION
**Changes**
Still run the collect script on build on failures, so build failures on a specific platform (*cough fedora*) does not prevent all builds from being published.

**Issues**
N/A
