### PR TITLE
Fix localization of audio title

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -5694,13 +5694,17 @@ AND Type = @InternalPersonType)");
 
             item.IsHearingImpaired = reader.TryGetBoolean(43, out var result) && result;
 
-            if (item.Type == MediaStreamType.Subtitle)
+            if (item.Type is MediaStreamType.Audio or MediaStreamType.Subtitle)
             {
-                item.LocalizedUndefined = _localization.GetLocalizedString("Undefined");
                 item.LocalizedDefault = _localization.GetLocalizedString("Default");
-                item.LocalizedForced = _localization.GetLocalizedString("Forced");
                 item.LocalizedExternal = _localization.GetLocalizedString("External");
-                item.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
+
+                if (item.Type is MediaStreamType.Subtitle)
+                {
+                    item.LocalizedUndefined = _localization.GetLocalizedString("Undefined");
+                    item.LocalizedForced = _localization.GetLocalizedString("Forced");
+                    item.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
+                }
             }
 
             return item;

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -721,6 +721,8 @@ namespace MediaBrowser.MediaEncoding.Probing
             if (streamInfo.CodecType == CodecType.Audio)
             {
                 stream.Type = MediaStreamType.Audio;
+                stream.LocalizedDefault = _localization.GetLocalizedString("Default");
+                stream.LocalizedExternal = _localization.GetLocalizedString("External");
 
                 stream.Channels = streamInfo.Channels;
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
     public class ProbeResultNormalizerTests
     {
         private readonly JsonSerializerOptions _jsonOptions;
-        private readonly ProbeResultNormalizer _probeResultNormalizer = new ProbeResultNormalizer(new NullLogger<EncoderValidatorTests>(), null);
+        private readonly ProbeResultNormalizer _probeResultNormalizer = new ProbeResultNormalizer(new NullLogger<EncoderValidatorTests>(), new Mock<ILocalizationManager>().Object);
 
         public ProbeResultNormalizerTests()
         {


### PR DESCRIPTION
Maybe passing ILocalizationManager into the ctor of MediaStream is a better solution for master?

Fixes #12276
