### PR TITLE
Allow setting range of ports for dynamic assignment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -168,6 +168,7 @@
  - [TheTyrius](https://github.com/TheTyrius)
  - [tallbl0nde](https://github.com/tallbl0nde)
  - [sleepycatcoding](https://github.com/sleepycatcoding)
+ - [tnyeanderson](https://github.com/tnyeanderson)
 
 # Emby Contributors
 


### PR DESCRIPTION
When running jellyfin in docker, it has to run in host mode since it needs to listen on random UDP ports. This PR gives the option for a user to set a range of ports that jellyfin will select from when it needs to bind to a random port. Now, the user may avoid host mode by setting aside a range of ports for jellyfin and forwarding all of them to the container.

**Changes**
Adds logic to select a random port between the configured range and try to bind to it. If it fails it will retry a configured number of times with different ports. If the max and min port values are not set (i.e. `0`) then no new behavior is introduced.

**Issues**
Fixes #790

## WIP

This PR is a proof of concept at the moment. This is my first time (since college) writing C# so open to any advice. Still need to wire up configuration of the parameters and add the retry functionality to the other `SocketFactory` methods, but wanted to see if there were any other ideas for implementing this by someone who is more familiar with the available libraries, etc.

I know this implementation isn't ideal, but the bind syscall doesn't allow setting this range. It is a kernel option at `/proc/sys/net/ipv4/ip_local_port_range`, but that can't be set solely for jellyfin (and in a container, is shared by the host and can't/shouldn't be edited). And others have noted that any solution which first checks if a port is available, then binds to it, could be undermined by some other process binding to the port between our check and bind calls anyways. This implementation does not have this problem, at the expense of blindly trying options a certain amount of times until it works (or gives up).

With the default value of 5 tries, I have no idea what the performance impact might be. It could be unacceptable. However, if the user provided a range including 100 available ports and 50 were currently in use, there is a 96.875% chance that the bind will be successful.

I really hope there is a better way to do this. Just wanted to float an idea and get feedback.