### PR TITLE
Use real temp dir instead of cache dir for temp files

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -104,6 +104,6 @@ namespace Emby.Server.Implementations.AppBase
         /// Gets the folder path to the temp directory within the cache folder.
         /// </summary>
         /// <value>The temp directory.</value>
-        public string TempDirectory => Path.Combine(CachePath, "temp");
+        public string TempDirectory => Path.Join(Path.GetTempPath(), "jellyfin");
     }
 }

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -466,7 +466,7 @@ namespace Emby.Server.Implementations.IO
             File.Copy(file1, temp1, true);
 
             File.Copy(file2, file1, true);
-            File.Copy(temp1, file2, true);
+            File.Move(temp1, file2, true);
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -122,6 +122,7 @@ namespace Emby.Server.Implementations.Images
             }
 
             await ProviderManager.SaveImage(item, outputPath, mimeType, imageType, null, false, cancellationToken).ConfigureAwait(false);
+            File.Delete(outputPath);
 
             return ItemUpdateType.ImageUpdate;
         }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -29,7 +29,7 @@ public partial class AudioNormalizationTask : IScheduledTask
     private readonly IItemRepository _itemRepository;
     private readonly ILibraryManager _libraryManager;
     private readonly IMediaEncoder _mediaEncoder;
-    private readonly IConfigurationManager _configurationManager;
+    private readonly IApplicationPaths _applicationPaths;
     private readonly ILocalizationManager _localization;
     private readonly ILogger<AudioNormalizationTask> _logger;
 
@@ -39,21 +39,21 @@ public partial class AudioNormalizationTask : IScheduledTask
     /// <param name="itemRepository">Instance of the <see cref="IItemRepository"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
-    /// <param name="configurationManager">Instance of the <see cref="IConfigurationManager"/> interface.</param>
+    /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
     /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{AudioNormalizationTask}"/> interface.</param>
     public AudioNormalizationTask(
         IItemRepository itemRepository,
         ILibraryManager libraryManager,
         IMediaEncoder mediaEncoder,
-        IConfigurationManager configurationManager,
+        IApplicationPaths applicationPaths,
         ILocalizationManager localizationManager,
         ILogger<AudioNormalizationTask> logger)
     {
         _itemRepository = itemRepository;
         _libraryManager = libraryManager;
         _mediaEncoder = mediaEncoder;
-        _configurationManager = configurationManager;
+        _applicationPaths = applicationPaths;
         _localization = localizationManager;
         _logger = logger;
     }
@@ -107,7 +107,9 @@ public partial class AudioNormalizationTask : IScheduledTask
                 }
 
                 _logger.LogInformation("Calculating LUFS for album: {Album} with id: {Id}", a.Name, a.Id);
-                var tempFile = Path.Join(_configurationManager.GetTranscodePath(), a.Id + ".concat");
+                var tempDir = _applicationPaths.TempDirectory;
+                Directory.CreateDirectory(tempDir);
+                var tempFile = Path.Join(tempDir, a.Id + ".concat");
                 var inputLines = albumTracks.Select(x => string.Format(CultureInfo.InvariantCulture, "file '{0}'", x.Path.Replace("'", @"'\''", StringComparison.Ordinal)));
                 await File.WriteAllLinesAsync(tempFile, inputLines, cancellationToken).ConfigureAwait(false);
                 try

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -230,7 +230,7 @@ public class TrickplayManager : ITrickplayManager
             throw new ArgumentException("Can't create trickplay from 0 images.");
         }
 
