### PR TITLE
Don't close inactive session on default

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -163,7 +163,7 @@ public class ServerConfiguration : BaseApplicationConfiguration
     /// If set to 0 the check for inactive sessions gets disabled.
     /// </summary>
     /// <value>The close inactive session threshold in minutes. 0 to disable.</value>
-    public int InactiveSessionThreshold { get; set; } = 10;
+    public int InactiveSessionThreshold { get; set; }
 
     /// <summary>
     /// Gets or sets the delay in seconds that we will wait after a file system change to try and discover what has been added/removed


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

This option does not have any GUI to configure it yet and causes a major behavior change that most users may not expect. Disable this behavior on default and the user want to use this feature should manually edit the config/system.xml

Ideally, we should add some documentation for this option on our website.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Change the default value of `InactiveSessionThreshold` from 10 to 0

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See jellyfin/jellyfin-web#5118
