### PR TITLE
Change initialization of library root folders to app start

### DIFF
--- a/Emby.Dlna/ContentDirectory/ControlHandler.cs
+++ b/Emby.Dlna/ContentDirectory/ControlHandler.cs
@@ -772,7 +772,7 @@ namespace Emby.Dlna.ContentDirectory
         /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
         private QueryResult<ServerItem> GetFolders(User user, int? startIndex, int? limit)
         {
-            var folders = _libraryManager.GetUserRootFolder().GetChildren(user, true);
+            var folders = LibraryRoot.UserRootFolder.GetChildren(user, true);
             var totalRecordCount = folders.Count;
             // Handle paging
             var items = folders
@@ -1216,7 +1216,7 @@ namespace Emby.Dlna.ContentDirectory
         private ServerItem GetItemFromObjectId(string id)
         {
             return DidlBuilder.IsIdRoot(id)
-                 ? new ServerItem(_libraryManager.GetUserRootFolder(), null)
+                 ? new ServerItem(LibraryRoot.UserRootFolder, null)
                  : ParseItemId(id);
         }
 
@@ -1256,7 +1256,7 @@ namespace Emby.Dlna.ContentDirectory
 
             Logger.LogError("Error parsing item Id: {Id}. Returning user root folder.", id);
 
-            return new ServerItem(_libraryManager.GetUserRootFolder(), null);
+            return new ServerItem(LibraryRoot.UserRootFolder, null);
         }
     }
 }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -543,6 +543,7 @@ namespace Emby.Server.Implementations
             serviceCollection.AddTransient(provider => new Lazy<IProviderManager>(provider.GetRequiredService<IProviderManager>));
             serviceCollection.AddTransient(provider => new Lazy<IUserViewManager>(provider.GetRequiredService<IUserViewManager>));
             serviceCollection.AddSingleton<ILibraryManager, LibraryManager>();
+            serviceCollection.AddSingleton<ILibraryRoot, LibraryRoot>();
             serviceCollection.AddSingleton<NamingOptions>();
 
             serviceCollection.AddSingleton<IMusicManager, MusicManager>();
@@ -631,6 +632,8 @@ namespace Emby.Server.Implementations
             await localizationManager.LoadAll().ConfigureAwait(false);
 
             SetStaticProperties();
