### PR TITLE
Add functionality to remove empty media folders on item delete

### DIFF
--- a/Emby.Server.Implementations/Channels/ChannelManager.cs
+++ b/Emby.Server.Implementations/Channels/ChannelManager.cs
@@ -761,15 +761,14 @@ namespace Emby.Server.Implementations.Channels
                     var deadItem = _libraryManager.GetItemById(deadId);
                     if (deadItem is not null)
                     {
-                        _libraryManager.DeleteItem(
+                        await _libraryManager.DeleteItemAsync(
                             deadItem,
+                            parentItem,
                             new DeleteOptions
                             {
                                 DeleteFileLocation = false,
                                 DeleteFromExternalProvider = false
-                            },
-                            parentItem,
-                            false);
+                            });
                     }
                 }
             }

--- a/Emby.Server.Implementations/Channels/ChannelPostScanTask.cs
+++ b/Emby.Server.Implementations/Channels/ChannelPostScanTask.cs
@@ -38,15 +38,14 @@ namespace Emby.Server.Implementations.Channels
         /// <param name="progress">The progress.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The completed task.</returns>
-        public Task Run(IProgress<double> progress, CancellationToken cancellationToken)
+        public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            CleanDatabase(cancellationToken);
+            await CleanDatabaseAsync(cancellationToken);
 
             progress.Report(100);
-            return Task.CompletedTask;
         }
 
-        private void CleanDatabase(CancellationToken cancellationToken)
+        private async Task CleanDatabaseAsync(CancellationToken cancellationToken)
         {
             var installedChannelIds = ((ChannelManager)_channelManager).GetInstalledChannelIds();
 
@@ -60,11 +59,11 @@ namespace Emby.Server.Implementations.Channels
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                CleanChannel((Channel)channel, cancellationToken);
+                await CleanChannelAsync((Channel)channel, cancellationToken);
             }
         }
 
-        private void CleanChannel(Channel channel, CancellationToken cancellationToken)
+        private async Task CleanChannelAsync(Channel channel, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Cleaning channel {0} from database", channel.Id);
 
@@ -78,23 +77,21 @@ namespace Emby.Server.Implementations.Channels
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                _libraryManager.DeleteItem(
+                await _libraryManager.DeleteItemAsync(
                     item,
                     new DeleteOptions
                     {
                         DeleteFileLocation = false
-                    },
-                    false);
+                    });
             }
 
             // Finally, delete the channel itself
-            _libraryManager.DeleteItem(
+            await _libraryManager.DeleteItemAsync(
                 channel,
                 new DeleteOptions
                 {
                     DeleteFileLocation = false
-                },
-                false);
+                });
         }
     }
 }

--- a/Emby.Server.Implementations/Data/CleanDatabaseScheduledTask.cs
+++ b/Emby.Server.Implementations/Data/CleanDatabaseScheduledTask.cs
@@ -22,11 +22,10 @@ namespace Emby.Server.Implementations.Data
 
         public Task Run(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            CleanDeadItems(cancellationToken, progress);
-            return Task.CompletedTask;
+            return CleanDeadItemsAsync(cancellationToken, progress);
         }
 
