### PR TITLE
feat(livetv): add filter for channel groups

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -3693,6 +3693,22 @@ namespace Emby.Server.Implementations.Data
                 clauseBuilder.Length = 0;
             }
 
+            if (query.ChannelGroups.Count > 0)
+            {
+                clauseBuilder.Append('(');
+                for (var i = 0; i < query.ChannelGroups.Count; i++)
+                {
+                    clauseBuilder.Append("(json_extract(data, '$.ChannelGroup')=@ChannelGroup")
+                        .Append(i)
+                        .Append(") OR ");
+                    statement?.TryBind("@ChannelGroup" + i, query.ChannelGroups[i]);
+                }
+
+                clauseBuilder.Length -= Or.Length;
+                whereClauses.Add(clauseBuilder.Append(')').ToString());
+                clauseBuilder.Length = 0;
+            }
+
             if (tags.Count > 0)
             {
                 clauseBuilder.Append('(');

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -195,6 +195,7 @@ namespace Emby.Server.Implementations.LiveTv
                 IsLiked = query.IsLiked,
                 StartIndex = query.StartIndex,
                 Limit = query.Limit,
+                ChannelGroups = query.ChannelGroups,
                 DtoOptions = dtoOptions
             };
 

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
@@ -114,6 +114,7 @@ public class LiveTvController : BaseJellyfinApiController
     /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
     /// <param name="enableImageTypes">"Optional. The image types to include in the output.</param>
     /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
+    /// <param name="channelGroups">Optional. If specified, results will be filtered based on group. This allows multiple, pipe delimited.</param>
     /// <param name="enableUserData">Optional. Include user data.</param>
     /// <param name="sortBy">Optional. Key to sort by.</param>
     /// <param name="sortOrder">Optional. Sort order.</param>
@@ -143,6 +144,7 @@ public class LiveTvController : BaseJellyfinApiController
         [FromQuery] int? imageTypeLimit,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
+        [FromQuery, ModelBinder(typeof(PipeDelimitedArrayModelBinder))] string[] channelGroups,
         [FromQuery] bool? enableUserData,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemSortBy[] sortBy,
         [FromQuery] SortOrder? sortOrder,
@@ -172,7 +174,8 @@ public class LiveTvController : BaseJellyfinApiController
                 IsSports = isSports,
                 SortBy = sortBy,
                 SortOrder = sortOrder ?? SortOrder.Ascending,
-                AddCurrentProgram = addCurrentProgram
+                AddCurrentProgram = addCurrentProgram,
+                ChannelGroups = channelGroups
             },
             dtoOptions,
             CancellationToken.None);

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -585,6 +585,12 @@ namespace MediaBrowser.Controller.Entities
         public string Overview { get; set; }
 
         /// <summary>
+        /// Gets or sets the group of the channel.
+        /// </summary>
+        /// <value>The group of the channel.</value>
+        public string ChannelGroup { get; set; }
+
+        /// <summary>
         /// Gets or sets the studios.
         /// </summary>
         /// <value>The studios.</value>

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -32,6 +32,7 @@ namespace MediaBrowser.Controller.Entities
             ExcludeTags = Array.Empty<string>();
             GenreIds = Array.Empty<Guid>();
             Genres = Array.Empty<string>();
+            ChannelGroups = Array.Empty<string>();
             GroupByPresentationUniqueKey = true;
             ImageTypes = Array.Empty<ImageType>();
             IncludeItemTypes = Array.Empty<BaseItemKind>();
@@ -99,6 +100,8 @@ namespace MediaBrowser.Controller.Entities
         public string[] IncludeInheritedTags { get; set; }
 
         public IReadOnlyList<string> Genres { get; set; }
+
+        public IReadOnlyList<string> ChannelGroups { get; set; }
 
         public bool? IsSpecialSeason { get; set; }
 

--- a/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using Jellyfin.Data.Enums;
 
 namespace MediaBrowser.Model.LiveTv
@@ -15,6 +16,7 @@ namespace MediaBrowser.Model.LiveTv
         {
             EnableUserData = true;
             SortBy = Array.Empty<ItemSortBy>();
+            ChannelGroups = Array.Empty<string>();
         }
 
         /// <summary>
@@ -106,5 +108,10 @@ namespace MediaBrowser.Model.LiveTv
         /// </summary>
         /// <value>The sort order.</value>
         public SortOrder? SortOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the channel groups to filter on.
+        /// </summary>
+        public IReadOnlyList<string> ChannelGroups { get; set; }
     }
 }

--- a/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
+++ b/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
@@ -22,5 +22,7 @@ namespace MediaBrowser.Model.Querying
         public string[] OfficialRatings { get; set; }
 
         public int[] Years { get; set; }
+
+        public string[] ChannelGroups { get; set; }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR adds a filter to the LiveTV channels allowing users to filter by channel groups.
Linked to this [PR](https://github.com/jellyfin/jellyfin-web/pull/4937).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Addresses #1227 (moved [here](https://features.jellyfin.org/posts/186/iptv-channel-groupings))
