### PR TITLE
Delimeters : "," added to split multiple value fields like artists

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -29,7 +29,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private const string ArtistReplaceValue = " | ";
 
-        private readonly char[] _nameDelimiters = { '/', '|', ';', '\\', '&', ',' };
+        private readonly char[] _nameDelimiters = { '/', '|', ';', '\\', ',' };
 
         private readonly ILogger _logger;
         private readonly ILocalizationManager _localization;

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -29,7 +29,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private const string ArtistReplaceValue = " | ";
 
-        private readonly char[] _nameDelimiters = { '/', '|', ';', '\\' };
+        private readonly char[] _nameDelimiters = { '/', '|', ';', '\\', '&', ',' };
 
         private readonly ILogger _logger;
         private readonly ILocalizationManager _localization;


### PR DESCRIPTION
**Delimeters** : `,` and `&` added to split multiple value fields like artists

Fixing: https://github.com/jellyfin/jellyfin/issues/10730

Allowing Edits by maintainer to add any nitpicks if necessary.