### PR TITLE
Add support for out-of-spec but existent, Dolby Vision Profile 8 CCid 6 media.

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -730,6 +730,8 @@ namespace MediaBrowser.Model.Entities
                         1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
                         2 => (VideoRange.SDR, VideoRangeType.DOVIWithSDR),
+                        // While not in Dolby Spec, Profile 8 CCid 6 media have been circulating, and since CCid 6 stems from Bluray (Profile 7 originally) an HDR10 base layer is guaranteed to exist.
+                        6 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         // There is no other case to handle here as per Dolby Spec. Default case included for completeness and linting purposes
                         _ => (VideoRange.SDR, VideoRangeType.SDR)
                     },

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -730,7 +730,7 @@ namespace MediaBrowser.Model.Entities
                         1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
                         2 => (VideoRange.SDR, VideoRangeType.DOVIWithSDR),
-                        // While not in Dolby Spec, Profile 8 CCid 6 media have been circulating, and since CCid 6 stems from Bluray (Profile 7 originally) an HDR10 base layer is guaranteed to exist.
+                        // While not in Dolby Spec, Profile 8 CCid 6 media are possible to create, and since CCid 6 stems from Bluray (Profile 7 originally) an HDR10 base layer is guaranteed to exist.
                         6 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
                         // There is no other case to handle here as per Dolby Spec. Default case included for completeness and linting purposes
                         _ => (VideoRange.SDR, VideoRangeType.SDR)


### PR DESCRIPTION
As described in the linked issue, there are media that are identified by mediainfo as Dolby Vision Profile 8 CCid 6. Since BluRay spec guarantees, as far as I could tell, that all HDR containing BluRays have at least an HDR10 layer acting as the base layer, and more specifically in this case, since the above must stem from a DoVi BluRay (which is the only case that uses CCid 6, see Profile 7), Dolby Spec requires that a "BluRay compatible" HDR base/fallback layer exists, which should be HDR10 as described above.

Hence, given that FFmpeg supports profile 8, the above cases should be tagged as DOVIWithHDR10.
Any corrections are encouraged and appreciated!

**Changes**
Add an extra switch case, so as to tag Profile 8 CCid 6 as DOVIWithHDR10

**Issues**
Fixes #11330
