### PR TITLE
Fix WebSocket disconnecting when exception is thrown during processing

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -199,13 +199,20 @@ namespace Emby.Server.Implementations.HttpServer
             }
             else
             {
-                await OnReceive(
-                    new WebSocketMessageInfo
-                    {
-                        MessageType = stub.MessageType,
-                        Data = stub.Data?.ToString(), // Data can be null
-                        Connection = this
-                    }).ConfigureAwait(false);
+                try
+                {
+                    await OnReceive(
+                        new WebSocketMessageInfo
+                        {
+                            MessageType = stub.MessageType,
+                            Data = stub.Data?.ToString(), // Data can be null
+                            Connection = this
+                        }).ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(exception, "Failed to process WebSocket message");
+                }
             }
         }
 


### PR DESCRIPTION
A WebSocket connection should not (forcefully) be closed when an incoming message fails to process. In the specific issue I encountered it was due to new authorization requirements, which we should just NO-OP to.

```
[2024-04-21 14:53:52.405 +02:00] [INF] [113] Emby.Server.Implementations.HttpServer.WebSocketManager: WS "192.168.1.1" request
[2024-04-21 14:53:52.417 +02:00] [ERR] [46] Emby.Server.Implementations.HttpServer.WebSocketManager: WS "192.168.1.1" WebSocketRequestHandler error
MediaBrowser.Controller.Authentication.AuthenticationException: Only admin users can subscribe to session information.
   at Jellyfin.Api.WebSocketListeners.SessionInfoWebSocketListener.Start(WebSocketMessageInfo message) in jellyfin\Jellyfin.Api\WebSocketListeners\SessionInfoWebSocketListener.cs:line 84
   at Emby.Server.Implementations.HttpServer.WebSocketManager.ProcessWebSocketMessageReceived(WebSocketMessageInfo result) in jellyfin\Emby.Server.Implementations\HttpServer\WebSocketManager.cs:line 92
   at Emby.Server.Implementations.HttpServer.WebSocketConnection.ProcessInternal(PipeReader reader)
   at Emby.Server.Implementations.HttpServer.WebSocketConnection.ReceiveAsync(CancellationToken cancellationToken) in jellyfin\Emby.Server.Implementations\HttpServer\WebSocketConnection.cs:line 140
   at Emby.Server.Implementations.HttpServer.WebSocketManager.WebSocketRequestHandler(HttpContext context) in jellyfin\Emby.Server.Implementations\HttpServer\WebSocketManager.cs:line 69
   at Emby.Server.Implementations.HttpServer.WebSocketManager.WebSocketRequestHandler(HttpContext context) in jellyfin\Emby.Server.Implementations\HttpServer\WebSocketManager.cs:line 70
```

**Changes**
- Add try-catch to avoid WS from closing due to uncaught exception

**Issues**

Regression from #9875
