### PR TITLE
 Add MALLOC_TRIM_THRESHOLD_ to default ENV

### DIFF
--- a/debian/conf/jellyfin
+++ b/debian/conf/jellyfin
@@ -27,6 +27,9 @@ JELLYFIN_RESTART_OPT="--restartpath=/usr/lib/jellyfin/restart.sh"
 # ffmpeg binary paths, overriding the system values
 JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
+# Disable glibc dynamic heap adjustment
+MALLOC_TRIM_THRESHOLD_=131072
+
 # [OPTIONAL] run Jellyfin as a headless service
 #JELLYFIN_SERVICE_OPT="--service"
 

--- a/fedora/jellyfin.env
+++ b/fedora/jellyfin.env
@@ -26,6 +26,9 @@ JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
 # In-App service control
 JELLYFIN_RESTART_OPT="--restartpath=/usr/libexec/jellyfin/restart.sh"
 
+# Disable glibc dynamic heap adjustment
+MALLOC_TRIM_THRESHOLD_=131072
+
 # [OPTIONAL] ffmpeg binary paths, overriding the UI-configured values
 #JELLYFIN_FFMPEG_OPT="--ffmpeg=/usr/bin/ffmpeg"
 


### PR DESCRIPTION
**Changes**
* Add `MALLOC_TRIM_THRESHOLD_=131072` to fix Skia memory issues

**Issues**
Partially fixes #6306
