### PR TITLE
Relax remuxing requirement for LiveTV

### DIFF
--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -385,19 +385,6 @@ public class MediaInfoHelper
     /// <returns>A <see cref="Task"/> containing the <see cref="LiveStreamResponse"/>.</returns>
     public async Task<LiveStreamResponse> OpenMediaSource(HttpContext httpContext, LiveStreamRequest request)
     {
-        // Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
-        // Cap the MaxStreamingBitrate to 20Mbps, because we are unable to reliably probe source bitrate,
-        // which will cause the client to request extremely high bitrate that may fail the player/encoder
-        request.MaxStreamingBitrate = request.MaxStreamingBitrate > 20000000 ? 20000000 : request.MaxStreamingBitrate;
-
-        if (request.DeviceProfile is not null)
-        {
-            // Remove all fmp4 transcoding profiles, because it causes playback error and/or A/V sync issues
-            // Notably: Some channels won't play on FireFox and LG webOs
-            // Some channels from HDHomerun will experience A/V sync issues
-            request.DeviceProfile.TranscodingProfiles = request.DeviceProfile.TranscodingProfiles.Where(p => !string.Equals(p.Container, "mp4", StringComparison.OrdinalIgnoreCase)).ToArray();
-        }
-
         var result = await _mediaSourceManager.OpenLiveStream(request, CancellationToken.None).ConfigureAwait(false);
 
         var profile = request.DeviceProfile;

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -143,7 +143,7 @@ public static class StreamingHelpers
         else
         {
             // Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
-            // Cap the MaxStreamingBitrate to 20Mbps, because we are unable to reliably probe source bitrate,
+            // Cap the MaxStreamingBitrate to 30Mbps, because we are unable to reliably probe source bitrate,
             // which will cause the client to request extremely high bitrate that may fail the player/encoder
             streamingRequest.VideoBitRate = streamingRequest.VideoBitRate > 30000000 ? 30000000 : streamingRequest.VideoBitRate;
 

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -142,6 +142,20 @@ public static class StreamingHelpers
         }
         else
         {
+            // Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
+            // Cap the MaxStreamingBitrate to 20Mbps, because we are unable to reliably probe source bitrate,
+            // which will cause the client to request extremely high bitrate that may fail the player/encoder
+            streamingRequest.VideoBitRate = streamingRequest.VideoBitRate > 30000000 ? 30000000 : streamingRequest.VideoBitRate;
+
+            if (streamingRequest.SegmentContainer is not null)
+            {
+                // Remove all fmp4 transcoding profiles, because it causes playback error and/or A/V sync issues
+                // Notably: Some channels won't play on FireFox and LG webOS
+                // Some channels from HDHomerun will experience A/V sync issues
+                streamingRequest.SegmentContainer = "ts";
+                streamingRequest.VideoCodec = "h264";
+            }
+
             var liveStreamInfo = await mediaSourceManager.GetLiveStreamWithDirectStreamProvider(streamingRequest.LiveStreamId, cancellationToken).ConfigureAwait(false);
             mediaSource = liveStreamInfo.Item1;
             state.DirectStreamProvider = liveStreamInfo.Item2;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2320,7 +2320,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (request.VideoBitRate.HasValue
                 && (!videoStream.BitRate.HasValue || videoStream.BitRate.Value > request.VideoBitRate.Value))
             {
-                return false;
+                // For LiveTV that has no bitrate, let's try copy if other conditions are met
+                if (string.IsNullOrWhiteSpace(request.LiveStreamId) || videoStream.BitRate.HasValue)
+                {
+                    return false;
+                }
             }
 
             var maxBitDepth = state.GetRequestedVideoBitDepth(videoStream.Codec);


### PR DESCRIPTION
Yet another attempt to cover more use case without an API change.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Moved profile enforcement to StreamingHelper because not all LiveTV requests call OpenMediaSource
- Raised bitrate limit from 20M to 30M
- When LiveTV input source has no valid bitrate, still try copy stream when other constraints are satisfied

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11847