### PR TITLE
Add UploadHelper to validate true MimeTypes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,6 +49,8 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="MimeTypes" Version="2.5.2" />
+    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
+    <PackageVersion Include="Mime-Detective.Definitions.Exhaustive" Version="25.8.1" />
     <PackageVersion Include="Morestachio" Version="5.0.1.670" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NEbml" Version="1.1.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,6 +49,8 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MimeTypes" Version="2.5.2" />
+    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
+    <PackageVersion Include="Mime-Detective.Definitions.Exhaustive" Version="25.8.1" />
     <PackageVersion Include="Morestachio" Version="5.0.1.670" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NEbml" Version="1.1.0.5" />

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -630,6 +630,7 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<ITranscodeManager, TranscodeManager>();
             serviceCollection.AddScoped<MediaInfoHelper>();
             serviceCollection.AddScoped<AudioHelper>();
+            serviceCollection.AddSingleton<UploadHelper>();
             serviceCollection.AddScoped<DynamicHlsHelper>();
             serviceCollection.AddScoped<IClientEventLogger, ClientEventLogger>();
             serviceCollection.AddSingleton<IDirectoryService, DirectoryService>();

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -630,7 +630,7 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<ITranscodeManager, TranscodeManager>();
             serviceCollection.AddScoped<MediaInfoHelper>();
             serviceCollection.AddScoped<AudioHelper>();
-            serviceCollection.AddScoped<UploadHelper>();
+            serviceCollection.AddSingleton<UploadHelper>();
             serviceCollection.AddScoped<DynamicHlsHelper>();
             serviceCollection.AddScoped<IClientEventLogger, ClientEventLogger>();
             serviceCollection.AddSingleton<IDirectoryService, DirectoryService>();

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -630,6 +630,7 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<ITranscodeManager, TranscodeManager>();
             serviceCollection.AddScoped<MediaInfoHelper>();
             serviceCollection.AddScoped<AudioHelper>();
+            serviceCollection.AddScoped<UploadHelper>();
             serviceCollection.AddScoped<DynamicHlsHelper>();
             serviceCollection.AddScoped<IClientEventLogger, ClientEventLogger>();
             serviceCollection.AddSingleton<IDirectoryService, DirectoryService>();

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -50,6 +49,7 @@ public class ImageController : BaseJellyfinApiController
     private readonly ILogger<ImageController> _logger;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly IApplicationPaths _appPaths;
+    private readonly UploadHelper _uploadHelper;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageController"/> class.
@@ -62,6 +62,7 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="logger">Instance of the <see cref="ILogger{ImageController}"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
     /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="uploadHelper">The <see cref="UploadHelper"/> instance.</param>
     public ImageController(
         IUserManager userManager,
         ILibraryManager libraryManager,
@@ -70,7 +71,8 @@ public class ImageController : BaseJellyfinApiController
         IFileSystem fileSystem,
         ILogger<ImageController> logger,
         IServerConfigurationManager serverConfigurationManager,
-        IApplicationPaths appPaths)
+        IApplicationPaths appPaths,
+        UploadHelper uploadHelper)
     {
         _userManager = userManager;
         _libraryManager = libraryManager;
@@ -80,6 +82,7 @@ public class ImageController : BaseJellyfinApiController
         _logger = logger;
         _serverConfigurationManager = serverConfigurationManager;
         _appPaths = appPaths;
+        _uploadHelper = uploadHelper;
     }
 
     private static CryptoStream GetFromBase64Stream(Stream inputStream)
@@ -115,16 +118,18 @@ public class ImageController : BaseJellyfinApiController
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the image.");
         }
 
-        if (!TryGetImageExtensionFromContentType(Request.ContentType, out string? extension))
-        {
-            return BadRequest("Incorrect ContentType.");
-        }
-
         var stream = GetFromBase64Stream(Request.Body);
         await using (stream.ConfigureAwait(false))
         {
-            // Handle image/png; charset=utf-8
-            var mimeType = Request.ContentType?.Split(';').FirstOrDefault();
+            var prefix = new byte[UploadHelper.MaxSniffBytes];
+            var prefixCount = await stream.ReadAtLeastAsync(prefix, prefix.Length, throwOnEndOfStream: false, HttpContext.RequestAborted).ConfigureAwait(false);
+
+            var mimeInfo = _uploadHelper.GetMimeInfo(new ArraySegment<byte>(prefix, 0, prefixCount), Request.ContentType);
+            if (mimeInfo is null)
+            {
+                return BadRequest("Incorrect ContentType.");
+            }
+
             var userConfigurationDirectoryPath = _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath;
             var userDataPath = Path.Combine(userConfigurationDirectoryPath, user.Username);
             if (!PathHelper.IsContainedIn(userConfigurationDirectoryPath, userDataPath))
@@ -137,10 +142,12 @@ public class ImageController : BaseJellyfinApiController
                 await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
             }
 
