### PR TITLE
#10333 Updates issue stale action to fix issues with not running

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -2,20 +2,21 @@ name: Stale Check
 
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 */12 * * *'
   workflow_dispatch:
 
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   issues:
-    name: Check issues
+    name: Check for stale issues
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'jellyfin/') }}
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+      - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
           days-before-stale: 120
@@ -26,11 +27,11 @@ jobs:
           exempt-issue-labels: regression,security,roadmap,future,feature,enhancement,confirmed
           stale-issue-label: stale
           stale-issue-message: |-
-            This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.
+            This issue has gone 120 days without an update and will be closed within 21 days if there is no new activity. To prevent this issue from being closed, please confirm the issue has not already been fixed by providing updated examples or logs.  
 
-            If you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or master branch, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.
-
-            This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
+            If you have any questions you can use one of several ways to [contact us](https://jellyfin.org/contact).
+          close-issue-message: |-
+            This issue was closed due to inactivity.
 
   prs-conflicts:
     name: Check PRs with merge conflicts


### PR DESCRIPTION
GitHub actions are difficult to test locally, so I'm making some educated guesses about why the stale action was not running correctly. It looks like the primary culprit is that the action is not caching state and is subsequently starting with the most recent issue/PR and never getting past the first 75 as described in [this issue](https://github.com/actions/stale/issues/1090#issuecomment-1710940734). A view of the action logs corroberates this.

**Changes**
- Adds the `actions: write` permission to enable writing to the cache to maintain state
- Updates the `cron` to run twice daily instead of once
- Updates the verbiage on the `stale-issue-message` to be more concise
- Updates the link for getting help
- Adds a `close-issue-message`

**Issues**
#10333
