### PR TITLE
add EnableSubtitleManagement permission

### DIFF
--- a/Jellyfin.Api/Constants/Policies.cs
+++ b/Jellyfin.Api/Constants/Policies.cs
@@ -84,4 +84,9 @@ public static class Policies
     /// Policy name for managing LiveTV.
     /// </summary>
     public const string LiveTvManagement = "LiveTvManagement";
+
+    /// <summary>
+    /// Policy name for accessing subtitles management.
+    /// </summary>
+    public const string SubtitleManagement = "SubtitleManagement";
 }

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -115,7 +115,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">Subtitles retrieved.</response>
     /// <returns>An array of <see cref="RemoteSubtitleInfo"/>.</returns>
     [HttpGet("Items/{itemId}/RemoteSearch/Subtitles/{language}")]
-    [Authorize]
+    [Authorize(Policy = Policies.SubtitleManagement)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<RemoteSubtitleInfo>>> SearchRemoteSubtitles(
         [FromRoute, Required] Guid itemId,
@@ -135,7 +135,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="204">Subtitle downloaded.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Items/{itemId}/RemoteSearch/Subtitles/{subtitleId}")]
-    [Authorize]
+    [Authorize(Policy = Policies.SubtitleManagement)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DownloadRemoteSubtitles(
         [FromRoute, Required] Guid itemId,
@@ -399,7 +399,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="204">Subtitle uploaded.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Videos/{itemId}/Subtitles")]
-    [Authorize(Policy = Policies.RequiresElevation)]
+    [Authorize(Policy = Policies.SubtitleManagement)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> UploadSubtitle(
         [FromRoute, Required] Guid itemId,

--- a/Jellyfin.Data/Entities/User.cs
+++ b/Jellyfin.Data/Entities/User.cs
@@ -499,6 +499,7 @@ namespace Jellyfin.Data.Entities
             Permissions.Add(new Permission(PermissionKind.ForceRemoteSourceTranscoding, false));
             Permissions.Add(new Permission(PermissionKind.EnableRemoteControlOfOtherUsers, false));
             Permissions.Add(new Permission(PermissionKind.EnableCollectionManagement, false));
+            Permissions.Add(new Permission(PermissionKind.EnableSubtitleManagement, false));
         }
 
         /// <summary>

--- a/Jellyfin.Data/Enums/PermissionKind.cs
+++ b/Jellyfin.Data/Enums/PermissionKind.cs
@@ -113,6 +113,11 @@ namespace Jellyfin.Data.Enums
         /// <summary>
         /// Whether the user can create, modify and delete collections.
         /// </summary>
-        EnableCollectionManagement = 21
+        EnableCollectionManagement = 21,
+
+        /// <summary>
+        /// Whether the user can edit subtitles.
+        /// </summary>
+        EnableSubtitleManagement = 22
     }
 }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -349,6 +349,7 @@ namespace Jellyfin.Server.Implementations.Users
                     ForceRemoteSourceTranscoding = user.HasPermission(PermissionKind.ForceRemoteSourceTranscoding),
                     EnablePublicSharing = user.HasPermission(PermissionKind.EnablePublicSharing),
                     EnableCollectionManagement = user.HasPermission(PermissionKind.EnableCollectionManagement),
+                    EnableSubtitleManagement = user.HasPermission(PermissionKind.EnableSubtitleManagement),
                     AccessSchedules = user.AccessSchedules.ToArray(),
                     BlockedTags = user.GetPreference(PreferenceKind.BlockedTags),
                     AllowedTags = user.GetPreference(PreferenceKind.AllowedTags),
@@ -666,6 +667,7 @@ namespace Jellyfin.Server.Implementations.Users
                 user.SetPermission(PermissionKind.EnableRemoteControlOfOtherUsers, policy.EnableRemoteControlOfOtherUsers);
                 user.SetPermission(PermissionKind.EnablePlaybackRemuxing, policy.EnablePlaybackRemuxing);
                 user.SetPermission(PermissionKind.EnableCollectionManagement, policy.EnableCollectionManagement);
+                user.SetPermission(PermissionKind.EnableSubtitleManagement, policy.EnableSubtitleManagement);
                 user.SetPermission(PermissionKind.ForceRemoteSourceTranscoding, policy.ForceRemoteSourceTranscoding);
                 user.SetPermission(PermissionKind.EnablePublicSharing, policy.EnablePublicSharing);
 

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ namespace Jellyfin.Server.Extensions
                 options.AddPolicy(Policies.SyncPlayCreateGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.CreateGroup));
                 options.AddPolicy(Policies.SyncPlayJoinGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.JoinGroup));
                 options.AddPolicy(Policies.SyncPlayIsInGroup, new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.IsInGroup));
+                options.AddPolicy(Policies.SubtitleManagement, new UserPermissionRequirement(PermissionKind.EnableSubtitleManagement));
                 options.AddPolicy(
                     Policies.RequiresElevation,
                     policy => policy.AddAuthenticationSchemes(AuthenticationSchemes.CustomAuthentication)

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -15,6 +15,7 @@ namespace MediaBrowser.Model.Users
         {
             IsHidden = true;
             EnableCollectionManagement = false;
+            EnableSubtitleManagement = false;
 
             EnableContentDeletion = false;
             EnableContentDeletionFromFolders = Array.Empty<string>();
@@ -82,6 +83,13 @@ namespace MediaBrowser.Model.Users
         /// <value><c>true</c> if this instance is hidden; otherwise, <c>false</c>.</value>
         [DefaultValue(false)]
         public bool EnableCollectionManagement { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance can manage subtitles.
+        /// </summary>
+        /// <value><c>true</c> if this instance is allowed; otherwise, <c>false</c>.</value>
+        [DefaultValue(false)]
+        public bool EnableSubtitleManagement { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance is disabled.


### PR DESCRIPTION
Add new feature: ability for a user to "Edit subtitles" without administrator rights

**Changes**
Create a new Jellyfin.Data/Enums/PermissionKind: EnableSubtitleManagement
Add that permission to the UserPolicy

Related PR
 - Front-end: [jellyfin-web](https://github.com/jellyfin/jellyfin-web/pull/4883)

TODO
 - Fix [permissions issue](https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/131#issuecomment-1677299539) in opensubtitle plugin

**Issues**
https://features.jellyfin.org/posts/185/non-admin-users-download-subtitles
