### PR TITLE
README Typo Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ API documentation can be viewed at `http://localhost:8096/api-docs/swagger/index
 
 As Jellyfin will run on a container on a github hosted server, JF needs to handle some things differently.
 
-**NOTE:** Depending on the selected configuration (if you just click 'create codespace' it will create a default configuration one) it might take 20-30 seconds to load all extensions and prepare the environment while VSCode is already open. Just give it some time and wait until you see `Downloading .NET version(s) 7.0.15~x64 ...... Done!` in the output tab.
+**NOTE:** Depending on the selected configuration (if you just click 'create codespace' it will create a default configuration one) it might take 20-30 seconds to load all extensions and prepare the environment while VS Code is already open. Just give it some time and wait until you see `Downloading .NET version(s) 7.0.15~x64 ...... Done!` in the output tab.
 
-**NOTE:** If you want to access the JF instance from outside, like with a WebClient on another PC, remember to set the "ports" in the lower VSCode window to public.
+**NOTE:** If you want to access the JF instance from outside, like with a WebClient on another PC, remember to set the "ports" in the lower VS Code window to public.
 
 **NOTE:** When first opening the server instance with any WebUI, you will be sent to the login instead of the setup page. Refresh the login page once and you should be redirected to the Setup.
 


### PR DESCRIPTION
**Changes**
Various typos were changed in the README.md

**Specifically:**

"lunch config" => launch config
"this extens" => this extends
"enviorment" => environment
"vscode" => VSCode
"VsCode" => VSCode
"to chose from" => "to choose from"
"getgo" => "get-go"
"secounds" => "seconds"
"you will be send" => "you will be sent"
"have to run though" => "have to run through"
"with an default" => "with a default"
"extenal client" => "external client"

Due to the minor nature of the PR no issue was created.