### PR TITLE
Display DOVI title in DisplayTitle when available

### DIFF
--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -196,7 +196,7 @@ namespace MediaBrowser.Model.Entities
                         || dvProfile == 8
                         || dvProfile == 9))
                 {
-                    var title = "DV Profile " + dvProfile;
+                    var title = "Dolby Vision Profile " + dvProfile;
 
                     if (dvBlCompatId > 0)
                     {
@@ -208,6 +208,7 @@ namespace MediaBrowser.Model.Entities
                         1 => title + " (HDR10)",
                         2 => title + " (SDR)",
                         4 => title + " (HLG)",
+                        6 => title + " (HDR10)", // Technically means Blu-ray, but practically always HDR10
                         _ => title
                     };
                 }
@@ -330,7 +331,11 @@ namespace MediaBrowser.Model.Entities
                             attributes.Add(Codec.ToUpperInvariant());
                         }
 
-                        if (VideoRange != VideoRange.Unknown)
+                        if (VideoDoViTitle is not null)
+                        {
+                            attributes.Add(VideoDoViTitle);
+                        }
+                        else if (VideoRange != VideoRange.Unknown)
                         {
                             attributes.Add(VideoRange.ToString());
                         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

This displays the Dolby Vision Profile when available instead of just "HDR" in the display title.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Use full name "Dolby Vision" in `VideoDoViTitle` as we are using full name in other fields like the audio title. 
- Add fallback description for compat id 6
- Prefer `VideoDoViTitle` in display title when available, otherwise keep using `VideoRange`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

The feature request: https://features.jellyfin.org/posts/2314/add-dolby-vision-tag-whenever-applicable