### PR TITLE
Use subtitle cache when burning-in subs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -187,6 +187,7 @@
  - [HonestlyWhoKnows](https://github.com/honestlywhoknows)
  - [TheMelmacian](https://github.com/TheMelmacian)
  - [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
+ - [jaina heartles](https://github.com/heartles)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1525,13 +1525,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                     setPtsParam);
             }
 
-            var mediaPath = state.MediaPath ?? string.Empty;
+            var subtitlePath = _subtitleEncoder.GetSubtitleFilePath(
+                    state.SubtitleStream,
+                    state.MediaSource,
+                    CancellationToken.None).GetAwaiter().GetResult();
 
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "subtitles=f='{0}':si={1}{2}{3}{4}{5}",
-                _mediaEncoder.EscapeSubtitleFilterPath(mediaPath),
-                state.InternalSubtitleStreamOffset.ToString(CultureInfo.InvariantCulture),
+                "subtitles=f='{0}'{1}{2}{3}{4}",
+                _mediaEncoder.EscapeSubtitleFilterPath(subtitlePath),
                 alphaParam,
                 sub2videoParam,
                 fontParam,

--- a/MediaBrowser.Controller/MediaEncoding/ISubtitleEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/ISubtitleEncoder.cs
@@ -44,5 +44,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>System.String.</returns>
         Task<string> GetSubtitleFileCharacterSet(MediaStream subtitleStream, string language, MediaSourceInfo mediaSource, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the path to a subtitle file.
+        /// </summary>
+        /// <param name="subtitleStream">The subtitle stream.</param>
+        /// <param name="mediaSource">The media source.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>System.String.</returns>
+        Task<string> GetSubtitleFilePath(MediaStream subtitleStream, MediaSourceInfo mediaSource, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -902,6 +902,12 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
+        public async Task<string> GetSubtitleFilePath(MediaStream subtitleStream, MediaSourceInfo mediaSource, CancellationToken cancellationToken)
+        {
+            var info = await GetReadableFile(mediaSource, subtitleStream, cancellationToken);
+            return info.Path;
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

The server does not currently use the subtitle cache (the one used for serving subtitles to clients to render) when burning-in subtitles at transcode time for clients that do not support client-side rendering. This can cause playback to stall when trying to play large files from slow media sources such as HDDs. 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR adds a method to `MediaBrowser.Controller.MediaEncoding.ISubtitleEncoder` to get the path of the extracted subtitle. `MediaBrowser.Controller.MediaEncoding.EncodingHelper` is modified to call this method instead of getting the subtitle directly from the media file itself.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
This provides a partial solution to #11938, but the first attempt to play a file might still time out due to not already having the subtitles cached. This can be mitigated with a plugin like [Subtitle Extract](https://github.com/jellyfin/jellyfin-plugin-subtitleextract).