+            var extension = "." + mimeInfo.Definition.File.Extensions.First();
             user.ProfileImage = new Database.Implementations.Entities.ImageInfo(Path.Combine(userDataPath, "profile" + extension));
 
+            var payload = new PrefixedStream(prefix, prefixCount, stream);
             await _providerManager
-                .SaveImage(stream, mimeType, user.ProfileImage.Path)
+                .SaveImage(payload, mimeInfo.Definition.File.MimeType, user.ProfileImage.Path)
                 .ConfigureAwait(false);
             await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
@@ -366,17 +373,20 @@ public class ImageController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!TryGetImageExtensionFromContentType(Request.ContentType, out _))
-        {
-            return BadRequest("Incorrect ContentType.");
-        }
-
         var stream = GetFromBase64Stream(Request.Body);
         await using (stream.ConfigureAwait(false))
         {
-            // Handle image/png; charset=utf-8
-            var mimeType = Request.ContentType?.Split(';').FirstOrDefault();
-            await _providerManager.SaveImage(item, stream, mimeType, imageType, null, CancellationToken.None).ConfigureAwait(false);
+            var prefix = new byte[UploadHelper.MaxSniffBytes];
+            var prefixCount = await stream.ReadAtLeastAsync(prefix, prefix.Length, throwOnEndOfStream: false, HttpContext.RequestAborted).ConfigureAwait(false);
+
+            var mimeInfo = _uploadHelper.GetMimeInfo(new ArraySegment<byte>(prefix, 0, prefixCount), Request.ContentType);
+            if (mimeInfo is null)
+            {
+                return BadRequest("Incorrect ContentType.");
+            }
+
+            var payload = new PrefixedStream(prefix, prefixCount, stream);
+            await _providerManager.SaveImage(item, payload, mimeInfo.Definition.File.MimeType, imageType, null, CancellationToken.None).ConfigureAwait(false);
             await item.UpdateToRepositoryAsync(ItemUpdateType.ImageUpdate, CancellationToken.None).ConfigureAwait(false);
 
             return NoContent();
@@ -410,17 +420,20 @@ public class ImageController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!TryGetImageExtensionFromContentType(Request.ContentType, out _))
-        {
-            return BadRequest("Incorrect ContentType.");
-        }
-
         var stream = GetFromBase64Stream(Request.Body);
         await using (stream.ConfigureAwait(false))
         {
-            // Handle image/png; charset=utf-8
-            var mimeType = Request.ContentType?.Split(';').FirstOrDefault();
-            await _providerManager.SaveImage(item, stream, mimeType, imageType, null, CancellationToken.None).ConfigureAwait(false);
+            var prefix = new byte[UploadHelper.MaxSniffBytes];
+            var prefixCount = await stream.ReadAtLeastAsync(prefix, prefix.Length, throwOnEndOfStream: false, HttpContext.RequestAborted).ConfigureAwait(false);
+
+            var mimeInfo = _uploadHelper.GetMimeInfo(new ArraySegment<byte>(prefix, 0, prefixCount), Request.ContentType);
+            if (mimeInfo is null)
+            {
+                return BadRequest("Incorrect ContentType.");
+            }
+
+            var payload = new PrefixedStream(prefix, prefixCount, stream);
+            await _providerManager.SaveImage(item, payload, mimeInfo.Definition.File.MimeType, imageType, null, CancellationToken.None).ConfigureAwait(false);
             await item.UpdateToRepositoryAsync(ItemUpdateType.ImageUpdate, CancellationToken.None).ConfigureAwait(false);
 
             return NoContent();
@@ -1726,24 +1739,24 @@ public class ImageController : BaseJellyfinApiController
     [AcceptsImageFile]
     public async Task<ActionResult> UploadCustomSplashscreen()
     {
-        if (!TryGetImageExtensionFromContentType(Request.ContentType, out var extension))
-        {
-            return BadRequest("Incorrect ContentType.");
-        }
-
         var stream = GetFromBase64Stream(Request.Body);
         await using (stream.ConfigureAwait(false))
         {
-            var filePath = Path.Combine(_appPaths.DataPath, "splashscreen-upload" + extension);
-            var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
-            brandingOptions.SplashscreenLocation = filePath;
-            _serverConfigurationManager.SaveConfiguration("branding", brandingOptions);
+            var prefix = new byte[UploadHelper.MaxSniffBytes];
+            var prefixCount = await stream.ReadAtLeastAsync(prefix, prefix.Length, throwOnEndOfStream: false, HttpContext.RequestAborted).ConfigureAwait(false);
 
-            var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
-            await using (fs.ConfigureAwait(false))
+            var mimeInfo = _uploadHelper.GetMimeInfo(new ArraySegment<byte>(prefix, 0, prefixCount), Request.ContentType);
+            if (mimeInfo is null)
             {
-                await stream.CopyToAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                return BadRequest("Incorrect ContentType.");
             }
+
+            var filePathWithExtension = Path.Combine(_appPaths.DataPath, "splashscreen-upload." + mimeInfo.Definition.File.Extensions.First());
+            var payload = new PrefixedStream(prefix, prefixCount, stream);
+            await UploadHelper.WriteStreamToFile(payload, filePathWithExtension, HttpContext.RequestAborted).ConfigureAwait(false);
+            var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
+            brandingOptions.SplashscreenLocation = filePathWithExtension;
+            _serverConfigurationManager.SaveConfiguration("branding", brandingOptions);
 
             return NoContent();
         }

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -50,6 +50,7 @@ public class ImageController : BaseJellyfinApiController
     private readonly ILogger<ImageController> _logger;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly IApplicationPaths _appPaths;
+    private readonly UploadHelper _uploadHelper;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageController"/> class.
@@ -62,6 +63,7 @@ public class ImageController : BaseJellyfinApiController
     /// <param name="logger">Instance of the <see cref="ILogger{ImageController}"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
     /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="uploadHelper">The <see cref="UploadHelper"/> instance.</param>
     public ImageController(
         IUserManager userManager,
         ILibraryManager libraryManager,
@@ -70,7 +72,8 @@ public class ImageController : BaseJellyfinApiController
         IFileSystem fileSystem,
         ILogger<ImageController> logger,
         IServerConfigurationManager serverConfigurationManager,
-        IApplicationPaths appPaths)
+        IApplicationPaths appPaths,
+        UploadHelper uploadHelper)
     {
         _userManager = userManager;
         _libraryManager = libraryManager;
@@ -80,6 +83,7 @@ public class ImageController : BaseJellyfinApiController
         _logger = logger;
         _serverConfigurationManager = serverConfigurationManager;
         _appPaths = appPaths;
+        _uploadHelper = uploadHelper;
     }
 
     private static CryptoStream GetFromBase64Stream(Stream inputStream)
@@ -1726,26 +1730,22 @@ public class ImageController : BaseJellyfinApiController
     [AcceptsImageFile]
     public async Task<ActionResult> UploadCustomSplashscreen()
     {
-        if (!TryGetImageExtensionFromContentType(Request.ContentType, out var extension))
-        {
-            return BadRequest("Incorrect ContentType.");
-        }
-
         var stream = GetFromBase64Stream(Request.Body);
         await using (stream.ConfigureAwait(false))
         {
-            var filePath = Path.Combine(_appPaths.DataPath, "splashscreen-upload" + extension);
-            var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
-            brandingOptions.SplashscreenLocation = filePath;
-            _serverConfigurationManager.SaveConfiguration("branding", brandingOptions);
-
-            var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
-            await using (fs.ConfigureAwait(false))
+            var mimeInfo = _uploadHelper.GetMimeInfo(stream, Request.ContentType);
+            if (mimeInfo is not null)
             {
-                await stream.CopyToAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                var filePathWithExtension = Path.Combine(_appPaths.DataPath, "splashscreen-upload" + mimeInfo.Definition.File.Extensions.First());
+                UploadHelper.WriteStreamToFile(stream, filePathWithExtension, CancellationToken.None);
+                var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
+                brandingOptions.SplashscreenLocation = filePathWithExtension;
+                _serverConfigurationManager.SaveConfiguration("branding", brandingOptions);
+
+                return NoContent();
             }
 
-            return NoContent();
+            return BadRequest("Incorrect ContentType.");
         }
     }
 

--- a/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
+++ b/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
@@ -24,18 +24,22 @@ public class VideoAttachmentsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IAttachmentExtractor _attachmentExtractor;
+    private readonly UploadHelper _uploadHelper;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VideoAttachmentsController"/> class.
     /// </summary>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="attachmentExtractor">Instance of the <see cref="IAttachmentExtractor"/> interface.</param>
+    /// <param name="uploadHelper">The <see cref="UploadHelper"/> instance.</param>
     public VideoAttachmentsController(
         ILibraryManager libraryManager,
-        IAttachmentExtractor attachmentExtractor)
+        IAttachmentExtractor attachmentExtractor,
+        UploadHelper uploadHelper)
     {
         _libraryManager = libraryManager;
         _attachmentExtractor = attachmentExtractor;
+        _uploadHelper = uploadHelper;
     }
 
     /// <summary>
