### PR TITLE
feat: Fully support hardware filters on Apple VideoToolbox

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6094,7 +6094,9 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Hardware surface only make sense when interop with OpenCL
             // VideoToolbox's Hardware surface in ffmpeg is not only slower than hwupload, but also breaks HDR in many cases.
             // For example: https://trac.ffmpeg.org/ticket/10884
-            var useOclToneMapping = !IsVideoToolboxTonemapAvailable(state, options) && IsHwTonemapAvailable(state, options);
+            var useOclToneMapping = !IsVideoToolboxTonemapAvailable(state, options) &&
+                                    options.EnableTonemapping &&
+                                    state.VideoStream.VideoRangeType == VideoRangeType.DOVI;
             var useHwSurface = useOclToneMapping && IsVideoToolBoxFullSupported() && _mediaEncoder.SupportsFilter("alphasrc");
 
             if (is8bitSwFormatsVt)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2970,14 +2970,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 arg2 = (isSizeFixed ? ':' : '=') + arg2;
             }
 
-            if (string.Equals(hwScaleSuffix, "vt", StringComparison.OrdinalIgnoreCase))
-            {
-                // VideoToolBox scaling filter requires different syntax
-                arg1 = isSizeFixed ? ("=" + outWidth.Value + ":" + outHeight.Value) : string.Empty;
-                // VideoToolBox does format conversion automatically
-                arg2 = string.Empty;
-            }
-
             if (!string.IsNullOrEmpty(hwScaleSuffix) && (isSizeFixed || isFormatFixed))
             {
                 return string.Format(
@@ -5026,11 +5018,13 @@ namespace MediaBrowser.Controller.MediaEncoding
             newfilters.Add("hwupload");
             if (supportsHwScale)
             {
-                var hwScaleFilter = GetHwScaleFilter("vt", string.Empty, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
-                if (true)
+                var hwScaleFilter = GetHwScaleFilter("vt", null, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
+                if (useHwToneMapping)
                 {
-                    hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter) ? "scale_vt=0:0:bt709:bt709:bt709"
-                        : string.Format(CultureInfo.InvariantCulture, hwScaleFilter, ":bt709:bt709:bt709");
+                    var tonemapArgs = "color_matrix=bt709:color_primaries=bt709:color_transfer=bt709";
+                    hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter)
+                        ? "scale_vt=" + tonemapArgs
+                        : hwScaleFilter + ":" + tonemapArgs;
                 }
 
                 newfilters.Add(hwScaleFilter);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -309,7 +309,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                    && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
         }
 
-        private bool IsVideoToolboxVppTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
+        private bool IsVideoToolboxTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
         {
             if (state.VideoStream is null
                 || !options.EnableVideoToolboxTonemapping
@@ -5003,7 +5003,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var supportsHwDeint = _mediaEncoder.SupportsFilter("yadif_videotoolbox");
             var supportsHwScale = _mediaEncoder.SupportsFilter("scale_vt");
             // VideoToolbox is special. It does not use a separate tone mapping filter like others. Instead, it performs both tone mapping and scaling in a single filter.
-            var useHwToneMapping = IsVideoToolboxVppTonemapAvailable(state, options) && supportsHwScale;
+            var useHwToneMapping = IsVideoToolboxTonemapAvailable(state, options) && supportsHwScale;
             // fallback to software filters if we are using filters not supported by hardware yet.
             var useHardwareFilters = noOverlay && (!doDeintH2645 || supportsHwDeint);
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5019,7 +5019,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doOclTonemap = !doVtTonemap && IsHwTonemapAvailable(state, options);
 
             var scaleFormat = string.Empty;
-            if (GetVideoColorBitDepth(state) == 10)
+            if (!string.Equals(state.VideoStream.PixelFormat, "yuv420p", StringComparison.OrdinalIgnoreCase))
             {
                 // Use P010 for OpenCL tone mapping, otherwise force an 8bit output.
                 scaleFormat = doOclTonemap ? "p010le" : "nv12";

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5039,12 +5039,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            if (!(doTonemap || doScale || hasSubs || doDeintH2645))
-            {
-                // Dummy action to return empty filters when nothing to do.
-                return (mainFilters, mainFilters, mainFilters);
-            }
-
             // Color override is only required for OpenCL where hardware surface is in use
             if (doOclTonemap)
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -272,8 +272,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var isNvdecDecoder = vidDecoder.Contains("cuda", StringComparison.OrdinalIgnoreCase);
                 var isVaapiDecoder = vidDecoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase);
                 var isD3d11vaDecoder = vidDecoder.Contains("d3d11va", StringComparison.OrdinalIgnoreCase);
-                var isVideoToolBoxDecoder = vidDecoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase);
-                return isSwDecoder || isNvdecDecoder || isVaapiDecoder || isD3d11vaDecoder || isVideoToolBoxDecoder;
+                return isSwDecoder || isNvdecDecoder || isVaapiDecoder || isD3d11vaDecoder;
             }
 
             return state.VideoStream.VideoRange == VideoRange.HDR
@@ -317,8 +316,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 return false;
             }
+
+            // Certain DV profile 5 video works in Safari with direct playing, but the VideoToolBox does not produce correct mapping results with trascoding.
+            // All other HDR formats working.
             return state.VideoStream.VideoRange == VideoRange.HDR
-                   && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
+                   && state.VideoStream.VideoRangeType is VideoRangeType.HDR10 or VideoRangeType.HLG or VideoRangeType.HDR10Plus;
         }
 
         /// <summary>
