### PR TITLE
Move rename command permission check to script

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -124,7 +124,7 @@ jobs:
 
   rename:
     name: Rename
-    if: contains(github.event.comment.body, '@jellyfin-bot rename') && github.event.comment.author_association == 'MEMBER'
+    if: contains(github.event.comment.body, '@jellyfin-bot rename')
     runs-on: ubuntu-latest
     steps:
       - name: pull in script


### PR DESCRIPTION
Removes the permission check from the GHA and let the script handle it instead.
This command was intended to allow triage team members to rename issue, but the GHA permission check makes it so that it can only be ran by people who already have rename permissions.

The change to the script:
https://github.com/jellyfin/jellyfin-triage-scripts/pull/14/

**Issues**
None
