### PR TITLE
Fix default values missing in ClientCapabilities(Dto)

### DIFF
--- a/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
+++ b/Jellyfin.Api/Models/SessionDtos/ClientCapabilitiesDto.cs
@@ -55,12 +55,12 @@ public class ClientCapabilitiesDto
     // TODO: Remove after 10.9
     [Obsolete("Unused")]
     [DefaultValue(false)]
-    public bool? SupportsContentUploading { get; set; }
+    public bool? SupportsContentUploading { get; set; } = false;
 
     // TODO: Remove after 10.9
     [Obsolete("Unused")]
     [DefaultValue(false)]
-    public bool? SupportsSync { get; set; }
+    public bool? SupportsSync { get; set; } = false;
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>

--- a/MediaBrowser.Model/Session/ClientCapabilities.cs
+++ b/MediaBrowser.Model/Session/ClientCapabilities.cs
@@ -35,11 +35,11 @@ namespace MediaBrowser.Model.Session
         // TODO: Remove after 10.9
         [Obsolete("Unused")]
         [DefaultValue(false)]
-        public bool? SupportsContentUploading { get; set; }
+        public bool? SupportsContentUploading { get; set; } = false;
 
         // TODO: Remove after 10.9
         [Obsolete("Unused")]
         [DefaultValue(false)]
-        public bool? SupportsSync { get; set; }
+        public bool? SupportsSync { get; set; } = false;
     }
 }


### PR DESCRIPTION
We emit the DefaultValue in OpenAPI spec so a 10.9 based SDK can automatically fill in a default, but we didn't actually send a default value causing a 10.8 based SDK to fail.


**Changes**

Updated the ClientCapabilities to send default values for SupportsContentUploading and SupportsSync to fix sign in in the ATV app.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
