### PR TITLE
Do not override <year> if <releasedate> is set

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -518,13 +518,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 case "releasedate":
                     if (reader.TryReadDateTimeExact(nfoConfiguration.ReleaseDateFormat, out var releaseDate))
                     {
-                        // Production year could already be set by the year tag
-                        if (item.ProductionYear is null)
-                        {
-                            item.ProductionYear = releaseDate.Year;
-                        }
-
                         item.PremiereDate = releaseDate;
+
+                        // Production year can already be set by the year tag
+                        item.ProductionYear ??= releaseDate.Year;
                     }
 
                     break;

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -518,8 +518,13 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 case "releasedate":
                     if (reader.TryReadDateTimeExact(nfoConfiguration.ReleaseDateFormat, out var releaseDate))
                     {
+                        // Production year could already be set by the year tag
+                        if (item.ProductionYear is null)
+                        {
+                            item.ProductionYear = releaseDate.Year;
+                        }
+
                         item.PremiereDate = releaseDate;
-                        item.ProductionYear = releaseDate.Year;
                     }
 
                     break;


### PR DESCRIPTION
`<year>` is the  tag for production year. The date in `<releasedate>` can be different due to locale, so we should only use it if it is unset.

**Changes**
* Do not override already set `ProductionYear`

**Issues**
Fixes #12111
