### PR TITLE
Do not delete file locations for virtual episodes and seasons

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -119,7 +119,8 @@ namespace MediaBrowser.Providers.TV
                         virtualSeason,
                         new DeleteOptions
                         {
-                            DeleteFileLocation = true
+                            // Internal metadata paths are removed regardless of this.
+                            DeleteFileLocation = false
                         },
                         false);
                 }
@@ -176,7 +177,8 @@ namespace MediaBrowser.Providers.TV
                 episode,
                 new DeleteOptions
                 {
-                    DeleteFileLocation = true
+                    // Internal metadata paths are removed regardless of this.
+                    DeleteFileLocation = false
                 },
                 false);
         }


### PR DESCRIPTION
These options should never be true since this will delete any folders and files if the virtual season has a path associtated.

**Changes**
* Only remove internal metadata path on virtual episode/season removal

**Issues**
* Someone on forum reported losing a full series when a virtual season was removed