### PR TITLE
fix: use a more recent UA for M3U Tuner

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -150,7 +150,7 @@ namespace Jellyfin.LiveTv.TunerHosts
             {
                 // Use user-defined user-agent. If there isn't one, make it look like a browser.
                 httpHeaders[HeaderNames.UserAgent] = string.IsNullOrWhiteSpace(info.UserAgent) ?
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.85 Safari/537.36" :
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" :
                     info.UserAgent;
             }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This changes the default User-Agent of M3U Tuner to a recent version of Chrome, as the current one uses an ancient version and seems to be blocked by a lot of servers as reported by various users.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11015