-        private void CleanDeadItems(CancellationToken cancellationToken, IProgress<double> progress)
+        private async Task CleanDeadItemsAsync(CancellationToken cancellationToken, IProgress<double> progress)
         {
             var itemIds = _libraryManager.GetItemIds(new InternalItemsQuery
             {
@@ -48,7 +47,7 @@ namespace Emby.Server.Implementations.Data
                 {
                     _logger.LogInformation("Cleaning item {0} type: {1} path: {2}", item.Name, item.GetType().Name, item.Path ?? string.Empty);
 
-                    _libraryManager.DeleteItem(item, new DeleteOptions
+                    await _libraryManager.DeleteItemAsync(item, new DeleteOptions
                     {
                         DeleteFileLocation = false
                     });

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -517,7 +517,10 @@ namespace Emby.Server.Implementations.IO
         public virtual void DeleteFile(string path)
         {
             SetAttributes(path, false, false);
-            File.Delete(path);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -280,7 +280,7 @@ namespace Emby.Server.Implementations.Library
             }
         }
 
-        public void RegisterItem(BaseItem item)
+        public void RegisterItemInCache(BaseItem item)
         {
             ArgumentNullException.ThrowIfNull(item);
 
@@ -760,7 +760,7 @@ namespace Emby.Server.Implementations.Library
 
             rootFolder.AddVirtualChild(folder);
 
-            RegisterItem(folder);
+            RegisterItemInCache(folder);
 
             return rootFolder;
         }
@@ -1241,7 +1241,7 @@ namespace Emby.Server.Implementations.Library
 
             if (item is not null)
             {
-                RegisterItem(item);
+                RegisterItemInCache(item);
             }
 
             return item;
@@ -1785,7 +1785,7 @@ namespace Emby.Server.Implementations.Library
 
             foreach (var item in items)
             {
-                RegisterItem(item);
+                RegisterItemInCache(item);
             }
 
             if (ItemAdded is not null)
@@ -1850,7 +1850,7 @@ namespace Emby.Server.Implementations.Library
             // Skip image processing if current or live tv source
             if (outdated.Length == 0 || item.SourceType != SourceType.Library)
             {
-                RegisterItem(item);
+                RegisterItemInCache(item);
                 return;
             }
 
@@ -1917,7 +1917,7 @@ namespace Emby.Server.Implementations.Library
             }
 
             _itemRepository.SaveImages(item);
-            RegisterItem(item);
+            RegisterItemInCache(item);
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -347,16 +347,13 @@ namespace Emby.Server.Implementations.Library
                 _itemRepository.DeleteItem(child.Id);
             }
 
-            item.SetParent(null);
-
             _cache.TryRemove(item.Id, out _);
-
             ReportItemRemoved(item, parent);
 
             // Delete empty media folders if collection option is enabled.
             // Don't delete the top level folder. We don't want for users to have to re-create
             // folders where they might be auto-sorting media into.
-            if (parent.IsFolder && !parent.IsTopParent)
+            if (parent != null && parent.IsFolder && !parent.IsTopParent)
             {
                 var siblingItems = (parent as Folder)?.Children;
                 if (!siblingItems.Any())
@@ -376,6 +373,8 @@ namespace Emby.Server.Implementations.Library
                     }
                 }
             }
+
+            item.SetParent(null);
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
@@ -96,13 +96,12 @@ namespace Emby.Server.Implementations.Library.Validators
 
                 _logger.LogInformation("Deleting dead {2} {0} {1}.", item.Id.ToString("N", CultureInfo.InvariantCulture), item.Name, item.GetType().Name);
 
-                _libraryManager.DeleteItem(
+                await _libraryManager.DeleteItemAsync(
                     item,
                     new DeleteOptions
                     {
                         DeleteFileLocation = false
-                    },
-                    false);
+                    });
             }
 
             progress.Report(100);

--- a/Emby.Server.Implementations/Library/Validators/PeopleValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/PeopleValidator.cs
@@ -105,13 +105,12 @@ namespace Emby.Server.Implementations.Library.Validators
                     item.Name,
                     item.GetType().Name);
 
-                _libraryManager.DeleteItem(
+                await _libraryManager.DeleteItemAsync(
                     item,
                     new DeleteOptions
                     {
                         DeleteFileLocation = false
-                    },
-                    false);
+                    });
             }
 
             progress.Report(100);

--- a/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
@@ -90,13 +90,12 @@ namespace Emby.Server.Implementations.Library.Validators
             {
                 _logger.LogInformation("Deleting dead {ItemType} {ItemId} {ItemName}", item.GetType().Name, item.Id.ToString("N", CultureInfo.InvariantCulture), item.Name);
 
-                _libraryManager.DeleteItem(
+                await _libraryManager.DeleteItemAsync(
                     item,
                     new DeleteOptions
                     {
                         DeleteFileLocation = false
-                    },
-                    false);
+                    });
             }
 
             progress.Report(100);

--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1499,7 +1499,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                     .Skip(seriesTimer.KeepUpTo - 1)
                     .ToList();
 
