### PR TITLE
Add file hash to images and remove duplicates after scan

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,6 +74,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageVersion Include="System.Globalization" Version="4.3.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.3" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.3" />
     <PackageVersion Include="System.Text.Json" Version="9.0.3" />

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1892,7 +1892,7 @@ namespace Emby.Server.Implementations.Library
         {
             if (image.Path is not null && image.IsLocalFile)
             {
-                if (image.Width == 0 || image.Height == 0 || string.IsNullOrEmpty(image.BlurHash))
+                if (image.Width == 0 || image.Height == 0 || string.IsNullOrEmpty(image.BlurHash) || string.IsNullOrEmpty(image.FileHash))
                 {
                     return true;
                 }
@@ -1916,9 +1916,11 @@ namespace Emby.Server.Implementations.Library
         {
             ArgumentNullException.ThrowIfNull(item);
 
+            var imagesWithPaths = item.ImageInfos.Where(i => i.Path is not null).ToArray();
             var outdated = forceUpdate
-                ? item.ImageInfos.Where(i => i.Path is not null).ToArray()
+                ? imagesWithPaths
                 : item.ImageInfos.Where(ImageNeedsRefresh).ToArray();
+
             // Skip image processing if current or live tv source
             if (outdated.Length == 0 || item.SourceType != SourceType.Library)
             {
@@ -1980,11 +1982,57 @@ namespace Emby.Server.Implementations.Library
 
                 try
                 {
+                    image.FileHash = _imageProcessor.GetImageFileHash(image.Path);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Cannot compute file hash for {ImagePath}", image.Path);
+                    image.FileHash = string.Empty;
+                }
+
+                try
+                {
                     image.DateModified = _fileSystem.GetLastWriteTimeUtc(image.Path);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Cannot update DateModified for {ImagePath}", image.Path);
+                }
+            }
+
+            // Remove duplicate images
+            var metadataPath = item.GetInternalMetadataPath();
+            var distinctImages = imagesWithPaths
+                                    // Prefer external images
+                                    .OrderBy(i => !i.Path.StartsWith(metadataPath, StringComparison.Ordinal))
+                                    .DistinctBy(i => i.FileHash);
+            var imagesToRemove = imagesWithPaths.Where(i => !string.IsNullOrEmpty(i.FileHash)).Except(distinctImages).ToList();
+            if (imagesToRemove.Count > 0)
+            {
+                foreach (var image in imagesToRemove)
+                {
+                    _logger.LogDebug("Removing {ImagePath} due to duplication", image.Path);
+                    item.RemoveImage(image);
+                    List<string> failedFiles = [];
+
+                    if (image.IsLocalFile)
+                    {
+                        try
+                        {
+                            _fileSystem.DeleteFile(image.Path);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+                            {
+                                _logger.LogDebug("Removing {ImagePath} failed due to {Exception}", image.Path, ex.Message);
+                            }
+                            else
+                            {
+                                throw;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1094,6 +1094,7 @@ public sealed class BaseItemRepository
             Id = Guid.NewGuid(),
             Path = e.Path,
             Blurhash = e.BlurHash is null ? null : Encoding.UTF8.GetBytes(e.BlurHash),
+            FileHash = e.FileHash is null ? null : Encoding.UTF8.GetBytes(e.FileHash),
             DateModified = e.DateModified,
             Height = e.Height,
             Width = e.Width,

--- a/MediaBrowser.Controller/Drawing/IImageProcessor.cs
+++ b/MediaBrowser.Controller/Drawing/IImageProcessor.cs
@@ -59,12 +59,11 @@ namespace MediaBrowser.Controller.Drawing
         string GetImageBlurHash(string path, ImageDimensions imageDimensions);
 
         /// <summary>
-        /// Gets the image cache tag.
+        /// Gets the file hash of the image.
         /// </summary>
-        /// <param name="baseItemPath">The items basePath.</param>
-        /// <param name="imageDateModified">The image last modification date.</param>
-        /// <returns>Guid.</returns>
-        string? GetImageCacheTag(string baseItemPath, DateTime imageDateModified);
+        /// <param name="path">Path to the image file.</param>
+        /// <returns>FileHash.</returns>
+        string GetImageFileHash(string path);
 
         /// <summary>
         /// Gets the image cache tag.
@@ -73,6 +72,14 @@ namespace MediaBrowser.Controller.Drawing
         /// <param name="image">The image.</param>
         /// <returns>Guid.</returns>
         string? GetImageCacheTag(BaseItemDto item, ChapterInfo image);
+
+        /// <summary>
+        /// Gets the image cache tag.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="image">The image.</param>
+        /// <returns>Guid.</returns>
+        string? GetImageCacheTag(BaseItemEntity item, ChapterInfo image);
 
         /// <summary>
         /// Gets the image cache tag.

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1915,6 +1915,7 @@ namespace MediaBrowser.Controller.Entities
                 existingImage.Width = image.Width;
                 existingImage.Height = image.Height;
                 existingImage.BlurHash = image.BlurHash;
+                existingImage.FileHash = image.FileHash;
             }
         }
 

--- a/MediaBrowser.Controller/Entities/ItemImageInfo.cs
+++ b/MediaBrowser.Controller/Entities/ItemImageInfo.cs
@@ -36,6 +36,12 @@ namespace MediaBrowser.Controller.Entities
         /// <value>The blurhash.</value>
         public string? BlurHash { get; set; }
 
+        /// <summary>
+        /// Gets or sets the file hash.
+        /// </summary>
+        /// <value>The file hash.</value>
+        public string? FileHash { get; set; }
+
         [JsonIgnore]
         public bool IsLocalFile => !Path.StartsWith("http", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/BaseItemImageInfo.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/BaseItemImageInfo.cs
@@ -1,4 +1,5 @@
-#pragma warning disable CA2227
+#pragma warning disable CA1819 // Properties should not return arrays
+#pragma warning disable CA2227 // Collection properties should be read only
 
 using System;
 
@@ -39,12 +40,15 @@ public class BaseItemImageInfo
     /// </summary>
     public int Height { get; set; }
 
-#pragma warning disable CA1819 // Properties should not return arrays
     /// <summary>
     /// Gets or Sets the blurhash.
     /// </summary>
     public byte[]? Blurhash { get; set; }
-#pragma warning restore CA1819
+
+    /// <summary>
+    /// Gets or Sets the file hash.
+    /// </summary>
+    public byte[]? FileHash { get; set; }
 
     /// <summary>
     /// Gets or Sets the reference id to the BaseItem.

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250326065939_AddImageFileHash.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250326065939_AddImageFileHash.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Database.Implementations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Server.Implementations.Migrations
 {
     [DbContext(typeof(JellyfinDbContext))]
-    partial class JellyfinDbModelSnapshot : ModelSnapshot
+    [Migration("20250326065939_AddImageFileHash")]
+    partial class AddImageFileHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.3");

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250326065939_AddImageFileHash.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250326065939_AddImageFileHash.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Server.Implementations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageFileHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "FileHash",
+                table: "BaseItemImageInfos",
+                type: "BLOB",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FileHash",
+                table: "BaseItemImageInfos");
+        }
+    }
+}

--- a/src/Jellyfin.Drawing/Jellyfin.Drawing.csproj
+++ b/src/Jellyfin.Drawing/Jellyfin.Drawing.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
 </Project>

--- a/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteItemRepositoryTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteItemRepositoryTests.cs
@@ -47,65 +47,80 @@ namespace Jellyfin.Server.Implementations.Tests.Data
 
         public static TheoryData<string, ItemImageInfo> ItemImageInfoFromValueString_Valid_TestData()
         {
-            var data = new TheoryData<string, ItemImageInfo>();
-
-            data.Add(
-                "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN",
-                new ItemImageInfo
+            var data = new TheoryData<string, ItemImageInfo>
+            {
                 {
-                    Path = "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg",
-                    Type = ImageType.Primary,
-                    DateModified = new DateTime(637452096478512963, DateTimeKind.Utc),
-                    Width = 1920,
-                    Height = 1080,
-                    BlurHash = "WjQbtJtSO8nhNZ%L_Io#R*oaS6o}-;adXAoIn7j[%hW9s:WGw[nN"
-                });
-
-            data.Add(
-                "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary*0*0",
-                new ItemImageInfo
+                    "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN*938c2cc0dcc05f2b68c4287040cfcf71",
+                    new ItemImageInfo
+                    {
+                        Path = "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg",
+                        Type = ImageType.Primary,
+                        DateModified = new DateTime(637452096478512963, DateTimeKind.Utc),
+                        Width = 1920,
+                        Height = 1080,
+                        BlurHash = "WjQbtJtSO8nhNZ%L_Io#R*oaS6o}-;adXAoIn7j[%hW9s:WGw[nN",
+                        FileHash = "938c2cc0dcc05f2b68c4287040cfcf71"
+                    }
+                },
                 {
-                    Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
-                    Type = ImageType.Primary,
-                });
-
-            data.Add(
-                "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary",
-                new ItemImageInfo
+                    "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary*0*0",
+                    new ItemImageInfo
+                    {
+                        Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
+                        Type = ImageType.Primary,
+                    }
+                },
                 {
-                    Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
-                    Type = ImageType.Primary,
-                });
-
-            data.Add(
-                "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary*600",
-                new ItemImageInfo
+                    "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary",
+                    new ItemImageInfo
+                    {
+                        Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
+                        Type = ImageType.Primary,
+                    }
+                },
                 {
-                    Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
-                    Type = ImageType.Primary,
-                });
-
-            data.Add(
-                "%MetadataPath%/library/68/68578562b96c80a7ebd530848801f645/poster.jpg*637264380567586027*Primary*600*336",
-                new ItemImageInfo
+                    "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg*0*Primary*600",
+                    new ItemImageInfo
+                    {
+                        Path = "https://image.tmdb.org/t/p/original/zhB5CHEgqqh4wnEqDNJLfWXJlcL.jpg",
+                        Type = ImageType.Primary,
+                    }
+                },
                 {
-                    Path = "/meta/data/path/library/68/68578562b96c80a7ebd530848801f645/poster.jpg",
-                    Type = ImageType.Primary,
-                    DateModified = new DateTime(637264380567586027, DateTimeKind.Utc),
-                    Width = 600,
-                    Height = 336
-                });
+                    "%MetadataPath%/library/68/68578562b96c80a7ebd530848801f645/poster.jpg*637264380567586027*Primary*600*336",
+                    new ItemImageInfo
+                    {
+                        Path = "/meta/data/path/library/68/68578562b96c80a7ebd530848801f645/poster.jpg",
+                        Type = ImageType.Primary,
+                        DateModified = new DateTime(637264380567586027, DateTimeKind.Utc),
+                        Width = 600,
+                        Height = 336
+                    }
+                },
+                {
+                    "%MetadataPath%/library/68/68578562b96c80a7ebd530848801f645/poster.jpg*637264380567586027*Primary*600*336**938c2cc0dcc05f2b68c4287040cfcf71",
+                    new ItemImageInfo
+                    {
+                        Path = "/meta/data/path/library/68/68578562b96c80a7ebd530848801f645/poster.jpg",
+                        Type = ImageType.Primary,
+                        DateModified = new DateTime(637264380567586027, DateTimeKind.Utc),
+                        Width = 600,
+                        Height = 336,
+                        FileHash = "938c2cc0dcc05f2b68c4287040cfcf71"
+                    }
+                }
+            };
 
             return data;
         }
 
         public static TheoryData<string, ItemImageInfo[]> DeserializeImages_Valid_TestData()
         {
-            var data = new TheoryData<string, ItemImageInfo[]>();
-            data.Add(
-                "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN",
-                new ItemImageInfo[]
+            var data = new TheoryData<string, ItemImageInfo[]>
+            {
                 {
+                    "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN",
+                    [
                     new ItemImageInfo()
                     {
                         Path = "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg",
@@ -115,12 +130,11 @@ namespace Jellyfin.Server.Implementations.Tests.Data
                         Height = 1080,
                         BlurHash = "WjQbtJtSO8nhNZ%L_Io#R*oaS6o}-;adXAoIn7j[%hW9s:WGw[nN"
                     }
-                });
-
-            data.Add(
-                "%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/poster.jpg*637261226720645297*Primary*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/logo.png*637261226720805297*Logo*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/landscape.jpg*637261226721285297*Thumb*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/backdrop.jpg*637261226721685297*Backdrop*0*0",
-                new ItemImageInfo[]
+                ]
+                },
                 {
+                    "%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/poster.jpg*637261226720645297*Primary*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/logo.png*637261226720805297*Logo*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/landscape.jpg*637261226721285297*Thumb*0*0|%MetadataPath%/library/2a/2a27372f1e9bc757b1db99721bbeae1e/backdrop.jpg*637261226721685297*Backdrop*0*0",
+                    [
                     new ItemImageInfo()
                     {
                         Path = "/meta/data/path/library/2a/2a27372f1e9bc757b1db99721bbeae1e/poster.jpg",
@@ -145,22 +159,24 @@ namespace Jellyfin.Server.Implementations.Tests.Data
                         Type = ImageType.Backdrop,
                         DateModified = new DateTime(637261226721685297, DateTimeKind.Utc),
                     }
-                });
+                ]
+                }
+            };
 
             return data;
         }
 
         public static TheoryData<string, ItemImageInfo[]> DeserializeImages_ValidAndInvalid_TestData()
         {
-            var data = new TheoryData<string, ItemImageInfo[]>();
-            data.Add(
-                string.Empty,
-                Array.Empty<ItemImageInfo>());
-
-            data.Add(
-                "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN|test|1234||ss",
-                new ItemImageInfo[]
+            var data = new TheoryData<string, ItemImageInfo[]>
+            {
                 {
+                    string.Empty,
+                    Array.Empty<ItemImageInfo>()
+                },
+                {
+                    "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg*637452096478512963*Primary*1920*1080*WjQbtJtSO8nhNZ%L_Io#R/oaS6o}-;adXAoIn7j[%hW9s:WGw[nN|test|1234||ss",
+                    [
                     new()
                     {
                         Path = "/mnt/series/Family Guy/Season 1/Family Guy - S01E01-thumb.jpg",
@@ -170,18 +186,20 @@ namespace Jellyfin.Server.Implementations.Tests.Data
                         Height = 1080,
                         BlurHash = "WjQbtJtSO8nhNZ%L_Io#R*oaS6o}-;adXAoIn7j[%hW9s:WGw[nN"
                     }
-                });
-
-            data.Add(
-                "|",
-                Array.Empty<ItemImageInfo>());
+                ]
+                },
+                {
+                    "|",
+                    Array.Empty<ItemImageInfo>()
+                }
+            };
 
             return data;
         }
 
         private sealed class ProviderIdsExtensionsTestsObject : IHasProviderIds
         {
-            public Dictionary<string, string> ProviderIds { get; set; } = new Dictionary<string, string>();
+            public Dictionary<string, string> ProviderIds { get; set; } = [];
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/EfMigrations/EfMigrationTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/EfMigrations/EfMigrationTests.cs
@@ -1,5 +1,4 @@
 using Jellyfin.Database.Providers.Sqlite.Migrations;
-using Jellyfin.Server.Implementations.Migrations;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 


### PR DESCRIPTION
We are allowing multiple backdrops but never clean up duplicates after scan - these might appear if we have an image in the media folder and download the image from the NFO but they are the same.

**Changes**
* Use `XxHash3` to calcultate image file hash on scan if we haven't already
* Save hash to the database
* Remove duplicate backdrops on scan based on hash, preferring external images over ones in the JF metadata folder

**ToDo**
* Potentially write a migration, though it is fixed by a simple rescan

**Issues**
Fixes #9456
Replaces #9551