### PR TITLE
fix: use a reentrant lock when accessing active connections

### DIFF
--- a/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
+++ b/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
@@ -250,7 +250,7 @@ namespace MediaBrowser.Controller.Net
             Logger.LogDebug("WS {1} stop transmitting to {0}", connection.Connection.RemoteEndPoint, GetType().Name);
 
             // TODO disposing the connection seems to break websockets in subtle ways, so what is the purpose of this function really...
-            connection.Connection.Dispose();
+            // connection.Item1.Dispose();
 
             try
             {

--- a/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
+++ b/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
@@ -33,7 +33,7 @@ namespace MediaBrowser.Controller.Net
             SingleWriter = false
         });
 
-        private readonly SemaphoreSlim _lock = new(1, 1);
+        private readonly object _activeConnectionsLock = new();
 
         /// <summary>
         /// The _active connections.
@@ -126,14 +126,9 @@ namespace MediaBrowser.Controller.Net
                 InitialDelayMs = dueTimeMs
             };
 
-            _lock.Wait();
-            try
+            lock (_activeConnectionsLock)
             {
                 _activeConnections.Add((message.Connection, cancellationTokenSource, state));
-            }
-            finally
-            {
-                _lock.Release();
             }
         }
 
@@ -153,8 +148,7 @@ namespace MediaBrowser.Controller.Net
                         (IWebSocketConnection Connection, CancellationTokenSource CancellationTokenSource, TStateType State)[] tuples;
 
                         var now = DateTime.UtcNow;
-                        await _lock.WaitAsync().ConfigureAwait(false);
-                        try
+                        lock (_activeConnectionsLock)
                         {
                             if (_activeConnections.Count == 0)
                             {
@@ -173,10 +167,6 @@ namespace MediaBrowser.Controller.Net
                                     return force || (now - state.DateLastSendUtc).TotalMilliseconds >= state.IntervalMs;
                                 })
                                 .ToArray();
-                        }
-                        finally
-                        {
-                            _lock.Release();
                         }
 
                         if (tuples.Length == 0)
@@ -240,8 +230,7 @@ namespace MediaBrowser.Controller.Net
         /// <param name="message">The message.</param>
         private void Stop(WebSocketMessageInfo message)
         {
-            _lock.Wait();
-            try
+            lock (_activeConnectionsLock)
             {
                 var connection = _activeConnections.FirstOrDefault(c => c.Connection == message.Connection);
 
@@ -249,10 +238,6 @@ namespace MediaBrowser.Controller.Net
                 {
                     DisposeConnection(connection);
                 }
-            }
-            finally
-            {
-                _lock.Release();
             }
         }
 
@@ -265,7 +250,7 @@ namespace MediaBrowser.Controller.Net
             Logger.LogDebug("WS {1} stop transmitting to {0}", connection.Connection.RemoteEndPoint, GetType().Name);
 
             // TODO disposing the connection seems to break websockets in subtle ways, so what is the purpose of this function really...
-            // connection.Item1.Dispose();
+            connection.Connection.Dispose();
 
             try
             {
@@ -283,14 +268,9 @@ namespace MediaBrowser.Controller.Net
                 Logger.LogError(ex, "Error disposing websocket");
             }
 
-            _lock.Wait();
-            try
+            lock (_activeConnectionsLock)
             {
                 _activeConnections.Remove(connection);
-            }
-            finally
-            {
-                _lock.Release();
             }
         }
 
@@ -306,17 +286,12 @@ namespace MediaBrowser.Controller.Net
                 Logger.LogError(ex, "Disposing the message consumer failed");
             }
 
-            await _lock.WaitAsync().ConfigureAwait(false);
-            try
+            lock (_activeConnectionsLock)
             {
                 foreach (var connection in _activeConnections.ToArray())
                 {
                     DisposeConnection(connection);
                 }
-            }
-            finally
-            {
-                _lock.Release();
             }
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Use a re-entrant lock

**Issues**
Fixes #11218
