### PR TITLE
Change default value of `UseFileCreationTimeForDateAdded` to `false`

### DIFF
--- a/MediaBrowser.Model/Configuration/MetadataConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/MetadataConfiguration.cs
@@ -6,7 +6,7 @@ namespace MediaBrowser.Model.Configuration
     {
         public MetadataConfiguration()
         {
-            UseFileCreationTimeForDateAdded = true;
+            UseFileCreationTimeForDateAdded = false;
         }
 
         public bool UseFileCreationTimeForDateAdded { get; set; }


### PR DESCRIPTION
Use current timestamp instead of files `last modified` date by default. This change make jellyfin better match users expectations relating to ordering by "last added" and "Latest \<library name\>".

**Changes**
Change default value of `UseFileCreationTimeForDateAdded` to `false`

**Issues**
Fixes #10001 
