### PR TITLE
Fix warning CA1819 in TaskManager

### DIFF
--- a/MediaBrowser.Model/Tasks/ITaskManager.cs
+++ b/MediaBrowser.Model/Tasks/ITaskManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Jellyfin.Data.Events;
 
@@ -17,7 +18,7 @@ namespace MediaBrowser.Model.Tasks
         /// Gets the list of Scheduled Tasks.
         /// </summary>
         /// <value>The scheduled tasks.</value>
-        IScheduledTaskWorker[] ScheduledTasks { get; }
+        ImmutableList<IScheduledTaskWorker> ScheduledTasks { get; }
 
         /// <summary>
         /// Cancels if running and queue.


### PR DESCRIPTION
**Changes**
Fix [CA1819: Properties should not return arrays](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1819) by changing the type of `ScheduledTasks` to an `ImmutableList`. Other improvements related to newer syntax and structured logging were made while fixing this class up.

**Issues**
Related to #2149 
