### PR TITLE
Add messages to LiveTvConflict exception

### DIFF
--- a/MediaBrowser.Controller/LiveTv/LiveTvConflictException.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvConflictException.cs
@@ -9,10 +9,6 @@ namespace MediaBrowser.Controller.LiveTv
     /// </summary>
     public class LiveTvConflictException : Exception
     {
-        public LiveTvConflictException()
-        {
-        }
-
         public LiveTvConflictException(string message)
             : base(message)
         {

--- a/src/Jellyfin.LiveTv/TunerHosts/BaseTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/BaseTunerHost.cs
@@ -219,7 +219,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                 }
             }
 
-            throw new LiveTvConflictException();
+            throw new LiveTvConflictException("Unable to find host to play channel");
         }
 
         protected virtual bool IsValidChannelId(string channelId)

--- a/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunManager.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunManager.cs
@@ -145,7 +145,7 @@ namespace Jellyfin.LiveTv.TunerHosts.HdHomerun
             }
 
             _activeTuner = -1;
-            throw new LiveTvConflictException();
+            throw new LiveTvConflictException("No tuners available");
         }
 
         public async Task ChangeChannel(IHdHomerunChannelCommands commands, CancellationToken cancellationToken)


### PR DESCRIPTION
Different error messages are welcome.

Current:
```
[2024-06-27 22:54:12.993 -04:00] [ERR] [18] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL "POST" "/Items/b26b7fddc7b41a49f7d45f13b0db7dc5/PlaybackInfo".
MediaBrowser.Controller.LiveTv.LiveTvConflictException: Exception of type 'MediaBrowser.Controller.LiveTv.LiveTvConflictException' was thrown.
   at Jellyfin.LiveTv.TunerHosts.BaseTunerHost.GetChannelStream(String channelId, String streamId, IList`1 currentLiveStreams, CancellationToken cancellationToken)
   at Jellyfin.LiveTv.DefaultLiveTvService.GetChannelStreamWithDirectStreamProvider(String channelId, String streamId, List`1 currentLiveStreams, CancellationToken cancellationToken)
   at Jellyfin.LiveTv.LiveTvMediaSourceProvider.GetChannelStream(String id, String mediaSourceId, List`1 currentLiveStreams, CancellationToken cancellationToken)
   at Jellyfin.LiveTv.LiveTvMediaSourceProvider.OpenMediaSource(String openToken, List`1 currentLiveStreams, CancellationToken cancellationToken)
   at Emby.Server.Implementations.Library.MediaSourceManager.OpenLiveStreamInternal(LiveStreamRequest request, CancellationToken cancellationToken)
   at Emby.Server.Implementations.Library.MediaSourceManager.OpenLiveStream(LiveStreamRequest request, CancellationToken cancellationToken)
   at Jellyfin.Api.Helpers.MediaInfoHelper.OpenMediaSource(HttpContext httpContext, LiveStreamRequest request)
   at Jellyfin.Api.Controllers.MediaInfoController.GetPostedPlaybackInfo(Guid itemId, Nullable`1 userId, Nullable`1 maxStreamingBitrate, Nullable`1 startTimeTicks, Nullable`1 audioStreamIndex, Nullable`1 subtitleStreamIndex, Nullable`1 maxAudioChannels, String mediaSourceId, String liveStreamId, Nullable`1 autoOpenLiveStream, Nullable`1 enableDirectPlay, Nullable`1 enableDirectStream, Nullable`1 enableTranscoding, Nullable`1 allowVideoStreamCopy, Nullable`1 allowAudioStreamCopy, PlaybackInfoDto playbackInfoDto)
   at lambda_method460(Closure, Object)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Prometheus.HttpMetrics.HttpRequestDurationMiddleware.Invoke(HttpContext context)
   at Prometheus.HttpMetrics.HttpRequestCountMiddleware.Invoke(HttpContext context)
   at Prometheus.HttpMetrics.HttpInProgressMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager)
   at Jellyfin.Api.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager)
   at Jellyfin.Api.Middleware.IPBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager)
   at Jellyfin.Api.Middleware.LanFilteringMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext)
   at Jellyfin.Api.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Jellyfin.Api.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context, IServerConfigurationManager serverConfigurationManager)
   at Jellyfin.Api.Middleware.ExceptionMiddleware.Invoke(HttpContext context)
```