### PR TITLE
Add function to fix cast with localhost server

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -918,7 +918,14 @@ namespace Emby.Server.Implementations
                 return GetLocalApiUrl(request.Host.Host, request.Scheme, requestPort);
             }
 
-            return GetSmartApiUrl(request.HttpContext.Connection.RemoteIpAddress ?? IPAddress.Loopback);
+            // Gets the server URL that can also be used by applications not on the server, for instance
+            // a cast receiver device. In case the request has a localhost url, LocalAddress will be set to a
+            // server Private network address (IPv4) or Unique Local Address (ULA, IPv6) which is valid for all
+            // devices on the LAN.
+            IPAddress localAddress = request.HttpContext.Connection.RemoteIpAddress ?? IPAddress.Loopback;
+            return NetworkConstants.IPv4RFC5735Loopback.Contains(localAddress) || NetworkConstants.IPv6RFC4291Loopback.Contains(localAddress)
+                ? GetSmartApiUrl(NetworkManager.ServerLanAddress)
+                : GetSmartApiUrl(localAddress);
         }
 
         /// <inheritdoc/>

--- a/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -131,6 +131,11 @@ namespace Jellyfin.Networking.Manager
         public bool TrustAllIPv6Interfaces { get; private set; }
 
         /// <summary>
+        /// Gets the IP LAN address of Jellyfin server usable for a Google cast receiver and such.
+        /// </summary>
+        public static string ServerLanAddress { get; private set; } = string.Empty;
+
+        /// <summary>
         /// Gets the Published server override list.
         /// </summary>
         public IReadOnlyList<PublishedServerUriOverride> PublishedServerUrls => _publishedServerUrls;
@@ -631,6 +636,8 @@ namespace Jellyfin.Networking.Manager
             InitializeOverrides(config);
 
             PrintNetworkInformation(config, false);
+
+            InitializeServerLanAddress(config);
         }
 
         /// <summary>
@@ -1119,6 +1126,82 @@ namespace Jellyfin.Networking.Manager
                 _logger.Log(logLevel, "Remote IP filter is {0}", config.IsRemoteIPFilterBlacklist ? "Blocklist" : "Allowlist");
                 _logger.Log(logLevel, "Filter list: {0}", _remoteAddressFilter.Select(s => s.Prefix + "/" + s.PrefixLength));
             }
+        }
+
+        /// <summary>
+        /// Initializes the LAN IP address that the server advertises for cast receivers.
+        /// A LAN device like a Chromecast receiver needs an unique LAN address of the Jellyfin server.
+        /// For IPv4, a Private network address (like 192.168.0.0/16 )serves this purpose, and for IPv6
+        /// the Unique Local Address (ULA, fd00::/8) does. An IPv6 global address (2000::/3) also works
+        /// as unique server address but is ranked as less desirable than a local address.
+        /// See e.g. https://en.wikipedia.org/wiki/Private_network
+        ///
+        /// If multiple addresses are available:
+        /// - prefer Unique Local Addresses (ULA) or Site Local Addresses over other (global) addresses.
+        /// - all things equal, prefer IPv4 over IPv6 as the former in practice appears to be more stable.
+        /// </summary>
+        private void InitializeServerLanAddress(NetworkConfiguration config)
+        {
+            lock (_initLock)
+            {
+                int rank = 0;   // ranks most preferable ip address
+                IPAddress ipSrv = IPAddress.None;
+                NetworkInterface[] adapters = NetworkInterface.GetAllNetworkInterfaces();
+
+                foreach (var adapter in adapters)
+                {
+                    if (adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    {
+                        continue;
+                    }
+
+                    // check if the network interface serves as IPv4 gateway
+                    bool haveIP4GateWay = false;
+                    foreach (var address in adapter.GetIPProperties().GatewayAddresses)
+                    {
+                        haveIP4GateWay = haveIP4GateWay || address.Address.AddressFamily == AddressFamily.InterNetwork;
+                    }
+
+                    // if the network interface is used as gateway, and has an acceptable IP address for this server,
+                    // then this address is assumed to be accessible by other devices on the LAN.
+                    foreach (var inf in _interfaces)
+                    {
+                        IPAddress ip = inf.Address;
+
+                        if (!inf.Name.Equals(adapter.Name, StringComparison.OrdinalIgnoreCase) ||
+                            ip.Equals(IPAddress.Loopback) || ip.Equals(IPAddress.IPv6Loopback))
+                        {
+                            continue;
+                        }
+
+                        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                        {
+                            if (IsIPv6Enabled)
+                            {
+                                if (rank < 2 && (ip.IsIPv6SiteLocal || ip.IsIPv6UniqueLocal))
+                                {
+                                    rank = 2;
+                                    ipSrv = ip;
+                                }
+                                else if (rank < 1)
+                                {
+                                    rank = 1;
+                                    ipSrv = ip;
+                                }
+                            }
+                        }
+                        else if (haveIP4GateWay && IsIPv4Enabled && rank < 3)
+                        {
+                            rank = 3;
+                            ipSrv = ip;
+                        }
+                    }
+
+                    ServerLanAddress = ipSrv.ToString();
+                }
+            }
+
+            _logger.LogInformation("ServerLanAddress: {0} ", ServerLanAddress);
         }
     }
 }


### PR DESCRIPTION
Adds a function to supply the webclient with a unique server LAN address after a localhost server API call. This enables the webclient to play to a chromecast receiver in such a case.

**Changes**
- Determine unique local server address in Jellyfin.Networking/Manager/NetworkManager.cs
- Pass this to the webclient with the GetPublicSystemInfo API call in Emby.Server.Implementations/ApplicationHost.cs

**Explanation**
This PR originates from the jellyfin-web issue with chromecast: https://github.com/jellyfin/jellyfin-web/issues/4745

While starting jellyfin-server it finds the bind addresses to listen to. And when starting jellyfin-web, it is able to find jellyfin-server alright. But when both jellyfin-server and jellyfin-web run on the same machine, they by default connect on url http://localhost:8096.

This works fine for the communication between jellyfin-web and jellyfin-server, but as a result this localhost url is also submitted to the cast receiver as url to connect to jellyfin-server. And for the cast receiver, localhost is not a valid address for jellyfin-server (in fact, with this address the cast receiver would try to find jellyfin-server internally ;-) )

So in this specific case of jellyfin-server and jellyfin-web communicating via localhost, the url to be passed to the cast receiver needs to be the 'real' LAN address of jellyfin-server.

As jellyfin-web is not able to establish this LAN address, jellyfin-server should deliver that via the API to jellyfin-client. So this issue requires changes in both jellyfin-server and jellyfin-web.

**Issues**
Fixes #10098


**Remark**
This is a resubmit of PR #10101 which was closed while the concerning src files were heavily changed and improved recently.