### PR TITLE
Fix some incompatible API deprecations

### DIFF
--- a/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
+++ b/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions.Json.Converters;
@@ -49,6 +50,18 @@ public class ClientCapabilitiesDto
     /// Gets or sets the icon url.
     /// </summary>
     public string? IconUrl { get; set; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    // TODO: Remove after 10.9
+    [Obsolete("Unused")]
+    [DefaultValue(false)]
+    public bool? SupportsContentUploading { get; set; }
+
+    // TODO: Remove after 10.9
+    [Obsolete("Unused")]
+    [DefaultValue(false)]
+    public bool? SupportsSync { get; set; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Convert the dto to the full <see cref="ClientCapabilities"/> model.

--- a/MediaBrowser.Model/Session/ClientCapabilities.cs
+++ b/MediaBrowser.Model/Session/ClientCapabilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Dlna;
 
@@ -30,5 +31,15 @@ namespace MediaBrowser.Model.Session
         public string AppStoreUrl { get; set; }
 
         public string IconUrl { get; set; }
+
+        // TODO: Remove after 10.9
+        [Obsolete("Unused")]
+        [DefaultValue(false)]
+        public bool? SupportsContentUploading { get; set; }
+
+        // TODO: Remove after 10.9
+        [Obsolete("Unused")]
+        [DefaultValue(false)]
+        public bool? SupportsSync { get; set; }
     }
 }

--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -3,29 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.ComponentModel;
 using MediaBrowser.Model.Updates;
 
 namespace MediaBrowser.Model.System
 {
-    /// <summary>
-    /// Enum describing the location of the FFmpeg tool.
-    /// </summary>
-    public enum FFmpegLocation
-    {
-        /// <summary>No path to FFmpeg found.</summary>
-        NotFound,
-
-        /// <summary>Path supplied via command line using switch --ffmpeg.</summary>
-        SetByArgument,
-
-        /// <summary>User has supplied path via Transcoding UI page.</summary>
-        Custom,
-
-        /// <summary>FFmpeg tool found on system $PATH.</summary>
-        System
-    }
-
     /// <summary>
     /// Class SystemInfo.
     /// </summary>
@@ -83,9 +65,11 @@ namespace MediaBrowser.Model.System
         /// </summary>
         /// <value><c>true</c>.</value>
         [Obsolete("This is always true")]
+        [DefaultValue(true)]
         public bool CanSelfRestart { get; set; } = true;
 
         [Obsolete("This is always false")]
+        [DefaultValue(false)]
         public bool CanLaunchWebBrowser { get; set; } = false;
 
         /// <summary>
@@ -140,12 +124,15 @@ namespace MediaBrowser.Model.System
         /// </summary>
         /// <value><c>true</c> if this instance has update available; otherwise, <c>false</c>.</value>
         [Obsolete("This should be handled by the package manager")]
+        [DefaultValue(false)]
         public bool HasUpdateAvailable { get; set; }
 
         [Obsolete("This isn't set correctly anymore")]
-        public FFmpegLocation EncoderLocation { get; set; }
+        [DefaultValue("System")]
+        public string EncoderLocation { get; set; } = "System";
 
         [Obsolete("This is no longer set")]
-        public Architecture SystemArchitecture { get; set; } = Architecture.X64;
+        [DefaultValue("X64")]
+        public string SystemArchitecture { get; set; } = "X64";
     }
 }


### PR DESCRIPTION
Some small changes to make the current Android TV release work with unstable. There might be more, I'll hunt for all of them once the initial release candidate is out.

**Changes**
- Add back `SupportsContentUploading` and `SupportsSync` to client capabilities, but mark them as nullable and set a default value. Will propagate through the Kotlin SDK to the app with 10.9 so we can remove the properties in 10.10 (as the SDK no longer requires them).
- In SystemInfo specify some default values so we can remove those properties in the future
- In SystemInfo remove some types (Architecture and ffmpeglocation) so they generate as simple strings. this is just to reduce the amount of models in the OpenAPI spec, nothing fancy.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
