### PR TITLE
Fix fallback artist when taglib fails

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -193,11 +193,11 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             tags ??= new TagLib.Id3v2.Tag();
-            tags.AlbumArtists ??= mediaInfo.AlbumArtists;
+            tags.AlbumArtists = tags.AlbumArtists.Length == 0 ? mediaInfo.AlbumArtists : tags.AlbumArtists;
             tags.Album ??= mediaInfo.Album;
             tags.Title ??= mediaInfo.Name;
             tags.Year = tags.Year == 0U ? Convert.ToUInt32(mediaInfo.ProductionYear, CultureInfo.InvariantCulture) : tags.Year;
-            tags.Performers ??= mediaInfo.Artists;
+            tags.Performers = tags.Performers.Length == 0 ? mediaInfo.Artists : tags.Performers;
             tags.Genres ??= mediaInfo.Genres;
             tags.Track = tags.Track == 0U ? Convert.ToUInt32(mediaInfo.IndexNumber, CultureInfo.InvariantCulture) : tags.Track;
             tags.Disc = tags.Disc == 0U ? Convert.ToUInt32(mediaInfo.ParentIndexNumber, CultureInfo.InvariantCulture) : tags.Disc;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

When TagLib fails, artists are empty arrays instead of null

Don't back-port this one as we are going to move away from taglib in 10.10

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11899
