### PR TITLE
Empty Guids shouldn't make it into the refresh queue

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -943,6 +943,12 @@ namespace MediaBrowser.Providers.Manager
         /// <inheritdoc/>
         public void QueueRefresh(Guid itemId, MetadataRefreshOptions options, RefreshPriority priority)
         {
+            ArgumentNullException.ThrowIfNull(itemId);
+            if (itemId.Equals(default))
+            {
+                throw new ArgumentException("Guid can't be empty", nameof(itemId));
+            }
+
             if (_disposed)
             {
                 return;


### PR DESCRIPTION
```
System.ArgumentException: Guid can't be empty (Parameter 'id')
   at Emby.Server.Implementations.Library.LibraryManager.GetItemById(Guid id) in /home/loma/dev/jellyfin/Emby.Server.Implementations/Library/LibraryManager.cs:line 1224
   at MediaBrowser.Providers.Manager.ProviderManager.StartProcessingRefreshQueue() in /home/loma/dev/jellyfin/MediaBrowser.Providers/Manager/ProviderManager.cs:line 983
```
This doesn't fix the cause, but at least they won't make it into the queue
