### PR TITLE
Downgrade SkiaSharp.NativeAssets.Linux to prevent segfault

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Serilog.Sinks.Graylog" Version="3.0.2" />
     <PackageVersion Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageVersion Include="SharpFuzz" Version="2.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageVersion Include="SkiaSharp.Svg" Version="1.60.0" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />


### PR DESCRIPTION
```
Thread 16 ".NET ThreadPool" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fbeae7fc6c0 (LWP 15740)]
0x00007fbead7b33e0 in ?? ()
   from /.../dev/jellyfin/Jellyfin.Server/bin/Release/net7.0/runtimes/linux-x64/native/libSkiaSharp.so
```
