### PR TITLE
Fix disabled libraries being returned in MediaFolders api

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -520,7 +520,11 @@ public class LibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<QueryResult<BaseItemDto>> GetMediaFolders([FromQuery] bool? isHidden)
     {
-        var items = _libraryManager.GetUserRootFolder().Children.Concat(_libraryManager.RootFolder.VirtualChildren).OrderBy(i => i.SortName).ToList();
+        var items = _libraryManager.GetUserRootFolder().Children
+            .Concat(_libraryManager.RootFolder.VirtualChildren)
+            .Where(i => _libraryManager.GetLibraryOptions(i).Enabled)
+            .OrderBy(i => i.SortName)
+            .ToList();
 
         if (isHidden.HasValue)
         {


### PR DESCRIPTION
**Changes**
While testing https://github.com/jellyfin/jellyfin-web/pull/5215 I found that disabled libraries were still being listed in the metadata editor and selecting a disabled library crashes the web client. I believe this will fix the issue by excluding disabled libraries from the results.

**Issues**
N/A