### PR TITLE
Fix CentOS/Fedora build and partial fix for Debian/Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
-                dotnet-sdk-8.0,
                 libc6-dev,
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,

--- a/deployment/Dockerfile.centos.amd64
+++ b/deployment/Dockerfile.centos.amd64
@@ -12,8 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare CentOS environment
 RUN dnf update -yq \
  && dnf install -yq \
-    @buildsys-build rpmdevtools git \
-    dnf-plugins-core libcurl-devel fontconfig-devel \
+    rpmdevtools git libcurl-devel fontconfig-devel \
     freetype-devel openssl-devel glibc-devel \
     libicu-devel systemd wget make \
  && dnf clean all \

--- a/deployment/Dockerfile.fedora.amd64
+++ b/deployment/Dockerfile.fedora.amd64
@@ -12,8 +12,7 @@ ENV IS_DOCKER=YES
 # Prepare Fedora environment
 RUN dnf update -yq \
  && dnf install -yq \
-    @buildsys-build rpmdevtools git \
-    dnf-plugins-core libcurl-devel fontconfig-devel \
+    rpmdevtools git libcurl-devel fontconfig-devel \
     freetype-devel openssl-devel glibc-devel \
     libicu-devel systemd wget make \
  && dnf clean all \

--- a/deployment/build.centos.amd64
+++ b/deployment/build.centos.amd64
@@ -10,7 +10,7 @@ pushd "${SOURCE_DIR}"
 
 if [[ ${IS_DOCKER} == YES ]]; then
     # Remove BuildRequires for dotnet, since it's installed manually
-    pushd centos
+    pushd fedora
 
     cp -a jellyfin.spec /tmp/spec.orig
     sed -i 's/BuildRequires:  dotnet/# BuildRequires:  dotnet/' jellyfin.spec
@@ -20,7 +20,7 @@ fi
 
 # Modify changelog to unstable configuration if IS_UNSTABLE
 if [[ ${IS_UNSTABLE} == 'yes' ]]; then
-    pushd centos
+    pushd fedora
 
     PR_ID=$( git log --grep 'Merge pull request' --oneline --single-worktree --first-parent | head -1 | grep --color=none -Eo '#[0-9]+' | tr -d '#' )
 
@@ -35,7 +35,7 @@ EOF
 fi
 
 # Build RPM
-make -f centos/Makefile srpm outdir=/root/rpmbuild/SRPMS
+make -f fedora/Makefile srpm outdir=/root/rpmbuild/SRPMS
 rpmbuild --rebuild -bb /root/rpmbuild/SRPMS/jellyfin-*.src.rpm
 
 # Move the artifacts out
@@ -45,10 +45,10 @@ if [[ ${IS_DOCKER} == YES ]]; then
     chown -Rc "$(stat -c %u:%g "${ARTIFACT_DIR}")" "${ARTIFACT_DIR}"
 fi
 
-rm -f centos/jellyfin*.tar.gz
+rm -f fedorajellyfin*.tar.gz
 
 if [[ ${IS_DOCKER} == YES ]]; then
-    pushd centos
+    pushd fedora
 
     cp -a /tmp/spec.orig jellyfin.spec
     chown -Rc "$(stat -c %u:%g "${ARTIFACT_DIR}")" "${ARTIFACT_DIR}"


### PR DESCRIPTION
This PR is in draft since it's not fixing completely action building because of the related issue mentionned, but it fix the CentOS failing build.

**Changes**
- Removed dotnet-sdk-8.0 from required dependencies because of the NET 8.0 docker image that install dotnet-sdk-8.0 not as a package
- Remove unnecessary package from CentOS/Fedora Dockerfile

**Issues**
Related Issue: https://github.com/jellyfin/jellyfin/issues/10970
