### PR TITLE
Add new VideoRangeTypes to fully support DoVi on webOS

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -177,10 +177,11 @@
  - [Chris-Codes-It](https://github.com/Chris-Codes-It)
  - [Pithaya](https://github.com/Pithaya)
  - [Çağrı Sakaoğlu](https://github.com/ilovepilav)
- _ [Barasingha](https://github.com/MaVdbussche)
+ - [Barasingha](https://github.com/MaVdbussche)
  - [Gauvino](https://github.com/Gauvino)
  - [felix920506](https://github.com/felix920506)
  - [btopherjohnson](https://github.com/btopherjohnson)
+ - [GeorgeH005](https://github.com/GeorgeH005)
 
 # Emby Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -182,6 +182,7 @@
  - [felix920506](https://github.com/felix920506)
  - [btopherjohnson](https://github.com/btopherjohnson)
  - [GeorgeH005](https://github.com/GeorgeH005)
+ - [Vedant](https://github.com/viktory36/)
 
 # Emby Contributors
 

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1804,8 +1804,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         {
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHLGFallback
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG
                     || string.Equals(state.VideoStream.CodecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1797,8 +1797,6 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         var args = "-codec:v:0 " + codec;
 
-        var requestedRange = state.GetRequestedRangeTypes(codec);
-
         if (string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "h265", StringComparison.OrdinalIgnoreCase)
@@ -1806,8 +1804,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         {
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))))
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG))
             {
                 // Prefer dvh1 to dvhe
                 args += " -tag:v:0 dvh1 -strict -2";

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1797,18 +1797,22 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         var args = "-codec:v:0 " + codec;
 
-        var requestedRange = state.GetRequestedRangeTypes(codec);
-
         if (string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "hevc", StringComparison.OrdinalIgnoreCase))
         {
+            var requestedRange = state.GetRequestedRangeTypes(codec);
+            var requestHasDOVI = requestedRange.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase);
+            var requestHasDOVIWithHDR10 = requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase);
+            var requestHasDOVIWithHLG = requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase);
+            var requestHasDOVIWithSDR = requestedRange.Contains(VideoRangeType.DOVIWithSDR.ToString(), StringComparison.OrdinalIgnoreCase);
+
             if (EncodingHelper.IsCopyCodec(codec)
-                && ((state.VideoStream.VideoRangeType == VideoRangeType.DOVI && requestedRange.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithSDR && requestedRange.Contains(VideoRangeType.DOVIWithSDR.ToString(), StringComparison.OrdinalIgnoreCase))))
+                && ((state.VideoStream.VideoRangeType == VideoRangeType.DOVI && requestHasDOVI)
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestHasDOVIWithHDR10)
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestHasDOVIWithHLG)
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithSDR && requestHasDOVIWithSDR)))
             {
                 // Prefer dvh1 to dvhe
                 args += " -tag:v:0 dvh1 -strict -2";

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1807,7 +1807,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             if (EncodingHelper.IsCopyCodec(codec)
                 && ((state.VideoStream.VideoRangeType == VideoRangeType.DOVI && requestedRange.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase))
                     || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithSDR && requestedRange.Contains(VideoRangeType.DOVIWithSDR.ToString(), StringComparison.OrdinalIgnoreCase))))
             {
                 // Prefer dvh1 to dvhe
                 args += " -tag:v:0 dvh1 -strict -2";

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1804,8 +1804,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         {
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHLGFallback
                     || string.Equals(state.VideoStream.CodecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1797,15 +1797,17 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         var args = "-codec:v:0 " + codec;
 
+        var requestedRange = state.GetRequestedRangeTypes(codec);
+
         if (string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "hevc", StringComparison.OrdinalIgnoreCase))
         {
             if (EncodingHelper.IsCopyCodec(codec)
-                && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG))
+                && ((state.VideoStream.VideoRangeType == VideoRangeType.DOVI && requestedRange.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))))
             {
                 // Prefer dvh1 to dvhe
                 args += " -tag:v:0 dvh1 -strict -2";

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1807,10 +1807,7 @@ public class DynamicHlsController : BaseJellyfinApiController
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
                     || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))
-                    || string.Equals(state.VideoStream.CodecTag, "dovi", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))))
             {
                 // Prefer dvh1 to dvhe
                 args += " -tag:v:0 dvh1 -strict -2";

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1804,6 +1804,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         {
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback
                     || string.Equals(state.VideoStream.CodecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1797,6 +1797,8 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         var args = "-codec:v:0 " + codec;
 
+        var requestedRange = state.GetRequestedRangeTypes(codec);
+
         if (string.Equals(state.ActualOutputVideoCodec, "h265", StringComparison.OrdinalIgnoreCase)
             || string.Equals(state.ActualOutputVideoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
             || string.Equals(codec, "h265", StringComparison.OrdinalIgnoreCase)
@@ -1804,8 +1806,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         {
             if (EncodingHelper.IsCopyCodec(codec)
                 && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10 && requestedRange.Contains(VideoRangeType.DOVIWithHDR10.ToString(), StringComparison.OrdinalIgnoreCase))
+                    || (state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG && requestedRange.Contains(VideoRangeType.DOVIWithHLG.ToString(), StringComparison.OrdinalIgnoreCase))
                     || string.Equals(state.VideoStream.CodecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(state.VideoStream.CodecTag, "dvhe", StringComparison.OrdinalIgnoreCase)))

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -39,6 +39,7 @@ public enum VideoRangeType
     /// Dolby Vision with HLG video range fallback (10bit).
     /// </summary>
     DOVIWithHLG,
+
     /// <summary>
     /// Dolby Vision with HLG video range fallback (10bit).
     /// </summary>

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -33,12 +33,12 @@ public enum VideoRangeType
     /// <summary>
     /// Dolby Vision with HDR10 video range fallback (12bit or 10bit).
     /// </summary>
-    DolbyVisionWithHDR10Fallback,
+    DOVIWithHDR10,
 
     /// <summary>
     /// Dolby Vision with HLG video range fallback (12bit or 10bit).
     /// </summary>
-    DolbyVisionWithHLGFallback,
+    DOVIWithHLG,
 
     /// <summary>
     /// HDR10+ video range type (10bit to 16bit).

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -41,7 +41,7 @@ public enum VideoRangeType
     DOVIWithHLG,
 
     /// <summary>
-    /// Dolby Vision with HLG video range fallback (10bit).
+    /// Dolby Vision with SDR video range fallback (8bit / 10bit).
     /// </summary>
     DOVIWithSDR,
 

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -33,12 +33,12 @@ public enum VideoRangeType
     /// <summary>
     /// Dolby Vision with HDR10 video range fallback (12bit or 10bit).
     /// </summary>
-    DOVI_with_HDR10_Fallback,
+    DolbyVisionWithHDR10Fallback,
 
     /// <summary>
     /// Dolby Vision with HLG video range fallback (12bit or 10bit).
     /// </summary>
-    DOVI_with_HLG_Fallback,
+    DolbyVisionWithHLGFallback,
 
     /// <summary>
     /// HDR10+ video range type (10bit to 16bit).

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -26,19 +26,23 @@ public enum VideoRangeType
     HLG,
 
     /// <summary>
-    /// Dolby Vision video range type (12bit).
+    /// Dolby Vision video range type (10bit).
     /// </summary>
     DOVI,
 
     /// <summary>
-    /// Dolby Vision with HDR10 video range fallback (12bit or 10bit).
+    /// Dolby Vision with HDR10 video range fallback (10bit).
     /// </summary>
     DOVIWithHDR10,
 
     /// <summary>
-    /// Dolby Vision with HLG video range fallback (12bit or 10bit).
+    /// Dolby Vision with HLG video range fallback (10bit).
     /// </summary>
     DOVIWithHLG,
+    /// <summary>
+    /// Dolby Vision with HLG video range fallback (10bit).
+    /// </summary>
+    DOVIWithSDR,
 
     /// <summary>
     /// HDR10+ video range type (10bit to 16bit).

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -26,7 +26,7 @@ public enum VideoRangeType
     HLG,
 
     /// <summary>
-    /// Dolby Vision video range type (10bit).
+    /// Dolby Vision video range type (10bit encoded / 12bit remapped).
     /// </summary>
     DOVI,
 

--- a/Jellyfin.Data/Enums/VideoRangeType.cs
+++ b/Jellyfin.Data/Enums/VideoRangeType.cs
@@ -31,6 +31,16 @@ public enum VideoRangeType
     DOVI,
 
     /// <summary>
+    /// Dolby Vision with HDR10 video range fallback (12bit or 10bit).
+    /// </summary>
+    DOVI_with_HDR10_Fallback,
+
+    /// <summary>
+    /// Dolby Vision with HLG video range fallback (12bit or 10bit).
+    /// </summary>
+    DOVI_with_HLG_Fallback,
+
+    /// <summary>
     /// HDR10+ video range type (10bit to 16bit).
     /// </summary>
     HDR10Plus

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -272,7 +272,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(state.VideoStream.Codec, "hevc", StringComparison.OrdinalIgnoreCase)
                 && state.VideoStream.VideoRange == VideoRange.HDR
-                && state.VideoStream.VideoRangeType == VideoRangeType.DOVI)
+                && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
+                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback))
             {
                 // Only native SW decoder and HW accelerator can parse dovi rpu.
                 var vidDecoder = GetHardwareVideoDecoder(state, options) ?? string.Empty;
@@ -286,9 +288,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return state.VideoStream.VideoRange == VideoRange.HDR
                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
-                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG
-                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
-                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback);
+                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG);
         }
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
@@ -316,8 +316,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Native VPP tonemapping may come to QSV in the future.
 
             return state.VideoStream.VideoRange == VideoRange.HDR