@@ -5025,7 +5027,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (supportsHwScale)
             {
                 var hwScaleFilter = GetHwScaleFilter("vt", string.Empty, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
-                if (useHwToneMapping)
+                if (true)
                 {
                     hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter) ? "scale_vt=0:0:bt709:bt709:bt709"
                         : string.Format(CultureInfo.InvariantCulture, hwScaleFilter, ":bt709:bt709:bt709");

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -309,6 +309,18 @@ namespace MediaBrowser.Controller.MediaEncoding
                    && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
         }
 
+        private bool IsVideoToolboxVppTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
+        {
+            if (state.VideoStream is null
+                || !options.EnableVideoToolboxTonemapping
+                || GetVideoColorBitDepth(state) != 10)
+            {
+                return false;
+            }
+            return state.VideoStream.VideoRange == VideoRange.HDR
+                   && state.VideoStream.VideoRangeType == VideoRangeType.HDR10;
+        }
+
         /// <summary>
         /// Gets the name of the output video codec.
         /// </summary>
@@ -4991,7 +5003,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var supportsHwDeint = _mediaEncoder.SupportsFilter("yadif_videotoolbox");
             var supportsHwScale = _mediaEncoder.SupportsFilter("scale_vt");
             // VideoToolbox is special. It does not use a separate tone mapping filter like others. Instead, it performs both tone mapping and scaling in a single filter.
-            var useHwToneMapping = IsHwTonemapAvailable(state, options) && supportsHwScale;
+            var useHwToneMapping = IsVideoToolboxVppTonemapAvailable(state, options) && supportsHwScale;
             // fallback to software filters if we are using filters not supported by hardware yet.
             var useHardwareFilters = noOverlay && (!doDeintH2645 || supportsHwDeint);
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2955,6 +2955,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 arg2 = (isSizeFixed ? ':' : '=') + arg2;
             }
+
             if (string.Equals(hwScaleSuffix, "vt", StringComparison.OrdinalIgnoreCase))
             {
                 // VideoToolBox scaling filter requires different syntax
@@ -5004,18 +5005,20 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, inW, inH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 newfilters.Add(swScaleFilter);
             }
+
             // hwupload on videotoolbox encoders can automatically convert AVFrame into its CVPixelBuffer equivalent
             // videotoolbox will automatically convert the CVPixelBuffer to a pixel format the encoder supports, so we don't have to set a pixel format explicitly here
             // This will reduce CPU usage significantly on UHD videos with 10 bit colors because we bypassed the ffmpeg pixel format conversion
             newfilters.Add("hwupload");
             if (supportsHwScale)
             {
-                var hwScaleFilter = GetHwScaleFilter("vt", "", inW, inH, reqW, reqH, reqMaxW, reqMaxH);
+                var hwScaleFilter = GetHwScaleFilter("vt", string.Empty, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
                 if (useHwToneMapping)
                 {
                     hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter) ? "scale_vt=0:0:bt709:bt709:bt709"
                         : string.Format(CultureInfo.InvariantCulture, hwScaleFilter, ":bt709:bt709:bt709");
                 }
+
                 newfilters.Add(hwScaleFilter);
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -253,7 +253,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                    && _mediaEncoder.SupportsFilterWithOption(FilterOptionType.OverlayVulkanFrameSync);
         }
 
