### PR TITLE
Use SharedStream for LiveTV more restrictively

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -30,25 +30,8 @@ namespace Jellyfin.LiveTv.TunerHosts
 {
     public class M3UTunerHost : BaseTunerHost, ITunerHost, IConfigurableTunerHost
     {
-        private static readonly string[] _disallowedMimeTypes =
-        {
-            "text/plain",
-            "text/html",
-            "video/x-matroska",
-            "video/mp4",
-            "application/vnd.apple.mpegurl",
-            "application/mpegurl",
-            "application/x-mpegurl",
-            "video/vnd.mpeg.dash.mpd"
-        };
-
-        private static readonly string[] _disallowedSharedStreamExtensions =
-        {
-            ".mkv",
-            ".mp4",
-            ".m3u8",
-            ".mpd"
-        };
+        private static readonly string[] _mimeTypesCanShareHttpStream = ["video/MP2T"];
+        private static readonly string[] _extensionsCanShareHttpStream = [".ts", ".tsv", ".m2t"];
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IServerApplicationHost _appHost;
@@ -113,27 +96,33 @@ namespace Jellyfin.LiveTv.TunerHosts
 
             if (mediaSource.Protocol == MediaProtocol.Http && !mediaSource.RequiresLooping)
             {
-                using var message = new HttpRequestMessage(HttpMethod.Head, mediaSource.Path);
-                using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
-                    .SendAsync(message, cancellationToken)
-                    .ConfigureAwait(false);
+                var extension = Path.GetExtension(new UriBuilder(mediaSource.Path).Path);
 
-                if (response.IsSuccessStatusCode)
+                if (string.IsNullOrEmpty(extension))
                 {
-                    if (!_disallowedMimeTypes.Contains(response.Content.Headers.ContentType?.MediaType, StringComparison.OrdinalIgnoreCase))
+                    try
                     {
-                        return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
+                        using var message = new HttpRequestMessage(HttpMethod.Head, mediaSource.Path);
+                        using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
+                            .SendAsync(message, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (response.IsSuccessStatusCode)
+                        {
+                            if (_mimeTypesCanShareHttpStream.Contains(response.Content.Headers.ContentType?.MediaType, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
+                            }
+                        }
+                    }
+                    catch (HttpRequestException)
+                    {
+                        Logger.LogWarning("HEAD request to check MIME type failed, shared stream disabled");
                     }
                 }
-                else
+                else if (_extensionsCanShareHttpStream.Contains(extension, StringComparison.OrdinalIgnoreCase))
                 {
-                    // Fallback to check path extension when the server does not support HEAD method
-                    // Use UriBuilder to remove all query string as GetExtension will include them when used directly
-                    var extension = Path.GetExtension(new UriBuilder(mediaSource.Path).Path);
-                    if (!_disallowedSharedStreamExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
-                    }
+                    return new SharedHttpStream(mediaSource, tunerHost, streamId, FileSystem, _httpClientFactory, Logger, Config, _appHost, _streamHelper);
                 }
             }
 

--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -115,7 +115,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                             }
                         }
                     }
-                    catch (HttpRequestException)
+                    catch (Exception)
                     {
                         Logger.LogWarning("HEAD request to check MIME type failed, shared stream disabled");
                     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Only use `SharedHttpStream` for streams that appear to be MPEG-TS streams, and only use a HEAD request when there is no extension in the URL. This is the only solution I can think of without making API changes. `SharedHttpStream` is really uncommon for M3U Tuners where most of them is using HLS, and the ones not using HLS almost uses MPEG-TS streams exclusively. Any other weird Tuners that lies in the mime type and does not provide valid file extension, just treat that stream as normal livestream. If that does not work the only way to make that work is to add an option to the Tuner config to force the stream type, but that would not be feasible for 10.9.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Potentially: 

#11679 #11554 
