### PR TITLE
fix: prefer cli ffmpeg path over config file

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -154,12 +154,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         public void SetFFmpegPath()
         {
-            // 1) Custom path stored in config/encoding xml file under tag <EncoderAppPath> takes precedence
-            var ffmpegPath = _configurationManager.GetEncodingOptions().EncoderAppPath;
+            // 1) Check if the --ffmpeg CLI switch has been given
+            var ffmpegPath = _startupOptionFFmpegPath;
             if (string.IsNullOrEmpty(ffmpegPath))
             {
-                // 2) Check if the --ffmpeg CLI switch has been given
-                ffmpegPath = _startupOptionFFmpegPath;
+                // 2) Custom path stored in config/encoding xml file under tag <EncoderAppPath> should be used as a fallback
+                ffmpegPath = _configurationManager.GetEncodingOptions().EncoderAppPath;
                 if (string.IsNullOrEmpty(ffmpegPath))
                 {
                     // 3) Check "ffmpeg"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR changed the order which path is used. Previously we use the ffmpeg path in the config file at first, but the config file entry is no longer editable with a GUI, and most of our packaging will use the CLI to set the ffmpeg path, where the leftover config could cause our new server to use the incorrect ffmpeg. This order is also easier to work with, as the CLI is easier to modify than the XML config file and can help users fix the ffmpeg path more easily.

One side effect of this would be that it could be hard for our users to change the ffmpeg in our Docker images, as our Docker entrypoint has a hard-coded path. To support the custom ffmpeg use case in Docker, we need to modify that hardcoded path into an environment variable-based path.

This behavior change should be documented in the changelog to notify our users and downstream packagers.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
