### PR TITLE
Add jacket to the list of music images

### DIFF
--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -32,6 +32,7 @@ namespace MediaBrowser.LocalMetadata.Images
             "folder",
             "poster",
             "cover",
+            "jacket",
             "default"
         };
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This adds "jacket" to the list of paths searched for the default image of music media types. This is a very common name for the cover art of albums that is often found even in official digital releases of albums. Without this change, users often need to either use an online metadata provider or rename the file, even though their copy of the album already contained a proper cover art. This is also supported by other media clients.

I'm not sure if an issue / feature request was needed for such a small change, if so I'll gladly make one if asked to.

An update to the docs at https://github.com/jellyfin/jellyfin.org/blob/master/docs/general/server/media/music.md must also be made if this change is merged.