### PR TITLE
Fix season handling ("Season Unknown" / unneccesary empty seasons)

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -350,10 +350,17 @@ namespace MediaBrowser.Controller.Entities.TV
 
         public List<BaseItem> GetSeasonEpisodes(Season parentSeason, User user, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
+            var queryFromSeries = ConfigurationManager.Configuration.DisplaySpecialsWithinSeasons;
+
+            // add optimization when this setting is not enabled
+            var seriesKey = queryFromSeries ?
+                GetUniqueSeriesKey(this) :
+                GetUniqueSeriesKey(parentSeason);
+
             var query = new InternalItemsQuery(user)
             {
-                AncestorWithPresentationUniqueKey = null,
-                SeriesPresentationUniqueKey = GetUniqueSeriesKey(this),
+                AncestorWithPresentationUniqueKey = queryFromSeries ? null : seriesKey,
+                SeriesPresentationUniqueKey = queryFromSeries ? seriesKey : null,
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 OrderBy = new[] { (ItemSortBy.SortName, SortOrder.Ascending) },
                 DtoOptions = options


### PR DESCRIPTION
Reverts a part of #12050.

**Changes**

Starting with 10.9.7, when refreshing metadata or scanning a series it would reset the virtual season to "Season Unknown". Reverting a part of the 10.9.7 related to season lookups fixed this.

~~Probably needs more testing for non-virtual season usages.~~

**Issues**

Fixes #12208 (confirmed via forum)
