### PR TITLE
Secure local playlist path handling

### DIFF
--- a/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -25,10 +26,13 @@ namespace MediaBrowser.Providers.Playlists
         IHasItemChangeMonitor
     {
         private readonly ILogger<PlaylistItemsProvider> _logger;
+        private readonly ILibraryManager _libraryManager;
+        private readonly CollectionType[] _ignoredCollections = [CollectionType.livetv, CollectionType.boxsets, CollectionType.playlists];
 
-        public PlaylistItemsProvider(ILogger<PlaylistItemsProvider> logger)
+        public PlaylistItemsProvider(ILogger<PlaylistItemsProvider> logger, ILibraryManager libraryManager)
         {
             _logger = logger;
+            _libraryManager = libraryManager;
         }
 
         public string Name => "Playlist Reader";
@@ -59,80 +63,87 @@ namespace MediaBrowser.Providers.Playlists
 
         private IEnumerable<LinkedChild> GetItems(string path, string extension)
         {
+            var libraryRoots = _libraryManager.GetUserRootFolder().Children
+                                .OfType<CollectionFolder>()
+                                .Where(f => f.CollectionType.HasValue && !_ignoredCollections.Contains(f.CollectionType.Value))
+                                .SelectMany(f => f.PhysicalLocations)
+                                .Distinct(StringComparer.OrdinalIgnoreCase)
+                                .ToList();
+
             using (var stream = File.OpenRead(path))
             {
                 if (string.Equals(".wpl", extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetWplItems(stream, path);
+                    return GetWplItems(stream, path, libraryRoots);
                 }
 
                 if (string.Equals(".zpl", extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetZplItems(stream, path);
+                    return GetZplItems(stream, path, libraryRoots);
                 }
 
                 if (string.Equals(".m3u", extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetM3uItems(stream, path);
+                    return GetM3uItems(stream, path, libraryRoots);
                 }
 
                 if (string.Equals(".m3u8", extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetM3uItems(stream, path);
+                    return GetM3uItems(stream, path, libraryRoots);
                 }
 
                 if (string.Equals(".pls", extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    return GetPlsItems(stream, path);
+                    return GetPlsItems(stream, path, libraryRoots);
                 }
             }
 
             return Enumerable.Empty<LinkedChild>();
         }
 
-        private IEnumerable<LinkedChild> GetPlsItems(Stream stream, string path)
+        private IEnumerable<LinkedChild> GetPlsItems(Stream stream, string playlistPath, List<string> libraryRoots)
         {
             var content = new PlsContent();
             var playlist = content.GetFromStream(stream);
 
             return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, path))
+                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
                     .Where(i => i is not null);
         }
 
-        private IEnumerable<LinkedChild> GetM3uItems(Stream stream, string path)
+        private IEnumerable<LinkedChild> GetM3uItems(Stream stream, string playlistPath, List<string> libraryRoots)
         {
             var content = new M3uContent();
             var playlist = content.GetFromStream(stream);
 
             return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, path))
+                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
                     .Where(i => i is not null);
         }
 
-        private IEnumerable<LinkedChild> GetZplItems(Stream stream, string path)
+        private IEnumerable<LinkedChild> GetZplItems(Stream stream, string playlistPath, List<string> libraryRoots)
         {
             var content = new ZplContent();
             var playlist = content.GetFromStream(stream);
 
             return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, path))
+                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
                     .Where(i => i is not null);
         }
 
-        private IEnumerable<LinkedChild> GetWplItems(Stream stream, string path)
+        private IEnumerable<LinkedChild> GetWplItems(Stream stream, string playlistPath, List<string> libraryRoots)
         {
             var content = new WplContent();
             var playlist = content.GetFromStream(stream);
 
             return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, path))
+                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
                     .Where(i => i is not null);
         }
 
-        private LinkedChild GetLinkedChild(string itemPath, string playlistPath)
+        private LinkedChild GetLinkedChild(string itemPath, string playlistPath, List<string> libraryRoots)
         {
-            if (TryGetPlaylistItemPath(itemPath, playlistPath, out var parsedPath))
+            if (TryGetPlaylistItemPath(itemPath, playlistPath, libraryRoots, out var parsedPath))
             {
                 return new LinkedChild
                 {
@@ -144,23 +155,20 @@ namespace MediaBrowser.Providers.Playlists
             return null;
         }
 
-        private bool TryGetPlaylistItemPath(string itemPath, string playlistPath, out string path)
+        private bool TryGetPlaylistItemPath(string itemPath, string playlistPath, List<string> libraryPaths, out string path)
         {
             path = null;
             var baseFolder = Path.GetDirectoryName(playlistPath);
-
-            if (itemPath.StartsWith(baseFolder, StringComparison.OrdinalIgnoreCase) && File.Exists(itemPath))
-            {
-                path = itemPath;
-                return true;
-            }
-
             var basePath = Path.Combine(baseFolder, itemPath);
             var fullPath = Path.GetFullPath(basePath);
-            if (fullPath.StartsWith(baseFolder, StringComparison.OrdinalIgnoreCase) && File.Exists(fullPath))
+
+            foreach (var libraryPath in libraryPaths)
             {
-                path = fullPath;
-                return true;
+                if (fullPath.StartsWith(libraryPath, StringComparison.OrdinalIgnoreCase) && File.Exists(fullPath))
+                {
+                    path = fullPath;
+                    return true;
+                }
             }
 
             return false;

--- a/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
@@ -158,15 +158,27 @@ namespace MediaBrowser.Providers.Playlists
         private bool TryGetPlaylistItemPath(string itemPath, string playlistPath, List<string> libraryPaths, out string path)
         {
             path = null;
-            var baseFolder = Path.GetDirectoryName(playlistPath);
-            var basePath = Path.Combine(baseFolder, itemPath);
-            var fullPath = Path.GetFullPath(basePath);
+            string pathToCheck;
+            if (File.Exists(itemPath))
+            {
+                pathToCheck = itemPath;
+            }
+            else
+            {
+                var baseFolder = Path.GetDirectoryName(playlistPath);
+                var basePath = Path.Combine(baseFolder, itemPath);
+                pathToCheck = Path.GetFullPath(basePath);
+                if (!File.Exists(pathToCheck))
+                {
+                    return false;
+                }
+            }
 
             foreach (var libraryPath in libraryPaths)
             {
-                if (fullPath.StartsWith(libraryPath, StringComparison.OrdinalIgnoreCase) && File.Exists(fullPath))
+                if (pathToCheck.StartsWith(libraryPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    path = fullPath;
+                    path = pathToCheck;
                     return true;
                 }
             }


### PR DESCRIPTION
Currently we resolved any valid paths denoted in the playlist, possibly also to files outside of libraries

**Changes**
* Restrict referenced items in playlists to be within any library
