### PR TITLE
Add support for transcode audio file to PCM format

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -191,6 +191,11 @@ public static class StreamingHelpers
             state.OutputAudioBitrate = encodingHelper.GetAudioBitrateParam(streamingRequest.AudioBitRate, streamingRequest.AudioCodec, state.AudioStream, state.OutputAudioChannels) ?? 0;
         }
 
+        if (outputAudioCodec.StartsWith("pcm_", StringComparison.Ordinal))
+        {
+            containerInternal = ".pcm";
+        }
+
         state.OutputAudioCodec = outputAudioCodec;
         state.OutputContainer = (containerInternal ?? string.Empty).TrimStart('.');
         state.OutputAudioChannels = encodingHelper.GetNumAudioChannelsParam(state, state.AudioStream, state.OutputAudioCodec);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6244,7 +6244,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (GetAudioEncoder(state).StartsWith("pcm_", StringComparison.Ordinal))
             {
-                audioTranscodeParams.Add(string.Concat("-f ", GetAudioEncoder(state).Substring(4)));
+                audioTranscodeParams.Add(string.Concat("-f ", GetAudioEncoder(state).AsSpan(4)));
                 audioTranscodeParams.Add("-ar " + state.BaseRequest.AudioBitRate);
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6242,6 +6242,12 @@ namespace MediaBrowser.Controller.MediaEncoding
                 audioTranscodeParams.Add("-acodec " + GetAudioEncoder(state));
             }
 
+            if (GetAudioEncoder(state).StartsWith("pcm_", StringComparison.Ordinal))
+            {
+                audioTranscodeParams.Add(string.Concat("-f ", GetAudioEncoder(state).Substring(4)));
+                audioTranscodeParams.Add("-ar " + state.BaseRequest.AudioBitRate);
+            }
+
             if (!string.Equals(outputCodec, "opus", StringComparison.OrdinalIgnoreCase))
             {
                 // opus only supports specific sampling rates


### PR DESCRIPTION
Support transcoding audio to PCM format; this allows the client to play directly through the I2S bus without decoding. This feature is particularly useful when playing with MCUs.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add support for transcode audio file to PCM format
1. set file ext name to pcm when audiocodec is pcm_*
2. add pcm params for ffmpegs

