### PR TITLE
Always make userId query parameter optional

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using Jellyfin.Api.Helpers;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Extensions;
@@ -48,15 +49,17 @@ public class DisplayPreferencesController : BaseJellyfinApiController
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "displayPreferencesId", Justification = "Imported from ServiceStack")]
     public ActionResult<DisplayPreferencesDto> GetDisplayPreferences(
         [FromRoute, Required] string displayPreferencesId,
-        [FromQuery, Required] Guid userId,
+        [FromQuery] Guid? userId,
         [FromQuery, Required] string client)
     {
+        userId = RequestHelpers.GetUserId(User, userId);
+
         if (!Guid.TryParse(displayPreferencesId, out var itemId))
         {
             itemId = displayPreferencesId.GetMD5();
         }
 
-        var displayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId, itemId, client);
+        var displayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId.Value, itemId, client);
         var itemPreferences = _displayPreferencesManager.GetItemDisplayPreferences(displayPreferences.UserId, itemId, displayPreferences.Client);
         itemPreferences.ItemId = itemId;
 
@@ -113,10 +116,12 @@ public class DisplayPreferencesController : BaseJellyfinApiController
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "displayPreferencesId", Justification = "Imported from ServiceStack")]
     public ActionResult UpdateDisplayPreferences(
         [FromRoute, Required] string displayPreferencesId,
-        [FromQuery, Required] Guid userId,
+        [FromQuery] Guid? userId,
         [FromQuery, Required] string client,
         [FromBody, Required] DisplayPreferencesDto displayPreferences)
     {
+        userId = RequestHelpers.GetUserId(User, userId);
+
         HomeSectionType[] defaults =
         {
             HomeSectionType.SmallLibraryTiles,
@@ -134,7 +139,7 @@ public class DisplayPreferencesController : BaseJellyfinApiController
             itemId = displayPreferencesId.GetMD5();
         }
 
-        var existingDisplayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId, itemId, client);
+        var existingDisplayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId.Value, itemId, client);
         existingDisplayPreferences.IndexBy = Enum.TryParse<IndexingKind>(displayPreferences.IndexBy, true, out var indexBy) ? indexBy : null;
         existingDisplayPreferences.ShowBackdrop = displayPreferences.ShowBackdrop;
         existingDisplayPreferences.ShowSidebar = displayPreferences.ShowSidebar;
@@ -204,7 +209,7 @@ public class DisplayPreferencesController : BaseJellyfinApiController
         itemPrefs.ItemId = itemId;
 
         // Set all remaining custom preferences.
-        _displayPreferencesManager.SetCustomItemDisplayPreferences(userId, itemId, existingDisplayPreferences.Client, displayPreferences.CustomPrefs);
+        _displayPreferencesManager.SetCustomItemDisplayPreferences(userId.Value, itemId, existingDisplayPreferences.Client, displayPreferences.CustomPrefs);
         _displayPreferencesManager.SaveChanges();
 
         return NoContent();

--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -64,8 +64,9 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <returns>A <see cref="Task"/> containing a <see cref="PlaybackInfoResponse"/> with the playback information.</returns>
     [HttpGet("Items/{itemId}/PlaybackInfo")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<ActionResult<PlaybackInfoResponse>> GetPlaybackInfo([FromRoute, Required] Guid itemId, [FromQuery, Required] Guid userId)
+    public async Task<ActionResult<PlaybackInfoResponse>> GetPlaybackInfo([FromRoute, Required] Guid itemId, [FromQuery] Guid? userId)
     {
+        userId = RequestHelpers.GetUserId(User, userId);
         return await _mediaInfoHelper.GetPlaybackInfo(
                 itemId,
                 userId)

--- a/Jellyfin.Api/Controllers/PlaylistsController.cs
+++ b/Jellyfin.Api/Controllers/PlaylistsController.cs
@@ -174,7 +174,7 @@ public class PlaylistsController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<QueryResult<BaseItemDto>> GetPlaylistItems(
         [FromRoute, Required] Guid playlistId,
-        [FromQuery, Required] Guid userId,
+        [FromQuery] Guid? userId,
         [FromQuery] int? startIndex,
         [FromQuery] int? limit,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ItemFields[] fields,
@@ -183,15 +183,16 @@ public class PlaylistsController : BaseJellyfinApiController
         [FromQuery] int? imageTypeLimit,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] ImageType[] enableImageTypes)
     {
+        userId = RequestHelpers.GetUserId(User, userId);
         var playlist = (Playlist)_libraryManager.GetItemById(playlistId);
         if (playlist is null)
         {
             return NotFound();
         }
 
-        var user = userId.IsEmpty()
+        var user = userId.IsNullOrEmpty()
             ? null
-            : _userManager.GetUserById(userId);
+            : _userManager.GetUserById(userId.Value);
 
         var items = playlist.GetManageableItems().ToArray();
         var count = items.Length;


### PR DESCRIPTION
This changes a few API endpoints that currently require a user id as query parameter.

This is both a nice-to-have change for client devs and a potential security fix. I haven't verified but it looks like before this change any authenticated user could get/post the display preferences of all users.

**Changes**
- Make userId optional in various operations from the DisplayPreferences, MediaInfo and Playlists API's

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
