### PR TITLE
Resolve remote images using providers

### DIFF
--- a/Jellyfin.Api/Controllers/RemoteImageController.cs
+++ b/Jellyfin.Api/Controllers/RemoteImageController.cs
@@ -180,6 +180,12 @@ public class RemoteImageController : BaseJellyfinApiController
                 return BadRequest();
             }
 
+            var images = await provider.GetImages(item, CancellationToken.None);
+            if (!images.Any(image => string.Equals(image.Url, imageUrl, StringComparison.Ordinal)))
+            {
+                return BadRequest();
+            }
+
             await _providerManager.SaveImage(item, provider, imageUrl, type, null, CancellationToken.None)
                 .ConfigureAwait(false);
         }

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -68,6 +68,18 @@ namespace MediaBrowser.Controller.Providers
         /// Saves the image.
         /// </summary>
         /// <param name="item">The item.</param>
+        /// <param name="provider">Remote image provider to resolve the URL for us.</param>
+        /// <param name="url">The URL.</param>
+        /// <param name="type">The type.</param>
+        /// <param name="imageIndex">Index of the image.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Task.</returns>
+        Task SaveImage(BaseItem item, IRemoteImageProvider provider, string url, ImageType type, int? imageIndex, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Saves the image.
+        /// </summary>
+        /// <param name="item">The item.</param>
         /// <param name="source">The source.</param>
         /// <param name="mimeType">Type of the MIME.</param>
         /// <param name="type">The type.</param>


### PR DESCRIPTION
Currently the resolution of remote images provided by plugins are handled differently in two places;

- If a remote image is acquired internally in Jellyfin it will ask the provider to fetch the image for us. As seen [here](https://github.com/jellyfin/jellyfin/blob/18dd6b2875b05d6b9c8249476ae509bfd20e8314/MediaBrowser.Providers/Manager/ItemImageProvider.cs#L535) and [here](https://github.com/jellyfin/jellyfin/blob/18dd6b2875b05d6b9c8249476ae509bfd20e8314/MediaBrowser.Providers/Manager/ItemImageProvider.cs#L644).

- If a remote image is asked by a client to be added to an item, it will always be downloaded using a standard HTTP client. As seen [here](https://github.com/jellyfin/jellyfin/blob/6fb6b5f1766a1f37a61b9faaa40209bab995bf30/Jellyfin.Api/Controllers/RemoteImageController.cs#L166). I'll also note that the client is sending the image url, provider name, and image type with each request. As seen [here](https://github.com/jellyfin/jellyfin-web/blob/20381bd3ec2f23907ed53d7da568cae921b05506/src/components/imageDownloader/imageDownloader.js#L140-L154).

**Changes**

This PR changes the behavior of the second scenario to better align with the first scenario, where it will ask the provider to fetch the image if the client tells us which provider to use. Of course, the provider needs to be enabled for the item, otherwise it will result in a `400 Bad Request`. I feel this change is necessary to accommodate when it's not possible for the Jellyfin server itself to directly fetch the images, but a provider can fetch it for the server, all the while the clients can also fetch the images. This can arise when the server and clients use different DNS server and live on different LANs, e.g. a docker network and normal LAN outside the docker network on a different sub-net, both with different DNS servers, where nether have the other DNS server in their DNS stack.

**Issues**
- None yet, because I never made any.
