### PR TITLE
Workarounds TV tuners rejecting HEAD method

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +38,14 @@ namespace Jellyfin.LiveTv.TunerHosts
             "application/mpegurl",
             "application/x-mpegurl",
             "video/vnd.mpeg.dash.mpd"
+        };
+
+        private static readonly string[] _disallowedSharedStreamExtensions =
+        {
+            ".mkv",
+            ".mp4",
+            ".m3u8",
+            ".mpd"
         };
 
         private readonly IHttpClientFactory _httpClientFactory;
@@ -106,11 +116,26 @@ namespace Jellyfin.LiveTv.TunerHosts
                     .SendAsync(message, cancellationToken)
                     .ConfigureAwait(false);
 
-                response.EnsureSuccessStatusCode();
-
-                if (!_disallowedMimeTypes.Contains(response.Content.Headers.ContentType?.ToString(), StringComparison.OrdinalIgnoreCase))
+                if (response.IsSuccessStatusCode)
                 {
-                    return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
+                    if (!_disallowedMimeTypes.Contains(response.Content.Headers.ContentType?.ToString(), StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
+                    }
+                }
+                else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+                {
+                    // Fallback to check path extension when the server does not support HEAD method
+                    // Use UriBuilder to remove all query string as GetExtension will include them when used directly
+                    var extension = Path.GetExtension(new UriBuilder(mediaSource.Path).Path);
+                    if (!_disallowedSharedStreamExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
+                    }
+                }
+                else
+                {
+                    response.EnsureSuccessStatusCode();
                 }
             }
 


### PR DESCRIPTION
Fallback to the old behavior of checking path extension when 405 occurs on HEAD request. Required as the TV Tuner's http sever is not always properly implemented.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Check path extension when HEAD request got 405

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11493
