### PR TITLE
Add OpenAPI spec generator for stable releases

### DIFF
--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -140,7 +140,7 @@ jobs:
 
             No changes to OpenAPI specification found. See history of this comment for previous changes.
 
-  publish_unstable:
+  publish-unstable:
     name: OpenAPI - Publish Unstable Spec
     if: |
       github.event_name != 'pull_request_target' && 
@@ -205,7 +205,7 @@ jobs:
             fi
             ) 200>/run/workflows/openapi-unstable.lock
 
-  publish_stable:
+  publish-stable:
     name: OpenAPI - Publish Stable Spec
     if: |
       startsWith(github.ref, 'refs/tags/v') && 

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -144,7 +144,7 @@ jobs:
     name: OpenAPI - Publish Unstable Spec
     if: |
       github.event_name != 'pull_request_target' && 
-      ${{ ! startsWith(github.ref, 'refs/tags/v') }} && 
+      ${{ ! startsWith(github.ref, 'refs/tags/v') }} &&
       contains(github.repository_owner, 'jellyfin')
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
   pull_request_target:
 
 permissions: {}
@@ -138,7 +140,7 @@ jobs:
 
             No changes to OpenAPI specification found. See history of this comment for previous changes.
 
-  publish:
+  publish_unstable:
     name: OpenAPI - Publish Unstable Spec
     if: |
       github.event_name != 'pull_request_target' && 
@@ -201,3 +203,67 @@ jobs:
                 sudo ln -s unstable/${LAST_SPEC} ${TGT_DIR}/jellyfin-openapi-unstable_previous.json
             fi
             ) 200>/run/workflows/openapi-unstable.lock
+
+  publish_stable:
+    name: OpenAPI - Publish Stable Spec
+    if: |
+      startsWith(github.ref, 'refs/tags/v') && 
+      contains(github.repository_owner, 'jellyfin')
+    runs-on: ubuntu-latest
+    needs:
+      - openapi-head
+    steps:
+      - name: Set version number
+        id: version
+        run: |-
+          echo "JELLYFIN_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Download openapi-head
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: openapi-head
+          path: openapi-head
+      - name: Upload openapi.json (stable) to repository server
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
+        with:
+          host: "${{ secrets.REPO_HOST }}"
+          username: "${{ secrets.REPO_USER }}"
+          key: "${{ secrets.REPO_KEY }}"
+          source: openapi-head/openapi.json
+          strip_components: 1
+          target: "/srv/incoming/openapi/stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}"
+      - name: Move openapi.json (stable) into place
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
+        with:
+          host: "${{ secrets.REPO_HOST }}"
+          username: "${{ secrets.REPO_USER }}"
+          key: "${{ secrets.REPO_KEY }}"
+          debug: false
+          script_stop: false
+          script: |
+            if ! test -d /run/workflows; then
+                sudo mkdir -p /run/workflows
+                sudo chown ${{ secrets.REPO_USER }} /run/workflows
+            fi
+            (
+            flock -x -w 300 200 || exit 1
+            TGT_DIR="/srv/repository/main/openapi"
+            LAST_SPEC="$( ls -lt ${TGT_DIR}/stable/ | grep 'jellyfin-openapi' | head -1 | awk '{ print $NF }' )"
+            # If new and previous spec don't differ (diff retcode 0), remove incoming and finish
+            if diff /srv/incoming/openapi/stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}/openapi.json ${TGT_DIR}/stable/${LAST_SPEC} &>/dev/null; then
+                rm -r /srv/incoming/openapi/stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}
+                exit 0
+            fi
+            # Move new spec into place
+            sudo mv /srv/incoming/openapi/stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}/openapi.json ${TGT_DIR}/stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}.json
+            # Delete previous jellyfin-openapi-stable_previous.json
+            sudo rm ${TGT_DIR}/jellyfin-openapi-stable_previous.json
+            # Move current jellyfin-openapi-stable.json symlink to jellyfin-openapi-stable_previous.json
+            sudo mv ${TGT_DIR}/jellyfin-openapi-stable.json ${TGT_DIR}/jellyfin-openapi-stable_previous.json
+            # Create new jellyfin-openapi-stable.json symlink
+            sudo ln -s stable/jellyfin-openapi-${{ env.JELLYFIN_VERSION }}.json ${TGT_DIR}/jellyfin-openapi-stable.json
+            # Check that the previous openapi stable spec link is correct
+            if [[ "$( readlink ${TGT_DIR}/jellyfin-openapi-stable_previous.json )" != "stable/${LAST_SPEC}" ]]; then
+                sudo rm ${TGT_DIR}/jellyfin-openapi-stable_previous.json
+                sudo ln -s stable/${LAST_SPEC} ${TGT_DIR}/jellyfin-openapi-stable_previous.json
+            fi
+            ) 200>/run/workflows/openapi-stable.lock

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -144,6 +144,7 @@ jobs:
     name: OpenAPI - Publish Unstable Spec
     if: |
       github.event_name != 'pull_request_target' && 
+      !startsWith(github.ref, 'refs/tags/v') && 
       contains(github.repository_owner, 'jellyfin')
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -144,7 +144,7 @@ jobs:
     name: OpenAPI - Publish Unstable Spec
     if: |
       github.event_name != 'pull_request_target' && 
-      !startsWith(github.ref, 'refs/tags/v') && 
+      ${{ ! startsWith(github.ref, 'refs/tags/v') }} && 
       contains(github.repository_owner, 'jellyfin')
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
**Changes**
Adds a stable publish action which runs on new tags and pushes the spec to the repository server. Uses all the same logic as Unstable specs but with the correct paths.

Now, I'm not 100% sure if this being on master will let it run on the stable branch. I think it does but not 100%. If not we can forward-port cherry-pick it into the release branch.

**Issues**
N/A
