### PR TITLE
fix: add image count check to splash screen generation

### DIFF
--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -554,9 +554,13 @@ public class SkiaEncoder : IImageEncoder
     /// <inheritdoc />
     public void CreateSplashscreen(IReadOnlyList<string> posters, IReadOnlyList<string> backdrops)
     {
-        var splashBuilder = new SplashscreenBuilder(this);
-        var outputPath = Path.Combine(_appPaths.DataPath, "splashscreen.png");
-        splashBuilder.GenerateSplash(posters, backdrops, outputPath);
+        // Only generate the splash screen if we have at least one poster and at least one backdrop/thumbnail.
+        if (posters.Count > 0 && backdrops.Count > 0)
+        {
+            var splashBuilder = new SplashscreenBuilder(this);
+            var outputPath = Path.Combine(_appPaths.DataPath, "splashscreen.png");
+            splashBuilder.GenerateSplash(posters, backdrops, outputPath);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This check will prevent the splash screen generation from running if we have no posters or no backdrops/thumbnails to generate a splash screen from. Since even if it ran it would just err out when it tried to retrieve the missing poster/backdrop/thumbnail.

I added the check inside `SkiaEncoder.CreateSplashscreen` to stop it from running if somebody tried to create a splash screen regardless of where the `IImageEncoder.CreateSplashscreen` might be called from. If you want me to move the check to the `SplashscreenPostScanTask` instead, to prevent it from running even if we change the underlying implementation of the `IImageEncoder` in the future, then just say the word.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
