### PR TITLE
Fix action building for .NET 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These instructions will help you get set up with a local development environment
 
 ### Prerequisites
 
-Before the project can be built, you must first install the [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet) on your system.
+Before the project can be built, you must first install the [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet) on your system.
 
 Instructions to run this project from the command line are included here, but you will also need to install an IDE if you want to debug the server while it is running. Any IDE that supports .NET 6 development will work, but two options are recent versions of [Visual Studio](https://visualstudio.microsoft.com/downloads/) (at least 2022) and [Visual Studio Code](https://code.visualstudio.com/Download).
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
-                dotnet-sdk-7.0,
+                dotnet-sdk-8.0,
                 libc6-dev,
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -7,27 +7,27 @@ HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
 ifeq ($(HOST_ARCH),x86_64)
     # Building AMD64
-    DOTNETRUNTIME := debian-x64
+    DOTNETRUNTIME := linux-x64
     ifeq ($(BUILD_ARCH),arm-linux-gnueabihf)
         # Cross-building ARM on AMD64
-        DOTNETRUNTIME := debian-arm
+        DOTNETRUNTIME := linux-arm
     endif
     ifeq ($(BUILD_ARCH),aarch64-linux-gnu)
         # Cross-building ARM on AMD64
-        DOTNETRUNTIME := debian-arm64
+        DOTNETRUNTIME := linux-arm64
     endif
 endif
 ifeq ($(HOST_ARCH),armv7l)
     # Building ARM
-    DOTNETRUNTIME := debian-arm
+    DOTNETRUNTIME := linux-arm
 endif
 ifeq ($(HOST_ARCH),arm64)
     # Building ARM
-    DOTNETRUNTIME := debian-arm64
+    DOTNETRUNTIME := linux-arm64
 endif
 ifeq ($(HOST_ARCH),aarch64)
     # Building ARM
-    DOTNETRUNTIME := debian-arm64
+    DOTNETRUNTIME := linux-arm64
 endif
 
 export DH_VERBOSE=1

--- a/deployment/Dockerfile.centos.amd64
+++ b/deployment/Dockerfile.centos.amd64
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/deployment/Dockerfile.debian.amd64
+++ b/deployment/Dockerfile.debian.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts build-essential mmv \
     libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev \
-    libssl3 liblttng-ust0
+    libssl3 liblttng-ust1
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.amd64 /build.sh

--- a/deployment/Dockerfile.debian.amd64
+++ b/deployment/Dockerfile.debian.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts build-essential mmv \
     libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libssl-dev \
-    libssl1.1 liblttng-ust0
+    libssl3 liblttng-ust0
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.amd64 /build.sh

--- a/deployment/Dockerfile.debian.arm64
+++ b/deployment/Dockerfile.debian.arm64
@@ -18,16 +18,16 @@ RUN apt-get update -yqq \
 RUN dpkg --add-architecture arm64 \
   && apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends cross-gcc-dev \
-  && TARGET_LIST="arm64" cross-gcc-gensource 9 \
-  && cd cross-gcc-packages-amd64/cross-gcc-9-arm64 \
+  && TARGET_LIST="arm64" cross-gcc-gensource 12 \
+  && cd cross-gcc-packages-amd64/cross-gcc-12-arm64 \
   && apt-get install -yqq --no-install-recommends \
-    gcc-9-source libstdc++-9-dev-arm64-cross \
+    gcc-12-source libstdc++-12-dev-arm64-cross \
     binutils-aarch64-linux-gnu bison flex libtool \
     gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev \
     systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip \
     libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 \
     libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 \
-    libfreetype6-dev:arm64 libssl-dev:arm64 liblttng-ust0:arm64 libstdc++-9-dev:arm64
+    libfreetype6-dev:arm64 libssl-dev:arm64 liblttng-ust1:arm64 libstdc++-12-dev:arm64
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.arm64 /build.sh

--- a/deployment/Dockerfile.debian.armhf
+++ b/deployment/Dockerfile.debian.armhf
@@ -18,17 +18,17 @@ RUN apt-get update -yqq \
 RUN dpkg --add-architecture armhf \
   && apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends cross-gcc-dev \
-  && TARGET_LIST="armhf" cross-gcc-gensource 9 \
-  && cd cross-gcc-packages-amd64/cross-gcc-9-armhf \
+  && TARGET_LIST="armhf" cross-gcc-gensource 12 \
+  && cd cross-gcc-packages-amd64/cross-gcc-12-armhf \
   && apt-get install -yqq --no-install-recommends\
-    gcc-9-source libstdc++-9-dev-armhf-cross \
+    gcc-12-source libstdc++-12-dev-armhf-cross \
     binutils-aarch64-linux-gnu bison flex libtool gdb \
     sharutils netbase libmpc-dev libmpfr-dev libgmp-dev \
     systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
     zip binutils-arm-linux-gnueabihf libc6-dev:armhf \
     linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf \
     libfontconfig1-dev:armhf libfreetype6-dev:armhf libssl-dev:armhf \
-    liblttng-ust0:armhf libstdc++-9-dev:armhf
+    liblttng-ust1:armhf libstdc++-12-dev:armhf
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.armhf /build.sh

--- a/deployment/Dockerfile.linux.amd64
+++ b/deployment/Dockerfile.linux.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64 /build.sh

--- a/deployment/Dockerfile.linux.amd64
+++ b/deployment/Dockerfile.linux.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64 /build.sh

--- a/deployment/Dockerfile.linux.amd64-musl
+++ b/deployment/Dockerfile.linux.amd64-musl
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64-musl /build.sh

--- a/deployment/Dockerfile.linux.amd64-musl
+++ b/deployment/Dockerfile.linux.amd64-musl
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.amd64-musl /build.sh

--- a/deployment/Dockerfile.linux.arm64
+++ b/deployment/Dockerfile.linux.arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.arm64 /build.sh

--- a/deployment/Dockerfile.linux.arm64
+++ b/deployment/Dockerfile.linux.arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.arm64 /build.sh

--- a/deployment/Dockerfile.linux.armhf
+++ b/deployment/Dockerfile.linux.armhf
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.armhf /build.sh

--- a/deployment/Dockerfile.linux.armhf
+++ b/deployment/Dockerfile.linux.armhf
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.armhf /build.sh

--- a/deployment/Dockerfile.linux.musl-linux-arm64
+++ b/deployment/Dockerfile.linux.musl-linux-arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.musl-linux-arm64 /build.sh

--- a/deployment/Dockerfile.linux.musl-linux-arm64
+++ b/deployment/Dockerfile.linux.musl-linux-arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     apt-transport-https debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.linux.musl-linux-arm64 /build.sh

--- a/deployment/Dockerfile.macos.amd64
+++ b/deployment/Dockerfile.macos.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.amd64 /build.sh

--- a/deployment/Dockerfile.macos.amd64
+++ b/deployment/Dockerfile.macos.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.amd64 /build.sh

--- a/deployment/Dockerfile.macos.arm64
+++ b/deployment/Dockerfile.macos.arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.arm64 /build.sh

--- a/deployment/Dockerfile.macos.arm64
+++ b/deployment/Dockerfile.macos.arm64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.macos.arm64 /build.sh

--- a/deployment/Dockerfile.portable
+++ b/deployment/Dockerfile.portable
@@ -13,7 +13,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.portable /build.sh

--- a/deployment/Dockerfile.portable
+++ b/deployment/Dockerfile.portable
@@ -13,7 +13,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.portable /build.sh

--- a/deployment/Dockerfile.ubuntu.amd64
+++ b/deployment/Dockerfile.ubuntu.amd64
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg wget ca-certificates devscripts \
     mmv build-essential libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1
 
 # Install dotnet repository
 RUN wget -q https://download.visualstudio.microsoft.com/download/pr/5226a5fa-8c0b-474f-b79a-8984ad7c5beb/3113ccbf789c9fd29972835f0f334b7a/dotnet-sdk-8.0.100-linux-x64.tar.gz -O dotnet-sdk.tar.gz \

--- a/deployment/Dockerfile.ubuntu.amd64
+++ b/deployment/Dockerfile.ubuntu.amd64
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist
@@ -14,7 +14,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg wget ca-certificates devscripts \
     mmv build-essential libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0
 
 # Install dotnet repository
 RUN wget -q https://download.visualstudio.microsoft.com/download/pr/5226a5fa-8c0b-474f-b79a-8984ad7c5beb/3113ccbf789c9fd29972835f0f334b7a/dotnet-sdk-8.0.100-linux-x64.tar.gz -O dotnet-sdk.tar.gz \

--- a/deployment/Dockerfile.ubuntu.arm64
+++ b/deployment/Dockerfile.ubuntu.arm64
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/deployment/Dockerfile.ubuntu.arm64
+++ b/deployment/Dockerfile.ubuntu.arm64
@@ -35,15 +35,15 @@ RUN rm /etc/apt/sources.list \
   && dpkg --add-architecture arm64 \
   && apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends cross-gcc-dev \
-  && TARGET_LIST="arm64" cross-gcc-gensource 6 \
-  && cd cross-gcc-packages-amd64/cross-gcc-6-arm64 \
+  && TARGET_LIST="arm64" cross-gcc-gensource 12 \
+  && cd cross-gcc-packages-amd64/cross-gcc-12-arm64 \
   && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
   && apt-get install -yqq --no-install-recommends \
-    gcc-6-source libstdc++6-arm64-cross binutils-aarch64-linux-gnu \
+    gcc-12-source libstdc++6-arm64-cross binutils-aarch64-linux-gnu \
     bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev \
     libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
     zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 \
-    libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64 libssl-dev:arm64
+    libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust1:arm64 libstdc++6:arm64 libssl-dev:arm64
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.ubuntu.arm64 /build.sh

--- a/deployment/Dockerfile.ubuntu.armhf
+++ b/deployment/Dockerfile.ubuntu.armhf
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin
 ARG ARTIFACT_DIR=/dist

--- a/deployment/Dockerfile.ubuntu.armhf
+++ b/deployment/Dockerfile.ubuntu.armhf
@@ -35,15 +35,15 @@ RUN rm /etc/apt/sources.list \
   && dpkg --add-architecture armhf \
   && apt-get update -yqq \
   && apt-get install -yqq cross-gcc-dev \
-  && TARGET_LIST="armhf" cross-gcc-gensource 6 \
-  && cd cross-gcc-packages-amd64/cross-gcc-6-armhf \
+  && TARGET_LIST="armhf" cross-gcc-gensource 12 \
+  && cd cross-gcc-packages-amd64/cross-gcc-12-armhf \
   && ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime \
   && apt-get install -yqq --no-install-recommends \
-    gcc-6-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf \
+    gcc-12-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf \
     bison flex libtool gdb sharutils netbase libcloog-isl-dev libmpc-dev \
     libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev \
     zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf \
-    libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf libssl-dev:armhf
+    libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust1:armhf libstdc++6:armhf libssl-dev:armhf
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.debian.armhf /build.sh

--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -13,7 +13,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl3 liblttng-ust0 zip
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust1 zip
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.windows.amd64 /build.sh

--- a/deployment/Dockerfile.windows.amd64
+++ b/deployment/Dockerfile.windows.amd64
@@ -13,7 +13,7 @@ RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
     debhelper gnupg devscripts unzip \
     mmv libcurl4-openssl-dev libfontconfig1-dev \
-    libfreetype6-dev libssl-dev libssl1.1 liblttng-ust0 zip
+    libfreetype6-dev libssl-dev libssl3 liblttng-ust0 zip
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.windows.amd64 /build.sh

--- a/deployment/build.centos.amd64
+++ b/deployment/build.centos.amd64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#= CentOS/RHEL 7+ amd64 .rpm
+#= CentOS/RHEL 8+ amd64 .rpm
 
 set -o errexit
 set -o xtrace

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -14,8 +14,10 @@ The RPM package for Fedora/CentOS requires some additional repositories as ffmpe
 # ffmpeg from RPMfusion free
 # Fedora
 $ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
-# CentOS
+# CentOS 8
 $ sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
+# CentOS 9
+$ sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm
 ```
 
 ## Building with dotnet
@@ -26,8 +28,10 @@ Jellyfin is build with `--self-contained` so no dotnet required for runtime.
 # dotnet required for building the RPM
 # Fedora
 $ sudo dnf copr enable @dotnet-sig/dotnet
-# CentOS
+# CentOS 8
 $ sudo rpm -Uvh https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+# CentOS 9
+$ sudo rpm -Uvh https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm
 ```
 
 ## TODO

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -14,8 +14,8 @@ The RPM package for Fedora/CentOS requires some additional repositories as ffmpe
 # ffmpeg from RPMfusion free
 # Fedora
 $ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
-# CentOS 7
-$ sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
+# CentOS
+$ sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
 ```
 
 ## Building with dotnet
@@ -27,7 +27,7 @@ Jellyfin is build with `--self-contained` so no dotnet required for runtime.
 # Fedora
 $ sudo dnf copr enable @dotnet-sig/dotnet
 # CentOS
-$ sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+$ sudo rpm -Uvh https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
 ```
 
 ## TODO

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -2,7 +2,6 @@
 # Set the dotnet runtime
 %if 0%{?fedora}
 %else
-%global         dotnet_runtime  centos-x64
 %endif
 
 Name:           jellyfin
@@ -66,7 +65,7 @@ dotnet publish --configuration Release --self-contained --runtime linux-x64 \
 %install
 # Jellyfin files
 %{__mkdir} -p %{buildroot}%{_libdir}/jellyfin %{buildroot}%{_bindir}
-%{__cp} -r Jellyfin.Server/bin/Release/net8.0/%{dotnet_runtime}/publish/* %{buildroot}%{_libdir}/jellyfin
+%{__cp} -r Jellyfin.Server/bin/Release/net8.0/centos-x64/publish/* %{buildroot}%{_libdir}/jellyfin
 %{__install} -D %{SOURCE10} %{buildroot}%{_bindir}/jellyfin
 sed -i -e 's|/usr/lib64|%{_libdir}|g' %{buildroot}%{_bindir}/jellyfin
 

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -1,7 +1,6 @@
 %global         debug_package %{nil}
 # Set the dotnet runtime
 %if 0%{?fedora}
-%global         dotnet_runtime  fedora.%{fedora}-x64
 %else
 %global         dotnet_runtime  centos-x64
 %endif
@@ -66,7 +65,7 @@ the Jellyfin server to bind to ports 80 and/or 443 for example.
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export PATH=$PATH:/usr/local/bin
 # cannot use --output due to https://github.com/dotnet/sdk/issues/22220
-dotnet publish --configuration Release --self-contained --runtime %{dotnet_runtime} \
+dotnet publish --configuration Release --self-contained --runtime linux-x64 \
     -p:DebugSymbols=false -p:DebugType=none Jellyfin.Server
 
 

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -1,8 +1,4 @@
 %global         debug_package %{nil}
-# Set the dotnet runtime
-%if 0%{?fedora}
-%else
-%endif
 
 Name:           jellyfin
 Version:        10.9.0

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -26,7 +26,7 @@ BuildRequires:  systemd
 BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, glibc-devel, libicu-devel
 # Requirements not packaged in RHEL 7 main repos, added via Makefile
 # https://packages.microsoft.com/rhel/7/prod/
-BuildRequires:  dotnet-runtime-7.0, dotnet-sdk-7.0
+BuildRequires:  dotnet-runtime-8.0, dotnet-sdk-8.0
 Requires: %{name}-server = %{version}-%{release}, %{name}-web = %{version}-%{release}
 
 # Temporary (hopefully?) fix for https://github.com/jellyfin/jellyfin/issues/7471

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -61,7 +61,7 @@ dotnet publish --configuration Release --self-contained --runtime linux-x64 \
 %install
 # Jellyfin files
 %{__mkdir} -p %{buildroot}%{_libdir}/jellyfin %{buildroot}%{_bindir}
-%{__cp} -r Jellyfin.Server/bin/Release/net8.0/centos-x64/publish/* %{buildroot}%{_libdir}/jellyfin
+%{__cp} -r Jellyfin.Server/bin/Release/net8.0/linux-x64/publish/* %{buildroot}%{_libdir}/jellyfin
 %{__install} -D %{SOURCE10} %{buildroot}%{_bindir}/jellyfin
 sed -i -e 's|/usr/lib64|%{_libdir}|g' %{buildroot}%{_bindir}/jellyfin
 

--- a/fedora/jellyfin.spec
+++ b/fedora/jellyfin.spec
@@ -28,12 +28,6 @@ BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, 
 BuildRequires:  dotnet-runtime-8.0, dotnet-sdk-8.0
 Requires: %{name}-server = %{version}-%{release}, %{name}-web = %{version}-%{release}
 
-# Temporary (hopefully?) fix for https://github.com/jellyfin/jellyfin/issues/7471
-%if 0%{?fedora} >= 36
-%global __requires_exclude ^liblttng-ust\\.so\\.0.*$
-%endif
-
-
 %description
 Jellyfin is a free software media system that puts you in control of managing and streaming your media.
 


### PR DESCRIPTION
Switch docker building from CentOS 7 to 8 because of depracted package:
![chrome_cb8dmNGMFw](https://github.com/jellyfin/jellyfin/assets/68083474/c98d51c2-5375-46d0-85d2-7b7f46966d38)

Switch from Ubuntu 18 to 22 (LTS) and changed the package in consequence.