### PR TITLE
Add support DoVi Profile 10

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -193,7 +193,8 @@ namespace MediaBrowser.Model.Entities
                         || dvProfile == 5
                         || dvProfile == 7
                         || dvProfile == 8
-                        || dvProfile == 9))
+                        || dvProfile == 9
+                        || dvProfile == 10))
                 {
                     var title = "DV Profile " + dvProfile;
 
@@ -713,7 +714,7 @@ namespace MediaBrowser.Model.Entities
             var blPresentFlag = BlPresentFlag == 1;
             var dvBlCompatId = DvBlSignalCompatibilityId;
 
-            var isDoViProfile = dvProfile == 5 || dvProfile == 7 || dvProfile == 8;
+            var isDoViProfile = dvProfile == 5 || dvProfile == 7 || dvProfile == 8 || dvProfile == 10;
             var isDoViFlag = rpuPresentFlag && blPresentFlag && (dvBlCompatId == 0 || dvBlCompatId == 1 || dvBlCompatId == 4 || dvBlCompatId == 2 || dvBlCompatId == 6);
 
             if ((isDoViProfile && isDoViFlag)
@@ -736,6 +737,17 @@ namespace MediaBrowser.Model.Entities
                         _ => (VideoRange.SDR, VideoRangeType.SDR)
                     },
                     7 => (VideoRange.HDR, VideoRangeType.HDR10),
+                    10 => dvBlCompatId switch
+                    {
+                        0 => (VideoRange.HDR, VideoRangeType.DOVI),
+                        1 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
+                        2 => (VideoRange.SDR, VideoRangeType.DOVIWithSDR),
+                        4 => (VideoRange.HDR, VideoRangeType.DOVIWithHLG),
+                        // While not in Dolby Spec, Profile 8 CCid 6 media are possible to create, and since CCid 6 stems from Bluray (Profile 7 originally) an HDR10 base layer is guaranteed to exist.
+                        6 => (VideoRange.HDR, VideoRangeType.DOVIWithHDR10),
+                        // There is no other case to handle here as per Dolby Spec. Default case included for completeness and linting purposes
+                        _ => (VideoRange.SDR, VideoRangeType.SDR)
+                    },
                     _ => (VideoRange.SDR, VideoRangeType.SDR)
                 };
             }


### PR DESCRIPTION
Added compatibility for AV1 DoVi Profile 10 based on dolby documentation

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Dolby Vision profile 10 detection added for movies and series encoded with AV1 codec with Dolby Vision HDR layer.

Sources : https://professionalsupport.dolby.com/s/article/What-is-Dolby-Vision-Profile

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

I'm starting to get movies and series encoded in AV1 with DV but I can't see whether or not they are Dolby Vision compatible in the media information.