### PR TITLE
Require elevation for plugin related endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/DashboardController.cs
+++ b/Jellyfin.Api/Controllers/DashboardController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Mime;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Models;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Plugins;
@@ -45,9 +46,9 @@ public class DashboardController : BaseJellyfinApiController
     /// <response code="404">Server still loading.</response>
     /// <returns>An <see cref="IEnumerable{ConfigurationPageInfo}"/> with infos about the plugins.</returns>
     [HttpGet("web/ConfigurationPages")]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [Authorize]
     public ActionResult<IEnumerable<ConfigurationPageInfo>> GetConfigurationPages(
         [FromQuery] bool? enableInMainMenu)
     {

--- a/Jellyfin.Api/Controllers/PackageController.cs
+++ b/Jellyfin.Api/Controllers/PackageController.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Api.Controllers;
 /// Package Controller.
 /// </summary>
 [Route("")]
-[Authorize]
+[Authorize(Policy = Policies.RequiresElevation)]
 public class PackageController : BaseJellyfinApiController
 {
     private readonly IInstallationManager _installationManager;
@@ -90,7 +90,6 @@ public class PackageController : BaseJellyfinApiController
     [HttpPost("Packages/Installed/{name}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [Authorize(Policy = Policies.RequiresElevation)]
     public async Task<ActionResult> InstallPackage(
         [FromRoute, Required] string name,
         [FromQuery] Guid? assemblyGuid,
@@ -128,7 +127,6 @@ public class PackageController : BaseJellyfinApiController
     /// <response code="204">Installation cancelled.</response>
     /// <returns>A <see cref="NoContentResult"/> on successfully cancelling a package installation.</returns>
     [HttpDelete("Packages/Installing/{packageId}")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult CancelPackageInstallation(
         [FromRoute, Required] Guid packageId)
@@ -156,7 +154,6 @@ public class PackageController : BaseJellyfinApiController
     /// <response code="204">Package repositories saved.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Repositories")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult SetRepositories([FromBody, Required] RepositoryInfo[] repositoryInfos)
     {

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Api.Controllers;
 /// <summary>
 /// Plugins controller.
 /// </summary>
-[Authorize]
+[Authorize(Policy = Policies.RequiresElevation)]
 public class PluginsController : BaseJellyfinApiController
 {
     private readonly IInstallationManager _installationManager;
@@ -66,7 +66,6 @@ public class PluginsController : BaseJellyfinApiController
     /// <response code="404">Plugin not found.</response>
     /// <returns>An <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the plugin could not be found.</returns>
     [HttpPost("{pluginId}/{version}/Enable")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult EnablePlugin([FromRoute, Required] Guid pluginId, [FromRoute, Required] Version version)
@@ -90,7 +89,6 @@ public class PluginsController : BaseJellyfinApiController
     /// <response code="404">Plugin not found.</response>
     /// <returns>An <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the plugin could not be found.</returns>
     [HttpPost("{pluginId}/{version}/Disable")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult DisablePlugin([FromRoute, Required] Guid pluginId, [FromRoute, Required] Version version)
@@ -114,7 +112,6 @@ public class PluginsController : BaseJellyfinApiController
     /// <response code="404">Plugin not found.</response>
     /// <returns>An <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the plugin could not be found.</returns>
     [HttpDelete("{pluginId}/{version}")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult UninstallPluginByVersion([FromRoute, Required] Guid pluginId, [FromRoute, Required] Version version)
@@ -137,7 +134,6 @@ public class PluginsController : BaseJellyfinApiController
     /// <response code="404">Plugin not found.</response>
     /// <returns>An <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the plugin could not be found.</returns>
     [HttpDelete("{pluginId}")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Please use the UninstallPluginByVersion API.")]


### PR DESCRIPTION
This came up in chat yesterday. We allow reading of installed/available plugins and repositories in addition to allowing both read and write for plugin configuration. This is **unsafe** and something we never encouraged (plugins should only be available in the dashboard).
In case this breaks a plugin (although that is unlikely) it should be fixed in the plugin by adding additional endpoints.

The only plugin related APIs left as open-access are:
- The endpoint to get a plugin image.
- The endpoint to get the HTML of a plugin page

**Changes**

- Require elevation for plugin related endpoints

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
