### PR TITLE
fix: fallback to artist if album artist not provided

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -338,6 +338,12 @@ namespace MediaBrowser.Providers.MediaInfo
                         audio.Artists = performers;
                     }
 
+                    if (albumArtists.Length == 0)
+                    {
+                        // Album artists not provided, fall back to performers (artists).
+                        albumArtists = performers;
+                    }
+
                     if (options.ReplaceAllMetadata && albumArtists.Length != 0)
                     {
                         audio.AlbumArtists = albumArtists;


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/10974

Same as https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs#L1298-L1302