### PR TITLE
Refresh live TV channel image when remapped (alt #7843) (fixes #7834)

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1869,8 +1869,14 @@ namespace Emby.Server.Implementations.Library
             var outdated = forceUpdate
                 ? item.ImageInfos.Where(i => i.Path is not null).ToArray()
                 : item.ImageInfos.Where(ImageNeedsRefresh).ToArray();
-            // Skip image processing if current or live tv source
-            if (outdated.Length == 0 || item.SourceType != SourceType.Library)
+
+            var parentItem = item.GetParent();
+            var isLiveTvShow = item.SourceType != SourceType.Library &&
+                               parentItem is not null &&
+                               parentItem.SourceType != SourceType.Library; // not a channel
+
+            // Skip image processing if current or live tv show
+            if (outdated.Length == 0 || isLiveTvShow)
             {
                 RegisterItem(item);
                 return;

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2432,8 +2432,14 @@ namespace Emby.Server.Implementations.Library
             var outdated = forceUpdate
                 ? item.ImageInfos.Where(i => i.Path is not null).ToArray()
                 : item.ImageInfos.Where(ImageNeedsRefresh).ToArray();
-            // Skip image processing if current or live tv source
-            if (outdated.Length == 0 || item.SourceType != SourceType.Library)
+
+            var parentItem = item.GetParent();
+            var isLiveTvShow = item.SourceType != SourceType.Library &&
+                               parentItem is not null &&
+                               parentItem.SourceType != SourceType.Library; // not a channel
+
+            // Skip image processing if current or live tv show
+            if (outdated.Length == 0 || isLiveTvShow)
             {
                 RegisterItem(item);
                 return;

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -432,14 +432,19 @@ public class GuideManager : IGuideManager
 
         item.Name = channelInfo.Name;
 
-        if (!item.HasImage(ImageType.Primary))
+        var currentPrimary = item.GetImageInfo(ImageType.Primary, 0);
+        var imageUrlIsNull = string.IsNullOrWhiteSpace(channelInfo.ImageUrl);
+
+        // Update channel image if image URL has changed
+        if (currentPrimary is null
+            || (!imageUrlIsNull && currentPrimary.Path != channelInfo.ImageUrl))
         {
             if (!string.IsNullOrWhiteSpace(channelInfo.ImagePath))
             {
                 item.SetImagePath(ImageType.Primary, channelInfo.ImagePath);
                 forceUpdate = true;
             }
-            else if (!string.IsNullOrWhiteSpace(channelInfo.ImageUrl))
+            else if (!imageUrlIsNull)
             {
                 item.SetImagePath(ImageType.Primary, channelInfo.ImageUrl);
                 forceUpdate = true;

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -448,14 +448,19 @@ public class GuideManager : IGuideManager
 
         item.Name = channelInfo.Name;
 
-        if (!item.HasImage(ImageType.Primary))
+        var currentPrimary = item.GetImageInfo(ImageType.Primary, 0);
+        var imageUrlIsNull = string.IsNullOrWhiteSpace(channelInfo.ImageUrl);
+
+        // Update channel image if image URL has changed
+        if (currentPrimary is null
+            || (!imageUrlIsNull && !string.Equals(currentPrimary.Path, channelInfo.ImageUrl, StringComparison.Ordinal)))
         {
             if (!string.IsNullOrWhiteSpace(channelInfo.ImagePath))
             {
                 item.SetImagePath(ImageType.Primary, channelInfo.ImagePath);
                 forceUpdate = true;
             }
-            else if (!string.IsNullOrWhiteSpace(channelInfo.ImageUrl))
+            else if (!imageUrlIsNull)
             {
                 item.SetImagePath(ImageType.Primary, channelInfo.ImageUrl);
                 forceUpdate = true;


### PR DESCRIPTION
Alternative solution that doesn't add another prop to `LiveTvChannel`