### PR TITLE
Don't expect `BaseItem` to be a movie/video file.

### DIFF
--- a/Emby.Server.Implementations/Library/ResolverHelper.cs
+++ b/Emby.Server.Implementations/Library/ResolverHelper.cs
@@ -39,7 +39,7 @@ namespace Emby.Server.Implementations.Library
                 item.GetParents().Any(i => i.IsLocked);
 
             // Make sure DateCreated and DateModified have values
-            var fileInfo = directoryService.GetFile(item.Path);
+            var fileInfo = directoryService.GetFileSystemEntry(item.Path);
             if (fileInfo is null)
             {
                 return false;

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -63,13 +63,13 @@ namespace MediaBrowser.Controller.Providers
         public FileSystemMetadata? GetFile(string path)
         {
             var entry = GetFileSystemEntry(path);
-            return entry != null && !entry.IsDirectory ? entry : null;
+            return entry is not null && !entry.IsDirectory ? entry : null;
         }
 
         public FileSystemMetadata? GetDirectory(string path)
         {
             var entry = GetFileSystemEntry(path);
-            return entry != null && entry.IsDirectory ? entry : null;
+            return entry is not null && entry.IsDirectory ? entry : null;
         }
 
         public FileSystemMetadata? GetFileSystemEntry(string path)

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -77,7 +77,7 @@ namespace MediaBrowser.Controller.Providers
             if (!_fileCache.TryGetValue(path, out var result))
             {
                 var file = _fileSystem.GetFileSystemInfo(path);
-                if (file.Exists)
+                if (file?.Exists ?? false)
                 {
                     result = file;
                     _fileCache.TryAdd(path, result);

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -62,9 +62,21 @@ namespace MediaBrowser.Controller.Providers
 
         public FileSystemMetadata? GetFile(string path)
         {
+            var entry = GetFileSystemEntry(path);
+            return entry != null && !entry.IsDirectory ? entry : null;
+        }
+
+        public FileSystemMetadata? GetDirectory(string path)
+        {
+            var entry = GetFileSystemEntry(path);
+            return entry != null && entry.IsDirectory ? entry : null;
+        }
+
+        public FileSystemMetadata? GetFileSystemEntry(string path)
+        {
             if (!_fileCache.TryGetValue(path, out var result))
             {
-                var file = _fileSystem.GetFileInfo(path);
+                var file = _fileSystem.GetFileSystemInfo(path);
                 if (file.Exists)
                 {
                     result = file;

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -15,6 +15,10 @@ namespace MediaBrowser.Controller.Providers
 
         FileSystemMetadata? GetFile(string path);
 
+        FileSystemMetadata? GetDirectory(string path);
+
+        FileSystemMetadata? GetFileSystemEntry(string path);
+
         IReadOnlyList<string> GetFilePaths(string path);
 
         IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);

--- a/tests/Jellyfin.Controller.Tests/DirectoryServiceTests.cs
+++ b/tests/Jellyfin.Controller.Tests/DirectoryServiceTests.cs
@@ -80,6 +80,21 @@ namespace Jellyfin.Controller.Tests
         }
 
         [Fact]
+        public void GetDirectories_GivenPathsWithDifferentCasing_ReturnsCorrectDirectories()
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(f => f.GetFileSystemEntries(It.Is<string>(x => x == UpperCasePath), false)).Returns(_upperCaseFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemEntries(It.Is<string>(x => x == LowerCasePath), false)).Returns(_lowerCaseFileSystemMetadata);
+            var directoryService = new DirectoryService(fileSystemMock.Object);
+
+            var upperCaseResult = directoryService.GetDirectories(UpperCasePath);
+            var lowerCaseResult = directoryService.GetDirectories(LowerCasePath);
+
+            Assert.Equal(_upperCaseFileSystemMetadata.Where(f => f.IsDirectory), upperCaseResult);
+            Assert.Equal(_lowerCaseFileSystemMetadata.Where(f => f.IsDirectory), lowerCaseResult);
+        }
+
+        [Fact]
         public void GetFile_GivenFilePathsWithDifferentCasing_ReturnsCorrectFile()
         {
             const string lowerCasePath = "/music/someartist/song 1.mp3";
@@ -95,15 +110,52 @@ namespace Jellyfin.Controller.Tests
                 Exists = false
             };
             var fileSystemMock = new Mock<IFileSystem>();
-            fileSystemMock.Setup(f => f.GetFileInfo(It.Is<string>(x => x == upperCasePath))).Returns(upperCaseFileSystemMetadata);
-            fileSystemMock.Setup(f => f.GetFileInfo(It.Is<string>(x => x == lowerCasePath))).Returns(lowerCaseFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == upperCasePath))).Returns(upperCaseFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == lowerCasePath))).Returns(lowerCaseFileSystemMetadata);
             var directoryService = new DirectoryService(fileSystemMock.Object);
 