-        private bool IsVideoToolBoxFullSupported()
+        private bool IsVideoToolboxFullSupported()
         {
             return _mediaEncoder.SupportsHwaccel("videotoolbox")
                 && _mediaEncoder.SupportsFilter("yadif_videotoolbox")
@@ -4978,100 +4978,118 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return (null, null, null);
             }
 
-            var swFilterChain = GetSwVidFilterChain(state, options, vidEncoder);
+            var isMacOS = OperatingSystem.IsMacOS();
+            var vidDecoder = GetHardwareVideoDecoder(state, options) ?? string.Empty;
+            var isVtEncoder = vidEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase);
+            var isVtFullSupported = isMacOS && IsVideoToolboxFullSupported();
+            var isVtOclSupported = isVtFullSupported && IsOpenclFullSupported();
 
-            if (!options.EnableHardwareEncoding)
+            // legacy videotoolbox pipeline (disable hw filters)
+            if (!isVtEncoder
+                || !isVtOclSupported
+                || !_mediaEncoder.SupportsFilter("alphasrc"))
             {
-                return swFilterChain;
+                return GetSwVidFilterChain(state, options, vidEncoder);
             }
 
-            var doDeintH264 = state.DeInterlace("h264", true) || state.DeInterlace("avc", true);
-            var doDeintHevc = state.DeInterlace("h265", true) || state.DeInterlace("hevc", true);
-            var doDeintH2645 = doDeintH264 || doDeintHevc;
+            // preferred videotoolbox + vt/ocl filters pipeline
+            return GetAppleVidFiltersPreferred(state, options, vidDecoder, vidEncoder);
+        }
+
+        public (List<string> MainFilters, List<string> SubFilters, List<string> OverlayFilters) GetAppleVidFiltersPreferred(
+            EncodingJobInfo state,
+            EncodingOptions options,
+            string vidDecoder,
+            string vidEncoder)
+        {
             var inW = state.VideoStream?.Width;
             var inH = state.VideoStream?.Height;
             var reqW = state.BaseRequest.Width;
             var reqH = state.BaseRequest.Height;
             var reqMaxW = state.BaseRequest.MaxWidth;
             var reqMaxH = state.BaseRequest.MaxHeight;
-            var mainFilters = new List<string>();
+            var threeDFormat = state.MediaSource.Video3DFormat;
+
+            var isVtEncoder = vidEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase);
+
+            var doDeintH264 = state.DeInterlace("h264", true) || state.DeInterlace("avc", true);
+            var doDeintHevc = state.DeInterlace("h265", true) || state.DeInterlace("hevc", true);
+            var doDeintH2645 = doDeintH264 || doDeintHevc;
+            var doVtTonemap = IsVideoToolboxTonemapAvailable(state, options);
+            var doOclTonemap = !doVtTonemap && IsHwTonemapAvailable(state, options);
+            var doTonemap = doVtTonemap || doOclTonemap;
+
             var hasSubs = state.SubtitleStream is not null && state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode;
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
             var hasGraphicalSubs = hasSubs && !state.SubtitleStream.IsTextSubtitleStream;
             var hasAssSubs = hasSubs
