### PR TITLE
Add Env Var to disable WAL journaling

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -20,7 +20,7 @@ namespace Emby.Server.Implementations
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString },
             { SqliteCacheSizeKey, "20000" },
-            { SqliteDisableWalKey, bool.FalseString }
+            { SqliteJournalModeKey, "WAL" }
         };
     }
 }

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -19,7 +19,8 @@ namespace Emby.Server.Implementations
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString },
-            { SqliteCacheSizeKey, "20000" }
+            { SqliteCacheSizeKey, "20000" },
+            { SqliteDisableWalKey, bool.FalseString }
         };
     }
 }

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -5,22 +5,27 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Extensions;
+using MediaBrowser.Controller.Extensions;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Data
 {
     public abstract class BaseSqliteRepository : IDisposable
     {
+        private readonly IConfiguration _configuration;
         private bool _disposed = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseSqliteRepository"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        protected BaseSqliteRepository(ILogger<BaseSqliteRepository> logger)
+        /// <param name="configuration">The configuration.</param>
+        protected BaseSqliteRepository(ILogger<BaseSqliteRepository> logger, IConfiguration configuration)
         {
             Logger = logger;
+            _configuration = configuration;
         }
 
         /// <summary>
@@ -60,7 +65,7 @@ namespace Emby.Server.Implementations.Data
         /// Gets the journal mode. <see href="https://www.sqlite.org/pragma.html#pragma_journal_mode" />.
         /// </summary>
         /// <value>The journal mode.</value>
-        protected virtual string JournalMode => "WAL";
+        protected virtual string JournalMode => _configuration.GetSqliteWalDisabled() ? "TRUNCATE" : "WAL";
 
         /// <summary>
         /// Gets the journal size limit. <see href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit" />.

--- a/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
+++ b/Emby.Server.Implementations/Data/BaseSqliteRepository.cs
@@ -65,7 +65,7 @@ namespace Emby.Server.Implementations.Data
         /// Gets the journal mode. <see href="https://www.sqlite.org/pragma.html#pragma_journal_mode" />.
         /// </summary>
         /// <value>The journal mode.</value>
-        protected virtual string JournalMode => _configuration.GetSqliteWalDisabled() ? "TRUNCATE" : "WAL";
+        protected virtual string JournalMode => _configuration.GetSqliteJournalMode();
 
         /// <summary>
         /// Gets the journal size limit. <see href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit" />.

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -314,7 +314,7 @@ namespace Emby.Server.Implementations.Data
             ILocalizationManager localization,
             IImageProcessor imageProcessor,
             IConfiguration configuration)
-            : base(logger)
+            : base(logger, configuration)
         {
             _config = config;
             _appHost = appHost;

--- a/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteUserDataRepository.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Data
@@ -23,8 +24,9 @@ namespace Emby.Server.Implementations.Data
         public SqliteUserDataRepository(
             ILogger<SqliteUserDataRepository> logger,
             IServerConfigurationManager config,
-            IUserManager userManager)
-            : base(logger)
+            IUserManager userManager,
+            IConfiguration configuration)
+            : base(logger, configuration)
         {
             _userManager = userManager;
 

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -65,6 +65,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string SqliteCacheSizeKey = "sqlite:cacheSize";
 
         /// <summary>
+        /// Disable WAL journaling of sqlite.
+        /// </summary>
+        public const string SqliteDisableWalKey = "sqlite:disableWal";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>
@@ -128,5 +133,26 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The sqlite cache size.</returns>
         public static int? GetSqliteCacheSize(this IConfiguration configuration)
             => configuration.GetValue<int?>(SqliteCacheSizeKey);
+
+        /// <summary>
+        /// Gets whether WAL journaling disabled from the <see cref="IConfiguration" />.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns>Whether WAL journaling disabled.</returns>
+        public static bool GetSqliteWalDisabled(this IConfiguration configuration)
+        {
+            var disableSqliteWal = configuration.GetValue<string?>(SqliteDisableWalKey);
+            var disableWal = false;
+            if (disableSqliteWal is not null)
+            {
+                disableWal = disableSqliteWal.ToUpperInvariant() switch
+                {
+                    "FALSE" or "NO" or "0" => false,
+                    _ => true
+                };
+            }
+
+            return disableWal;
+        }
     }
 }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -65,9 +65,9 @@ namespace MediaBrowser.Controller.Extensions
         public const string SqliteCacheSizeKey = "sqlite:cacheSize";
 
         /// <summary>
-        /// Disable WAL journaling of sqlite.
+        /// SQLite journal mode.
         /// </summary>
-        public const string SqliteDisableWalKey = "sqlite:disableWal";
+        public const string SqliteJournalModeKey = "sqlite:journalMode";
 
         /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
@@ -135,24 +135,14 @@ namespace MediaBrowser.Controller.Extensions
             => configuration.GetValue<int?>(SqliteCacheSizeKey);
 
         /// <summary>
-        /// Gets whether WAL journaling disabled from the <see cref="IConfiguration" />.
+        /// Gets SQLite journal mode from the <see cref="IConfiguration" />.
         /// </summary>
         /// <param name="configuration">The configuration to read the setting from.</param>
-        /// <returns>Whether WAL journaling disabled.</returns>
-        public static bool GetSqliteWalDisabled(this IConfiguration configuration)
+        /// <returns>SQLite journal mode.</returns>
+        public static string GetSqliteJournalMode(this IConfiguration configuration)
         {
-            var disableSqliteWal = configuration.GetValue<string?>(SqliteDisableWalKey);
-            var disableWal = false;
-            if (disableSqliteWal is not null)
-            {
-                disableWal = disableSqliteWal.ToUpperInvariant() switch
-                {
-                    "FALSE" or "NO" or "0" => false,
-                    _ => true
-                };
-            }
-
-            return disableWal;
+            var journalMode = configuration.GetValue<string?>(SqliteJournalModeKey);
+            return journalMode is not null ? journalMode.ToUpperInvariant() : "WAL";
         }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

SQLite WAL journaling is not compatible with all filesystems/VFS extensions, causing the database being locked up in certain conditions. 

It's worth noting that database lockup is just one potential issue that can arise from compatibility issues with certain filesystems. In some cases, the use of WAL can even lead to the database being saved in a non-consistent state, resulting in database corruption.

Add an env var to let the user to choose the Journal mode for better compatibility.

For example, when the default WAL is causing problems:

```
export JELLYFIN_SQLITE__JOURNALMODE=TRUNCATE
```


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->