### PR TITLE
Fix playlist listings

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -244,7 +244,8 @@ namespace Jellyfin.Api.Controllers
                 .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
 
             if (includeItemTypes.Length == 1
-                && includeItemTypes[0] == BaseItemKind.BoxSet)
+                && (includeItemTypes[0] == BaseItemKind.Playlist
+                    || includeItemTypes[0] == BaseItemKind.BoxSet))
             {
                 parentId = null;
             }


### PR DESCRIPTION
This reverts commit 98c6c34fbbcdb556873bdcdb577fbc55a296b650.

**Changes**
It doesn't seem like playlists currently have parent ids, so including parent ids in requests cause no playlists to be displayed. I think reverting this is the best course of action for 10.8.

**Issues**
Fixes #10272
