### PR TITLE
Do not stop validation if folder was removed

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -364,7 +364,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (IsFileProtocol)
             {
-                IEnumerable<BaseItem> nonCachedChildren;
+                IEnumerable<BaseItem> nonCachedChildren = [];
 
                 try
                 {
@@ -373,7 +373,6 @@ namespace MediaBrowser.Controller.Entities
                 catch (Exception ex)
                 {
                     Logger.LogError(ex, "Error retrieving children folder");
-                    return;
                 }
 
                 progress.Report(ProgressHelpers.RetrievedChildren);


### PR DESCRIPTION
Got an error when an item was moved and even after a library validation it reappeared, even though the folder was removed. Checked the code and found this.

**Changes**
* do not stop validation if no children are returned, instead continue and cleanup all children

**Issues**