### PR TITLE
fix: av1 codecs string

### DIFF
--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -220,9 +220,6 @@ public static class HlsCodecStringHelpers
             level = 19;
         }
 
-        // Needed to pad it two double digits; otherwise, browsers will reject the stream.
-        var levelString = level < 10 ? $"0{level}" : $"{level}";
-
         if (bitDepth != 8
             && bitDepth != 10
             && bitDepth != 12)
@@ -232,7 +229,8 @@ public static class HlsCodecStringHelpers
         }
 
         result.Append('.')
-            .Append(levelString)
+            // Needed to pad it double digits; otherwise, browsers will reject the stream.
+            .Append(CultureInfo.InvariantCulture, $"{level:D2}")
             .Append(tierFlag ? 'H' : 'M');
 
         string bitDepthD2 = bitDepth.ToString("D2", CultureInfo.InvariantCulture);

--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -192,7 +192,7 @@ public static class HlsCodecStringHelpers
     /// <returns>The AV1 codec string.</returns>
     public static string GetAv1String(string? profile, int level, bool tierFlag, int bitDepth)
     {
-        // https://aomedia.org/av1/specification/annex-a/
+        // https://aomediacodec.github.io/av1-isobmff/#codecsparam
         // FORMAT: [codecTag].[profile].[level][tier].[bitDepth]
         StringBuilder result = new StringBuilder("av01", 13);
 

--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -214,12 +214,14 @@ public static class HlsCodecStringHelpers
             result.Append(".0");
         }
 
-        if (level <= 0
-            || level > 31)
+        if (level is <= 0 or > 31)
         {
             // Default to the maximum defined level 6.3
             level = 19;
         }
+
+        // Needed to pad it two double digits; otherwise, browsers will reject the stream.
+        var levelString = level < 10 ? $"0{level}" : $"level";
 
         if (bitDepth != 8
             && bitDepth != 10
@@ -230,7 +232,7 @@ public static class HlsCodecStringHelpers
         }
 
         result.Append('.')
-            .Append(level)
+            .Append(levelString)
             .Append(tierFlag ? 'H' : 'M');
 
         string bitDepthD2 = bitDepth.ToString("D2", CultureInfo.InvariantCulture);

--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -230,7 +230,7 @@ public static class HlsCodecStringHelpers
 
         result.Append('.')
             // Needed to pad it double digits; otherwise, browsers will reject the stream.
-            .Append(CultureInfo.InvariantCulture, $"{level:D2}")
+            .AppendFormat(CultureInfo.InvariantCulture, "{0:D2}", level)
             .Append(tierFlag ? 'H' : 'M');
 
         string bitDepthD2 = bitDepth.ToString("D2", CultureInfo.InvariantCulture);

--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -221,7 +221,7 @@ public static class HlsCodecStringHelpers
         }
 
         // Needed to pad it two double digits; otherwise, browsers will reject the stream.
-        var levelString = level < 10 ? $"0{level}" : $"level";
+        var levelString = level < 10 ? $"0{level}" : $"{level}";
 
         if (bitDepth != 8
             && bitDepth != 10


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Browsers are very picky about this string. The profile level has to be padded to double digits otherwise the stream is going to be rejected and the playback would not continue.

This is confirmed to work with latest Chromium 122 and Firefox 124, but Chromium used to be more picky about this string so additional hacks to lying about the level to it may be needed.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes jellyfin/jellyfin-web#5364