### PR TITLE
fix: disable tracerpt for debian package build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Team <team@jellyfin.org>
 Build-Depends:  debhelper (>= 9),
-                dotnet-sdk-8.0,
                 libc6-dev,
                 libcurl4-openssl-dev,
                 libfontconfig1-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -32,6 +32,7 @@ endif
 
 export DH_VERBOSE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_LTTNG=0
 
 %:
 	dh $@
@@ -45,6 +46,9 @@ override_dh_clistrip:
 override_dh_auto_build:
 	dotnet publish -maxcpucount:1 --configuration $(CONFIG) --output='$(CURDIR)/usr/lib/jellyfin/bin' --self-contained --runtime $(DOTNETRUNTIME) \
 		-p:DebugSymbols=false -p:DebugType=none Jellyfin.Server
+	# A workaround for upstream issue: https://github.com/dotnet/runtime/issues/57784
+	# dotnet is requiring an old version of liblttng which is no longer shipped in debian
+	rm -f '$(CURDIR)/usr/lib/jellyfin/bin/libcoreclrtraceptprovider.so'
 
 override_dh_auto_clean:
 	dotnet clean -maxcpucount:1 --configuration $(CONFIG) Jellyfin.Server || true


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR removed dotnet package dependency from the package meta because the Microsoft official docker image no longer providing them.
This PR also disabled tracerpt for debian builds, as the `libcoreclrtraceptprovider` is linking against an older version of `liblttng-ust` which is no longer available in debian and prevents the package to be built. This lib does not affect the normal operation of jellyfin.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #10970