### PR TITLE
Fix Somalia's display name

### DIFF
--- a/Emby.Server.Implementations/Localization/countries.json
+++ b/Emby.Server.Implementations/Localization/countries.json
@@ -696,7 +696,7 @@
         "TwoLetterISORegionName": "SI"
     },
     {
-        "DisplayName": "Soomaaliya",
+        "DisplayName": "Somalia",
         "Name": "SO",
         "ThreeLetterISORegionName": "SOM",
         "TwoLetterISORegionName": "SO"


### PR DESCRIPTION
**Changes**

Somalia's current display name is in Somali (Soomaaliya), this change will display the English name instead (Somalia).

Reference: https://en.wikipedia.org/wiki/Somalia