-                   && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
-                        || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback);
+                   && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
         }
 
         private bool IsVideoToolboxTonemapAvailable(EncodingJobInfo state, EncodingOptions options)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -272,9 +272,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (string.Equals(state.VideoStream.Codec, "hevc", StringComparison.OrdinalIgnoreCase)
                 && state.VideoStream.VideoRange == VideoRange.HDR
-                && (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
-                    || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback))
+                && state.VideoStream.VideoRangeType == VideoRangeType.DOVI)
             {
                 // Only native SW decoder and HW accelerator can parse dovi rpu.
                 var vidDecoder = GetHardwareVideoDecoder(state, options) ?? string.Empty;
@@ -288,7 +286,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return state.VideoStream.VideoRange == VideoRange.HDR
                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
-                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG);
+                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHLGFallback);
         }
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
@@ -316,7 +316,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Native VPP tonemapping may come to QSV in the future.
 
             return state.VideoStream.VideoRange == VideoRange.HDR
-                   && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
+                   && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback);
         }
 
         private bool IsVideoToolboxTonemapAvailable(EncodingJobInfo state, EncodingOptions options)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2208,10 +2208,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                     return false;
                 }
 
-                // DOVIWithHDR10 should be compatible with HDR10 supporting players. Same goes with HLG. So allow copy of those formats
+                // DOVIWithHDR10 should be compatible with HDR10 supporting players. Same goes with HLG and of course SDR. So allow copy of those formats
                 if (!requestedRangeTypes.Contains(videoStream.VideoRangeType.ToString(), StringComparison.OrdinalIgnoreCase)
                      && !((requestedRangeTypes.Contains("HDR10", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10)
-                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)))
+                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)
+                            || (requestedRangeTypes.Contains("SDR", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithSDR)))
                 {
                     return false;
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2209,10 +2209,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 // DOVIWithHDR10 should be compatible with HDR10 supporting players. Same goes with HLG and of course SDR. So allow copy of those formats
+
+                var requestHasHDR10 = requestedRangeTypes.Contains(VideoRangeType.HDR10.ToString(), StringComparison.OrdinalIgnoreCase);
+                var requestHasHLG = requestedRangeTypes.Contains(VideoRangeType.HLG.ToString(), StringComparison.OrdinalIgnoreCase);
+                var requestHasSDR = requestedRangeTypes.Contains(VideoRangeType.SDR.ToString(), StringComparison.OrdinalIgnoreCase);
+
                 if (!requestedRangeTypes.Contains(videoStream.VideoRangeType.ToString(), StringComparison.OrdinalIgnoreCase)
-                     && !((requestedRangeTypes.Contains("HDR10", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10)
-                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)
-                            || (requestedRangeTypes.Contains("SDR", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithSDR)))
+                     && !((requestHasHDR10 && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10)
+                            || (requestHasHLG && videoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)
+                            || (requestHasSDR && videoStream.VideoRangeType == VideoRangeType.DOVIWithSDR)))
                 {
                     return false;
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2210,8 +2210,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 // DOVIWithHDR10 should be compatible with HDR10 supporting players. Same goes with HLG. So allow copy of those formats
                 if (!requestedRangeTypes.Contains(videoStream.VideoRangeType.ToString(), StringComparison.OrdinalIgnoreCase)
-                     && !((requestedRangeTypes.Contains("HDR10", StringComparison.OrdinalIgnoreCase) && string.Equals(videoStream.VideoRangeType.ToString(), "DOVIWithHDR10", StringComparison.OrdinalIgnoreCase))
-                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && string.Equals(videoStream.VideoRangeType.ToString(), "DOVIWithHLG", StringComparison.OrdinalIgnoreCase))))
+                     && !((requestedRangeTypes.Contains("HDR10", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10)
+                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && videoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)))
                 {
                     return false;
                 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -332,7 +332,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Certain DV profile 5 video works in Safari with direct playing, but the VideoToolBox does not produce correct mapping results with transcoding.
             // All other HDR formats working.
             return state.VideoStream.VideoRange == VideoRange.HDR
-                   && state.VideoStream.VideoRangeType is VideoRangeType.HDR10 or VideoRangeType.HLG or VideoRangeType.HDR10Plus;
+                   && state.VideoStream.VideoRangeType is VideoRangeType.HDR10 or VideoRangeType.HLG or VideoRangeType.HDR10Plus or VideoRangeType.DOVIWithHDR10 or VideoRangeType.DOVIWithHLG;
         }
 
         /// <summary>
