### PR TITLE
Reverse textless images above English images

### DIFF
--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -24,27 +24,24 @@ namespace MediaBrowser.Model.Extensions
                 requestedLanguage = "en";
             }
 
+            var isRequestedLanguageEn = string.Equals(requestedLanguage, "en", StringComparison.OrdinalIgnoreCase);
+
             return remoteImageInfos.OrderByDescending(i =>
                 {
-                    // Image priority ordering:
-                    //  - Images that match the requested language
-                    //  - Images with no language
-                    //  - TODO: Images that match the original language
-                    //  - Images in English
-                    //  - Images that don't match the requested language
-
                     if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return 4;
-                    }
-
-                    if (string.IsNullOrEmpty(i.Language))
                     {
                         return 3;
                     }
 
-                    if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+                    if (string.IsNullOrEmpty(i.Language))
                     {
+                        // Assume empty image language is likely to be English.
+                        return isRequestedLanguageEn ? 3 : 2;
+                    }
+
+                    if (!isRequestedLanguageEn && string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Prioritize English over non-requested languages.
                         return 2;
                     }
 


### PR DESCRIPTION
In version 10.8.13, when searching for images, a poster in the set language is searched for first. If that is not found, it falls back to the English version. 

![afbeelding](https://github.com/user-attachments/assets/bf718e62-7700-4649-8837-bd193dec3400)

In newer versions, preference is now given to textless images. This more often results in incorrect images and, in my opinion, compromises quality.

![afbeelding](https://github.com/user-attachments/assets/536f60c9-31b2-46a6-9c4a-0c80709e3970)

Even when the preferred language is set to English, it chooses the textless poster instead of the English version.

Examples:
Non-text: https://image.tmdb.org/t/p/original/knVvNKM5JGJsMFGDAIJ3F3TF8iX.jpg
English: https://image.tmdb.org/t/p/original/AewKpiZ76mLTnr8dx9skROzMX7P.jpg

English: https://image.tmdb.org/t/p/original/zP4CK9O70P8GDilfTkPm4lrmaks.jpg
non-text: https://image.tmdb.org/t/p/original/jHHpEnAGdDAnbJI2o4o4IYHldGL.jpg

I understand that this is a subjective topic. In some countries, dubbing is more standard, while in other countries, subtitles are preferred. However, the local version is often available.

English is a global language, and it seems more logical to fall back on it rather than on textless images. These images are often unclear, making it difficult to see which series or film it is. And that seems to defeat the purpose of a poster. (And manually changing each poster to the English version every time is not something I am keen on either.)

The best solution would be a fallback image language option. I don't have enough experience to create this myself, and I personally find English more important than textless images. Therefore, I propose this rollback. Full credit goes to whoever wrote this code before this [PR](https://github.com/jellyfin/jellyfin/commit/144d58a21ec782d31cca2b37f6119c1d12ed81e5).

_I have researched whether this topic has been addressed before. I couldn't find anything. My apologies if this is incorrect and it is indeed a deliberate choice. - Feedback is also always welcome._
