### PR TITLE
Make TMDb api key configurable, fix missing/wrong image urls

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbBoxSetProvider.cs
@@ -75,12 +75,14 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
             var collections = new RemoteSearchResult[collectionSearchResults.Count];
             for (var i = 0; i < collectionSearchResults.Count; i++)
             {
+                var result = collectionSearchResults[i];
                 var collection = new RemoteSearchResult
                 {
-                    Name = collectionSearchResults[i].Name,
-                    SearchProviderName = Name
+                    Name = result.Name,
+                    SearchProviderName = Name,
+                    ImageUrl = _tmdbClientManager.GetPosterUrl(result.PosterPath)
                 };
-                collection.SetProviderId(MetadataProvider.Tmdb, collectionSearchResults[i].Id.ToString(CultureInfo.InvariantCulture));
+                collection.SetProviderId(MetadataProvider.Tmdb, result.Id.ToString(CultureInfo.InvariantCulture));
 
                 collections[i] = collection;
             }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// Gets or sets a value to use as the API key for accessing TMDb. This is intentionally excluded from the
         /// settings page as the API key should not need to be changed by most users.
         /// </summary>
-        public string TmdbApiKey { get; set; } = TmdbUtils.ApiKey;
+        public string TmdbApiKey { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether include adult content when searching with TMDb.

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/PluginConfiguration.cs
@@ -8,6 +8,12 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
     public class PluginConfiguration : BasePluginConfiguration
     {
         /// <summary>
+        /// Gets or sets a value to use as the API key for accessing TMDb. This is intentionally excluded from the
+        /// settings page as the API key should not need to be changed by most users.
+        /// </summary>
+        public string TmdbApiKey { get; set; } = TmdbUtils.ApiKey;
+
+        /// <summary>
         /// Gets or sets a value indicating whether include adult content when searching with TMDb.
         /// </summary>
         public bool IncludeAdult { get; set; }

--- a/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Configuration/config.html
@@ -64,8 +64,17 @@
 
                     var clientConfig, pluginConfig;
                     var configureImageScaling = function() {
-                        if (clientConfig === null || pluginConfig === null) {
+                        if (clientConfig === undefined || pluginConfig === undefined) {
                             return;
+                        }
+                        if (Object.keys(clientConfig).length === 0) {
+                            clientConfig = {
+                                PosterSizes: [pluginConfig.PosterSize],
+                                BackdropSizes: [pluginConfig.BackdropSize],
+                                LogoSizes: [pluginConfig.LogoSize],
+                                ProfileSizes: [pluginConfig.ProfileSize],
+                                StillSizes: [pluginConfig.StillSize]
+                            };
                         }
 
                         var sizeOptionsGenerator = function (size) {
@@ -104,6 +113,15 @@
                     ApiClient.fetch(request).then(function (config) {
                         clientConfig = config;
                         configureImageScaling();
+                    }, function (error) {
+                        error.text().then(function (contents) {
+                            Dashboard.alert({
+                                title: error.statusText,
+                                message: contents
+                            });
+                            clientConfig = {};
+                            configureImageScaling();
+                        });
                     });
 
                     ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {

--- a/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Movies/TmdbMovieProvider.cs
@@ -299,7 +299,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Movies
 
                     if (!string.IsNullOrWhiteSpace(person.ProfilePath))
                     {
-                        personInfo.ImageUrl = _tmdbClientManager.GetPosterUrl(person.ProfilePath);
+                        personInfo.ImageUrl = _tmdbClientManager.GetProfileUrl(person.ProfilePath);
                     }
 
                     if (person.Id > 0)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -36,7 +36,11 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         public TmdbClientManager(IMemoryCache memoryCache)
         {
             _memoryCache = memoryCache;
-            _tmDbClient = new TMDbClient(Plugin.Instance.Configuration.TmdbApiKey);
+
+            var apiKey = Plugin.Instance.Configuration.TmdbApiKey;
+            apiKey = string.IsNullOrEmpty(apiKey) ? TmdbUtils.ApiKey : apiKey;
+            _tmDbClient = new TMDbClient(apiKey);
+
             // Not really interested in NotFoundException
             _tmDbClient.ThrowApiExceptions = false;
         }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -36,7 +36,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         public TmdbClientManager(IMemoryCache memoryCache)
         {
             _memoryCache = memoryCache;
-            _tmDbClient = new TMDbClient(TmdbUtils.ApiKey);
+            _tmDbClient = new TMDbClient(Plugin.Instance.Configuration.TmdbApiKey);
             // Not really interested in NotFoundException
             _tmDbClient.ThrowApiExceptions = false;
         }


### PR DESCRIPTION
The API key is added to the config file but not the user-facing plugin page. Most users should not mess with the key, but as discussed in #10529 some users like tracking their own API usage or dislike that using the Jellyfin key includes their statistics where someone else could possibly see.

To change the key open the TMDb plugin settings and hit save, then open `Jellyfin.Plugin.Tmdb.xml` (at `~/.local/share/jellyfin/plugins/configurations/Jellyfin.Plugin.Tmdb.xml` in my dev environment), set the `TmdbApiKey` value, and restart Jellyfin to pick up changes.

An empty or missing `TmdbApiKey` value will cause Jellyfin to use the Jellyfin key, which will not be saved to the xml file.

**Changes**
- Add API key to configuration file, as well as error handling for the plugin config page in case the key is invalid
- Fix missing posters in collection identify page
- Fix a case where poster settings were used for person profile images

**Issues**

