### PR TITLE
Add stream compatibility flag and errors

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -269,10 +269,7 @@ namespace MediaBrowser.Model.Dlna
         {
             foreach (var stream in mediaSource.MediaStreams)
             {
-                if (!stream.DirectPlayErrors.HasValue)
-                {
-                    stream.DirectPlayErrors = GetCompatibility(mediaType, mediaSource, stream, profile);
-                }
+                stream.DirectPlayErrors ??= GetCompatibility(mediaType, mediaSource, stream, profile);
             }
         }
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1495,13 +1495,13 @@ namespace MediaBrowser.Model.Dlna
                     .Where(containerProfile => containerProfile.Type == DlnaProfileType.Video && containerProfile.ContainsContainer(container))
                     .SelectMany(containerProfile => checkVideoConditions(containerProfile.Conditions)));
 
-            // FIXME: Throw if CompatibilityErrors has no value?
+            // FIXME: Throw if DirectPlayErrors has no value?
             var videoCodecProfileReasons = (videoStream?.DirectPlayErrors ?? 0) & ~GenericReasons;
 
-            // FIXME: Throw if CompatibilityErrors has no value?
+            // FIXME: Throw if DirectPlayErrors has no value?
             var audioStreamMatches = candidateAudioStreams.ToDictionary(s => s, audioStream => (audioStream.DirectPlayErrors ?? 0) & ~GenericReasons);
 
