### PR TITLE
Broken Image Downloads for Azure Storage files.

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2834,27 +2834,22 @@ namespace Emby.Server.Implementations.Library
                 }
                 catch (HttpRequestException ex)
                 {
-                    if (ex.StatusCode is not (HttpStatusCode.NotFound or HttpStatusCode.Forbidden))
-                    {
-                        throw;
-                    }
-
-                    switch (ex.StatusCode.Value)
+                    switch (ex.StatusCode)
                     {
                         case HttpStatusCode.NotFound:
-                            _logger.LogDebug(ex, "Image {Url} not found: {HttpStatusCode}", url, ex.StatusCode.Value);
+                            _logger.LogWarning(ex, "Image not found response received: {HttpStausCode} {URL}", ex.StatusCode, url);
                             break;
                         case HttpStatusCode.Forbidden:
-                            _logger.LogDebug(ex, "Forbidden to access image: {HttpStausCode} {URL}", ex.StatusCode.Value, url);
+                            _logger.LogWarning(ex, "Forbidden response received for image: {HttpStausCode} {URL}", ex.StatusCode, url);
                             break;
                         default:
-                            _logger.LogDebug(ex, "The requestes to get the image failed: {HttpStausCode} {URL}", ex.StatusCode.Value, url);
-                            throw;
+                            _logger.LogWarning(ex, "Image download failed: {HttpStausCode} {URL}", ex.StatusCode, url);
+                            break;
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error converting image to local: {Url}", url);
+                    _logger.LogWarning(ex, "Error converting image to local: {Url}", url);
                 }
 
                 if (!removeOnFailure)
@@ -2862,7 +2857,6 @@ namespace Emby.Server.Implementations.Library
                     continue;
                 }
 
-                // Remove this image to prevent it from retrying over and over
                 item.RemoveImage(image);
                 await item.UpdateToRepositoryAsync(ItemUpdateType.ImageUpdate, CancellationToken.None).ConfigureAwait(false);
             }

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1961,7 +1961,19 @@ public class ImageController : BaseJellyfinApiController
 
         if (!imageInfo.IsLocalFile && item is not null)
         {
-            imageInfo = await _libraryManager.ConvertImageToLocal(item, imageInfo, imageIndex ?? 0).ConfigureAwait(false);
+            try
+            {
+                imageInfo = await _libraryManager.ConvertImageToLocal(item, imageInfo, imageIndex ?? 0).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Log the exception. Adjust the logging mechanism based on your application's logging setup.
+                _logger.LogError(ex, "Failed to convert image to local for item {ItemId} and imageIndex {ImageIndex}", item.Id, imageIndex);
+
+                // Fallback action: return a default image or an error response.
+                // This example returns a NotFound result. Replace this with your chosen fallback action.
+                return NotFound("Failed to convert image to local. A default image is not available.");
+            }
         }
 
         var options = new ImageProcessingOptions

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1967,11 +1967,7 @@ public class ImageController : BaseJellyfinApiController
             }
             catch (Exception ex)
             {
-                // Log the exception. Adjust the logging mechanism based on your application's logging setup.
-                _logger.LogError(ex, "Failed to convert image to local for item {ItemId} and imageIndex {ImageIndex}", item.Id, imageIndex);
-
-                // Fallback action: return a default image or an error response.
-                // This example returns a NotFound result. Replace this with your chosen fallback action.
+                _logger.LogWarning(ex, "Failed to convert image to local for item {ItemId} and imageIndex {ImageIndex}", item.Id, imageIndex);
                 return NotFound("Failed to convert image to local. A default image is not available.");
             }
         }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -222,19 +222,7 @@ namespace MediaBrowser.Providers.Manager
                 if (contentType.StartsWith("application/octet-stream", StringComparison.OrdinalIgnoreCase))
                 {
                     var extension = Path.GetExtension(url).ToLowerInvariant();
-                    contentType = extension switch
-                    {
-                        ".png" => MediaTypeNames.Image.Png,
-                        ".jpg" or ".jpeg" => MediaTypeNames.Image.Jpeg,
-                        ".gif" => MediaTypeNames.Image.Gif,
-                        ".bmp" => MediaTypeNames.Image.Bmp,
-                        ".webp" => "image/webp",
-                        ".svg" => "image/svg+xml",
-                        ".tiff" or ".tif" => "image/tiff",
-                        ".heif" or ".heic" => "image/heif",
-                        ".ico" => "image/x-icon",
-                        _ => throw new HttpRequestException("Invalid image received: contentType not set.", null, response.StatusCode)
-                    };
+                    contentType = MimeTypes.GetMimeType(extension);
                 }
 
                 if (!contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
- Improved error handling on image download failures to prevent log flooding and provide more info about the status code from the source.
- Addition to the SaveImage method to handle application/octet-stream from Azure Blob Storage when providers do not set the content type.

**Issues**
#12143 

Pre-Change
![Screenshot 2024-07-07 164602](https://github.com/jellyfin/jellyfin/assets/4193377/a02bfa96-0616-4444-9a33-cf3d37eb1d42)

Post-Change
![Screenshot 2024-07-07 164921](https://github.com/jellyfin/jellyfin/assets/4193377/492d7f9a-477e-406d-920b-2ca78c03c713)
