### PR TITLE
fix: make sure the dimension is divisible by two for zscale

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -691,7 +691,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 Video3DFormat.HalfTopAndBottom => @"crop=iw:ih/2:0:0,scale=(iw*2):ih),setdar=dar=a,crop=min(iw\,ih*dar):min(ih\,iw/dar):(iw-min(iw\,iw*sar))/2:(ih - min (ih\,ih/sar))/2,setsar=sar=1",
                 // ftab crop height in half, set the display aspect,crop out any black bars we may have made
                 Video3DFormat.FullTopAndBottom => @"crop=iw:ih/2:0:0,setdar=dar=a,crop=min(iw\,ih*dar):min(ih\,iw/dar):(iw-min(iw\,iw*sar))/2:(ih - min (ih\,ih/sar))/2,setsar=sar=1",
-                _ => "scale=trunc(iw*sar):ih"
+                _ => "scale=round(iw*dar/2)*2:ih"
             };
 
             filters.Add(scaler);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -691,7 +691,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 Video3DFormat.HalfTopAndBottom => @"crop=iw:ih/2:0:0,scale=(iw*2):ih),setdar=dar=a,crop=min(iw\,ih*dar):min(ih\,iw/dar):(iw-min(iw\,iw*sar))/2:(ih - min (ih\,ih/sar))/2,setsar=sar=1",
                 // ftab crop height in half, set the display aspect,crop out any black bars we may have made
                 Video3DFormat.FullTopAndBottom => @"crop=iw:ih/2:0:0,setdar=dar=a,crop=min(iw\,ih*dar):min(ih\,iw/dar):(iw-min(iw\,iw*sar))/2:(ih - min (ih\,ih/sar))/2,setsar=sar=1",
-                _ => "scale=round(iw*dar/2)*2:ih"
+                _ => "scale=round(iw*dar/2)*2:round(ih/2)*2"
             };
 
             filters.Add(scaler);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

zscale filter has an assertion that image dimensions must be divisible by subsampling factor, and for most yuv formats, this means the dimension has to be divisible by two. Our current logic recalculating dimensions may yield an odd number, especially for anamorphic videos, which fails the thumbnail generation.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Modify the filter logic for image extraction to use DAR instead of SAR, as SAR could be different from DAR for anamorphic videos, and DAR is what the video is expecting.
- Use `scale=round(iw*dar/2)*2:round(ih/2)*2` to generate an always even dimension. This would cause a side effect where 1x1 inputs being upscaled to 2x2, but this case is very unlikely.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11183
