### PR TITLE
Always scan ReplayGain tag

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -135,7 +135,7 @@ namespace MediaBrowser.Controller.Entities
         /// </summary>
         /// <value>The LUFS Value.</value>
         [JsonIgnore]
-        public float LUFS { get; set; }
+        public float? LUFS { get; set; }
 
         /// <summary>
         /// Gets or sets the channel identifier.

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -35,8 +35,6 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableLUFSScan { get; set; }
 
-        public bool UseReplayGainTags { get; set; }
-
         public bool EnableChapterImageExtraction { get; set; }
 
         public bool ExtractChapterImagesDuringLibraryScan { get; set; }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -70,9 +70,6 @@ namespace MediaBrowser.Providers.MediaInfo
         [GeneratedRegex(@"I:\s+(.*?)\s+LUFS")]
         private static partial Regex LUFSRegex();
 
-        [GeneratedRegex(@"REPLAYGAIN_TRACK_GAIN:\s+-?([0-9.]+)\s+dB")]
-        private static partial Regex ReplayGainTagRegex();
-
         /// <summary>
         /// Probes the specified item for metadata.
         /// </summary>
@@ -116,50 +113,7 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             var libraryOptions = _libraryManager.GetLibraryOptions(item);
-            bool foundLUFSValue = false;
-
-            if (libraryOptions.UseReplayGainTags)
-            {
-                using (var process = new Process()
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = _mediaEncoder.ProbePath,
-                        Arguments = $"-hide_banner -i \"{path}\"",
-                        RedirectStandardOutput = false,
-                        RedirectStandardError = true
-                    },
-                })
-                {
-                    try
-                    {
-                        process.Start();
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error starting ffmpeg");
-
-                        throw;
-                    }
-
-                    using var reader = process.StandardError;
-                    var output = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-                    cancellationToken.ThrowIfCancellationRequested();
-                    Match split = ReplayGainTagRegex().Match(output);
-
-                    if (split.Success)
-                    {
-                        item.LUFS = DefaultLUFSValue - float.Parse(split.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
-                        foundLUFSValue = true;
-                    }
-                    else
-                    {
-                        item.LUFS = DefaultLUFSValue;
-                    }
-                }
-            }
-
-            if (libraryOptions.EnableLUFSScan && !foundLUFSValue)
+            if (libraryOptions.EnableLUFSScan && item.LUFS is null)
             {
                 using (var process = new Process()
                 {
@@ -192,16 +146,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     {
                         item.LUFS = float.Parse(split[0].Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
                     }
-                    else
-                    {
-                        item.LUFS = DefaultLUFSValue;
-                    }
                 }
-            }
-
-            if (!libraryOptions.EnableLUFSScan && !libraryOptions.UseReplayGainTags)
-            {
-                item.LUFS = DefaultLUFSValue;
             }
 
             _logger.LogDebug("LUFS for {ItemName} is {LUFS}.", item.Name, item.LUFS);
@@ -389,6 +334,11 @@ namespace MediaBrowser.Providers.MediaInfo
                     audio.Genres = options.ReplaceAllMetadata || audio.Genres == null || audio.Genres.Length == 0
                         ? tags.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
                         : audio.Genres;
+                }
+
+                if (!double.IsNaN(tags.ReplayGainTrackGain))
+                {
+                    audio.LUFS = DefaultLUFSValue - (float)tags.ReplayGainTrackGain;
                 }
 
                 if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))


### PR DESCRIPTION
* Removes the UseReplayGainTags option from the LibraryOptions
* Removes extra ffrobe instance when option was enabled
* Makes LUFS value nullable

cc @TelepathicWalrus 
