### PR TITLE
Remove SessionInfo.FullNowPlayingItem from API responses

### DIFF
--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -134,6 +134,7 @@ namespace MediaBrowser.Controller.Session
         /// <value>The now playing item.</value>
         public BaseItemDto NowPlayingItem { get; set; }
 
+        [JsonIgnore]
         public BaseItem FullNowPlayingItem { get; set; }
 
         public BaseItemDto NowViewingItem { get; set; }


### PR DESCRIPTION
I guess this is regression from when we moved over to ASP.NET. Seems to be available starting from our first OpenAPI schema.

There are two properties in SessionInfo:

- NowPlayingItem (BaseItemDto)
- FullNowPlayingItem (BaseItem)

The second one is the only place in the API that "exposes" BaseItem (the non-dto one). All other places use BaseItemDto. Fortunately, the property is nullable and an org-wide search shows none of our clients use FullNowPlayingItem. So removing it should not have any impact.

**Changes**
- Remove SessionInfo.FullNowPlayingItem from API responses

**Issues**

Partial fix for #11244, other exposed types like ClientCapabilities need a proper SessionInfoDto.

