### PR TITLE
Fix multi-part album folder being detected as artist folder

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/MusicArtistResolver.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Emby.Naming.Audio;
 using Emby.Naming.Common;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities.Audio;
@@ -85,6 +86,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
             }
 
             var albumResolver = new MusicAlbumResolver(_logger, _namingOptions, _directoryService);
+            var albumParser = new AlbumParser(_namingOptions);
 
             var directories = args.FileSystemChildren.Where(i => i.IsDirectory);
 
@@ -98,6 +100,12 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
                         // Stop once we see an artist subfolder
                         state.Stop();
                     }
+                }
+
+                // If the folder is a multi-disc folder, then it is not an artist folder
+                if (albumParser.IsMultiPart(fileSystemInfo.FullName))
+                {
+                    return;
                 }
 
                 // If we contain a music album assume we are an artist folder


### PR DESCRIPTION
In rare cases, such as when an artist only has multi-part albums, the multi-part album folder might be incorrectly detected as an artist folder, causing the album discs to be split.

Caveat 1: For some artists with names indistinguishable from an album part (for example, "Volume 10"), the folder name for the artist needs to be escaped, like `[Volume 10]`.

Caveat 2: Users already affected by this might see multiple duplicated albums, both the wrongly split ones and the correctly grouped ones, after a library-specific scan. This can be fixed by performing a global validation in the scheduled task -> scan media library. Only the valid albums will remain after that is completed.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Don't mark folder as artist folder when the folder appears to be a multi-part album.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
