### PR TITLE
Fix track MBID in audio metadata

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -408,6 +408,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzTrack, out _))
                 {
                     // Fallback to ffprobe as TagLib incorrectly provides recording MBID in `tags.MusicBrainzTrackId`.
+                    // See https://github.com/mono/taglib-sharp/issues/304
                     var mediaInfo = await GetMediaInfo(audio, CancellationToken.None).ConfigureAwait(false);
                     var trackMbId = mediaInfo.GetProviderId(MetadataProvider.MusicBrainzTrack);
                     if (trackMbId is not null)

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -431,5 +431,20 @@ namespace MediaBrowser.Providers.MediaInfo
             audio.LyricFiles = externalLyricFiles.Select(i => i.Path).Distinct().ToArray();
             currentStreams.AddRange(externalLyricFiles);
         }
+
+        private async Task<Model.MediaInfo.MediaInfo> GetMediaInfo(BaseItem item, CancellationToken cancellationToken)
+        {
+            var request = new MediaInfoRequest
+            {
+                MediaType = DlnaProfileType.Audio,
+                MediaSource = new MediaSourceInfo
+                {
+                    Path = item.Path,
+                    Protocol = item.PathProtocol ?? MediaProtocol.File
+                }
+            };
+
+            return await _mediaEncoder.GetMediaInfo(request, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -407,7 +407,13 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzTrack, out _))
                 {
-                    audio.SetProviderId(MetadataProvider.MusicBrainzTrack, tags.MusicBrainzTrackId);
+                    // Fallback to ffprobe as TagLib incorrectly provides recording MBID in `tags.MusicBrainzTrackId`.
+                    var mediaInfo = await GetMediaInfo(audio, CancellationToken.None).ConfigureAwait(false);
+                    var trackMbId = mediaInfo.GetProviderId(MetadataProvider.MusicBrainzTrack);
+                    if (trackMbId is not null)
+                    {
+                        audio.SetProviderId(MetadataProvider.MusicBrainzTrack, trackMbId);
+                    }
                 }
 
                 // Save extracted lyrics if they exist,


### PR DESCRIPTION
**Changes**

Fall back to ffprobe to get a correct value for track MBID.

**Issues**

Fixes #11020 
