### PR TITLE
Improve album artwork filename hashing

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioImageProvider.cs
@@ -116,9 +116,10 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 if (item.AlbumArtists.Count > 0
                     && !string.IsNullOrWhiteSpace(item.Album)
-                    && !string.IsNullOrWhiteSpace(item.AlbumArtists[0]))
+                    && !string.IsNullOrWhiteSpace(item.AlbumArtists[0])
+                    && item.PremiereDate.HasValue)
                 {
-                    filename = (item.Album + "-" + item.AlbumArtists[0]).GetMD5().ToString("N", CultureInfo.InvariantCulture);
+                    filename = (item.Album + "-" + item.PremiereDate + "-" + item.AlbumArtists[0]).GetMD5().ToString("N", CultureInfo.InvariantCulture);
                 }
                 else
                 {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR adds an additional field (`.PremiereDate`) to the hashing that determines what an albums artwork should be.
Also added a check to `if` to ensure the `.PremiereDate` exists alongside the exists checks for `.Album` and `.AlbumArtists[0]`.

**Issues**

Fixes #11942 
<!-- Tag any issues that this PR solves here.
ex. Fixes