### PR TITLE
Default to not extract lyrics

### DIFF
--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -20,8 +20,8 @@ namespace MediaBrowser.Model.Configuration
 
             AutomaticallyAddToCollection = false;
             EnablePhotos = true;
-            SaveSubtitlesWithMedia = true;
-            SaveLyricsWithMedia = true;
+            SaveSubtitlesWithMedia = false;
+            SaveLyricsWithMedia = false;
             PathInfos = Array.Empty<MediaPathInfo>();
             EnableAutomaticSeriesGrouping = true;
             SeasonZeroDisplayName = "Specials";
@@ -94,7 +94,7 @@ namespace MediaBrowser.Model.Configuration
 
         public bool SaveSubtitlesWithMedia { get; set; }
 
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool SaveLyricsWithMedia { get; set; }
 
         public bool AutomaticallyAddToCollection { get; set; }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -20,7 +20,7 @@ namespace MediaBrowser.Model.Configuration
 
             AutomaticallyAddToCollection = false;
             EnablePhotos = true;
-            SaveSubtitlesWithMedia = false;
+            SaveSubtitlesWithMedia = true;
             SaveLyricsWithMedia = false;
             PathInfos = Array.Empty<MediaPathInfo>();
             EnableAutomaticSeriesGrouping = true;


### PR DESCRIPTION
Such operations require filesystem write permissions and should not be set as default. Users should be required to explicitly enable them.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Default value for  `SaveLyricsWithMedia` is now`false`

The `SaveSubtitlesWithMedia` should also default to `false`, but this change is postponed to 10.10

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
