### PR TITLE
Improve reliability of HasChanged check

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -143,14 +143,14 @@ namespace MediaBrowser.Providers.MediaInfo
                 && !video.IsPlaceHolder)
             {
                 var externalFiles = new HashSet<string>(_subtitleResolver.GetExternalFiles(video, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
-                if (!new HashSet<string>(video.SubtitleFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
+                if (!new HashSet<string>(video.SubtitleFiles, StringComparer.Ordinal).SetEquals(externalFiles))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external subtitles change.", item.Path);
                     return true;
                 }
 
                 externalFiles = new HashSet<string>(_audioResolver.GetExternalFiles(video, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
-                if (!new HashSet<string>(video.AudioFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
+                if (!new HashSet<string>(video.AudioFiles, StringComparer.Ordinal).SetEquals(externalFiles))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external audio change.", item.Path);
                     return true;
@@ -161,7 +161,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 && item.SupportsLocalMetadata)
             {
                 var externalFiles = new HashSet<string>(_lyricResolver.GetExternalFiles(audio, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
-                if (!new HashSet<string>(audio.LyricFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
+                if (!new HashSet<string>(audio.LyricFiles, StringComparer.Ordinal).SetEquals(externalFiles))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external lyrics change.", item.Path);
                     return true;

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -141,19 +142,15 @@ namespace MediaBrowser.Providers.MediaInfo
                 && item.SupportsLocalMetadata
                 && !video.IsPlaceHolder)
             {
-                if (!video.SubtitleFiles.Order().SequenceEqual(
-                        _subtitleResolver.GetExternalFiles(video, directoryService, false)
-                            .Select(info => info.Path).Distinct().Order().ToList(),
-                        StringComparer.Ordinal))
+                var externalFiles = new HashSet<string>(_subtitleResolver.GetExternalFiles(video, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
+                if (!new HashSet<string>(video.SubtitleFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external subtitles change.", item.Path);
                     return true;
                 }
 
-                if (!video.AudioFiles.Order().SequenceEqual(
-                        _audioResolver.GetExternalFiles(video, directoryService, false)
-                            .Select(info => info.Path).Distinct().Order().ToList(),
-                        StringComparer.Ordinal))
+                externalFiles = new HashSet<string>(_audioResolver.GetExternalFiles(video, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
+                if (!new HashSet<string>(video.AudioFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external audio change.", item.Path);
                     return true;
@@ -161,14 +158,14 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             if (item is Audio audio
-                && item.SupportsLocalMetadata
-                && !audio.LyricFiles.Order().SequenceEqual(
-                    _lyricResolver.GetExternalFiles(audio, directoryService, false)
-                        .Select(info => info.Path).Distinct().Order().ToList(),
-                    StringComparer.Ordinal))
+                && item.SupportsLocalMetadata)
             {
-                _logger.LogDebug("Refreshing {ItemPath} due to external lyrics change.", item.Path);
-                return true;
+                var externalFiles = new HashSet<string>(_lyricResolver.GetExternalFiles(audio, directoryService, false).Select(info => info.Path), StringComparer.OrdinalIgnoreCase);
+                if (!new HashSet<string>(audio.LyricFiles, StringComparer.OrdinalIgnoreCase).SetEquals(externalFiles))
+                {
+                    _logger.LogDebug("Refreshing {ItemPath} due to external lyrics change.", item.Path);
+                    return true;
+                }
             }
 
             return false;

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -141,18 +141,18 @@ namespace MediaBrowser.Providers.MediaInfo
                 && item.SupportsLocalMetadata
                 && !video.IsPlaceHolder)
             {
-                if (!video.SubtitleFiles.SequenceEqual(
+                if (!video.SubtitleFiles.Order().SequenceEqual(
                         _subtitleResolver.GetExternalFiles(video, directoryService, false)
-                            .Select(info => info.Path).ToList(),
+                            .Select(info => info.Path).Distinct().Order().ToList(),
                         StringComparer.Ordinal))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external subtitles change.", item.Path);
                     return true;
                 }
 
-                if (!video.AudioFiles.SequenceEqual(
+                if (!video.AudioFiles.Order().SequenceEqual(
                         _audioResolver.GetExternalFiles(video, directoryService, false)
-                            .Select(info => info.Path).ToList(),
+                            .Select(info => info.Path).Distinct().Order().ToList(),
                         StringComparer.Ordinal))
                 {
                     _logger.LogDebug("Refreshing {ItemPath} due to external audio change.", item.Path);
@@ -162,9 +162,9 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (item is Audio audio
                 && item.SupportsLocalMetadata
-                && !audio.LyricFiles.SequenceEqual(
+                && !audio.LyricFiles.Order().SequenceEqual(
                     _lyricResolver.GetExternalFiles(audio, directoryService, false)
-                        .Select(info => info.Path).ToList(),
+                        .Select(info => info.Path).Distinct().Order().ToList(),
                     StringComparer.Ordinal))
             {
                 _logger.LogDebug("Refreshing {ItemPath} due to external lyrics change.", item.Path);


### PR DESCRIPTION
Before we write the Paths to the item we check for distinction. This should be done on the comparison too. I threw in ordering to prevent issues of potential FS inconsistent return values.

**Issues**
Potentially #11783