-                DeleteLibraryItemsForTimers(timersToDelete);
+                await DeleteLibraryItemsForTimers(timersToDelete);
 
                 if (_libraryManager.FindByPath(seriesPath, true) is not Folder librarySeries)
                 {
@@ -1523,13 +1523,12 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
                 {
                     try
                     {
-                        _libraryManager.DeleteItem(
+                        await _libraryManager.DeleteItemAsync(
                             item,
                             new DeleteOptions
                             {
                                 DeleteFileLocation = true
-                            },
-                            true);
+                            });
                     }
                     catch (Exception ex)
                     {
@@ -1543,7 +1542,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
         }
 
-        private void DeleteLibraryItemsForTimers(List<TimerInfo> timers)
+        private async Task DeleteLibraryItemsForTimers(List<TimerInfo> timers)
         {
             foreach (var timer in timers)
             {
@@ -1554,7 +1553,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
                 try
                 {
-                    DeleteLibraryItemForTimer(timer);
+                    await DeleteLibraryItemForTimer(timer);
                 }
                 catch (Exception ex)
                 {
@@ -1563,19 +1562,18 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
             }
         }
 
-        private void DeleteLibraryItemForTimer(TimerInfo timer)
+        private async Task DeleteLibraryItemForTimer(TimerInfo timer)
         {
             var libraryItem = _libraryManager.FindByPath(timer.RecordingPath, false);
 
             if (libraryItem is not null)
             {
-                _libraryManager.DeleteItem(
+                await _libraryManager.DeleteItemAsync(
                     libraryItem,
                     new DeleteOptions
                     {
                         DeleteFileLocation = true
-                    },
-                    true);
+                    });
             }
             else if (File.Exists(timer.RecordingPath))
             {

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -1080,8 +1080,8 @@ namespace Emby.Server.Implementations.LiveTv
 
             if (cleanDatabase)
             {
-                CleanDatabaseInternal(newChannelIdList.ToArray(), new[] { BaseItemKind.LiveTvChannel }, progress, cancellationToken);
-                CleanDatabaseInternal(newProgramIdList.ToArray(), new[] { BaseItemKind.LiveTvProgram }, progress, cancellationToken);
+                await CleanDatabaseInternal(newChannelIdList.ToArray(), new[] { BaseItemKind.LiveTvChannel }, progress, cancellationToken);
+                await CleanDatabaseInternal(newProgramIdList.ToArray(), new[] { BaseItemKind.LiveTvProgram }, progress, cancellationToken);
             }
 
             var coreService = _services.OfType<EmbyTV.EmbyTV>().FirstOrDefault();
@@ -1256,7 +1256,7 @@ namespace Emby.Server.Implementations.LiveTv
             return new Tuple<List<Guid>, List<Guid>>(channels, programs);
         }
 
-        private void CleanDatabaseInternal(Guid[] currentIdList, BaseItemKind[] validTypes, IProgress<double> progress, CancellationToken cancellationToken)
+        private async Task CleanDatabaseInternal(Guid[] currentIdList, BaseItemKind[] validTypes, IProgress<double> progress, CancellationToken cancellationToken)
         {
             var list = _itemRepo.GetItemIdsList(new InternalItemsQuery
             {
@@ -1282,14 +1282,13 @@ namespace Emby.Server.Implementations.LiveTv
 
                     if (item is not null)
                     {
-                        _libraryManager.DeleteItem(
+                        await _libraryManager.DeleteItemAsync(
                             item,
                             new DeleteOptions
                             {
                                 DeleteFileLocation = false,
                                 DeleteFromExternalProvider = false
-                            },
-                            false);
+                            });
                     }
                 }
 

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -553,15 +553,14 @@ namespace Emby.Server.Implementations.Playlists
                 else if (!playlist.OpenAccess)
                 {
                     // Remove playlist if not shared
-                    _libraryManager.DeleteItem(
+                    await _libraryManager.DeleteItemAsync(
                         playlist,
+                        playlist.GetParent(),
                         new DeleteOptions
                         {
                             DeleteFileLocation = false,
                             DeleteFromExternalProvider = false
-                        },
-                        playlist.GetParent(),
-                        false);
+                        });
                 }
             }
         }

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -334,7 +334,7 @@ public class LibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult DeleteItem(Guid itemId)
+    public async Task<ActionResult> DeleteItem(Guid itemId)
     {
         var isApiKey = User.GetIsApiKey();
         var userId = User.GetUserId();
@@ -357,10 +357,10 @@ public class LibraryController : BaseJellyfinApiController
             return Unauthorized("Unauthorized access");
         }
 
-        _libraryManager.DeleteItem(
+        await _libraryManager.DeleteItemAsync(
             item,
-            new DeleteOptions { DeleteFileLocation = true },
-            true);
+            new DeleteOptions { DeleteFileLocation = true })
+            .ConfigureAwait(false);
 
         return NoContent();
     }
@@ -377,7 +377,7 @@ public class LibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult DeleteItems([FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] ids)
+    public async Task<ActionResult> DeleteItems([FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] Guid[] ids)
     {
         var isApiKey = User.GetIsApiKey();
         var userId = User.GetUserId();
@@ -403,10 +403,10 @@ public class LibraryController : BaseJellyfinApiController
                 return Unauthorized("Unauthorized access");
             }
 
-            _libraryManager.DeleteItem(
+            await _libraryManager.DeleteItemAsync(
                 item,
-                new DeleteOptions { DeleteFileLocation = true },
-                true);
+                new DeleteOptions { DeleteFileLocation = true })
+                .ConfigureAwait(false);
         }
 
         return NoContent();

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
@@ -758,7 +758,7 @@ public class LiveTvController : BaseJellyfinApiController
     [Authorize(Policy = Policies.LiveTvManagement)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult DeleteRecording([FromRoute, Required] Guid recordingId)
+    public async Task<ActionResult> DeleteRecording([FromRoute, Required] Guid recordingId)
     {
         var item = _libraryManager.GetItemById(recordingId);
         if (item is null)
@@ -766,10 +766,11 @@ public class LiveTvController : BaseJellyfinApiController
             return NotFound();
         }
 
-        _libraryManager.DeleteItem(item, new DeleteOptions
-        {
-            DeleteFileLocation = false
-        });
+        await _libraryManager.DeleteItemAsync(item, new DeleteOptions
+            {
+                DeleteFileLocation = false
+            })
+            .ConfigureAwait(false);
 
         return NoContent();
     }

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -405,7 +405,13 @@ namespace MediaBrowser.Controller.Entities
                             Logger.LogDebug("Removed item: {Path}", item.Path);
 
                             item.SetParent(null);