-                             && (string.Equals(state.SubtitleStream.Codec, "ass", StringComparison.OrdinalIgnoreCase)
-                                 || string.Equals(state.SubtitleStream.Codec, "ssa", StringComparison.OrdinalIgnoreCase));
-            // VideoToolbox is special. It does not use a separate tone mapping filter like others.
-            // Instead, it performs both tone mapping and scaling in a single filter.
-            var useVtToneMapping = IsVideoToolboxTonemapAvailable(state, options);
-            // Use OpenCL tone mapping as a fallback
-            var useOclToneMapping = !useVtToneMapping && IsHwTonemapAvailable(state, options);
-            // Fallback to software filters if we are using filters not supported by hardware yet.
-            // OpenCL won't work without proper VT support as the hwmap interop required will not be present there
-            var useHardwareFilters = IsVideoToolBoxFullSupported();
+                && (string.Equals(state.SubtitleStream.Codec, "ass", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(state.SubtitleStream.Codec, "ssa", StringComparison.OrdinalIgnoreCase));
 
-            if (!useHardwareFilters)
+            // FIXME: scale_vt lacks of format option for the time being.
+            // hwdownload/hwmap to sw requires setting a format explicitly.
+            if (!isVtEncoder)
             {
-                return swFilterChain;
+                // should not happen.
+                return (null, null, null);
             }
 
-            if (!(useVtToneMapping || useOclToneMapping || hasSubs || doDeintH2645))
+            /* Make main filters for video stream */
+            var mainFilters = new List<string>();
+
+            if (!(doTonemap || hasSubs || doDeintH2645))
             {
                 // Dummy action to return empty filters when nothing to do.
                 return (mainFilters, mainFilters, mainFilters);
             }
 
-            // Override the color when doing OpenCL Tone mapping, where we are using hardware surface output.
-            if (useOclToneMapping)
+            // Color override is only required for OpenCL where hardware surface is in use
+            if (doOclTonemap)
             {
-                mainFilters.Add(GetOverwriteColorPropertiesParam(state, true));
+                mainFilters.Add(GetOverwriteColorPropertiesParam(state, doOclTonemap));
             }
 
-            // With OpenCL tone mapping, we are using native hwmap and there's no need to specify a format for the main stream.
-            // However, for other cases, we have to specify the format for the main stream when we are doing subtitle burn-in.
-            // This is because the default upload option is not always processable with VideoToolbox.
-            // Most notably, yuv420p should be replaced by nv12.
-            else if (hasSubs)
-            {
-                var is8Bit = string.Equals("yuv420p", state.VideoStream.PixelFormat, StringComparison.OrdinalIgnoreCase)
-                                        || string.Equals("yuvj420p", state.VideoStream.PixelFormat, StringComparison.OrdinalIgnoreCase);
-                var is10Bit = string.Equals("yuv420p10le", state.VideoStream.PixelFormat, StringComparison.OrdinalIgnoreCase);
+            // INPUT videotoolbox/memory surface(vram/uma)
+            // this will pass-through automatically if in/out format matches.
+            mainFilters.Add("format=nv12|p010le|videotoolbox_vld");
+            mainFilters.Add("hwupload=derive_device=videotoolbox");
 
-                if (is8Bit)
-                {
-                    mainFilters.Add("format=nv12");
-                }
-                else if (is10Bit)
-                {
-                    mainFilters.Add("format=p010");
-                }
-            }
-
-            mainFilters.Add("hwupload");
-            var hwScaleFilter = GetHwScaleFilter("vt", null, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
-            if (useVtToneMapping)
-            {
-                const string TonemapArgs = "color_matrix=bt709:color_primaries=bt709:color_transfer=bt709";
-                hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter)
-                    ? "scale_vt=" + TonemapArgs
-                    : hwScaleFilter + ":" + TonemapArgs;
-            }
-
-            mainFilters.Add(hwScaleFilter);
-
-            if (useOclToneMapping)
-            {
-                mainFilters.Add("hwmap=derive_device=opencl");
-                mainFilters.Add(GetHwTonemapFilter(options, "opencl", "nv12"));
-                mainFilters.Add("hwmap=derive_device=videotoolbox:reverse=1");
-            }
-
+            // hw deint
             if (doDeintH2645)
             {
                 var deintFilter = GetHwDeinterlaceFilter(state, options, "videotoolbox");
                 mainFilters.Add(deintFilter);
             }
 
+            var hwScaleFilter = GetHwScaleFilter("vt", null, inW, inH, reqW, reqH, reqMaxW, reqMaxH);
+            if (doVtTonemap)
+            {
+                const string VtTonemapArgs = "color_matrix=bt709:color_primaries=bt709:color_transfer=bt709";
+
+                // scale_vt can handle scaling & tonemapping in one shot, just like vpp_qsv.
+                hwScaleFilter = string.IsNullOrEmpty(hwScaleFilter)
+                    ? "scale_vt=" + VtTonemapArgs
+                    : hwScaleFilter + ":" + VtTonemapArgs;
+            }
+
+            // hw scale & vt tonemap
+            mainFilters.Add(hwScaleFilter);
+
+            // ocl tonemap
+            if (doOclTonemap)
+            {
+                // map from videotoolbox to opencl via videotoolbox-opencl interop.
+                mainFilters.Add("hwmap=derive_device=opencl:mode=read");
+
+                var tonemapFilter = GetHwTonemapFilter(options, "opencl", "nv12");
+                mainFilters.Add(tonemapFilter);
+
+                // OUTPUT videotoolbox(nv12) surface(vram/uma)
+                // reverse-mapping via videotoolbox-opencl interop.
+                mainFilters.Add("hwmap=derive_device=videotoolbox:mode=write:reverse=1");
+            }
+
+            /* Make sub and overlay filters for subtitle stream */
             var subFilters = new List<string>();
             var overlayFilters = new List<string>();
 
@@ -6094,10 +6112,17 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Hardware surface only make sense when interop with OpenCL
             // VideoToolbox's Hardware surface in ffmpeg is not only slower than hwupload, but also breaks HDR in many cases.
             // For example: https://trac.ffmpeg.org/ticket/10884
-            var useOclToneMapping = !IsVideoToolboxTonemapAvailable(state, options) &&
-                                    options.EnableTonemapping &&
-                                    state.VideoStream.VideoRangeType == VideoRangeType.DOVI;
-            var useHwSurface = useOclToneMapping && IsVideoToolBoxFullSupported() && _mediaEncoder.SupportsFilter("alphasrc");
+            var useOclToneMapping = !IsVideoToolboxTonemapAvailable(state, options)
+                                    && options.EnableTonemapping
+                                    && state.VideoStream is not null
+                                    && GetVideoColorBitDepth(state) == 10
+                                    && state.VideoStream.VideoRange == VideoRange.HDR
+                                    && (state.VideoStream.VideoRangeType == VideoRangeType.HDR10
+                                        || state.VideoStream.VideoRangeType == VideoRangeType.HLG
+                                        || (state.VideoStream.VideoRangeType == VideoRangeType.DOVI
+                                            && string.Equals(state.VideoStream.Codec, "hevc", StringComparison.OrdinalIgnoreCase)));
+
+            var useHwSurface = useOclToneMapping && IsVideoToolboxFullSupported() && _mediaEncoder.SupportsFilter("alphasrc");
 
             if (is8bitSwFormatsVt)
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4999,7 +4999,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // VideoToolbox is special. It does not use a separate tone mapping filter like others. Instead, it performs both tone mapping and scaling in a single filter.
             var useHwToneMapping = IsVideoToolboxTonemapAvailable(state, options) && supportsHwScale;
             // fallback to software filters if we are using filters not supported by hardware yet.
-            var useHardwareFilters = noOverlay && (!doDeintH2645 || supportsHwDeint);
+            var useHardwareFilters = noOverlay && (!doDeintH2645 || supportsHwDeint || supportsHwScale);
 
             if (!useHardwareFilters)
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5026,6 +5026,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 mainFilters.Add(GetOverwriteColorPropertiesParam(state, true));
             }
