### PR TITLE
Force more compatible transcoding profile for LiveTV

### DIFF
--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -395,9 +395,7 @@ public class MediaInfoHelper
             // Remove all fmp4 transcoding profiles, because it causes playback error and/or A/V sync issues
             // Notably: Some channels won't play on FireFox and LG webOs
             // Some channels from HDHomerun will experience A/V sync issues
-            var profileForCompatibility = request.DeviceProfile.TranscodingProfiles.ToList();
-            profileForCompatibility.RemoveAll(p => p.Container == "mp4");
-            request.DeviceProfile.TranscodingProfiles = profileForCompatibility!.ToArray();
+            request.DeviceProfile.TranscodingProfiles = request.DeviceProfile.TranscodingProfiles.Where(p => !string.Equals(p.Container, "mp4", StringComparison.OrdinalIgnoreCase)).ToArray();
         }
 
         var result = await _mediaSourceManager.OpenLiveStream(request, CancellationToken.None).ConfigureAwait(false);

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -385,6 +385,21 @@ public class MediaInfoHelper
     /// <returns>A <see cref="Task"/> containing the <see cref="LiveStreamResponse"/>.</returns>
     public async Task<LiveStreamResponse> OpenMediaSource(HttpContext httpContext, LiveStreamRequest request)
     {
+        // Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
+        // Cap the MaxStreamingBitrate to 20Mbps, because we are unable to reliably probe source bitrate,
+        // which will cause the client to request extremely high bitrate that may fail the player/encoder
+        request.MaxStreamingBitrate = request.MaxStreamingBitrate > 20000000 ? 20000000 : request.MaxStreamingBitrate;
+
+        if (request.DeviceProfile is not null)
+        {
+            // Remove all fmp4 transcoding profiles, because it causes playback error and/or A/V sync issues
+            // Notably: Some channels won't play on FireFox and LG webOs
+            // Some channels from HDHomerun will experience A/V sync issues
+            var profileForCompatibility = request.DeviceProfile.TranscodingProfiles.ToList();
+            profileForCompatibility.RemoveAll(p => p.Container == "mp4");
+            request.DeviceProfile.TranscodingProfiles = profileForCompatibility!.ToArray();
+        }
+
         var result = await _mediaSourceManager.OpenLiveStream(request, CancellationToken.None).ConfigureAwait(false);
 
         var profile = request.DeviceProfile;


### PR DESCRIPTION
Live TV streams are unlikely to use modern features like HEVC and HDR, and the bitrate is also unlikely to be very high.

This sets a hard limit of 20 Mbps for Live TV transcoding and forces the use of the MPEG-TS container to solve compatibility issues with certain providers/tuners.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11742
Fixes #11723