### PR TITLE
 fix: don't do empty hwupload for VT

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5096,14 +5096,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return (null, null, null);
             }
 
-            // INPUT videotoolbox/memory surface(vram/uma)
-            // this will pass-through automatically if in/out format matches.
-            var hwuploadFilters = new List<string>
-            {
-                "format=nv12|p010le|videotoolbox_vld",
-                "hwupload=derive_device=videotoolbox"
-            };
-
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
@@ -5171,8 +5163,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             // will cause the encoder to produce incorrect frames.
             if (needFiltering)
             {
-                hwuploadFilters.AddRange(mainFilters);
-                mainFilters = hwuploadFilters;
+                // INPUT videotoolbox/memory surface(vram/uma)
+                // this will pass-through automatically if in/out format matches.
+                mainFilters.Insert(0, "format=nv12|p010le|videotoolbox_vld");
+                mainFilters.Insert(0, "hwupload=derive_device=videotoolbox");
             }
 
             return (mainFilters, subFilters, overlayFilters);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5166,6 +5166,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                                 subFilters.Any(f => !string.IsNullOrEmpty(f)) ||
                                 overlayFilters.Any(f => !string.IsNullOrEmpty(f));
 
+            // This is a workaround for ffmpeg's hwupload implementation
+            // For VideoToolbox encoders, a hwupload without a valid filter actually consuming its frame
+            // will cause the encoder to produce incorrect frames.
             if (needFiltering)
             {
                 hwuploadFilters.AddRange(mainFilters);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

A hwupload without any filter to actually consume the frame would cause VideoToolbox's encoder to produce frames with artifacts. Check if the filter chain actually has a valid filter before adding hwupload.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
