### PR TITLE
Fallback to local dir when saving to media dir fails

### DIFF
--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -126,7 +126,11 @@ namespace MediaBrowser.Providers.Manager
 
             var paths = GetSavePaths(item, type, imageIndex, mimeType, saveLocally);
 
-            var retryPaths = GetSavePaths(item, type, imageIndex, mimeType, !saveLocally);
+            string[] retryPaths = [];
+            if (saveLocally)
+            {
+                retryPaths = GetSavePaths(item, type, imageIndex, mimeType, false);
+            }
 
             // If there are more than one output paths, the stream will need to be seekable
             if (paths.Length > 1 && !source.CanSeek)


### PR DESCRIPTION
We should never write to the media dir if not configured.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
