### PR TITLE
Fix ArgumentNullException while scanning music

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1319,23 +1319,38 @@ namespace MediaBrowser.MediaEncoding.Probing
             // These support multiple values, but for now we only store the first.
             var mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Album Artist Id"))
                 ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_ALBUMARTISTID"));
-            audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, mb);
+            if (!string.IsNullOrEmpty(mb))
+            {
+                audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, mb);
+            }
 
             mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Artist Id"))
                 ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_ARTISTID"));
-            audio.SetProviderId(MetadataProvider.MusicBrainzArtist, mb);
+            if (!string.IsNullOrEmpty(mb))
+            {
+                audio.SetProviderId(MetadataProvider.MusicBrainzArtist, mb);
+            }
 
             mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Album Id"))
                 ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_ALBUMID"));
-            audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, mb);
+            if (!string.IsNullOrEmpty(mb))
+            {
+                audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, mb);
+            }
 
             mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Release Group Id"))
                  ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_RELEASEGROUPID"));
-            audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, mb);
+            if (!string.IsNullOrEmpty(mb))
+            {
+                audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, mb);
+            }
 
             mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Release Track Id"))
                  ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_RELEASETRACKID"));
-            audio.SetProviderId(MetadataProvider.MusicBrainzTrack, mb);
+            if (!string.IsNullOrEmpty(mb))
+            {
+                audio.SetProviderId(MetadataProvider.MusicBrainzTrack, mb);
+            }
         }
 
         private string GetMultipleMusicBrainzId(string value)


### PR DESCRIPTION
```
[2024-07-16 18:00:20.517 +02:00] [ERR] [65] MediaBrowser.Providers.Music.AudioMetadataService: Error in "Probe Provider"
System.ArgumentNullException: Value cannot be null. (Parameter 'value')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.SetProviderId(IHasProviderIds instance, String name, String value) in /home/loma/dev/jellyfin/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs:line 121
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.SetProviderId(IHasProviderIds instance, MetadataProvider provider, String value) in /home/loma/dev/jellyfin/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs:line 151
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.SetAudioInfoFromTags(MediaInfo audio, Dictionary`2 tags) in /home/loma/dev/jellyfin/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs:line 1322
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.GetMediaInfo(InternalMediaInfoResult data, Nullable`1 videoType, Boolean isAudio, String path, MediaProtocol protocol) in /home/loma/dev/jellyfin/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs:line 199
```
Fixes a regression from https://github.com/jellyfin/jellyfin/pull/12274