### PR TITLE
Change "try" to "attempt" english translation

### DIFF
--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -13,7 +13,7 @@
     "DeviceOfflineWithName": "{0} has disconnected",
     "DeviceOnlineWithName": "{0} is connected",
     "External": "External",
-    "FailedLoginAttemptWithUserName": "Failed login try from {0}",
+    "FailedLoginAttemptWithUserName": "Failed login attempt from {0}",
     "Favorites": "Favorites",
     "Folders": "Folders",
     "Forced": "Forced",


### PR DESCRIPTION
Changes the US English translation of `FailedLoginAttemptWithUserName`. Personally I have never heard or read `try` being used in this way. I always have seen `attempt` being used in this context.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
This changes "Failed login try from {0}" to "Failed login attempt from {0}" which is a more usual way of writing such sentence.

**Issues**
N/ A
