### PR TITLE
Migrate to z440.atl from TagLib-Sharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,6 +81,7 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
+    <PackageVersion Include="z440.atl.core" Version="5.24.0" />
     <PackageVersion Include="TMDbLib" Version="2.2.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />
     <PackageVersion Include="Xunit.Priority" Version="1.1.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,7 +81,7 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
-    <PackageVersion Include="z440.atl.core" Version="5.24.0" />
+    <PackageVersion Include="z440.atl.core" Version="5.25.0" />
     <PackageVersion Include="TMDbLib" Version="2.2.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />
     <PackageVersion Include="Xunit.Priority" Version="1.1.6" />

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="PlaylistsNET" />
-    <PackageReference Include="TagLibSharp" />
+    <PackageReference Include="z440.atl.core"/>
     <PackageReference Include="TMDbLib" />
   </ItemGroup>
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -27,6 +27,7 @@ namespace MediaBrowser.Providers.MediaInfo
     /// </summary>
     public class AudioFileProber
     {
+        private const char InternalValueSeparator = '\u001F';
         private readonly IMediaEncoder _mediaEncoder;
         private readonly IItemRepository _itemRepo;
         private readonly ILibraryManager _libraryManager;
@@ -61,6 +62,7 @@ namespace MediaBrowser.Providers.MediaInfo
             _mediaSourceManager = mediaSourceManager;
             _lyricResolver = lyricResolver;
             _lyricManager = lyricManager;
+            ATL.Settings.DisplayValueSeparator = InternalValueSeparator;
         }
 
         /// <summary>
@@ -156,7 +158,7 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <param name="tryExtractEmbeddedLyrics">Whether to extract embedded lyrics to lrc file. </param>
         private async Task FetchDataFromTags(Audio audio, Model.MediaInfo.MediaInfo mediaInfo, MetadataRefreshOptions options, bool tryExtractEmbeddedLyrics)
         {
-            ATL.Settings.DisplayValueSeparator = '\u001F';
+            var test = ATL.Settings.DisplayValueSeparator;
             Track track = new Track(audio.Path);
 
             // ATL will fall back to filename as title when it does not understand the metadata
@@ -173,7 +175,7 @@ namespace MediaBrowser.Providers.MediaInfo
             if (audio.SupportsPeople && !audio.LockedFields.Contains(MetadataField.Cast))
             {
                 var people = new List<PersonInfo>();
-                var albumArtists = string.IsNullOrEmpty(track.AlbumArtist) ? mediaInfo.AlbumArtists : track.AlbumArtist.Split('\u001F');
+                var albumArtists = string.IsNullOrEmpty(track.AlbumArtist) ? mediaInfo.AlbumArtists : track.AlbumArtist.Split(InternalValueSeparator);
                 foreach (var albumArtist in albumArtists)
                 {
                     if (!string.IsNullOrEmpty(albumArtist))
@@ -186,7 +188,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
                 }
 
-                var performers = string.IsNullOrEmpty(track.Artist) ? mediaInfo.Artists : track.Artist.Split('\u001F');
+                var performers = string.IsNullOrEmpty(track.Artist) ? mediaInfo.Artists : track.Artist.Split(InternalValueSeparator);
                 foreach (var performer in performers)
                 {
                     if (!string.IsNullOrEmpty(performer))
@@ -199,7 +201,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
                 }
 
-                foreach (var composer in track.Composer.Split('\u001F'))
+                foreach (var composer in track.Composer.Split(InternalValueSeparator))
                 {
                     if (!string.IsNullOrEmpty(composer))
                     {
@@ -283,7 +285,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (!audio.LockedFields.Contains(MetadataField.Genres))
             {
-                var genres = string.IsNullOrEmpty(track.Genre) ? mediaInfo.Genres : track.Genre.Split('\u001F').Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+                var genres = string.IsNullOrEmpty(track.Genre) ? mediaInfo.Genres : track.Genre.Split(InternalValueSeparator).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 audio.Genres = options.ReplaceAllMetadata || audio.Genres == null || audio.Genres.Length == 0
                     ? genres
                     : audio.Genres;

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -159,8 +159,13 @@ namespace MediaBrowser.Providers.MediaInfo
             ATL.Settings.DisplayValueSeparator = '\u001F';
             Track track = new Track(audio.Path);
 
+            // ATL will fall back to filename as title when it does not understand the metadata
+            if (track.MetadataFormats.All(mf => mf.Equals(ATL.Factory.UNKNOWN_FORMAT)))
+            {
+                track.Title = mediaInfo.Name;
+            }
+
             track.Album = string.IsNullOrEmpty(track.Album) ? mediaInfo.Album : track.Album;
-            track.Title = string.IsNullOrEmpty(track.Title) ? mediaInfo.Name : track.Title;
             track.Year ??= mediaInfo.ProductionYear;
             track.TrackNumber ??= mediaInfo.IndexNumber;
             track.DiscNumber ??= mediaInfo.ParentIndexNumber;

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -360,10 +360,6 @@ namespace MediaBrowser.Providers.MediaInfo
                      || track.AdditionalFields.TryGetValue("MusicBrainz Release Track Id", out trackMbId))
                     && !string.IsNullOrEmpty(trackMbId))
                 {
-                    audio.SetProviderId(MetadataProvider.MusicBrainzTrack, trackMbId);
-                }
-                if (trackMbId is not null)
-                {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzTrack, trackMbId);
                 }
             }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -291,7 +291,6 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             track.AdditionalFields.TryGetValue("REPLAYGAIN_TRACK_GAIN", out var trackGainTag);
-            float trackGain = float.NaN;
 
             if (trackGainTag is not null)
             {
@@ -302,17 +301,11 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (float.TryParse(trackGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
                 {
-                    trackGain = value;
+                    audio.NormalizationGain = value;
                 }
             }
 
-            if (!float.IsNaN(trackGain))
-            {
-                audio.NormalizationGain = trackGain;
-            }
-
-            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
-                && !string.IsNullOrEmpty(tags.MusicBrainzArtistId))
+            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
             {
                 if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ARTISTID", out var musicBrainzArtistTag)
                      || track.AdditionalFields.TryGetValue("MusicBrainz Artist Id", out musicBrainzArtistTag))
@@ -322,8 +315,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbumArtist, out _))
-                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseArtistId))
+            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbumArtist, out _))
             {
                 if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMARTISTID", out var musicBrainzReleaseArtistIdTag)
                      || track.AdditionalFields.TryGetValue("MusicBrainz Album Artist Id", out musicBrainzReleaseArtistIdTag))
