### PR TITLE
Validate Collection Folders on adding and removal

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1038,6 +1038,7 @@ namespace Emby.Server.Implementations.Library
                 new Progress<double>(),
                 new MetadataRefreshOptions(new DirectoryService(_fileSystem)),
                 recursive: false,
+                allowRemoveRoot: removeRoot,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             await GetUserRootFolder().RefreshMetadata(cancellationToken).ConfigureAwait(false);

--- a/MediaBrowser.Controller/Entities/AggregateFolder.cs
+++ b/MediaBrowser.Controller/Entities/AggregateFolder.cs
@@ -159,7 +159,7 @@ namespace MediaBrowser.Controller.Entities
         {
             ClearCache();
 
-            await base.ValidateChildrenInternal(progress, recursive, refreshChildMetadata, false, refreshOptions, directoryService, cancellationToken)
+            await base.ValidateChildrenInternal(progress, recursive, refreshChildMetadata, allowRemoveRoot, refreshOptions, directoryService, cancellationToken)
                 .ConfigureAwait(false);
 
             ClearCache();

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -333,8 +333,13 @@ namespace MediaBrowser.Controller.Entities
             }
         }
 
-        private static bool IsLibraryFolderAccessible(IDirectoryService directoryService, BaseItem item)
+        private static bool IsLibraryFolderAccessible(IDirectoryService directoryService, BaseItem item, bool checkCollection)
         {
+            if (!checkCollection && (item is BoxSet || string.Equals(item.FileNameWithoutExtension, "collections", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
             // For top parents i.e. Library folders, skip the validation if it's empty or inaccessible
             if (item.IsTopParent && !directoryService.IsAccessible(item.ContainingFolderPath))
             {
@@ -347,7 +352,7 @@ namespace MediaBrowser.Controller.Entities
 
         private async Task ValidateChildrenInternal2(IProgress<double> progress, bool recursive, bool refreshChildMetadata, bool allowRemoveRoot, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService, CancellationToken cancellationToken)
         {
-            if (!IsLibraryFolderAccessible(directoryService, this))
+            if (!IsLibraryFolderAccessible(directoryService, this, allowRemoveRoot))
             {
                 return;
             }
@@ -388,7 +393,7 @@ namespace MediaBrowser.Controller.Entities
 
                 foreach (var child in nonCachedChildren)
                 {
-                    if (!IsLibraryFolderAccessible(directoryService, child))
+                    if (!IsLibraryFolderAccessible(directoryService, child, allowRemoveRoot))
                     {
                         continue;
                     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR validates the collection folder on addition and removal. This folder is very special and is hard to follow the common virtual folder validation. It needs to skip the accessible validation on addition to be successfully added, and it will require the accessible validation to actually remove this virtual folder. The current approach is to use the `allowRemoveRoot` parameter to determine if the path accessible check is needed, because when `allowRemoveRoot == true`, it means the user explicitly requires a deletion.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11258
Fixes #11385 
