### PR TITLE
Fix: parsing of xbmc style multi episode nfo files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -185,6 +185,7 @@
  - [Vedant](https://github.com/viktory36/)
  - [NotSaifA](https://github.com/NotSaifA)
  - [HonestlyWhoKnows](https://github.com/honestlywhoknows)
+ - [TheMelmacian](https://github.com/TheMelmacian)
 
 # Emby Contributors
 

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -79,8 +79,15 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     // Extract episode details from additional episodedetails block
                     ReadEpisodeDetailsFromXml(additionalEpisode, xml, settings, cancellationToken);
 
-                    name.Append(" / ").Append(additionalEpisode.Item.Name);
-                    overview.Append(" / ").Append(additionalEpisode.Item.Overview);
+                    if (!string.IsNullOrEmpty(additionalEpisode.Item.Name))
+                    {
+                        name.Append(" / ").Append(additionalEpisode.Item.Name);
+                    }
+
+                    if (!string.IsNullOrEmpty(additionalEpisode.Item.Overview))
+                    {
+                        overview.Append(" / ").Append(additionalEpisode.Item.Overview);
+                    }
 
                     if (additionalEpisode.Item.IndexNumber != null)
                     {

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -59,30 +59,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             try
             {
                 // Extract episode details from the first episodedetails block
-                using (var stringReader = new StringReader(xml))
-                using (var reader = XmlReader.Create(stringReader, settings))
-                {
-                    reader.MoveToContent();
-                    reader.Read();
-
-                    // Loop through each element
-                    while (!reader.EOF && reader.ReadState == ReadState.Interactive)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        if (reader.NodeType == XmlNodeType.Element)
-                        {
-                            FetchDataFromXmlNode(reader, item);
-                        }
-                        else
-                        {
-                            reader.Read();
-                        }
-                    }
-                }
+                ReadEpisodeDetailsFromXml(item, xml, settings, cancellationToken);
 
                 // Extract the last episode number from nfo
-                // Retrieves all title and plot tags from the rest of the nfo and concatenates them with the first episode
+                // Retrieves all additional episodedetails blocks from the rest of the nfo and concatenates the name and overview tags with the first episode
                 // This is needed because XBMC metadata uses multiple episodedetails blocks instead of episodenumberend tag
                 var name = new StringBuilder(item.Item.Name);
                 var overview = new StringBuilder(item.Item.Overview);
@@ -91,44 +71,20 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     xml = xmlFile.Substring(0, index + srch.Length);
                     xmlFile = xmlFile.Substring(index + srch.Length);
 
-                    using (var stringReader = new StringReader(xml))
-                    using (var reader = XmlReader.Create(stringReader, settings))
+                    var additionalEpisode = new MetadataResult<Episode>()
                     {
-                        reader.MoveToContent();
+                        Item = new Episode()
+                    };
 
-                        while (!reader.EOF && reader.ReadState == ReadState.Interactive)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
+                    // Extract episode details from additional episodedetails block
+                    ReadEpisodeDetailsFromXml(additionalEpisode, xml, settings, cancellationToken);
 
-                            if (reader.NodeType == XmlNodeType.Element)
-                            {
-                                switch (reader.Name)
-                                {
-                                    case "name":
-                                    case "title":
-                                    case "localtitle":
-                                        name.Append(" / ").Append(reader.ReadElementContentAsString());
-                                        break;
-                                    case "episode":
-                                        {
-                                            if (int.TryParse(reader.ReadElementContentAsString(), out var num))
-                                            {
-                                                item.Item.IndexNumberEnd = Math.Max(num, item.Item.IndexNumberEnd ?? num);
-                                            }
+                    name.Append(" / ").Append(additionalEpisode.Item.Name);
+                    overview.Append(" / ").Append(additionalEpisode.Item.Overview);
 
-                                            break;
-                                        }
-
-                                    case "biography":
-                                    case "plot":
-                                    case "review":
-                                        overview.Append(" / ").Append(reader.ReadElementContentAsString());
-                                        break;
-                                }
-                            }
-
-                            reader.Read();
-                        }
+                    if (additionalEpisode.Item.IndexNumber != null)
+                    {
+                        item.Item.IndexNumberEnd = Math.Max((int)additionalEpisode.Item.IndexNumber, item.Item.IndexNumberEnd ?? (int)additionalEpisode.Item.IndexNumber);
                     }
                 }
 
@@ -198,6 +154,34 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 default:
                     base.FetchDataFromXmlNode(reader, itemResult);
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Reads the episode details from the given xml and saves the result in the provided result item.
+        /// </summary>
+        private void ReadEpisodeDetailsFromXml(MetadataResult<Episode> item, string xml, XmlReaderSettings settings, CancellationToken cancellationToken)
+        {
+            using (var stringReader = new StringReader(xml))
+            using (var reader = XmlReader.Create(stringReader, settings))
+            {
+                reader.MoveToContent();
+                reader.Read();
+
+                // Loop through each element
+                while (!reader.EOF && reader.ReadState == ReadState.Interactive)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        FetchDataFromXmlNode(reader, item);
+                    }
+                    else
+                    {
+                        reader.Read();
+                    }
+                }
             }
         }
     }

