### PR TITLE
Fix (another) ArgumentNullException while scanning music

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -325,22 +325,26 @@ namespace MediaBrowser.Providers.MediaInfo
                 audio.NormalizationGain = (float)tags.ReplayGainTrackGain;
             }
 
-            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
+            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
+                && !string.IsNullOrEmpty(tags.MusicBrainzArtistId))
             {
                 audio.SetProviderId(MetadataProvider.MusicBrainzArtist, tags.MusicBrainzArtistId);
             }
 
-            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbumArtist, out _))
+            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbumArtist, out _))
+                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseArtistId))
             {
                 audio.SetProviderId(MetadataProvider.MusicBrainzAlbumArtist, tags.MusicBrainzReleaseArtistId);
             }
 
-            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbum, out _))
+            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzAlbum, out _))
+                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseId))
             {
                 audio.SetProviderId(MetadataProvider.MusicBrainzAlbum, tags.MusicBrainzReleaseId);
             }
 
-            if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzReleaseGroup, out _))
+            if ((options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzReleaseGroup, out _))
+                && !string.IsNullOrEmpty(tags.MusicBrainzReleaseGroupId))
             {
                 audio.SetProviderId(MetadataProvider.MusicBrainzReleaseGroup, tags.MusicBrainzReleaseGroupId);
             }


### PR DESCRIPTION
```
[2024-07-17 14:31:18.202 +02:00] [ERR] [19] MediaBrowser.Providers.Music.AudioMetadataService: Error in "Probe Provider"
System.ArgumentNullException: Value cannot be null. (Parameter 'value')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.SetProviderId(IHasProviderIds instance, String name, String value) in /home/loma/dev/jellyfin/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs:line 121
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.SetProviderId(IHasProviderIds instance, MetadataProvider provider, String value) in /home/loma/dev/jellyfin/MediaBrowser.Model/Entities/ProviderIdsExtensions.cs:line 151
   at MediaBrowser.Providers.MediaInfo.AudioFileProber.FetchDataFromTags(Audio audio, MediaInfo mediaInfo, MetadataRefreshOptions options, Boolean tryExtractEmbeddedLyrics) in /home/loma/dev/jellyfin/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs:line 330
   at MediaBrowser.Providers.MediaInfo.AudioFileProber.FetchAsync(Audio audio, MediaInfo mediaInfo, MetadataRefreshOptions options, CancellationToken cancellationToken) in /home/loma/dev/jellyfin/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs:line 139
   at MediaBrowser.Providers.MediaInfo.AudioFileProber.Probe[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken) in /home/loma/dev/jellyfin/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs:line 105
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken) in /home/loma/dev/jellyfin/MediaBrowser.Providers/Manager/MetadataService.cs:line 800
```
