### PR TITLE
Map IPv6 mapped IPv4 addresses back to IPv4 before running checks

### DIFF
--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -919,10 +919,14 @@ public class NetworkManager : INetworkManager, IDisposable
     {
         ArgumentNullException.ThrowIfNull(address);
 
-        // See conversation at https://github.com/jellyfin/jellyfin/pull/3515.
+        // Map IPv6 mapped IPv4 back to IPv4 (happens if Kestrel runs in dual-socket mode)
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
         if ((TrustAllIPv6Interfaces && address.AddressFamily == AddressFamily.InterNetworkV6)
-            || address.Equals(IPAddress.Loopback)
-            || address.Equals(IPAddress.IPv6Loopback))
+            || IPAddress.IsLoopback(address))
         {
             return true;
         }


### PR DESCRIPTION
Kestrel in dual-socket mode will always serve IPv4 addresses as IPv6 mapped, making our checks fail.

**Changes**
* Check if address is IPv6 mapped IPv4 and map back to IPv4
* Use `IsLoopback` for more reliable loopback checks

**Issues**
Fixes #11968