### PR TITLE
Quote bash paths to prevent word splitting

### DIFF
--- a/deployment/build.centos.amd64
+++ b/deployment/build.centos.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove BuildRequires for dotnet, since it's installed manually
@@ -39,10 +39,10 @@ make -f fedora/Makefile srpm outdir=/root/rpmbuild/SRPMS
 rpmbuild --rebuild -bb /root/rpmbuild/SRPMS/jellyfin-*.src.rpm
 
 # Move the artifacts out
-mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm ${ARTIFACT_DIR}/
+mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 rm -f fedora/jellyfin*.tar.gz
@@ -51,7 +51,7 @@ if [[ ${IS_DOCKER} == YES ]]; then
     pushd fedora
 
     cp -a /tmp/spec.orig jellyfin.spec
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 
     popd
 fi

--- a/deployment/build.debian.amd64
+++ b/deployment/build.debian.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -32,12 +32,12 @@ fi
 # Build DEB
 dpkg-buildpackage -us -uc --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.debian.arm64
+++ b/deployment/build.debian.arm64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -33,12 +33,12 @@ fi
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a arm64 --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.debian.armhf
+++ b/deployment/build.debian.armhf
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -33,12 +33,12 @@ fi
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a armhf --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.fedora.amd64
+++ b/deployment/build.fedora.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove BuildRequires for dotnet, since it's installed manually
@@ -39,10 +39,10 @@ make -f fedora/Makefile srpm outdir=/root/rpmbuild/SRPMS
 rpmbuild -rb /root/rpmbuild/SRPMS/jellyfin-*.src.rpm
 
 # Move the artifacts out
-mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm ${ARTIFACT_DIR}/
+mv /root/rpmbuild/RPMS/x86_64/jellyfin-*.rpm /root/rpmbuild/SRPMS/jellyfin-*.src.rpm "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 rm -f fedora/jellyfin*.tar.gz
@@ -51,7 +51,7 @@ if [[ ${IS_DOCKER} == YES ]]; then
     pushd fedora
 
     cp -a /tmp/spec.orig jellyfin.spec
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 
     popd
 fi

--- a/deployment/build.linux.amd64
+++ b/deployment/build.linux.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_linux-amd64.tar.gz -C dist jellyfin-server_$
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.linux.amd64-musl
+++ b/deployment/build.linux.amd64-musl
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_linux-amd64-musl.tar.gz -C dist jellyfin-ser
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.linux.arm64
+++ b/deployment/build.linux.arm64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_linux-arm64.tar.gz -C dist jellyfin-server_$
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.linux.armhf
+++ b/deployment/build.linux.armhf
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_linux-armhf.tar.gz -C dist jellyfin-server_$
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.linux.musl-linux-arm64
+++ b/deployment/build.linux.musl-linux-arm64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_linux-arm64-musl.tar.gz -C dist jellyfin-ser
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.macos.amd64
+++ b/deployment/build.macos.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_macos-amd64.tar.gz -C dist jellyfin-server_$
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.macos.arm64
+++ b/deployment/build.macos.arm64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_macos-arm64.tar.gz -C dist jellyfin-server_$
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.portable
+++ b/deployment/build.portable
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -21,11 +21,11 @@ tar -czf jellyfin-server_${version}_portable.tar.gz -C dist jellyfin-server_${ve
 rm -rf dist/jellyfin-server_${version}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv jellyfin[-_]*.tar.gz ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv jellyfin[-_]*.tar.gz "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.ubuntu.amd64
+++ b/deployment/build.ubuntu.amd64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -32,12 +32,12 @@ fi
 # Build DEB
 dpkg-buildpackage -us -uc --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.ubuntu.arm64
+++ b/deployment/build.ubuntu.arm64
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -33,12 +33,12 @@ fi
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a arm64 --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.ubuntu.armhf
+++ b/deployment/build.ubuntu.armhf
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove build-dep for dotnet-sdk-8.0, since it's installed manually
@@ -33,12 +33,12 @@ fi
 export CONFIG_SITE=/etc/dpkg-cross/cross-config.${ARCH}
 dpkg-buildpackage -us -uc -a armhf --pre-clean --post-clean
 
-mkdir -p ${ARTIFACT_DIR}/
-mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv ../jellyfin*.{deb,dsc,tar.gz,buildinfo,changes} "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     cp -a /tmp/control.orig debian/control
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd

--- a/deployment/build.windows.amd64
+++ b/deployment/build.windows.amd64
@@ -11,7 +11,7 @@ NSSM_URL="http://files.evilt.win/nssm/${NSSM_VERSION}.zip"
 FFMPEG_URL="https://repo.jellyfin.org/releases/server/windows/ffmpeg/jellyfin-ffmpeg-portable_win64.zip";
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Get version
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
@@ -42,11 +42,11 @@ popd
 rm -rf ${output_dir}
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/
-mv dist/jellyfin[-_]*.zip ${ARTIFACT_DIR}/
+mkdir -p "${ARTIFACT_DIR}/"
+mv dist/jellyfin[-_]*.zip "${ARTIFACT_DIR}/"
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
+    chown -Rc $(stat -c %u:%g "${ARTIFACT_DIR}") "${ARTIFACT_DIR}"
 fi
 
 popd


### PR DESCRIPTION
This PR makes a modification to the bash build scripts to quote variables that could contain directories with spaces. This prevents bash from word splitting the arguments, and will allow those unholy souls who use spaces in their path names to run these scripts.

I restricted this to `SOURCE_DIR` and  `ARTIFACT_DIR`, as it looked like the other paths were guaranteed to not have spaces in them.

Note, did automate this change using regex search / replace, and while I did check the diff to make sure I didn't introduce anything silly, reviewers should double check that I didn't make a mistake. 

**Changes**
Add quotes to bash names to allow directories with spaces for native builds.

