### PR TITLE
Fix FirstTimeSetupHandler allowing public access

### DIFF
--- a/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
@@ -32,16 +32,8 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupPolicy
             {
                 context.Fail();
             }
-            else if (!requirement.RequireAdmin && context.User.IsInRole(UserRoles.Guest))
-            {
-                context.Fail();
-            }
-            else
-            {
-                // Any user-specific checks are handled in the DefaultAuthorizationHandler.
-                context.Succeed(requirement);
-            }
 
+            // Any user-specific checks are handled in the DefaultAuthorizationHandler.
             return Task.CompletedTask;
         }
     }

--- a/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
+using Jellyfin.Api.Extensions;
 using MediaBrowser.Common.Configuration;
 using Microsoft.AspNetCore.Authorization;
 
@@ -25,6 +26,10 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupPolicy
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, FirstTimeSetupRequirement requirement)
         {
             if (!_configurationManager.CommonConfiguration.IsStartupWizardCompleted)
+            {
+                context.Succeed(requirement);
+            }
+            else if (context.User.GetIsApiKey())
             {
                 context.Succeed(requirement);
             }

--- a/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupPolicy
             {
                 context.Succeed(requirement);
             }
-            else if (context.User.GetIsApiKey())
+            else if (context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(requirement);
             }

--- a/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
@@ -25,17 +25,28 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupPolicy
         /// <inheritdoc />
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, FirstTimeSetupRequirement requirement)
         {
+            // Succeed if the startup wizard / first time setup is not complete
             if (!_configurationManager.CommonConfiguration.IsStartupWizardCompleted)
             {
                 context.Succeed(requirement);
             }
-            else if (context.User.IsInRole(UserRoles.Administrator))
+
+            // Succeed if user is admin or api key
+            else if (context.User.GetIsApiKey() || context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(requirement);
             }
+
+            // Fail if admin is required and user is not admin
             else if (requirement.RequireAdmin && !context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Fail();
+            }
+
+            // Succeed if admin is not required and user is not guest
+            else if (!requirement.RequireAdmin && context.User.IsInRole(UserRoles.User))
+            {
+                context.Succeed(requirement);
             }
 
             // Any user-specific checks are handled in the DefaultAuthorizationHandler.

--- a/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
+++ b/Jellyfin.Api/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandler.cs
@@ -31,20 +31,20 @@ namespace Jellyfin.Api.Auth.FirstTimeSetupPolicy
                 context.Succeed(requirement);
             }
 
-            // Succeed if user is admin or api key
-            else if (context.User.GetIsApiKey() || context.User.IsInRole(UserRoles.Administrator))
+            // Succeed if user is admin
+            else if (context.User.IsInRole(UserRoles.Administrator))
             {
                 context.Succeed(requirement);
             }
 
             // Fail if admin is required and user is not admin
-            else if (requirement.RequireAdmin && !context.User.IsInRole(UserRoles.Administrator))
+            else if (requirement.RequireAdmin)
             {
                 context.Fail();
             }
 
             // Succeed if admin is not required and user is not guest
-            else if (!requirement.RequireAdmin && context.User.IsInRole(UserRoles.User))
+            else if (context.User.IsInRole(UserRoles.User))
             {
                 context.Succeed(requirement);
             }

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
@@ -107,16 +107,6 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
         }
 
         [Fact]
-        public async Task ShouldAllowAdminApiKeyIfStartupWizardComplete()
-        {
-            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim(InternalClaimTypes.IsApiKey, bool.TrueString)]));
-
-            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTime");
-            Assert.True(allowed.Succeeded);
-        }
-
-        [Fact]
         public async Task ShouldDisallowUserIfOutsideSchedule()
         {
             AccessSchedule[] accessSchedules = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
@@ -52,10 +52,10 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
         }
 
         [Theory]
-        [InlineData(UserRoles.Administrator, true)]
-        [InlineData(UserRoles.Guest, false)]
-        [InlineData(UserRoles.User, false)]
-        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
+        [InlineData(UserRoles.Administrator, false)]
+        [InlineData(UserRoles.Guest, true)]
+        [InlineData(UserRoles.User, true)]
+        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldFail)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var claims = TestHelpers.SetupUser(
@@ -66,14 +66,14 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.Equal(shouldSucceed, context.HasSucceeded);
+            Assert.Equal(shouldFail, context.HasFailed);
         }
 
         [Theory]
-        [InlineData(UserRoles.Administrator, true)]
-        [InlineData(UserRoles.Guest, false)]
-        [InlineData(UserRoles.User, true)]
-        public async Task ShouldRequireUserIfNotRequiresAdmin(string userRole, bool shouldSucceed)
+        [InlineData(UserRoles.Administrator)]
+        [InlineData(UserRoles.Guest)]
+        [InlineData(UserRoles.User)]
+        public async Task ShouldDeferIfNotRequiresAdmin(string userRole)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var claims = TestHelpers.SetupUser(
@@ -87,7 +87,8 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
                 null);
 
             await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.Equal(shouldSucceed, context.HasSucceeded);
