### PR TITLE
Fix absolute path checking on windows

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -80,12 +80,14 @@ namespace Emby.Server.Implementations.IO
         public virtual string MakeAbsolutePath(string folderPath, string filePath)
         {
             // path is actually a stream
-            if (string.IsNullOrWhiteSpace(filePath) || filePath.Contains("://", StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(filePath))
             {
                 return filePath;
             }
 
-            if (filePath.Length > 3 && filePath[1] == ':' && filePath[2] == '/')
+            var isAbsolutePath = Path.IsPathRooted(filePath) && (!OperatingSystem.IsWindows() || filePath[0] != '\\');
+
+            if (isAbsolutePath)
             {
                 // absolute local path
                 return filePath;
@@ -97,17 +99,10 @@ namespace Emby.Server.Implementations.IO
                 return filePath;
             }
 
-            var firstChar = filePath[0];
-            if (firstChar == '/')
-            {
-                // for this we don't really know
-                return filePath;
-            }
-
             var filePathSpan = filePath.AsSpan();
 
-            // relative path
-            if (firstChar == '\\')
+            // relative path on windows
+            if (filePath[0] == '\\')
             {
                 filePathSpan = filePathSpan.Slice(1);
             }

--- a/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
@@ -20,7 +20,7 @@ namespace Jellyfin.Server.Implementations.Tests.IO
             _sut = _fixture.Create<ManagedFileSystem>();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "../Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Music/Beethoven/Misc/Moonlight Sonata.mp3")]
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "../../Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Beethoven/Misc/Moonlight Sonata.mp3")]
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Music/Playlists/Beethoven/Misc/Moonlight Sonata.mp3")]
@@ -30,16 +30,13 @@ namespace Jellyfin.Server.Implementations.Tests.IO
             string filePath,
             string expectedAbsolutePath)
         {
-            if (OperatingSystem.IsWindows())
-            {
-                return;
-            }
+            Skip.If(OperatingSystem.IsWindows());
 
             var generatedPath = _sut.MakeAbsolutePath(folderPath, filePath);
             Assert.Equal(expectedAbsolutePath, generatedPath);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Music\Beethoven\Misc\Moonlight Sonata.mp3")]
         [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Beethoven\Misc\Moonlight Sonata.mp3")]
         [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Music\Playlists\Beethoven\Misc\Moonlight Sonata.mp3")]
@@ -49,10 +46,7 @@ namespace Jellyfin.Server.Implementations.Tests.IO
             string filePath,
             string expectedAbsolutePath)
         {
-            if (!OperatingSystem.IsWindows())
-            {
-                return;
-            }
+            Skip.If(!OperatingSystem.IsWindows());
 
             var generatedPath = _sut.MakeAbsolutePath(folderPath, filePath);
 

--- a/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
@@ -40,9 +40,9 @@ namespace Jellyfin.Server.Implementations.Tests.IO
         }
 
         [Theory]
-        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Music\Beethoven\Misc\Moonlight Sonata.mp3")]
-        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Beethoven\Misc\Moonlight Sonata.mp3")]
-        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Music\Playlists\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Music\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"Beethoven\Misc\Moonlight Sonata.mp3", @"C:\Volumes\Library\Sample\Music\Playlists\Beethoven\Misc\Moonlight Sonata.mp3")]
         [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"D:\\Beethoven\Misc\Moonlight Sonata.mp3", @"D:\\Beethoven\Misc\Moonlight Sonata.mp3")]
         public void MakeAbsolutePathCorrectlyHandlesRelativeFilePathsOnWindows(
             string folderPath,

--- a/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/IO/ManagedFileSystemTests.cs
@@ -24,22 +24,39 @@ namespace Jellyfin.Server.Implementations.Tests.IO
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "../Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Music/Beethoven/Misc/Moonlight Sonata.mp3")]
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "../../Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Beethoven/Misc/Moonlight Sonata.mp3")]
         [InlineData("/Volumes/Library/Sample/Music/Playlists/", "Beethoven/Misc/Moonlight Sonata.mp3", "/Volumes/Library/Sample/Music/Playlists/Beethoven/Misc/Moonlight Sonata.mp3")]
-        public void MakeAbsolutePathCorrectlyHandlesRelativeFilePaths(
+        [InlineData("/Volumes/Library/Sample/Music/Playlists/", "/mnt/Beethoven/Misc/Moonlight Sonata.mp3", "/mnt/Beethoven/Misc/Moonlight Sonata.mp3")]
+        public void MakeAbsolutePathCorrectlyHandlesRelativeFilePathsOnUnixLike(
             string folderPath,
             string filePath,
             string expectedAbsolutePath)
         {
-            var generatedPath = _sut.MakeAbsolutePath(folderPath, filePath);
-
             if (OperatingSystem.IsWindows())
             {
-                var expectedWindowsPath = expectedAbsolutePath.Replace('/', '\\');
-                Assert.Equal(expectedWindowsPath, generatedPath.Split(':')[1]);
+                return;
             }
-            else
+
+            var generatedPath = _sut.MakeAbsolutePath(folderPath, filePath);
+            Assert.Equal(expectedAbsolutePath, generatedPath);
+        }
+
+        [Theory]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Music\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"..\..\Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"Beethoven\Misc\Moonlight Sonata.mp3", @"C:\\Volumes\Library\Sample\Music\Playlists\Beethoven\Misc\Moonlight Sonata.mp3")]
+        [InlineData(@"C:\\Volumes\Library\Sample\Music\Playlists\", @"D:\\Beethoven\Misc\Moonlight Sonata.mp3", @"D:\\Beethoven\Misc\Moonlight Sonata.mp3")]
+        public void MakeAbsolutePathCorrectlyHandlesRelativeFilePathsOnWindows(
+            string folderPath,
+            string filePath,
+            string expectedAbsolutePath)
+        {
+            if (!OperatingSystem.IsWindows())
             {
-                Assert.Equal(expectedAbsolutePath, generatedPath);
+                return;
             }
+
+            var generatedPath = _sut.MakeAbsolutePath(folderPath, filePath);
+
+            Assert.Equal(expectedAbsolutePath, generatedPath);
         }
 
         [Theory]


### PR DESCRIPTION
The fragile path matching no longer works with dotnet 8, causing Windows users to lose collection items because the item path is incorrectly validated, then the server will remove all items due to file not found.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See forum https://forum.jellyfin.org/t-items-in-collections-all-gone-after-10-9-0-upgrade?pid=22471#pid22471
