### PR TITLE
Clean up synchronization

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -457,7 +457,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         /// <returns>Task.</returns>
         private async Task ExtractAllTextSubtitles(MediaSourceInfo mediaSource, CancellationToken cancellationToken)
         {
-            var locks = new List<AsyncKeyedLockReleaser<string>>();
+            var locks = new List<IDisposable>();
             var extractableStreams = new List<MediaStream>();
 
             try
@@ -469,16 +469,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 {
                     var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetTextSubtitleFormat(subtitleStream));
 
-                    var @lock = _semaphoreLocks.GetOrAdd(outputPath);
-                    await @lock.SemaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    var releaser = await _semaphoreLocks.LockAsync(outputPath, cancellationToken).ConfigureAwait(false);
 
                     if (File.Exists(outputPath))
                     {
-                        @lock.Dispose();
+                        releaser.Dispose();
                         continue;
                     }
 
-                    locks.Add(@lock);
+                    locks.Add(releaser);
                     extractableStreams.Add(subtitleStream);
                 }
 
@@ -493,10 +492,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
             finally
             {
-                foreach (var @lock in locks)
-                {
-                    @lock.Dispose();
-                }
+                locks.ForEach(x => x.Dispose());
             }
         }
 


### PR DESCRIPTION
Fixes an issue where if the cancellationToken is cancelled, a semaphore could be left in the dictionary.