### PR TITLE
Fix series status parsing

### DIFF
--- a/Emby.Naming/TV/TvParserHelpers.cs
+++ b/Emby.Naming/TV/TvParserHelpers.cs
@@ -1,0 +1,40 @@
+using System;
+using Emby.Naming.Common;
+using MediaBrowser.Model.Entities;
+
+namespace Emby.Naming.TV;
+
+/// <summary>
+/// Helper class for tv metadata parsing.
+/// </summary>
+public static class TvParserHelpers
+{
+    /// <summary>
+    /// Parses a information about series from path.
+    /// </summary>
+    /// <param name="status">The status string.</param>
+    /// <param name="enumValue">The enum value.</param>
+    /// <returns>Returns true if parsing was successful.</returns>
+    public static bool TryParseSeriesStatus(string status, out SeriesStatus? enumValue)
+    {
+        if (Enum.TryParse(status, true, out SeriesStatus seriesStatus))
+        {
+            enumValue = seriesStatus;
+            return true;
+        }
+
+        switch (status)
+        {
+            case "Pilot":
+            case "Returning Series":
+                enumValue = SeriesStatus.Continuing;
+                return true;
+            case "Cancelled":
+                enumValue = SeriesStatus.Ended;
+                return true;
+            default:
+                enumValue = null;
+                return false;
+        }
+    }
+}

--- a/Emby.Naming/TV/TvParserHelpers.cs
+++ b/Emby.Naming/TV/TvParserHelpers.cs
@@ -1,19 +1,23 @@
 using System;
-using Emby.Naming.Common;
+using System.Collections.Generic;
+using System.Linq;
 using MediaBrowser.Model.Entities;
 
 namespace Emby.Naming.TV;
 
 /// <summary>
-/// Helper class for tv metadata parsing.
+/// Helper class for TV metadata parsing.
 /// </summary>
 public static class TvParserHelpers
 {
+    private static readonly List<string> _continuingState = ["Pilot", "Returning Series", "Returning"];
+    private static readonly List<string> _endedState = ["Cancelled"];
+
     /// <summary>
-    /// Parses a information about series from path.
+    /// Tries to parse a string into <see cref="SeriesStatus"/>.
     /// </summary>
     /// <param name="status">The status string.</param>
-    /// <param name="enumValue">The enum value.</param>
+    /// <param name="enumValue">The <see cref="SeriesStatus"/>.</param>
     /// <returns>Returns true if parsing was successful.</returns>
     public static bool TryParseSeriesStatus(string status, out SeriesStatus? enumValue)
     {
@@ -23,18 +27,19 @@ public static class TvParserHelpers
             return true;
         }
 
-        switch (status)
+        if (_continuingState.Contains(status, StringComparer.OrdinalIgnoreCase))
         {
-            case "Pilot":
-            case "Returning Series":
-                enumValue = SeriesStatus.Continuing;
-                return true;
-            case "Cancelled":
-                enumValue = SeriesStatus.Ended;
-                return true;
-            default:
-                enumValue = null;
-                return false;
+            enumValue = SeriesStatus.Continuing;
+            return true;
         }
+
+        if (_endedState.Contains(status, StringComparer.OrdinalIgnoreCase))
+        {
+            enumValue = SeriesStatus.Ended;
+            return true;
+        }
+
+        enumValue = null;
+        return false;
     }
 }

--- a/Emby.Naming/TV/TvParserHelpers.cs
+++ b/Emby.Naming/TV/TvParserHelpers.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Model.Entities;
 
