### PR TITLE
feat(i18n): transliterate item name before sorting and filtering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="4.2.3" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
+    <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />
     <PackageVersion Include="IDisposableAnalyzers" Version="4.0.7" />
     <PackageVersion Include="Jellyfin.XmlTv" Version="10.8.0" />
     <PackageVersion Include="libse" Version="3.6.13" />

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -962,7 +962,13 @@ namespace MediaBrowser.Controller.Entities
             AppendChunk(builder, isDigitChunk, name.Slice(chunkStart));
 
             // logger.LogDebug("ModifySortChunks Start: {0} End: {1}", name, builder.ToString());
-            return builder.ToString().RemoveDiacritics();
+            var result = builder.ToString().RemoveDiacritics();
+            if (!result.All(char.IsAscii))
+            {
+                result = result.Transliterated();
+            }
+
+            return result;
         }
 
         public BaseItem GetParent()

--- a/src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
+++ b/src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Diacritics" />
+    <PackageReference Include="ICU4N.Transliterator" />
   </ItemGroup>
 
 </Project>

--- a/src/Jellyfin.Extensions/StringExtensions.cs
+++ b/src/Jellyfin.Extensions/StringExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using ICU4N.Text;
 
 namespace Jellyfin.Extensions
 {
@@ -8,6 +9,9 @@ namespace Jellyfin.Extensions
     /// </summary>
     public static partial class StringExtensions
     {
+        private static readonly Lazy<Transliterator> _transliterator = new(() => Transliterator.GetInstance(
+            "Any-Latin; Latin-Ascii; Lower; NFD; [:Nonspacing Mark:] Remove; [:Punctuation:] Remove;"));
+
         // Matches non-conforming unicode chars
         // https://mnaoumov.wordpress.com/2014/06/14/stripping-invalid-characters-from-utf-16-strings/
 
@@ -95,6 +99,16 @@ namespace Jellyfin.Extensions
             }
 
             return haystack[(pos + 1)..];
+        }
+
+        /// <summary>
+        /// Returns a transliterated string which only contain ascii characters.
+        /// </summary>
+        /// <param name="text">The string to act on.</param>
+        /// <returns>The transliterated string.</returns>
+        public static string Transliterated(this string text)
+        {
+            return _transliterator.Value.Transliterate(text);
         }
     }
 }


### PR DESCRIPTION
**Changes**
Since Jellyfin assume user will use a latin-based language as media title, it will be a problem for CJK language users. This patch attempted to use a `Transliterator` to transliterate the title if the `SortName` still contains non-ascii characters at the end of `ModifySortChunks()`.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/3202

**Note**
Library will need to be re-scanned to make the existing items uses the new SortName working.

**Screenshot when the patch gets applied**

Showcase the sort issue is gone: (Note: 赌博默示录 `du bo mo shi lu` < 前目的地 `qian mu di di` < 子弹列车 `zi dan lie che`)

![image](https://github.com/jellyfin/jellyfin/assets/10095765/1ba47f0c-7ead-46be-96dd-96b36fcebf82)

Showcase of the `NameStartsWith` filter on the right side: (Note: `D` is selected, 赌博默示录 `du bo mo shi lu` is shown)

![image](https://github.com/jellyfin/jellyfin/assets/10095765/abcac750-c37e-45ae-9df1-4fcd59df7b2e)
