### PR TITLE
Add shebang to jellyfin.init

### DIFF
--- a/debian/jellyfin.init
+++ b/debian/jellyfin.init
@@ -1,3 +1,4 @@
+#!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          Jellyfin Media Server
 # Required-Start:    $local_fs $network


### PR DESCRIPTION
**Changes**
Add a shebang to the init script used in non-systemd distros.

**Issues**
#10317