### PR TITLE
Fixes  'replace missing metadata' overwrites existing metadata that does exist

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -773,7 +773,7 @@ namespace MediaBrowser.Providers.Manager
                             MergeData(metadata, temp, Array.Empty<MetadataField>(), false, false);
                         }
 
-                        MergeData(temp, metadata, item.LockedFields, true, false);
+                        MergeData(temp, metadata, item.LockedFields, options.ReplaceAllMetadata, false);
                     }
                 }
             }


### PR DESCRIPTION
Fixes  'replace missing metadata' overwrites existing metadata that does exist

**Changes**
https://github.com/jellyfin/jellyfin/blob/9dbef98a157ca316deb2d634d288d8fe4aeda427/MediaBrowser.Providers/Manager/MetadataService.cs#L776
The above code will always cause new metadata to overwrite the existing metadata. Changed from true to options.ReplaceAllMetadata.
**Issues**
Fixes #9760
