### PR TITLE
Use order in TMDb episode group as the episode number

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -276,7 +276,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 if (ep is not null)
                 {
                     seasonNumber = ep.SeasonNumber;
-                    episodeNumber = ep.EpisodeNumber;
+                    episodeNumber = ep.Order + 1;
                 }
             }
 


### PR DESCRIPTION
**Changes**
Jellyfin can use episode groups on TMDb to display different episode orders (e.g. the DVD order), if the user so chooses. This is currently broken, however, as Jellyfin displays the default (aired) order on TMDb.

I've changed this behaviour so that the episodes are now listed according to their order in the TMDb episode group.

**Issues**
Fixes #10937