### PR TITLE
fix: map encoder preset to quality setting for VideoToolbox

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1846,6 +1846,31 @@ namespace MediaBrowser.Controller.MediaEncoding
                     param += " -gops_per_idr 1";
                 }
             }
+            else if (string.Equals(videoEncoder, "h264_videotoolbox", StringComparison.OrdinalIgnoreCase) // h264 (h264_videotoolbox)
+                     || string.Equals(videoEncoder, "hevc_videotoolbox", StringComparison.OrdinalIgnoreCase)) // hevc (hevc_videotoolbox)
+            {
+                switch (encodingOptions.EncoderPreset)
+                {
+                    case "veryslow":
+                    case "slower":
+                    case "slow":
+                    case "medium":
+                        param += " -prio_speed 0";
+                        break;
+
+                    case "fast":
+                    case "faster":
+                    case "veryfast":
+                    case "superfast":
+                    case "ultrafast":
+                        param += " -prio_speed 1";
+                        break;
+
+                    default:
+                        param += " -prio_speed 1";
+                        break;
+                }
+            }
             else if (string.Equals(videoEncoder, "libvpx", StringComparison.OrdinalIgnoreCase)) // vp8
             {
                 // Values 0-3, 0 being highest quality but slower


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This maps the encoder presets to VideoToolbox encoder quality settings. Use prefer speed as default like other encoders.

This is a quick fix that takes minimal changes, but VideoToolbox is using a tuning logic that is very different from other encoders to control its behavior, so a more specialized config panel is needed for it, but it will be a 10.10 thing.

10.10 notes below
----

VideoToolbox utilizes hints, unlike explicitly set levels, to control its behavior. These hints only inform the framework what to optimize for, and the final determination of speed, quality, and power constraints is still made by the framework's internal logic. For instance, when you instruct it to run faster, it may not always comply, but rather speeds up when it deems it necessary. The hints we are interested in are:

- `kVTCompressionPropertyKey_MaximizePowerEfficiency`: Setting this to true instructs the encoder to optimize for power efficiency, resulting in throttled encoding fps.
- `kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality`: This is the one we are using to map the encoding presets. When set to true, the encoder maximizes encoding fps, sacrificing quality if necessary. This can significantly boost encoding speed for 4K videos (from ~90 fps to ~140 fps), but has minimal effect on 1080p videos (where ~300 fps remains ~300 fps). 
- `kVTCompressionPropertyKey_RealTime`: Setting this to true instructs the encoder to optimize for real-time encoding, balancing power consumption and picture quality. If the encoder's current quality setting causes it to encode slower than real-time (encoding fps < video fps), the encoder will attempt to decrease quality to reach the video fps target and disable power efficiency targets. However, with this hint enabled, if the encoder exceeds the target fps (encoding fps > video fps), it will throttle to optimize power efficiency. It behaves a little bit like the combination of `MaximizePowerEfficiency` and `PrioritizeEncodingSpeedOverQuality`: use the former when the encoding is fast enough, and use the latter when the encoder can not keep up.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
