### PR TITLE
Revert SkiaSharp upgrade, fix library scan crashes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,9 +67,9 @@
     <PackageVersion Include="Serilog.Sinks.Graylog" Version="3.1.0" />
     <PackageVersion Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageVersion Include="SharpFuzz" Version="2.1.1" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.6" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.5" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.5" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageVersion Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
     <PackageVersion Include="Svg.Skia" Version="1.0.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageVersion Include="AutoFixture" Version="4.18.0" />
     <PackageVersion Include="BDInfo" Version="0.7.6.2" />
-    <PackageVersion Include="BlurHashSharp.SkiaSharp" Version="1.3.1" />
-    <PackageVersion Include="BlurHashSharp" Version="1.3.1" />
+    <PackageVersion Include="BlurHashSharp.SkiaSharp" Version="1.3.0" />
+    <PackageVersion Include="BlurHashSharp" Version="1.3.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Diacritics" Version="3.3.18" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This resolves the segfaults on library scan by reverting the recent upgrades related to SkiaSharp 2.88.6.  Upstream defect here: https://github.com/mono/SkiaSharp/issues/2645

The problem is most likely [this line in BlurHashEncoder's resize/encode method](https://github.com/Bond-009/BlurHashSharp/blob/5befb4f383d9f5270897076af4427cf47e2838a6/src/BlurHashSharp.SkiaSharp/BlurHashEncoder.cs#L84) called by Jellyfin [here](https://github.com/jellyfin/jellyfin/blob/9d4352789d6ff7a59cdda37e3bbb02aa740ed99f/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs#L198).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #10532
