### PR TITLE
Only update if actively refreshing

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -460,15 +460,7 @@ namespace MediaBrowser.Controller.Entities
 
                     progress.Report(percent);
 
-                    // TODO: this is sometimes being called after the refresh has completed.
-                    try
-                    {
-                        ProviderManager.OnRefreshProgress(folder, percent);
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        Logger.LogError(e, "Error refreshing folder");
-                    }
+                    ProviderManager.OnRefreshProgress(folder, percent);
                 });
 
                 if (validChildrenNeedGeneration)
@@ -500,15 +492,7 @@ namespace MediaBrowser.Controller.Entities
 
                     if (recursive)
                     {
-                        // TODO: this is sometimes being called after the refresh has completed.
-                        try
-                        {
-                            ProviderManager.OnRefreshProgress(folder, percent);
-                        }
-                        catch (InvalidOperationException e)
-                        {
-                            Logger.LogError(e, "Error refreshing folder");
-                        }
+                        ProviderManager.OnRefreshProgress(folder, percent);
                     }
                 });
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -969,7 +969,8 @@ namespace MediaBrowser.Providers.Manager
             _logger.LogDebug("OnRefreshProgress {Id:N} {Progress}", id, progress);
 
             if (!_activeRefreshes.TryGetValue(id, out var current)
-                || !_activeRefreshes.TryUpdate(id, progress, current))
+                || progress <= current
+                || (progress > current && !_activeRefreshes.TryUpdate(id, progress, current)))
             {
                 // Item isn't currently refreshing so don't trigger event.
                 return;

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -968,16 +968,12 @@ namespace MediaBrowser.Providers.Manager
             var id = item.Id;
             _logger.LogDebug("OnRefreshProgress {Id:N} {Progress}", id, progress);
 
-            // TODO: Need to hunt down the conditions for this happening
-            _activeRefreshes.AddOrUpdate(
-                id,
-                _ => throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Cannot update refresh progress of item '{0}' ({1}) because a refresh for this item is not running",
-                        item.GetType().Name,
-                        item.Id.ToString("N", CultureInfo.InvariantCulture))),
-                (_, _) => progress);
+            if (!_activeRefreshes.TryGetValue(id, out var current)
+                || !_activeRefreshes.TryUpdate(id, progress, current))
+            {
+                // Item isn't currently refreshing so don't trigger event.
+                return;
+            }
 
             try
             {

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -970,7 +970,7 @@ namespace MediaBrowser.Providers.Manager
 
             if (!_activeRefreshes.TryGetValue(id, out var current)
                 || progress <= current
-                || (progress > current && !_activeRefreshes.TryUpdate(id, progress, current)))
+                || !_activeRefreshes.TryUpdate(id, progress, current))
             {
                 // Item isn't currently refreshing so don't trigger event.
                 return;


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/11264

`.AddOrUpdate()` is doing essentially the same thing internally, this just removes the exception