@@ -64,18 +68,20 @@ public class VideoAttachmentsController : BaseJellyfinApiController
                 return NotFound();
             }
 
-            var (attachment, stream) = await _attachmentExtractor.GetAttachment(
+            var (_, stream) = await _attachmentExtractor.GetAttachment(
                     item,
                     mediaSourceId,
                     index,
                     CancellationToken.None)
                 .ConfigureAwait(false);
 
-            var contentType = string.IsNullOrWhiteSpace(attachment.MimeType)
-                ? MediaTypeNames.Application.Octet
-                : attachment.MimeType;
+            // The MIME type the media file declares for the attachment is chosen by whoever created that
+            // file, so serving it would let an attachment claim to be e.g. HTML and run scripts on our origin.
+            // Detect the format from the content instead and ignore what the attachment claims to be.
+            Response.Headers.ContentDisposition = "attachment";
+            Response.Headers.XContentTypeOptions = "nosniff";
 
-            return new FileStreamResult(stream, contentType);
+            return new FileStreamResult(stream, _uploadHelper.GetAttachmentMimeType(stream));
         }
         catch (ResourceNotFoundException e)
         {

--- a/Jellyfin.Api/Helpers/PrefixedStream.cs
+++ b/Jellyfin.Api/Helpers/PrefixedStream.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Api.Helpers;
+
+/// <summary>
+/// Forward-only read-only stream that yields a buffered prefix before delegating reads to an inner stream.
+/// </summary>
+/// <remarks>
+/// Used to "peek" the first bytes of an upload for MIME sniffing without losing them
+/// when the underlying stream (e.g. a <see cref="System.Security.Cryptography.CryptoStream"/>)
+/// is non-seekable. The wrapper does not take ownership of the inner stream's lifetime.
+/// </remarks>
+public sealed class PrefixedStream : Stream
+{
+    private readonly byte[] _prefix;
+    private readonly int _prefixLength;
+    private readonly Stream _inner;
+    private readonly bool _leaveOpen;
+    private int _prefixPosition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrefixedStream"/> class.
+    /// </summary>
+    /// <param name="prefix">Buffer holding the prefix bytes.</param>
+    /// <param name="prefixLength">Number of valid bytes in <paramref name="prefix"/>, starting at offset 0.</param>
+    /// <param name="inner">The stream that produces the remainder of the data after the prefix is exhausted.</param>
+    /// <param name="leaveOpen"><see langword="true"/> to leave the inner stream open when this wrapper is disposed; <see langword="false"/> to dispose it as well.</param>
+    public PrefixedStream(byte[] prefix, int prefixLength, Stream inner, bool leaveOpen = true)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentOutOfRangeException.ThrowIfNegative(prefixLength);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(prefixLength, prefix.Length);
+
+        _prefix = prefix;
+        _prefixLength = prefixLength;
+        _inner = inner;
+        _leaveOpen = leaveOpen;
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if (count == 0)
+        {
+            return 0;
+        }
+
+        var prefixRemaining = _prefixLength - _prefixPosition;
+        if (prefixRemaining > 0)
+        {
+            var toCopy = Math.Min(prefixRemaining, count);
+            Buffer.BlockCopy(_prefix, _prefixPosition, buffer, offset, toCopy);
+            _prefixPosition += toCopy;
+            return toCopy;
+        }
+
+        return _inner.Read(buffer, offset, count);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (buffer.Length == 0)
+        {
+            return 0;
+        }
+
+        var prefixRemaining = _prefixLength - _prefixPosition;
+        if (prefixRemaining > 0)
+        {
+            var toCopy = Math.Min(prefixRemaining, buffer.Length);
+            _prefix.AsSpan(_prefixPosition, toCopy).CopyTo(buffer.Span);
+            _prefixPosition += toCopy;
+            return toCopy;
+        }
+
+        return await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    /// <inheritdoc />
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_leaveOpen)
+        {
+            _inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_leaveOpen)
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/Jellyfin.Api/Helpers/UploadHelper.cs
+++ b/Jellyfin.Api/Helpers/UploadHelper.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Frozen;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Naming.Common;
+using MediaBrowser.Model.IO;
+using MimeDetective;
+using MimeDetective.Definitions;
+using MimeDetective.Definitions.Licensing;
+using MimeDetective.Engine;
+using MimeDetective.Storage;
+
+namespace Jellyfin.Api.Helpers;
+
+/// <summary>
+/// Utitlity class providing upload helper functions.
+/// </summary>
+public class UploadHelper
+{
+    private readonly FrozenSet<Definition> _videoDefinitions;
+    private readonly FrozenSet<Definition> _audioDefinitions;
+    private readonly FrozenSet<Definition> _imageDefinitions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UploadHelper"/> class.
+    /// </summary>
+    /// <param name="namingOptions">The naming options.</param>
+    public UploadHelper(
+        NamingOptions namingOptions)
+    {
+        var allDefinitions = new ExhaustiveBuilder()
+            {
+                UsageType = UsageType.PersonalNonCommercial
+            }.Build();
+
+        var extensions = namingOptions.AudioFileExtensions.Select(x => x.Replace(".", string.Empty, StringComparison.OrdinalIgnoreCase)).ToArray();
+        _audioDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToFrozenSet();
+
+        extensions = namingOptions.VideoFileExtensions.Select(x => x.Replace(".", string.Empty, StringComparison.OrdinalIgnoreCase)).ToArray();
+        _videoDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToFrozenSet();
+
+        extensions =
+            [
+                "jpg",
+                "png",
+                "gif",
+                "webp",
+                "bmp"
+            ];
+        _imageDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToFrozenSet();
+    }
+
+    /// <summary>
+    /// Checks if data MIME type matches content type and returns the MIME type information.
+    /// </summary>
+    /// <param name="stream">The data stream.</param>
+    /// <param name="contentType">The content type.</param>
+    /// <returns>MIME type information.</returns>
+    public DefinitionMatch? GetMimeInfo(Stream? stream, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(contentType);
+
+        var definitions = GetDefinitionsForType(contentType.Split('/')[0]);
+        var inspector = new ContentInspectorBuilder()
+        {
+            Definitions = definitions.ToList(),
+        }.Build();
+
+        var realMimeTypeMatchesContentType = inspector.Inspect(stream)
+            .Where(r => string.Equals(r.Definition.File.MimeType, contentType, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(r => r.Points)
+            .FirstOrDefault(r => r.Type == DefinitionMatchType.Complete);
+        if (realMimeTypeMatchesContentType is not null)
+        {
+            return realMimeTypeMatchesContentType;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Writes the stream content to a file.
+    /// </summary>
+    /// <param name="stream">The data stream.</param>
+    /// <param name="filePath">The file path to write the data to.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static async void WriteStreamToFile(Stream stream, string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+        await using (fs.ConfigureAwait(false))
+        {
+            await stream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private FrozenSet<Definition> GetDefinitionsForType(string type)
+    {
+        return type switch
+        {
+            "audio" => _audioDefinitions,
+            "video" => _videoDefinitions,
+            "image" => _imageDefinitions,
+            _ => FrozenSet<Definition>.Empty,
+        };
+    }
+}

--- a/Jellyfin.Api/Helpers/UploadHelper.cs
+++ b/Jellyfin.Api/Helpers/UploadHelper.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Naming.Common;
+using Jellyfin.Extensions;
+using MediaBrowser.Model.IO;
+using MimeDetective;
+using MimeDetective.Definitions;
+using MimeDetective.Definitions.Licensing;
+using MimeDetective.Engine;
+using MimeDetective.Storage;
+
+namespace Jellyfin.Api.Helpers;
+
+/// <summary>
+/// Utitlity class providing upload helper functions.
+/// </summary>
+public class UploadHelper
+{
+    /// <summary>
+    /// Maximum number of bytes to read from the start of an upload for MIME sniffing.
+    /// </summary>
+    public const int MaxSniffBytes = 8192;
+
+    private readonly List<Definition> _videoDefinitions;
+    private readonly List<Definition> _audioDefinitions;
+    private readonly List<Definition> _imageDefinitions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UploadHelper"/> class.
+    /// </summary>
+    /// <param name="namingOptions">The naming options.</param>
+    public UploadHelper(
+        NamingOptions namingOptions)
+    {
+        var allDefinitions = new ExhaustiveBuilder()
+            {
+                UsageType = UsageType.PersonalNonCommercial
+            }.Build();
+
+        var extensions = namingOptions.AudioFileExtensions.Select(x => x.Replace(".", string.Empty, StringComparison.Ordinal)).ToArray();
+        _audioDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToList();
+
+        extensions = namingOptions.VideoFileExtensions.Select(x => x.Replace(".", string.Empty, StringComparison.Ordinal)).ToArray();
+        _videoDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToList();
+
+        extensions =
+            [
+                "jpg",
+                "png",
+                "gif",
+                "webp",
+                "bmp"
+            ];
+        _imageDefinitions = allDefinitions
+            .ScopeExtensions(extensions)
+            .TrimMeta()
+            .TrimDescription()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Checks if the declared content type matches the bytes of the upload prefix and returns the matching definition.
+    /// </summary>
+    /// <param name="prefix">A prefix of the upload payload, typically the first <see cref="MaxSniffBytes"/> bytes.</param>
+    /// <param name="contentType">The declared content type, optionally followed by parameters (e.g. <c>image/png; charset=utf-8</c>).</param>
+    /// <returns>The matching definition, or <see langword="null"/> if the content type is unknown or does not match the bytes.</returns>
+    public DefinitionMatch? GetMimeInfo(ArraySegment<byte> prefix, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(contentType);
+
+        var mediaType = contentType.AsSpan().LeftPart(';').Trim().ToString();
+        var slash = mediaType.IndexOf('/', StringComparison.Ordinal);
+        if (slash <= 0)
+        {
+            return null;
+        }
+
+        var definitions = GetDefinitionsForType(mediaType[..slash]);
+        if (definitions is null)
+        {
+            return null;
+        }
+
+        using var stream = new MemoryStream(prefix.Array ?? [], prefix.Offset, prefix.Count, writable: false);
+        var inspector = new ContentInspectorBuilder()
+        {
+            Definitions = definitions,
+        }.Build();
+
+        return inspector.Inspect(stream)
+            .Where(r => string.Equals(r.Definition.File.MimeType, mediaType, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(r => r.Points)
+            .FirstOrDefault(r => r.Type == DefinitionMatchType.Complete);
+    }
+
+    /// <summary>
+    /// Writes the stream content to a file.
+    /// </summary>
+    /// <param name="stream">The data stream.</param>
+    /// <param name="filePath">The file path to write the data to.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
+    public static async Task WriteStreamToFile(Stream stream, string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+        await using (fs.ConfigureAwait(false))
+        {
+            await stream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private List<Definition>? GetDefinitionsForType(string type)
+    {
+        return type switch
+        {
+            "audio" => _audioDefinitions,
+            "video" => _videoDefinitions,
+            "image" => _imageDefinitions,
+            _ => null,
+        };
+    }
+}

--- a/Jellyfin.Api/Helpers/UploadHelper.cs
+++ b/Jellyfin.Api/Helpers/UploadHelper.cs
@@ -37,9 +37,9 @@ public class UploadHelper
         NamingOptions namingOptions)
     {
         var allDefinitions = new ExhaustiveBuilder()
-            {
-                UsageType = UsageType.PersonalNonCommercial
-            }.Build();
+        {
+            UsageType = UsageType.PersonalNonCommercial
+        }.Build();
 
         var extensions = namingOptions.AudioFileExtensions.Select(x => x.Replace(".", string.Empty, StringComparison.Ordinal)).ToArray();
         _audioDefinitions = allDefinitions

--- a/Jellyfin.Api/Helpers/UploadHelper.cs
+++ b/Jellyfin.Api/Helpers/UploadHelper.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using Emby.Naming.Common;
@@ -19,9 +21,38 @@ namespace Jellyfin.Api.Helpers;
 /// </summary>
 public class UploadHelper
 {
+    /// <summary>
+    /// The number of bytes inspected to determine the format of a file.
+    /// Every format recognized here is identified by a header at the very start of the file.
+    /// </summary>
+    public const int MaxSniffBytes = 8192;
+
+    /// <summary>
+    /// The formats that may be served straight out of a media file, mapped to the MIME type to serve them as.
+    /// A media file declares the MIME type of its own attachments, so that value is controlled by whoever
+    /// created the file and must never reach the response. The format is detected from the content instead
+    /// and the MIME type is taken from this table, which holds nothing a browser will execute in our origin.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> _attachmentMimeTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        { "bmp", MediaTypeNames.Image.Bmp },
+        { "gif", MediaTypeNames.Image.Gif },
+        { "jpeg", MediaTypeNames.Image.Jpeg },
+        { "jpg", MediaTypeNames.Image.Jpeg },
+        { "otc", MediaTypeNames.Font.Collection },
+        { "otf", MediaTypeNames.Font.Otf },
+        { "png", MediaTypeNames.Image.Png },
+        { "ttc", MediaTypeNames.Font.Collection },
+        { "ttf", MediaTypeNames.Font.Ttf },
+        { "webp", MediaTypeNames.Image.Webp },
+        { "woff", MediaTypeNames.Font.Woff },
+        { "woff2", MediaTypeNames.Font.Woff2 }
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
     private readonly FrozenSet<Definition> _videoDefinitions;
     private readonly FrozenSet<Definition> _audioDefinitions;
     private readonly FrozenSet<Definition> _imageDefinitions;
+    private readonly IContentInspector _attachmentInspector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UploadHelper"/> class.
@@ -62,6 +93,15 @@ public class UploadHelper
             .TrimMeta()
             .TrimDescription()
             .ToFrozenSet();
+
+        _attachmentInspector = new ContentInspectorBuilder()
+        {
+            Definitions = allDefinitions
+                .ScopeExtensions(_attachmentMimeTypes.Keys)
+                .TrimMeta()
+                .TrimDescription()
+                .ToList(),
+        }.Build();
     }
 
     /// <summary>
@@ -91,6 +131,54 @@ public class UploadHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Determines the MIME type an attachment embedded in a media file may be served with.
+    /// </summary>
+    /// <param name="stream">The attachment data stream, positioned at the start of the attachment.</param>
+    /// <returns>
+    /// The MIME type matching the detected format, or <c>application/octet-stream</c> if the format is not
+    /// one that is safe to hand to a browser. The stream is left at the position it was passed in at.
+    /// </returns>
+    public string GetAttachmentMimeType(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!stream.CanSeek)
+        {
+            return MediaTypeNames.Application.Octet;
+        }
+
+        var position = stream.Position;
+        DefinitionMatch? match;
+        try
+        {
+            // Inspecting reads to the end of the stream, so only hand it the header the formats are recognized by.
+            var prefix = new byte[MaxSniffBytes];
+            var read = stream.ReadAtLeast(prefix, prefix.Length, throwOnEndOfStream: false);
+            using var prefixStream = new MemoryStream(prefix, 0, read, writable: false);
+            match = _attachmentInspector.Inspect(prefixStream)
+                .Where(r => r.Type == DefinitionMatchType.Complete)
+                .MaxBy(r => r.Points);
+        }
+        finally
+        {
+            stream.Position = position;
+        }
+
+        if (match is not null)
+        {
+            foreach (var extension in match.Definition.File.Extensions)
+            {
+                if (_attachmentMimeTypes.TryGetValue(extension, out var mimeType))
+                {
+                    return mimeType;
+                }
+            }
+        }
+
+        return MediaTypeNames.Application.Octet;
     }
 
     /// <summary>

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Mime-Detective" />
+    <PackageReference Include="Mime-Detective.Definitions.Exhaustive" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" />
   </ItemGroup>

--- a/tests/Jellyfin.Api.Tests/Helpers/UploadHelperTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/UploadHelperTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Net.Mime;
+using System.Text;
+using Emby.Naming.Common;
+using Jellyfin.Api.Helpers;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Helpers
+{
+    public class UploadHelperTests
+    {
+        // Building the MIME definitions is expensive, so share one instance across all cases.
+        private static readonly UploadHelper _uploadHelper = new UploadHelper(new NamingOptions());
+
+        [Theory]
+        [MemberData(nameof(GetAttachmentMimeType_TestData))]
+        public void GetAttachmentMimeType_DetectsFormatFromContent(byte[] content, string expected)
+        {
+            using var stream = new MemoryStream(content, writable: false);
+
+            Assert.Equal(expected, _uploadHelper.GetAttachmentMimeType(stream));
+        }
+
+        [Fact]
+        public void GetAttachmentMimeType_LeavesStreamPositionUntouched()
+        {
+            // The stream is served to the client afterwards, so inspecting it must not consume it.
+            using var stream = new MemoryStream(TrueTypeFont(), writable: false);
+
+            Assert.Equal(MediaTypeNames.Font.Ttf, _uploadHelper.GetAttachmentMimeType(stream));
+            Assert.Equal(0, stream.Position);
+
+            stream.Position = 4;
+            _uploadHelper.GetAttachmentMimeType(stream);
+            Assert.Equal(4, stream.Position);
+        }
+
+        [Fact]
+        public void GetAttachmentMimeType_NonSeekableStream_ReturnsOctetStream()
+        {
+            using var stream = new NonSeekableStream(TrueTypeFont());
+
+            Assert.Equal(MediaTypeNames.Application.Octet, _uploadHelper.GetAttachmentMimeType(stream));
+        }
+
+        [Fact]
+        public void GetAttachmentMimeType_NullStream_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _uploadHelper.GetAttachmentMimeType(null!));
+        }
+
+        public static TheoryData<byte[], string> GetAttachmentMimeType_TestData()
+        {
+            return new TheoryData<byte[], string>
+            {
+                // Fonts and cover art are what media files legitimately carry as attachments.
+                { TrueTypeFont(), MediaTypeNames.Font.Ttf },
+                { OpenTypeFont(), MediaTypeNames.Font.Otf },
+                { Header([0x77, 0x4F, 0x46, 0x46, 0x00, 0x01, 0x00, 0x00]), MediaTypeNames.Font.Woff },
+                { Header([0x77, 0x4F, 0x46, 0x32, 0x00, 0x01, 0x00, 0x00]), MediaTypeNames.Font.Woff2 },
+                { Header([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00]), MediaTypeNames.Image.Jpeg },
+                { Header([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52]), MediaTypeNames.Image.Png },
+                { Header(Encoding.ASCII.GetBytes("GIF89a")), MediaTypeNames.Image.Gif },
+                { Header([.. Encoding.ASCII.GetBytes("RIFF"), 0x24, 0x00, 0x00, 0x00, .. Encoding.ASCII.GetBytes("WEBPVP8 ")]), MediaTypeNames.Image.Webp },
+                { Header([0x42, 0x4D, 0x00, 0x10, 0x00, 0x00]), MediaTypeNames.Image.Bmp },
+
+                // An attachment claiming to be HTML must never be served as anything a browser will execute,
+                // otherwise its script runs on the Jellyfin origin and can read the stored access token.
+                { Encoding.UTF8.GetBytes("<html><body><script>alert(document.cookie)</script></body></html>"), MediaTypeNames.Application.Octet },
+                { Encoding.UTF8.GetBytes("<!DOCTYPE html>\n<script src=\"//example.invalid/x.js\"></script>\n"), MediaTypeNames.Application.Octet },
+                { Encoding.UTF8.GetBytes("<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script></svg>"), MediaTypeNames.Application.Octet },
+                { Encoding.UTF8.GetBytes("plain text is not a font"), MediaTypeNames.Application.Octet },
+                { Array.Empty<byte>(), MediaTypeNames.Application.Octet },
+
+                // Script smuggled in behind a valid header is still served as the format the header says,
+                // which is inert, so the payload cannot execute.
+                { Header([.. Encoding.ASCII.GetBytes("GIF89a"), .. Encoding.UTF8.GetBytes("<script>alert(1)</script>")]), MediaTypeNames.Image.Gif }
+            };
+        }
+
+        /// <summary>
+        /// Builds the sfnt header and table tags a TrueType font is recognized by.
+        /// </summary>
+        private static byte[] TrueTypeFont()
+        {
+            var font = Header([0x00, 0x01, 0x00, 0x00, 0x00]);
+            Encoding.ASCII.GetBytes("cmapglyfheadlocamaxpnamepost$hmtx6hhea").CopyTo(font, 128);
+            return font;
+        }
+
+        /// <summary>
+        /// Builds the sfnt header and table tags an OpenType font is recognized by.
+        /// </summary>
+        private static byte[] OpenTypeFont()
+        {
+            var font = Header([0x4F, 0x54, 0x54, 0x4F, 0x00]);
+            Encoding.ASCII.GetBytes("cmapheadmaxpnamepost").CopyTo(font, 12);
+            return font;
+        }
+
+        private static byte[] Header(byte[] header)
+        {
+            var content = new byte[1024];
+            header.CopyTo(content, 0);
+            return content;
+        }
+
+        private sealed class NonSeekableStream(byte[] content) : MemoryStream(content, writable: false)
+        {
+            public override bool CanSeek => false;
+        }
+    }
+}


### PR DESCRIPTION
Our current MIME type checks solely rely on file extension. Use https://github.com/MediatedCommunications/Mime-Detective for file-based MIME recogition

**Changes**
* Implement file based MIME type recognition

**Issues**
