### PR TITLE
Fix the IOSurf error in QSV transcoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4301,6 +4301,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     // map from qsv to vaapi.
                     mainFilters.Add("hwmap=derive_device=vaapi");
+                    mainFilters.Add("format=vaapi");
                 }
 
                 var tonemapFilter = GetHwTonemapFilter(options, "vaapi", "nv12");
@@ -4310,6 +4311,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     // map from vaapi to qsv.
                     mainFilters.Add("hwmap=derive_device=qsv");
+                    mainFilters.Add("format=qsv");
                 }
             }
 


### PR DESCRIPTION
ffmpeg6 and ffmpeg5 work a little differently.

**Changes**
- Fix the IOSurf error in QSV transcoding

**Issues**
- Fixes #11819
`Error querying (IOSurf) the encoding parameters: invalid video parameters (-15)`