### PR TITLE
Use more accurate rounding in GetFixedOutputSize

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -83,11 +83,13 @@ public class TrickplayManager : ITrickplayManager
         var options = _config.Configuration.TrickplayOptions;
         foreach (var width in options.WidthResolutions)
         {
+            // The width has to be even, otherwise a lot of filters will not be able to sample it.
+            var evenWidth = 2 * (width / 2);
             cancellationToken.ThrowIfCancellationRequested();
             await RefreshTrickplayDataInternal(
                 video,
                 replace,
-                width,
+                evenWidth,
                 options,
                 cancellationToken).ConfigureAwait(false);
         }

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -83,13 +83,11 @@ public class TrickplayManager : ITrickplayManager
         var options = _config.Configuration.TrickplayOptions;
         foreach (var width in options.WidthResolutions)
         {
-            // The width has to be even, otherwise a lot of filters will not be able to sample it.
-            var evenWidth = 2 * (width / 2);
             cancellationToken.ThrowIfCancellationRequested();
             await RefreshTrickplayDataInternal(
                 video,
                 replace,
-                evenWidth,
+                width,
                 options,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -108,18 +106,11 @@ public class TrickplayManager : ITrickplayManager
         }
 
         var imgTempDir = string.Empty;
-        var outputDir = GetTrickplayDirectory(video, width);
 
         using (await _resourcePool.LockAsync(cancellationToken).ConfigureAwait(false))
         {
             try
             {
-                if (!replace && Directory.Exists(outputDir) && (await GetTrickplayResolutions(video.Id).ConfigureAwait(false)).ContainsKey(width))
-                {
-                    _logger.LogDebug("Found existing trickplay files for {ItemId}. Exiting.", video.Id);
-                    return;
-                }
-
                 // Extract images
                 // Note: Media sources under parent items exist as their own video/item as well. Only use this video stream for trickplay.
                 var mediaSource = video.GetMediaSources(false).Find(source => Guid.Parse(source.Id).Equals(video.Id));
@@ -130,17 +121,35 @@ public class TrickplayManager : ITrickplayManager
                     return;
                 }
 
+                // The width has to be even, otherwise a lot of filters will not be able to sample it
+                var actualWidth = 2 * (width / 2);
+
+                // Force using the video width when the trickplay setting has a too large width
+                if (mediaSource.VideoStream.Width is not null && mediaSource.VideoStream.Width < width)
+                {
+                    _logger.LogWarning("Video width {VideoWidth} is smaller than trickplay setting {TrickPlayWidth}, using video width for thumbnails", mediaSource.VideoStream.Width, width);
+                    actualWidth = 2 * ((int)mediaSource.VideoStream.Width / 2);
+                }
+
+                var outputDir = GetTrickplayDirectory(video, actualWidth);
+
+                if (!replace && Directory.Exists(outputDir) && (await GetTrickplayResolutions(video.Id).ConfigureAwait(false)).ContainsKey(actualWidth))
+                {
+                    _logger.LogDebug("Found existing trickplay files for {ItemId}. Exiting", video.Id);
+                    return;
+                }
+
                 var mediaPath = mediaSource.Path;
                 var mediaStream = mediaSource.VideoStream;
                 var container = mediaSource.Container;
 
-                _logger.LogInformation("Creating trickplay files at {Width} width, for {Path} [ID: {ItemId}]", width, mediaPath, video.Id);
+                _logger.LogInformation("Creating trickplay files at {Width} width, for {Path} [ID: {ItemId}]", actualWidth, mediaPath, video.Id);
                 imgTempDir = await _mediaEncoder.ExtractVideoImagesOnIntervalAccelerated(
                     mediaPath,
                     container,
                     mediaSource,
                     mediaStream,
-                    width,
+                    actualWidth,
                     TimeSpan.FromMilliseconds(options.Interval),
                     options.EnableHwAcceleration,
                     options.EnableHwEncoding,
@@ -161,7 +170,7 @@ public class TrickplayManager : ITrickplayManager
                     .ToList();
 
                 // Create tiles
-                var trickplayInfo = CreateTiles(images, width, options, outputDir);
+                var trickplayInfo = CreateTiles(images, actualWidth, options, outputDir);
 
                 // Save tiles info
                 try

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2984,8 +2984,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var scaleW = (double)maximumWidth / outputWidth;
                 var scaleH = (double)maximumHeight / outputHeight;
                 var scale = Math.Min(scaleW, scaleH);
-                outputWidth = Math.Min(maximumWidth, (int)Math.Round(outputWidth * scale, MidpointRounding.AwayFromZero));
-                outputHeight = Math.Min(maximumHeight, (int)Math.Round(outputHeight * scale, MidpointRounding.AwayFromZero));
+                outputWidth = Math.Min(maximumWidth, Convert.ToInt32(outputWidth * scale));
+                outputHeight = Math.Min(maximumHeight, Convert.ToInt32(outputHeight * scale));
             }
 
             outputWidth = 2 * (outputWidth / 2);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2984,8 +2984,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var scaleW = (double)maximumWidth / outputWidth;
                 var scaleH = (double)maximumHeight / outputHeight;
                 var scale = Math.Min(scaleW, scaleH);
-                outputWidth = Math.Min(maximumWidth, (int)(outputWidth * scale));
-                outputHeight = Math.Min(maximumHeight, (int)(outputHeight * scale));
+                outputWidth = Math.Min(maximumWidth, (int)Math.Round(outputWidth * scale, MidpointRounding.AwayFromZero));
+                outputHeight = Math.Min(maximumHeight, (int)Math.Round(outputHeight * scale, MidpointRounding.AwayFromZero));
             }
 
             outputWidth = 2 * (outputWidth / 2);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The current method of rounding to an integer for calculating output size may suffer from accuracy loss, resulting in the output size not being exact. This used to be a non-issue until we introduced trickplay, which requires the generated images to have an exact width to make tiles.

For example, for a video with a width of 1432 pixels and a required output width of 480 pixels, the calculated `scale * inputWidth` will become `479.99999999999994`, which is smaller than the requested `480`. Our logic will then pick the smaller value, which is cast into an integer. The casting simply discards all decimal parts, making it `479`. Then, in the next part of rounding, we round it to an even number, which makes it smaller and the produced width becomes `478`.

This PR also forces the trickplay manager to generate images with even width because a lot of filters may have trouble sampling a frame with odd width.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11409