### PR TITLE
Add Not Implemented response check to m3u tuner HEAD request

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -123,7 +123,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                         return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
                     }
                 }
-                else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+                else if (response.StatusCode == HttpStatusCode.MethodNotAllowed || response.StatusCode == HttpStatusCode.NotImplemented)
                 {
                     // Fallback to check path extension when the server does not support HEAD method
                     // Use UriBuilder to remove all query string as GetExtension will include them when used directly


### PR DESCRIPTION
Complements #11495 . Some M3UTuners will respond with a 501 instead of a 405 code. This PR addresses that case.
Relevant logs:
```
[09:26:53] [INF] [10] Jellyfin.LiveTv.DefaultLiveTvService: Streaming Channel m3u_64c4f0be7c72228e1b290faadf903396c5a4a90c0b075383574e42769cc4efa1
[09:26:53] [ERR] [10] Jellyfin.LiveTv.TunerHosts.M3UTunerHost: Error opening tuner
System.Net.Http.HttpRequestException: Response status code does not indicate success: 501 (Not Implemented).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
```

**Changes**
- Add 501 HTTP response code (Not implemented) handler to M3UTunerHost

**Issues**
Complements #11495 
Fixes #11493 