@@ -6121,7 +6121,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                                     && state.VideoStream.VideoRange == VideoRange.HDR
                                     && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
                                         || state.VideoStream.VideoRangeType == VideoRangeType.HLG
-                                        || (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
+                                        || ((state.VideoStream.VideoRangeType == VideoRangeType.DOVI
+                                            || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
+                                            || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG)
                                             && string.Equals(state.VideoStream.Codec, "hevc", StringComparison.OrdinalIgnoreCase)));
 
             var useHwSurface = useOclToneMapping && IsVideoToolboxFullSupported() && _mediaEncoder.SupportsFilter("alphasrc");

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -286,7 +286,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return state.VideoStream.VideoRange == VideoRange.HDR
                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
-                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG);
+                       || state.VideoStream.VideoRangeType == VideoRangeType.HLG
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HLG_Fallback);
         }
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
@@ -314,7 +316,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Native VPP tonemapping may come to QSV in the future.
 
             return state.VideoStream.VideoRange == VideoRange.HDR
-                   && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
+                   && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
+                        || state.VideoStream.VideoRangeType == VideoRangeType.DOVI_with_HDR10_Fallback);
         }
 
         private bool IsVideoToolboxTonemapAvailable(EncodingJobInfo state, EncodingOptions options)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -287,8 +287,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             return state.VideoStream.VideoRange == VideoRange.HDR
                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
                        || state.VideoStream.VideoRangeType == VideoRangeType.HLG
