### PR TITLE
Revert "chore(deps): update dependency efcoresecondlevelcacheinterceptor to v4.3.0"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Diacritics" Version="3.3.27" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="4.3.0" />
+    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="4.2.3" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />


### PR DESCRIPTION
Reverts jellyfin/jellyfin#11263

```
[10:47:23] [FTL] [1] Main: Error while starting server
System.MissingMethodException: Method not found: 'EFCoreSecondLevelCacheInterceptor.EFCoreSecondLevelCacheOptions EFCoreSecondLevelCacheInterceptor.EFCoreSecondLevelCacheOptions.DisableLogging(Boolean)'.
   at Jellyfin.Server.Implementations.Extensions.ServiceCollectionExtensions.<>c.<AddJellyfinDbContext>b__0_0(EFCoreSecondLevelCacheOptions options)
   at EFCoreSecondLevelCacheInterceptor.EFServiceCollectionExtensions.ConfigOptions(IServiceCollection services, Action`1 options) in D:\a\EFCoreSecondLevelCacheInterceptor\EFCoreSecondLevelCacheInterceptor\src\EFCoreSecondLevel
CacheInterceptor\EFServiceCollectionExtensions.cs:line 46
```