### PR TITLE
Added LatestRelease home section type for "New Releases" home section

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -126,6 +126,7 @@ public class DisplayPreferencesController : BaseJellyfinApiController
             HomeSectionType.LiveTv,
             HomeSectionType.NextUp,
             HomeSectionType.LatestMedia,
+            HomeSectionType.LatestRelease,
             HomeSectionType.None,
         };
 

--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -126,7 +126,6 @@ public class DisplayPreferencesController : BaseJellyfinApiController
             HomeSectionType.LiveTv,
             HomeSectionType.NextUp,
             HomeSectionType.LatestMedia,
-            HomeSectionType.LatestRelease,
             HomeSectionType.None,
         };
 

--- a/Jellyfin.Data/Enums/HomeSectionType.cs
+++ b/Jellyfin.Data/Enums/HomeSectionType.cs
@@ -1,4 +1,4 @@
-﻿namespace Jellyfin.Data.Enums
+namespace Jellyfin.Data.Enums
 {
     /// <summary>
     /// An enum representing the different options for the home screen sections.
@@ -53,6 +53,11 @@
         /// <summary>
         /// Continue Reading.
         /// </summary>
-        ResumeBook = 9
+        ResumeBook = 9,
+
+        /// <summary>
+        /// Latest Release.
+        /// </summary>
+        LatestRelease = 10
     }
 }

--- a/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -146,7 +146,7 @@ namespace Jellyfin.Server.Migrations.Routines
                     dto.CustomPrefs.Remove("dashboardtheme");
                     dto.CustomPrefs.Remove("tvhome");
 
-                    for (int i = 0; i < 7; i++)
+                    for (int i = 0; i < defaults.Length; i++)
                     {
                         var key = "homesection" + i;
                         dto.CustomPrefs.TryGetValue(key, out var homeSection);

--- a/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
@@ -68,9 +68,11 @@ namespace Jellyfin.Server.Migrations.Routines
                 HomeSectionType.SmallLibraryTiles,
                 HomeSectionType.Resume,
                 HomeSectionType.ResumeAudio,
+                HomeSectionType.ResumeBook,
                 HomeSectionType.LiveTv,
                 HomeSectionType.NextUp,
                 HomeSectionType.LatestMedia,
+                HomeSectionType.LatestRelease,
                 HomeSectionType.None,
             };
 

--- a/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateDisplayPreferencesDb.cs
@@ -68,11 +68,9 @@ namespace Jellyfin.Server.Migrations.Routines
                 HomeSectionType.SmallLibraryTiles,
                 HomeSectionType.Resume,
                 HomeSectionType.ResumeAudio,
-                HomeSectionType.ResumeBook,
                 HomeSectionType.LiveTv,
                 HomeSectionType.NextUp,
                 HomeSectionType.LatestMedia,
-                HomeSectionType.LatestRelease,
                 HomeSectionType.None,
             };
 
@@ -148,7 +146,7 @@ namespace Jellyfin.Server.Migrations.Routines
                     dto.CustomPrefs.Remove("dashboardtheme");
                     dto.CustomPrefs.Remove("tvhome");
 
-                    for (int i = 0; i < defaults.Length; i++)
+                    for (int i = 0; i < 7; i++)
                     {
                         var key = "homesection" + i;
                         dto.CustomPrefs.TryGetValue(key, out var homeSection);


### PR DESCRIPTION
**Changes**
This PR adds a new home section type `LatestRelease` as preperation for the `New Releases` home section in the `jellyfin-web` 
 project which shows newly added items ordered by their official release date and not when they got added to the library.

**Issues**
https://github.com/orgs/jellyfin/projects/43/views/1?pane=issue&itemId=30103153
