### PR TITLE
#10333 Fix for stale PRs check: increase operations, process ascending

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -28,7 +28,7 @@ jobs:
           exempt-issue-labels: regression,security,roadmap,future,feature,enhancement,confirmed
           stale-issue-label: stale
           stale-issue-message: |-
-            This issue has gone 120 days without an update and will be closed within 21 days if there is no new activity. To prevent this issue from being closed, please confirm the issue has not already been fixed by providing updated examples or logs.
+            This issue has gone 120 days without an update and will be closed within 21 days if there is no new activity. To prevent this issue from being closed, please confirm the issue has not already been fixed by providing updated examples or logs.  
 
             If you have any questions you can use one of several ways to [contact us](https://jellyfin.org/contact).
           close-issue-message: |-

--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -28,7 +28,7 @@ jobs:
           exempt-issue-labels: regression,security,roadmap,future,feature,enhancement,confirmed
           stale-issue-label: stale
           stale-issue-message: |-
-            This issue has gone 120 days without an update and will be closed within 21 days if there is no new activity. To prevent this issue from being closed, please confirm the issue has not already been fixed by providing updated examples or logs.  
+            This issue has gone 120 days without an update and will be closed within 21 days if there is no new activity. To prevent this issue from being closed, please confirm the issue has not already been fixed by providing updated examples or logs.
 
             If you have any questions you can use one of several ways to [contact us](https://jellyfin.org/contact).
           close-issue-message: |-
@@ -42,7 +42,8 @@ jobs:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
-          operations-per-run: 75
+          ascending: true
+          operations-per-run: 150
           # The merge conflict action will remove the label when updated
           remove-stale-when-updated: false
           days-before-stale: -1


### PR DESCRIPTION
The changes (workaround) to increase the operations per run for stale issues is working. This will do the same thing for the stale PR check.

**Changes**
- Increases the operations per run to `150` for stale PR checks
- Adds `ascending: true` to process PRs from oldest first

**Issues**
#10333