### PR TITLE
Fix: parsing of xbmc style multi episode nfo files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -185,6 +185,7 @@
  - [Vedant](https://github.com/viktory36/)
  - [NotSaifA](https://github.com/NotSaifA)
  - [HonestlyWhoKnows](https://github.com/honestlywhoknows)
+ - [TheMelmacian](https://github.com/TheMelmacian)
 
 # Emby Contributors
 

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -59,30 +59,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             try
             {
                 // Extract episode details from the first episodedetails block
-                using (var stringReader = new StringReader(xml))
-                using (var reader = XmlReader.Create(stringReader, settings))
-                {
-                    reader.MoveToContent();
-                    reader.Read();
-
-                    // Loop through each element
-                    while (!reader.EOF && reader.ReadState == ReadState.Interactive)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        if (reader.NodeType == XmlNodeType.Element)
-                        {
-                            FetchDataFromXmlNode(reader, item);
-                        }
-                        else
-                        {
-                            reader.Read();
-                        }
-                    }
-                }
+                ReadEpisodeDetailsFromXml(item, xml, settings, cancellationToken);
 
                 // Extract the last episode number from nfo
-                // Retrieves all title and plot tags from the rest of the nfo and concatenates them with the first episode
+                // Retrieves all additional episodedetails blocks from the rest of the nfo and concatenates the name and overview tags with the first episode
                 // This is needed because XBMC metadata uses multiple episodedetails blocks instead of episodenumberend tag
                 var name = new StringBuilder(item.Item.Name);
                 var overview = new StringBuilder(item.Item.Overview);
@@ -91,44 +71,20 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     xml = xmlFile.Substring(0, index + srch.Length);
                     xmlFile = xmlFile.Substring(index + srch.Length);
 
-                    using (var stringReader = new StringReader(xml))
-                    using (var reader = XmlReader.Create(stringReader, settings))
+                    var additionalEpisode = new MetadataResult<Episode>()
                     {
-                        reader.MoveToContent();
+                        Item = new Episode()
+                    };
 
-                        while (!reader.EOF && reader.ReadState == ReadState.Interactive)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
+                    // Extract episode details from additional episodedetails block
+                    ReadEpisodeDetailsFromXml(additionalEpisode, xml, settings, cancellationToken);
 
-                            if (reader.NodeType == XmlNodeType.Element)
-                            {
-                                switch (reader.Name)
-                                {
-                                    case "name":
-                                    case "title":
-                                    case "localtitle":
-                                        name.Append(" / ").Append(reader.ReadElementContentAsString());
-                                        break;
-                                    case "episode":
-                                        {
-                                            if (int.TryParse(reader.ReadElementContentAsString(), out var num))
-                                            {
-                                                item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
-                                            }
+                    name.Append(" / ").Append(additionalEpisode.Item.Name);
+                    overview.Append(" / ").Append(additionalEpisode.Item.Overview);
 
-                                            break;
-                                        }
-
-                                    case "biography":
-                                    case "plot":
-                                    case "review":
-                                        overview.Append(" / ").Append(reader.ReadElementContentAsString());
-                                        break;
-                                }
-                            }
-
-                            reader.Read();
-                        }
+                    if (additionalEpisode.Item.IndexNumber != null)
+                    {
+                        item.Item.IndexNumberEnd = Math.Max((int)additionalEpisode.Item.IndexNumber, item.Item.IndexNumberEnd ?? (int)additionalEpisode.Item.IndexNumber);
                     }
                 }
 
@@ -198,6 +154,34 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 default:
                     base.FetchDataFromXmlNode(reader, itemResult);
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Reads the episode details from the given xml and saves the result in the provided result item.
+        /// </summary>
+        private void ReadEpisodeDetailsFromXml(MetadataResult<Episode> item, string xml, XmlReaderSettings settings, CancellationToken cancellationToken)
+        {
+            using (var stringReader = new StringReader(xml))
+            using (var reader = XmlReader.Create(stringReader, settings))
+            {
+                reader.MoveToContent();
+                reader.Read();
+
+                // Loop through each element
+                while (!reader.EOF && reader.ReadState == ReadState.Interactive)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        FetchDataFromXmlNode(reader, item);
+                    }
+                    else
+                    {
+                        reader.Read();
+                    }
+                }
             }
         }
     }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
@@ -7,6 +7,18 @@
   <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25333.jpg</thumb>
   <watched>false</watched>
   <rating>8.0</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
 </episodedetails>
 <episodedetails>
   <title>Rising (2)</title>
@@ -17,4 +29,16 @@
   <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25334.jpg</thumb>
   <watched>false</watched>
   <rating>7.9</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
 </episodedetails>


### PR DESCRIPTION
Fixing the `EpisodeNfoParser` so it no longer picks up fields of sub elements (like actor/name) and appending it to the title of the combined Episode object, if a xbmc style multi episode nfo file (multiple `<episodedetails>` blocks) is parsed.
The old implementation iterated over all elements searching for specific tag names without checking the level or parent element.

I didn't test the code in a productive environment but simply extended the test file and fixed the code so the test passes again.

**Changes**
- replaced the current parser implementation that was used for all blocks but the first with the standard episode xml parser
- extracted the parser code to it's own method to prevent code duplication
- extended the test file to include actors so this case is covered by a test in the future

**Issues**
Fixes #12243
