### PR TITLE
fix: don't apply whitelist tags to libraries

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1602,6 +1602,12 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
+            var parent = GetParents().FirstOrDefault() ?? this;
+            if (parent is UserRootFolder)
+            {
+                return true;
+            }
+
             var allowedTagsPreference = user.GetPreference(PreferenceKind.AllowedTags);
             if (allowedTagsPreference.Length != 0 && !allowedTagsPreference.Any(i => allTags.Contains(i, StringComparison.OrdinalIgnoreCase)))
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The way the whitelist tag currently works is weird. It requires the entire library to have that tag to be shown, and if the library has the tag, all items inside it inherit that tag, making all items visible. This change aims to make it more sensible by allowing the whitelist to work on a per-item basis, ensuring that the allowed libraries are always shown and the whitelist tag only applies to the items inside the library, not the library itself.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11375