@@ -333,8 +325,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbum, out _))
-                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseId))
+            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbum, out _))
             {
                 if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMID", out var musicBrainzReleaseIdTag)
                      || track.AdditionalFields.TryGetValue("MusicBrainz Album Id", out musicBrainzReleaseIdTag))
@@ -344,8 +335,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzReleaseGroup, out _))
-                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseGroupId))
+            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzReleaseGroup, out _))
             {
                 if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_RELEASEGROUPID", out var musicBrainzReleaseGroupIdTag)
                      || track.AdditionalFields.TryGetValue("MusicBrainz Release Group Id", out musicBrainzReleaseGroupIdTag))

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -158,7 +158,6 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <param name="tryExtractEmbeddedLyrics">Whether to extract embedded lyrics to lrc file. </param>
         private async Task FetchDataFromTags(Audio audio, Model.MediaInfo.MediaInfo mediaInfo, MetadataRefreshOptions options, bool tryExtractEmbeddedLyrics)
         {
-            var test = ATL.Settings.DisplayValueSeparator;
             Track track = new Track(audio.Path);
 
             // ATL will fall back to filename as title when it does not understand the metadata

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -294,7 +294,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (trackGainTag is not null)
             {
-                if (trackGainTag.ToLower(CultureInfo.InvariantCulture).EndsWith("db", StringComparison.OrdinalIgnoreCase))
+                if (trackGainTag.EndsWith("db", StringComparison.OrdinalIgnoreCase))
                 {
                     trackGainTag = trackGainTag[..^2].Trim();
                 }
@@ -313,13 +313,9 @@ namespace MediaBrowser.Providers.MediaInfo
             if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
                 && !string.IsNullOrEmpty(tags.MusicBrainzArtistId))
             {
-                track.AdditionalFields.TryGetValue("MUSICBRAINZ_ARTISTID", out var musicBrainzArtistTag);
-                if (musicBrainzArtistTag is null)
-                {
-                    track.AdditionalFields.TryGetValue("MusicBrainz Artist Id", out musicBrainzArtistTag);
-                }
-
-                if (musicBrainzArtistTag is not null)
+                if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ARTISTID", out var musicBrainzArtistTag)
+                     || track.AdditionalFields.TryGetValue("MusicBrainz Artist Id", out musicBrainzArtistTag))
+                    && !string.IsNullOrEmpty(musicBrainzArtistTag))
                 {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzArtist, musicBrainzArtistTag);
                 }
