### PR TITLE
Notifications: use original title if req.Name is null

### DIFF
--- a/Emby.Notifications/NotificationManager.cs
+++ b/Emby.Notifications/NotificationManager.cs
@@ -72,6 +72,10 @@ namespace Emby.Notifications
                 .ToArray();
 
             var title = request.Name;
+            if (string.IsNullOrEmpty(title) && relatedItem != null)
+            {
+                title = relatedItem.OriginalTitle;
+            }
             var description = request.Description;
 
             var tasks = _services.Where(i => IsEnabled(i, notificationType))


### PR DESCRIPTION

**Changes**
Fixes problem about notifications receiving only the description of the movie instead of the title.


**Issues**
Related: https://github.com/MindFlavor/Jellyfin.Plugins.Telegram/pull/14
