### PR TITLE
Add Plugin Images for Default Plugins (Omdb, MusicBrainz & tmdb)

### DIFF
--- a/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
@@ -43,7 +43,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public override Guid Id => new Guid("8c95c4d2-e50c-4fb0-a4f3-6c06ff0f9a1a");
     
     /// <inheritdoc />
-    public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-musicbrainz.png";
+    public override string imageUrl => "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-musicbrainz.png";
 
     /// <inheritdoc />
     public override string Name => "MusicBrainz";

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
@@ -41,6 +41,9 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     /// <inheritdoc />
     public override Guid Id => new Guid("8c95c4d2-e50c-4fb0-a4f3-6c06ff0f9a1a");
+    
+    /// <inheritdoc />
+    public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-musicbrainz.png";
 
     /// <inheritdoc />
     public override string Name => "MusicBrainz";

--- a/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
@@ -22,6 +22,8 @@ namespace MediaBrowser.Providers.Plugins.Omdb
 
         public override Guid Id => new Guid("a628c0da-fac5-4c7e-9d1a-7134223f14c8");
 
+        public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-omdb.png";
+
         public override string Name => "OMDb";
 
         public override string Description => "Get metadata for movies and other video content from OMDb.";

--- a/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
 
         public override Guid Id => new Guid("a628c0da-fac5-4c7e-9d1a-7134223f14c8");
 
-        public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-omdb.png";
+        public override string imageUrl => "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-omdb.png";
 
         public override string Name => "OMDb";
 

--- a/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
@@ -34,6 +34,9 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         public override Guid Id => new Guid("b8715ed1-6c47-4528-9ad3-f72deb539cd4");
 
         /// <inheritdoc/>
+        public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tmdb.png";
+
+        /// <inheritdoc/>
         public override string Name => "TMDb";
 
         /// <inheritdoc/>

--- a/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Plugin.cs
@@ -34,7 +34,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         public override Guid Id => new Guid("b8715ed1-6c47-4528-9ad3-f72deb539cd4");
 
         /// <inheritdoc/>
-        public override string imageUrl=> "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tmdb.png";
+        public override string imageUrl => "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tmdb.png";
 
         /// <inheritdoc/>
         public override string Name => "TMDb";


### PR DESCRIPTION
My first time submitting a patch so please let me know if I've made any mistakes.

The Intent of this change is to allow for the default plugins that are enable with a jellyfin install to have a plugin image listed so they do not appear blank such as in the below screenshots.

![image](https://github.com/jellyfin/jellyfin/assets/18419688/de4f3a45-4509-4c44-ade4-c0acbdf0abec)
![image](https://github.com/jellyfin/jellyfin/assets/18419688/07914d91-e232-4f91-ab69-8b2b9a1740fe)
![image](https://github.com/jellyfin/jellyfin/assets/18419688/78b53768-bf60-41c3-ad3a-96d91dda0ffe)


**Changes**

Added imageUrl references to image hosted on the Jellyfin Repo for Omdb, MusicBrainz & tmdb under 

- jellyfin/MediaBrowser.Providers/Plugins/Omdb/Plugin.cs
- jellyfin/MediaBrowser.Providers/Plugins/MusicBrainz/Plugin.cs
- jellyfin/MediaBrowser.Providers/Plugins/tmdb /Plugin.cs

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
