### PR TITLE
Use CryptoStream to convert stream from base64

### DIFF
--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -263,7 +263,11 @@ namespace MediaBrowser.Providers.Manager
 
                 var fileStreamOptions = AsyncFile.WriteOptions;
                 fileStreamOptions.Mode = FileMode.Create;
-                fileStreamOptions.PreallocationSize = source.Length;
+                if (source.CanSeek)
+                {
+                    fileStreamOptions.PreallocationSize = source.Length;
+                }
+
                 var fs = new FileStream(path, fileStreamOptions);
                 await using (fs.ConfigureAwait(false))
                 {


### PR DESCRIPTION
Is way more efficient

Tested with a 185676 byte base64 encoded png (size before base64 encode was 137446 bytes)
```
| Method | Mean     | Error    | StdDev   | Gen0     | Gen1     | Gen2     | Allocated |
|------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
| Old    | 905.3 us | 17.81 us | 17.50 us | 154.2969 | 153.3203 | 153.3203 | 891.25 KB |
| New    | 349.4 us |  2.44 us |  2.29 us |   2.4414 |        - |        - |   7.18 KB |
```

Bench code:
```cs
[MemoryDiagnoser]
public class FromBase64Benches
{
    private Stream InputStream()
        => File.OpenRead("Test Data/image.base64");

    private Stream OutPutStream()
        => File.OpenWrite("/dev/null");

    [Benchmark]
    public async Task Old()
    {
        using var input = new StreamReader(InputStream());
        var str = await input.ReadToEndAsync().ConfigureAwait(false);
        var bytes = Convert.FromBase64String(str);
        var ms = new MemoryStream(bytes, 0, bytes.Length, false, true);
        await using (ms.ConfigureAwait(false))
        {
            var output = OutPutStream();
            await using (output.ConfigureAwait(false))
            {
                await ms.CopyToAsync(output).ConfigureAwait(false);
            }
        }
    }

    [Benchmark]
    public async Task New()
    {
        var input = new CryptoStream(InputStream(), new FromBase64Transform(), CryptoStreamMode.Read);
        await using (input.ConfigureAwait(false))
        {
            var output = OutPutStream();
            await using (output.ConfigureAwait(false))
            {
                await input.CopyToAsync(output).ConfigureAwait(false);
            }
        }
    }
}
```