### PR TITLE
Fix Library renaming

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1029,7 +1029,7 @@ namespace Emby.Server.Implementations.Library
             }
         }
 
-        private async Task ValidateTopLibraryFolders(CancellationToken cancellationToken, bool removeRoot = false)
+        public async Task ValidateTopLibraryFolders(CancellationToken cancellationToken, bool removeRoot = false)
         {
             await RootFolder.RefreshMetadata(cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -149,6 +149,14 @@ namespace MediaBrowser.Controller.Library
         /// <returns>Task.</returns>
         Task ValidateMediaLibrary(IProgress<double> progress, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Reloads the root media folder.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="removeRoot">Is remove the library itself allowed.</param>
+        /// <returns>Task.</returns>
+        Task ValidateTopLibraryFolders(CancellationToken cancellationToken, bool removeRoot = false);
+
         Task UpdateImagesAsync(BaseItem item, bool forceUpdate = false);
 
         /// <summary>


### PR DESCRIPTION
This handler should not just spawn a normal library validation task because our new logic will prevent the removal of library root folder unless explicitly required, which will cause the old lib still "ghosting" in the db.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Validate top folder with explicit requirement to remove invalid libraries during library renaming
- Attempt to refresh the new lib only when possible

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11937

Fixes #11885


## Notes for affected users:

If you already have duplicated libs ghosting, just upgrade to a version contains this PR won't fix your issue. 

A mitigation to this is to rename your lib one more time after you updated to a version contains this PR. This will remove the ghosting one.

Alternatively, you can remove the renamed library, which will also remove the ghosting one, then you can add it back with your desired name.
