### PR TITLE
Fix quality parameter for vaapi_mjpeg

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -871,6 +871,15 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 throw new InvalidOperationException("Empty or invalid input argument.");
             }
 
+            float? encoderQuality = qualityScale;
+            if (vidEncoder.Contains("vaapi", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // vaapi's mjpeg encoder uses jpeg quality divided by QP2LAMBDA (118) as input, instead of ffmpeg defined qscale
+                // ffmpeg qscale is a value from 1-31, with 1 being best quality and 31 being worst
+                // jpeg quality is a value from 0-100, with 0 being worst quality and 100 being best
+                encoderQuality = (100 - ((qualityScale - 1) * (100 / 30))) / 118;
+            }
+
             // Output arguments
             var targetDirectory = Path.Combine(_configurationManager.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(targetDirectory);
@@ -884,7 +893,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 filterParam,
                 outputThreads.GetValueOrDefault(_threads),
                 vidEncoder,
-                qualityScale.HasValue ? "-qscale:v " + qualityScale.Value.ToString(CultureInfo.InvariantCulture) + " " : string.Empty,
+                qualityScale.HasValue ? "-qscale:v " + encoderQuality.Value.ToString(CultureInfo.InvariantCulture) + " " : string.Empty,
                 "image2",
                 outputPath);
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -872,7 +872,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             float? encoderQuality = qualityScale;
-            if (vidEncoder.Contains("vaapi", StringComparison.InvariantCultureIgnoreCase))
+            if (vidEncoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase))
             {
                 // vaapi's mjpeg encoder uses jpeg quality divided by QP2LAMBDA (118) as input, instead of ffmpeg defined qscale
                 // ffmpeg qscale is a value from 1-31, with 1 being best quality and 31 being worst


### PR DESCRIPTION
Hardware encoders have different expectations about quality input. VAAPI's mjpeg encoder excepts JPEG quality divided by QP2LAMBDA as input.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Maps the ffmpeg qscale to the QP2LAMBDA divided mjpeg quality value that vaapi_mjpeg expects.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See issue comment: https://github.com/jellyfin/jellyfin/issues/11556#issuecomment-2113327889
