### PR TITLE
Fix FindExtras overwriting current extra type

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2677,7 +2677,12 @@ namespace Emby.Server.Implementations.Library
                     extra = itemById;
                 }
 
-                extra.ExtraType = extraType;
+                // Only update extra type if it is more specific then the currently known extra type
+                if (extra.ExtraType is null or ExtraType.Unknown || extraType != ExtraType.Unknown)
+                {
+                    extra.ExtraType = extraType;
+                }
+
                 extra.ParentId = Guid.Empty;
                 extra.OwnerId = owner.Id;
                 return extra;


### PR DESCRIPTION
The scanner will always overwrite all extras it found with new data. It doesn't really care about the existing database entry. In some cases this can change the type of an extra. This is a fix for that case by checking if the new type to set is not "unknown".

**Changes**

- Only update extra type if it is more specific then the currently known extra type

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
