### PR TITLE
Add nuget.config file to fix NU1507 by only allowing nuget.org as package source. see: https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping and https://github.com/dotnet/sdk/issues/25379

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
`dotnet build` fails with the following error if more than one nuget source is defined:

```
error NU1507: Warning As Error: There are 4 package so
urces defined in your configuration. When using central package management, please map your package sources with package source ma
pping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: nuget.o
rg, BuildB, BuildA, TelerikNuGetV3 [C:\_git\jellyfin\Jellyfin.sln]
```


**Changes**
Added a nuget.config file which removes all sources other than nuget.org for this repo.
Doc: https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping
More infos: https://github.com/dotnet/sdk/issues/25379

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