-        var workDir = Path.Combine(_appPaths.TempDirectory, Guid.NewGuid().ToString("N"));
+        var workDir = Path.Combine(_appPaths.TempDirectory, "trickplay_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workDir);
 
         var trickplayInfo = new TrickplayInfo

--- a/Jellyfin.Server/Helpers/StartupHelpers.cs
+++ b/Jellyfin.Server/Helpers/StartupHelpers.cs
@@ -60,6 +60,7 @@ public static class StartupHelpers
         logger.LogInformation("Log directory path: {LogDirectoryPath}", appPaths.LogDirectoryPath);
         logger.LogInformation("Config directory path: {ConfigurationDirectoryPath}", appPaths.ConfigurationDirectoryPath);
         logger.LogInformation("Cache path: {CachePath}", appPaths.CachePath);
+        logger.LogInformation("Temp directory path: {TempDirPath}", appPaths.TempDirectory);
         logger.LogInformation("Web resources path: {WebPath}", appPaths.WebPath);
         logger.LogInformation("Application directory: {ApplicationPath}", appPaths.ProgramSystemPath);
     }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1188,10 +1188,14 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
             {
-                var tmpConcatPath = Path.Join(_configurationManager.GetTranscodePath(), state.MediaSource.Id + ".concat");
-                _mediaEncoder.GenerateConcatConfig(state.MediaSource, tmpConcatPath);
+                var concatFilePath = Path.Join(_configurationManager.CommonApplicationPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
+                if (!File.Exists(concatFilePath))
+                {
+                    _mediaEncoder.GenerateConcatConfig(state.MediaSource, concatFilePath);
+                }
+
                 arg.Append(" -f concat -safe 0 -i \"")
-                    .Append(tmpConcatPath)
+                    .Append(concatFilePath)
                     .Append("\" ");
             }
             else

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1197,6 +1197,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // Generate concat configuration entries for each file and write to file
+            Directory.CreateDirectory(Path.GetDirectoryName(concatFilePath));
             using StreamWriter sw = new StreamWriter(concatFilePath);
             foreach (var path in files)
             {

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -235,15 +235,6 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         if (delete(job.Path!))
         {
             await DeletePartialStreamFiles(job.Path!, job.Type, 0, 1500).ConfigureAwait(false);
-            if (job.MediaSource?.VideoType == VideoType.Dvd || job.MediaSource?.VideoType == VideoType.BluRay)
-            {
-                var concatFilePath = Path.Join(_serverConfigurationManager.GetTranscodePath(), job.MediaSource.Id + ".concat");
-                if (File.Exists(concatFilePath))
-                {
-                    _logger.LogInformation("Deleting ffmpeg concat configuration at {Path}", concatFilePath);
-                    File.Delete(concatFilePath);
-                }
-            }
         }
 
         if (closeLiveStream && !string.IsNullOrWhiteSpace(job.LiveStreamId))
@@ -419,7 +410,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
             var attachmentPath = Path.Combine(_appPaths.CachePath, "attachments", state.MediaSource.Id);
             if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
             {
-                var concatPath = Path.Join(_serverConfigurationManager.GetTranscodePath(), state.MediaSource.Id + ".concat");
+                var concatPath = Path.Join(_appPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
                 await _attachmentExtractor.ExtractAllAttachments(concatPath, state.MediaSource, attachmentPath, cancellationTokenSource.Token).ConfigureAwait(false);
             }
             else

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -219,7 +219,7 @@ public class SkiaEncoder : IImageEncoder
             return path;
         }
 
-        var tempPath = Path.Combine(_appPaths.TempDirectory, string.Concat(Guid.NewGuid().ToString(), Path.GetExtension(path.AsSpan())));
+        var tempPath = Path.Join(_appPaths.TempDirectory, string.Concat("skia_", Guid.NewGuid().ToString(), Path.GetExtension(path.AsSpan())));
         var directory = Path.GetDirectoryName(tempPath) ?? throw new ResourceNotFoundException($"Provided path ({tempPath}) is not valid.");
         Directory.CreateDirectory(directory);
         File.Copy(path, tempPath, true);


### PR DESCRIPTION
This way we take advantage of systems where the temp directory is backed by RAM.

* Clean up temp files right after use where possible
* Prefer temp dir over cache/trancode dir for short lived one time use files
* Add more identifiable information to some temp files/directories
* Cache DVD/Blu-Ray concat file to improve subsequent playback start times
