### PR TITLE
Fix local playlist scanning

### DIFF
--- a/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
@@ -11,7 +11,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
-using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Images
 {
@@ -33,12 +32,12 @@ namespace Emby.Server.Implementations.Images
                 Parent = item,
                 Recursive = true,
                 DtoOptions = new DtoOptions(true),
-                ImageTypes = new ImageType[] { ImageType.Primary },
-                OrderBy = new (ItemSortBy, SortOrder)[]
-                {
+                ImageTypes = [ImageType.Primary],
+                OrderBy =
+                [
                     (ItemSortBy.IsFolder, SortOrder.Ascending),
                     (ItemSortBy.SortName, SortOrder.Ascending)
-                },
+                ],
                 Limit = 1
             });
         }

--- a/Emby.Server.Implementations/Images/MusicAlbumImageProvider.cs
+++ b/Emby.Server.Implementations/Images/MusicAlbumImageProvider.cs
@@ -1,7 +1,10 @@
 #pragma warning disable CS1591
 
+using System.Collections.Generic;
+using System.Linq;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
@@ -14,6 +17,14 @@ namespace Emby.Server.Implementations.Images
         public MusicAlbumImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor, libraryManager)
         {
+        }
+
+        protected override IReadOnlyList<BaseItem> GetItemsWithImages(BaseItem item)
+        {
+            var items = base.GetItemsWithImages(item);
+
+            // Ignore any folders because they can have generated collages
+            return items.Where(i => i is not Folder).ToList();
         }
     }
 }

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -169,8 +169,7 @@ namespace MediaBrowser.Controller.Entities.Audio
 
             var childUpdateType = ItemUpdateType.None;
 
-            // Refresh songs only and not m3u files in album folder
-            foreach (var item in items.OfType<Audio>())
+            foreach (var item in items)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;

--- a/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
@@ -54,7 +54,7 @@ namespace MediaBrowser.Providers.Playlists
 
             item.LinkedChildren = items;
 
-            return Task.FromResult(ItemUpdateType.None);
+            return Task.FromResult(ItemUpdateType.MetadataImport);
         }
 
         private IEnumerable<LinkedChild> GetItems(string path, string extension)


### PR DESCRIPTION
#8163 removed scanning of local playlists. Since they are now always excluded, only a manual refresh actually populates the playlist.

**Changes**
* Essentially revert the mentioned PR
* Some other small fixes
* Properly fix infinite collage duplication if playlist is in album without picture

**Issues**
Fixes #11625
Fixes #3088
