### PR TITLE
#10333 Increases operations per run of GitHub 'stale' action

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -2,7 +2,7 @@ name: Stale Check
 
 on:
   schedule:
-    - cron: '30 */12 * * *'
+    - cron: '30 1 * * *'
   workflow_dispatch:
 
 permissions:
@@ -19,11 +19,12 @@ jobs:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
+          ascending: true
           days-before-stale: 120
           days-before-pr-stale: -1
           days-before-close: 21
           days-before-pr-close: -1
-          operations-per-run: 75
+          operations-per-run: 500
           exempt-issue-labels: regression,security,roadmap,future,feature,enhancement,confirmed
           stale-issue-label: stale
           stale-issue-message: |-


### PR DESCRIPTION
Attempts to work around the issues described in #10333. The stale action is not caching state between runs. This workaround is an attempt to increase the operations per run so that every issue can be looked at in every run -- no need to maintain state.

NOTE: There is a chance that running 500 operations this quickly will result in GitHub throttling our bot and/or blocking it for up to 1 hour. If that happens, we'll reduce the value again.

**Changes**
- Returns the cron schedule to once a day instead of twice daily since we are now processing every issue in every run
- Adds the `ascending: true` property to process the older items first
- Increases the `operations-per-run` to 500 to process the entire list of open issues

**Issues**
#10333
