### PR TITLE
Fix Folder Child Count

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -431,14 +431,7 @@ namespace Emby.Server.Implementations.Dto
 
         private static int GetChildCount(Folder folder, User user)
         {
-            // Right now this is too slow to calculate for top level folders on a per-user basis
-            // Just return something so that apps that are expecting a value won't think the folders are empty
-            if (folder is ICollectionFolder || folder is UserView)
-            {
-                return Random.Shared.Next(1, 10);
-            }
-
-            return folder.GetChildCount(user);
+            return folder.Children.Count();
         }
 
         private static void SetBookProperties(BaseItemDto dto, Book item)


### PR DESCRIPTION
Why Luke?! (see blame)

### Changes

Fixes child count for folders/libraries. We already have the immediate children (we don't want recursive) so just ... count them instead of some random number.

My dev library is very small so I don't know impact on large libraries, or I may also be missing something that should be addressed.

### Example Usage

In clients we can use this number to show an amount of placeholder items in a list/grid while items are being fetched lazily in the background.