### PR TITLE
fix: catch collectible access non-collectible exception

### DIFF
--- a/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
@@ -32,7 +32,8 @@ namespace Emby.Server.Implementations.Serialization
                 throw new NotSupportedException($"It seems you are using the server's XML serializer in your plugin.\n" +
                                                 $"This serializer is only used by the server to handle the plugin's config file " +
                                                 $"and is not intended for the plugin to use directly.\n" +
-                                                $"Please create your own XML serializer instance to handle plugin specific files.");
+                                                $"Please create your own XML serializer instance to handle plugin specific files.",
+                                                e);
             }
         }
 

--- a/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
@@ -24,7 +24,7 @@ namespace Emby.Server.Implementations.Serialization
                 static (_, t) => new XmlSerializer(t),
                 type);
 
-        private static void ThrowCollectibleException(Exception e)
+        private static void ThrowCollectibleException(NotSupportedException e)
         {
             var isCollectibleException = string.Equals(e.Message, "A non-collectible assembly may not reference a collectible assembly.", StringComparison.Ordinal);
             if (isCollectibleException)

--- a/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
@@ -29,11 +29,12 @@ namespace Emby.Server.Implementations.Serialization
             var isCollectibleException = string.Equals(e.Message, "A non-collectible assembly may not reference a collectible assembly.", StringComparison.Ordinal);
             if (isCollectibleException)
             {
-                throw new NotSupportedException($"It seems you are using the server's XML serializer in your plugin.\n" +
-                                                $"This serializer is only used by the server to handle the plugin's config file " +
-                                                $"and is not intended for the plugin to use directly.\n" +
-                                                $"Please create your own XML serializer instance to handle plugin specific files.",
-                                                e);
+                throw new NotSupportedException(
+                    $"It seems you are using the server's XML serializer in your plugin.\n" +
+                    $"This serializer is only used by the server to handle the plugin's config file " +
+                    $"and is not intended for the plugin to use directly.\n" +
+                    $"Please create your own XML serializer instance to handle plugin specific files.",
+                    e);
             }
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Catch the `NotSupportedException` caused by plugins directly using the server's XML serializer and throw a new one with informative messages, notifying the plugin developer that directly using this serializer is not a supported use case.

This is an alternative to #11254 to retain the in-process restart functionality.

This change could have a long-term impact, meaning that our plugins need to use their own XML serializers from now on, and this change may not be limited to 10.9, but also in later versions.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11251
