### PR TITLE
Support "extra" folder for extras content

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -540,6 +540,12 @@ namespace Emby.Naming.Common
                 new ExtraRule(
                     ExtraType.Unknown,
                     ExtraRuleType.DirectoryName,
+                    "extra",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.Unknown,
+                    ExtraRuleType.DirectoryName,
                     "other",
                     MediaType.Video),
 


### PR DESCRIPTION
In my library structure I've always used the folder "extra" for extra content, when I migrated to Jellyfin (years ago) I never imported all this media. Figured I should do something about that so I can develop support for theme songs/video in the ATV app. 

**Changes**
- Add an extra rule for the "extra" folder

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
