### PR TITLE
Set FFmpeg path for ProbeProvider

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -82,6 +82,9 @@ namespace MediaBrowser.Providers.MediaInfo
             NamingOptions namingOptions,
             ILyricManager lyricManager)
         {
+            // Set FFmpeg path before using it in custom provider
+            mediaEncoder?.SetFFmpegPath();
+
             _logger = loggerFactory.CreateLogger<ProbeProvider>();
             _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _subtitleResolver = new SubtitleResolver(loggerFactory.CreateLogger<SubtitleResolver>(), localization, mediaEncoder, fileSystem, namingOptions);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Some library may be configured with this provider enabled, but the ffmpeg path is not set correctly for the prober, causing ffprobe not found during metadata extraction.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11577
