### PR TITLE
Fix replace all and respect metadata settings

### DIFF
--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -80,7 +80,8 @@ public class ItemRefreshController : BaseJellyfinApiController
                 || imageRefreshMode == MetadataRefreshMode.FullRefresh
                 || replaceAllImages
                 || replaceAllMetadata,
-            IsAutomated = false
+            IsAutomated = false,
+            RemoveOldMetadata = replaceAllMetadata
         };
 
         _providerManager.QueueRefresh(item.Id, refreshOptions, RefreshPriority.High);

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -669,6 +669,8 @@ namespace MediaBrowser.Providers.Manager
             };
             temp.Item.Path = item.Path;
             temp.Item.Id = item.Id;
+            temp.Item.PreferredMetadataCountryCode = item.PreferredMetadataCountryCode;
+            temp.Item.PreferredMetadataLanguage = item.PreferredMetadataLanguage;
 
             var foundImageTypes = new List<ImageType>();
 


### PR DESCRIPTION
Metadata fields are not cleared on replace if the newly fetched metadata does not include it.
Additionally, previously set language options for metadata are also replaced which should not be the case.

**Changes**
* Clear existing fields on replace all
* Respect previously set metadata language options on replace all

**Issues**
Fixes #5236
Fixes #12015
Fixes #12021
Possibly fixes #11923