--- a/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/EpisodeNfoParser.cs
@@ -62,9 +62,10 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 ReadEpisodeDetailsFromXml(item, xml, settings, cancellationToken);
 
                 // Extract the last episode number from nfo
-                // Retrieves all additional episodedetails blocks from the rest of the nfo and concatenates the name and overview tags with the first episode
+                // Retrieves all additional episodedetails blocks from the rest of the nfo and concatenates the name, originalTitle and overview tags with the first episode
                 // This is needed because XBMC metadata uses multiple episodedetails blocks instead of episodenumberend tag
                 var name = new StringBuilder(item.Item.Name);
+                var originalTitle = new StringBuilder(item.Item.OriginalTitle);
                 var overview = new StringBuilder(item.Item.Overview);
                 while ((index = xmlFile.IndexOf(srch, StringComparison.OrdinalIgnoreCase)) != -1)
                 {
@@ -89,6 +90,11 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         overview.Append(" / ").Append(additionalEpisode.Item.Overview);
                     }
 
+                    if (!string.IsNullOrEmpty(additionalEpisode.Item.OriginalTitle))
+                    {
+                        originalTitle.Append(" / ").Append(additionalEpisode.Item.OriginalTitle);
+                    }
+
                     if (additionalEpisode.Item.IndexNumber != null)
                     {
                         item.Item.IndexNumberEnd = Math.Max((int)additionalEpisode.Item.IndexNumber, item.Item.IndexNumberEnd ?? (int)additionalEpisode.Item.IndexNumber);
@@ -96,6 +102,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 }
 
                 item.Item.Name = name.ToString();
+                item.Item.OriginalTitle = originalTitle.ToString();
                 item.Item.Overview = overview.ToString();
             }
             catch (XmlException)

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/EpisodeNfoProviderTests.cs
@@ -124,6 +124,30 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
         }
 
         [Fact]
