### PR TITLE
fix metadata refresh for artists

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -1106,7 +1106,8 @@ namespace MediaBrowser.Providers.Manager
 
             var musicArtists = albums
                 .Select(i => i.MusicArtist)
-                .Where(i => i is not null);
+                .Where(i => i is not null)
+                .Distinct();
 
             var musicArtistRefreshTasks = musicArtists.Select(i => i.ValidateChildren(new Progress<double>(), options, true, cancellationToken));
 


### PR DESCRIPTION
Fix "Error refreshing folder" for the items of type "MusicArtist".

**Changes**
Visit each artist folder only once.

**Issues**
partly fixes #6340 (for the MusicArtist case)
