### PR TITLE
Fix sed failing on Docker builds for CentOS/Fedora

### DIFF
--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -75,7 +75,7 @@ dotnet publish --configuration Release --self-contained --runtime %{dotnet_runti
 %{__mkdir} -p %{buildroot}%{_libdir}/jellyfin %{buildroot}%{_bindir}
 %{__cp} -r Jellyfin.Server/bin/Release/net7.0/%{dotnet_runtime}/publish/* %{buildroot}%{_libdir}/jellyfin
 %{__install} -D %{SOURCE10} %{buildroot}%{_bindir}/jellyfin
-sed -i -e 's/\/usr\/lib64/%{_libdir}/g' %{buildroot}%{_bindir}/jellyfin
+sed -i -e 's|/usr/lib64|%{_libdir}|g' %{buildroot}%{_bindir}/jellyfin
 
 # Jellyfin config
 %{__install} -D Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/jellyfin/logging.json


### PR DESCRIPTION
**Changes**
Switch the sed separator from '/' to '|', this makes it far clearer to parse a POSIX path, and resolves the build issues
with the CentOS and Fedora docker builds where we can't easily escape the '/' chars from the buildroot var


**Testing**
This is based on a failing CI job:

```
docker build -f deployment/Dockerfile.fedora.amd64 -t jellyfin-server-fedora.amd64 --label "org.opencontainers.image.url=https://github.com/jellyfin/jellyfin" --label "org.opencontainers.image.revision=2ae2145192e47887d4168ad383e021e50de70ef7"  deployment
docker image ls -a && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="yes" -e BUILD_ID=20230926.1 jellyfin-server-fedora.amd64
```

Sed still fires, but can handle the '/' char without any problems:
```
+ /usr/bin/install -D /root/rpmbuild/SOURCES/jellyfin-selinux-launcher.sh /root/rpmbuild/BUILDROOT/jellyfin-20230926.1-1.el7.x86_64/usr/bin/jellyfin
+ sed -i -e 's|/usr/lib64|/usr/lib64|g' /root/rpmbuild/BUILDROOT/jellyfin-20230926.1-1.el7.x86_64/usr/bin/jellyfin
+ /usr/bin/install -D Jellyfin.Server/Resources/Configuration/logging.json /root/rpmbuild/BUILDROOT/jellyfin-20230926.1-1.el7.x86_64/etc/jellyfin/logging.json
```

Also IMO it's more readable without extra escaping too