### PR TITLE
Update issue report.yml to use 10.9.8 version

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue report.yml
+++ b/.github/ISSUE_TEMPLATE/issue report.yml
@@ -86,7 +86,7 @@ body:
       label: Jellyfin Server version
       description: What version of Jellyfin are you using?
       options:
-        - 10.9.7
+        - 10.9.8
         - Master
         - Unstable
         - Older*

--- a/.github/ISSUE_TEMPLATE/issue report.yml
+++ b/.github/ISSUE_TEMPLATE/issue report.yml
@@ -86,7 +86,7 @@ body:
       label: Jellyfin Server version
       description: What version of Jellyfin are you using?
       options:
-        - 10.9.8
+        - 10.9.8+
         - Master
         - Unstable
         - Older*


### PR DESCRIPTION
Jellyfin has updated to 10.9.8. This change updates the issue template to update the server version selector from 10.9.7 to 10.9.8.

**Changes**
The version selector for server has been updated to 10.9.8.

**Issues**
N/A