### PR TITLE
fix: keep current season name if no override exists

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -237,7 +237,7 @@ namespace MediaBrowser.Providers.TV
 
                 if (!seasonNumber.HasValue || !seasonNames.TryGetValue(seasonNumber.Value, out var seasonName))
                 {
-                    seasonName = GetValidSeasonNameForSeries(series, null, seasonNumber);
+                    seasonName = GetValidSeasonNameForSeries(series, existingSeason?.Name, seasonNumber);
                 }
 
                 if (existingSeason is null)


### PR DESCRIPTION
**Changes**
TL;DR: Keep the season name if the no override exists for the season.

Longer version:
So my plugin uses custom season names — which have worked fine throughout all of 10.8's lifecycle — but after the new NFO named season parsing was added in 10.9 (21 months ago no less), then the support for custom season names provided by remote metadata plugins partially broke as a result. This simple change fixes the issue by keeping the current season name for the existing seasons but allows the NFO season names to override the name if needed/desired, thus **not** breaking the support for custom season names provided by remote metadata plugins that we've loved Jellyfin for so far.

Also, I did the digging and debugging to fix this _before_ checking for existing issues, and also doesn't think the other PR addressed the root issue here, so I decided to submit this PR  since I believe it fixes it.

**Issues**
https://github.com/jellyfin/jellyfin/issues/11655 ← Fixes this.
https://github.com/jellyfin/jellyfin/issues/11656 ← Fixes this.
https://github.com/jellyfin/jellyfin/pull/11647 ← I felt this didn't address the issue I was having, as I've been debugging Jellyfin to find out _why_ it changed it back, and saw that PR didn't address that issue.
