### PR TITLE
Fix empty image folder removal for legacy locations

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -389,7 +389,7 @@ namespace Emby.Server.Implementations.IO
             var info = new FileInfo(path);
 
             if (info.Exists &&
-                ((info.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden) != isHidden)
+                (info.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden != isHidden)
             {
                 if (isHidden)
                 {
@@ -417,8 +417,8 @@ namespace Emby.Server.Implementations.IO
                 return;
             }
 
-            if (((info.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly) == readOnly
-                && ((info.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden) == isHidden)
+            if ((info.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly == readOnly
+                && (info.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden == isHidden)
             {
                 return;
             }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1884,7 +1884,7 @@ namespace Emby.Server.Implementations.Library
                     try
                     {
                         var index = item.GetImageIndex(img);
-                        image = await ConvertImageToLocal(item, img, index, removeOnFailure: true).ConfigureAwait(false);
+                        image = await ConvertImageToLocal(item, img, index, true).ConfigureAwait(false);
                     }
                     catch (ArgumentException)
                     {

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
@@ -133,53 +134,14 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                DeleteFile(file.FullName);
+                FileSystemHelper.DeleteFile(_fileSystem, file.FullName, _logger);
 
                 index++;
             }
 
-            DeleteEmptyFolders(directory);
+            FileSystemHelper.DeleteEmptyFolders(_fileSystem, directory, _logger);
 
             progress.Report(100);
-        }
-
-        private void DeleteEmptyFolders(string parent)
-        {
-            foreach (var directory in _fileSystem.GetDirectoryPaths(parent))
-            {
-                DeleteEmptyFolders(directory);
-                if (!_fileSystem.GetFileSystemEntryPaths(directory).Any())
-                {
-                    try
-                    {
-                        Directory.Delete(directory, false);
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogError(ex, "Error deleting directory {Path}", directory);
-                    }
-                    catch (IOException ex)
-                    {
-                        _logger.LogError(ex, "Error deleting directory {Path}", directory);
-                    }
-                }
-            }
-        }
-
-        private void DeleteFile(string path)
-        {
-            try
-            {
-                _fileSystem.DeleteFile(path);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogError(ex, "Error deleting file {Path}", path);
-            }
-            catch (IOException ex)
-            {
-                _logger.LogError(ex, "Error deleting file {Path}", path);
-            }
         }
     }
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
@@ -113,53 +113,14 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                DeleteFile(file.FullName);
+                FileSystemHelper.DeleteFile(_fileSystem, file.FullName, _logger);
 
                 index++;
             }
 
-            DeleteEmptyFolders(directory);
+            FileSystemHelper.DeleteEmptyFolders(_fileSystem, directory, _logger);
 
             progress.Report(100);
-        }
-
-        private void DeleteEmptyFolders(string parent)
-        {
-            foreach (var directory in _fileSystem.GetDirectoryPaths(parent))
-            {
-                DeleteEmptyFolders(directory);
-                if (!_fileSystem.GetFileSystemEntryPaths(directory).Any())
-                {
-                    try
-                    {
-                        Directory.Delete(directory, false);
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogError(ex, "Error deleting directory {Path}", directory);
-                    }
-                    catch (IOException ex)
-                    {
-                        _logger.LogError(ex, "Error deleting directory {Path}", directory);
-                    }
-                }
-            }
-        }
-
-        private void DeleteFile(string path)
-        {
-            try
-            {
-                _fileSystem.DeleteFile(path);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogError(ex, "Error deleting file {Path}", path);
-            }
-            catch (IOException ex)
-            {
-                _logger.LogError(ex, "Error deleting file {Path}", path);
-            }
         }
     }
 }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1949,13 +1949,14 @@ namespace MediaBrowser.Controller.Entities
                 return;
             }
 
-            // Remove it from the item
-            RemoveImage(info);
-
+            // Remove from file system
             if (info.IsLocalFile)
             {
                 FileSystem.DeleteFile(info.Path);
             }
+
+            // Remove from item
+            RemoveImage(info);
 
             await UpdateToRepositoryAsync(ItemUpdateType.ImageUpdate, CancellationToken.None).ConfigureAwait(false);
         }

