### PR TITLE
Use enum for BaseItemDto.ExtraType

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -903,10 +903,7 @@ namespace Emby.Server.Implementations.Dto
             if (item is Audio audio)
             {
                 dto.Album = audio.Album;
-                if (audio.ExtraType.HasValue)
-                {
-                    dto.ExtraType = audio.ExtraType.Value.ToString();
-                }
+                dto.ExtraType = audio.ExtraType;
 
                 var albumParent = audio.AlbumEntity;
 
@@ -1058,10 +1055,7 @@ namespace Emby.Server.Implementations.Dto
                     dto.Trickplay = _trickplayManager.GetTrickplayManifest(item).GetAwaiter().GetResult();
                 }
 
-                if (video.ExtraType.HasValue)
-                {
-                    dto.ExtraType = video.ExtraType.Value.ToString();
-                }
+                dto.ExtraType = video.ExtraType;
             }
 
             if (options.ContainsField(ItemFields.MediaStreams))

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -65,7 +65,7 @@ namespace MediaBrowser.Model.Dto
 
         public DateTime? DateLastMediaAdded { get; set; }
 
-        public string ExtraType { get; set; }
+        public ExtraType? ExtraType { get; set; }
 
         public int? AirsBeforeSeasonNumber { get; set; }
 


### PR DESCRIPTION
Easy change, too late for 10.9 though :p

**Changes**
- Use enum for BaseItemDto.ExtraType

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
