### PR TITLE
feat: add EnableMetrics override with environment variable

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -263,6 +263,8 @@ namespace Emby.Server.Implementations
         /// <inheritdoc/>
         public bool ListenWithHttps => Certificate is not null && ConfigurationManager.GetNetworkConfiguration().EnableHttps;
 
+        public bool EnableMetrics => ConfigurationManager.Configuration.EnableMetrics || this._startupConfig.GetValue<bool>(EnableMetricsKey);
+
         public string FriendlyName =>
             string.IsNullOrEmpty(ConfigurationManager.Configuration.ServerName)
                 ? Environment.MachineName
@@ -449,7 +451,7 @@ namespace Emby.Server.Implementations
             NetManager = new NetworkManager(ConfigurationManager, _startupConfig, LoggerFactory.CreateLogger<NetworkManager>());
 
             // Initialize runtime stat collection
-            if (ConfigurationManager.Configuration.EnableMetrics)
+            if (this.EnableMetrics)
             {
                 DotNetRuntimeStatsBuilder.Default().StartCollecting();
             }

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -19,7 +19,8 @@ namespace Emby.Server.Implementations
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString },
-            { SqliteCacheSizeKey, "20000" }
+            { SqliteCacheSizeKey, "20000" },
+            { EnableMetricsKey, bool.FalseString }
         };
     }
 }

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -201,7 +201,7 @@ namespace Jellyfin.Server
                 mainApp.UseWebSocketHandler();
                 mainApp.UseServerStartupMessage();
 
-                if (_serverConfigurationManager.Configuration.EnableMetrics)
+                if (_serverApplicationHost.EnableMetrics)
                 {
                     // Must be registered after any middleware that could change HTTP response codes or the data will be bad
                     mainApp.UseHttpMetrics();
@@ -210,7 +210,7 @@ namespace Jellyfin.Server
                 mainApp.UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();
-                    if (_serverConfigurationManager.Configuration.EnableMetrics)
+                    if (_serverApplicationHost.EnableMetrics)
                     {
                         endpoints.MapMetrics();
                     }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -65,6 +65,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string SqliteCacheSizeKey = "sqlite:cacheSize";
 
         /// <summary>
+        /// The key for enabling the metrics endpoint.
+        /// </summary>
+        public const string EnableMetricsKey = "EnableMetrics";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>

--- a/MediaBrowser.Controller/IServerApplicationHost.cs
+++ b/MediaBrowser.Controller/IServerApplicationHost.cs
@@ -39,6 +39,11 @@ namespace MediaBrowser.Controller
         string FriendlyName { get; }
 
         /// <summary>
+        /// Gets a value indicating whether if the server should enable the metrics endpoint.
+        /// </summary>
+        bool EnableMetrics { get; }
+
+        /// <summary>
         /// Gets a URL specific for the request.
         /// </summary>
         /// <param name="request">The <see cref="HttpRequest"/> instance.</param>


### PR DESCRIPTION
**Changes**
Adds the ability to override the `EnableMetrics` configuration value from the `system.xml` files.  The configuration value is added to the ASP.NET config framework so it can also be set through the other config sources (`appsettings.json`, etc.),

**Issues**
[Fixes issue 6247](https://github.com/jellyfin/jellyfin/issues/6247) / [Feature request](https://features.jellyfin.org/posts/2397/enable-metrics-with-env-variable)