### PR TITLE
Add full version tag for renovate

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'jellyfin/') }}
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
           days-before-stale: 120


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

I haven't been able to keep up with notifications lately (not that I'm complaining about the recent increase in activity) and noticed this too late to chime in.

This file ended up with renovate comment tags for "v8" and "v8.0.0" with the same hash. This will result in two renovate pull requests whenever there is a new release because it doesn't see them as being the same thing.

Fully tagging the version is preferable because it causes renovate to link to the release notes instead of just the diff between hashes.

**Changes**

 - Fix renovate version tag to be consistent within the file

**Issues**

