### PR TITLE
Support age in LocalizationManager.GetRatingLevel

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -278,6 +278,13 @@ namespace Emby.Server.Implementations.Localization
                 return null;
             }
 
+            // Convert integers directly
+            // This may override some of the locale specific age ratings (but those always map to the same age)
+            if (int.TryParse(rating, out var ratingAge))
+            {
+                return ratingAge;
+            }
+
             // Fairly common for some users to have "Rated R" in their rating field
             rating = rating.Replace("Rated :", string.Empty, StringComparison.OrdinalIgnoreCase);
             rating = rating.Replace("Rated ", string.Empty, StringComparison.OrdinalIgnoreCase);

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -127,6 +127,22 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             Assert.Equal(expectedLevel, level!);
         }
 
+        [Theory]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("6", 6)]
+        [InlineData("12", 12)]
+        [InlineData("42", 42)]
+        [InlineData("9999", 9999)]
+        public async Task GetRatingLevel_GivenValidAge_Success(string value, int expectedLevel)
+        {
+            var localizationManager = Setup(new ServerConfiguration { MetadataCountryCode = "nl" });
+            await localizationManager.LoadAll();
+            var level = localizationManager.GetRatingLevel(value);
+            Assert.NotNull(level);
+            Assert.Equal(expectedLevel, level);
+        }
+
         [Fact]
         public async Task GetRatingLevel_GivenUnratedString_Success()
         {


### PR DESCRIPTION
I've recently added a PG-13 content only limit to the screensaver in the Android TV app. I'm planning to make this configurable but I want to store the chosen rating as integer (age) instead of the rating name, which is dependent on the server localization.
One problem I ran into is that I can't filter items based on age, this PR adds a small change to the LocalizationManager to always try parsing the requested rating level as integer first before using its mapping files. This way it is possible to request items with `maxOfficialRating=13` instead of `maxOfficialRating=PG-13`.

**Changes**
- Support age (as integer) in LocalizationManager.GetRatingLevel, skipping the mappings

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
