### PR TITLE
Raise transcoding kill timeout.

### DIFF
--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -147,14 +147,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
             return;
         }
 
-        var timerDuration = 10000;
-
-        if (job.Type != TranscodingJobType.Progressive)
-        {
-            timerDuration = 60000;
-        }
-
-        job.PingTimeout = timerDuration;
+        job.PingTimeout = 60_000;
         job.LastPingDate = DateTime.UtcNow;
 
         // Don't start the timer for playback checkins with progressive streaming


### PR DESCRIPTION

**Changes**
The Chromecast client only pings every 10 seconds, so having a 10 second timeout will result in spurious killing any time there is slight deviation in the polling. Set to a much safer value so that transcoding will only get killed if there is a serious hang somewhere.

**Issues**
Fixes: https://github.com/jellyfin/jellyfin/issues/11640
