### PR TITLE
Build Windows installer as part of packaging CI job

### DIFF
--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -10,8 +10,8 @@ ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
 RUN apt-get update -yqq \
-  && apt-get install -yqq --no-install-recommends \
-    debhelper gnupg devscripts unzip \
+    && apt-get install -yqq --no-install-recommends \
+    debhelper gnupg devscripts unzip nsis \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
     libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
 

--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -6,12 +6,30 @@ set -o errexit
 set -o xtrace
 
 # Version variables
+
+# Figure out the latest version by sorting based on the date then version number
+# ideally we should just have a symlink called latest that points to the latest version...
+JELLYFIN_WEB_LATEST_VERSION=$(curl -q https://repo.jellyfin.org/releases/server/portable/versions/unstable/web/ | grep -oP 'href="\K[0-9]+\.[0-9]+' | sort -t. -rn -k1,1 -k2,2 | head -1)
+
+JELLYFIN_WEB_FILENAME="jellyfin-web_${JELLYFIN_WEB_LATEST_VERSION}_portable.tar.gz"
+JELLYFIN_WEB_URL="https://repo.jellyfin.org/releases/server/portable/versions/unstable/web/${JELLYFIN_WEB_LATEST_VERSION}/${JELLYFIN_WEB_FILENAME}"
+
+JELLYFIN_INSTALLER_VERSION=master
+JELLYFIN_INSTALLER_URL="https://github.com/jellyfin/jellyfin-server-windows"
+
+JELLYFIN_UX_VERSION=master
+JELLYFIN_UX_URL="https://github.com/jellyfin/jellyfin-ux"
+
 NSSM_VERSION="nssm-2.24-101-g897c7ad"
 NSSM_URL="http://files.evilt.win/nssm/${NSSM_VERSION}.zip"
+
+NSIS_VERSION="3.09"
+NSIS_URL="https://download.sourceforge.net/project/nsis/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip"
+
 FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg-portable_win64.zip";
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+cd ${SOURCE_DIR}
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -20,33 +38,75 @@ else
     version="$( grep "version:" ./build.yaml | sed -E 's/version: "([0-9\.]+.*)"/\1/' )"
 fi
 
-output_dir="dist/jellyfin-server_${version}"
+mkdir -p ${ARTIFACT_DIR}/
+output_dir="${SOURCE_DIR}/dist/jellyfin-server_${version}"
+mkdir -p ${output_dir}
+
+# Prepare addins working directory
+addin_build_dir="$( mktemp -d )"
+
+# # Workaround https://github.com/dotnet/core/issues/7868
+OLD_XDG_DATA_HOME="${XDG_DATA_HOME}"
+export XDG_DATA_HOME=${addin_build_dir}
+export DOTNET_CLI_HOME=${addin_build_dir}/.dotnet
 
 # Build binary
 dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime win-x64 --output ${output_dir}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
 
-# Prepare addins
-addin_build_dir="$( mktemp -d )"
-wget ${NSSM_URL} -O ${addin_build_dir}/nssm.zip
-wget ${FFMPEG_URL} -O ${addin_build_dir}/jellyfin-ffmpeg.zip
+# NSSM
+wget -q ${NSSM_URL} -O ${addin_build_dir}/nssm.zip
 unzip ${addin_build_dir}/nssm.zip -d ${addin_build_dir}
 cp ${addin_build_dir}/${NSSM_VERSION}/win64/nssm.exe ${output_dir}/nssm.exe
+
+# FFMPEG
+wget -q ${FFMPEG_URL} -O ${addin_build_dir}/jellyfin-ffmpeg.zip
 unzip ${addin_build_dir}/jellyfin-ffmpeg.zip -d ${addin_build_dir}/jellyfin-ffmpeg
 cp ${addin_build_dir}/jellyfin-ffmpeg/* ${output_dir}
+
+# Web files
+pushd ${addin_build_dir}
+wget -q "${JELLYFIN_WEB_URL}"
+wget -q "${JELLYFIN_WEB_URL}.sha256sum"
+sha256sum -c ${JELLYFIN_WEB_FILENAME}.sha256sum
+tar -xzf ${JELLYFIN_WEB_FILENAME}
+
+rm jellyfin-web*.tar.gz*
+cp -r jellyfin-web* ${output_dir}/jellyfin-web
+popd
+
+# UX and license for installer
+cp ${SOURCE_DIR}/LICENSE ${output_dir}/LICENSE
+
+git clone ${JELLYFIN_UX_URL} ${addin_build_dir}/jellyfin-ux
+pushd ${addin_build_dir}/jellyfin-ux
+git checkout ${JELLYFIN_UX_VERSION}
+popd
+
+# Installer deps
+git clone ${JELLYFIN_INSTALLER_URL} ${addin_build_dir}/jellyfin-installer
+pushd ${addin_build_dir}/jellyfin-installer
+git checkout ${JELLYFIN_INSTALLER_VERSION}
+dotnet publish Jellyfin.Windows.Tray --configuration Release --runtime win-x64 --output ${output_dir}/ -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
+popd
+
+# Run makensis
+InstallLocation=${output_dir} ProgramData="C:\ProgramData" makensis \
+    -Dx64 -DUXPATH=${addin_build_dir}/jellyfin-ux \
+    ${addin_build_dir}/jellyfin-installer/nsis/jellyfin.nsi
+
+mv ${addin_build_dir}/jellyfin-installer/nsis/jellyfin*windows-x64.exe ${ARTIFACT_DIR}/jellyfin-${version}-windows-x64.exe
+
 rm -rf ${addin_build_dir}
+export XDG_DATA_HOME="${OLD_XDG_DATA_HOME}"
 
 # Create zip package
-pushd dist
+pushd "${SOURCE_DIR}/dist"
 zip -qr jellyfin-server_${version}.portable.zip jellyfin-server_${version}
+mv jellyfin[-_]*.zip ${ARTIFACT_DIR}/
 popd
-rm -rf ${output_dir}
 
-# Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv dist/jellyfin[-_]*.zip ${ARTIFACT_DIR}/
+rm -rf ${output_dir}
 
 if [[ ${IS_DOCKER} == YES ]]; then
     chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
 fi
-
-popd

--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -26,7 +26,8 @@ NSSM_URL="http://files.evilt.win/nssm/${NSSM_VERSION}.zip"
 NSIS_VERSION="3.09"
 NSIS_URL="https://download.sourceforge.net/project/nsis/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip"
 
-FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg-portable_win64.zip";
+FFMPEG_VERSION="6.0-6"
+FFMPEG_URL="https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${FFMPEG_VERSION}/jellyfin-ffmpeg_${FFMPEG_VERSION}-portable_win64.zip";
 
 # Move to source directory
 cd ${SOURCE_DIR}


### PR DESCRIPTION
This is more a proposal / proof of concept. I'm happy to take any suggestions and ideas, hence it's marked as a draft:

**Changes**
Using all the existing bits we can easily build the Windows installer for existing versions.

In this ~commit~ PR we:
- Grab the latest version of JF Web (based on the latest unstable)
- Grab the latest version of JF_UX
- Install nsis
- Build an installer as a dedicated artifact

Why; because being able to bundle JF installer as part of the daily builds increases the chances of finding bugs / getting fixes out. It also means that people don't have to figure out how to install ffmpeg...etc. if they want to test an unstable fix.

Limitations
- The installer tags itself as the real version, this needs fixing in the upstream installer

- We don't upload the installer as part of the CI to repos.jellyfin, this is partially because we don't want users easily finding "a released version", which is actually unstable but the installer is incorrect.

- Some assumptions have been made about how JF web will name its files. Ideally we want a symlink which is repointed on repos.jellyfin which points to the latest version. For the moment (ab)use the date naming.


**Testing**
Run the docker build as follows from the source dir:
```
cd deployment && docker build .  -f Dockerfile.windows.amd64 -t win_build
cd .. && docker run -v $(pwd)/deployment/dist:/dist -v $(pwd):/jellyfin -e IS_UNSTABLE="yes" -e BUILD_ID="local" win_build
```

There will be an installer in `deployment/dist/jellyfin-local-windows-x64.exe`
Test on a Windows machine, I've got it working locally with the limitations described above:
![image](https://github.com/jellyfin/jellyfin/assets/1817032/4141c368-aa74-45aa-b133-271579919f98)

I've also tested it with a forked pipeline to verify it plays nice with the CI (albeit with most of the packaging / testing steps deleted for my sanity) [here](https://dev.azure.com/DavidFair/Jellyfin%20Fork/_build/results?buildId=11&view=logs&j=b239e49c-c2c4-5033-bc88-01d0d0cdac65)