### PR TITLE
Fix Contains for Sets

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PhotoResolver.cs
@@ -4,13 +4,11 @@ using System.Linq;
 using Emby.Naming.Common;
 using Emby.Naming.Video;
 using Jellyfin.Data.Enums;
-using Jellyfin.Extensions;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Resolvers;
-using MediaBrowser.Model.Entities;
 
 namespace Emby.Server.Implementations.Library.Resolvers
 {
@@ -103,8 +101,8 @@ namespace Emby.Server.Implementations.Library.Resolvers
         {
             ArgumentNullException.ThrowIfNull(path);
 
-            var extension = Path.GetExtension(path.AsSpan()).TrimStart('.');
-            if (!imageProcessor.SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase))
+            var extension = Path.GetExtension(path.AsSpan()).TrimStart('.').ToString();
+            if (!imageProcessor.SupportedInputFormats.Contains(extension))
             {
                 return false;
             }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2285,7 +2285,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Source and target codecs must match
             if (string.IsNullOrEmpty(audioStream.Codec)
-                || !supportedAudioCodecs.Contains(audioStream.Codec, StringComparison.OrdinalIgnoreCase))
+                || !supportedAudioCodecs.Contains(audioStream.Codec, StringComparer.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -640,7 +640,7 @@ namespace MediaBrowser.Providers.Manager
 
         /// <inheritdoc/>
         public Task SaveMetadataAsync(BaseItem item, ItemUpdateType updateType, IEnumerable<string> savers)
-            => SaveMetadataAsync(item, updateType, _savers.Where(i => savers.Contains(i.Name, StringComparison.OrdinalIgnoreCase)));
+            => SaveMetadataAsync(item, updateType, _savers.Where(i => savers.Contains(i.Name, StringComparer.OrdinalIgnoreCase)));
 
         /// <summary>
         /// Saves the metadata.

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Jellyfin.Data.Enums;
-using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -1005,7 +1004,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                         var name = reader.Name;
 
                         if (!_commonTags.Contains(name)
-                            && !xmlTagsUsed.Contains(name, StringComparison.OrdinalIgnoreCase))
+                            && !xmlTagsUsed.Contains(name, StringComparer.OrdinalIgnoreCase))
                         {
                             writer.WriteNode(reader, false);
                         }

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using BlurHashSharp.SkiaSharp;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
@@ -69,8 +71,8 @@ public class SkiaEncoder : IImageEncoder
     public bool SupportsImageEncoding => true;
 
     /// <inheritdoc/>
-    public IReadOnlyCollection<string> SupportedInputFormats =>
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    public IReadOnlyCollection<string> SupportedInputFormats { get; } =
+        new[]
         {
             "jpeg",
             "jpg",
@@ -91,7 +93,7 @@ public class SkiaEncoder : IImageEncoder
             "nef",
             "arw",
             SvgFormat
-        };
+        }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IReadOnlyCollection<ImageFormat> SupportedOutputFormats
@@ -187,8 +189,8 @@ public class SkiaEncoder : IImageEncoder
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        var extension = Path.GetExtension(path.AsSpan()).TrimStart('.');
-        if (!SupportedInputFormats.Contains(extension, StringComparison.OrdinalIgnoreCase)
+        var extension = Path.GetExtension(path.AsSpan()).TrimStart('.').ToString();
+        if (!SupportedInputFormats.Contains(extension)
             || extension.Equals(SvgFormat, StringComparison.OrdinalIgnoreCase))
         {
             _logger.LogDebug("Unable to compute blur hash due to unsupported format: {ImagePath}", path);
@@ -427,8 +429,8 @@ public class SkiaEncoder : IImageEncoder
         ArgumentException.ThrowIfNullOrEmpty(inputPath);
         ArgumentException.ThrowIfNullOrEmpty(outputPath);
 
-        var inputFormat = Path.GetExtension(inputPath.AsSpan()).TrimStart('.');
-        if (!SupportedInputFormats.Contains(inputFormat, StringComparison.OrdinalIgnoreCase))
+        var inputFormat = Path.GetExtension(inputPath.AsSpan()).TrimStart('.').ToString();
+        if (!SupportedInputFormats.Contains(inputFormat))
         {
             _logger.LogDebug("Unable to encode image due to unsupported format: {ImagePath}", inputPath);
             return inputPath;

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -75,8 +76,8 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
     private string ResizedImageCachePath => Path.Combine(_appPaths.ImageCachePath, "resized-images");
 
     /// <inheritdoc />
-    public IReadOnlyCollection<string> SupportedInputFormats =>
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    public IReadOnlyCollection<string> SupportedInputFormats { get; } =
+        new[]
         {
             "tiff",
             "tif",
@@ -104,7 +105,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
             "pkm",
             "wbmp",
             "avif"
-        };
+        }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
     public bool SupportsImageCollageCreation => _imageEncoder.SupportsImageCollageCreation;

--- a/src/Jellyfin.Extensions/EnumerableExtensions.cs
+++ b/src/Jellyfin.Extensions/EnumerableExtensions.cs
@@ -16,7 +16,7 @@ public static class EnumerableExtensions
     /// <param name="stringComparison">The string comparison.</param>
     /// <returns>A value indicating whether the value is contained in the collection.</returns>
     /// <exception cref="ArgumentNullException">The source is null.</exception>
-    public static bool Contains(this IEnumerable<string> source, ReadOnlySpan<char> value, StringComparison stringComparison)
+    public static bool Contains(this IReadOnlyList<string> source, ReadOnlySpan<char> value, StringComparison stringComparison)
     {
         ArgumentNullException.ThrowIfNull(source);
 


### PR DESCRIPTION
Our [Contains](https://github.com/jellyfin/jellyfin/blob/f49de51225b2206609df6a89f3cbb5fd7459ff68/src/Jellyfin.Extensions/EnumerableExtensions.cs#L19) extension method from EnumerableExtensions.cs is used for HashSets and actually kills their performance.
So I decided to fix these places and limit the extension method by IReadOnlyList to prevent this in the future.

Please write if you have better ideas.