### PR TITLE
Don't create non existent persons in LibraryManager.GetPerson

### DIFF
--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/PersonsControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/PersonsControllerTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public class PersonsControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private readonly JellyfinApplicationFactory _factory;
+    private static string? _accessToken;
+
+    public PersonsControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetPerson_DoesntExist_NotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync($"Persons/DoesntExist");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
return null instead.

GetStudio, GetGenre, GetMusicGenre, GetYear, GetArtist still create a new one when the requested one doesn't exist

Fixes #3901

