### PR TITLE
DLNA fix : Make media visible and playable

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1616,7 +1616,7 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
         private IRecorder GetRecorder(MediaSourceInfo mediaSource)
         {
-            if (mediaSource.RequiresLooping || !(mediaSource.Container ?? string.Empty).EndsWith("ts", StringComparison.OrdinalIgnoreCase) || (mediaSource.Protocol != MediaProtocol.File && mediaSource.Protocol != MediaProtocol.Http))
+            if (mediaSource.RequiresLooping || !mediaSource.Container.EndsWith("ts", StringComparison.OrdinalIgnoreCase) || (mediaSource.Protocol != MediaProtocol.File && mediaSource.Protocol != MediaProtocol.Http))
             {
                 return new EncodedRecorder(_logger, _mediaEncoder, _config.ApplicationPaths, _config);
             }

--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -248,6 +248,7 @@ public class AudioController : BaseJellyfinApiController
     /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
+    /// <param name="ext">Optional. The original stream extension.</param>///
     /// <response code="200">Audio stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream.{container}", Name = "GetAudioStreamByContainer")]
@@ -303,7 +304,8 @@ public class AudioController : BaseJellyfinApiController
         [FromQuery] int? audioStreamIndex,
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
-        [FromQuery] Dictionary<string, string>? streamOptions)
+        [FromQuery] Dictionary<string, string>? streamOptions,
+        [FromQuery] string? ext)
     {
         StreamingRequestDto streamingRequest = new StreamingRequestDto
         {
@@ -355,7 +357,8 @@ public class AudioController : BaseJellyfinApiController
             AudioStreamIndex = audioStreamIndex,
             VideoStreamIndex = videoStreamIndex,
             Context = context ?? EncodingContext.Static,
-            StreamOptions = streamOptions
+            StreamOptions = streamOptions,
+            OriginalExtension = ext
         };
 
         return await _audioHelper.GetAudioStream(_transcodingJobType, streamingRequest).ConfigureAwait(false);

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -311,6 +311,7 @@ public class VideosController : BaseJellyfinApiController
     /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
+    /// <param name="ext">Optional. The stream's original extension.</param>
     /// <response code="200">Video stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream")]
@@ -368,7 +369,8 @@ public class VideosController : BaseJellyfinApiController
         [FromQuery] int? audioStreamIndex,
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
-        [FromQuery] Dictionary<string, string> streamOptions)
+        [FromQuery] Dictionary<string, string> streamOptions,
+        [FromQuery] string? ext)
     {
         var isHeadRequest = Request.Method == System.Net.WebRequestMethods.Http.Head;
         // CTS lifecycle is managed internally.
@@ -425,7 +427,8 @@ public class VideosController : BaseJellyfinApiController
             AudioStreamIndex = audioStreamIndex,
             VideoStreamIndex = videoStreamIndex,
             Context = context ?? EncodingContext.Streaming,
-            StreamOptions = streamOptions
+            StreamOptions = streamOptions,
+            OriginalExtension = ext
         };
 
         var state = await StreamingHelpers.GetStreamingState(
@@ -564,6 +567,7 @@ public class VideosController : BaseJellyfinApiController
     /// <param name="videoStreamIndex">Optional. The index of the video stream to use. If omitted the first video stream will be used.</param>
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
+    /// <param name="ext">Optional. The stream's original extension.</param>
     /// <response code="200">Video stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream.{container}")]
@@ -621,7 +625,8 @@ public class VideosController : BaseJellyfinApiController
         [FromQuery] int? audioStreamIndex,
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
-        [FromQuery] Dictionary<string, string> streamOptions)
+        [FromQuery] Dictionary<string, string> streamOptions,
+        [FromQuery] string? ext)
     {
         return GetVideoStream(
             itemId,
@@ -674,6 +679,7 @@ public class VideosController : BaseJellyfinApiController
             audioStreamIndex,
             videoStreamIndex,
             context,
-            streamOptions);
+            streamOptions,
+            ext);
     }
 }

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -287,7 +287,7 @@ public class MediaInfoHelper
                 mediaSource.SupportsDirectPlay = false;
                 mediaSource.SupportsDirectStream = false;
 
-                mediaSource.TranscodingUrl = streamInfo.ToUrl("-", claimsPrincipal.GetToken()).TrimStart('-');
+                mediaSource.TranscodingUrl = streamInfo.ToUrl(null, claimsPrincipal.GetToken());
                 mediaSource.TranscodingUrl += "&allowVideoStreamCopy=false";
                 mediaSource.TranscodingUrl += "&allowAudioStreamCopy=false";
                 mediaSource.TranscodingContainer = streamInfo.Container;
