### PR TITLE
Forward user_agent config to ffprobe

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -418,10 +418,24 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public Task<MediaInfo> GetMediaInfo(MediaInfoRequest request, CancellationToken cancellationToken)
         {
             var extractChapters = request.MediaType == DlnaProfileType.Video && request.ExtractChapters;
-            var requiredHeaders = request.MediaSource.RequiredHttpHeaders;
-            var analyzeDuration = string.Empty;
+            var extraArgs = GetExtraArguments(request);
+
+            return GetMediaInfoInternal(
+                GetInputArgument(request.MediaSource.Path, request.MediaSource),
+                request.MediaSource.Path,
+                request.MediaSource.Protocol,
+                extractChapters,
+                extraArgs,
+                request.MediaType == DlnaProfileType.Audio,
+                request.MediaSource.VideoType,
+                cancellationToken);
+        }
+
+        internal string GetExtraArguments(MediaInfoRequest request)
+        {
             var ffmpegAnalyzeDuration = _config.GetFFmpegAnalyzeDuration() ?? string.Empty;
             var ffmpegProbeSize = _config.GetFFmpegProbeSize() ?? string.Empty;
+            var analyzeDuration = string.Empty;
             var extraArgs = string.Empty;
 
             if (request.MediaSource.AnalyzeDurationMs > 0)
@@ -443,20 +457,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 extraArgs += " -probesize " + ffmpegProbeSize;
             }
 
-            if (requiredHeaders.ContainsKey("user_agent"))
+            if (request.MediaSource.RequiredHttpHeaders.TryGetValue("user_agent", out var userAgent))
             {
-                extraArgs += " -user_agent " + requiredHeaders["user_agent"];
+                extraArgs += " -user_agent " + userAgent;
             }
 
-            return GetMediaInfoInternal(
-                GetInputArgument(request.MediaSource.Path, request.MediaSource),
-                request.MediaSource.Path,
-                request.MediaSource.Protocol,
-                extractChapters,
-                extraArgs,
-                request.MediaType == DlnaProfileType.Audio,
-                request.MediaSource.VideoType,
-                cancellationToken);
+            return extraArgs;
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -418,6 +418,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public Task<MediaInfo> GetMediaInfo(MediaInfoRequest request, CancellationToken cancellationToken)
         {
             var extractChapters = request.MediaType == DlnaProfileType.Video && request.ExtractChapters;
+            var requiredHeaders = request.MediaSource.RequiredHttpHeaders;
             var analyzeDuration = string.Empty;
             var ffmpegAnalyzeDuration = _config.GetFFmpegAnalyzeDuration() ?? string.Empty;
             var ffmpegProbeSize = _config.GetFFmpegProbeSize() ?? string.Empty;
@@ -440,6 +441,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
             if (!string.IsNullOrEmpty(ffmpegProbeSize))
             {
                 extraArgs += " -probesize " + ffmpegProbeSize;
+            }
+
+            if (requiredHeaders.ContainsKey("user_agent"))
+            {
+                extraArgs += " -user_agent " + requiredHeaders["user_agent"];
             }
 
             return GetMediaInfoInternal(

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Threading;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.MediaEncoding.Encoder;
 using MediaBrowser.Model.Globalization;
@@ -15,7 +15,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
     public class ProbeExternalSourcesTests
     {
         [Fact]
-        public void GetMediaInfo_Uses_UserAgent()
+        public void GetExtraArguments_Forwards_UserAgent()
         {
             var encoder = new MediaEncoder(
                 Mock.Of<ILogger<MediaEncoder>>(),
@@ -26,6 +26,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
                 new ConfigurationBuilder().Build(),
                 Mock.Of<IServerConfigurationManager>());
 
+            var userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
             var req = new MediaBrowser.Controller.MediaEncoding.MediaInfoRequest()
             {
                 MediaSource = new MediaBrowser.Model.Dto.MediaSourceInfo
@@ -34,14 +35,16 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
                     Protocol = MediaProtocol.Http,
                     RequiredHttpHeaders = new Dictionary<string, string>()
                     {
-                        { "user_agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/530.35 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/530.35" },
+                        { "user_agent", userAgent },
                     }
                 },
                 ExtractChapters = false,
                 MediaType = MediaBrowser.Model.Dlna.DlnaProfileType.Video,
             };
 
-            encoder.GetMediaInfo(req, CancellationToken.None);
+            var extraArg = encoder.GetExtraArguments(req);
+
+            Assert.Contains(userAgent, extraArg, StringComparison.InvariantCulture);
         }
     }
 }

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.MediaEncoding.Encoder;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.Probing
+{
+    public class ProbeExternalSourcesTests
+    {
+        [Fact]
+        public void GetMediaInfo_Uses_UserAgent()
+        {
+            var encoder = new MediaEncoder(
+                Mock.Of<ILogger<MediaEncoder>>(),
+                Mock.Of<IServerConfigurationManager>(),
+                Mock.Of<IFileSystem>(),
+                Mock.Of<IBlurayExaminer>(),
+                Mock.Of<ILocalizationManager>(),
+                new ConfigurationBuilder().Build(),
+                Mock.Of<IServerConfigurationManager>());
+
+            var req = new MediaBrowser.Controller.MediaEncoding.MediaInfoRequest()
+            {
+                MediaSource = new MediaBrowser.Model.Dto.MediaSourceInfo
+                {
+                    Path = "/path/to/stream",
+                    Protocol = MediaProtocol.Http,
+                    RequiredHttpHeaders = new Dictionary<string, string>()
+                    {
+                        { "user_agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/530.35 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/530.35" },
+                    }
+                },
+                ExtractChapters = false,
+                MediaType = MediaBrowser.Model.Dlna.DlnaProfileType.Video,
+            };
+
+            encoder.GetMediaInfo(req, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
Adds the user_agent source config in the ffprobe MediaEncode command.

**Issues**
ex. Fixes #10175