@@ -10,8 +9,8 @@ namespace Emby.Naming.TV;
 /// </summary>
 public static class TvParserHelpers
 {
-    private static readonly List<string> _continuingState = ["Pilot", "Returning Series", "Returning"];
-    private static readonly List<string> _endedState = ["Cancelled"];
+    private static readonly string[] _continuingState = ["Pilot", "Returning Series", "Returning"];
+    private static readonly string[] _endedState = ["Cancelled"];
 
     /// <summary>
     /// Tries to parse a string into <see cref="SeriesStatus"/>.

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -278,17 +278,12 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             series.RunTimeTicks = seriesResult.EpisodeRunTime.Select(i => TimeSpan.FromMinutes(i).Ticks).FirstOrDefault();
 
-            if (string.Equals(seriesResult.Status, "Ended", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(seriesResult.Status, "Canceled", StringComparison.OrdinalIgnoreCase))
+            if (Emby.Naming.TV.TvParserHelpers.TryParseSeriesStatus(seriesResult.Status, out var seriesStatus))
             {
-                series.Status = SeriesStatus.Ended;
-                series.EndDate = seriesResult.LastAirDate;
-            }
-            else
-            {
-                series.Status = SeriesStatus.Continuing;
+                series.Status = seriesStatus;
             }
 
+            series.EndDate = seriesResult.LastAirDate;
             series.PremiereDate = seriesResult.FirstAirDate;
 
             var ids = seriesResult.ExternalIds;

--- a/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Globalization;
 using System.Xml;
+using Emby.Naming.TV;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Extensions;
@@ -87,7 +87,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                         if (!string.IsNullOrWhiteSpace(status))
                         {
-                            if (Enum.TryParse(status, true, out SeriesStatus seriesStatus))
+                            if (TvParserHelpers.TryParseSeriesStatus(status, out var seriesStatus))
                             {
                                 item.Status = seriesStatus;
                             }

--- a/tests/Jellyfin.Naming.Tests/TV/TvParserHelpersTest.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/TvParserHelpersTest.cs
@@ -2,27 +2,30 @@ using Emby.Naming.TV;
 using MediaBrowser.Model.Entities;
 using Xunit;
 
-namespace Jellyfin.Naming.Tests.TV
-{
-    public class TvParserHelpersTest
-    {
-        [Theory]
-        [InlineData("Ended", SeriesStatus.Ended, true)]
-        [InlineData("Cancelled", SeriesStatus.Ended, true)]
-        [InlineData("Continuing", SeriesStatus.Continuing, true)]
-        [InlineData("Returning", SeriesStatus.Continuing, true)]
-        [InlineData("Returning Series", SeriesStatus.Continuing, true)]
-        [InlineData("Unreleased", SeriesStatus.Unreleased, true)]
-        [InlineData("XXX", null, false)]
-        public void SeriesStatusParserTest(string statusString, SeriesStatus? status, bool success)
-        {
-            var successful = TvParserHelpers.TryParseSeriesStatus(statusString, out var parsered);
-            Assert.Equal(success, successful);
+namespace Jellyfin.Naming.Tests.TV;
 
-            if (success)
-            {
-                Assert.Equal(status, parsered);
-            }
-        }
+public class TvParserHelpersTest
+{
+    [Theory]
+    [InlineData("Ended", SeriesStatus.Ended)]
+    [InlineData("Cancelled", SeriesStatus.Ended)]
+    [InlineData("Continuing", SeriesStatus.Continuing)]
+    [InlineData("Returning", SeriesStatus.Continuing)]
+    [InlineData("Returning Series", SeriesStatus.Continuing)]
+    [InlineData("Unreleased", SeriesStatus.Unreleased)]
+    public void SeriesStatusParserTest_Valid(string statusString, SeriesStatus? status)
+    {
+        var successful = TvParserHelpers.TryParseSeriesStatus(statusString, out var parsered);
+        Assert.True(successful);
+        Assert.Equal(status, parsered);
+    }
+
+    [Theory]
+    [InlineData("XXX")]
+    public void SeriesStatusParserTest_InValid(string statusString)
+    {
+        var successful = TvParserHelpers.TryParseSeriesStatus(statusString, out var parsered);
+        Assert.False(successful);
+        Assert.Null(parsered);
     }
 }

--- a/tests/Jellyfin.Naming.Tests/TV/TvParserHelpersTest.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/TvParserHelpersTest.cs
@@ -1,0 +1,28 @@
+using Emby.Naming.TV;
+using MediaBrowser.Model.Entities;
+using Xunit;
+
+namespace Jellyfin.Naming.Tests.TV
+{
+    public class TvParserHelpersTest
+    {
+        [Theory]
+        [InlineData("Ended", SeriesStatus.Ended, true)]
+        [InlineData("Cancelled", SeriesStatus.Ended, true)]
+        [InlineData("Continuing", SeriesStatus.Continuing, true)]
+        [InlineData("Returning", SeriesStatus.Continuing, true)]
+        [InlineData("Returning Series", SeriesStatus.Continuing, true)]
+        [InlineData("Unreleased", SeriesStatus.Unreleased, true)]
+        [InlineData("XXX", null, false)]
+        public void SeriesStatusParserTest(string statusString, SeriesStatus? status, bool success)
+        {
+            var successful = TvParserHelpers.TryParseSeriesStatus(statusString, out var parsered);
+            Assert.Equal(success, successful);
+
+            if (success)
+            {
+                Assert.Equal(status, parsered);
+            }
+        }
+    }
+}


### PR DESCRIPTION
NFOs can include more than our three status descriptions: https://www.themoviedb.org/bible/tv

**Changes**
* Add helper function to properly transform different strings into our enum values
