### PR TITLE
Prefer profile over codec for display title

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -267,13 +267,13 @@ namespace MediaBrowser.Model.Entities
                             attributes.Add(StringHelper.FirstToUpper(fullLanguage ?? Language));
                         }
 
-                        if (!string.IsNullOrEmpty(Codec) && !string.Equals(Codec, "dca", StringComparison.OrdinalIgnoreCase) && !string.Equals(Codec, "dts", StringComparison.OrdinalIgnoreCase))
-                        {
-                            attributes.Add(AudioCodec.GetFriendlyName(Codec));
-                        }
-                        else if (!string.IsNullOrEmpty(Profile) && !string.Equals(Profile, "lc", StringComparison.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(Profile) && !string.Equals(Profile, "lc", StringComparison.OrdinalIgnoreCase))
                         {
                             attributes.Add(Profile);
+                        }
+                        else if (!string.IsNullOrEmpty(Codec))
+                        {
+                            attributes.Add(AudioCodec.GetFriendlyName(Codec));
                         }
 
                         if (!string.IsNullOrEmpty(ChannelLayout))


### PR DESCRIPTION
FFmpeg 6.1 and newer can recognize Dolby Atmos and DTS:X. This change makes it possible to see if a track has one of these technologies if the used FFmpeg supports it.

![Screenshot 2024-05-21 at 14-52-34 Jellyfin](https://github.com/jellyfin/jellyfin/assets/21289123/434922c8-a68c-48e4-9c68-382eb5858d16)
![Screenshot 2024-05-21 at 14-52-49 Jellyfin](https://github.com/jellyfin/jellyfin/assets/21289123/925e0e4e-4f0d-4a7b-9aae-157b3f723c16)
