### PR TITLE
Fix refresh data does not retain LinkedChildren

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1090,6 +1090,11 @@ namespace MediaBrowser.Providers.Manager
                 target.RemoteTrailers = target.RemoteTrailers.Concat(source.RemoteTrailers).DistinctBy(t => t.Url).ToArray();
             }
 
+            if (source is Folder sourceFolder && target is Folder targetFolder)
+            {
+                targetFolder.LinkedChildren = sourceFolder.LinkedChildren;
+            }
+
             MergeAlbumArtist(source, target, replaceData);
             MergeVideoInfo(source, target, replaceData);
             MergeDisplayOrder(source, target, replaceData);


### PR DESCRIPTION
I think the issue is caused by new `LinkedChildren` introduced in 10.9. 
When refreshing metadata, a new item is created instead of updating. but `LinkedChildren` is not copied.

**Changes**
When refreshing metadata, the `LinkedChildren` should also be copied if the item is `Folder`.
Otherwise, all the added items will be removed on refreshing metadata.

**Issues**
Fixes: #12155