### PR TITLE
Fix using movie.nfo first when <filename>.nfo also exists

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -60,13 +60,13 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
             else
             {
-                yield return Path.ChangeExtension(item.Path, ".nfo");
-
                 // only allow movie object to read movie.nfo, not owned videos (which will be itemtype video, not movie)
                 if (!item.IsInMixedFolder && item.ItemType == typeof(Movie))
                 {
                     yield return Path.Combine(item.ContainingFolderPath, "movie.nfo");
                 }
+
+                yield return Path.ChangeExtension(item.Path, ".nfo");
             }
         }
 


### PR DESCRIPTION
`<filename>.nfo` is used for store custom information of movie uploader on some private tracker bittorrent website, which is not a valid movie metadata nfo file. Overwrite `<filename>.nfo` will lead errors with file sharing. Therefor using `movie.nfo` first may be better when `<filename>.nfo` also exists.

**Changes**
Use `movie.nfo` first when `<filename>.nfo` also exists.

**Issues**
Fixes #1558
