### PR TITLE
Do not run trickplay on scan if disabled

### DIFF
--- a/MediaBrowser.Providers/Trickplay/TrickplayProvider.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayProvider.cs
@@ -101,7 +101,7 @@ public class TrickplayProvider : ICustomMetadataProvider<Episode>,
         bool? enableDuringScan = libraryOptions?.ExtractTrickplayImagesDuringLibraryScan;
         bool replace = options.ReplaceAllImages;
 
-        if (options.IsAutomated && !enableDuringScan.GetValueOrDefault(false))
+        if (!enableDuringScan.GetValueOrDefault(false))
         {
             return ItemUpdateType.None;
         }


### PR DESCRIPTION
On a normal scan `IsAutomated` is always false, therefore triggering trickplay generation.

**Changes**
* Remove the condition. If it is disabled for the library on scan it should always skip it.

**Issues**
Fixes #11730
