### PR TITLE
Change parsing logic of audio track title

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -348,9 +348,9 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
                 }
 
-                if (!audio.LockedFields.Contains(MetadataField.Name))
+                if (!audio.LockedFields.Contains(MetadataField.Name) && !string.IsNullOrEmpty(tags.Title))
                 {
-                    audio.Name = options.ReplaceAllMetadata || string.IsNullOrEmpty(audio.Name) ? tags.Title : audio.Name;
+                    audio.Name = tags.Title;
                 }
 
                 if (options.ReplaceAllMetadata)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Ensure that the track title is read from a tag, if it exists.

Before: 
\>  On the first scan of a music library, every track title is set to the file name, ignoring the `TITLE` tag, even if the tag is set. "Replace all metadata" always reads it from the tag, even if it is not set.

After:  
\> If the tag exists, set the name to it. When it doesn't, keep the file name as a track title. Same logic when using "Replace all metadata". `options.ReplaceAllMetadata` doesn't do anything here.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Potentially, partially fixes  #9359?