### PR TITLE
Fix InvalidOperationException if log file not found

### DIFF
--- a/tests/Jellyfin.Api.Tests/Controllers/SystemControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/SystemControllerTests.cs
@@ -1,0 +1,35 @@
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller;
+using MediaBrowser.Model.IO;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers
+{
+    public class SystemControllerTests
+    {
+        [Fact]
+        public void GetLogFile_FileDoesNotExist_ReturnsNotFound()
+        {
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem
+                .Setup(fs => fs.GetFiles(It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns([new() { Name = "file1.txt" }, new() { Name = "file2.txt" }]);
+
+            var controller = new SystemController(
+                Mock.Of<ILogger<SystemController>>(),
+                Mock.Of<IServerApplicationHost>(),
+                Mock.Of<IServerApplicationPaths>(),
+                mockFileSystem.Object,
+                Mock.Of<INetworkManager>(),
+                Mock.Of<ISystemManager>());
+
+            var result = controller.GetLogFile("DOES_NOT_EXIST.txt");
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
API route `System/Logs/Log` currently throws an InvalidOperationException and returns a 500 if the requested log file does not exist. 

I updated this method to handle this edge case and reutrn a 404.  

I also added unit tests to check that NotFound is returned if the file does not exist. I was going to add more unit tests for this method, but testing it is slightly difficult due to the lack of abstraction and using FileStream directly.  

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None