### PR TITLE
Allow collection sort by Release Date Descending

### DIFF
--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -125,7 +125,7 @@ namespace MediaBrowser.Controller.Entities.Movies
             if (string.Equals(DisplayOrder, "PremiereDate", StringComparison.OrdinalIgnoreCase))
             {
                 // Sort by release date
-                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Ascending).ToList();
+                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Descending).ToList();
             }
 
             // Default sorting


### PR DESCRIPTION
- default sort is still Release Date Ascending
- choosing sort by Release Date will change it to sort by Release Date Descending

This is because most people go to collections to browse new movies to watch, and recently released movies should be on top.

I could also add a new sort order option instead, "PremiereDateDesc" if that's more suitable.

**Changes**
Currently collections default to sort order "Release Date Ascending"
This change allows to sort by Release Date Descending when sort order "Release Date" is chosen
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
