### PR TITLE
Add limit on metadata pathlength

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -174,6 +174,7 @@
  - [Chris-Codes-It] (https://github.com/Chris-Codes-It)
  - [Pithaya](https://github.com/Pithaya)
  - [Çağrı Sakaoğlu](https://github.com/ilovepilav)
+ - [devstra](https://github.com/devstra)
 
 # Emby Contributors
 

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -94,7 +94,7 @@ namespace MediaBrowser.LocalMetadata.Savers
         {
             var path = GetSavePath(item);
             var directory = Path.GetDirectoryName(path) ?? throw new InvalidDataException($"Provided path ({path}) is not valid.");
-            Directory.CreateDirectory(directory);
+            _ = directory.Length > 260 ? Directory.CreateDirectory(directory[..260]) : Directory.CreateDirectory(directory);
 
             // On Windows, savint the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -204,7 +204,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
         private async Task SaveToFileAsync(Stream stream, string path)
         {
             var directory = Path.GetDirectoryName(path) ?? throw new ArgumentException($"Provided path ({path}) is not valid.", nameof(path));
-            Directory.CreateDirectory(directory);
+            _ = directory.Length > 260 ? Directory.CreateDirectory(directory[..260]) : Directory.CreateDirectory(directory);
 
             // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);


### PR DESCRIPTION
**Changes**
Modify BaseXmlSaver and BaseNfoSaver to prevent metadata directory of excessive length from being created (260 as per Windows PATH_MAX, also prevents common Unix NAME_MAX of 255 from being exceeded).

**Issues**
https://github.com/jellyfin/jellyfin/issues/10780