-                            LibraryManager.DeleteItem(item, new DeleteOptions { DeleteFileLocation = false }, this, false);
+                            await LibraryManager.DeleteItemAsync(
+                                item,
+                                this,
+                                new DeleteOptions
+                                {
+                                    DeleteFileLocation = false
+                                });
                         }
                     }
 

--- a/MediaBrowser.Controller/Entities/UserRootFolder.cs
+++ b/MediaBrowser.Controller/Entities/UserRootFolder.cs
@@ -134,7 +134,7 @@ namespace MediaBrowser.Controller.Entities
             // In theory this can be removed eventually.
             foreach (var item in Children)
             {
-                LibraryManager.RegisterItem(item);
+                LibraryManager.RegisterItemInCache(item);
             }
         }
     }

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -290,31 +290,24 @@ namespace MediaBrowser.Controller.Library
         /// Registers the item.
         /// </summary>
         /// <param name="item">The item.</param>
-        void RegisterItem(BaseItem item);
+        void RegisterItemInCache(BaseItem item);
 
         /// <summary>
         /// Deletes the item.
         /// </summary>
         /// <param name="item">Item to delete.</param>
         /// <param name="options">Options to use for deletion.</param>
-        void DeleteItem(BaseItem item, DeleteOptions options);
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DeleteItemAsync(BaseItem item, DeleteOptions options);
 
         /// <summary>
         /// Deletes the item.
         /// </summary>
         /// <param name="item">Item to delete.</param>
-        /// <param name="options">Options to use for deletion.</param>
-        /// <param name="notifyParentItem">Notify parent of deletion.</param>
-        void DeleteItem(BaseItem item, DeleteOptions options, bool notifyParentItem);
-
-        /// <summary>
-        /// Deletes the item.
-        /// </summary>
-        /// <param name="item">Item to delete.</param>
-        /// <param name="options">Options to use for deletion.</param>
         /// <param name="parent">Parent of item.</param>
-        /// <param name="notifyParentItem">Notify parent of deletion.</param>
-        void DeleteItem(BaseItem item, DeleteOptions options, BaseItem parent, bool notifyParentItem);
+        /// <param name="options">Options to use for deletion.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DeleteItemAsync(BaseItem item, BaseItem parent, DeleteOptions options);
 
         /// <summary>
         /// Gets the named view.

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -208,5 +208,9 @@ namespace MediaBrowser.Controller.Providers
         void OnRefreshComplete(BaseItem item);
 
         double? GetRefreshProgress(Guid id);
+
+        void DeleteMetadata(BaseItem item);
+
+        void DeleteAllImages(BaseItem item);
     }
 }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -92,8 +92,6 @@ namespace MediaBrowser.Model.Configuration
 
         public TypeOptions[] TypeOptions { get; set; }
 
-        public bool RemoveEmptyMediaFoldersOnItemDelete { get; set; }
-
         public TypeOptions? GetTypeOptions(string type)
         {
             foreach (var options in TypeOptions)

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -92,6 +92,8 @@ namespace MediaBrowser.Model.Configuration
 
         public TypeOptions[] TypeOptions { get; set; }
 
+        public bool RemoveEmptyMediaFoldersOnItemDelete { get; set; }
+
         public TypeOptions? GetTypeOptions(string type)
         {
             foreach (var options in TypeOptions)


### PR DESCRIPTION
**Changes**
- Make LibraryManager.DeleteItem async
- Remove LibraryManager.DeleteItem notifyParentItem param (unused)
- Delete all metadata and images on media item delete (when deleting media item from filesystem)
- Remove empty folders from filesystem on media item delete

Eempty media folders will be deleted when the last item is deleted. Eg. deleting the last episode from a season in a series would delete the season in the library and directory on disk. If that season was the last season for that series, the series would also be deleted from the library and disk.

Tested on Windows only, though I expect it should work for other operating systems. 

Detection for existing files uses the same ignore list as media import to ensure standard hidden files are not mistaked for user files. If there are any remaning files that are not safe to ignore and do not belong to Jellyfin, the delete action for the folder will be skipped.

**Issues**
ex. Fixes #832 
