### PR TITLE
fix: use new serializer cache per IXmlSerializer

### DIFF
--- a/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
@@ -15,10 +15,9 @@ namespace Emby.Server.Implementations.Serialization
     {
         // Need to cache these
         // http://dotnetcodebox.blogspot.com/2013/01/xmlserializer-class-may-result-in.html
-        private static readonly ConcurrentDictionary<string, XmlSerializer> _serializers =
-            new ConcurrentDictionary<string, XmlSerializer>();
+        private readonly ConcurrentDictionary<string, XmlSerializer> _serializers = new();
 
-        private static XmlSerializer GetSerializer(Type type)
+        private XmlSerializer GetSerializer(Type type)
             => _serializers.GetOrAdd(
                 type.FullName ?? throw new ArgumentException($"Invalid type {type}."),
                 static (_, t) => new XmlSerializer(t),


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/11349

Other option is to clear the dictionary when a new `MyXmlSerializer` is created, but this is cleaner and essentially just as performant 