### PR TITLE
Fix scaleFactor limit - Backport #9738

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2070,7 +2070,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var outputScaleFactor = GetVideoBitrateScaleFactor(outputVideoCodec);
 
             // Don't scale the real bitrate lower than the requested bitrate
-            var scaleFactor = Math.Min(outputScaleFactor / inputScaleFactor, 1);
+            var scaleFactor = Math.Max(outputScaleFactor / inputScaleFactor, 1);
 
             if (bitrate <= 500000)
             {


### PR DESCRIPTION
**Changes**
Changed the scaleFactor limit from max 1 to min 1.

**Issues**
Fixes bad transcode picture quality (e.g. from hevc to h264), as maximum transcoding bitrate is limited to the input bitrate now.
(introduced by pull request  https://github.com/jellyfin/jellyfin/pull/9485)