### PR TITLE
Fix parsing of audio PremiereDate property

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -228,6 +228,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             audio.RunTimeTicks = mediaInfo.RunTimeTicks;
             audio.Size = mediaInfo.Size;
+            audio.PremiereDate = mediaInfo.PremiereDate;
 
             if (!audio.IsLocked)
             {
@@ -370,7 +371,6 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     var year = Convert.ToInt32(tags.Year);
                     audio.ProductionYear = year;
-                    audio.PremiereDate = new DateTime(year, 01, 01);
                 }
 
                 if (!audio.LockedFields.Contains(MetadataField.Genres))

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -371,6 +371,11 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     var year = Convert.ToInt32(tags.Year);
                     audio.ProductionYear = year;
+
+                    if (!audio.PremiereDate.HasValue)
+                    {
+                        audio.PremiereDate = new DateTime(year, 01, 01);
+                    }
                 }
 
                 if (!audio.LockedFields.Contains(MetadataField.Genres))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Retrieve the release date from a ffmpeg probe, instead of hard-coding it.

While parsing the music library, PremiereDate was written incorrectly, only getting the year properly, which resulted in it having a format of YYYY-01-01. This commit #7514 introduced `TagLibSharp` library, which, looks like, despite reading full raw metadata from a file, unfortunately, doesn't provide a method to retrieve a full date from it. That behavior is incorrect for some tag formats.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
fixes #7667 