### PR TITLE
NextUp query respects Limit

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -91,7 +91,7 @@ namespace Emby.Server.Implementations.TV
             }
 
             string? presentationUniqueKey = null;
-            int? limit = null;
+            int? limit = request.Limit;
             if (!request.SeriesId.IsNullOrEmpty())
             {
                 if (_libraryManager.GetItemById(request.SeriesId.Value) is Series series)


### PR DESCRIPTION
**Changes**
Currently Nextup query does not use the limit defined in the query. It just gets ignored halfway through and defaults to "null". This means that no limit is placed and the sqlite query just pulls everything. This fix uses the query to define a limit X. This should also massively speed up nextup from pulling everything to only pulling X number of items.

Originally PR https://github.com/jellyfin/jellyfin/pull/11955 - but redid it against 10.9 as recommeneded.

**Issues**



Resolves slow homescreen loading due to slow nextup query. - https://github.com/jellyfin/jellyfin/issues/11888 https://github.com/jellyfin/jellyfin/issues/11316
