### PR TITLE
Catch delete encoded media file exceptions

### DIFF
--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -724,7 +724,14 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
 
         foreach (var file in _fileSystem.GetFilePaths(path, true))
         {
-            _fileSystem.DeleteFile(file);
+            try
+            {
+                _fileSystem.DeleteFile(file);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting encoded media cache file {Path}", path);
+            }
         }
     }
 


### PR DESCRIPTION
**Changes**

- Catch delete encoded media file exceptions


```
Mar 16 07:54:33 archlinux jellyfin[11977]: System.UnauthorizedAccessException: Access to the path '/tmp/.X0-lock' is denied.
Mar 16 07:54:33 archlinux jellyfin[11977]:  ---> System.IO.IOException: Operation not permitted
Mar 16 07:54:33 archlinux jellyfin[11977]:    --- End of inner exception stack trace ---
Mar 16 07:54:33 archlinux jellyfin[11977]:    at System.IO.FileSystem.DeleteFile(String fullPath)
Mar 16 07:54:33 archlinux jellyfin[11977]:    at System.IO.File.Delete(String path)
Mar 16 07:54:33 archlinux jellyfin[11977]:    at Emby.Server.Implementations.IO.ManagedFileSystem.DeleteFile(String path)
Mar 16 07:54:33 archlinux jellyfin[11977]:    at Jellyfin.Api.Helpers.TranscodingJobHelper.DeleteEncodedMediaCache()
Mar 16 07:54:33 archlinux jellyfin[11977]:    at Jellyfin.Api.Helpers.TranscodingJobHelper..ctor(IAttachmentExtractor attachmentExtractor, IApplicationPaths appPaths, ILogger`1 logger, IMediaSourceManager mediaSourceManager, IFileSystem fileSystem, IMed>
```