### PR TITLE
Add audio remux to UniversalAudioController

### DIFF
--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -17,6 +17,7 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Model.Session;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -137,6 +138,8 @@ public class UniversalAudioController : BaseJellyfinApiController
         // set device specific data
         foreach (var sourceInfo in info.MediaSources)
         {
+            sourceInfo.TranscodingContainer = transcodingContainer;
+            sourceInfo.TranscodingSubProtocol = transcodingProtocol ?? sourceInfo.TranscodingSubProtocol;
             _mediaInfoHelper.SetDeviceSpecificData(
                 item,
                 sourceInfo,
@@ -171,27 +174,30 @@ public class UniversalAudioController : BaseJellyfinApiController
             return Redirect(mediaSource.Path);
         }
 
+        // This one is currently very misleading as the SupportsDirectStream is always false
+        // The definition of DirectStream also seems changed during development
+        // It used to mean HTTP direct streaming, but now HLS is used even for DirectStream
         var isStatic = mediaSource.SupportsDirectStream;
-        if (!isStatic && mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
+        if (mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
         {
             // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
             // ffmpeg option -> file extension
             //        mpegts -> ts
             //          fmp4 -> mp4
-            // TODO: remove this when we switch back to the segment muxer
             var supportedHlsContainers = new[] { "ts", "mp4" };
 
+            // fallback to mpegts if device reports some weird value unsupported by hls
+            var segmentContainer = Array.Exists(supportedHlsContainers, element => element == transcodingContainer) ? transcodingContainer : "ts";
             var dynamicHlsRequestDto = new HlsAudioRequestDto
             {
                 Id = itemId,
                 Container = ".m3u8",
                 Static = isStatic,
                 PlaySessionId = info.PlaySessionId,
-                // fallback to mpegts if device reports some weird value unsupported by hls
-                SegmentContainer = Array.Exists(supportedHlsContainers, element => element == transcodingContainer) ? transcodingContainer : "ts",
+                SegmentContainer = segmentContainer,
                 MediaSourceId = mediaSourceId,
                 DeviceId = deviceId,
-                AudioCodec = audioCodec,
+                AudioCodec = mediaSource.TranscodeReasons == TranscodeReason.ContainerNotSupported ? "copy" : audioCodec,
                 EnableAutoStreamCopy = true,
                 AllowAudioStreamCopy = true,
                 AllowVideoStreamCopy = true,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -187,7 +187,8 @@ public class UniversalAudioController : BaseJellyfinApiController
             var supportedHlsContainers = new[] { "ts", "mp4" };
 
             // fallback to mpegts if device reports some weird value unsupported by hls
-            var segmentContainer = Array.Exists(supportedHlsContainers, element => element == transcodingContainer) ? transcodingContainer : "ts";
+            var requestedSegmentContainer = Array.Exists(supportedHlsContainers, element => element == transcodingContainer) ? transcodingContainer : "ts";
+            var segmentContainer = Array.Exists(supportedHlsContainers, element => element == mediaSource.TranscodingContainer) ? mediaSource.TranscodingContainer : requestedSegmentContainer;
             var dynamicHlsRequestDto = new HlsAudioRequestDto
             {
                 Id = itemId,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -174,11 +174,10 @@ public class UniversalAudioController : BaseJellyfinApiController
             return Redirect(mediaSource.Path);
         }
 
-        // This one is currently very misleading as the SupportsDirectStream is always false
+        // This one is currently very misleading as the SupportsDirectStream actually means "can direct play"
         // The definition of DirectStream also seems changed during development
-        // It used to mean HTTP direct streaming, but now HLS is used even for DirectStream
         var isStatic = mediaSource.SupportsDirectStream;
-        if (mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
+        if (!isStatic && mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
         {
             // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
             // ffmpeg option -> file extension

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -187,7 +187,7 @@ public class UniversalAudioController : BaseJellyfinApiController
 
             // fallback to mpegts if device reports some weird value unsupported by hls
             var requestedSegmentContainer = Array.Exists(
-                supportedHlsContainers, 
+                supportedHlsContainers,
                 element => string.Equals(element, transcodingContainer, StringComparison.OrdinalIgnoreCase)) ? transcodingContainer : "ts";
             var segmentContainer = Array.Exists(
                 supportedHlsContainers,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -186,8 +186,12 @@ public class UniversalAudioController : BaseJellyfinApiController
             var supportedHlsContainers = new[] { "ts", "mp4" };
 
             // fallback to mpegts if device reports some weird value unsupported by hls
-            var requestedSegmentContainer = Array.Exists(supportedHlsContainers, element => element == transcodingContainer) ? transcodingContainer : "ts";
-            var segmentContainer = Array.Exists(supportedHlsContainers, element => element == mediaSource.TranscodingContainer) ? mediaSource.TranscodingContainer : requestedSegmentContainer;
+            var requestedSegmentContainer = Array.Exists(
+                supportedHlsContainers, 
+                element => string.Equals(element, transcodingContainer, StringComparison.OrdinalIgnoreCase)) ? transcodingContainer : "ts";
+            var segmentContainer = Array.Exists(
+                supportedHlsContainers,
+                element => string.Equals(element, mediaSource.TranscodingContainer, StringComparison.OrdinalIgnoreCase)) ? mediaSource.TranscodingContainer : requestedSegmentContainer;
             var dynamicHlsRequestDto = new HlsAudioRequestDto
             {
                 Id = itemId,

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -151,6 +151,14 @@ public class DynamicHlsHelper
 
         var queryString = _httpContextAccessor.HttpContext.Request.QueryString.ToString();
 
+        // from universal audio service, need to override the AudioCodec when the actual request differs from original query
+        if (!string.Equals(state.OutputAudioCodec, _httpContextAccessor.HttpContext.Request.Query["AudioCodec"].ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            var newQuery = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(_httpContextAccessor.HttpContext.Request.QueryString.ToString());
+            newQuery["AudioCodec"] = state.OutputAudioCodec;
+            queryString = Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(string.Empty, newQuery);
+        }
+
         // from universal audio service
         if (!string.IsNullOrWhiteSpace(state.Request.SegmentContainer)
             && !queryString.Contains("SegmentContainer", StringComparison.OrdinalIgnoreCase))

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -479,6 +479,11 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
                 : "FFmpeg.DirectStream-";
         }
 
+        if (state.VideoRequest is null && EncodingHelper.IsCopyCodec(state.OutputAudioCodec))
+        {
+            logFilePrefix = "FFmpeg.Remux-";
+        }
+
         var logFilePath = Path.Combine(
             _serverConfigurationManager.ApplicationPaths.LogDirectoryPath,
             $"{logFilePrefix}{DateTime.Now:yyyy-MM-dd_HH-mm-ss}_{state.Request.MediaSourceId}_{Guid.NewGuid().ToString()[..8]}.log");

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -127,6 +127,10 @@ namespace MediaBrowser.Model.Dlna
             if (directPlayMethod is PlayMethod.DirectStream)
             {
                 var remuxContainer = item.TranscodingContainer ?? "ts";
+                var supportedHlsContainers = new[] { "ts", "mp4" };
+                // If the container specified for the profile is an HLS supported container, use that container instead, overriding the preference
+                // The client should be responsible to ensure this container is compatible
+                remuxContainer = Array.Exists(supportedHlsContainers, element => element == directPlayInfo.Profile?.Container) ? directPlayInfo.Profile?.Container : remuxContainer;
                 bool codeIsSupported;
                 if (item.TranscodingSubProtocol == MediaStreamProtocol.hls)
                 {
@@ -152,6 +156,7 @@ namespace MediaBrowser.Model.Dlna
                     playlistItem.Container = remuxContainer;
                     playlistItem.TranscodeReasons = transcodeReasons;
                     playlistItem.SubProtocol = item.TranscodingSubProtocol;
+                    item.TranscodingContainer = remuxContainer;
                     return playlistItem;
                 }
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -466,7 +466,10 @@ namespace MediaBrowser.Model.Dlna
             {
                 if (!IsBitrateLimitExceeded(item, options.GetMaxBitrate(true) ?? 0))
                 {
-                    if (options.EnableDirectStream)
+                    // Note: as of 10.10 codebase, the options.EnableDirectStream is always false due to
+                    // "direct-stream http streaming is currently broken"
+                    // Don't check that option for audio as we always assume that is supported
+                    if (transcodeReasons == TranscodeReason.ContainerNotSupported)
                     {
                         return (directPlayProfile, PlayMethod.DirectStream, transcodeReasons);
                     }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -130,7 +130,7 @@ namespace MediaBrowser.Model.Dlna
                 var supportedHlsContainers = new[] { "ts", "mp4" };
                 // If the container specified for the profile is an HLS supported container, use that container instead, overriding the preference
                 // The client should be responsible to ensure this container is compatible
-                remuxContainer = Array.Exists(supportedHlsContainers, element => element == directPlayInfo.Profile?.Container) ? directPlayInfo.Profile?.Container : remuxContainer;
+                remuxContainer = Array.Exists(supportedHlsContainers, element => string.Equals(element, directPlayInfo.Profile?.Container, StringComparison.OrdinalIgnoreCase)) ? directPlayInfo.Profile?.Container : remuxContainer;
                 bool codeIsSupported;
                 if (item.TranscodingSubProtocol == MediaStreamProtocol.hls)
                 {

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -2185,6 +2185,7 @@ namespace MediaBrowser.Model.Dlna
         private static bool IsAudioDirectStreamSupported(DirectPlayProfile profile, MediaSourceInfo item, MediaStream audioStream)
         {
             // Check container type, this should NOT be supported
+            // If the container is supported, the file should be directly played
             if (!profile.SupportsContainer(item.Container))
             {
                 // Check audio codec, we cannot use the SupportsAudioCodec here


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR adds audio remuxing (copying audio into another container without transcoding) support to the UniversalAudioController, allowing the client to request the audio to be in a specific container. When remuxing with HLS, the HLS container's constraint applies, and it will fallback to transcoding when the original audio codec is not supported by the chosen HLS container. When remuxing with HTTP, this assumes that the client-provided container supports the audio codec. If it does not, ffmpeg would fail.

To workaround the complex codec+container support situation in HLS, an HLS container override feature has been added. The client can explicitly require a container+codec combination supported by HLS. For example, `ts|mp3` and `mp4|flac`. When combinations like these are present, the HLS stream will use the container specified in this profile, ignoring the one set by the `TranscodingContainer` query string. The most common use case for this mode is to force mp3 to be remuxed in mpegts container because most browsers do not support mp3 in mp4 container, although it is technically supported by HLS. When specifying such overrides, the client should be responsible to ensure the container and codec compatibility. 

This would allow clients with strict container requirements to playback certain audio codecs. For example, Opus on Safari can be played with HLS + fmp4.

This can also workarounds a lot of container related issues, as listed below in the issues section.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

#11113 This one is due to the flac/mp3 container containing too little information, the client's estimation of the "ticks" might not be accurate enough. Allowing the client to force an HLS remuxing with fmp4 can mitigate this issue as the mp4 container has more information about the timing. Most browsers do not support mp3 in mp4 container, so probably need to force to remux into mpegts to workaround the timing issue for mp3.

#3731 This issue arises because the flac container has non-standard metadata tags, causing the client to refuse to play the file. This can be mitigated by falling back to HLS remuxing when direct play fails, or simply by forcing HLS remuxing anyway.