+
+            Resolve<ILibraryRoot>().Initialize();
 
             FindParts();
         }

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -71,7 +71,7 @@ namespace Emby.Server.Implementations.Collections
 
         private IEnumerable<Folder> FindFolders(string path)
         {
-            return _libraryManager
+            return LibraryRoot
                 .RootFolder
                 .Children
                 .OfType<Folder>()

--- a/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
@@ -382,7 +382,7 @@ namespace Emby.Server.Implementations.EntryPoints
             newAndRemoved.AddRange(foldersAddedTo);
             newAndRemoved.AddRange(foldersRemovedFrom);
 
-            var allUserRootChildren = _libraryManager.GetUserRootFolder().GetChildren(user, true).OfType<Folder>().ToList();
+            var allUserRootChildren = LibraryRoot.UserRootFolder.GetChildren(user, true).OfType<Folder>().ToList();
 
             return new LibraryUpdateInfo
             {
@@ -450,7 +450,7 @@ namespace Emby.Server.Implementations.EntryPoints
             // If the physical root changed, return the user root
             if (item is AggregateFolder)
             {
-                return new[] { _libraryManager.GetUserRootFolder() as T };
+                return new[] { LibraryRoot.UserRootFolder as T };
             }
 
             // Return it only if it's in the user's library

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -122,7 +122,7 @@ namespace Emby.Server.Implementations.IO
 
             var pathsToWatch = new List<string>();
 
-            var paths = _libraryManager
+            var paths = LibraryRoot
                 .RootFolder
                 .Children
                 .Where(IsLibraryMonitorEnabled)

--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -51,7 +51,7 @@ namespace Emby.Server.Implementations.Library
                 throw new ArgumentException("User id specified in the query does not exist.", nameof(query));
             }
 
-            var folders = _libraryManager.GetUserRootFolder()
+            var folders = LibraryRoot.UserRootFolder
                 .GetChildren(user, true)
                 .OfType<Folder>()
                 .ToList();
@@ -287,7 +287,7 @@ namespace Emby.Server.Implementations.Library
 
             if (parents.Count == 0)
             {
-                parents = _libraryManager.GetUserRootFolder().GetChildren(user, true)
+                parents = LibraryRoot.UserRootFolder.GetChildren(user, true)
                     .Where(i => i is Folder)
                     .Where(i => !user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes)
                         .Contains(i.Id))

--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -49,7 +49,7 @@ namespace Emby.Server.Implementations.Library.Validators
         {
             var collectionNameMoviesMap = new Dictionary<string, HashSet<Guid>>();
 
-            foreach (var library in _libraryManager.RootFolder.Children)
+            foreach (var library in LibraryRoot.RootFolder.Children)
             {
                 if (!_libraryManager.GetLibraryOptions(library).AutomaticallyAddToCollection)
                 {

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -527,8 +527,8 @@ namespace Emby.Server.Implementations.Playlists
         {
             const string TypeName = "PlaylistsFolder";
 
-            return _libraryManager.RootFolder.Children.OfType<Folder>().FirstOrDefault(i => string.Equals(i.GetType().Name, TypeName, StringComparison.Ordinal)) ??
-                _libraryManager.GetUserRootFolder().Children.OfType<Folder>().FirstOrDefault(i => string.Equals(i.GetType().Name, TypeName, StringComparison.Ordinal));
+            return LibraryRoot.RootFolder.Children.OfType<Folder>().FirstOrDefault(i => string.Equals(i.GetType().Name, TypeName, StringComparison.Ordinal)) ??
+                LibraryRoot.UserRootFolder.Children.OfType<Folder>().FirstOrDefault(i => string.Equals(i.GetType().Name, TypeName, StringComparison.Ordinal));
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -71,7 +71,7 @@ namespace Emby.Server.Implementations.TV
             }
             else
             {
-                parents = _libraryManager.GetUserRootFolder().GetChildren(user, true)
+                parents = LibraryRoot.UserRootFolder.GetChildren(user, true)
                    .Where(i => i is Folder)
                    .Where(i => !user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes).Contains(i.Id))
                    .ToArray();

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -266,7 +266,7 @@ public class ItemsController : BaseJellyfinApiController
 
         if (item is not Folder folder)
         {
-            folder = _libraryManager.GetUserRootFolder();
+            folder = LibraryRoot.UserRootFolder;
         }
 
         string? collectionType = null;
@@ -838,7 +838,7 @@ public class ItemsController : BaseJellyfinApiController
         var excludeFolderIds = user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes);
         if (parentIdGuid.Equals(default) && excludeFolderIds.Length > 0)
         {
-            ancestorIds = _libraryManager.GetUserRootFolder().GetChildren(user, true)
+            ancestorIds = LibraryRoot.UserRootFolder.GetChildren(user, true)
                 .Where(i => i is Folder)
                 .Where(i => !excludeFolderIds.Contains(i.Id))
                 .Select(i => i.Id)

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -151,8 +151,8 @@ public class LibraryController : BaseJellyfinApiController
 
         var item = itemId.Equals(default)
             ? (userId.Value.Equals(default)
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
+                ? LibraryRoot.RootFolder
+                : LibraryRoot.UserRootFolder)
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -218,8 +218,8 @@ public class LibraryController : BaseJellyfinApiController
 
         var item = itemId.Equals(default)
             ? (userId.Value.Equals(default)
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
+                ? LibraryRoot.RootFolder
+                : LibraryRoot.UserRootFolder)
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -506,7 +506,7 @@ public class LibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<IEnumerable<string>> GetPhysicalPaths()
     {
-        return Ok(_libraryManager.RootFolder.Children
+        return Ok(LibraryRoot.RootFolder.Children
             .SelectMany(c => c.PhysicalLocations));
     }
 
@@ -521,7 +521,7 @@ public class LibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<QueryResult<BaseItemDto>> GetMediaFolders([FromQuery] bool? isHidden)
     {
-        var items = _libraryManager.GetUserRootFolder().Children.Concat(_libraryManager.RootFolder.VirtualChildren).OrderBy(i => i.SortName).ToList();
+        var items = LibraryRoot.UserRootFolder.Children.Concat(LibraryRoot.RootFolder.VirtualChildren).OrderBy(i => i.SortName).ToList();
 
         if (isHidden.HasValue)
         {
@@ -703,8 +703,8 @@ public class LibraryController : BaseJellyfinApiController
         userId = RequestHelpers.GetUserId(User, userId);
         var item = itemId.Equals(default)
             ? (userId.Value.Equals(default)
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
+                ? LibraryRoot.RootFolder
+                : LibraryRoot.UserRootFolder)
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -899,7 +899,7 @@ public class LibraryController : BaseJellyfinApiController
     private BaseItem? TranslateParentItem(BaseItem item, User user)
     {
         return item.GetParent() is AggregateFolder
-            ? _libraryManager.GetUserRootFolder().GetChildren(user, true)
+            ? LibraryRoot.UserRootFolder.GetChildren(user, true)
                 .FirstOrDefault(i => i.PhysicalLocations.Contains(item.Path))
             : item;
     }

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -212,7 +212,7 @@ public class LiveTvController : BaseJellyfinApiController
             ? null
             : _userManager.GetUserById(userId.Value);
         var item = channelId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(channelId);
 
         var dtoOptions = new DtoOptions()
@@ -407,7 +407,7 @@ public class LiveTvController : BaseJellyfinApiController
         var user = userId.Value.Equals(default)
             ? null
             : _userManager.GetUserById(userId.Value);
-        var item = recordingId.Equals(default) ? _libraryManager.GetUserRootFolder() : _libraryManager.GetItemById(recordingId);
+        var item = recordingId.Equals(default) ? LibraryRoot.UserRootFolder : _libraryManager.GetItemById(recordingId);
 
         var dtoOptions = new DtoOptions()
             .AddClientFields(User);

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -85,7 +85,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -123,7 +123,7 @@ public class UserLibraryController : BaseJellyfinApiController
             return NotFound();
         }
 
-        var item = _libraryManager.GetUserRootFolder();
+        var item = LibraryRoot.UserRootFolder;
         var dtoOptions = new DtoOptions().AddClientFields(User);
         return _dtoService.GetBaseItemDto(item, dtoOptions, user);
     }
@@ -146,7 +146,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -186,7 +186,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -222,7 +222,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -258,7 +258,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -295,7 +295,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -331,7 +331,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -376,7 +376,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)
@@ -559,7 +559,7 @@ public class UserLibraryController : BaseJellyfinApiController
         }
 
         var item = itemId.Equals(default)
-            ? _libraryManager.GetUserRootFolder()
+            ? LibraryRoot.UserRootFolder
             : _libraryManager.GetItemById(itemId);
 
         if (item is null)

--- a/Jellyfin.Api/Controllers/UserViewsController.cs
+++ b/Jellyfin.Api/Controllers/UserViewsController.cs
@@ -121,7 +121,7 @@ public class UserViewsController : BaseJellyfinApiController
             return NotFound();
         }
 
-        return Ok(_libraryManager.GetUserRootFolder()
+        return Ok(LibraryRoot.UserRootFolder
             .GetChildren(user, true)
             .OfType<Folder>()
             .Where(UserView.IsEligibleForGrouping)

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -111,8 +111,8 @@ public class VideosController : BaseJellyfinApiController
 
         var item = itemId.Equals(default)
             ? (userId.Value.Equals(default)
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
+                ? LibraryRoot.RootFolder
+                : LibraryRoot.UserRootFolder)
             : _libraryManager.GetItemById(itemId);
 
         var dtoOptions = new DtoOptions();

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -835,7 +835,7 @@ namespace MediaBrowser.Controller.Entities
 
         public bool CanDelete(User user)
         {
-            var allCollectionFolders = LibraryManager.GetUserRootFolder().Children.OfType<Folder>().ToList();
+            var allCollectionFolders = LibraryRoot.UserRootFolder.Children.OfType<Folder>().ToList();
 
             return CanDelete(user, allCollectionFolders);
         }
@@ -1306,7 +1306,7 @@ namespace MediaBrowser.Controller.Entities
 
                 if (itemCollectionFolders.Count > 0)
                 {
-                    var userCollectionFolders = LibraryManager.GetUserRootFolder().GetChildren(user, true).Select(i => i.Id).ToList();
+                    var userCollectionFolders = LibraryRoot.UserRootFolder.GetChildren(user, true).Select(i => i.Id).ToList();
                     if (!itemCollectionFolders.Any(userCollectionFolders.Contains))
                     {
                         return false;

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -330,7 +330,7 @@ namespace MediaBrowser.Controller.Entities
                 return PhysicalFolderIds.Select(i => LibraryManager.GetItemById(i)).OfType<Folder>();
             }
 
-            var rootChildren = LibraryManager.RootFolder.Children
+            var rootChildren = LibraryRoot.RootFolder.Children
                 .OfType<Folder>()
                 .ToList();
 

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1262,7 +1262,7 @@ namespace MediaBrowser.Controller.Entities
             // the true root should return our users root folder children
             if (IsPhysicalRoot)
             {
-                return LibraryManager.GetUserRootFolder().GetChildren(user, includeLinkedChildren);
+                return LibraryRoot.UserRootFolder.GetChildren(user, includeLinkedChildren);
             }
 
             var result = new Dictionary<Guid, BaseItem>();
@@ -1469,7 +1469,7 @@ namespace MediaBrowser.Controller.Entities
                 return list;
             }
 
-            var allUserRootChildren = LibraryManager.GetUserRootFolder()
+            var allUserRootChildren = LibraryRoot.UserRootFolder
                 .GetChildren(user, true)
                 .OfType<Folder>()
                 .ToList();

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Querying;
 
@@ -190,7 +191,7 @@ namespace MediaBrowser.Controller.Entities.Movies
 
         private Guid[] GetLibraryFolderIds(User user)
         {
-            return LibraryManager.GetUserRootFolder().GetChildren(user, true)
+            return LibraryRoot.UserRootFolder.GetChildren(user, true)
                 .Select(i => i.Id)
                 .ToArray();
         }

--- a/MediaBrowser.Controller/Entities/PlaylistsFolder.cs
+++ b/MediaBrowser.Controller/Entities/PlaylistsFolder.cs
@@ -5,11 +5,10 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Model.Querying;
 
-namespace Emby.Server.Implementations.Playlists
+namespace MediaBrowser.Controller.Entities
 {
     public class PlaylistsFolder : BasePluginFolder
     {

--- a/MediaBrowser.Controller/Entities/UserRootFolder.cs
+++ b/MediaBrowser.Controller/Entities/UserRootFolder.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Library;
 using MediaBrowser.Model.Querying;
@@ -91,7 +92,7 @@ namespace MediaBrowser.Controller.Entities
         protected override IEnumerable<BaseItem> GetEligibleChildrenForRecursiveChildren(User user)
         {
             var list = base.GetEligibleChildrenForRecursiveChildren(user).ToList();
-            list.AddRange(LibraryManager.RootFolder.VirtualChildren);
+            list.AddRange(LibraryRoot.RootFolder.VirtualChildren);
 
             return list;
         }

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -59,7 +59,7 @@ namespace MediaBrowser.Controller.Entities
             switch (viewType)
             {
                 case CollectionType.Folders:
-                    return GetResult(_libraryManager.GetUserRootFolder().GetChildren(user, true), query);
+                    return GetResult(LibraryRoot.UserRootFolder.GetChildren(user, true), query);
 
                 case CollectionType.TvShows:
                     return GetTvView(queryParent, user, query);
@@ -931,13 +931,13 @@ namespace MediaBrowser.Controller.Entities
         {
             if (user is null)
             {
-                return _libraryManager.RootFolder
+                return LibraryRoot.RootFolder
                     .Children
                     .OfType<Folder>()
                     .Where(UserView.IsEligibleForGrouping);
             }
 
-            return _libraryManager.GetUserRootFolder()
+            return LibraryRoot.UserRootFolder
                 .GetChildren(user, true)
                 .OfType<Folder>()
                 .Where(i => user.IsFolderGrouped(i.Id) && UserView.IsEligibleForGrouping(i));

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -45,12 +45,6 @@ namespace MediaBrowser.Controller.Library
         /// </summary>
         event EventHandler<ItemChangeEventArgs> ItemRemoved;
 
-        /// <summary>
-        /// Gets the root folder.
-        /// </summary>
-        /// <value>The root folder.</value>
-        AggregateFolder RootFolder { get; }
-
         bool IsScanRunning { get; }
 
         /// <summary>
@@ -202,12 +196,6 @@ namespace MediaBrowser.Controller.Library
         IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user, IEnumerable<string> sortBy, SortOrder sortOrder);
 
         IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user, IEnumerable<(string OrderBy, SortOrder SortOrder)> orderBy);
-
-        /// <summary>
-        /// Gets the user root folder.
-        /// </summary>
-        /// <returns>UserRootFolder.</returns>
-        Folder GetUserRootFolder();
 
         /// <summary>
         /// Creates the item.

--- a/MediaBrowser.Controller/Library/ILibraryRoot.cs
+++ b/MediaBrowser.Controller/Library/ILibraryRoot.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.Library
+{
+    /// <summary>
+    /// Initialize and get library root folders.
+    /// </summary>
+    public interface ILibraryRoot
+    {
+        /// <summary>
+        /// Called on application start. Create root folders if they do not exist and setup static references.
+        /// </summary>
+        void Initialize();
+    }
+}

--- a/MediaBrowser.Controller/Library/LibraryRoot.cs
+++ b/MediaBrowser.Controller/Library/LibraryRoot.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Threading;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Controller.Library
+{
+    /// <summary>
+    /// Represents the media library root directories.
+    /// </summary>
+    public class LibraryRoot : ILibraryRoot
+    {
+        private readonly ILibraryManager _libraryManager;
+        private readonly IFileSystem _fileSystem;
+        private readonly IServerConfigurationManager _configurationManager;
+        private readonly ILogger<LibraryRoot> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibraryRoot"/> class.
+        /// </summary>
+        /// <param name="libraryManager">The library manager.</param>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="configurationManager">the configuration manager.</param>
+        /// <param name="logger">The logger.</param>
+        public LibraryRoot(
+            ILibraryManager libraryManager,
+            IFileSystem fileSystem,
+            IServerConfigurationManager configurationManager,
+            ILogger<LibraryRoot> logger)
+        {
+            _libraryManager = libraryManager;
+            _fileSystem = fileSystem;
+            _configurationManager = configurationManager;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the library root folder.
+        /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public static AggregateFolder RootFolder { get; private set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        /// <summary>
+        /// Gets the library root user folder.
+        /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public static Folder UserRootFolder { get; private set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        /// <summary>
+        /// Called on application start. Create root folders if they do not exist and setup static references.
+        /// </summary>
+        public void Initialize()
+        {
+            CreateUserRootFolder();
+            CreateRootFolder();
+        }
+
+        private void CreateRootFolder()
+        {
+            var rootFolderPath = _configurationManager.ApplicationPaths.RootFolderPath;
+
+            Directory.CreateDirectory(rootFolderPath);
+
+            var rootFolder = _libraryManager.GetItemById(_libraryManager.GetNewItemId(rootFolderPath, typeof(AggregateFolder))) as AggregateFolder ??
+                             ((Folder)_libraryManager.ResolvePath(_fileSystem.GetDirectoryInfo(rootFolderPath)))
+                             .DeepCopy<Folder, AggregateFolder>();
+
+            // In case program data folder was moved
+            if (!string.Equals(rootFolder.Path, rootFolderPath, StringComparison.Ordinal))
+            {
+                _logger.LogInformation("Resetting root folder path to {0}", rootFolderPath);
+                rootFolder.Path = rootFolderPath;
+            }
+
+            // Add in the plug-in folders
+            var path = Path.Combine(_configurationManager.ApplicationPaths.DataPath, "playlists");
+
+            Directory.CreateDirectory(path);
+
+            Folder folder = new PlaylistsFolder
+            {
+                Path = path
+            };
+
+            if (folder.Id.Equals(Guid.Empty))
+            {
+                if (string.IsNullOrEmpty(folder.Path))
+                {
+                    folder.Id = _libraryManager.GetNewItemId(folder.GetType().Name, folder.GetType());
+                }
+                else
+                {
+                    folder.Id = _libraryManager.GetNewItemId(folder.Path, folder.GetType());
+                }
+            }
+
+            var dbItem = _libraryManager.GetItemById(folder.Id) as BasePluginFolder;
+
+            if (dbItem is not null && string.Equals(dbItem.Path, folder.Path, StringComparison.OrdinalIgnoreCase))
+            {
+                folder = dbItem;
+            }
+
+            if (!folder.ParentId.Equals(rootFolder.Id))
+            {
+                folder.ParentId = rootFolder.Id;
+                folder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
+            }
+
+            rootFolder.AddVirtualChild(folder);
+
+            RootFolder = rootFolder;
+        }
+
+        private void CreateUserRootFolder()
+        {
+            var userRootPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
+            _logger.LogDebug("Creating userRootPath at {Path}", userRootPath);
+
+            var newItemId = _libraryManager.GetNewItemId(userRootPath, typeof(UserRootFolder));
+            UserRootFolder? tmpItem = null;
+
+            try
+            {
+                Directory.CreateDirectory(userRootPath);
+                tmpItem = _libraryManager.GetItemById(newItemId) as UserRootFolder;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating UserRootFolder {Path}", newItemId);
+            }
+
+            if (tmpItem is null)
+            {
+                _logger.LogDebug("Creating new userRootFolder with DeepCopy");
+                tmpItem = ((Folder)_libraryManager.ResolvePath(_fileSystem.GetDirectoryInfo(userRootPath))).DeepCopy<Folder, UserRootFolder>();
+            }
+
+            // In case program data folder was moved
+            if (!string.Equals(tmpItem.Path, userRootPath, StringComparison.Ordinal))
+            {
+                _logger.LogInformation("Resetting user root folder path to {0}", userRootPath);
+                tmpItem.Path = userRootPath;
+            }
+
+            _logger.LogDebug("Setting userRootFolder: {Folder}", tmpItem);
+
+            UserRootFolder = tmpItem;
+        }
+    }
+}

--- a/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
@@ -72,7 +72,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             var dict = new Dictionary<Guid, BaseItem>();
 
-            foreach (var library in _libraryManager.RootFolder.Children.ToList())
+            foreach (var library in LibraryRoot.RootFolder.Children.ToList())
             {
                 var libraryOptions = _libraryManager.GetLibraryOptions(library);
 


### PR DESCRIPTION
**Changes**
Remove lazy creation of root folders and reduce dependency on LibraryManager. 
Root folder references are now statically available on the LibraryRoot class.
