### PR TITLE
Always fallback for failed HEAD request

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -123,7 +123,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                         return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
                     }
                 }
-                else if (response.StatusCode == HttpStatusCode.MethodNotAllowed || response.StatusCode == HttpStatusCode.NotImplemented)
+                else
                 {
                     // Fallback to check path extension when the server does not support HEAD method
                     // Use UriBuilder to remove all query string as GetExtension will include them when used directly
@@ -132,10 +132,6 @@ namespace Jellyfin.LiveTv.TunerHosts
                     {
                         return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
                     }
-                }
-                else
-                {
-                    response.EnsureSuccessStatusCode();
                 }
             }
 


### PR DESCRIPTION
TV Tuners have basically unpredictable behaviors on HEAD requests, and we cannot fail and try all potential code it returns. Just fallback to check for extension for all HEAD request that appears to be failed.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11661, and some reports in #11554