+
             // With OpenCL tone mapping, we are using native hwmap and there's no need to specify a format for the main stream.
             // However, for other cases, we have to specify the format for the main stream when we are doing subtitle burn-in.
             // This is because the default upload option is not always processable with VideoToolbox.
@@ -5039,7 +5040,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (is8Bit)
                 {
                     mainFilters.Add("format=nv12");
-                } else if (is10Bit)
+                }
+                else if (is10Bit)
                 {
                     mainFilters.Add("format=p010");
                 }

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -129,6 +129,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // videotoolbox
             "yadif_videotoolbox",
             "scale_vt",
+            "overlay_videotoolbox",
             // rkrga
             "scale_rkrga",
             "vpp_rkrga",

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -128,6 +128,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "overlay_vulkan",
             // videotoolbox
             "yadif_videotoolbox",
+            "scale_vt",
             // rkrga
             "scale_rkrga",
             "vpp_rkrga",

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -28,6 +28,7 @@ public class EncodingOptions
         VaapiDevice = "/dev/dri/renderD128";
         EnableTonemapping = false;
         EnableVppTonemapping = false;
+        EnableVideoToolboxTonemapping = false;
         TonemappingAlgorithm = "bt2390";
         TonemappingMode = "auto";
         TonemappingRange = "auto";

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -147,6 +147,11 @@ public class EncodingOptions
     public bool EnableVppTonemapping { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether videotoolbox tonemapping is enabled.
+    /// </summary>
+    public bool EnableVideoToolboxTonemapping { get; set; }
+
+    /// <summary>
     /// Gets or sets the tone-mapping algorithm.
     /// </summary>
     public string TonemappingAlgorithm { get; set; }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The upstream ffmpeg 6.1 released with a new `scale_vt` filter which provides support for scaling and tone mapping using VideoToolBox's native method.  This PR:
- Enables hardware scale filter if possible
- Enables hardware tone mapping is possible

One thing to note is that the VideoToolBox's tone mapping method has to use hard-coded Apple's parameters and does not have any tunable like other filters, but Apple's settings looks good enough to me.

Currently the WebUI does not have the options for enabling Tone Mapping for VideoToolBox, which need to be implemented separately as it does not have the tunable options available to other implementations.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
