### PR TITLE
Fix external LRC files being incorrectly overwritten during the initial scan

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -323,9 +323,9 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
 
                 // Save extracted lyrics if they exist,
-                // and if we are replacing all metadata or the audio doesn't yet have lyrics.
+                // and if the audio doesn't yet have lyrics.
                 if (!string.IsNullOrWhiteSpace(tags.Lyrics)
-                    && (options.ReplaceAllMetadata || currentStreams.All(s => s.Type != MediaStreamType.Lyric)))
+                    && currentStreams.All(s => s.Type != MediaStreamType.Lyric))
                 {
                     await _lyricManager.SaveLyricAsync(audio, "lrc", tags.Lyrics).ConfigureAwait(false);
                 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The external LRC should be added to the current stream first; otherwise, the initial scan will always overwrite the external LRC if that audio file also has an embedded lyric.

Now, such overwrite will no longer happen even if the user requested full replacement metadata.

If users want to get rid of the current external lrc and use the embedded version instead, they should manually remove that lrc file and do a find missing metadata library scan.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11454
