### PR TITLE
Fix reference to deprecated package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,6 @@
     <PackageVersion Include="LrcParser" Version="2023.524.0" />
     <PackageVersion Include="MetaBrainz.MusicBrainz" Version="6.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.4" />

--- a/MediaBrowser.Model/MediaBrowser.Model.csproj
+++ b/MediaBrowser.Model/MediaBrowser.Model.csproj
@@ -33,7 +33,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="MimeTypes">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Found when verifying 10.9 nuget packages
https://www.nuget.org/packages/Microsoft.AspNetCore.HttpOverrides/

According to `dotnet list package --deprecated` this was the only deprecated package