### PR TITLE
Move external url listing to provider for plugin use

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -664,7 +664,8 @@ namespace Emby.Server.Implementations
                 GetExports<IMetadataService>(),
                 GetExports<IMetadataProvider>(),
                 GetExports<IMetadataSaver>(),
-                GetExports<IExternalId>());
+                GetExports<IExternalId>(),
+                GetExports<IExternalUrlProvider>());
 
             Resolve<IMediaSourceManager>().AddParts(GetExports<IMediaSourceProvider>());
         }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2497,11 +2497,6 @@ namespace MediaBrowser.Controller.Entities
             return new[] { Id };
         }
 
-        public virtual List<ExternalUrl> GetRelatedUrls()
-        {
-            return new List<ExternalUrl>();
-        }
-
         public virtual double? GetRefreshProgress()
         {
             return null;

--- a/MediaBrowser.Controller/Entities/Movies/Movie.cs
+++ b/MediaBrowser.Controller/Entities/Movies/Movie.cs
@@ -121,23 +121,5 @@ namespace MediaBrowser.Controller.Entities.Movies
 
             return hasChanges;
         }
-
-        /// <inheritdoc />
-        public override List<ExternalUrl> GetRelatedUrls()
-        {
-            var list = base.GetRelatedUrls();
-
-            var imdbId = this.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdbId))
-            {
-                list.Add(new ExternalUrl
-                {
-                    Name = "Trakt",
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://trakt.tv/movies/{0}", imdbId)
-                });
-            }
-
-            return list;
-        }
     }
 }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -344,22 +344,5 @@ namespace MediaBrowser.Controller.Entities.TV
 
             return hasChanges;
         }
-
-        public override List<ExternalUrl> GetRelatedUrls()
-        {
-            var list = base.GetRelatedUrls();
-
-            var imdbId = this.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdbId))
-            {
-                list.Add(new ExternalUrl
-                {
-                    Name = "Trakt",
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://trakt.tv/episodes/{0}", imdbId)
-                });
-            }
-
-            return list;
-        }
     }
 }

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -482,22 +482,5 @@ namespace MediaBrowser.Controller.Entities.TV
 
             return hasChanges;
         }
-
-        public override List<ExternalUrl> GetRelatedUrls()
-        {
-            var list = base.GetRelatedUrls();
-
-            var imdbId = this.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdbId))
-            {
-                list.Add(new ExternalUrl
-                {
-                    Name = "Trakt",
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://trakt.tv/shows/{0}", imdbId)
-                });
-            }
-
-            return list;
-        }
     }
 }

--- a/MediaBrowser.Controller/Entities/Trailer.cs
+++ b/MediaBrowser.Controller/Entities/Trailer.cs
@@ -80,22 +80,5 @@ namespace MediaBrowser.Controller.Entities
 
             return hasChanges;
         }
-
-        public override List<ExternalUrl> GetRelatedUrls()
-        {
-            var list = base.GetRelatedUrls();
-
-            var imdbId = this.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdbId))
-            {
-                list.Add(new ExternalUrl
-                {
-                    Name = "Trakt",
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://trakt.tv/movies/{0}", imdbId)
-                });
-            }
-
-            return list;
-        }
     }
 }

--- a/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvProgram.cs
@@ -254,25 +254,5 @@ namespace MediaBrowser.Controller.LiveTv
 
             return name;
         }
-
-        public override List<ExternalUrl> GetRelatedUrls()
-        {
-            var list = base.GetRelatedUrls();
-
-            var imdbId = this.GetProviderId(MetadataProvider.Imdb);
-            if (!string.IsNullOrEmpty(imdbId))
-            {
-                if (IsMovie)
-                {
-                    list.Add(new ExternalUrl
-                    {
-                        Name = "Trakt",
-                        Url = string.Format(CultureInfo.InvariantCulture, "https://trakt.tv/movies/{0}", imdbId)
-                    });
-                }
-            }
-
-            return list;
-        }
     }
 }