-            // FIXME: Throw if CompatibilityErrors has no value?
+            // FIXME: Throw if DirectPlayErrors has no value?
             var subtitleProfileReasons = (subtitleStream?.DirectPlayErrors ?? 0) & ~GenericReasons;
 
             if ((subtitleProfileReasons & TranscodeReason.SubtitleCodecNotSupported) != 0)

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -13,6 +13,7 @@ using Jellyfin.Extensions;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Model.Session;
 
 namespace MediaBrowser.Model.Entities
 {
@@ -671,6 +672,24 @@ namespace MediaBrowser.Model.Entities
         /// </summary>
         /// <value><c>true</c> if this instance is anamorphic; otherwise, <c>false</c>.</value>
         public bool? IsAnamorphic { get; set; }
+
+        /// <summary>
+        /// Gets or sets DirectPlay errors.
+        /// </summary>
+        /// <value>DirectPlay errors.</value>
+        public TranscodeReason? DirectPlayErrors { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is compatible with the device.
+        /// </summary>
+        /// <value><c>true</c> if this instance is compatible with the device; otherwise, <c>false</c>.</value>
+        public bool SupportsDirectPlay
+        {
+            get
+            {
+                return DirectPlayErrors == 0;
+            }
+        }
 
         internal string GetResolutionText()
         {

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -327,6 +327,39 @@ namespace Jellyfin.Model.Tests
             Assert.Equal(streamInfo?.SubtitleStreamIndex, options.SubtitleStreamIndex);
         }
 
+        [Theory]
+        // Chrome
+        [InlineData("Chrome", "mp4-h264-ac3-aac-aac-srt-2600k", new TranscodeReason[] { 0, TranscodeReason.AudioCodecNotSupported, TranscodeReason.SecondaryAudioNotSupported, TranscodeReason.SecondaryAudioNotSupported, 0 })]
+        [InlineData("Chrome", "mp4-h264-dts-srt-2600k", new TranscodeReason[] { 0, TranscodeReason.AudioCodecNotSupported, 0 })]
+        [InlineData("Chrome", "mkv-vp9-aac-srt-2600k", new TranscodeReason[] { TranscodeReason.ContainerNotSupported | TranscodeReason.VideoCodecNotSupported, TranscodeReason.ContainerNotSupported | TranscodeReason.AudioCodecNotSupported, 0 })]
+        // Firefox
+        [InlineData("Firefox", "mp4-h264-ac3-aac-aac-srt-2600k", new TranscodeReason[] { 0, TranscodeReason.AudioCodecNotSupported, TranscodeReason.SecondaryAudioNotSupported, TranscodeReason.SecondaryAudioNotSupported, 0 })]
+        [InlineData("Firefox", "mp4-h264-dts-srt-2600k", new TranscodeReason[] { 0, TranscodeReason.AudioCodecNotSupported, 0 })]
+        [InlineData("Firefox", "mkv-vp9-aac-srt-2600k", new TranscodeReason[] { TranscodeReason.ContainerNotSupported | TranscodeReason.VideoCodecNotSupported, TranscodeReason.ContainerNotSupported | TranscodeReason.AudioCodecNotSupported, 0 })]
+        // Tizen3-stereo
+        [InlineData("Tizen3-stereo", "mp4-h264-ac3-aac-aac-srt-2600k", new TranscodeReason[] { 0, 0, TranscodeReason.SecondaryAudioNotSupported, TranscodeReason.SecondaryAudioNotSupported, 0 })]
+        [InlineData("Tizen3-stereo", "mp4-h264-dts-srt-2600k", new TranscodeReason[] { 0, 0, 0 })]
+        [InlineData("Tizen3-stereo", "mkv-vp9-aac-srt-2600k", new TranscodeReason[] { 0, 0, 0 })]
+        // Tizen4-4K-5.1
+        [InlineData("Tizen4-4K-5.1", "mp4-h264-ac3-aac-aac-srt-2600k", new TranscodeReason[] { 0, 0, TranscodeReason.SecondaryAudioNotSupported, TranscodeReason.SecondaryAudioNotSupported, 0 })]
+        [InlineData("Tizen4-4K-5.1", "mp4-h264-dts-srt-2600k", new TranscodeReason[] { 0, TranscodeReason.AudioCodecNotSupported, 0 })]
+        [InlineData("Tizen4-4K-5.1", "mkv-vp9-aac-srt-2600k", new TranscodeReason[] { 0, 0, 0 })]
+        public async Task CheckCompatibility(string deviceName, string mediaSourceName, TranscodeReason[] directPlayErrors)
+        {
+            var options = await GetMediaOptions(deviceName, mediaSourceName);
+
+            var builder = GetStreamBuilder();
+
+            var streamInfo = builder.GetOptimalVideoStream(options);
+            Assert.NotNull(streamInfo);
+
+            var mediaSource = options.MediaSources.First(source => source.Id == streamInfo.MediaSourceId);
+            Assert.NotNull(mediaSource);
+
+            Assert.Equal(directPlayErrors.Length, mediaSource.MediaStreams.Count);
+            Assert.All(mediaSource.MediaStreams, (stream, i) => Assert.Equal(stream.DirectPlayErrors, directPlayErrors[i]));
+        }
+
         private StreamInfo? BuildVideoItemSimpleTest(MediaOptions options, PlayMethod? playMethod, TranscodeReason why, string transcodeMode, string transcodeProtocol)
         {
             if (string.IsNullOrEmpty(transcodeProtocol))


### PR DESCRIPTION
_Server-side for https://github.com/jellyfin/jellyfin-web/pull/5252_

Every player has to recheck stream compatibility to determine which streams can be played directly.
[This example](https://github.com/jellyfin/jellyfin-web/blob/3d6b27e6a3ca8fa78f0d9050eb5dbfaf01cf82c8/src/plugins/htmlVideoPlayer/plugin.js#L728-L747) has only a generic test (container+codec), but no codec conditions.

On the other hand, the server performs a full validation for the provided device profile (only requested streams, but still).
This PR adds full validation and access to such information.

**Changes**
- Add stream compatibility flag (`SupportsDirectPlay`) and errors (`DirectPlayErrors`).
- Re-use stream compatibility errors.

**Issues**
N/A

**More Info**
It looks like we have a bug with detecting secondary audio: browsers skip unsupported streams, and the second audio stream (supported) becomes the first.
Moreover, Chrome 115+ detects only default audio tracks (bug?).
This can be fixed after complete stream analysis (this PR).

_And I need this for AVPlay player._ :relaxed: 
