### PR TITLE
Fix Cleanup Task metadata saving

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -127,15 +127,8 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
         {
             _logger.LogDebug("Updating {FolderName}", folder.Name);
             folder.LinkedChildren = folder.LinkedChildren.Except(itemsToRemove).ToArray();
+            _providerManager.SaveMetadataAsync(folder, ItemUpdateType.MetadataEdit);
             folder.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken);
-
-            _providerManager.QueueRefresh(
-                folder.Id,
-                new MetadataRefreshOptions(new DirectoryService(_fileSystem))
-                {
-                    ForceSave = true
-                },
-                RefreshPriority.High);
         }
     }
 


### PR DESCRIPTION
We only save to the database, not to the file system. This leads to the bad data being re-read on scan. Therefore just run save item and save metadata without running a metadata scan.

**Changes**
* Only run metadata savers, don't run metadata update