### PR TITLE
Trickplay: kill ffmpeg when task is cancelled

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -183,6 +183,7 @@
  - [btopherjohnson](https://github.com/btopherjohnson)
  - [GeorgeH005](https://github.com/GeorgeH005)
  - [Vedant](https://github.com/viktory36/)
+ - [NotSaifA](https://github.com/NotSaifA)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -959,17 +959,31 @@ namespace MediaBrowser.MediaEncoding.Encoder
                             // We don't actually expect the process to be finished in one timeout span, just that one image has been generated.
                         }
 
+                        try
+                        {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         var jpegCount = _fileSystem.GetFilePaths(targetDirectory).Count();
 
                         isResponsive = jpegCount > lastCount;
                         lastCount = jpegCount;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            ranToCompletion = false;
+                            break;
+                        }
+
                     }
 
                     if (!ranToCompletion)
                     {
-                        _logger.LogInformation("Stopping trickplay extraction due to process inactivity.");
+                        if (!isResponsive)
+                        {
+                            _logger.LogInformation("Trickplay process unresponsive.");
+                        }
+
+                        _logger.LogInformation("Stopping trickplay extraction.");
                         StopProcess(processWrapper, 1000);
                     }
                 }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -945,7 +945,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
                     timeoutMs = timeoutMs <= 0 ? DefaultHdrImageExtractionTimeout : timeoutMs;
 
-                    while (isResponsive)
+                    while (isResponsive && !cancellationToken.IsCancellationRequested)
                     {
                         try
                         {
@@ -959,21 +959,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
                             // We don't actually expect the process to be finished in one timeout span, just that one image has been generated.
                         }
 
-                        try
-                        {
-                        cancellationToken.ThrowIfCancellationRequested();
-
                         var jpegCount = _fileSystem.GetFilePaths(targetDirectory).Count();
 
                         isResponsive = jpegCount > lastCount;
                         lastCount = jpegCount;
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            ranToCompletion = false;
-                            break;
-                        }
-
                     }
 
                     if (!ranToCompletion)


### PR DESCRIPTION
**Changes**
Kill ffmpeg process when trickplay scheduled task is stopped.

**Issues**
Fixes #11787
