### PR TITLE
fix: restore os name in GetPublicSystemInfo endpoint

### DIFF
--- a/Emby.Server.Implementations/SystemManager.cs
+++ b/Emby.Server.Implementations/SystemManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
@@ -78,6 +79,7 @@ public class SystemManager : ISystemManager
         {
             Version = _applicationHost.ApplicationVersionString,
             ProductName = _applicationHost.Name,
+            OperatingSystem = GetServerOs(),
             Id = _applicationHost.SystemId,
             ServerName = _applicationHost.FriendlyName,
             LocalAddress = _applicationHost.GetSmartApiUrl(request),
@@ -99,5 +101,25 @@ public class SystemManager : ISystemManager
             _applicationHost.ShouldRestart = restart;
             _applicationLifetime.StopApplication();
         });
+    }
+
+    private static string GetServerOs()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return "Linux";
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return "Windows";
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return "macOS";
+        }
+
+        return "Others";
     }
 }

--- a/MediaBrowser.Model/System/PublicSystemInfo.cs
+++ b/MediaBrowser.Model/System/PublicSystemInfo.cs
@@ -34,7 +34,6 @@ namespace MediaBrowser.Model.System
         /// Gets or sets the operating system.
         /// </summary>
         /// <value>The operating system.</value>
-        [Obsolete("This is no longer set")]
         public string OperatingSystem { get; set; } = string.Empty;
 
         /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This is still used by clients to show platform-specific hardware acceleration options, restore the os name for now.

A better approach would be to create another endpoint that returns the underlying hardware capabilities from the server instead of checking from the client side. Hardware capabilities can be very complicated and cannot be easily tested by clients with limited information. With this API, we can remove the OS name again from GetPublicSystemInfo.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11382