### PR TITLE
Implement Device Cache to replace EFCoreSecondLevelCacheInterceptor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,6 @@
     <PackageVersion Include="Diacritics" Version="3.3.29" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="4.5.0" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.2" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -19,8 +19,7 @@ namespace Emby.Server.Implementations
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString },
-            { SqliteCacheSizeKey, "20000" },
-            { SqliteDisableSecondLevelCacheKey, bool.FalseString }
+            { SqliteCacheSizeKey, "20000" }
         };
     }
 }

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -47,10 +47,10 @@ public class DevicesController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the list of devices.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<ActionResult<QueryResult<DeviceInfo>>> GetDevices([FromQuery] Guid? userId)
+    public ActionResult<QueryResult<DeviceInfo>> GetDevices([FromQuery] Guid? userId)
     {
         userId = RequestHelpers.GetUserId(User, userId);
-        return await _deviceManager.GetDevicesForUser(userId).ConfigureAwait(false);
+        return _deviceManager.GetDevicesForUser(userId);
     }
 
     /// <summary>
@@ -63,9 +63,9 @@ public class DevicesController : BaseJellyfinApiController
     [HttpGet("Info")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DeviceInfo>> GetDeviceInfo([FromQuery, Required] string id)
+    public ActionResult<DeviceInfo> GetDeviceInfo([FromQuery, Required] string id)
     {
-        var deviceInfo = await _deviceManager.GetDevice(id).ConfigureAwait(false);
+        var deviceInfo = _deviceManager.GetDevice(id);
         if (deviceInfo is null)
         {
             return NotFound();
@@ -84,9 +84,9 @@ public class DevicesController : BaseJellyfinApiController
     [HttpGet("Options")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DeviceOptions>> GetDeviceOptions([FromQuery, Required] string id)
+    public ActionResult<DeviceOptions> GetDeviceOptions([FromQuery, Required] string id)
     {
-        var deviceInfo = await _deviceManager.GetDeviceOptions(id).ConfigureAwait(false);
+        var deviceInfo = _deviceManager.GetDeviceOptions(id);
         if (deviceInfo is null)
         {
             return NotFound();
@@ -124,13 +124,13 @@ public class DevicesController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteDevice([FromQuery, Required] string id)
     {
-        var existingDevice = await _deviceManager.GetDevice(id).ConfigureAwait(false);
+        var existingDevice = _deviceManager.GetDevice(id);
         if (existingDevice is null)
         {
             return NotFound();
         }
 
-        var sessions = await _deviceManager.GetDevices(new DeviceQuery { DeviceId = id }).ConfigureAwait(false);
+        var sessions = _deviceManager.GetDevices(new DeviceQuery { DeviceId = id });
 
         foreach (var session in sessions.Items)
         {

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -123,7 +123,7 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public DeviceInfo? GetDevice(string id)
         {
-            var device = _devices.Values.OrderByDescending(d => d.DateLastActivity).FirstOrDefault(d => d.DeviceId == id);
+            var device = _devices.Values.Where(d => d.DeviceId == id).OrderByDescending(d => d.DateLastActivity).FirstOrDefault();
             _deviceOptions.TryGetValue(id, out var deviceOption);
 
             var deviceInfo = device is null ? null : ToDeviceInfo(device, deviceOption);

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -172,10 +172,9 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public QueryResult<DeviceInfo> GetDevicesForUser(Guid? userId)
         {
-            var devices = _devices.Values
+            IEnumerable<Device> devices = _devices.Values
                 .OrderByDescending(d => d.DateLastActivity)
-                .ThenBy(d => d.DeviceId)
-                .AsEnumerable();
+                .ThenBy(d => d.DeviceId);
 
             if (!userId.IsNullOrEmpty())
             {

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -199,8 +199,7 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public async Task DeleteDevice(Device device)
         {
-            var id = _devices.FirstOrDefault(x => x.Value.Equals(device)).Key;
-            _devices.TryRemove(id, out _);
+            _devices.TryRemove(device.Id, out _);
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -97,12 +97,8 @@ namespace Jellyfin.Server.Implementations.Devices
             await using (dbContext.ConfigureAwait(false))
             {
                 dbContext.Devices.Add(device);
-
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
-                var newDevice = await dbContext.Devices
-                    .FirstAsync(d => d.Id == device.Id)
-                    .ConfigureAwait(false);
-                _devices.TryAdd(device.Id, newDevice);
+                _devices.TryAdd(device.Id, device);
             }
 
             return device;

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -133,10 +133,11 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public QueryResult<Device> GetDevices(DeviceQuery query)
         {
-            IEnumerable<Device> devices = _devices.Values.OrderBy(d => d.Id)
+            IEnumerable<Device> devices = _devices.Values
                 .Where(device => !query.UserId.HasValue || device.UserId.Equals(query.UserId.Value))
                 .Where(device => query.DeviceId == null || device.DeviceId == query.DeviceId)
                 .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken)
+                .OrderBy(d => d.Id)
                 .ToList();
             var count = devices.Count();
 

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -100,9 +100,12 @@ namespace Jellyfin.Server.Implementations.Devices
                 dbContext.Devices.Add(device);
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
+                var newDevice = await dbContext.Devices
+                    .Include(d => d.User)
+                    .FirstOrDefaultAsync(d => d.Id == device.Id)
+                    .ConfigureAwait(false);
+                _devices.Add(device.Id, newDevice!);
             }
-
-            _devices.Add(device.Id, device);
 
             return device;
         }

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -27,6 +27,8 @@ namespace Jellyfin.Server.Implementations.Devices
         private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
         private readonly IUserManager _userManager;
         private readonly ConcurrentDictionary<string, ClientCapabilities> _capabilitiesMap = new();
+        private readonly IDictionary<int, Device> _devices;
+        private readonly IDictionary<string, DeviceOptions> _deviceOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceManager"/> class.
@@ -37,6 +39,24 @@ namespace Jellyfin.Server.Implementations.Devices
         {
             _dbProvider = dbProvider;
             _userManager = userManager;
+            _devices = new ConcurrentDictionary<int, Device>();
+            _deviceOptions = new ConcurrentDictionary<string, DeviceOptions>();
+
+            using var dbContext = _dbProvider.CreateDbContext();
+            foreach (var device in dbContext.Devices
+                         .Include(d => d.User)
+                         .OrderBy(d => d.Id)
+                         .AsEnumerable())
+            {
+                _devices.Add(device.Id, device);
+            }
+
+            foreach (var deviceOption in dbContext.DeviceOptions
+                         .OrderBy(d => d.Id)
+                         .AsEnumerable())
+            {
+                _deviceOptions.Add(deviceOption.DeviceId, deviceOption);
+            }
         }
 
         /// <inheritdoc />
@@ -66,6 +86,8 @@ namespace Jellyfin.Server.Implementations.Devices
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
             }
 
+            _deviceOptions[deviceId] = deviceOptions;
+
             DeviceOptionsUpdated?.Invoke(this, new GenericEventArgs<Tuple<string, DeviceOptions>>(new Tuple<string, DeviceOptions>(deviceId, deviceOptions)));
         }
 
@@ -80,21 +102,15 @@ namespace Jellyfin.Server.Implementations.Devices
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
             }
 
+            _devices.Add(device.Id, device);
+
             return device;
         }
 
         /// <inheritdoc />
-        public async Task<DeviceOptions> GetDeviceOptions(string deviceId)
+        public DeviceOptions GetDeviceOptions(string deviceId)
         {
-            var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-            DeviceOptions? deviceOptions;
-            await using (dbContext.ConfigureAwait(false))
-            {
-                deviceOptions = await dbContext.DeviceOptions
-                    .AsNoTracking()
-                    .FirstOrDefaultAsync(d => d.DeviceId == deviceId)
-                    .ConfigureAwait(false);
-            }
+            _deviceOptions.TryGetValue(deviceId, out var deviceOptions);
 
             return deviceOptions ?? new DeviceOptions(deviceId);
         }
@@ -108,57 +124,45 @@ namespace Jellyfin.Server.Implementations.Devices
         }
 
         /// <inheritdoc />
-        public async Task<DeviceInfo?> GetDevice(string id)
+        public DeviceInfo? GetDevice(string id)
         {
-            var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-            await using (dbContext.ConfigureAwait(false))
-            {
-                var device = await dbContext.Devices
-                    .Where(d => d.DeviceId == id)
-                    .OrderByDescending(d => d.DateLastActivity)
-                    .Include(d => d.User)
-                    .SelectMany(d => dbContext.DeviceOptions.Where(o => o.DeviceId == d.DeviceId).DefaultIfEmpty(), (d, o) => new { Device = d, Options = o })
-                    .FirstOrDefaultAsync()
-                    .ConfigureAwait(false);
+            var device = _devices.Values.OrderByDescending(d => d.DateLastActivity).FirstOrDefault(d => d.DeviceId == id);
+            _deviceOptions.TryGetValue(id, out var deviceOption);
 
-                var deviceInfo = device is null ? null : ToDeviceInfo(device.Device, device.Options);
-
-                return deviceInfo;
-            }
+            var deviceInfo = device is null ? null : ToDeviceInfo(device, deviceOption);
+            return deviceInfo;
         }
 
         /// <inheritdoc />
-        public async Task<QueryResult<Device>> GetDevices(DeviceQuery query)
+        public QueryResult<Device> GetDevices(DeviceQuery query)
         {
-            var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-            await using (dbContext.ConfigureAwait(false))
+            var devices = _devices.Values.OrderBy(d => d.Id)
+                .Where(device => !query.UserId.HasValue || device.UserId.Equals(query.UserId.Value))
+                .Where(device => query.DeviceId == null || device.DeviceId == query.DeviceId)
+                .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken);
+            var canGetCountDirectly = devices.TryGetNonEnumeratedCount(out var count);
+            if (!canGetCountDirectly)
             {
-                var devices = dbContext.Devices
-                    .OrderBy(d => d.Id)
-                    .Where(device => !query.UserId.HasValue || device.UserId.Equals(query.UserId.Value))
-                    .Where(device => query.DeviceId == null || device.DeviceId == query.DeviceId)
-                    .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken);
-
-                var count = await devices.CountAsync().ConfigureAwait(false);
-
-                if (query.Skip.HasValue)
-                {
-                    devices = devices.Skip(query.Skip.Value);
-                }
-
-                if (query.Limit.HasValue)
-                {
-                    devices = devices.Take(query.Limit.Value);
-                }
-
-                return new QueryResult<Device>(query.Skip, count, await devices.ToListAsync().ConfigureAwait(false));
+                count = devices.Count();
             }
+
+            if (query.Skip.HasValue)
+            {
+                devices = devices.Skip(query.Skip.Value);
+            }
+
+            if (query.Limit.HasValue)
+            {
+                devices = devices.Take(query.Limit.Value);
+            }
+
+            return new QueryResult<Device>(query.Skip, count, devices.ToList());
         }
 
         /// <inheritdoc />
-        public async Task<QueryResult<DeviceInfo>> GetDeviceInfos(DeviceQuery query)
+        public QueryResult<DeviceInfo> GetDeviceInfos(DeviceQuery query)
         {
-            var devices = await GetDevices(query).ConfigureAwait(false);
+            var devices = GetDevices(query);
 
             return new QueryResult<DeviceInfo>(
                 devices.StartIndex,
@@ -167,44 +171,57 @@ namespace Jellyfin.Server.Implementations.Devices
         }
 
         /// <inheritdoc />
-        public async Task<QueryResult<DeviceInfo>> GetDevicesForUser(Guid? userId)
+        public QueryResult<DeviceInfo> GetDevicesForUser(Guid? userId)
         {
-            var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-            await using (dbContext.ConfigureAwait(false))
+            var devices = _devices.Values
+                .OrderByDescending(d => d.DateLastActivity)
+                .ThenBy(d => d.DeviceId)
+                .AsEnumerable();
+
+            if (!userId.IsNullOrEmpty())
             {
-                var sessions = dbContext.Devices
-                    .Include(d => d.User)
-                    .OrderByDescending(d => d.DateLastActivity)
-                    .ThenBy(d => d.DeviceId)
-                    .SelectMany(d => dbContext.DeviceOptions.Where(o => o.DeviceId == d.DeviceId).DefaultIfEmpty(), (d, o) => new { Device = d, Options = o })
-                    .AsAsyncEnumerable();
-
-                if (!userId.IsNullOrEmpty())
+                var user = _userManager.GetUserById(userId.Value);
+                if (user is null)
                 {
-                    var user = _userManager.GetUserById(userId.Value);
-                    if (user is null)
-                    {
-                        throw new ResourceNotFoundException();
-                    }
-
-                    sessions = sessions.Where(i => CanAccessDevice(user, i.Device.DeviceId));
+                    throw new ResourceNotFoundException();
                 }
 
-                var array = await sessions.Select(device => ToDeviceInfo(device.Device, device.Options)).ToArrayAsync().ConfigureAwait(false);
-
-                return new QueryResult<DeviceInfo>(array);
+                devices = devices.Where(i => CanAccessDevice(user, i.DeviceId));
             }
+
+            var array = devices.Select(device =>
+                {
+                    _deviceOptions.TryGetValue(device.DeviceId, out var option);
+                    return ToDeviceInfo(device, option);
+                }).ToArray();
+
+            return new QueryResult<DeviceInfo>(array);
         }
 
         /// <inheritdoc />
         public async Task DeleteDevice(Device device)
         {
+            var id = _devices.FirstOrDefault(x => x.Value.Equals(device)).Key;
+            _devices.Remove(id);
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
                 dbContext.Devices.Remove(device);
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
             }
+        }
+
+        /// <inheritdoc />
+        public async Task UpdateDevice(Device device)
+        {
+            var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
+            await using (dbContext.ConfigureAwait(false))
+            {
+                dbContext.Devices.Update(device);
+                await dbContext.SaveChangesAsync().ConfigureAwait(false);
+            }
+
+            _devices[device.Id] = device;
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -137,10 +137,11 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public QueryResult<Device> GetDevices(DeviceQuery query)
         {
-            var devices = _devices.Values.OrderBy(d => d.Id)
+            IEnumerable<Device> devices = _devices.Values.OrderBy(d => d.Id)
                 .Where(device => !query.UserId.HasValue || device.UserId.Equals(query.UserId.Value))
                 .Where(device => query.DeviceId == null || device.DeviceId == query.DeviceId)
-                .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken);
+                .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken)
+                .ToList();
             var count = devices.Count();
 
             if (query.Skip.HasValue)

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -100,9 +100,9 @@ namespace Jellyfin.Server.Implementations.Devices
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
                 var newDevice = await dbContext.Devices
-                    .FirstOrDefaultAsync(d => d.Id == device.Id)
+                    .FirstAsync(d => d.Id == device.Id)
                     .ConfigureAwait(false);
-                _devices.TryAdd(device.Id, newDevice!);
+                _devices.TryAdd(device.Id, newDevice);
             }
 
             return device;

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -241,7 +241,7 @@ namespace Jellyfin.Server.Implementations.Devices
             var user = _userManager.GetUserById(authInfo.UserId);
             if (user is null)
             {
-                throw new ResourceNotFoundException();
+                throw new ResourceNotFoundException("User with UserId " + authInfo.UserId + " not found");
             }
 
             return new DeviceInfo

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -143,11 +143,7 @@ namespace Jellyfin.Server.Implementations.Devices
                 .Where(device => !query.UserId.HasValue || device.UserId.Equals(query.UserId.Value))
                 .Where(device => query.DeviceId == null || device.DeviceId == query.DeviceId)
                 .Where(device => query.AccessToken == null || device.AccessToken == query.AccessToken);
-            var canGetCountDirectly = devices.TryGetNonEnumeratedCount(out var count);
-            if (!canGetCountDirectly)
-            {
-                count = devices.Count();
-            }
+            var count = devices.Count();
 
             if (query.Skip.HasValue)
             {

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using EFCoreSecondLevelCacheInterceptor;
 using MediaBrowser.Common.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,28 +15,13 @@ public static class ServiceCollectionExtensions
     /// Adds the <see cref="IDbContextFactory{TContext}"/> interface to the service collection with second level caching enabled.
     /// </summary>
     /// <param name="serviceCollection">An instance of the <see cref="IServiceCollection"/> interface.</param>
-    /// <param name="disableSecondLevelCache">Whether second level cache disabled..</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddJellyfinDbContext(this IServiceCollection serviceCollection, bool disableSecondLevelCache)
+    public static IServiceCollection AddJellyfinDbContext(this IServiceCollection serviceCollection)
     {
-        if (!disableSecondLevelCache)
-        {
-            serviceCollection.AddEFSecondLevelCache(options =>
-                options.UseMemoryCacheProvider()
-                    .CacheAllQueries(CacheExpirationMode.Sliding, TimeSpan.FromMinutes(10))
-                    .UseCacheKeyPrefix("EF_")
-                    // Don't cache null values. Remove this optional setting if it's not necessary.
-                    .SkipCachingResults(result => result.Value is null or EFTableRows { RowsCount: 0 }));
-        }
-
         serviceCollection.AddPooledDbContextFactory<JellyfinDbContext>((serviceProvider, opt) =>
         {
             var applicationPaths = serviceProvider.GetRequiredService<IApplicationPaths>();
-            var dbOpt = opt.UseSqlite($"Filename={Path.Combine(applicationPaths.DataPath, "jellyfin.db")}");
-            if (!disableSecondLevelCache)
-            {
-                dbOpt.AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>());
-            }
+            opt.UseSqlite($"Filename={Path.Combine(applicationPaths.DataPath, "jellyfin.db")}");
         });
 
         return serviceCollection;

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" />
-    <PackageReference Include="EFCoreSecondLevelCacheInterceptor" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />

--- a/Jellyfin.Server.Implementations/Users/DeviceAccessHost.cs
+++ b/Jellyfin.Server.Implementations/Users/DeviceAccessHost.cs
@@ -60,10 +60,10 @@ public sealed class DeviceAccessHost : IHostedService
 
     private async Task UpdateDeviceAccess(User user)
     {
-        var existing = (await _deviceManager.GetDevices(new DeviceQuery
+        var existing = _deviceManager.GetDevices(new DeviceQuery
         {
             UserId = user.Id
-        }).ConfigureAwait(false)).Items;
+        }).Items;
 
         foreach (var device in existing)
         {

--- a/Jellyfin.Server/Extensions/WebHostBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/WebHostBuilderExtensions.cs
@@ -85,6 +85,6 @@ public static class WebHostBuilderExtensions
                     logger.LogInformation("Kestrel listening to unix socket {SocketPath}", socketPath);
                 }
             })
-            .UseStartup(_ => new Startup(appHost, startupConfig));
+            .UseStartup(_ => new Startup(appHost));
     }
 }

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -40,18 +40,15 @@ namespace Jellyfin.Server
     {
         private readonly CoreAppHost _serverApplicationHost;
         private readonly IServerConfigurationManager _serverConfigurationManager;
-        private readonly IConfiguration _startupConfig;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup" /> class.
         /// </summary>
         /// <param name="appHost">The server application host.</param>
-        /// <param name="startupConfig">The server startupConfig.</param>
-        public Startup(CoreAppHost appHost, IConfiguration startupConfig)
+        public Startup(CoreAppHost appHost)
         {
             _serverApplicationHost = appHost;
             _serverConfigurationManager = appHost.ConfigurationManager;
-            _startupConfig = startupConfig;
         }
 
         /// <summary>
@@ -70,7 +67,7 @@ namespace Jellyfin.Server
             // TODO remove once this is fixed upstream https://github.com/dotnet/aspnetcore/issues/34371
             services.AddSingleton<IActionResultExecutor<PhysicalFileResult>, SymlinkFollowingPhysicalFileResultExecutor>();
             services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
-            services.AddJellyfinDbContext(_startupConfig.GetSqliteSecondLevelCacheDisabled());
+            services.AddJellyfinDbContext();
             services.AddJellyfinApiSwagger();
 
             // configure custom legacy authentication

--- a/MediaBrowser.Controller/Devices/IDeviceManager.cs
+++ b/MediaBrowser.Controller/Devices/IDeviceManager.cs
@@ -44,25 +44,27 @@ namespace MediaBrowser.Controller.Devices
         /// </summary>
         /// <param name="id">The identifier.</param>
         /// <returns>DeviceInfo.</returns>
-        Task<DeviceInfo> GetDevice(string id);
+        DeviceInfo GetDevice(string id);
 
         /// <summary>
         /// Gets devices based on the provided query.
         /// </summary>
         /// <param name="query">The device query.</param>
         /// <returns>A <see cref="Task{QueryResult}"/> representing the retrieval of the devices.</returns>
-        Task<QueryResult<Device>> GetDevices(DeviceQuery query);
+        QueryResult<Device> GetDevices(DeviceQuery query);
 
-        Task<QueryResult<DeviceInfo>> GetDeviceInfos(DeviceQuery query);
+        QueryResult<DeviceInfo> GetDeviceInfos(DeviceQuery query);
 
         /// <summary>
         /// Gets the devices.
         /// </summary>
         /// <param name="userId">The user's id, or <c>null</c>.</param>
         /// <returns>IEnumerable&lt;DeviceInfo&gt;.</returns>
-        Task<QueryResult<DeviceInfo>> GetDevicesForUser(Guid? userId);
+        QueryResult<DeviceInfo> GetDevicesForUser(Guid? userId);
 
         Task DeleteDevice(Device device);
+
+        Task UpdateDevice(Device device);
 
         /// <summary>
         /// Determines whether this instance [can access device] the specified user identifier.
@@ -74,6 +76,6 @@ namespace MediaBrowser.Controller.Devices
 
         Task UpdateDeviceOptions(string deviceId, string deviceName);
 
-        Task<DeviceOptions> GetDeviceOptions(string deviceId);
+        DeviceOptions GetDeviceOptions(string deviceId);
     }
 }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -65,11 +65,6 @@ namespace MediaBrowser.Controller.Extensions
         public const string SqliteCacheSizeKey = "sqlite:cacheSize";
 
         /// <summary>
-        /// Disable second level cache of sqlite.
-        /// </summary>
-        public const string SqliteDisableSecondLevelCacheKey = "sqlite:disableSecondLevelCache";
-
-        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>
@@ -133,15 +128,5 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The sqlite cache size.</returns>
         public static int? GetSqliteCacheSize(this IConfiguration configuration)
             => configuration.GetValue<int?>(SqliteCacheSizeKey);
-
-        /// <summary>
-        /// Gets whether second level cache disabled from the <see cref="IConfiguration" />.
-        /// </summary>
-        /// <param name="configuration">The configuration to read the setting from.</param>
-        /// <returns>Whether second level cache disabled.</returns>
-        public static bool GetSqliteSecondLevelCacheDisabled(this IConfiguration configuration)
-        {
-            return configuration.GetValue<bool>(SqliteDisableSecondLevelCacheKey);
-        }
     }
 }


### PR DESCRIPTION
The EFCoreSecondLevelCacheInterceptor will place a huge lock even for reading. Implement a ConcurrentDictionary cache to replace it.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Closes #11823