@@ -298,7 +298,7 @@ public class MediaInfoHelper
                 if (!mediaSource.SupportsDirectPlay && (mediaSource.SupportsTranscoding || mediaSource.SupportsDirectStream))
                 {
                     streamInfo.PlayMethod = PlayMethod.Transcode;
-                    mediaSource.TranscodingUrl = streamInfo.ToUrl("-", claimsPrincipal.GetToken()).TrimStart('-');
+                    mediaSource.TranscodingUrl = streamInfo.ToUrl(null, claimsPrincipal.GetToken());
 
                     if (!allowVideoStreamCopy)
                     {

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -95,9 +95,9 @@ public static class StreamingHelpers
         var state = new StreamState(mediaSourceManager, transcodingJobType, transcodingJobHelper)
         {
             Request = streamingRequest,
-            RequestedUrl = url,
             UserAgent = httpRequest.Headers[HeaderNames.UserAgent],
-            EnableDlnaHeaders = enableDlnaHeaders
+            EnableDlnaHeaders = enableDlnaHeaders,
+            Extension = url
         };
 
         var userId = httpContext.User.GetUserId();
@@ -165,9 +165,9 @@ public static class StreamingHelpers
 
         var encodingOptions = serverConfigurationManager.GetEncodingOptions();
 
-        encodingHelper.AttachMediaSourceInfo(state, encodingOptions, mediaSource, url);
+        encodingHelper.AttachMediaSourceInfo(state, encodingOptions, mediaSource, state.Extension);
 
-        string? containerInternal = Path.GetExtension(state.RequestedUrl);
+        string? containerInternal = state.Extension;
 
         if (!string.IsNullOrEmpty(streamingRequest.Container))
         {
@@ -423,7 +423,7 @@ public static class StreamingHelpers
     /// <returns>System.String.</returns>
     private static string GetOutputFileExtension(StreamState state, MediaSourceInfo? mediaSource)
     {
-        var ext = Path.GetExtension(state.RequestedUrl);
+        var ext = Path.GetExtension(state.Extension);
         if (!string.IsNullOrEmpty(ext))
         {
             return ext;

--- a/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
+++ b/Jellyfin.Api/Helpers/TranscodingJobHelper.cs
@@ -808,7 +808,7 @@ public class TranscodingJobHelper : IDisposable
                 .ConfigureAwait(false);
             var encodingOptions = _serverConfigurationManager.GetEncodingOptions();
 
-            _encodingHelper.AttachMediaSourceInfo(state, encodingOptions, liveStreamResponse.MediaSource, state.RequestedUrl);
+            _encodingHelper.AttachMediaSourceInfo(state, encodingOptions, liveStreamResponse.MediaSource, state.Extension);
 
             if (state.VideoRequest is not null)
             {

--- a/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamState.cs
@@ -30,11 +30,6 @@ public class StreamState : EncodingJobInfo, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets the requested url.
-    /// </summary>
-    public string? RequestedUrl { get; set; }
-
-    /// <summary>
     /// Gets or sets the request.
     /// </summary>
     public StreamingRequestDto Request
@@ -122,6 +117,11 @@ public class StreamState : EncodingJobInfo, IDisposable
             return SegmentLength >= 10 ? 2 : 3;
         }
     }
+
+    /// <summary>
+    /// Gets or sets the stream's extension.
+    /// </summary>
+    public string? Extension { get; set; }
 
     /// <summary>
     /// Gets or sets the user agent.

--- a/Jellyfin.Api/Models/StreamingDtos/StreamingRequestDto.cs
+++ b/Jellyfin.Api/Models/StreamingDtos/StreamingRequestDto.cs
@@ -51,4 +51,9 @@ public class StreamingRequestDto : BaseEncodingJobOptions
     /// Gets or sets the actual segment length in ticks.
     /// </summary>
     public long ActualSegmentLengthTicks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the original file extension.
+    /// </summary>
+    public string? OriginalExtension { get; set; }
 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -544,12 +544,10 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Infers the video codec.
         /// </summary>
-        /// <param name="url">The URL.</param>
+         /// <param name="ext">The file extension.</param>
         /// <returns>System.Nullable{VideoCodecs}.</returns>
-        public string InferVideoCodec(string url)
+        public string InferVideoCodec(string ext)
         {
-            var ext = Path.GetExtension(url.AsSpan());
-
             if (ext.Equals(".asf", StringComparison.OrdinalIgnoreCase))
             {
                 return "wmv";
@@ -1182,20 +1180,17 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public static string GetAudioBitStreamArguments(EncodingJobInfo state, string segmentContainer, string mediaSourceContainer)
         {
-            var bitStreamArgs = string.Empty;
-            var segmentFormat = GetSegmentFileExtension(segmentContainer).TrimStart('.');
-
             // Apply aac_adtstoasc bitstream filter when media source is in mpegts.
-            if (string.Equals(segmentFormat, "mp4", StringComparison.OrdinalIgnoreCase)
+            if (string.Equals(segmentContainer, "mp4", StringComparison.OrdinalIgnoreCase)
                 && (string.Equals(mediaSourceContainer, "mpegts", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(mediaSourceContainer, "aac", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(mediaSourceContainer, "hls", StringComparison.OrdinalIgnoreCase)))
             {
-                bitStreamArgs = GetBitStreamArgs(state.AudioStream);
-                bitStreamArgs = string.IsNullOrEmpty(bitStreamArgs) ? string.Empty : " " + bitStreamArgs;
+                var bitStreamArgs = GetBitStreamArgs(state.AudioStream);
+                return string.IsNullOrEmpty(bitStreamArgs) ? string.Empty : " " + bitStreamArgs;
             }
 
-            return bitStreamArgs;
+            return string.Empty;
         }
 
         public static string GetSegmentFileExtension(string segmentContainer)
@@ -5812,7 +5807,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             EncodingJobInfo state,
             EncodingOptions encodingOptions,
             MediaSourceInfo mediaSource,
-            string requestedUrl)
+            string extension)
         {
             ArgumentNullException.ThrowIfNull(state);
 
@@ -5867,12 +5862,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (string.IsNullOrEmpty(videoRequest.VideoCodec))
                 {
-                    if (string.IsNullOrEmpty(requestedUrl))
-                    {
-                        requestedUrl = "test." + videoRequest.Container;
-                    }
-
-                    videoRequest.VideoCodec = InferVideoCodec(requestedUrl);
+                    videoRequest.VideoCodec = InferVideoCodec(extension);
                 }
 
                 state.VideoStream = GetMediaStream(mediaStreams, videoRequest.VideoStreamIndex, MediaStreamType.Video);

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -619,10 +619,8 @@ namespace MediaBrowser.Model.Dlna
             return null;
         }
 
-        public string ToUrl(string baseUrl, string? accessToken)
+        public string ToUrl(string? baseUrl, string? accessToken)
         {
-            ArgumentException.ThrowIfNullOrEmpty(baseUrl);
-
             var list = new List<string>();
             foreach (NameValuePair pair in BuildParams(this, accessToken))
             {
@@ -660,13 +658,9 @@ namespace MediaBrowser.Model.Dlna
             return GetUrl(baseUrl, queryString);
         }
 
-        private string GetUrl(string baseUrl, string queryString)
+        private string GetUrl(string? baseUrl, string queryString)
         {
-            ArgumentException.ThrowIfNullOrEmpty(baseUrl);
-
-            string extension = string.IsNullOrEmpty(Container) ? string.Empty : "." + Container;
-
-            baseUrl = baseUrl.TrimEnd('/');
+            baseUrl = baseUrl?.TrimEnd('/') ?? string.Empty;
 
             if (MediaType == DlnaProfileType.Audio)
             {
@@ -675,7 +669,13 @@ namespace MediaBrowser.Model.Dlna
                     return string.Format(CultureInfo.InvariantCulture, "{0}/audio/{1}/master.m3u8?{2}", baseUrl, ItemId, queryString);
                 }
 
-                return string.Format(CultureInfo.InvariantCulture, "{0}/audio/{1}/stream{2}?{3}", baseUrl, ItemId, extension, queryString);
+                // Store the original container name, and fake response a .ts so media will show up.
+                if (!string.IsNullOrEmpty(Container))
+                {
+                    queryString += "&ext=." + Container;
+                }
+
+                return string.Format(CultureInfo.InvariantCulture, "{0}/audio/{1}/stream.ts?{2}", baseUrl, ItemId, queryString);
             }
 
             if (string.Equals(SubProtocol, "hls", StringComparison.OrdinalIgnoreCase))
@@ -683,7 +683,13 @@ namespace MediaBrowser.Model.Dlna
                 return string.Format(CultureInfo.InvariantCulture, "{0}/videos/{1}/master.m3u8?{2}", baseUrl, ItemId, queryString);
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "{0}/videos/{1}/stream{2}?{3}", baseUrl, ItemId, extension, queryString);
+            // Store the original container name, and fake response a .ts so media will show up.
+            if (!string.IsNullOrEmpty(Container))
+            {
+                queryString += "&ext=." + Container;
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}/videos/{1}/stream.ts?{2}", baseUrl, ItemId, queryString);
         }
 
         private static IEnumerable<NameValuePair> BuildParams(StreamInfo item, string? accessToken)


### PR DESCRIPTION
Some devices / software do not show media if they cannot play use container, stopping the possibility of it being played by transcoding.
 
**Changes**
* This change returns all media via DLNA with the extension .ts. The original file extension is passed as a parameter.
* Once the request to stream has been received, this correct file extension is used for transcoding selection / playback.

**Issues**
* Possible fix for  jellyfin/jellyfin-plugin-dlna#8
* Subersedes jellyfin/jellyfin#5951