### PR TITLE
fix: don't mark Plugin's AssemblyLoadContext collectible

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginLoadContext.cs
+++ b/Emby.Server.Implementations/Plugins/PluginLoadContext.cs
@@ -14,7 +14,7 @@ public class PluginLoadContext : AssemblyLoadContext
     /// Initializes a new instance of the <see cref="PluginLoadContext"/> class.
     /// </summary>
     /// <param name="path">The path of the plugin assembly.</param>
-    public PluginLoadContext(string path) : base(true)
+    public PluginLoadContext(string path) : base(false)
     {
         _resolver = new AssemblyDependencyResolver(path);
     }

--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -442,10 +442,6 @@ namespace Emby.Server.Implementations.Plugins
         /// <inheritdoc />
         public void Dispose()
         {
-            foreach (var assemblyLoadContext in _assemblyLoadContexts)
-            {
-                assemblyLoadContext.Unload();
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
We are only unloading this context when disposing the plugin manager as a whole, and all plugin changes require a server restart to take effect anyway. Therefore, set `isCollectible` to false to allow the plugin to legally access the main server's assembly.

This is the most obvious fix for me but I may be missing some side effect that this change would make. Looking for comments on this change.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11251