### PR TITLE
Check trailer distinction by URL

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1080,7 +1080,7 @@ namespace MediaBrowser.Providers.Manager
             }
             else
             {
-                target.RemoteTrailers = target.RemoteTrailers.Concat(source.RemoteTrailers).Distinct().ToArray();
+                target.RemoteTrailers = target.RemoteTrailers.Concat(source.RemoteTrailers).DistinctBy(t => t.Url).ToArray();
             }
 
             MergeAlbumArtist(source, target, replaceData);


### PR DESCRIPTION
Distinct on trailers should only check URL distinction.

**Changes**
* Use distinct by URL

**Issues**
Fixes #11924
