### PR TITLE
Introduce scrutor for automagic dependency registration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,6 +58,7 @@
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="Scrutor" Version="4.2.2" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />

--- a/Jellyfin.Server/Helpers/DistinctRegistrationStrategy.cs
+++ b/Jellyfin.Server/Helpers/DistinctRegistrationStrategy.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Jellyfin.Server.Helpers;
+
+/// <summary>
+/// Skip registering the descriptor if it exists.
+/// </summary>
+public class DistinctRegistrationStrategy : RegistrationStrategy
+{
+    /// <summary>
+    /// The distinct registration strategy instance.
+    /// </summary>
+    public static readonly DistinctRegistrationStrategy Instance = new();
+
+    /// <inheritdoc />
+    public override void Apply(IServiceCollection services, ServiceDescriptor descriptor)
+    {
+        if (services.Any(service => service.ServiceType == descriptor.ServiceType && service.ImplementationType == descriptor.ImplementationType))
+        {
+            return;
+        }
+
+        services.Add(descriptor);
+    }
+}

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="prometheus-net" />
     <PackageReference Include="prometheus-net.AspNetCore" />
+    <PackageReference Include="Scrutor" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Thread" />
     <PackageReference Include="Serilog.Settings.Configuration" />


### PR DESCRIPTION
This allows the LDAP plugin to be registered without the plugin needing to manually register it.

I also tried hooking up the `IWebSocketListener` registration but it looks like not all assemblies are loaded yet? Further investigation is required.