--- a/MediaBrowser.Controller/Providers/IExternalId.cs
+++ b/MediaBrowser.Controller/Providers/IExternalId.cs
@@ -1,3 +1,4 @@
+using System;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 
@@ -33,6 +34,7 @@ namespace MediaBrowser.Controller.Providers
         /// <summary>
         /// Gets the URL format string for this id.
         /// </summary>
+        [Obsolete("Obsolete in 10.10, to be removed in 10.11")]
         string? UrlFormatString { get; }
 
         /// <summary>

--- a/MediaBrowser.Controller/Providers/IExternalUrlProvider.cs
+++ b/MediaBrowser.Controller/Providers/IExternalUrlProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using MediaBrowser.Controller.Entities;
+
+namespace MediaBrowser.Controller.Providers;
+
+/// <summary>
+/// Interface to include related urls for an item.
+/// </summary>
+public interface IExternalUrlProvider
+{
+    /// <summary>
+    /// Gets the external service name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Get the list of external urls.
+    /// </summary>
+    /// <param name="item">The item to get external urls for.</param>
+    /// <returns>The list of external urls.</returns>
+    IEnumerable<string> GetExternalUrls(BaseItem item);
+}

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -99,12 +99,14 @@ namespace MediaBrowser.Controller.Providers
         /// <param name="metadataProviders">Metadata providers to use.</param>
         /// <param name="metadataSavers">Metadata savers to use.</param>
         /// <param name="externalIds">External IDs to use.</param>
+        /// <param name="externalUrlProviders">The list of external url providers.</param>
         void AddParts(
             IEnumerable<IImageProvider> imageProviders,
             IEnumerable<IMetadataService> metadataServices,
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
-            IEnumerable<IExternalId> externalIds);
+            IEnumerable<IExternalId> externalIds,
+            IEnumerable<IExternalUrlProvider> externalUrlProviders);
 
         /// <summary>
         /// Gets the available remote images.

--- a/MediaBrowser.Model/Providers/ExternalIdInfo.cs
+++ b/MediaBrowser.Model/Providers/ExternalIdInfo.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediaBrowser.Model.Providers
 {
     /// <summary>
@@ -17,7 +19,9 @@ namespace MediaBrowser.Model.Providers
             Name = name;
             Key = key;
             Type = type;
+#pragma warning disable CS0618 // Type or member is obsolete - Remove 10.11
             UrlFormatString = urlFormatString;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -46,6 +50,7 @@ namespace MediaBrowser.Model.Providers
         /// <summary>
         /// Gets or sets the URL format string.
         /// </summary>
+        [Obsolete("Obsolete in 10.10, to be removed in 10.11")]
         public string? UrlFormatString { get; set; }
     }
 }

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -585,15 +585,17 @@ namespace Jellyfin.Providers.Tests.Manager
             IEnumerable<IMetadataService>? metadataServices = null,
             IEnumerable<IMetadataProvider>? metadataProviders = null,
             IEnumerable<IMetadataSaver>? metadataSavers = null,
-            IEnumerable<IExternalId>? externalIds = null)
+            IEnumerable<IExternalId>? externalIds = null,
+            IEnumerable<IExternalUrlProvider>? externalUrlProviders = null)
         {
             imageProviders ??= Array.Empty<IImageProvider>();
             metadataServices ??= Array.Empty<IMetadataService>();
             metadataProviders ??= Array.Empty<IMetadataProvider>();
             metadataSavers ??= Array.Empty<IMetadataSaver>();
             externalIds ??= Array.Empty<IExternalId>();
+            externalUrlProviders ??= Array.Empty<IExternalUrlProvider>();
 
-            providerManager.AddParts(imageProviders, metadataServices, metadataProviders, metadataSavers, externalIds);
+            providerManager.AddParts(imageProviders, metadataServices, metadataProviders, metadataSavers, externalIds, externalUrlProviders);
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Moves the `GetRelatedUrls()` out from `BaseItem` to a dedicated provider so plugins can add dynamic urls.

See linked plugin PRs for sample implementations.