### PR TITLE
Always use ffmpeg codec for bluray

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -324,20 +324,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 return;
             }
 
-            // Use BD Info if it has multiple m2ts. Otherwise, treat it like a video file and rely more on ffprobe output
-            int? currentHeight = null;
-            int? currentWidth = null;
-            int? currentBitRate = null;
-
-            var videoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
-
-            // Grab the values that ffprobe recorded
-            if (videoStream is not null)
-            {
-                currentBitRate = videoStream.BitRate;
-                currentWidth = videoStream.Width;
-                currentHeight = videoStream.Height;
-            }
+            var ffmpegVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
 
             // Fill video properties from the BDInfo result
             mediaStreams.Clear();
@@ -361,14 +348,16 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            videoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
+            var blurayVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
 
             // Use the ffprobe values if these are empty
-            if (videoStream is not null)
+            if (blurayVideoStream is not null && ffmpegVideoStream is not null)
             {
-                videoStream.BitRate = videoStream.BitRate.GetValueOrDefault() == 0 ? currentBitRate : videoStream.BitRate;
-                videoStream.Width = videoStream.Width.GetValueOrDefault() == 0 ? currentWidth : videoStream.Width;
-                videoStream.Height = videoStream.Height.GetValueOrDefault() == 0 ? currentHeight : videoStream.Height;
+                // Always use ffmpeg's detected codec since that is what the rest of the codebase expects.
+                blurayVideoStream.Codec = ffmpegVideoStream.Codec;
+                blurayVideoStream.BitRate = blurayVideoStream.BitRate.GetValueOrDefault() == 0 ? ffmpegVideoStream.BitRate : blurayVideoStream.BitRate;
+                blurayVideoStream.Width = blurayVideoStream.Width.GetValueOrDefault() == 0 ? ffmpegVideoStream.Width : blurayVideoStream.Width;
+                blurayVideoStream.Height = blurayVideoStream.Height.GetValueOrDefault() == 0 ? ffmpegVideoStream.Width : blurayVideoStream.Height;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/10975

I also have this ugly patch which mapped pretty much every property over... but turns out only codec was required.

```patch
Subject: [PATCH] Changes
---
Index: MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs	
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs	
@@ -324,20 +324,7 @@
                 return;
             }
 
-            // Use BD Info if it has multiple m2ts. Otherwise, treat it like a video file and rely more on ffprobe output
-            int? currentHeight = null;
-            int? currentWidth = null;
-            int? currentBitRate = null;
-
-            var videoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
-
-            // Grab the values that ffprobe recorded
-            if (videoStream is not null)
-            {
-                currentBitRate = videoStream.BitRate;
-                currentWidth = videoStream.Width;
-                currentHeight = videoStream.Height;
-            }
+            var ffmpegVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
 
             // Fill video properties from the BDInfo result
             mediaStreams.Clear();
@@ -361,14 +348,65 @@
                 }
             }
 
-            videoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
+            var blurayVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
 
             // Use the ffprobe values if these are empty
-            if (videoStream is not null)
+            if (blurayVideoStream is not null && ffmpegVideoStream is not null)
             {
-                videoStream.BitRate = videoStream.BitRate.GetValueOrDefault() == 0 ? currentBitRate : videoStream.BitRate;
-                videoStream.Width = videoStream.Width.GetValueOrDefault() == 0 ? currentWidth : videoStream.Width;
-                videoStream.Height = videoStream.Height.GetValueOrDefault() == 0 ? currentHeight : videoStream.Height;
+
+                blurayVideoStream.Codec = ffmpegVideoStream.Codec;
+                blurayVideoStream.CodecTag = Coalesce(blurayVideoStream.CodecTag, ffmpegVideoStream.CodecTag);
+                blurayVideoStream.Language = Coalesce(blurayVideoStream.Language, ffmpegVideoStream.Language);
+                blurayVideoStream.ColorRange = Coalesce(blurayVideoStream.ColorRange, ffmpegVideoStream.ColorRange);
+                blurayVideoStream.ColorSpace = Coalesce(blurayVideoStream.ColorSpace, ffmpegVideoStream.ColorSpace);
+                blurayVideoStream.ColorTransfer = Coalesce(blurayVideoStream.ColorTransfer, ffmpegVideoStream.ColorTransfer);
+                blurayVideoStream.ColorPrimaries = Coalesce(blurayVideoStream.ColorPrimaries, ffmpegVideoStream.ColorPrimaries);
+                blurayVideoStream.DvVersionMajor = Coalesce(blurayVideoStream.DvVersionMajor, ffmpegVideoStream.DvVersionMajor);
+                blurayVideoStream.DvVersionMinor = Coalesce(blurayVideoStream.DvVersionMinor, ffmpegVideoStream.DvVersionMinor);
+                blurayVideoStream.DvProfile = Coalesce(blurayVideoStream.DvProfile, ffmpegVideoStream.DvProfile);
+                blurayVideoStream.DvLevel = Coalesce(blurayVideoStream.DvLevel, ffmpegVideoStream.DvLevel);
+                blurayVideoStream.RpuPresentFlag = Coalesce(blurayVideoStream.RpuPresentFlag, ffmpegVideoStream.RpuPresentFlag);
+                blurayVideoStream.ElPresentFlag = Coalesce(blurayVideoStream.ElPresentFlag, ffmpegVideoStream.ElPresentFlag);
+                blurayVideoStream.BlPresentFlag = Coalesce(blurayVideoStream.BlPresentFlag, ffmpegVideoStream.BlPresentFlag);
+                blurayVideoStream.DvBlSignalCompatibilityId = Coalesce(blurayVideoStream.DvBlSignalCompatibilityId, ffmpegVideoStream.DvBlSignalCompatibilityId);
+                blurayVideoStream.Comment = Coalesce(blurayVideoStream.Comment, ffmpegVideoStream.Comment);
+                blurayVideoStream.TimeBase = Coalesce(blurayVideoStream.TimeBase, ffmpegVideoStream.TimeBase);
+                blurayVideoStream.CodecTimeBase = Coalesce(blurayVideoStream.CodecTimeBase, ffmpegVideoStream.CodecTimeBase);
+                blurayVideoStream.Title = Coalesce(blurayVideoStream.Title, ffmpegVideoStream.Title);
+                blurayVideoStream.LocalizedUndefined = Coalesce(blurayVideoStream.LocalizedUndefined, ffmpegVideoStream.LocalizedUndefined);
+                blurayVideoStream.LocalizedDefault = Coalesce(blurayVideoStream.LocalizedDefault, ffmpegVideoStream.LocalizedDefault);
+                blurayVideoStream.LocalizedForced = Coalesce(blurayVideoStream.LocalizedForced, ffmpegVideoStream.LocalizedForced);
+                blurayVideoStream.LocalizedExternal = Coalesce(blurayVideoStream.LocalizedExternal, ffmpegVideoStream.LocalizedExternal);
+                blurayVideoStream.LocalizedHearingImpaired = Coalesce(blurayVideoStream.LocalizedHearingImpaired, ffmpegVideoStream.LocalizedHearingImpaired);
+                blurayVideoStream.NalLengthSize = Coalesce(blurayVideoStream.NalLengthSize, ffmpegVideoStream.NalLengthSize);
+                blurayVideoStream.IsAVC = Coalesce(blurayVideoStream.IsAVC, ffmpegVideoStream.IsAVC);
+                blurayVideoStream.ChannelLayout = Coalesce(blurayVideoStream.ChannelLayout, ffmpegVideoStream.ChannelLayout);
+                blurayVideoStream.BitRate = Coalesce(blurayVideoStream.BitRate, ffmpegVideoStream.BitRate);
+                blurayVideoStream.BitDepth = Coalesce(blurayVideoStream.BitDepth, ffmpegVideoStream.BitDepth);
+                blurayVideoStream.RefFrames = Coalesce(blurayVideoStream.RefFrames, ffmpegVideoStream.RefFrames);
+                blurayVideoStream.PacketLength = Coalesce(blurayVideoStream.PacketLength, ffmpegVideoStream.PacketLength);
+                blurayVideoStream.Channels = Coalesce(blurayVideoStream.Channels, ffmpegVideoStream.Channels);
+                blurayVideoStream.SampleRate = Coalesce(blurayVideoStream.SampleRate, ffmpegVideoStream.SampleRate);
+                blurayVideoStream.Height = Coalesce(blurayVideoStream.Height, ffmpegVideoStream.Height);
+                blurayVideoStream.Width = Coalesce(blurayVideoStream.Width, ffmpegVideoStream.Width);
+                blurayVideoStream.AverageFrameRate = Coalesce(blurayVideoStream.AverageFrameRate, ffmpegVideoStream.AverageFrameRate);
+                blurayVideoStream.RealFrameRate = Coalesce(blurayVideoStream.RealFrameRate, ffmpegVideoStream.RealFrameRate);
+                blurayVideoStream.Profile = Coalesce(blurayVideoStream.Profile, ffmpegVideoStream.Profile);
+                blurayVideoStream.AspectRatio = Coalesce(blurayVideoStream.AspectRatio, ffmpegVideoStream.AspectRatio);
+                blurayVideoStream.Score = Coalesce(blurayVideoStream.Score, ffmpegVideoStream.Score);
+                blurayVideoStream.PixelFormat = Coalesce(blurayVideoStream.PixelFormat, ffmpegVideoStream.PixelFormat);
+                blurayVideoStream.Level = Coalesce(blurayVideoStream.Level, ffmpegVideoStream.Level);
+                blurayVideoStream.IsAnamorphic = Coalesce(blurayVideoStream.IsAnamorphic, ffmpegVideoStream.IsAnamorphic);
             }
         }
 
@@ -670,5 +708,20 @@
 
             return chapters;
         }
+
+        private static string? Coalesce(string? primaryValue, string? secondaryValue)
+            => string.IsNullOrEmpty(primaryValue) ? secondaryValue : primaryValue;
+
+        private static int? Coalesce(int? primaryValue, int? secondaryValue)
+            => primaryValue.GetValueOrDefault(0) == 0 ? secondaryValue : primaryValue;
+
+        private static float? Coalesce(float? primaryValue, float? secondaryValue)
+            => primaryValue.GetValueOrDefault(0) == 0 ? secondaryValue : primaryValue;
+
+        private static double? Coalesce(double? primaryValue, double? secondaryValue)
+                    => primaryValue.GetValueOrDefault(0) == 0 ? secondaryValue : primaryValue;
+
+        private static bool? Coalesce(bool? primaryValue, bool? secondaryValue)
+            => primaryValue ?? secondaryValue;
     }
 }
