### PR TITLE
Remove OpenAPI artifact upload from test workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        include:
-          - os: ubuntu-latest
-            openapi: true
 
     runs-on: "${{ matrix.os }}"
     steps:
@@ -45,10 +42,3 @@ jobs:
 
       # TODO - which action / tool to use to publish code coverage results?
       # - name: Publish code coverage results
-
-      - name: Publish OpenAPI Artifact
-        if: ${{ matrix.openapi }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
-        with:
-          name: "OpenAPI Spec"
-          path: "tests/Jellyfin.Server.Integration.Tests/bin/Release/net*/openapi.json"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        include:
+          - os: ubuntu-latest
+            openapi: true
 
     runs-on: "${{ matrix.os }}"
     steps:
@@ -44,6 +47,7 @@ jobs:
       # - name: Publish code coverage results
 
       - name: Publish OpenAPI Artifact
+        if: ${{ matrix.openapi }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
         with:
           name: "OpenAPI Spec"


### PR DESCRIPTION
We already have dedicated OpenAPI actions to upload those artifacts. No idea why the tests uploaded it. This should also fix the CI issue related to GH Actions. (not the build issues on Azure)

**Changes**
- Remove OpenAPI artifact upload from test workflow 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
