### PR TITLE
Use actual item removal count for library change determination

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -421,13 +421,12 @@ namespace MediaBrowser.Controller.Entities
                     validChildren.Add(child);
                 }
 
+                // That's all the new and changed ones - now see if there are any that are missing
+                var itemsRemoved = currentChildren.Values.Except(validChildren).ToList();
                 var shouldRemove = !IsRoot || allowRemoveRoot;
                 // If it's an AggregateFolder, don't remove
-                if (shouldRemove && currentChildren.Count != validChildren.Count)
+                if (shouldRemove && itemsRemoved.Count > 0)
                 {
-                    // That's all the new and changed ones - now see if there are any that are missing
-                    var itemsRemoved = currentChildren.Values.Except(validChildren).ToList();
-
                     foreach (var item in itemsRemoved)
                     {
                         if (item.IsFileProtocol)

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -421,7 +421,7 @@ namespace MediaBrowser.Controller.Entities
                     validChildren.Add(child);
                 }
 
-                // That's all the new and changed ones - now see if there are any that are missing
+                // That's all the new and changed ones - now see if any have been removed and need cleanup
                 var itemsRemoved = currentChildren.Values.Except(validChildren).ToList();
                 var shouldRemove = !IsRoot || allowRemoveRoot;
                 // If it's an AggregateFolder, don't remove


### PR DESCRIPTION
The library will also be updated when the number of children remains the same before and after scanning. For example, if one video file is removed and replaced with another version, we still need to remove the old one in this case.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Always check if there is mismatching children

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11255
Fixes #11524