### PR TITLE
Trim leading and trailing whitespace from item search term.

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -370,7 +370,7 @@ public class ItemsController : BaseJellyfinApiController
                 EnableTotalRecordCount = enableTotalRecordCount,
                 ExcludeItemIds = excludeItemIds,
                 DtoOptions = dtoOptions,
-                SearchTerm = searchTerm,
+                SearchTerm = !string.IsNullOrEmpty(searchTerm) ? searchTerm.Trim() : searchTerm,
                 MinDateLastSaved = minDateLastSaved?.ToUniversalTime(),
                 MinDateLastSavedForUser = minDateLastSavedForUser?.ToUniversalTime(),
                 MinPremiereDate = minPremiereDate?.ToUniversalTime(),


### PR DESCRIPTION
**Changes**
Trim the leading and trailing whitespace from the searchTerm used in the ItemsController GetItems() method.

**Issues**
Fixes #11868 