--- a/MediaBrowser.Controller/IO/FileSystemHelper.cs
+++ b/MediaBrowser.Controller/IO/FileSystemHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Linq;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Controller.IO;
+
+/// <summary>
+/// Helper methods for file system management.
+/// </summary>
+public static class FileSystemHelper
+{
+    /// <summary>
+    /// Deletes the file.
+    /// </summary>
+    /// <param name="fileSystem">The fileSystem.</param>
+    /// <param name="path">The path.</param>
+    /// <param name="logger">The logger.</param>
+    public static void DeleteFile(IFileSystem fileSystem, string path, ILogger logger)
+    {
+        try
+        {
+            fileSystem.DeleteFile(path);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger.LogError(ex, "Error deleting file {Path}", path);
+        }
+        catch (IOException ex)
+        {
+            logger.LogError(ex, "Error deleting file {Path}", path);
+        }
+    }
+
+    /// <summary>
+    /// Recursively delete empty folders.
+    /// </summary>
+    /// <param name="fileSystem">The fileSystem.</param>
+    /// <param name="path">The path.</param>
+    /// <param name="logger">The logger.</param>
+    public static void DeleteEmptyFolders(IFileSystem fileSystem, string path, ILogger logger)
+    {
+        foreach (var directory in fileSystem.GetDirectoryPaths(path))
+        {
+            DeleteEmptyFolders(fileSystem, directory, logger);
+            if (!fileSystem.GetFileSystemEntryPaths(directory).Any())
+            {
+                try
+                {
+                    Directory.Delete(directory, false);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    logger.LogError(ex, "Error deleting directory {Path}", directory);
+                }
+                catch (IOException ex)
+                {
+                    logger.LogError(ex, "Error deleting directory {Path}", directory);
+                }
+            }
+        }
+    }
+}

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
@@ -190,10 +191,7 @@ namespace MediaBrowser.Providers.Manager
 
                     // Remove containing directory if empty
                     var folder = Path.GetDirectoryName(currentPath);
