### PR TITLE
Only log item id in trickplay warning

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -124,7 +124,7 @@ public class TrickplayManager : ITrickplayManager
                 var mediaPath = mediaSource.Path;
                 if (!File.Exists(mediaPath))
                 {
-                    _logger.LogWarning("Media source {MediaSourceId} not found at {Path} for item {ItemID}", mediaSource.Id, mediaPath, video.Id);
+                    _logger.LogWarning("Media not found at {Path} for item {ItemID}", mediaPath, video.Id);
                     return;
                 }
 


### PR DESCRIPTION
Turns out it's the same
`[WRN] [53] Jellyfin.Server.Implementations.Trickplay.TrickplayManager: Media source "17a76092102691425e94624a69247057" not found at "/mnt/USBshare/Movies/Top Gun (1986)/extras/Top Gun_t04.mkv" for item 17a76092-1026-9142-5e94-624a69247057`

