### PR TITLE
Enable nullable for UserItemData

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
@@ -333,10 +333,10 @@ namespace Emby.Server.Implementations.Data
         /// <returns>The user item data.</returns>
         private UserItemData ReadRow(SqliteDataReader reader)
         {
-            var userData = new UserItemData();
-
-            userData.Key = reader[0].ToString();
-            // userData.UserId = reader[1].ReadGuidFromBlob();
+            var userData = new UserItemData
+            {
+                Key = reader.GetString(0)
+            };
 
             if (reader.TryGetDouble(2, out var rating))
             {

--- a/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/UserDataChangeNotifier.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -138,13 +137,13 @@ namespace Emby.Server.Implementations.EntryPoints
 
             return new UserDataChangeInfo
             {
-                UserId = userId.ToString("N", CultureInfo.InvariantCulture),
+                UserId = userId,
                 UserDataList = changedItems
                     .DistinctBy(x => x.Id)
                     .Select(i =>
                     {
                         var dto = _userDataManager.GetUserDataDto(i, user);
-                        dto.ItemId = i.Id.ToString("N", CultureInfo.InvariantCulture);
+                        dto.ItemId = i.Id;
                         return dto;
                     })
                     .ToArray()

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -379,7 +379,8 @@ namespace Emby.Server.Implementations.Library
 
         private void SetDefaultSubtitleStreamIndex(MediaSourceInfo source, UserItemData userData, User user, bool allowRememberingSelection)
         {
-            if (userData.SubtitleStreamIndex.HasValue
+            if (userData is not null
+                && userData.SubtitleStreamIndex.HasValue
                 && user.RememberSubtitleSelections
                 && user.SubtitleMode != SubtitlePlaybackMode.None
                 && allowRememberingSelection)
@@ -411,7 +412,7 @@ namespace Emby.Server.Implementations.Library
 
         private void SetDefaultAudioStreamIndex(MediaSourceInfo source, UserItemData userData, User user, bool allowRememberingSelection)
         {
-            if (userData.AudioStreamIndex.HasValue && user.RememberAudioSelections && allowRememberingSelection)
+            if (userData is not null && userData.AudioStreamIndex.HasValue && user.RememberAudioSelections && allowRememberingSelection)
             {
                 var index = userData.AudioStreamIndex.Value;
                 // Make sure the saved index is still valid
@@ -434,7 +435,7 @@ namespace Emby.Server.Implementations.Library
 
             if (mediaType == MediaType.Video)
             {
-                var userData = item is null ? new UserItemData() : _userDataManager.GetUserData(user, item);
+                var userData = item is null ? null : _userDataManager.GetUserData(user, item);
 
                 var allowRememberingSelection = item is null || item.EnableRememberingTrackSelections;
 

--- a/MediaBrowser.Controller/Entities/UserItemData.cs
+++ b/MediaBrowser.Controller/Entities/UserItemData.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 #pragma warning disable CS1591
 
 using System;
@@ -20,16 +18,10 @@ namespace MediaBrowser.Controller.Entities
         private double? _rating;
 
         /// <summary>
-        /// Gets or sets the user id.
-        /// </summary>
-        /// <value>The user id.</value>
-        public Guid UserId { get; set; }
-
-        /// <summary>
         /// Gets or sets the key.
         /// </summary>
         /// <value>The key.</value>
-        public string Key { get; set; }
+        public required string Key { get; set; }
 
         /// <summary>
         /// Gets or sets the users 0-10 rating.

--- a/MediaBrowser.Controller/Providers/MetadataResult.cs
+++ b/MediaBrowser.Controller/Providers/MetadataResult.cs
@@ -2,9 +2,7 @@
 
 #pragma warning disable CA1002, CA2227, CS1591
 
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 
@@ -32,8 +30,6 @@ namespace MediaBrowser.Controller.Providers
             get => _remoteImages ??= new List<(string Url, ImageType Type)>();
             set => _remoteImages = value;
         }
-
-        public List<UserItemData> UserDataList { get; set; }
 
         public List<PersonInfo> People { get; set; }
 
@@ -67,33 +63,6 @@ namespace MediaBrowser.Controller.Providers
             {
                 People.Clear();
             }
-        }
-
-        public UserItemData GetOrAddUserData(string userId)
-        {
-            UserDataList ??= new List<UserItemData>();
-
-            UserItemData userData = null;
-
-            foreach (var i in UserDataList)
-            {
-                if (string.Equals(userId, i.UserId.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
-                {
-                    userData = i;
-                }
-            }
-
-            if (userData is null)
-            {
-                userData = new UserItemData()
-                {
-                    UserId = new Guid(userId)
-                };
-
-                UserDataList.Add(userData);
-            }
-
-            return userData;
         }
     }
 }

--- a/MediaBrowser.Model/Dto/UserItemDataDto.cs
+++ b/MediaBrowser.Model/Dto/UserItemDataDto.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 
 namespace MediaBrowser.Model.Dto
@@ -66,12 +65,12 @@ namespace MediaBrowser.Model.Dto
         /// Gets or sets the key.
         /// </summary>
         /// <value>The key.</value>
-        public string Key { get; set; }
+        public required string Key { get; set; }
 
         /// <summary>
         /// Gets or sets the item identifier.
         /// </summary>
         /// <value>The item identifier.</value>
-        public string ItemId { get; set; }
+        public Guid ItemId { get; set; }
     }
 }

--- a/MediaBrowser.Model/Session/UserDataChangeInfo.cs
+++ b/MediaBrowser.Model/Session/UserDataChangeInfo.cs
@@ -1,4 +1,4 @@
-#nullable disable
+using System;
 using MediaBrowser.Model.Dto;
 
 namespace MediaBrowser.Model.Session
@@ -12,12 +12,12 @@ namespace MediaBrowser.Model.Session
         /// Gets or sets the user id.
         /// </summary>
         /// <value>The user id.</value>
-        public string UserId { get; set; }
+        public Guid UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the user data list.
         /// </summary>
         /// <value>The user data list.</value>
-        public UserItemDataDto[] UserDataList { get; set; }
+        public required UserItemDataDto[] UserDataList { get; set; }
     }
 }

--- a/MediaBrowser.XbmcMetadata/Providers/BaseVideoNfoProvider.cs
+++ b/MediaBrowser.XbmcMetadata/Providers/BaseVideoNfoProvider.cs
@@ -54,11 +54,6 @@ namespace MediaBrowser.XbmcMetadata.Providers
             result.People = tmpItem.People;
             result.Images = tmpItem.Images;
             result.RemoteImages = tmpItem.RemoteImages;
-
-            if (tmpItem.UserDataList is not null)
-            {
-                result.UserDataList = tmpItem.UserDataList;
-            }
         }
 
         /// <inheritdoc />

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -53,7 +53,10 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
 
             var userData = new Mock<IUserDataManager>();
             userData.Setup(x => x.GetUserData(_testUser, It.IsAny<BaseItem>()))
-                .Returns(new UserItemData());
+                .Returns(new UserItemData()
+                {
+                    Key = "Something"
+                });
 
             var directoryService = new Mock<IDirectoryService>();
             _localImageFileMetadata = new FileSystemMetadata()


### PR DESCRIPTION
MetadataResult.GetOrAddUserData doesn't ever get used and is probably broken since the migration to .NET Core as it still expects a Guid for userId

