### PR TITLE
Replaced some magic values used in property attributes `[MaxLength]` and `[StringLength]` in data entities

### DIFF
--- a/Jellyfin.Data/Entities/Group.cs
+++ b/Jellyfin.Data/Entities/Group.cs
@@ -39,10 +39,10 @@ namespace Jellyfin.Data.Entities
         /// Gets or sets the group's name.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 255.
+        /// Required, Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string Name { get; set; }
 
         /// <inheritdoc />

--- a/Jellyfin.Data/Entities/Libraries/Artwork.cs
+++ b/Jellyfin.Data/Entities/Libraries/Artwork.cs
@@ -37,10 +37,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the path.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 65535.
+        /// Required, Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string Path { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/CompanyMetadata.cs
+++ b/Jellyfin.Data/Entities/Libraries/CompanyMetadata.cs
@@ -20,20 +20,20 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the description.
         /// </summary>
         /// <remarks>
-        /// Max length = 65535.
+        /// Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the headquarters.
         /// </summary>
         /// <remarks>
-        /// Max length = 255.
+        /// Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string? Headquarters { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/EpisodeMetadata.cs
+++ b/Jellyfin.Data/Entities/Libraries/EpisodeMetadata.cs
@@ -30,10 +30,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the plot.
         /// </summary>
         /// <remarks>
-        /// Max length = 65535.
+        /// Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string? Plot { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/Genre.cs
+++ b/Jellyfin.Data/Entities/Libraries/Genre.cs
@@ -31,10 +31,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the name.
         /// </summary>
         /// <remarks>
-        /// Indexed, Required, Max length = 255.
+        /// Indexed, Required, Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string Name { get; set; }
 
         /// <inheritdoc />

--- a/Jellyfin.Data/Entities/Libraries/MediaFile.cs
+++ b/Jellyfin.Data/Entities/Libraries/MediaFile.cs
@@ -40,10 +40,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the path relative to the library root.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 65535.
+        /// Required, Max length = <see cref="ushort.MaxValue" />.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string Path { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/MovieMetadata.cs
+++ b/Jellyfin.Data/Entities/Libraries/MovieMetadata.cs
@@ -43,10 +43,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the plot.
         /// </summary>
         /// <remarks>
-        /// Max length = 65535.
+        /// Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string? Plot { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/MusicAlbumMetadata.cs
+++ b/Jellyfin.Data/Entities/Libraries/MusicAlbumMetadata.cs
@@ -22,20 +22,20 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the barcode.
         /// </summary>
         /// <remarks>
-        /// Max length = 255.
+        /// Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string? Barcode { get; set; }
 
         /// <summary>
         /// Gets or sets the label number.
         /// </summary>
         /// <remarks>
-        /// Max length = 255.
+        /// Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string? LabelNumber { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Libraries/SeriesMetadata.cs
+++ b/Jellyfin.Data/Entities/Libraries/SeriesMetadata.cs
@@ -33,10 +33,10 @@ namespace Jellyfin.Data.Entities.Libraries
         /// Gets or sets the plot.
         /// </summary>
         /// <remarks>
-        /// Max length = 65535.
+        /// Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string? Plot { get; set; }
 
         /// <summary>

--- a/Jellyfin.Data/Entities/Preference.cs
+++ b/Jellyfin.Data/Entities/Preference.cs
@@ -49,10 +49,10 @@ namespace Jellyfin.Data.Entities
         /// Gets or sets the value of this preference.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 65535.
+        /// Required, Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string Value { get; set; }
 
         /// <inheritdoc/>

--- a/Jellyfin.Data/Entities/User.cs
+++ b/Jellyfin.Data/Entities/User.cs
@@ -75,20 +75,20 @@ namespace Jellyfin.Data.Entities
         /// Gets or sets the user's name.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 255.
+        /// Required, Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string Username { get; set; }
 
         /// <summary>
         /// Gets or sets the user's password, or <c>null</c> if none is set.
         /// </summary>
         /// <remarks>
-        /// Max length = 65535.
+        /// Max length = <see cref="ushort.MaxValue"/>.
         /// </remarks>
-        [MaxLength(65535)]
-        [StringLength(65535)]
+        [MaxLength(ushort.MaxValue)]
+        [StringLength(ushort.MaxValue)]
         public string? Password { get; set; }
 
         /// <summary>
@@ -103,30 +103,30 @@ namespace Jellyfin.Data.Entities
         /// Gets or sets the audio language preference.
         /// </summary>
         /// <remarks>
-        /// Max length = 255.
+        /// Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string? AudioLanguagePreference { get; set; }
 
         /// <summary>
         /// Gets or sets the authentication provider id.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 255.
+        /// Required, Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string AuthenticationProviderId { get; set; }
 
         /// <summary>
         /// Gets or sets the password reset provider id.
         /// </summary>
         /// <remarks>
-        /// Required, Max length = 255.
+        /// Required, Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string PasswordResetProviderId { get; set; }
 
         /// <summary>
@@ -177,10 +177,10 @@ namespace Jellyfin.Data.Entities
         /// Gets or sets the subtitle language preference.
         /// </summary>
         /// <remarks>
-        /// Max length = 255.
+        /// Max length = <see cref="byte.MaxValue"/>.
         /// </remarks>
-        [MaxLength(255)]
-        [StringLength(255)]
+        [MaxLength(byte.MaxValue)]
+        [StringLength(byte.MaxValue)]
         public string? SubtitleLanguagePreference { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
The length of strings in many data entities is constrained by `[MaxLength]` and `[StringLength]` attributes, which are passed a numeric value. However, these constraints come without an explanation. In this pull request, those values that could be neatly represented by the `MaxValue` constants of numeric value types were changed accordingly. Presumably, these values of these constraints mean _something_, and this is a first step towards making the code more self-documenting. I envision that, in the future, it will all be named constants.