### PR TITLE
Add metrics collector to disposable parts

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -422,7 +422,7 @@ namespace Emby.Server.Implementations
             // Initialize runtime stat collection
             if (ConfigurationManager.Configuration.EnableMetrics)
             {
-                DotNetRuntimeStatsBuilder.Default().StartCollecting();
+                _disposableParts.Add(DotNetRuntimeStatsBuilder.Default().StartCollecting());
             }
 
             var networkConfiguration = ConfigurationManager.GetNetworkConfiguration();

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -185,6 +185,7 @@ namespace Jellyfin.Server
             }
             catch (Exception ex)
             {
+                _restartOnShutdown = false;
                 _logger.LogCritical(ex, "Error while starting server");
             }
             finally


### PR DESCRIPTION
Fixes following exception (and infinite startup loop):

```
[15:50:33] [FTL] [14] Main: Error while starting server
System.InvalidOperationException: .NET runtime metrics are already being collected. Dispose() of your previous collector before calling this method again.
   at Prometheus.DotNetRuntime.DotNetRuntimeStatsCollector..ctor(ServiceProvider serviceProvider, CollectorRegistry metricRegistry, Options options)
   at Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Builder.StartCollecting(CollectorRegistry registry)
   at Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Builder.StartCollecting()
   at Emby.Server.Implementations.ApplicationHost.Init(IServiceCollection serviceCollection) in /home/crobibero/Code/jellyfin/Emby.Server.Implementations/ApplicationHost.cs:line 425
   at Jellyfin.Server.Program.<>c__DisplayClass8_0.<StartServer>b__0(IServiceCollection services) in /home/crobibero/Code/jellyfin/Jellyfin.Server/Program.cs:line 142
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Jellyfin.Server.Program.StartServer(IServerApplicationPaths appPaths, StartupOptions options, IConfiguration startupConfig) in /home/crobibero/Code/jellyfin/Jellyfin.Server/Program.cs:line 140
```