### PR TITLE
Don't attempt to calculate blurhash for svg

### DIFF
--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -188,7 +188,8 @@ public class SkiaEncoder : IImageEncoder
         ArgumentException.ThrowIfNullOrEmpty(path);
 
         var extension = Path.GetExtension(path.AsSpan()).TrimStart('.');
-        if (!SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase))
+        if (!SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(SvgFormat, StringComparison.OrdinalIgnoreCase))
         {
             _logger.LogDebug("Unable to compute blur hash due to unsupported format: {ImagePath}", path);
             return string.Empty;


### PR DESCRIPTION
~I wasn't able to hit this code with any svgs from scanning, only from manually setting a media image, so just converting in-place should be fine?~

~Alternative is to just return an empty string instead of attempting conversion~

Ensure blurhash calculation isn't attempted for svg

Fixes #11128 