### PR TITLE
Update the default repository URL for the StudioImages plugin

### DIFF
--- a/MediaBrowser.Providers/Plugins/StudioImages/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/StudioImages/Plugin.cs
@@ -18,7 +18,7 @@ namespace MediaBrowser.Providers.Plugins.StudioImages
         /// <summary>
         /// Artwork repository URL.
         /// </summary>
-        public const string DefaultServer = "https://raw.github.com/jellyfin/emby-artwork/master/studios";
+        public const string DefaultServer = "https://raw.githubusercontent.com/jellyfin/emby-artwork/master/studios";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Plugin"/> class.

--- a/MediaBrowser.Providers/Plugins/StudioImages/StudiosImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/StudioImages/StudiosImageProvider.cs
@@ -53,10 +53,7 @@ namespace MediaBrowser.Providers.Plugins.StudioImages
         /// <inheritdoc />
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
         {
-            return new ImageType[]
-            {
-                ImageType.Thumb
-            };
+            return [ImageType.Thumb];
         }
 
         /// <inheritdoc />
@@ -72,13 +69,10 @@ namespace MediaBrowser.Providers.Plugins.StudioImages
 
             if (imageInfo is null)
             {
-                return Enumerable.Empty<RemoteImageInfo>();
+                return [];
             }
 
-            return new RemoteImageInfo[]
-            {
-                imageInfo
-            };
+            return [imageInfo];
         }
 
         private RemoteImageInfo GetImage(BaseItem item, string filename, ImageType type, string remoteFilename)


### PR DESCRIPTION
**Changes**
Point the default repository server to the `raw.githubusercontent.com` domain instead of the old `raw.github.com` domain.

**Issues**
Fixes #10538
