### PR TITLE
fix regression in subtitle provider instantiation

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -704,6 +704,7 @@ namespace Emby.Server.Implementations
 
             Resolve<ILiveTvManager>().AddParts(GetExports<ILiveTvService>(), GetExports<ITunerHost>(), GetExports<IListingsProvider>());
 
+            Resolve<ISubtitleManager>().AddParts(GetExports<ISubtitleProvider>());
             Resolve<IMediaSourceManager>().AddParts(GetExports<IMediaSourceProvider>());
         }
 

--- a/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
+++ b/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
@@ -15,6 +16,12 @@ namespace MediaBrowser.Controller.Subtitles
         /// Occurs when [subtitle download failure].
         /// </summary>
         event EventHandler<SubtitleDownloadFailureEventArgs> SubtitleDownloadFailure;
+
+        /// <summary>
+        /// Adds the parts.
+        /// </summary>
+        /// <param name="subtitleProviders">The subtitle providers.</param>
+        void AddParts(IEnumerable<ISubtitleProvider> subtitleProviders);
 
         /// <summary>
         /// Searches the subtitles.

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 #pragma warning disable CS1591
 
 using System;
@@ -33,28 +35,32 @@ namespace MediaBrowser.Providers.Subtitles
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly ILocalizationManager _localization;
 
-        private readonly ISubtitleProvider[] _subtitleProviders;
+        private ISubtitleProvider[] _subtitleProviders;
 
         public SubtitleManager(
             ILogger<SubtitleManager> logger,
             IFileSystem fileSystem,
             ILibraryMonitor monitor,
             IMediaSourceManager mediaSourceManager,
-            ILocalizationManager localizationManager,
-            IEnumerable<ISubtitleProvider> subtitleProviders)
+            ILocalizationManager localizationManager)
         {
             _logger = logger;
             _fileSystem = fileSystem;
             _monitor = monitor;
             _mediaSourceManager = mediaSourceManager;
             _localization = localizationManager;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<SubtitleDownloadFailureEventArgs> SubtitleDownloadFailure;
+
+        /// <inheritdoc />
+        public void AddParts(IEnumerable<ISubtitleProvider> subtitleProviders)
+        {
             _subtitleProviders = subtitleProviders
                 .OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)
                 .ToArray();
         }
-
-        /// <inheritdoc />
-        public event EventHandler<SubtitleDownloadFailureEventArgs>? SubtitleDownloadFailure;
 
         /// <inheritdoc />
         public async Task<RemoteSubtitleInfo[]> SearchSubtitles(SubtitleSearchRequest request, CancellationToken cancellationToken)
@@ -238,7 +244,7 @@ namespace MediaBrowser.Providers.Subtitles
 
         private async Task TrySaveToFiles(Stream stream, List<string> savePaths)
         {
-            List<Exception>? exs = null;
+            List<Exception> exs = null;
 
             foreach (var savePath in savePaths)
             {


### PR DESCRIPTION
Fix subtitle provider instantiation (regression).

**Changes**
Rolled back some changes made from 10.8 to 10.9 in order to have the opensubtitle provider working.

**Issues**
While working on [this feature](https://features.jellyfin.org/posts/185/non-admin-users-download-subtitles), i came across the following error when trying to use the opensubtitle plugin with jellyfin 10.9: 
```log
[22:33:27] [ERR] [18] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL POST /Jellyfin.Plugin.OpenSubtitles/ValidateLoginInfo.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Jellyfin.Plugin.OpenSubtitles.OpenSubtitlesHandler.RequestHandler.SendRequestAsync(String endpoint, HttpMethod method, Object body, Dictionary`2 headers, String apiKey, Int32 attempt, CancellationToken cancellationToken)
```

After investigating, I found out that the _subtitleProviders list from the subtitleManager was empty. This PR fixes the instantiation problem.

**PR linked**
https://github.com/jellyfin/jellyfin/pull/10410
https://github.com/jellyfin/jellyfin-web/pull/4883