### PR TITLE
Enable hardware Trickplay processing pipeline for VideoToolbox

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -120,7 +120,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         private static readonly Dictionary<string, string> _mjpegCodecMap = new(StringComparer.OrdinalIgnoreCase)
         {
             { "vaapi", _defaultMjpegEncoder + "_vaapi" },
-            { "qsv", _defaultMjpegEncoder + "_qsv" }
+            { "qsv", _defaultMjpegEncoder + "_qsv" },
+            { "videotoolbox", _defaultMjpegEncoder + "_videotoolbox" }
         };
 
         public static readonly string[] LosslessAudioCodecs = new string[]

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -95,6 +95,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "h264_v4l2m2m",
             "h264_videotoolbox",
             "hevc_videotoolbox",
+            "mjpeg_videotoolbox",
             "h264_rkmpp",
             "hevc_rkmpp"
         };

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -929,11 +929,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             if (vidEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase))
             {
-                // videotoolbox's mjpeg encoder uses jpeg quality instead of ffmpeg defined qscale
+                // videotoolbox's mjpeg encoder uses jpeg quality scaled to QP2LAMBDA (118) instead of ffmpeg defined qscale
                 // ffmpeg qscale is a value from 1-31, with 1 being best quality and 31 being worst
                 // jpeg quality is a value from 0-100, with 0 being worst quality and 100 being best
-                // This mapping is just an estimation, with bias towards higher quality
-                encoderQuality = 100 - ((qualityScale - 1) * 3);
+                encoderQuality = 118 - ((qualityScale - 1) * (118 / 30));
             }
 
             // Output arguments

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -142,7 +142,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
-        public bool IsJellyfinFfmpeg => SupportsFilter("alphasrc");
+        /// <summary>
+        /// Gets a value indicating whether the ffmpeg in use is likely Jellyfin FFmpeg.
+        /// Assume the FFmpeg currently using is Jellyfin ffmpeg if it supports alphasrc filter.
+        /// The alphasrc filter is only included in Jellyfin's own fork and is almost useless
+        /// on its own.
+        /// </summary>
+        public bool LikelyToBeJellyfinFfmpeg => SupportsFilter("alphasrc");
 
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
@@ -886,7 +892,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-threads " + threads + " " + inputArg; // HW accel args set a different input thread count, only set if disabled
             }
 
-            if (options.HardwareAccelerationType.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase) && IsJellyfinFfmpeg)
+            if (options.HardwareAccelerationType.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase) && LikelyToBeJellyfinFfmpeg)
             {
                 // VideoToolbox supports low priority decoding, which is useful for trickplay
                 inputArg = "-hwaccel_flags +low_priority " + inputArg;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -884,6 +884,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-threads " + threads + " " + inputArg; // HW accel args set a different input thread count, only set if disabled
             }
 
+            if (vidEncoder.Contains("videotoolbox", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // VideoToolbox supports low priority decoding, which is useful for trickplay
+                inputArg = "-hwaccel_flags +low_priority " + inputArg;
+            }
+
             if (enableKeyFrameOnlyExtraction)
             {
                 inputArg = "-skip_frame nokey " + inputArg;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -142,7 +142,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
-        /// <inheritdoc />
         public bool IsJellyfinFfmpeg => SupportsFilter("alphasrc");
 
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -142,6 +142,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
+        /// <inheritdoc />
+        public bool IsJellyfinFfmpeg => SupportsFilter("alphasrc");
+
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
 
@@ -884,7 +887,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-threads " + threads + " " + inputArg; // HW accel args set a different input thread count, only set if disabled
             }
 
-            if (vidEncoder.Contains("videotoolbox", StringComparison.InvariantCultureIgnoreCase))
+            if (options.HardwareAccelerationType.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase) && IsJellyfinFfmpeg)
             {
                 // VideoToolbox supports low priority decoding, which is useful for trickplay
                 inputArg = "-hwaccel_flags +low_priority " + inputArg;

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -143,14 +143,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
-        /// <summary>
-        /// Gets a value indicating whether the ffmpeg in use is likely Jellyfin FFmpeg.
-        /// Assume the FFmpeg currently using is Jellyfin ffmpeg if it supports alphasrc filter.
-        /// The alphasrc filter is only included in Jellyfin's own fork and is almost useless
-        /// on its own.
-        /// </summary>
-        public bool LikelyToBeJellyfinFfmpeg => SupportsFilter("alphasrc");
-
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -74,6 +74,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private IDictionary<int, bool> _filtersWithOption = new Dictionary<int, bool>();
 
         private bool _isPkeyPauseSupported = false;
+        private bool _isLowPriorityHwDecodeSupported = false;
 
         private bool _isVaapiDeviceAmd = false;
         private bool _isVaapiDeviceInteliHD = false;
@@ -202,6 +203,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _threads = EncodingHelper.GetNumberOfThreads(null, options, null);
 
                 _isPkeyPauseSupported = validator.CheckSupportedRuntimeKey("p      pause transcoding");
+                _isLowPriorityHwDecodeSupported = validator.CheckSupportedHwaccelFlag("low_priority");
 
                 // Check the Vaapi device vendor
                 if (OperatingSystem.IsLinux()
@@ -892,7 +894,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-threads " + threads + " " + inputArg; // HW accel args set a different input thread count, only set if disabled
             }
 
-            if (options.HardwareAccelerationType.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase) && LikelyToBeJellyfinFfmpeg)
+            if (options.HardwareAccelerationType.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase) && _isLowPriorityHwDecodeSupported)
             {
                 // VideoToolbox supports low priority decoding, which is useful for trickplay
                 inputArg = "-hwaccel_flags +low_priority " + inputArg;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Enable `mjpeg_videotoolbox` encoder
- Adapt the trickplay processing pipeline for VideoToolbox

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Requires jellyfin/jellyfin-ffmpeg#388