### PR TITLE
Update README to include default web client urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cd Jellyfin.Server/bin/Debug/net8.0 # Change into the build output directory
 
 #### Accessing the Hosted Web Client
 
-If the Server is configured to host the Web Client, and the Server is running, the Web Client can be accessed at `localhost:8096` by default.
+If the Server is configured to host the Web Client, and the Server is running, the Web Client can be accessed at `http://localhost:8096` by default.
 
 API documentation can be viewed at `http://localhost:8096/api-docs/swagger/index.html`
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ cd Jellyfin.Server/bin/Debug/net8.0 # Change into the build output directory
 
 2. Execute the build output. On Linux, Mac, etc. use `./jellyfin` and on Windows use `jellyfin.exe`.
 
+#### Accessing the Hosted Web Client
+
+If the Server is configured to host the Web Client, and the Server is running, the Web Client can be accessed at `localhost:8096` by default.
+
+API documentation can be viewed at `http://localhost:8096/api-docs/swagger/index.html`
+
+
 ### Running from GH-Codespaces
 
 As Jellyfin will run on a container on a github hosted server, JF needs to handle some things differently.


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

I noticed there was nothing in the README about accessing the hosted Web Client or Swagger docs after the Server has been started. I thought it might be useful to include this information to assist new contributors. 

Most users might not need this information because the Web Client is opened automatically when launching in Visual Studio or vscode, however those who like to start the project via `dotnet run` won't have the web client opened automatically and would need find the urls by searching the command output, finding the launchSettings.json, or looking through the code.

This pull request adds information to the Server Development section of the README to list the default urls where the hosted Web Client and Swagger docs can be found.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None

