### PR TITLE
Add check for ProviderIds to prevent '=' from appearing in keys, also support '=' in the values.

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -1046,9 +1046,10 @@ namespace Emby.Server.Implementations.Data
             foreach (var part in value.SpanSplit('|'))
             {
                 var providerDelimiterIndex = part.IndexOf('=');
-                if (providerDelimiterIndex != -1 && providerDelimiterIndex == part.LastIndexOf('='))
+                // Don't let empty values through
+                if (providerDelimiterIndex != -1 && part.Length != providerDelimiterIndex + 1)
                 {
-                    item.SetProviderId(part.Slice(0, providerDelimiterIndex).ToString(), part.Slice(providerDelimiterIndex + 1).ToString());
+                    item.SetProviderId(part[..providerDelimiterIndex].ToString(), part[(providerDelimiterIndex + 1)..].ToString());
                 }
             }
         }

--- a/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Entities/ProviderIdsExtensionsTests.cs
@@ -141,7 +141,7 @@ namespace Jellyfin.Model.Tests.Entities
         public void SetProviderId_Null_Remove()
         {
             var provider = new ProviderIdsExtensionsTestsObject();
-            provider.SetProviderId(MetadataProvider.Imdb, null!);
+            Assert.Throws<ArgumentNullException>(() => provider.SetProviderId(MetadataProvider.Imdb, null!));
             Assert.Empty(provider.ProviderIds);
         }
 
@@ -150,8 +150,8 @@ namespace Jellyfin.Model.Tests.Entities
         {
             var provider = new ProviderIdsExtensionsTestsObject();
             provider.ProviderIds[MetadataProvider.Imdb.ToString()] = ExampleImdbId;
-            provider.SetProviderId(MetadataProvider.Imdb, string.Empty);
-            Assert.Empty(provider.ProviderIds);
+            Assert.Throws<ArgumentException>(() => provider.SetProviderId(MetadataProvider.Imdb, string.Empty));
+            Assert.Single(provider.ProviderIds);
         }
 
         [Fact]
@@ -182,8 +182,18 @@ namespace Jellyfin.Model.Tests.Entities
                 ProviderIds = null!
             };
 
-            nullProvider.SetProviderId(MetadataProvider.Imdb, string.Empty);
+            Assert.Throws<ArgumentException>(() => nullProvider.SetProviderId(MetadataProvider.Imdb, string.Empty));
             Assert.Null(nullProvider.ProviderIds);
+        }
+
+        [Fact]
+        public void RemoveProviderId_Null_Remove()
+        {
+            var provider = new ProviderIdsExtensionsTestsObject();
+
+            provider.ProviderIds[MetadataProvider.Imdb.ToString()] = ExampleImdbId;
+            provider.RemoveProviderId(MetadataProvider.Imdb);
+            Assert.Empty(provider.ProviderIds);
         }
 
         private sealed class ProviderIdsExtensionsTestsObject : IHasProviderIds


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

So this prevents the deserialization code from breaking if there are `=` characters in the key or value of the provider id.
Also adds some documentation to the functions themselves.

This also add a set of `Remove*` functions and made the input checking stricter for the `Set*` functions.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Reference: https://github.com/ShokoAnime/Shokofin/issues/62
Custom ProviderIds were disappearing on a normal (non "replace") scan due to them not being deserialized (quietly)


When this is in, I'll manually backport it to the 10.9 branch but without the breaking behavior changes.
