### PR TITLE
Fix season names

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
@@ -83,7 +83,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                     var seasonNumber = season.IndexNumber.Value;
                     if (string.IsNullOrEmpty(season.Name))
                     {
-                        var seasonNames = series.SeasonNames;
+                        var seasonNames = series.GetSeasonNames();
                         if (seasonNames.TryGetValue(seasonNumber, out var seasonName))
                         {
                             season.Name = seasonName;

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -25,18 +25,17 @@ namespace MediaBrowser.Controller.Entities.TV
     /// </summary>
     public class Series : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<SeriesInfo>, IMetadataContainer
     {
+        private readonly Dictionary<int, string> _seasonNames;
+
         public Series()
         {
             AirDays = Array.Empty<DayOfWeek>();
-            SeasonNames = new Dictionary<int, string>();
+            _seasonNames = new Dictionary<int, string>();
         }
 
         public DayOfWeek[] AirDays { get; set; }
 
         public string AirTime { get; set; }
-
-        [JsonIgnore]
-        public Dictionary<int, string> SeasonNames { get; set; }
 
         [JsonIgnore]
         public override bool SupportsAddingToPlaylist => true;
@@ -211,6 +210,24 @@ namespace MediaBrowser.Controller.Entities.TV
             SetSeasonQueryOptions(query, user);
 
             return LibraryManager.GetItemList(query);
+        }
+
+        public Dictionary<int, string> GetSeasonNames()
+        {
+            if (_seasonNames.Count > 0)
+            {
+                return _seasonNames;
+            }
+
+            return Children.OfType<Season>()
+                .Where(s => s.IndexNumber.HasValue)
+                .DistinctBy(s => s.IndexNumber)
+                .ToDictionary(s => s.IndexNumber.Value, s => s.Name);
+        }
+
+        public void SetSeasonName(int index, string name)
+        {
+            _seasonNames[index] = name;
         }
 
         private void SetSeasonQueryOptions(InternalItemsQuery query, User user)

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -214,15 +214,19 @@ namespace MediaBrowser.Controller.Entities.TV
 
         public Dictionary<int, string> GetSeasonNames()
         {
-            if (_seasonNames.Count > 0)
+            if (_seasonNames.Count == 0)
             {
-                return _seasonNames;
+                var childSeasons = Children.OfType<Season>()
+                    .Where(s => s.IndexNumber.HasValue)
+                    .DistinctBy(s => s.IndexNumber);
+
+                foreach (var season in childSeasons)
+                {
+                    _seasonNames[season.IndexNumber.Value] = season.Name;
+                }
             }
 
-            return Children.OfType<Season>()
-                .Where(s => s.IndexNumber.HasValue)
-                .DistinctBy(s => s.IndexNumber)
-                .ToDictionary(s => s.IndexNumber.Value, s => s.Name);
+            return _seasonNames;
         }
 
         public void SetSeasonName(int index, string name)

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -214,16 +214,14 @@ namespace MediaBrowser.Controller.Entities.TV
 
         public Dictionary<int, string> GetSeasonNames()
         {
-            if (_seasonNames.Count == 0)
-            {
-                var childSeasons = Children.OfType<Season>()
-                    .Where(s => s.IndexNumber.HasValue)
-                    .DistinctBy(s => s.IndexNumber);
+            var newSeasons = Children.OfType<Season>()
+                .Where(s => s.IndexNumber.HasValue)
+                .Where(s => !_seasonNames.ContainsKey(s.IndexNumber.Value))
+                .DistinctBy(s => s.IndexNumber);
 
-                foreach (var season in childSeasons)
-                {
-                    _seasonNames[season.IndexNumber.Value] = season.Name;
-                }
+            foreach (var season in newSeasons)
+            {
+                SetSeasonName(season.IndexNumber.Value, season.Name);
             }
 
             return _seasonNames;

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -91,14 +91,19 @@ namespace MediaBrowser.Providers.TV
             var sourceSeasonNames = sourceItem.GetSeasonNames();
             var targetSeasonNames = targetItem.GetSeasonNames();
 
-            if (replaceData
-                || targetSeasonNames.Count == 0
-                || targetSeasonNames.Count != sourceSeasonNames.Count
-                || !sourceSeasonNames.Keys.All(targetSeasonNames.ContainsKey))
+            if (replaceData)
             {
                 foreach (var (number, name) in sourceSeasonNames)
                 {
-                    target.Item.SetSeasonName(number, name);
+                    targetItem.SetSeasonName(number, name);
+                }
+            }
+            else if (!sourceSeasonNames.Keys.All(targetSeasonNames.ContainsKey))
+            {
+                var newSeasons = sourceSeasonNames.Where(s => !targetSeasonNames.ContainsKey(s.Key));
+                foreach (var (number, name) in newSeasons)
+                {
+                    targetItem.SetSeasonName(number, name);
                 }
             }
 

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -244,7 +244,7 @@ namespace MediaBrowser.Providers.TV
                     var season = await CreateSeasonAsync(series, seasonName, seasonNumber, cancellationToken).ConfigureAwait(false);
                     series.AddChild(season);
                 }
-                else if (!string.Equals(existingSeason.Name, seasonName, StringComparison.Ordinal))
+                else if (!existingSeason.LockedFields.Contains(MetadataField.Name) && !string.Equals(existingSeason.Name, seasonName, StringComparison.Ordinal))
                 {
                     existingSeason.Name = seasonName;
                     await existingSeason.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -88,18 +88,17 @@ namespace MediaBrowser.Providers.TV
 
             var sourceItem = source.Item;
             var targetItem = target.Item;
-            var sourceSeasonNames = sourceItem.SeasonNames;
-            var targetSeasonNames = targetItem.SeasonNames;
+            var sourceSeasonNames = sourceItem.GetSeasonNames();
+            var targetSeasonNames = targetItem.GetSeasonNames();
 
-            if (replaceData || targetSeasonNames.Count == 0)
-            {
-                targetItem.SeasonNames = sourceSeasonNames;
-            }
-            else if (targetSeasonNames.Count != sourceSeasonNames.Count || !sourceSeasonNames.Keys.All(targetSeasonNames.ContainsKey))
+            if (replaceData
+                || targetSeasonNames.Count == 0
+                || targetSeasonNames.Count != sourceSeasonNames.Count
+                || !sourceSeasonNames.Keys.All(targetSeasonNames.ContainsKey))
             {
                 foreach (var (number, name) in sourceSeasonNames)
                 {
-                    targetSeasonNames.TryAdd(number, name);
+                    target.Item.SetSeasonName(number, name);
                 }
             }
 
@@ -221,7 +220,7 @@ namespace MediaBrowser.Providers.TV
         /// <returns>The async task.</returns>
         private async Task UpdateAndCreateSeasonsAsync(Series series, CancellationToken cancellationToken)
         {
-            var seasonNames = series.SeasonNames;
+            var seasonNames = series.GetSeasonNames();
             var seriesChildren = series.GetRecursiveChildren(i => i is Episode || i is Season);
             var seasons = seriesChildren.OfType<Season>().ToList();
             var uniqueSeasonNumbers = seriesChildren

--- a/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
@@ -107,7 +107,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                         if (!string.IsNullOrWhiteSpace(name) && parsed)
                         {
-                            item.SeasonNames[seasonNumber] = name;
+                            item.SetSeasonName(seasonNumber, name);
                         }
 
                         break;


### PR DESCRIPTION
Season names got lost when not scanning the base NFO, so they got reset on any subsequent scan.

**Changes**
Fetch them from the internal dict if it was filled while scanning, otherwise fetch from child seasons.
