### PR TITLE
Disable nuget warning in Jellyfin.Extensions

### DIFF
--- a/src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
+++ b/src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
@@ -8,6 +8,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- ICU4N.Transliterator only has prerelease versions -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Already applied to 10.9 https://github.com/jellyfin/jellyfin/commit/7d271547c6eeb0112f876c5028f73f7d0f7990d9