-                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback
-                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHLGFallback);
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHLG);
         }
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
@@ -317,7 +317,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             return state.VideoStream.VideoRange == VideoRange.HDR
                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
-                       || state.VideoStream.VideoRangeType == VideoRangeType.DolbyVisionWithHDR10Fallback);
+                       || state.VideoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10);
         }
 
         private bool IsVideoToolboxTonemapAvailable(EncodingJobInfo state, EncodingOptions options)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2208,7 +2208,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                     return false;
                 }
 
-                if (!requestedRangeTypes.Contains(videoStream.VideoRangeType.ToString(), StringComparison.OrdinalIgnoreCase))
+                // DOVIWithHDR10 should be compatible with HDR10 supporting players. Same goes with HLG. So allow copy of those formats
+                if (!requestedRangeTypes.Contains(videoStream.VideoRangeType.ToString(), StringComparison.OrdinalIgnoreCase)
+                     && !((requestedRangeTypes.Contains("HDR10", StringComparison.OrdinalIgnoreCase) && string.Equals(videoStream.VideoRangeType.ToString(), "DOVIWithHDR10", StringComparison.OrdinalIgnoreCase))
+                            || (requestedRangeTypes.Contains("HLG", StringComparison.OrdinalIgnoreCase) && string.Equals(videoStream.VideoRangeType.ToString(), "DOVIWithHLG", StringComparison.OrdinalIgnoreCase))))
                 {
                     return false;
                 }

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -714,7 +714,7 @@ namespace MediaBrowser.Model.Entities
             var dvBlCompatId = DvBlSignalCompatibilityId;
 
             var isDoViHDRProfile = dvProfile == 5 || dvProfile == 7 || dvProfile == 8;
