### PR TITLE
PhotoResolver: change how generated images are detected

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +23,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
         private readonly NamingOptions _namingOptions;
         private readonly IDirectoryService _directoryService;
 
-        private static readonly HashSet<string> _ignoreFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly string[] _ignoreFiles = new[]
         {
             "folder",
             "thumb",
@@ -56,7 +54,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
         /// </summary>
         /// <param name="args">The args.</param>
         /// <returns>Trailer.</returns>
-        protected override Photo Resolve(ItemResolveArgs args)
+        protected override Photo? Resolve(ItemResolveArgs args)
         {
             if (!args.IsDirectory)
             {
@@ -68,10 +66,11 @@ namespace Emby.Server.Implementations.Library.Resolvers
                 {
                     if (IsImageFile(args.Path, _imageProcessor))
                     {
-                        var filename = Path.GetFileNameWithoutExtension(args.Path);
+                        var filename = Path.GetFileNameWithoutExtension(args.Path.AsSpan());
 
                         // Make sure the image doesn't belong to a video file
-                        var files = _directoryService.GetFiles(Path.GetDirectoryName(args.Path));
+                        var files = _directoryService.GetFiles(Path.GetDirectoryName(args.Path)
+                            ?? throw new InvalidOperationException("Path can't be a root directory."));
 
                         foreach (var file in files)
                         {
@@ -92,32 +91,32 @@ namespace Emby.Server.Implementations.Library.Resolvers
             return null;
         }
 
-        internal static bool IsOwnedByMedia(NamingOptions namingOptions, string file, string imageFilename)
+        internal static bool IsOwnedByMedia(NamingOptions namingOptions, string file, ReadOnlySpan<char> imageFilename)
         {
             return VideoResolver.IsVideoFile(file, namingOptions) && IsOwnedByResolvedMedia(file, imageFilename);
         }
 
-        internal static bool IsOwnedByResolvedMedia(string file, string imageFilename)
+        internal static bool IsOwnedByResolvedMedia(ReadOnlySpan<char> file, ReadOnlySpan<char> imageFilename)
             => imageFilename.StartsWith(Path.GetFileNameWithoutExtension(file), StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsImageFile(string path, IImageProcessor imageProcessor)
         {
             ArgumentNullException.ThrowIfNull(path);
 
+            var extension = Path.GetExtension(path.AsSpan()).TrimStart('.');
+            if (!imageProcessor.SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
             var filename = Path.GetFileNameWithoutExtension(path);
 
-            if (_ignoreFiles.Contains(filename))
+            if (_ignoreFiles.Any(i => filename.StartsWith(i, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }
 
-            if (_ignoreFiles.Any(i => filename.IndexOf(i, StringComparison.OrdinalIgnoreCase) != -1))
-            {
-                return false;
-            }
-
-            string extension = Path.GetExtension(path).TrimStart('.');
-            return imageProcessor.SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase);
+            return true;
         }
     }
 }

--- a/MediaBrowser.Controller/Resolvers/IItemResolver.cs
+++ b/MediaBrowser.Controller/Resolvers/IItemResolver.cs
@@ -24,7 +24,7 @@ namespace MediaBrowser.Controller.Resolvers
         /// </summary>
         /// <param name="args">The args.</param>
         /// <returns>BaseItem.</returns>
-        BaseItem ResolvePath(ItemResolveArgs args);
+        BaseItem? ResolvePath(ItemResolveArgs args);
     }
 
     public interface IMultiItemResolver

--- a/MediaBrowser.Controller/Resolvers/ItemResolver.cs
+++ b/MediaBrowser.Controller/Resolvers/ItemResolver.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 
@@ -23,7 +21,7 @@ namespace MediaBrowser.Controller.Resolvers
         /// </summary>
         /// <param name="args">The args.</param>
         /// <returns>`0.</returns>
-        protected internal virtual T Resolve(ItemResolveArgs args)
+        protected internal virtual T? Resolve(ItemResolveArgs args)
         {
             return null;
         }
@@ -42,7 +40,7 @@ namespace MediaBrowser.Controller.Resolvers
         /// </summary>
         /// <param name="args">The args.</param>
         /// <returns>BaseItem.</returns>
-        public BaseItem ResolvePath(ItemResolveArgs args)
+        public BaseItem? ResolvePath(ItemResolveArgs args)
         {
             var item = Resolve(args);
 


### PR DESCRIPTION
Backdrops/fanart are generated as (backdrop)|(fanart)[0-9]*.extension

Fixes #7830