-            var lowerCaseResult = directoryService.GetFile(lowerCasePath);
-            var upperCaseResult = directoryService.GetFile(upperCasePath);
+            var lowerCaseDirResult = directoryService.GetDirectory(lowerCasePath);
+            var lowerCaseFileResult = directoryService.GetFile(lowerCasePath);
+            var upperCaseDirResult = directoryService.GetDirectory(upperCasePath);
+            var upperCaseFileResult = directoryService.GetFile(upperCasePath);
 
-            Assert.Equal(lowerCaseFileSystemMetadata, lowerCaseResult);
-            Assert.Null(upperCaseResult);
+            Assert.Null(lowerCaseDirResult);
+            Assert.Equal(lowerCaseFileSystemMetadata, lowerCaseFileResult);
+            Assert.Null(upperCaseDirResult);
+            Assert.Null(upperCaseFileResult);
+        }
+
+        [Fact]
+        public void GetDirectory_GivenFilePathsWithDifferentCasing_ReturnsCorrectDirectory()
+        {
+            const string lowerCasePath = "/music/someartist/Lyrics";
+            var lowerCaseFileSystemMetadata = new FileSystemMetadata
+            {
+                FullName = lowerCasePath,
+                IsDirectory = true,
+                Exists = true
+            };
+            const string upperCasePath = "/music/SOMEARTIST/LYRICS";
+            var upperCaseFileSystemMetadata = new FileSystemMetadata
+            {
+                FullName = upperCasePath,
+                IsDirectory = true,
+                Exists = false
+            };
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == upperCasePath))).Returns(upperCaseFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == lowerCasePath))).Returns(lowerCaseFileSystemMetadata);
+            var directoryService = new DirectoryService(fileSystemMock.Object);
+
+            var lowerCaseDirResult = directoryService.GetDirectory(lowerCasePath);
+            var lowerCaseFileResult = directoryService.GetFile(lowerCasePath);
+            var upperCaseDirResult = directoryService.GetDirectory(upperCasePath);
+            var upperCaseFileResult = directoryService.GetFile(upperCasePath);
+
+            Assert.Equal(lowerCaseFileSystemMetadata, lowerCaseDirResult);
+            Assert.Null(lowerCaseFileResult);
+            Assert.Null(upperCaseDirResult);
+            Assert.Null(upperCaseFileResult);
         }
 
         [Fact]
@@ -122,11 +174,11 @@ namespace Jellyfin.Controller.Tests
             };
 
             var fileSystemMock = new Mock<IFileSystem>();
-            fileSystemMock.Setup(f => f.GetFileInfo(It.Is<string>(x => x == path))).Returns(cachedFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == path))).Returns(cachedFileSystemMetadata);
             var directoryService = new DirectoryService(fileSystemMock.Object);
 
             var result = directoryService.GetFile(path);
-            fileSystemMock.Setup(f => f.GetFileInfo(It.Is<string>(x => x == path))).Returns(newFileSystemMetadata);
+            fileSystemMock.Setup(f => f.GetFileSystemInfo(It.Is<string>(x => x == path))).Returns(newFileSystemMetadata);
             var secondResult = directoryService.GetFile(path);
 
             Assert.Equal(cachedFileSystemMetadata, result);


### PR DESCRIPTION
**Changes**

This fix is mainly so I can mass-add series _and_ movie entries using a `IMultiItemResolver` without having to resort to complicated logic using _both_ a `IItemResolver` and a `IMultiItemResolver` by splitting up what gets added where.

I've also added three new interface methods to the `IDirectoryService`, one of which is used in the modified
`ResolverHelper.SetInitialItemValues(…)` to get the file system entry info for the item regardless of which type the file system entry is.

In my local testing so far I haven't found any issues introduced by this change.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
