### PR TITLE
fix: remove legacy codecs for VideoToolbox

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1100,7 +1100,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     return string.Empty;
                 }
 
-                // no videotoolbox hw filter.
+                // videotoolbox hw filter does not require device selection
                 args.Append(GetVideoToolboxDeviceArgs(VideotoolboxAlias));
             }
             else if (string.Equals(optHwaccelType, "rkmpp", StringComparison.OrdinalIgnoreCase))
@@ -6164,14 +6164,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                     return GetHwaccelType(state, options, "h264", bitDepth, UseHwSurface);
                 }
 
-                if (string.Equals("mpeg2video", videoStream.Codec, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals("vp8", videoStream.Codec, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetHwaccelType(state, options, "mpeg2video", bitDepth, UseHwSurface);
-                }
-
-                if (string.Equals("mpeg4", videoStream.Codec, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetHwaccelType(state, options, "mpeg4", bitDepth, UseHwSurface);
+                    return GetHwaccelType(state, options, "vp8", bitDepth, UseHwSurface);
                 }
             }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
These legacy codecs are not implemented with hardware-accelerated decoding in VideoToolbox and were using VideoToolbox's software fallback decoding before. Since ffmpeg now only allows software fallback for HEVC, enabling those codecs will cause VT session creation to fail. Remove them now.

This also added missing VP8 config to VideoToolbox, fixed hardware decoding for VP8 videos. It was using software decoding even enabled by user.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
