### PR TITLE
Fix build

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Extensions;


### PR DESCRIPTION
```
jellyfin/Jellyfin.Api/Controllers/LibraryStructureController.cs(183,79): error CS1061: 'IEnumerable<BaseItem>' does not contain a definition for 'FirstOrDefault' and no accessible extension method 'FirstOrDefault' accepting a first argument of type 'IEnumerable<BaseItem>' could be found (are you missing a using directive or an assembly reference?)
```