### PR TITLE
Rewrite PlaylistItemsProvider as ILocalMetadataProvider

### DIFF
--- a/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistItemsProvider.cs
@@ -1,7 +1,5 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,182 +16,212 @@ using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
 using PlaylistsNET.Content;
 
-namespace MediaBrowser.Providers.Playlists
+namespace MediaBrowser.Providers.Playlists;
+
+/// <summary>
+/// Local playlist provider.
+/// </summary>
+public class PlaylistItemsProvider : ILocalMetadataProvider<Playlist>,
+    IHasOrder,
+    IForcedProvider,
+    IHasItemChangeMonitor
 {
-    public class PlaylistItemsProvider : ICustomMetadataProvider<Playlist>,
-        IHasOrder,
-        IForcedProvider,
-        IPreRefreshProvider,
-        IHasItemChangeMonitor
+    private readonly IFileSystem _fileSystem;
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<PlaylistItemsProvider> _logger;
+    private readonly CollectionType[] _ignoredCollections = [CollectionType.livetv, CollectionType.boxsets, CollectionType.playlists];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaylistItemsProvider"/> class.
+    /// </summary>
+    /// <param name="logger">Instance of the <see cref="ILogger{PlaylistItemsProvider}"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+    public PlaylistItemsProvider(ILogger<PlaylistItemsProvider> logger, ILibraryManager libraryManager, IFileSystem fileSystem)
     {
-        private readonly IFileSystem _fileSystem;
-        private readonly ILibraryManager _libraryManager;
-        private readonly ILogger<PlaylistItemsProvider> _logger;
-        private readonly CollectionType[] _ignoredCollections = [CollectionType.livetv, CollectionType.boxsets, CollectionType.playlists];
+        _logger = logger;
+        _libraryManager = libraryManager;
+        _fileSystem = fileSystem;
+    }
 
-        public PlaylistItemsProvider(ILogger<PlaylistItemsProvider> logger, ILibraryManager libraryManager, IFileSystem fileSystem)
+    /// <inheritdoc />
+    public string Name => "Playlist Item Provider";
+
+    /// <inheritdoc />
+    public int Order => 100;
+
+    /// <inheritdoc />
+    public Task<MetadataResult<Playlist>> GetMetadata(
+        ItemInfo info,
+        IDirectoryService directoryService,
+        CancellationToken cancellationToken)
+    {
+        var result = new MetadataResult<Playlist>()
         {
-            _logger = logger;
-            _libraryManager = libraryManager;
-            _fileSystem = fileSystem;
+            Item = new Playlist
+            {
+                Path = info.Path
+            }
+        };
+        Fetch(result);
+
+        return Task.FromResult(result);
+    }
+
+    private void Fetch(MetadataResult<Playlist> result)
+    {
+        var item = result.Item;
+        var path = item.Path;
+        if (!Playlist.IsPlaylistFile(path))
+        {
+            return;
         }
 
-        public string Name => "Playlist Reader";
-
-        // Run last
-        public int Order => 100;
-
-        public Task<ItemUpdateType> FetchAsync(Playlist item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        var extension = Path.GetExtension(path);
+        if (!Playlist.SupportedExtensions.Contains(extension ?? string.Empty, StringComparison.OrdinalIgnoreCase))
         {
-            var path = item.Path;
-            if (!Playlist.IsPlaylistFile(path))
-            {
-                return Task.FromResult(ItemUpdateType.None);
-            }
+            return;
+        }
 
-            var extension = Path.GetExtension(path);
-            if (!Playlist.SupportedExtensions.Contains(extension ?? string.Empty, StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.FromResult(ItemUpdateType.None);
-            }
-
-            var items = GetItems(path, extension).ToArray();
-
+        var items = GetItems(path, extension).ToArray();
+        if (items.Length > 0)
+        {
+            result.HasMetadata = true;
             item.LinkedChildren = items;
-
-            return Task.FromResult(ItemUpdateType.MetadataImport);
         }
 
-        private IEnumerable<LinkedChild> GetItems(string path, string extension)
+        return;
+    }
+
+    private IEnumerable<LinkedChild> GetItems(string path, string extension)
+    {
+        var libraryRoots = _libraryManager.GetUserRootFolder().Children
+                            .OfType<CollectionFolder>()
+                            .Where(f => f.CollectionType.HasValue && !_ignoredCollections.Contains(f.CollectionType.Value))
+                            .SelectMany(f => f.PhysicalLocations)
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToList();
+
+        using (var stream = File.OpenRead(path))
         {
-            var libraryRoots = _libraryManager.GetUserRootFolder().Children
-                                .OfType<CollectionFolder>()
-                                .Where(f => f.CollectionType.HasValue && !_ignoredCollections.Contains(f.CollectionType.Value))
-                                .SelectMany(f => f.PhysicalLocations)
-                                .Distinct(StringComparer.OrdinalIgnoreCase)
-                                .ToList();
-
-            using (var stream = File.OpenRead(path))
+            if (string.Equals(".wpl", extension, StringComparison.OrdinalIgnoreCase))
             {
-                if (string.Equals(".wpl", extension, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetWplItems(stream, path, libraryRoots);
-                }
-
-                if (string.Equals(".zpl", extension, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetZplItems(stream, path, libraryRoots);
-                }
-
-                if (string.Equals(".m3u", extension, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetM3uItems(stream, path, libraryRoots);
-                }
-
-                if (string.Equals(".m3u8", extension, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetM3uItems(stream, path, libraryRoots);
-                }
-
-                if (string.Equals(".pls", extension, StringComparison.OrdinalIgnoreCase))
-                {
-                    return GetPlsItems(stream, path, libraryRoots);
-                }
+                return GetWplItems(stream, path, libraryRoots);
             }
 
-            return Enumerable.Empty<LinkedChild>();
-        }
-
-        private IEnumerable<LinkedChild> GetPlsItems(Stream stream, string playlistPath, List<string> libraryRoots)
-        {
-            var content = new PlsContent();
-            var playlist = content.GetFromStream(stream);
-
-            return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
-                    .Where(i => i is not null);
-        }
-
-        private IEnumerable<LinkedChild> GetM3uItems(Stream stream, string playlistPath, List<string> libraryRoots)
-        {
-            var content = new M3uContent();
-            var playlist = content.GetFromStream(stream);
-
-            return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
-                    .Where(i => i is not null);
-        }
-
-        private IEnumerable<LinkedChild> GetZplItems(Stream stream, string playlistPath, List<string> libraryRoots)
-        {
-            var content = new ZplContent();
-            var playlist = content.GetFromStream(stream);
-
-            return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
-                    .Where(i => i is not null);
-        }
-
-        private IEnumerable<LinkedChild> GetWplItems(Stream stream, string playlistPath, List<string> libraryRoots)
-        {
-            var content = new WplContent();
-            var playlist = content.GetFromStream(stream);
-
-            return playlist.PlaylistEntries
-                    .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
-                    .Where(i => i is not null);
-        }
-
-        private LinkedChild GetLinkedChild(string itemPath, string playlistPath, List<string> libraryRoots)
-        {
-            if (TryGetPlaylistItemPath(itemPath, playlistPath, libraryRoots, out var parsedPath))
+            if (string.Equals(".zpl", extension, StringComparison.OrdinalIgnoreCase))
             {
-                return new LinkedChild
-                {
-                    Path = parsedPath,
-                    Type = LinkedChildType.Manual
-                };
+                return GetZplItems(stream, path, libraryRoots);
             }
 
-            return null;
+            if (string.Equals(".m3u", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return GetM3uItems(stream, path, libraryRoots);
+            }
+
+            if (string.Equals(".m3u8", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return GetM3uItems(stream, path, libraryRoots);
+            }
+
+            if (string.Equals(".pls", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return GetPlsItems(stream, path, libraryRoots);
+            }
         }
 
-        private bool TryGetPlaylistItemPath(string itemPath, string playlistPath, List<string> libraryPaths, out string path)
+        return Enumerable.Empty<LinkedChild>();
+    }
+
+    private IEnumerable<LinkedChild> GetPlsItems(Stream stream, string playlistPath, List<string> libraryRoots)
+    {
+        var content = new PlsContent();
+        var playlist = content.GetFromStream(stream);
+
+        return playlist.PlaylistEntries
+                .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
+                .Where(i => i is not null);
+    }
+
+    private IEnumerable<LinkedChild> GetM3uItems(Stream stream, string playlistPath, List<string> libraryRoots)
+    {
+        var content = new M3uContent();
+        var playlist = content.GetFromStream(stream);
+
+        return playlist.PlaylistEntries
+                .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
+                .Where(i => i is not null);
+    }
+
+    private IEnumerable<LinkedChild> GetZplItems(Stream stream, string playlistPath, List<string> libraryRoots)
+    {
+        var content = new ZplContent();
+        var playlist = content.GetFromStream(stream);
+
+        return playlist.PlaylistEntries
+                .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
+                .Where(i => i is not null);
+    }
+
+    private IEnumerable<LinkedChild> GetWplItems(Stream stream, string playlistPath, List<string> libraryRoots)
+    {
+        var content = new WplContent();
+        var playlist = content.GetFromStream(stream);
+
+        return playlist.PlaylistEntries
+                .Select(i => GetLinkedChild(i.Path, playlistPath, libraryRoots))
+                .Where(i => i is not null);
+    }
+
+    private LinkedChild GetLinkedChild(string itemPath, string playlistPath, List<string> libraryRoots)
+    {
+        if (TryGetPlaylistItemPath(itemPath, playlistPath, libraryRoots, out var parsedPath))
         {
-            path = null;
-            string pathToCheck = _fileSystem.MakeAbsolutePath(Path.GetDirectoryName(playlistPath), itemPath);
-            if (!File.Exists(pathToCheck))
+            return new LinkedChild
             {
-                return false;
-            }
+                Path = parsedPath,
+                Type = LinkedChildType.Manual
+            };
+        }
 
-            foreach (var libraryPath in libraryPaths)
-            {
-                if (pathToCheck.StartsWith(libraryPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    path = pathToCheck;
-                    return true;
-                }
-            }
+        return null;
+    }
 
+    private bool TryGetPlaylistItemPath(string itemPath, string playlistPath, List<string> libraryPaths, out string path)
+    {
+        path = null;
+        string pathToCheck = _fileSystem.MakeAbsolutePath(Path.GetDirectoryName(playlistPath), itemPath);
+        if (!File.Exists(pathToCheck))
+        {
             return false;
         }
 
-        public bool HasChanged(BaseItem item, IDirectoryService directoryService)
+        foreach (var libraryPath in libraryPaths)
         {
-            var path = item.Path;
-
-            if (!string.IsNullOrWhiteSpace(path) && item.IsFileProtocol)
+            if (pathToCheck.StartsWith(libraryPath, StringComparison.OrdinalIgnoreCase))
             {
-                var file = directoryService.GetFile(path);
-                if (file is not null && file.LastWriteTimeUtc != item.DateModified)
-                {
-                    _logger.LogDebug("Refreshing {Path} due to date modified timestamp change.", path);
-                    return true;
-                }
+                path = pathToCheck;
+                return true;
             }
-
-            return false;
         }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool HasChanged(BaseItem item, IDirectoryService directoryService)
+    {
+        var path = item.Path;
+        if (!string.IsNullOrWhiteSpace(path) && item.IsFileProtocol)
+        {
+            var file = directoryService.GetFile(path);
+            if (file is not null && file.LastWriteTimeUtc != item.DateModified)
+            {
+                _logger.LogDebug("Refreshing {Path} due to date modified timestamp change.", path);
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
The XML provider would override the results of the item provider because the item provider wrote to the original item which is replaced by the results of the provider.

**Changes**
* Rewrite `PlaylistItemsProvider` as `ILocalMetadataProvider`
