### PR TITLE
Exclude virtual items from DateLastMediaAdded calculation

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -398,7 +398,8 @@ namespace MediaBrowser.Providers.Manager
 
                 foreach (var child in children)
                 {
-                    if (!child.IsFolder)
+                    // Exclude any folders and virtual items since they are only placeholders
+                    if (!child.IsFolder && !child.IsVirtualItem)
                     {
                         var childDateCreated = child.DateCreated;
                         if (childDateCreated > dateLastMediaAdded)


### PR DESCRIPTION
Virtual items such as missing episodes should not be taken into account when calculting `DateLastMediaAdded `

**Changes**
* Exclude virtual items from DateLastMediaAdded calculation

**Issues**
Fixes #11786 (potentially)