### PR TITLE
Make m2ts extension case-insensitive

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1155,10 +1155,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             // Get all files from the BDMV/STREAMING directory
             // Only return playable local .m2ts files
+            var files = _fileSystem.GetFiles(Path.Join(path, "BDMV", "STREAM")).ToList();
             return validPlaybackFiles
-                .Select(f => _fileSystem.GetFileInfo(Path.Join(path, "BDMV", "STREAM", f)))
-                .Where(f => f.Exists)
-                .Select(f => f.FullName)
+                .Select(validFile => files.FirstOrDefault(f => Path.GetFileName(f.FullName.AsSpan()).Equals(validFile, StringComparison.OrdinalIgnoreCase))?.FullName)
+                .Where(f => f is not null)
                 .ToList();
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
files extension returned by GetDiscInfo() are always uppercase(.M2TS). It causes issue when original filenames are in lowercase. This fixes it by ignoring the case while keeping the order.

**Issues**
Fixes #12060 
