### PR TITLE
Allow explicitly set userId for RequestHelpers.GetSession

### DIFF
--- a/Jellyfin.Api/Controllers/PlaystateController.cs
+++ b/Jellyfin.Api/Controllers/PlaystateController.cs
@@ -90,7 +90,7 @@ public class PlaystateController : BaseJellyfinApiController
             return NotFound();
         }
 
-        var session = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
+        var session = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext, userId).ConfigureAwait(false);
 
         var dto = UpdatePlayedStatus(user, item, true, datePlayed);
         foreach (var additionalUserInfo in session.AdditionalUsers)
@@ -155,7 +155,7 @@ public class PlaystateController : BaseJellyfinApiController
             return NotFound();
         }
 
-        var session = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
+        var session = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext, userId).ConfigureAwait(false);
 
         var dto = UpdatePlayedStatus(user, item, false, null);
         foreach (var additionalUserInfo in session.AdditionalUsers)

--- a/Jellyfin.Api/Helpers/RequestHelpers.cs
+++ b/Jellyfin.Api/Helpers/RequestHelpers.cs
@@ -120,7 +120,7 @@ public static class RequestHelpers
     internal static async Task<SessionInfo> GetSession(ISessionManager sessionManager, IUserManager userManager, HttpContext httpContext, Guid? userId = null)
     {
         userId ??= httpContext.User.GetUserId();
-        var user = userManager.GetUserById((Guid)userId);
+        var user = userManager.GetUserById(userId.Value);
         var session = await sessionManager.LogSessionActivity(
             httpContext.User.GetClient(),
             httpContext.User.GetVersion(),

--- a/Jellyfin.Api/Helpers/RequestHelpers.cs
+++ b/Jellyfin.Api/Helpers/RequestHelpers.cs
@@ -117,10 +117,10 @@ public static class RequestHelpers
         return user.EnableUserPreferenceAccess;
     }
 
-    internal static async Task<SessionInfo> GetSession(ISessionManager sessionManager, IUserManager userManager, HttpContext httpContext)
+    internal static async Task<SessionInfo> GetSession(ISessionManager sessionManager, IUserManager userManager, HttpContext httpContext, Guid? userId = null)
     {
-        var userId = httpContext.User.GetUserId();
-        var user = userManager.GetUserById(userId);
+        userId ??= httpContext.User.GetUserId();
+        var user = userManager.GetUserById((Guid)userId);
         var session = await sessionManager.LogSessionActivity(
             httpContext.User.GetClient(),
             httpContext.User.GetVersion(),


### PR DESCRIPTION
Only derive the userId from HttpContext may not work for api keys because there will be no userId for such HttpContext.

PlayedItems might not be the only one has this issue though, need to do a thorough check when we have time.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11501
