### PR TITLE
Add option to use replaygain tags for audio

### DIFF
--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -31,6 +31,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableLUFSScan { get; set; }
 
+        public bool UseReplayGainTags { get; set; }
+
         public bool EnableChapterImageExtraction { get; set; }
 
         public bool ExtractChapterImagesDuringLibraryScan { get; set; }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -136,11 +136,11 @@ namespace MediaBrowser.Providers.MediaInfo
                     using var reader = process.StandardError;
                     var output = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
                     cancellationToken.ThrowIfCancellationRequested();
-                    MatchCollection split = ReplayGainTagRegex().Matches(output);
+                    Match split = ReplayGainTagRegex().Match(output);
 
-                    if (split.Count != 0)
+                    if (split.Success)
                     {
-                        item.LUFS = DefaultLUFSValue - float.Parse(split[0].Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
+                        item.LUFS = DefaultLUFSValue - float.Parse(split.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
                         foundLUFSValue = true;
                     }
                     else

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -115,8 +115,8 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     StartInfo = new ProcessStartInfo
                     {
-                        FileName = _mediaEncoder.EncoderPath,
-                        Arguments = $"-hide_banner -i \"{path}\" -f null -",
+                        FileName = _mediaEncoder.ProbePath,
+                        Arguments = $"-hide_banner -i \"{path}\"",
                         RedirectStandardOutput = false,
                         RedirectStandardError = true
                     },

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -61,7 +61,7 @@ namespace MediaBrowser.Providers.MediaInfo
         [GeneratedRegex(@"I:\s+(.*?)\s+LUFS")]
         private static partial Regex LUFSRegex();
 
-        [GeneratedRegex(@"REPLAYGAIN_TRACK_GAIN:\s+(.*?)\s+dB")]
+        [GeneratedRegex(@"REPLAYGAIN_TRACK_GAIN:\s+-?([0-9.]+)\s+dB")]
         private static partial Regex ReplayGainTagRegex();
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (libraryOptions.UseReplayGainTags)
             {
-                    using (var process = new Process()
+                using (var process = new Process()
                 {
                     StartInfo = new ProcessStartInfo
                     {


### PR DESCRIPTION
Adds option to enable/disable scanning for replaygain tags. This is means that existing replaygain tags can be used instead of jellyfin scanning each track again. This may cause problems with consistency. If replaygain tags are enabled then they will override scanning for LUFS reducing computation, if they are not found and LUFS scan is still enabled then it will scan them tracks.

Frontend: https://github.com/jellyfin/jellyfin-web/pull/4984