### PR TITLE
Fix: Plugin Installed Alerts missing from Admin Dashboard #10620

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -173,6 +173,7 @@
  - [scampower3](https://github.com/scampower3)
  - [Chris-Codes-It] (https://github.com/Chris-Codes-It)
  - [Pithaya](https://github.com/Pithaya)
+ - [Çağrı Sakaoğlu](https://github.com/ilovepilav)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -321,9 +321,15 @@ namespace Emby.Server.Implementations.Updates
                 }
 
                 _completedInstallationsInternal.Add(package);
-                await _eventManager.PublishAsync(isUpdate
-                    ? (GenericEventArgs<InstallationInfo>)new PluginUpdatedEventArgs(package)
-                    : new PluginInstalledEventArgs(package)).ConfigureAwait(false);
+
+                if (isUpdate)
+                {
+                    await _eventManager.PublishAsync(new PluginUpdatedEventArgs(package)).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _eventManager.PublishAsync(new PluginInstalledEventArgs(package)).ConfigureAwait(false);
+                }
 
                 _applicationHost.NotifyPendingRestart();
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Ternary operator in the PublishAsync method was causing plugin installed event not raised. Logic changed with simple if/else statement.  

(Screenshot)
![jellyfin_alert_fix](https://github.com/jellyfin/jellyfin/assets/59802077/1edfdc32-1f22-4cfa-8467-029cef1dad1c)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #10620 