### PR TITLE
fix: don't extract external sub

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -463,7 +463,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             try
             {
                 var subtitleStreams = mediaSource.MediaStreams
-                    .Where(stream => stream is {IsTextSubtitleStream: true, SupportsExternalStream: true, IsExternal: false});
+                    .Where(stream => stream is { IsTextSubtitleStream: true, SupportsExternalStream: true, IsExternal: false });
 
                 foreach (var subtitleStream in subtitleStreams)
                 {

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -463,7 +463,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             try
             {
                 var subtitleStreams = mediaSource.MediaStreams
-                    .Where(stream => stream.IsTextSubtitleStream && stream.SupportsExternalStream);
+                    .Where(stream => stream is {IsTextSubtitleStream: true, SupportsExternalStream: true, IsExternal: false});
 
                 foreach (var subtitleStream in subtitleStreams)
                 {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Current subtitle extraction will attempt to map the external text subtitles as well during the extraction, which would obviously fail as that stream is not in the original video file. Ignore external streams during the extraction.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #11242
