### PR TITLE
Add non-standard multi-value audio tag support

### DIFF
--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -7,6 +7,8 @@ namespace MediaBrowser.Model.Configuration
 {
     public class LibraryOptions
     {
+        private static readonly char[] _defaultTagDelimiters = ['/', '|', ';', '\\'];
+
         public LibraryOptions()
         {
             TypeOptions = Array.Empty<TypeOptions>();
@@ -27,6 +29,11 @@ namespace MediaBrowser.Model.Configuration
             PathInfos = Array.Empty<MediaPathInfo>();
             EnableAutomaticSeriesGrouping = true;
             SeasonZeroDisplayName = "Specials";
+
+            PreferNonstandardArtistsTag = false;
+            UseCustomTagDelimiters = false;
+            CustomTagDelimiters = _defaultTagDelimiters;
+            DelimiterWhitelist = Array.Empty<string>();
         }
 
         public bool Enabled { get; set; } = true;
@@ -102,6 +109,17 @@ namespace MediaBrowser.Model.Configuration
         public string[] DisabledLyricFetchers { get; set; }
 
         public string[] LyricFetcherOrder { get; set; }
+
+        [DefaultValue(false)]
+        public bool PreferNonstandardArtistsTag { get; set; }
+
+        [DefaultValue(false)]
+        public bool UseCustomTagDelimiters { get; set; }
+
+        [DefaultValue(typeof(LibraryOptions), nameof(_defaultTagDelimiters))]
+        public char[] CustomTagDelimiters { get; set; }
+
+        public string[] DelimiterWhitelist { get; set; }
 
         public bool AutomaticallyAddToCollection { get; set; }
 


### PR DESCRIPTION
This adds support for widely used non-standard methods of recording multiple values in audio tags. Notably:

- The non-standard ARTISTS tag used by Kodi and Picard
- The use of a custom character (e.g., `;`) as a delimiter for tag values.

A user-customizable whitelist to exclude certain items from tag splitting is also added, as some artists may have special characters in their names.

Enabling this feature is a per-library setting and is disabled by default.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Adds customizable tag splitting in library options

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #11871
Fixes #12256
Fixes #10730
Fixes #10794
Fixes #11411
