### PR TITLE
Serve all static filetypes from webroot

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,6 +58,7 @@
  - [HelloWorld017](https://github.com/HelloWorld017)
  - [ikomhoog](https://github.com/ikomhoog)
  - [iwalton3](https://github.com/iwalton3)
+ - [Jack Urso](https://github.com/Jburso)
  - [jftuga](https://github.com/jftuga)
  - [jmshrv](https://github.com/jmshrv)
  - [joern-h](https://github.com/joern-h)

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -189,7 +189,11 @@ namespace Jellyfin.Server
                     mainApp.UseRobotsRedirection();
                 }
 
-                mainApp.UseStaticFiles();
+                mainApp.UseStaticFiles(new StaticFileOptions()
+                {
+                    ServeUnknownFileTypes = true
+                });
+
                 mainApp.UseAuthentication();
                 mainApp.UseJellyfinApiSwagger(_serverConfigurationManager);
                 mainApp.UseQueryStringDecoding();


### PR DESCRIPTION
Allows all files, including files without extensions, to be served to clients.

This enables external acme tools to use the `wwwroot` for http-01 challenges, which don't contain file extensions.