-                    if (Directory.Exists(folder) && !_fileSystem.GetFiles(folder, true).Any())
-                    {
-                        Directory.Delete(folder, true);
-                    }
+                    FileSystemHelper.DeleteEmptyFolders(_fileSystem, folder, _logger);
                 }
                 catch (FileNotFoundException)
                 {

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -192,6 +192,10 @@ namespace MediaBrowser.Providers.Manager
                     // Remove containing directory if empty
                     var folder = Path.GetDirectoryName(currentPath);
                     FileSystemHelper.DeleteEmptyFolders(_fileSystem, folder, _logger);
+                    if (!_fileSystem.GetFiles(folder).Any())
+                    {
+                        Directory.Delete(folder);
+                    }
                 }
                 catch (FileNotFoundException)
                 {

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -194,7 +194,7 @@ namespace MediaBrowser.Providers.Manager
                     if (item is Episode && directory.Equals("metadata", StringComparison.Ordinal))
                     {
                         var parentDirectoryPath = Directory.GetParent(currentPath).FullName;
-                        if (!_fileSystem.GetFiles(parentDirectoryPath).Any())
+                        if (_fileSystem.DirectoryExists(parentDirectoryPath) && !_fileSystem.GetFiles(parentDirectoryPath).Any())
                         {
                             try
                             {

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -190,9 +190,9 @@ namespace MediaBrowser.Providers.Manager
 
                     // Remove containing directory if empty
                     var folder = Path.GetDirectoryName(currentPath);
-                    if (!_fileSystem.GetFiles(folder).Any())
+                    if (Directory.Exists(folder) && !_fileSystem.GetFiles(folder, true).Any())
                     {
-                        Directory.Delete(folder);
+                        Directory.Delete(folder, true);
                     }
                 }
                 catch (FileNotFoundException)

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -379,18 +379,17 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
+            item.RemoveImages(images);
+
             // Cleanup old metadata directory for episodes if empty
             if (item is Episode)
             {
                 var oldLocalMetadataDirectory = Path.Combine(item.ContainingFolderPath, "metadata");
-                var localImages = images.Where(i => i.Path.StartsWith(oldLocalMetadataDirectory, StringComparison.Ordinal)).ToList();
                 if (_fileSystem.DirectoryExists(oldLocalMetadataDirectory) && !_fileSystem.GetFiles(oldLocalMetadataDirectory).Any())
                 {
                     Directory.Delete(oldLocalMetadataDirectory);
                 }
             }
-
-            item.RemoveImages(images);
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -381,9 +381,9 @@ namespace MediaBrowser.Providers.Manager
                     {
                         // Always remove empty parent folder
                         var folder = Path.GetDirectoryName(image.Path);
-                        if (Directory.Exists(folder) && !_fileSystem.GetFiles(folder).Any())
+                        if (Directory.Exists(folder) && !_fileSystem.GetFiles(folder, true).Any())
                         {
-                            Directory.Delete(folder);
+                            Directory.Delete(folder, true);
                         }
                     }
                 }

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -383,6 +383,10 @@ namespace MediaBrowser.Providers.Manager
                         // Always remove empty parent folder
                         var folder = Path.GetDirectoryName(image.Path);
                         FileSystemHelper.DeleteEmptyFolders(_fileSystem, folder, _logger);
+                        if (!_fileSystem.GetFiles(folder).Any())
+                        {
+                            Directory.Delete(folder);
+                        }
                     }
                 }
             }

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -384,7 +384,7 @@ namespace MediaBrowser.Providers.Manager
             {
                 var oldLocalMetadataDirectory = Path.Combine(item.ContainingFolderPath, "metadata");
                 var localImages = images.Where(i => i.Path.StartsWith(oldLocalMetadataDirectory, StringComparison.Ordinal)).ToList();
-                if (!_fileSystem.GetFiles(oldLocalMetadataDirectory).Any())
+                if (_fileSystem.DirectoryExists(oldLocalMetadataDirectory) && !_fileSystem.GetFiles(oldLocalMetadataDirectory).Any())
                 {
                     Directory.Delete(oldLocalMetadataDirectory);
                 }

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Providers;
@@ -381,10 +382,7 @@ namespace MediaBrowser.Providers.Manager
                     {
                         // Always remove empty parent folder
                         var folder = Path.GetDirectoryName(image.Path);
-                        if (Directory.Exists(folder) && !_fileSystem.GetFiles(folder, true).Any())
-                        {
-                            Directory.Delete(folder, true);
-                        }
+                        FileSystemHelper.DeleteEmptyFolders(_fileSystem, folder, _logger);
                     }
                 }
             }

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -92,10 +92,6 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            var localImagesFailed = false;
-
-            var allImageProviders = ProviderManager.GetImageProviders(item, refreshOptions).ToList();
-
             if (refreshOptions.RemoveOldMetadata && refreshOptions.ReplaceAllImages)
             {
                 if (ImageProvider.RemoveImages(item))
@@ -105,6 +101,8 @@ namespace MediaBrowser.Providers.Manager
             }
 
             // Start by validating images
+            var localImagesFailed = false;
+            var allImageProviders = ProviderManager.GetImageProviders(item, refreshOptions).ToList();
             try
             {
                 // Always validate images and check for new locally stored ones.
@@ -811,18 +809,15 @@ namespace MediaBrowser.Providers.Manager
         {
             var refreshResult = new RefreshResult();
 
-            var tmpDataMerged = false;
+            if (id is not null)
+            {
+                MergeNewData(temp.Item, id);
+            }
 
             foreach (var provider in providers)
             {
                 var providerName = provider.GetType().Name;
                 Logger.LogDebug("Running {Provider} for {Item}", providerName, logName);
-
-                if (id is not null && !tmpDataMerged)
-                {
-                    MergeNewData(temp.Item, id);
-                    tmpDataMerged = true;
-                }
 
                 try
                 {


### PR DESCRIPTION
Regression from #11934
Recursive removal is too wide scoped, so limit it to remove the legacy `metadata` directory for episodes

**Changes**
* Limit scope of empty directory removal after image removal
* Add helper class for recursive empty folder removal
* Do not remove images from items if they could not be removed from the file system

**Issues**
Fixes #12023 (potentially)
