### PR TITLE
Don't extract chapter images if chapters are <1s long on average

### DIFF
--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -124,7 +124,7 @@ namespace Emby.Server.Implementations.MediaEncoder
 
             var averageChapterDuration = GetAverageDurationBetweenChapters(chapters);
             var threshold = TimeSpan.FromSeconds(1).Ticks;
-            if (averageChapterDuration < TimeSpan.FromSeconds(1).Ticks)
+            if (averageChapterDuration < threshold)
             {
                 _logger.LogInformation("Skipping chapter image extraction for {Video} as the average chapter duration {AverageDuration} was lower than the minimum threshold {Threshold}", video.Name, averageChapterDuration, threshold);
                 extractImages = false;

--- a/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
+++ b/Emby.Server.Implementations/MediaEncoder/EncodingManager.cs
@@ -91,12 +91,42 @@ namespace Emby.Server.Implementations.MediaEncoder
             return video.DefaultVideoStreamIndex.HasValue;
         }
 
+        private long GetAverageDurationBetweenChapters(IReadOnlyList<ChapterInfo> chapters)
+        {
+            if (chapters.Count < 2)
+            {
+                return 0;
+            }
+
+            long sum = 0;
+            for (int i = 1; i < chapters.Count; i++)
+            {
+                sum += chapters[i].StartPositionTicks - chapters[i - 1].StartPositionTicks;
+            }
+
+            return sum / chapters.Count;
+        }
+
+
         public async Task<bool> RefreshChapterImages(Video video, IDirectoryService directoryService, IReadOnlyList<ChapterInfo> chapters, bool extractImages, bool saveChapters, CancellationToken cancellationToken)
         {
+            if (chapters.Count == 0)
+            {
+                return true;
+            }
+
             var libraryOptions = _libraryManager.GetLibraryOptions(video);
 
             if (!IsEligibleForChapterImageExtraction(video, libraryOptions))
             {
+                extractImages = false;
+            }
+
+            var averageChapterDuration = GetAverageDurationBetweenChapters(chapters);
+            var threshold = TimeSpan.FromSeconds(1).Ticks;
+            if (averageChapterDuration < TimeSpan.FromSeconds(1).Ticks)
+            {
+                _logger.LogInformation("Skipping chapter image extraction for {Video} as the average chapter duration {AverageDuration} was lower than the minimum threshold {Threshold}", video.Name, averageChapterDuration, threshold);
                 extractImages = false;
             }
 


### PR DESCRIPTION
Some DVD/Blu-ray extras are just streams of images with 1 chapter for each image

