### PR TITLE
Watch library directories with perm errors

### DIFF
--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -330,9 +330,9 @@ namespace Emby.Server.Implementations.IO
             var ex = e.GetException();
             var dw = (FileSystemWatcher)sender;
 
-            if (ex.GetType() == typeof(UnauthorizedAccessException))
+            if (ex is UnauthorizedAccessException unauthorizedAccessException)
             {
-                _logger.LogError(ex, "Permission error for Directory watcher: {Path}", dw.Path);
+                _logger.LogError(unauthorizedAccessException, "Permission error for Directory watcher: {Path}", dw.Path);
                 return;
             }
 

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -330,6 +330,12 @@ namespace Emby.Server.Implementations.IO
             var ex = e.GetException();
             var dw = (FileSystemWatcher)sender;
 
+            if (ex.GetType() == typeof(UnauthorizedAccessException))
+            {
+                _logger.LogError(ex, "Permission error for Directory watcher: {Path}", dw.Path);
+                return;
+            }
+
             _logger.LogError(ex, "Error in Directory watcher for: {Path}", dw.Path);
 
             DisposeWatcher(dw, true);


### PR DESCRIPTION
**Changes**
Continue to watch library directories if a subdirectory has invalid permissions.

An error message is printed but the watcher is not stopped so other subdirectories can still be monitored.
Error message:
```
[23:03:24] [ERR] [8] Emby.Server.Implementations.IO.LibraryMonitor: Permission error for Directory watcher: /tmp/jf-test2
System.UnauthorizedAccessException: Access to the path '/tmp/jf-test2' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
```

**Issues**
Fixes #7130