@@ -328,13 +324,9 @@ namespace MediaBrowser.Providers.MediaInfo
             if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbumArtist, out _))
                 && !string.IsNullOrEmpty(tags.MusicBrainzReleaseArtistId))
             {
-                track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMARTISTID", out var musicBrainzReleaseArtistIdTag);
-                if (musicBrainzReleaseArtistIdTag is null)
-                {
-                    track.AdditionalFields.TryGetValue("MusicBrainz Album Artist Id", out musicBrainzReleaseArtistIdTag);
-                }
-
-                if (musicBrainzReleaseArtistIdTag is not null)
+                if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMARTISTID", out var musicBrainzReleaseArtistIdTag)
+                     || track.AdditionalFields.TryGetValue("MusicBrainz Album Artist Id", out musicBrainzReleaseArtistIdTag))
+                    && !string.IsNullOrEmpty(musicBrainzReleaseArtistIdTag))
                 {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzAlbumArtist, musicBrainzReleaseArtistIdTag);
                 }
@@ -343,13 +335,9 @@ namespace MediaBrowser.Providers.MediaInfo
             if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbum, out _))
                 && !string.IsNullOrEmpty(tags.MusicBrainzReleaseId))
             {
-                track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMID", out var musicBrainzReleaseIdTag);
-                if (musicBrainzReleaseIdTag is null)
-                {
-                    track.AdditionalFields.TryGetValue("MusicBrainz Album Id", out musicBrainzReleaseIdTag);
-                }
-
-                if (musicBrainzReleaseIdTag is not null)
+                if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_ALBUMID", out var musicBrainzReleaseIdTag)
+                     || track.AdditionalFields.TryGetValue("MusicBrainz Album Id", out musicBrainzReleaseIdTag))
+                    && !string.IsNullOrEmpty(musicBrainzReleaseIdTag))
                 {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzAlbum, musicBrainzReleaseIdTag);
                 }
@@ -358,13 +346,9 @@ namespace MediaBrowser.Providers.MediaInfo
             if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzReleaseGroup, out _))
                 && !string.IsNullOrEmpty(tags.MusicBrainzReleaseGroupId))
             {
-                track.AdditionalFields.TryGetValue("MUSICBRAINZ_RELEASEGROUPID", out var musicBrainzReleaseGroupIdTag);
-                if (musicBrainzReleaseGroupIdTag is null)
-                {
-                    track.AdditionalFields.TryGetValue("MusicBrainz Release Group Id", out musicBrainzReleaseGroupIdTag);
-                }
-
-                if (musicBrainzReleaseGroupIdTag is not null)
+                if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_RELEASEGROUPID", out var musicBrainzReleaseGroupIdTag)
+                     || track.AdditionalFields.TryGetValue("MusicBrainz Release Group Id", out musicBrainzReleaseGroupIdTag))
+                    && !string.IsNullOrEmpty(musicBrainzReleaseGroupIdTag))
                 {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzReleaseGroup, musicBrainzReleaseGroupIdTag);
                 }
@@ -372,12 +356,12 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzTrack, out _))
             {
-                track.AdditionalFields.TryGetValue("MUSICBRAINZ_RELEASETRACKID", out var trackMbId);
-                if (trackMbId is null)
+                if ((track.AdditionalFields.TryGetValue("MUSICBRAINZ_RELEASETRACKID", out var trackMbId)
+                     || track.AdditionalFields.TryGetValue("MusicBrainz Release Track Id", out trackMbId))
+                    && !string.IsNullOrEmpty(trackMbId))
                 {
-                    track.AdditionalFields.TryGetValue("MusicBrainz Release Track Id", out trackMbId);
+                    audio.SetProviderId(MetadataProvider.MusicBrainzTrack, trackMbId);
                 }
-
                 if (trackMbId is not null)
                 {
                     audio.TrySetProviderId(MetadataProvider.MusicBrainzTrack, trackMbId);


### PR DESCRIPTION
The ATL lib provides a lot of advantages to the TagLib we are currently using.

Notably:

- auto-detect the format of the audio data, even if the file extension has the wrong label, and provides unified API for different file types.

- supports more audio formats than TagLib

- supports lyrics natively

- supports playlists and cuesheets

- provides relatively simple and controllable way for non-standard fields, enable us to implement compatibility features instead of waiting for lib updates

- is actually maintained

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
