### PR TITLE
fix: use release date from album metadata provider instead of year

### DIFF
--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -38,9 +38,6 @@ namespace MediaBrowser.Providers.Music
         }
 
         /// <inheritdoc />
-        protected override bool EnableUpdatingPremiereDateFromChildren => true;
-
-        /// <inheritdoc />
         protected override bool EnableUpdatingGenresFromChildren => true;
 
         /// <inheritdoc />


### PR DESCRIPTION
**Changes**
Disable updating `PremiereDate` from audio

**Issues**
If `EnableUpdatingPremiereDateFromChildren` is `true`, `AudioFileProber` override `PremiereDate` to `{year}-01-01` , even if provider like `MusicBrainzAlbumProvider` provide the exact date.

https://github.com/jellyfin/jellyfin/blob/478d8b07bf73d07c577ea4e39cbccab561d27b6a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs#L298-L314

https://github.com/jellyfin/jellyfin/blob/478d8b07bf73d07c577ea4e39cbccab561d27b6a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs#L148-L154