### PR TITLE
Don't decode animated images

### DIFF
--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -262,6 +262,11 @@ public class SkiaEncoder : IImageEncoder
                 return null;
             }
 
+            if (codec.FrameCount != 0)
+            {
+                throw new ArgumentException("Cannot decode images with multiple frames");
+            }
+
             // create the bitmap
             var bitmap = new SKBitmap(codec.Info.Width, codec.Info.Height, !requiresTransparencyHack);
 


### PR DESCRIPTION
Apparently animated WebP images are a thing
https://github.com/jellyfin/jellyfin/issues/5501#issuecomment-1977428971

This change makes it so an an image has any frames (is animated) we won't attempt to convert it from the original format