### PR TITLE
chore(deps): use Svg.Skia instead of the deprecated SkiaSharp.Svg

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <!-- Run "dotnet list package (dash,dash)outdated" to see the latest versions of each package.-->
-
   <ItemGroup Label="Package Dependencies">
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.0" />
@@ -72,9 +70,9 @@
     <PackageVersion Include="SkiaSharp" Version="2.88.5" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.5" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
-    <PackageVersion Include="SkiaSharp.Svg" Version="1.60.0" />
     <PackageVersion Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageVersion Include="Svg.Skia" Version="1.0.0.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageVersion Include="System.Globalization" Version="4.3.0" />

--- a/src/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
+++ b/src/Jellyfin.Drawing.Skia/Jellyfin.Drawing.Skia.csproj
@@ -18,11 +18,11 @@
   <ItemGroup>
     <PackageReference Include="BlurHashSharp" />
     <PackageReference Include="BlurHashSharp.SkiaSharp" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-    <PackageReference Include="SkiaSharp.Svg" />
     <PackageReference Include="SkiaSharp.HarfBuzz" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
+    <PackageReference Include="Svg.Skia" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -2,19 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography.Xml;
 using BlurHashSharp.SkiaSharp;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Drawing;
-using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Drawing;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
-using static System.Net.Mime.MediaTypeNames;
-using SKSvg = SkiaSharp.Extended.Svg.SKSvg;
+using Svg.Skia;
 
 namespace Jellyfin.Drawing.Skia;
 
@@ -123,10 +119,16 @@ public class SkiaEncoder : IImageEncoder
         var extension = Path.GetExtension(path.AsSpan());
         if (extension.Equals(".svg", StringComparison.OrdinalIgnoreCase))
         {
-            var svg = new SKSvg();
+            using var svg = new SKSvg();
             try
             {
                 using var picture = svg.Load(path);
+                if (picture is null)
+                {
+                    _logger.LogError("Unable to determine image dimensions for {FilePath}", path);
+                    return default;
+                }
+
                 return new ImageDimensions(Convert.ToInt32(picture.CullRect.Width), Convert.ToInt32(picture.CullRect.Height));
             }
             catch (FormatException skiaColorException)
@@ -289,10 +291,7 @@ public class SkiaEncoder : IImageEncoder
 
     private SKBitmap OrientImage(SKBitmap bitmap, SKEncodedOrigin origin)
     {
-        var needsFlip = origin == SKEncodedOrigin.LeftBottom
-                        || origin == SKEncodedOrigin.LeftTop
-                        || origin == SKEncodedOrigin.RightBottom
-                        || origin == SKEncodedOrigin.RightTop;
+        var needsFlip = origin is SKEncodedOrigin.LeftBottom or SKEncodedOrigin.LeftTop or SKEncodedOrigin.RightBottom or SKEncodedOrigin.RightTop;
         var rotated = needsFlip
             ? new SKBitmap(bitmap.Height, bitmap.Width)
             : new SKBitmap(bitmap.Width, bitmap.Height);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
According to https://github.com/mono/SkiaSharp.Extended/issues/83#issuecomment-674318895 we never should've used SkiaSharp.Svg and according to [Svg.Skia README](https://github.com/wieslawsoltes/Svg.Skia), it should be a drop-in replacement:

> The Svg.Skia can be used in same way as the SkiaSharp.Extended.Svg (load svg files as SKPicture).

I do not have any SVGs to test with.