-            var isDoViHDRFlag = rpuPresentFlag && blPresentFlag && (dvBlCompatId == 0 || dvBlCompatId == 1 || dvBlCompatId == 4);
+            var isDoViHDRFlag = rpuPresentFlag && blPresentFlag && (dvBlCompatId == 0 || dvBlCompatId == 1 || dvBlCompatId == 4 || dvBlCompatId == 2 || dvBlCompatId == 6);
 
             if ((isDoViHDRProfile && isDoViHDRFlag)
                 || string.Equals(codecTag, "dovi", StringComparison.OrdinalIgnoreCase)

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -706,11 +706,6 @@ namespace MediaBrowser.Model.Entities
             {
                 return (VideoRange.Unknown, VideoRangeType.Unknown);
             }
-
-            bool isDoVi = false;
-            bool isHDR10 = false;
-            bool isHLG = false;
-
             var codecTag = CodecTag;
             var dvProfile = DvProfile;
             var rpuPresentFlag = RpuPresentFlag == 1;
@@ -726,45 +721,23 @@ namespace MediaBrowser.Model.Entities
                 || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dav1", StringComparison.OrdinalIgnoreCase))
             {
-                isDoVi = true;
+                return dvBlCompatId switch {
+                    1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
+                    4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
+                    _ => (VideoRange.HDR, VideoRangeType.DOVI)
+                };
             }
 
             var colorTransfer = ColorTransfer;
 
             if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
             {
-                isHDR10 = true;
-            }
-
-            if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
-            {
-                isHLG = true;
-            }
-
-            if (isDoVi)
-            {
-                if (isHDR10)
-                {
-                    return (VideoRange.HDR, VideoRangeType.DolbyVisionWithHDR10Fallback);
-                }
-                else if (isHLG)
-                {
-                    return (VideoRange.HDR, VideoRangeType.DolbyVisionWithHLGFallback);
-                }
-
-                return (VideoRange.HDR, VideoRangeType.DOVI);
-            }
-
-            if (isHDR10)
-            {
                 return (VideoRange.HDR, VideoRangeType.HDR10);
             }
-
-            if (isHLG)
+            else if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
             {
                 return (VideoRange.HDR, VideoRangeType.HLG);
             }
-
             return (VideoRange.SDR, VideoRangeType.SDR);
         }
     }

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -722,10 +722,17 @@ namespace MediaBrowser.Model.Entities
                 || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dav1", StringComparison.OrdinalIgnoreCase))
             {
-                return dvBlCompatId switch {
-                    1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
-                    4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
-                    _ => (VideoRange.HDR, VideoRangeType.DOVI)
+                return dvProfile switch
+                {
+                    5 => (VideoRange.HDR, VideoRangeType.DOVI),
+                    8 => dvBlCompatId switch
+                    {
+                        1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
+                        4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
+                        _ => (VideoRange.HDR, VideoRangeType.DOVI)
+                    },
+                    7 => (VideoRange.HDR, VideoRangeType.HDR10),
+                    _ => (VideoRange.SDR, VideoRangeType.SDR)
                 };
             }
 

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -745,11 +745,11 @@ namespace MediaBrowser.Model.Entities
             {
                 if (isHDR10)
                 {
-                    return (VideoRange.HDR, VideoRangeType.DOVI_with_HDR10_Fallback);
+                    return (VideoRange.HDR, VideoRangeType.DolbyVisionWithHDR10Fallback);
                 }
                 else if (isHLG)
                 {
-                    return (VideoRange.HDR, VideoRangeType.DOVI_with_HLG_Fallback);
+                    return (VideoRange.HDR, VideoRangeType.DolbyVisionWithHLGFallback);
                 }
 
                 return (VideoRange.HDR, VideoRangeType.DOVI);

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -707,17 +707,9 @@ namespace MediaBrowser.Model.Entities
                 return (VideoRange.Unknown, VideoRangeType.Unknown);
             }
 
-            var colorTransfer = ColorTransfer;
-
-            if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
-            {
-                return (VideoRange.HDR, VideoRangeType.HDR10);
-            }
-
-            if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
-            {
-                return (VideoRange.HDR, VideoRangeType.HLG);
-            }
+            bool isDoVi = false;
+            bool isHDR10 = false;
+            bool isHLG = false;
 
             var codecTag = CodecTag;
             var dvProfile = DvProfile;
@@ -734,7 +726,43 @@ namespace MediaBrowser.Model.Entities
                 || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dav1", StringComparison.OrdinalIgnoreCase))
             {
+                isDoVi = true;
+            }
+
+            var colorTransfer = ColorTransfer;
+
+            if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
+            {
+                isHDR10 = true;
+            }
+
+            if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
+            {
+                isHLG = true;
+            }
+
+            if (isDoVi)
+            {
+                if (isHDR10)
+                {
+                    return (VideoRange.HDR, VideoRangeType.DOVI_with_HDR10_Fallback);
+                }
+                else if (isHLG)
+                {
+                    return (VideoRange.HDR, VideoRangeType.DOVI_with_HLG_Fallback);
+                }
+
                 return (VideoRange.HDR, VideoRangeType.DOVI);
+            }
+
+            if (isHDR10)
+            {
+                return (VideoRange.HDR, VideoRangeType.HDR10);
+            }
+
+            if (isHLG)
+            {
+                return (VideoRange.HDR, VideoRangeType.HLG);
             }
 
             return (VideoRange.SDR, VideoRangeType.SDR);

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -735,7 +735,6 @@ namespace MediaBrowser.Model.Entities
             {
                 return (VideoRange.HDR, VideoRangeType.HDR10);
             }
-
             else if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
             {
                 return (VideoRange.HDR, VideoRangeType.HLG);

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -706,6 +706,7 @@ namespace MediaBrowser.Model.Entities
             {
                 return (VideoRange.Unknown, VideoRangeType.Unknown);
             }
+
             var codecTag = CodecTag;
             var dvProfile = DvProfile;
             var rpuPresentFlag = RpuPresentFlag == 1;
@@ -734,10 +735,12 @@ namespace MediaBrowser.Model.Entities
             {
                 return (VideoRange.HDR, VideoRangeType.HDR10);
             }
+
             else if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
             {
                 return (VideoRange.HDR, VideoRangeType.HLG);
             }
+
             return (VideoRange.SDR, VideoRangeType.SDR);
         }
     }

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -713,10 +713,10 @@ namespace MediaBrowser.Model.Entities
             var blPresentFlag = BlPresentFlag == 1;
             var dvBlCompatId = DvBlSignalCompatibilityId;
 
