### PR TITLE
feat: Seeking/Fast forwarding transcoded videos played through DLNA

### DIFF
--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -474,12 +474,8 @@ public class VideosController : BaseJellyfinApiController
         }
 
         var outputPath = state.OutputFilePath;
-        var outputPathExists = System.IO.File.Exists(outputPath);
 
-        var transcodingJob = _transcodingJobHelper.GetTranscodingJob(outputPath, TranscodingJobType.Progressive);
-        var isTranscodeCached = outputPathExists && transcodingJob is not null;
-
-        StreamingHelpers.AddDlnaHeaders(state, Response.Headers, (@static.HasValue && @static.Value) || isTranscodeCached, state.Request.StartTimeTicks, Request, _dlnaManager);
+        StreamingHelpers.AddDlnaHeaders(state, Response.Headers, @static.HasValue && @static.Value, state.Request.StartTimeTicks, Request, _dlnaManager);
 
         // Static stream
         if (@static.HasValue && @static.Value)

--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -97,6 +97,8 @@ public static class FileStreamResponseHelpers
         await transcodingLock.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
         try
         {
+            await transcodingJobHelper.KillTranscodingJobs(state.Request.DeviceId, state.Request.PlaySessionId, outputPath, p => true).ConfigureAwait(false);
+
             TranscodingJobDto? job;
             if (!File.Exists(outputPath))
             {

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -230,6 +230,23 @@ public class TranscodingJobHelper : IDisposable
     }
 
     /// <summary>
+    /// Kills the transcoding jobs except those with an specific output path.
+    /// </summary>
+    /// <param name="deviceId">The device id.</param>
+    /// <param name="playSessionId">The play session identifier.</param>
+    /// <param name="excludeOutputPath">The output path not to kill.</param>
+    /// <param name="deleteFiles">The delete files.</param>
+    /// <returns>Task.</returns>
+    public Task KillTranscodingJobs(string deviceId, string? playSessionId, string excludeOutputPath, Func<string, bool> deleteFiles)
+    {
+        return KillTranscodingJobs(
+            j => (string.IsNullOrWhiteSpace(playSessionId)
+                ? string.Equals(deviceId, j.DeviceId, StringComparison.OrdinalIgnoreCase)
+                : string.Equals(playSessionId, j.PlaySessionId, StringComparison.OrdinalIgnoreCase)) && !string.Equals(j.Path, excludeOutputPath, StringComparison.OrdinalIgnoreCase),
+            deleteFiles);
+    }
+
+    /// <summary>
     /// Kills the transcoding jobs.
     /// </summary>
     /// <param name="killJob">The kill job.</param>

--- a/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
+++ b/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 
 #pragma warning disable CS1591
 
@@ -102,6 +102,12 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// </summary>
         /// <value>The start time ticks.</value>
         public long? StartTimeTicks { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end time ticks.
+        /// </summary>
+        /// <value>The end time ticks.</value>
+        public long? EndTimeTicks { get; set; }
 
         /// <summary>
         /// Gets or sets the width.

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -137,6 +137,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public long? StartTimeTicks => BaseRequest.StartTimeTicks;
 
+        public long? EndTimeTicks => BaseRequest.EndTimeTicks;
+
         public bool CopyTimestamps => BaseRequest.CopyTimestamps;
 
         public bool IsSegmentedLiveStream

--- a/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
+++ b/MediaBrowser.Model/Dlna/ContentFeatureBuilder.cs
@@ -159,10 +159,10 @@ namespace MediaBrowser.Model.Dlna
             }
 
             // Time based seek is currently disabled when streaming. On LG CX3 adding DlnaFlags.TimeBasedSeek and orgPn causes the DLNA playback to fail (format not supported). Further investigations are needed before enabling the remaining code paths.
-            //  else if (runtimeTicks.HasValue)
-            // {
-            //     flagValue = flagValue | DlnaFlags.TimeBasedSeek;
-            // }
+            else if (runtimeTicks.HasValue)
+            {
+                flagValue = flagValue | DlnaFlags.TimeBasedSeek;
+            }
 
             string dlnaflags = string.Format(
                 CultureInfo.InvariantCulture,
@@ -214,14 +214,9 @@ namespace MediaBrowser.Model.Dlna
                 {
                     contentFeatureList.Add(orgOp.TrimStart(';') + orgCi + dlnaflags);
                 }
-                else if (isDirectStream)
-                {
-                    // orgOp should be added all the time once the time based seek is resolved for transcoded streams
-                    contentFeatureList.Add("DLNA.ORG_PN=" + orgPn + orgOp + orgCi + dlnaflags);
-                }
                 else
                 {
-                    contentFeatureList.Add("DLNA.ORG_PN=" + orgPn + orgCi + dlnaflags);
+                    contentFeatureList.Add("DLNA.ORG_PN=" + orgPn + orgOp + orgCi + dlnaflags);
                 }
             }
 


### PR DESCRIPTION
**Changes**
When playing transcoded video via DLNA, you cannot use byte-based seeking, but tell the playback device to use time-based seeking. The playback device carries the "TimeSeekRange.dlna.org" request header when seeking, fast forwarding, and rewinding. Based on this time information, the transcoding job is reconstructed.

**Issues**
Fixes jellyfin/jellyfin-plugin-dlna#27, jellyfin/jellyfin#7329
Inspired by [#6360](https://github.com/jellyfin/jellyfin/issues/6360#issuecomment-1005633706)
