### PR TITLE
Fully specify version tags for renovate

### DIFF
--- a/.github/workflows/repo-bump-version.yaml
+++ b/.github/workflows/repo-bump-version.yaml
@@ -33,7 +33,7 @@ jobs:
           yq-version: v4.9.8
 
       - name: Checkout Repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ env.TAG_BRANCH }}
 
@@ -66,7 +66,7 @@ jobs:
       NEXT_VERSION: ${{ github.event.inputs.NEXT_VERSION }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ env.TAG_BRANCH }}
 


### PR DESCRIPTION

**Changes**
Fix version tagging in repo-bump-version workflow so renovate will update all actions/checkout versions together.

**Related**
To be in sync this depends on #10260
Supersedes #10258