-            var isDoViHDRProfile = dvProfile == 5 || dvProfile == 7 || dvProfile == 8;
-            var isDoViHDRFlag = rpuPresentFlag && blPresentFlag && (dvBlCompatId == 0 || dvBlCompatId == 1 || dvBlCompatId == 4 || dvBlCompatId == 2 || dvBlCompatId == 6);
+            var isDoViProfile = dvProfile == 5 || dvProfile == 7 || dvProfile == 8;
+            var isDoViFlag = rpuPresentFlag && blPresentFlag && (dvBlCompatId == 0 || dvBlCompatId == 1 || dvBlCompatId == 4 || dvBlCompatId == 2 || dvBlCompatId == 6);
 
-            if ((isDoViHDRProfile && isDoViHDRFlag)
+            if ((isDoViProfile && isDoViFlag)
                 || string.Equals(codecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -729,7 +729,7 @@ namespace MediaBrowser.Model.Entities
                     {
                         1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
-                        2 => (VideoRange.HDR, VideoRangeType.DOVIWithSDR),
+                        2 => (VideoRange.SDR, VideoRangeType.DOVIWithSDR),
                         // There is no other case to handle here as per Dolby Spec. Default case included for completeness and linting purposes
                         _ => (VideoRange.SDR, VideoRangeType.SDR)
                     },

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -729,7 +729,9 @@ namespace MediaBrowser.Model.Entities
                     {
                         1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
-                        _ => (VideoRange.HDR, VideoRangeType.DOVI)
+                        2 => (VideoRange.HDR, VideoRangeType.DOVIWithSDR),
+                        // There is no other case to handle here as per Dolby Spec. Default case included for completeness and linting purposes
+                        _ => (VideoRange.SDR, VideoRangeType.SDR)
                     },
                     7 => (VideoRange.HDR, VideoRangeType.HDR10),
                     _ => (VideoRange.SDR, VideoRangeType.SDR)


### PR DESCRIPTION
This commit adds two new values to the VideoRangeType enum to talk about media that have both DOVI and HDR10 or HLG data (DoVi Profile 8) to enable Dolby Vision playback on those browsers.

**Changes**
Introduced `DOVI_with_HDR10_Fallback` and `DOVI_with_HLG_Fallback` VideoRangeType enums, and added references to these new types wherever I found `VideoRangeType.HDR10 / HLG`.
MediaStream.cs will now test both of it's HDR10/HLG and DOVI conditions before returning the video range type.

**Issues**
Addresses #10468