### PR TITLE
Fix subtitle saving if file already exists

### DIFF
--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -257,7 +257,7 @@ namespace MediaBrowser.Providers.Subtitles
                     Directory.CreateDirectory(Path.GetDirectoryName(path) ?? throw new InvalidOperationException("Path can't be a root directory."));
 
                     var fileOptions = AsyncFile.WriteOptions;
-                    fileOptions.Mode = FileMode.Create;
+                    fileOptions.Mode = FileMode.CreateNew;
                     fileOptions.PreallocationSize = stream.Length;
                     var fs = new FileStream(path, fileOptions);
                     await using (fs.ConfigureAwait(false))

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -48,9 +48,7 @@ namespace MediaBrowser.Providers.Subtitles
             _monitor = monitor;
             _mediaSourceManager = mediaSourceManager;
             _localization = localizationManager;
-            _subtitleProviders = subtitleProviders
-                .OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)
-                .ToArray();
+            _subtitleProviders = [.. subtitleProviders.OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)];
         }
 
         /// <inheritdoc />
@@ -117,7 +115,7 @@ namespace MediaBrowser.Providers.Subtitles
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error downloading subtitles from {0}", i.Name);
+                    _logger.LogError(ex, "Error downloading subtitles from {Name}", i.Name);
                     return Array.Empty<RemoteSubtitleInfo>();
                 }
             });
@@ -251,7 +249,7 @@ namespace MediaBrowser.Providers.Subtitles
                     Directory.CreateDirectory(Path.GetDirectoryName(savePath) ?? throw new InvalidOperationException("Path can't be a root directory."));
 
                     var fileOptions = AsyncFile.WriteOptions;
-                    fileOptions.Mode = FileMode.CreateNew;
+                    fileOptions.Mode = FileMode.Create;
                     fileOptions.PreallocationSize = stream.Length;
                     var fs = new FileStream(savePath, fileOptions);
                     await using (fs.ConfigureAwait(false))
@@ -263,10 +261,7 @@ namespace MediaBrowser.Providers.Subtitles
                 }
                 catch (Exception ex)
                 {
-// Bug in analyzer -- https://github.com/dotnet/roslyn-analyzers/issues/5160
-#pragma warning disable CA1508
-                    (exs ??= new List<Exception>()).Add(ex);
-#pragma warning restore CA1508
+                    (exs ??= []).Add(ex);
                 }
                 finally
                 {

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -48,7 +48,9 @@ namespace MediaBrowser.Providers.Subtitles
             _monitor = monitor;
             _mediaSourceManager = mediaSourceManager;
             _localization = localizationManager;
-            _subtitleProviders = [.. subtitleProviders.OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)];
+            _subtitleProviders = subtitleProviders
+                .OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)
+                .ToArray();
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -240,10 +240,10 @@ namespace MediaBrowser.Providers.Subtitles
 
             foreach (var savePath in savePaths)
             {
-                var path = savePath;
+                var path = savePath + "." + extension;
                 try
                 {
-                    var fileExists = File.Exists(savePath + "." + extension);
+                    var fileExists = File.Exists(path);
                     var counter = 0;
 
                     while (fileExists)

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -228,19 +228,19 @@ namespace MediaBrowser.Providers.Subtitles
                 var path = savePath + "." + extension;
                 try
                 {
-                    var fileExists = File.Exists(path);
-                    var counter = 0;
-
-                    while (fileExists)
-                    {
-                        counter++;
-                        path = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", savePath, counter, extension);
-                        fileExists = File.Exists(path);
-                    }
-
                     if (path.StartsWith(video.ContainingFolderPath, StringComparison.Ordinal)
-                        || path.StartsWith(video.GetInternalMetadataPath(), StringComparison.Ordinal))
+                            || path.StartsWith(video.GetInternalMetadataPath(), StringComparison.Ordinal))
                     {
+                        var fileExists = File.Exists(path);
+                        var counter = 0;
+
+                        while (fileExists)
+                        {
+                            path = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", savePath, counter, extension);
+                            fileExists = File.Exists(path);
+                            counter++;
+                        }
+
                         _logger.LogInformation("Saving subtitles to {SavePath}", path);
                         _monitor.ReportFileSystemChangeBeginning(path);
 
@@ -254,14 +254,14 @@ namespace MediaBrowser.Providers.Subtitles
                         {
                             await stream.CopyToAsync(fs).ConfigureAwait(false);
                         }
+
+                        return;
                     }
                     else
                     {
                         // TODO: Add some error handling to the API user: return BadRequest("Could not save subtitle, bad path.");
                         _logger.LogError("An uploaded subtitle could not be saved because the resulting path was invalid.");
                     }
-
-                    return;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Subs currently fail to download if another subtitle with the same name (usually previously downloaded) exists. This change now modifies the saving filename before saving so it does not fail anymore.

**Issues**
Fixes #10696