### PR TITLE
Use NuGetAuthenticate@1

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -259,7 +259,7 @@ jobs:
       publishFeedCredentials: 'NugetOrg'
       allowPackageConflicts: true # This ignores an error if the version already exists
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'Authenticate to unstable Nuget feed'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 


### PR DESCRIPTION
From the latest ci run:

> ##[warning]Task 'NuGet authenticate' version 0 (NuGetAuthenticate@0) is deprecated. This task will be removed. From January 31, 2024, onwards it may no longer be available. Please see https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/nuget-authenticate-v0 for more information about this task.