+            Assert.False(context.HasSucceeded);
+            Assert.False(context.HasFailed);
         }
 
         [Fact]

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
@@ -1,14 +1,19 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
+using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Api.Auth.FirstTimeSetupPolicy;
 using Jellyfin.Api.Constants;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -18,7 +23,9 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
     {
         private readonly Mock<IConfigurationManager> _configurationManagerMock;
         private readonly List<IAuthorizationRequirement> _requirements;
+        private readonly DefaultAuthorizationHandler _defaultAuthorizationHandler;
         private readonly FirstTimeSetupHandler _firstTimeSetupHandler;
+        private readonly IAuthorizationService _authorizationService;
         private readonly Mock<IUserManager> _userManagerMock;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
@@ -31,6 +38,21 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
             _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
 
             _firstTimeSetupHandler = fixture.Create<FirstTimeSetupHandler>();
+            _defaultAuthorizationHandler = fixture.Create<DefaultAuthorizationHandler>();
+
+            var services = new ServiceCollection();
+            services.AddAuthorizationCore();
+            services.AddLogging();
+            services.AddOptions();
+            services.AddSingleton<IAuthorizationHandler>(_defaultAuthorizationHandler);
+            services.AddSingleton<IAuthorizationHandler>(_firstTimeSetupHandler);
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("FirstTime", policy => policy.Requirements.Add(new FirstTimeSetupRequirement()));
+                options.AddPolicy("FirstTimeNoAdmin", policy => policy.Requirements.Add(new FirstTimeSetupRequirement(false, false)));
+                options.AddPolicy("FirstTimeSchedule", policy => policy.Requirements.Add(new FirstTimeSetupRequirement(true, false)));
+            });
+            _authorizationService = services.BuildServiceProvider().GetRequiredService<IAuthorizationService>();
         }
 
         [Theory]
@@ -45,17 +67,33 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
                 _httpContextAccessor,
                 userRole);
 
-            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTime");
 
-            await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.True(context.HasSucceeded);
+            Assert.True(allowed.Succeeded);
         }
 
         [Theory]
-        [InlineData(UserRoles.Administrator, false)]
-        [InlineData(UserRoles.Guest, true)]
+        [InlineData(UserRoles.Administrator, true)]
+        [InlineData(UserRoles.Guest, false)]
+        [InlineData(UserRoles.User, false)]
+        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldSucceed)
+        {
+            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
+            var claims = TestHelpers.SetupUser(
+                _userManagerMock,
+                _httpContextAccessor,
+                userRole);
+
+            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTime");
+
+            Assert.Equal(shouldSucceed, allowed.Succeeded);
+        }
+
+        [Theory]
+        [InlineData(UserRoles.Administrator, true)]
+        [InlineData(UserRoles.Guest, false)]
         [InlineData(UserRoles.User, true)]
-        public async Task ShouldRequireAdministratorIfStartupWizardComplete(string userRole, bool shouldFail)
+        public async Task ShouldRequireUserIfNotAdministrator(string userRole, bool shouldSucceed)
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var claims = TestHelpers.SetupUser(
@@ -63,32 +101,9 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
                 _httpContextAccessor,
                 userRole);
 
-            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTimeNoAdmin");
 
-            await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.Equal(shouldFail, context.HasFailed);
-        }
-
-        [Theory]
-        [InlineData(UserRoles.Administrator)]
-        [InlineData(UserRoles.Guest)]
-        [InlineData(UserRoles.User)]
-        public async Task ShouldDeferIfNotRequiresAdmin(string userRole)
-        {
-            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var claims = TestHelpers.SetupUser(
-                _userManagerMock,
-                _httpContextAccessor,
-                userRole);
-
-            var context = new AuthorizationHandlerContext(
-                new List<IAuthorizationRequirement> { new FirstTimeSetupRequirement(false, false) },
-                claims,
-                null);
-
-            await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.False(context.HasSucceeded);
-            Assert.False(context.HasFailed);
+            Assert.Equal(shouldSucceed, allowed.Succeeded);
         }
 
         [Fact]
@@ -96,10 +111,26 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
             var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim(InternalClaimTypes.IsApiKey, bool.TrueString)]));
-            var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
-            await _firstTimeSetupHandler.HandleAsync(context);
-            Assert.True(context.HasSucceeded);
+            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTime");
+            Assert.True(allowed.Succeeded);
+        }
+
+        [Fact]
+        public async Task ShouldDisallowUserIfOutsideSchedule()
+        {
+            AccessSchedule[] accessSchedules = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };
+
+            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
+            var claims = TestHelpers.SetupUser(
+                _userManagerMock,
+                _httpContextAccessor,
+                UserRoles.User,
+                accessSchedules);
+
+            var allowed = await _authorizationService.AuthorizeAsync(claims, "FirstTimeSchedule");
+
+            Assert.False(allowed.Succeeded);
         }
     }
 }

--- a/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/FirstTimeSetupPolicy/FirstTimeSetupHandlerTests.cs
@@ -95,7 +95,7 @@ namespace Jellyfin.Api.Tests.Auth.FirstTimeSetupPolicy
         public async Task ShouldAllowAdminApiKeyIfStartupWizardComplete()
         {
             TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
-            var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Role, UserRoles.Administrator)]));
+            var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim(InternalClaimTypes.IsApiKey, bool.TrueString)]));
             var context = new AuthorizationHandlerContext(_requirements, claims, null);
 
             await _firstTimeSetupHandler.HandleAsync(context);


### PR DESCRIPTION
**Changes**
Instead of explicitly succeeding or failing, we should defer to DefaultAuthorizationHandler to handle user validation based on examples I could find. This seems to fix the issue when testing locally.

**Issues**
Fixes #11620 
