### PR TITLE
Revert "Allow collection sort by Release Date Descending"

### DIFF
--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -125,7 +125,7 @@ namespace MediaBrowser.Controller.Entities.Movies
             if (string.Equals(DisplayOrder, "PremiereDate", StringComparison.OrdinalIgnoreCase))
             {
                 // Sort by release date
-                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Descending).ToList();
+                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Ascending).ToList();
             }
 
             // Default sorting


### PR DESCRIPTION
Reverts jellyfin/jellyfin#11615

Items in boxsets show up in reverse order by default
https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Controller/Entities/Movies/BoxSet.cs#L23

![image](https://github.com/jellyfin/jellyfin/assets/21289123/32e8571c-e7e0-4ebe-8b02-f7f5872be2ea)