+        public void Fetch_Valid_MultiEpisode_With_Missing_Tags_Success()
+        {
+            var result = new MetadataResult<Episode>()
+            {
+                Item = new Episode()
+            };
+
+            _parser.Fetch(result, "Test Data/Stargate Atlantis S01E01-E04.nfo", CancellationToken.None);
+
+            var item = result.Item;
+            // <title> provided for episode 1, 3 and 4
+            Assert.Equal("Rising / Hide and Seek / Thirty-Eight Minutes", item.Name);
+            // <originaltitle> provided for all episodes
+            Assert.Equal("Rising (1) / Rising (2) / Hide and Seek / Thirty-Eight Minutes", item.OriginalTitle);
+            Assert.Equal(1, item.IndexNumber);
+            Assert.Equal(4, item.IndexNumberEnd);
+            Assert.Equal(1, item.ParentIndexNumber);
+            // <plot> only provided for episode 1
+            Assert.Equal("A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy.", item.Overview);
+            Assert.Equal(new DateTime(2004, 7, 16), item.PremiereDate);
+            Assert.Equal(2004, item.ProductionYear);
+        }
+
+        [Fact]
         public void Parse_GivenFileWithThumbWithoutAspect_Success()
         {
             var result = new MetadataResult<Episode>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Rising.nfo
@@ -7,6 +7,18 @@
   <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25333.jpg</thumb>
   <watched>false</watched>
   <rating>8.0</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
 </episodedetails>
 <episodedetails>
   <title>Rising (2)</title>
@@ -17,4 +29,16 @@
   <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25334.jpg</thumb>
   <watched>false</watched>
   <rating>7.9</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
 </episodedetails>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Stargate Atlantis S01E01-E04.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Stargate Atlantis S01E01-E04.nfo
@@ -1,0 +1,89 @@
+<episodedetails>
+  <title>Rising</title>
+  <originaltitle>Rising (1)</originaltitle>
+  <season>1</season>
+  <episode>1</episode>
+  <aired>2004-07-16</aired>
+  <plot>A new Stargate team embarks on a dangerous mission to a distant galaxy, where they discover a mythical lost city -- and a deadly new enemy.</plot>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25333.jpg</thumb>
+  <watched>false</watched>
+  <rating>8.0</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
+</episodedetails>
+<episodedetails>
+  <originaltitle>Rising (2)</originaltitle>
+  <season>1</season>
+  <episode>2</episode>
+  <aired>2004-07-16</aired>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25334.jpg</thumb>
+  <watched>false</watched>
+  <rating>7.9</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
+</episodedetails>
+<episodedetails>
+  <title>Hide and Seek</title>
+  <originaltitle>Hide and Seek</originaltitle>
+  <season>1</season>
+  <episode>3</episode>
+  <aired>2004-07-23</aired>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25335.jpg</thumb>
+  <watched>false</watched>
+  <rating>7.5</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
+</episodedetails>
+<episodedetails>
+  <title>Thirty-Eight Minutes</title>
+  <originaltitle>Thirty-Eight Minutes</originaltitle>
+  <season>1</season>
+  <episode>4</episode>
+  <aired>2004-07-23</aired>
+  <thumb>https://artworks.thetvdb.com/banners/episodes/70851/25336.jpg</thumb>
+  <watched>false</watched>
+  <rating>7.5</rating>
+  <actor>
+    <name>Joe Flanigan</name>
+    <role>John Sheppard</role>
+    <order>0</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/5AA1ORKIsnMakT6fCVy3JKlzMs6.jpg</thumb>
+  </actor>
+  <actor>
+    <name>David Hewlett</name>
+    <role>Rodney McKay</role>
+    <order>1</order>
+    <thumb>https://image.tmdb.org/t/p/w300_and_h450_bestv2/hUcYyssAPCqnZ4GjolhOWXHTWSa.jpg</thumb>
+  </actor>
+</episodedetails>
+


### PR DESCRIPTION
Fixing the `EpisodeNfoParser` so it no longer picks up fields of sub elements (like actor/name) and appending it to the title of the combined Episode object, if a xbmc style multi episode nfo file (multiple `<episodedetails>` blocks) is parsed.
The old implementation iterated over all elements searching for specific tag names without checking the level or parent element.

I didn't test the code in a productive environment but simply extended the test file and fixed the code so the test passes again.

**Changes**
- replaced the current parser implementation that was used for all blocks but the first with the standard episode xml parser
- extracted the parser code to it's own method to prevent code duplication
- extended the test file to include actors so this case is covered by a test in the future

**Issues**
Fixes #12243