### PR TITLE
fix: use Metal tonemap instead of OpenCL

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1377,6 +1377,14 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return FormattableString.Invariant($" -rc_mode VBR -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
             }
 
+            if (string.Equals(videoCodec, "h264_videotoolbox", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(videoCodec, "hevc_videotoolbox", StringComparison.OrdinalIgnoreCase))
+            {
+                // The `maxrate` and `bufsize` options can potentially lead to performance regression
+                // and even encoder hangs, especially when the value is very high.
+                return FormattableString.Invariant($" -b:v {bitrate}");
+            }
+
             return FormattableString.Invariant($" -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
         }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4998,7 +4998,9 @@ namespace MediaBrowser.Controller.MediaEncoding
             var isVtFullSupported = isMacOS && IsVideoToolboxFullSupported();
 
             // legacy videotoolbox pipeline (disable hw filters)
-            if (!isVtEncoder || !_mediaEncoder.SupportsFilter("alphasrc"))
+            if (!isVtEncoder
+                || !isVtFullSupported
+                || !_mediaEncoder.SupportsFilter("alphasrc"))
             {
                 return GetSwVidFilterChain(state, options, vidEncoder);
             }

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -130,6 +130,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "yadif_videotoolbox",
             "scale_vt",
             "overlay_videotoolbox",
+            "tonemap_videotoolbox",
             // rkrga
             "scale_rkrga",
             "vpp_rkrga",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

As discussed in jellyfin/jellyfin-ffmpeg#357, the current OpenCL kernel runs extremely slow on Apple Silicon. This change updates the filter chain to use the Metal implementation of the tone map filter to handle Dolby Vision Profile 5 videos introduced by jellyfin/jellyfin-ffmpeg#369.

For Intel Macs, the OpenCL kernel is not compatible with certain GPUs and we will have the following error:

```
[AVHWDeviceContext @ 0x7faa2510e200] OpenCL error: [CL_IMAGE_FORMAT_NOT_SUPPORTED] : OpenCL Error : clCreateImage failed: The specified format is not supported for the specified image type.
[Parsed_tonemap_opencl_5 @ 0x7faa2510b940] Failed to create image for dither matrix: -10.
```

We need the Metal kernel to properly support Intel Macs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
