### PR TITLE
Add ability to enable/disable libraries

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -180,6 +180,7 @@
  _ [Barasingha](https://github.com/MaVdbussche)
  - [Gauvino](https://github.com/Gauvino)
  - [felix920506](https://github.com/felix920506)
+- [btopherjohnson](https://github.com/btopherjohnson)
 
 # Emby Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -180,7 +180,7 @@
  _ [Barasingha](https://github.com/MaVdbussche)
  - [Gauvino](https://github.com/Gauvino)
  - [felix920506](https://github.com/felix920506)
-- [btopherjohnson](https://github.com/btopherjohnson)
+ - [btopherjohnson](https://github.com/btopherjohnson)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -98,12 +98,12 @@ namespace MediaBrowser.Controller.Entities
 
         public override bool IsVisible(User user)
         {
-            if (GetLibraryOptions().Disabled)
+            if (GetLibraryOptions().Enabled)
             {
-                return false;
+                return base.IsVisible(user);
             }
 
-            return base.IsVisible(user);
+            return false;
         }
 
         private static LibraryOptions LoadLibraryOptions(string path)

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Controller.IO;
@@ -93,6 +94,16 @@ namespace MediaBrowser.Controller.Entities
         public LibraryOptions GetLibraryOptions()
         {
             return GetLibraryOptions(Path);
+        }
+
+        public override bool IsVisible(User user)
+        {
+            if (GetLibraryOptions().Disabled)
+            {
+                return false;
+            }
+
+            return base.IsVisible(user);
         }
 
         private static LibraryOptions LoadLibraryOptions(string path)

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -25,6 +25,8 @@ namespace MediaBrowser.Model.Configuration
             SeasonZeroDisplayName = "Specials";
         }
 
+        public bool Disabled { get; set; }
+
         public bool EnablePhotos { get; set; }
 
         public bool EnableRealtimeMonitor { get; set; }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -25,7 +25,7 @@ namespace MediaBrowser.Model.Configuration
             SeasonZeroDisplayName = "Specials";
         }
 
-        public bool Disabled { get; set; }
+        public bool Enabled { get; set; } = true;
 
         public bool EnablePhotos { get; set; }
 


### PR DESCRIPTION
This change addresses users desires to have the option to disable particular libraries for all users at certain times. This is handy for seasonal libraries (like christmas movies/music/tv shows).

I added a "Disabled" option to LibraryOptions.cs and a check to see if a library is disabled in CollectionFolder.cs (it overrides Folder's IsVisible function).

I chose "disabled" over "enabled" because the default value for booleans loaded into the LibraryOptions class by the JsonDeserializer is false, so by default, existing libraries will remain enabled.

I also made a corresponding checkbox in the jellyfin-web repository.

This commit addresses the issue described here:
https://features.jellyfin.org/posts/2530/hide-a-library-from-all-users-disable-library

MediaBrowser.Controller/Entities/CollectionFolder.cs - Added override to IsVisible to check if the library is disabled
MediaBrowser.Model/Configuration/LibraryOptions.cs - Added "Disabled" as an option for libraries.

