### PR TITLE
Support resume on all audio

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/Audio.cs
+++ b/MediaBrowser.Controller/Entities/Audio/Audio.cs
@@ -38,6 +38,9 @@ namespace MediaBrowser.Controller.Entities.Audio
         public IReadOnlyList<string> AlbumArtists { get; set; }
 
         [JsonIgnore]
+        public override bool SupportsPositionTicksResume => true;
+
+        [JsonIgnore]
         public override bool SupportsPlayedStatus => true;
 
         [JsonIgnore]


### PR DESCRIPTION
I use Jellyfin to listen to multi-hour audio tracks. Not having Jellyfin remember my play position for audio files has been rough. I ended up patching my Jellyfin server build to allow all audio files to `SupportsPositionTicksResume`. This causes all playback positions for audio files to be saved.

I'm not sure if this is undesirable default behavior for others, but I'd love to have this change incorporated into upstream somehow, even if it needs to be behind a settings toggle (happy to help add this if that's the direction this needs to go).

![Screenshot from 2024-01-08 21-29-44](https://github.com/jellyfin/jellyfin/assets/44368/ac7fa96a-849d-47db-8e7f-ac72e51f29f5)

**Changes**

All `Audio` entity types now default to saving their playback position via `SupportsPositionTicksResume`.

**Issues**

See: https://github.com/jellyfin/jellyfin/issues/7228 and https://github.com/jellyfin/jellyfin/issues/2084
