### PR TITLE
Fix long live tv load times, Fixes #10761

### DIFF
--- a/Emby.Server.Implementations/Library/LiveStreamHelper.cs
+++ b/Emby.Server.Implementations/Library/LiveStreamHelper.cs
@@ -64,9 +64,13 @@ namespace Emby.Server.Implementations.Library
 
                     await jsonStream.DisposeAsync().ConfigureAwait(false);
                 }
-                catch
+                catch (IOException)
                 {
-                    _logger.LogError("Could not open cached media info");
+                    _logger.LogDebug("Could not open cached media info");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error opening cached media info");
                 }
             }
 

--- a/Emby.Server.Implementations/Library/LiveStreamHelper.cs
+++ b/Emby.Server.Implementations/Library/LiveStreamHelper.cs
@@ -64,9 +64,9 @@ namespace Emby.Server.Implementations.Library
 
                     await jsonStream.DisposeAsync().ConfigureAwait(false);
                 }
-                catch (IOException)
+                catch (IOException ex)
                 {
-                    _logger.LogDebug("Could not open cached media info");
+                    _logger.LogDebug(ex, "Could not open cached media info");
                 }
                 catch (Exception ex)
                 {

--- a/Emby.Server.Implementations/Library/LiveStreamHelper.cs
+++ b/Emby.Server.Implementations/Library/LiveStreamHelper.cs
@@ -48,20 +48,25 @@ namespace Emby.Server.Implementations.Library
 
             if (!string.IsNullOrEmpty(cacheKey))
             {
-                FileStream jsonStream = AsyncFile.OpenRead(cacheFilePath);
                 try
                 {
-                    mediaInfo = await JsonSerializer.DeserializeAsync<MediaInfo>(jsonStream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+                    FileStream jsonStream = AsyncFile.OpenRead(cacheFilePath);
 
-                    // _logger.LogDebug("Found cached media info");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error deserializing mediainfo cache");
-                }
-                finally
-                {
+                    try
+                    {
+                        mediaInfo = await JsonSerializer.DeserializeAsync<MediaInfo>(jsonStream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+                        // _logger.LogDebug("Found cached media info");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error deserializing mediainfo cache");
+                    }
+
                     await jsonStream.DisposeAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    _logger.LogError("Could not open cached media info");
                 }
             }
 

--- a/Emby.Server.Implementations/Library/LiveStreamHelper.cs
+++ b/Emby.Server.Implementations/Library/LiveStreamHelper.cs
@@ -52,17 +52,11 @@ namespace Emby.Server.Implementations.Library
                 {
                     FileStream jsonStream = AsyncFile.OpenRead(cacheFilePath);
 
-                    try
+                    await using (jsonStream.ConfigureAwait(false))
                     {
                         mediaInfo = await JsonSerializer.DeserializeAsync<MediaInfo>(jsonStream, _jsonOptions, cancellationToken).ConfigureAwait(false);
                         // _logger.LogDebug("Found cached media info");
                     }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error deserializing mediainfo cache");
-                    }
-
-                    await jsonStream.DisposeAsync().ConfigureAwait(false);
                 }
                 catch (IOException ex)
                 {


### PR DESCRIPTION
Second attempt at fixing this issue, this time i actually read the logs! Adds an extra test to check that the cached media info file can be read. This allows the rest of the function to run if the file doesn't exist.

**Changes**
Add extra try/catch to stop errors if trying to read cached media info file that doesn't exist

**Issues**
Fixes #10761 
