### PR TITLE
Fix mismatch between intel VAAPI UMD/KMD in rare cases

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -775,12 +775,17 @@ namespace MediaBrowser.Controller.MediaEncoding
         private string GetVaapiDeviceArgs(string renderNodePath, string driver, string kernelDriver, string srcDeviceAlias, string alias)
         {
             alias ??= VaapiAlias;
-            renderNodePath = renderNodePath ?? "/dev/dri/renderD128";
-            var driverOpts = string.IsNullOrEmpty(driver)
-                ? ":" + renderNodePath
-                : ":,driver=" + driver + (string.IsNullOrEmpty(kernelDriver) ? string.Empty : ",kernel_driver=" + kernelDriver);
+
+            // 'renderNodePath' has higher priority than 'kernelDriver'
+            var driverOpts = string.IsNullOrEmpty(renderNodePath)
+                ? (string.IsNullOrEmpty(kernelDriver) ? string.Empty : ",kernel_driver=" + kernelDriver)
+                : renderNodePath;
+
+            // 'driver' behaves similarly to env LIBVA_DRIVER_NAME
+            driverOpts += string.IsNullOrEmpty(driver) ? string.Empty : ",driver=" + driver;
+
             var options = string.IsNullOrEmpty(srcDeviceAlias)
-                ? driverOpts
+                ? (string.IsNullOrEmpty(driverOpts) ? string.Empty : ":" + driverOpts)
                 : "@" + srcDeviceAlias;
 
             return string.Format(
@@ -902,14 +907,14 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (_mediaEncoder.IsVaapiDeviceInteliHD)
                 {
-                    args.Append(GetVaapiDeviceArgs(null, "iHD", null, null, VaapiAlias));
+                    args.Append(GetVaapiDeviceArgs(options.VaapiDevice, "iHD", null, null, VaapiAlias));
                 }
                 else if (_mediaEncoder.IsVaapiDeviceInteli965)
                 {
                     // Only override i965 since it has lower priority than iHD in libva lookup.
                     Environment.SetEnvironmentVariable("LIBVA_DRIVER_NAME", "i965");
                     Environment.SetEnvironmentVariable("LIBVA_DRIVER_NAME_JELLYFIN", "i965");
-                    args.Append(GetVaapiDeviceArgs(null, "i965", null, null, VaapiAlias));
+                    args.Append(GetVaapiDeviceArgs(options.VaapiDevice, "i965", null, null, VaapiAlias));
                 }
 
                 var filterDevArgs = string.Empty;


### PR DESCRIPTION
Usually the iGPU is considered the first device `/dev/dri/renderD128`,
but in rare cases the iGPU can become the second `/dev/dri/renderD129`.

**Changes**
- Fix mismatch between intel VAAPI UMD/KMD in rare cases

**Issues**
- Fixes #8740
