### PR TITLE
Add PlaybackOrder to Session state

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -394,6 +394,7 @@ namespace Emby.Server.Implementations.Session
             session.PlayState.SubtitleStreamIndex = info.SubtitleStreamIndex;
             session.PlayState.PlayMethod = info.PlayMethod;
             session.PlayState.RepeatMode = info.RepeatMode;
+            session.PlayState.PlaybackOrder = info.PlaybackOrder;
             session.PlaylistItemId = info.PlaylistItemId;
 
             var nowPlayingQueue = info.NowPlayingQueue;

--- a/MediaBrowser.Model/Session/GeneralCommandType.cs
+++ b/MediaBrowser.Model/Session/GeneralCommandType.cs
@@ -48,6 +48,7 @@ namespace MediaBrowser.Model.Session
         PlayNext = 38,
         ToggleOsdMenu = 39,
         Play = 40,
-        SetMaxStreamingBitrate = 41
+        SetMaxStreamingBitrate = 41,
+        SetPlaybackOrder = 42
     }
 }

--- a/MediaBrowser.Model/Session/PlaybackOrder.cs
+++ b/MediaBrowser.Model/Session/PlaybackOrder.cs
@@ -1,0 +1,18 @@
+namespace MediaBrowser.Model.Session
+{
+    /// <summary>
+    /// Enum PlaybackOrder.
+    /// </summary>
+    public enum PlaybackOrder
+    {
+        /// <summary>
+        /// Sorted playlist.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Shuffled playlist.
+        /// </summary>
+        Shuffle = 1
+    }
+}

--- a/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
+++ b/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
@@ -107,6 +107,12 @@ namespace MediaBrowser.Model.Session
         /// <value>The repeat mode.</value>
         public RepeatMode RepeatMode { get; set; }
 
+        /// <summary>
+        /// Gets or sets the playback order.
+        /// </summary>
+        /// <value>The playback order.</value>
+        public PlaybackOrder PlaybackOrder { get; set; }
+
         public QueueItem[] NowPlayingQueue { get; set; }
 
         public string PlaylistItemId { get; set; }

--- a/MediaBrowser.Model/Session/PlayerStateInfo.cs
+++ b/MediaBrowser.Model/Session/PlayerStateInfo.cs
@@ -66,6 +66,12 @@ namespace MediaBrowser.Model.Session
         public RepeatMode RepeatMode { get; set; }
 
         /// <summary>
+        /// Gets or sets the playback order.
+        /// </summary>
+        /// <value>The playback order.</value>
+        public PlaybackOrder PlaybackOrder { get; set; }
+
+        /// <summary>
         /// Gets or sets the now playing live stream identifier.
         /// </summary>
         /// <value>The live stream identifier.</value>


### PR DESCRIPTION
Changes
~~Add ShuffleMode to Session state.~~
Add OrderMode to Session state.

SetShuffleQueue command is already listed as one of the supported commands by Session, but without the value of ShuffleMode it is not possible to send a valid request from jellyfin-web client.

Issues
Partially fixes https://github.com/jellyfin/jellyfin-web/issues/5012 (small changes in jellyfin-web client are required to fully fix this issue)