### PR TITLE
fix: disable api endpoint for ffmpeg path for security

### DIFF
--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -125,12 +125,14 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <param name="mediaEncoderPath">Media encoder path form body.</param>
     /// <response code="204">Media encoder path updated.</response>
     /// <returns>Status.</returns>
+    [Obsolete("This endpoint is obsolete.")]
     [HttpPost("MediaEncoder/Path")]
     [Authorize(Policy = Policies.FirstTimeSetupOrElevated)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateMediaEncoderPath([FromBody, Required] MediaEncoderPathDto mediaEncoderPath)
     {
-        _mediaEncoder.UpdateEncoderPath(mediaEncoderPath.Path, mediaEncoderPath.PathType);
+        // API ENDPOINT DISABLED (NOOP) FOR SECURITY PURPOSES
+        // _mediaEncoder.UpdateEncoderPath(mediaEncoderPath.Path, mediaEncoderPath.PathType);
         return NoContent();
     }
 }

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -126,6 +126,7 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <response code="204">Media encoder path updated.</response>
     /// <returns>Status.</returns>
     [Obsolete("This endpoint is obsolete.")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     [HttpPost("MediaEncoder/Path")]
     [Authorize(Policy = Policies.FirstTimeSetupOrElevated)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR ports the security fix for [GHSA-rr9h-w522-cvmr](https://github.com/jellyfin/jellyfin/security/advisories/GHSA-rr9h-w522-cvmr) and disabled the ffmpeg path setting API.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
