### PR TITLE
Bind to Any IP when no config or explicit configured

### DIFF
--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -361,6 +361,14 @@ public class NetworkManager : INetworkManager, IDisposable
             // Respect explicit bind addresses
             var interfaces = _interfaces.ToList();
             var localNetworkAddresses = config.LocalNetworkAddresses;
+            if (localNetworkAddresses.Length == 0 || localNetworkAddresses.Any(ip => IPAddress.Parse(ip).Equals(IPAddress.Any) || IPAddress.Parse(ip).Equals(IPAddress.IPv6Any)))
+            {
+                // remove all interfaces when no bind addresses set, or user requested 0.0.0.0 or ::
+                _logger.LogInformation("Binding to any IP");
+                _interfaces = new List<IPData>();
+                return;
+            }
+
             if (localNetworkAddresses.Length > 0 && !string.IsNullOrWhiteSpace(localNetworkAddresses[0]))
             {
                 var bindAddresses = localNetworkAddresses.Select(p => NetworkUtils.TryParseToSubnet(p, out var network)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

It turns out that certain OS will not wait for all interfaces up before start Jellyfin, and is causing binding problems. Just bind to all interfaces when user has no preference, or user has explicitly configured that way.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11627