### PR TITLE
Only set season path if season folder parsing was successful

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
@@ -55,7 +55,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                     IndexNumber = seasonParserResult.SeasonNumber,
                     SeriesId = series.Id,
                     SeriesName = series.Name,
-                    Path = seasonParserResult.IsSeasonFolder ? path : args.Parent.Path
+                    Path = seasonParserResult.IsSeasonFolder ? path : null
                 };
 
                 if (!season.IndexNumber.HasValue || !seasonParserResult.IsSeasonFolder)


### PR DESCRIPTION
**Changes**
* Only set season path if `IsSeasonFolder` is true

**Issues**
Fixes #11916
Fixes #11945
Fixes #11920