### PR TITLE
Fix InvalidCastException in ItemUpdateController

### DIFF
--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -288,7 +288,7 @@ public class ItemUpdateController : BaseJellyfinApiController
 
         if (item is Series rseries)
         {
-            foreach (Season season in rseries.Children)
+            foreach (var season in rseries.Children.OfType<Season>())
             {
                 season.OfficialRating = request.OfficialRating;
                 season.CustomRating = request.CustomRating;
@@ -296,7 +296,7 @@ public class ItemUpdateController : BaseJellyfinApiController
                 season.OnMetadataChanged();
                 await season.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None).ConfigureAwait(false);
 
-                foreach (Episode ep in season.Children)
+                foreach (var ep in season.Children.OfType<Episode>())
                 {
                     ep.OfficialRating = request.OfficialRating;
                     ep.CustomRating = request.CustomRating;
@@ -308,7 +308,7 @@ public class ItemUpdateController : BaseJellyfinApiController
         }
         else if (item is Season season)
         {
-            foreach (Episode ep in season.Children)
+            foreach (var ep in season.Children.OfType<Episode>())
             {
                 ep.OfficialRating = request.OfficialRating;
                 ep.CustomRating = request.CustomRating;


### PR DESCRIPTION
Regression from #8526.

**Changes**

- Don't cast without checking type in ItemUpdateController, as library structures are not always what we expect.

**Issues**

Fixes #11277