### PR TITLE
#11289 Fixed cleanup task not checking for folders

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -116,7 +116,7 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
         foreach (var linkedChild in folder.LinkedChildren)
         {
             var path = linkedChild.Path;
-            if (!File.Exists(path))
+            if (Path.HasExtension(path) ? !File.Exists(path) : !Directory.Exists(path))
             {
                 _logger.LogInformation("Item in {FolderName} cannot be found at {ItemPath}", folder.Name, path);
                 (itemsToRemove ??= new List<LinkedChild>()).Add(linkedChild);


### PR DESCRIPTION
**Changes**
- Check for an extension present in the checked path, if not check if the directory still exists, otherwise check for file presence

**Issues**
Fixes #11289 
