### PR TITLE
Use bluray protocol to play BDMVs

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1250,7 +1250,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 arg.Append(canvasArgs);
             }
 
-            if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
+            if (state.MediaSource.VideoType == VideoType.Dvd)
             {
                 var concatFilePath = Path.Join(_configurationManager.CommonApplicationPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
                 if (!File.Exists(concatFilePath))
@@ -1330,6 +1330,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (!isSwDecoder)
             {
                 arg.Append(" -noautoscale");
+            }
+
+            if (state.MediaSource.VideoType == VideoType.BluRay)
+            {
+                arg.Insert(0, "-skip_estimate_duration_from_pts 1 ");
             }
 
             return arg.ToString();

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -155,7 +155,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
                     .Any(s => s.Type == MediaStreamType.Video || s.Type == MediaStreamType.Audio);
                 var processArgs = string.Format(
                     CultureInfo.InvariantCulture,
-                    "-dump_attachment:t \"\" -y {0} -i {1} {2}",
+                    "-dump_attachment:t \"\" -y {0} -skip_estimate_duration_from_pts 1 -i {1} {2}",
                     inputPath.EndsWith(".concat\"", StringComparison.OrdinalIgnoreCase) ? "-f concat -safe 0" : string.Empty,
                     inputPath,
                     hasVideoOrAudioStream ? "-t 0 -f null null" : string.Empty);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -479,7 +479,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string GetInputArgument(string inputFile, MediaSourceInfo mediaSource)
         {
             var prefix = "file";
-            if (mediaSource.IsoType == IsoType.BluRay)
+            if (mediaSource.VideoType == VideoType.BluRay || mediaSource.IsoType == IsoType.BluRay)
             {
                 prefix = "bluray";
             }
@@ -747,7 +747,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var mapArg = imageStreamIndex.HasValue ? (" -map 0:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
             var args = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i {0}{1} -threads {2} -v quiet -vframes 1 -vf {3}{4}{5} -f image2 \"{6}\"",
+                "-skip_estimate_duration_from_pts 1 -i {0}{1} -threads {2} -v quiet -vframes 1 -vf {3}{4}{5} -f image2 \"{6}\"",
                 inputPath,
                 mapArg,
                 _threads,
@@ -1283,7 +1283,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return mediaSource.VideoType switch
             {
                 VideoType.Dvd => GetInputArgument(GetPrimaryPlaylistVobFiles(path, null), mediaSource),
-                VideoType.BluRay => GetInputArgument(GetPrimaryPlaylistM2tsFiles(path), mediaSource),
                 _ => GetInputArgument(path, mediaSource)
             };
         }
@@ -1297,10 +1296,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
             if (videoType == VideoType.Dvd)
             {
                 files = GetPrimaryPlaylistVobFiles(source.Path, null);
-            }
-            else if (videoType == VideoType.BluRay)
-            {
-                files = GetPrimaryPlaylistM2tsFiles(source.Path);
             }
             else
             {

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -398,7 +398,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         // If subtitles get burned in fonts may need to be extracted from the media file
         if (state.SubtitleStream is not null && (state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode || state.BaseRequest.AlwaysBurnInSubtitleWhenTranscoding))
         {
-            if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
+            if (state.MediaSource.VideoType == VideoType.Dvd)
             {
                 var concatPath = Path.Join(_appPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
                 await _attachmentExtractor.ExtractAllAttachments(concatPath, state.MediaSource, cancellationTokenSource.Token).ConfigureAwait(false);


### PR DESCRIPTION
This is way faster than using BDInfo to create concat file with all the correct segments. FFmpeg picks the longest playlist by default, same as Jellyfin.