### PR TITLE
Allow repeated same tv guide channels on M3U tuner

### DIFF
--- a/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/M3uParser.cs
@@ -94,14 +94,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts
                 else if (!string.IsNullOrWhiteSpace(extInf) && !trimmedLine.StartsWith('#'))
                 {
                     var channel = GetChannelnfo(extInf, tunerHostId, trimmedLine);
-                    if (string.IsNullOrWhiteSpace(channel.Id))
-                    {
-                        channel.Id = channelIdPrefix + trimmedLine.GetMD5().ToString("N", CultureInfo.InvariantCulture);
-                    }
-                    else
-                    {
-                        channel.Id = channelIdPrefix + channel.Id.GetMD5().ToString("N", CultureInfo.InvariantCulture);
-                    }
+                    channel.Id = channelIdPrefix + trimmedLine.GetMD5().ToString("N", CultureInfo.InvariantCulture);
 
                     channel.Path = trimmedLine;
                     channels.Add(channel);


### PR DESCRIPTION
Fixes issue #6527

Removed the the condition that checks if a channel has an id (tv guide id), it uses it as an unique id with md5 hash.
This was kinda wrong since :

1. We can have multiple channels lines in a m3u which uses same tv guide (SD and HD version of same broadcast for example)
2. The behavior of the code was not explicit, all the code flow kept all channels until we write them down to the database , then since they have same unique generated id , the first channel is written to the db and then the following channel with same id overwrites it.

I Thought of adding a checkbox to keep old behavior at m3u tuner level but I am quite sure the condition/old behavior is not needed and was wrong/not intended.

