### PR TITLE
Make userId optional in GetProgramsDto

### DIFF
--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -628,7 +628,7 @@ public class LiveTvController : BaseJellyfinApiController
     [Authorize(Policy = Policies.LiveTvAccess)]
     public async Task<ActionResult<QueryResult<BaseItemDto>>> GetPrograms([FromBody] GetProgramsDto body)
     {
-        var user = body.UserId.IsEmpty() ? null : _userManager.GetUserById(body.UserId);
+        var user = body.UserId.IsNullOrEmpty() ? null : _userManager.GetUserById(body.UserId.Value);
 
         var query = new InternalItemsQuery(user)
         {

--- a/Jellyfin.Api/Models/LiveTvDtos/GetProgramsDto.cs
+++ b/Jellyfin.Api/Models/LiveTvDtos/GetProgramsDto.cs
@@ -22,7 +22,7 @@ public class GetProgramsDto
     /// <summary>
     /// Gets or sets optional. Filter by user id.
     /// </summary>
-    public Guid UserId { get; set; }
+    public Guid? UserId { get; set; }
 
     /// <summary>
     /// Gets or sets the minimum premiere start date.


### PR DESCRIPTION
Similar to #11024 but updates the request models instead of query parameters. Only thing left now is routes which is a bit more of a challenge...

**Changes**
- Make userId optional in GetProgramsDto

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
