### PR TITLE
Added a check for the ReplaceAllImages value before updating an images

### DIFF
--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -60,6 +60,11 @@ namespace Emby.Server.Implementations.Images
                 return ItemUpdateType.None;
             }
 
+            if (!options.ReplaceAllImages)
+            {
+                return ItemUpdateType.None;
+            }
+
             var updateType = ItemUpdateType.None;
 
             if (SupportedImages.Contains(ImageType.Primary))


### PR DESCRIPTION
This check should prevent images from being updated unless the Replace existing images checkbox is checked in the refresh metadata dialog

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
