### PR TITLE
Catch exceptions in auto discovery

### DIFF
--- a/src/Jellyfin.Networking/AutoDiscoveryHost.cs
+++ b/src/Jellyfin.Networking/AutoDiscoveryHost.cs
@@ -78,28 +78,36 @@ public sealed class AutoDiscoveryHost : BackgroundService
 
     private async Task ListenForAutoDiscoveryMessage(IPAddress address, CancellationToken cancellationToken)
     {
-        using var udpClient = new UdpClient(new IPEndPoint(address, PortNumber));
-        udpClient.MulticastLoopback = false;
-
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            try
+            using var udpClient = new UdpClient(new IPEndPoint(address, PortNumber));
+            udpClient.MulticastLoopback = false;
+
+            while (!cancellationToken.IsCancellationRequested)
             {
-                var result = await udpClient.ReceiveAsync(cancellationToken).ConfigureAwait(false);
-                var text = Encoding.UTF8.GetString(result.Buffer);
-                if (text.Contains("who is JellyfinServer?", StringComparison.OrdinalIgnoreCase))
+                try
                 {
-                    await RespondToV2Message(udpClient, result.RemoteEndPoint, cancellationToken).ConfigureAwait(false);
+                    var result = await udpClient.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                    var text = Encoding.UTF8.GetString(result.Buffer);
+                    if (text.Contains("who is JellyfinServer?", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await RespondToV2Message(udpClient, result.RemoteEndPoint, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                catch (SocketException ex)
+                {
+                    _logger.LogError(ex, "Failed to receive data from socket");
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogDebug("Broadcast socket operation cancelled");
                 }
             }
-            catch (SocketException ex)
-            {
-                _logger.LogError(ex, "Failed to receive data from socket");
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogDebug("Broadcast socket operation cancelled");
-            }
+        }
+        catch (Exception ex)
+        {
+            // Exception in this function will prevent the background service from restarting in-process.
+            _logger.LogError(ex, "Unable to bind to {Address}:{Port}", address, PortNumber);
         }
     }
 

--- a/src/Jellyfin.Networking/AutoDiscoveryHost.cs
+++ b/src/Jellyfin.Networking/AutoDiscoveryHost.cs
@@ -98,11 +98,11 @@ public sealed class AutoDiscoveryHost : BackgroundService
                 {
                     _logger.LogError(ex, "Failed to receive data from socket");
                 }
-                catch (OperationCanceledException)
-                {
-                    _logger.LogDebug("Broadcast socket operation cancelled");
-                }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Broadcast socket operation cancelled");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
The exception was found when attempting to debug in-process restart issues

```
System.Net.Sockets.SocketException (98): Address already in use
   at System.Net.Sockets.Socket.DoBind(EndPoint endPointSnapshot, SocketAddress socketAddress)
   at System.Net.Sockets.Socket.Bind(EndPoint localEP)
   at Jellyfin.Networking.AutoDiscoveryHost.ListenForAutoDiscoveryMessage(IPAddress address, CancellationToken cancellationToken) in /home/crobibero/Code/jellyfin/src/Jellyfin.Networking/AutoDiscoveryHost.cs:line 83
```