### PR TITLE
Fix Grouped Alternate Version Behavior

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -252,3 +252,4 @@
  - [JPUC1143](https://github.com/Jpuc1143/)
  - [0x25CBFC4F](https://github.com/0x25CBFC4F)
  - [Robert Lützner](https://github.com/rluetzner)
+ - [melanie gemini emory](https://github.com/one-new-message)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -374,6 +374,17 @@ namespace Emby.Server.Implementations.Library
 
                 try
                 {
+                    if (item.HasLocalAlternateVersions)
+                    {
+                        if (parent.GetBaseItemKind() is BaseItemKind.BoxSet)
+                        {
+                            var collectionManager = Folder.CollectionManager;
+                            IEnumerable<Guid> itemIds = [item.Id];
+
+                            collectionManager.RemoveFromCollectionAsync(parent.Id, itemIds);
+                        }
+                    }
+
                     Directory.Delete(metadataPath, true);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
**Changes**
Implements a basic check in `LibraryManager` to remove an item from containing collections before deletion.

**Issues**
Intended to fix #9281 and its related unexpected behavior.