### PR TITLE
Don't check if admin has access to library when updating

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -319,7 +319,7 @@ public class LibraryStructureController : BaseJellyfinApiController
     public ActionResult UpdateLibraryOptions(
         [FromBody] UpdateLibraryOptionsDto request)
     {
-        var item = _libraryManager.GetItemById<CollectionFolder>(request.Id, User.GetUserId());
+        var item = _libraryManager.GetItemById<CollectionFolder>(request.Id);
         if (item is null)
         {
             return NotFound();


### PR DESCRIPTION
The access check also checks if the library is enabled, this makes it impossible to enable disabled libraries.

Regression from  #11171
Fixes #11875 and #11829