### PR TITLE
Return missing episodes for series when no user defined

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1202,7 +1202,8 @@ namespace Emby.Server.Implementations.Session
                             new DtoOptions(false)
                             {
                                 EnableImages = false
-                            })
+                            },
+                            user.DisplayMissingEpisodes)
                         .Where(i => !i.IsVirtualItem)
                         .SkipWhile(i => !i.Id.Equals(episode.Id))
                         .ToList();

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -231,7 +231,7 @@ public class TvShowsController : BaseJellyfinApiController
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddClientFields(User)
             .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
-        var shouldIncludeMissingEpisodes = (user is not null && !user.DisplayMissingEpisodes) || User.GetIsApiKey();
+        var shouldIncludeMissingEpisodes = (user is not null && user.DisplayMissingEpisodes) || User.GetIsApiKey();
 
         if (seasonId.HasValue) // Season id was supplied. Get episodes by season id.
         {

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -231,6 +231,7 @@ public class TvShowsController : BaseJellyfinApiController
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddClientFields(User)
             .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
+        var shouldIncludeMissingEpisodes = (user is not null && !user.DisplayMissingEpisodes) || User.GetIsApiKey();
 
         if (seasonId.HasValue) // Season id was supplied. Get episodes by season id.
         {
@@ -240,7 +241,7 @@ public class TvShowsController : BaseJellyfinApiController
                 return NotFound("No season exists with Id " + seasonId);
             }
 
-            episodes = seasonItem.GetEpisodes(user, dtoOptions);
+            episodes = seasonItem.GetEpisodes(user, dtoOptions, shouldIncludeMissingEpisodes);
         }
         else if (season.HasValue) // Season number was supplied. Get episodes by season number
         {
@@ -256,7 +257,7 @@ public class TvShowsController : BaseJellyfinApiController
 
             episodes = seasonItem is null ?
                 new List<BaseItem>()
-                : ((Season)seasonItem).GetEpisodes(user, dtoOptions);
+                : ((Season)seasonItem).GetEpisodes(user, dtoOptions, shouldIncludeMissingEpisodes);
         }
         else // No season number or season id was supplied. Returning all episodes.
         {
@@ -265,7 +266,7 @@ public class TvShowsController : BaseJellyfinApiController
                 return NotFound("Series not found");
             }
 
-            episodes = series.GetEpisodes(user, dtoOptions).ToList();
+            episodes = series.GetEpisodes(user, dtoOptions, shouldIncludeMissingEpisodes).ToList();
         }
 
         // Filter after the fact in case the ui doesn't want them

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -159,7 +159,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
             Func<BaseItem, bool> filter = i => UserViewBuilder.Filter(i, user, query, UserDataManager, LibraryManager);
 
-            var items = GetEpisodes(user, query.DtoOptions).Where(filter);
+            var items = GetEpisodes(user, query.DtoOptions, true).Where(filter);
 
             return PostFilterAndSort(items, query, false);
         }
@@ -169,30 +169,31 @@ namespace MediaBrowser.Controller.Entities.TV
         /// </summary>
         /// <param name="user">The user.</param>
         /// <param name="options">The options to use.</param>
+        /// <param name="shouldIncludeMissingEpisodes">If missing episodes should be included.</param>
         /// <returns>Set of episodes.</returns>
-        public List<BaseItem> GetEpisodes(User user, DtoOptions options)
+        public List<BaseItem> GetEpisodes(User user, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
-            return GetEpisodes(Series, user, options);
+            return GetEpisodes(Series, user, options, shouldIncludeMissingEpisodes);
         }
 
-        public List<BaseItem> GetEpisodes(Series series, User user, DtoOptions options)
+        public List<BaseItem> GetEpisodes(Series series, User user, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
-            return GetEpisodes(series, user, null, options);
+            return GetEpisodes(series, user, null, options, shouldIncludeMissingEpisodes);
         }
 
-        public List<BaseItem> GetEpisodes(Series series, User user, IEnumerable<Episode> allSeriesEpisodes, DtoOptions options)
+        public List<BaseItem> GetEpisodes(Series series, User user, IEnumerable<Episode> allSeriesEpisodes, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
-            return series.GetSeasonEpisodes(this, user, allSeriesEpisodes, options);
+            return series.GetSeasonEpisodes(this, user, allSeriesEpisodes, options, shouldIncludeMissingEpisodes);
         }
 
         public List<BaseItem> GetEpisodes()
         {
-            return Series.GetSeasonEpisodes(this, null, null, new DtoOptions(true));
+            return Series.GetSeasonEpisodes(this, null, null, new DtoOptions(true), true);
         }
 
         public override List<BaseItem> GetChildren(User user, bool includeLinkedChildren, InternalItemsQuery query)
         {
-            return GetEpisodes(user, new DtoOptions(true));
+            return GetEpisodes(user, new DtoOptions(true), true);
         }
 
         protected override bool GetBlockUnratedValue(User user)

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -286,10 +286,11 @@ namespace MediaBrowser.Controller.Entities.TV
                 SeriesPresentationUniqueKey = seriesKey,
                 IncludeItemTypes = new[] { BaseItemKind.Episode, BaseItemKind.Season },
                 OrderBy = new[] { (ItemSortBy.SortName, SortOrder.Ascending) },
-                DtoOptions = options
+                DtoOptions = options,
+                IsMissing = true
             };
 
-            if (user is null || !user.DisplayMissingEpisodes)
+            if (user is not null && !user.DisplayMissingEpisodes)
             {
                 query.IsMissing = false;
             }

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -162,7 +162,7 @@ namespace MediaBrowser.Providers.TV
 
         private void RemoveObsoleteEpisodes(Series series)
         {
-            var episodes = series.GetEpisodes(null, new DtoOptions()).OfType<Episode>().ToList();
+            var episodes = series.GetEpisodes(null, new DtoOptions(), true).OfType<Episode>().ToList();
             var numberOfEpisodes = episodes.Count;
             // TODO: O(n^2), but can it be done faster without overcomplicating it?
             for (var i = 0; i < numberOfEpisodes; i++)


### PR DESCRIPTION
The removal logic filters for virtual episodes but the query for getting all episodes of a series filtered out any missing episodes (which are the virtual episodes), so we only checked against file system episodes, rendering the function useless.

**Changes**
* Return missing items when getting episodes of a series without a user specified

**Issues**
Fixes #7207
