### PR TITLE
Filter invalid IPs on external interface matching

### DIFF
--- a/MediaBrowser.Common/Net/NetworkConstants.cs
+++ b/MediaBrowser.Common/Net/NetworkConstants.cs
@@ -59,6 +59,11 @@ public static class NetworkConstants
     public static readonly IPNetwork IPv4RFC1918PrivateClassC = new IPNetwork(IPAddress.Parse("192.168.0.0"), 16);
 
     /// <summary>
+    /// IPv4 Link-Local as defined in RFC 3927.
+    /// </summary>
+    public static readonly IPNetwork IPv4RFC3927LinkLocal = new IPNetwork(IPAddress.Parse("169.254.0.0"), 16);
+
+    /// <summary>
     /// IPv6 loopback as defined in RFC 4291.
     /// </summary>
     public static readonly IPNetwork IPv6RFC4291Loopback = new IPNetwork(IPAddress.IPv6Loopback, 128);

--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -903,6 +903,17 @@ public class NetworkManager : INetworkManager, IDisposable
         return false;
     }
 
+    /// <summary>
+    ///  Get if the IPAddress is Link-local.
+    /// </summary>
+    /// <param name="address">The IP Address.</param>
+    /// <returns>Bool indicates if the address is link-local.</returns>
+    public bool IsLinkLocalAddress(IPAddress address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        return IPNetwork.Parse("169.254.0.0/16").Contains(address) || address.IsIPv6LinkLocal;
+    }
+
     /// <inheritdoc/>
     public bool IsInLocalNetwork(IPAddress address)
     {
@@ -1084,7 +1095,11 @@ public class NetworkManager : INetworkManager, IDisposable
     private bool MatchesExternalInterface(IPAddress source, out string result)
     {
         // Get the first external interface address that isn't a loopback.
-        var extResult = _interfaces.Where(p => !IsInLocalNetwork(p.Address)).OrderBy(x => x.Index).ToArray();
+        var extResult = _interfaces
+            .Where(p => !IsInLocalNetwork(p.Address))
+            .Where(p => p.Address.AddressFamily.Equals(source.AddressFamily))
+            .Where(p => !IsLinkLocalAddress(p.Address))
+            .OrderBy(x => x.Index).ToArray();
 
         // No external interface found
         if (extResult.Length == 0)

--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -911,7 +911,7 @@ public class NetworkManager : INetworkManager, IDisposable
     public bool IsLinkLocalAddress(IPAddress address)
     {
         ArgumentNullException.ThrowIfNull(address);
-        return IPNetwork.Parse("169.254.0.0/16").Contains(address) || address.IsIPv6LinkLocal;
+        return NetworkConstants.IPv4RFC3927LinkLocal.Contains(address) || address.IsIPv6LinkLocal;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Currently, we are assuming all IPs not in user-set subnet are external IPs, but this is not accurate enough:

- IPv4 addresses are not in IPv6 subnets and vice versa, and we will be returning IPv4 binding address as IPv6 external IP

- Link Local Addresses are not considered as LAN address in most cases, but we are treating them as external address if available and that is wrong because such addresses are not route-able.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
