### PR TITLE
Fix Issue #12145: Audio Normalization Scheduled Task temp file race condition causing failure

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -116,7 +116,6 @@ public partial class AudioNormalizationTask : IScheduledTask
                 {
                     a.LUFS = await CalculateLUFSAsync(
                         string.Format(CultureInfo.InvariantCulture, "-f concat -safe 0 -i \"{0}\"", tempFile),
-                        true,
                         cancellationToken).ConfigureAwait(false);
                 }
                 finally
@@ -143,7 +142,7 @@ public partial class AudioNormalizationTask : IScheduledTask
                     continue;
                 }
 
-                t.LUFS = await CalculateLUFSAsync(string.Format(CultureInfo.InvariantCulture, "-i \"{0}\"", t.Path.Replace("\"", "\\\"", StringComparison.Ordinal)), false, cancellationToken);
+                t.LUFS = await CalculateLUFSAsync(string.Format(CultureInfo.InvariantCulture, "-i \"{0}\"", t.Path.Replace("\"", "\\\"", StringComparison.Ordinal)), cancellationToken);
             }
 
             _itemRepository.SaveItems(tracks, cancellationToken);
@@ -163,7 +162,7 @@ public partial class AudioNormalizationTask : IScheduledTask
         ];
     }
 
-    private async Task<float?> CalculateLUFSAsync(string inputArgs, bool waitForProcessToFinish, CancellationToken cancellationToken)
+    private async Task<float?> CalculateLUFSAsync(string inputArgs, CancellationToken cancellationToken)
     {
         var args = $"-hide_banner {inputArgs} -af ebur128=framelog=verbose -f null -";
 
@@ -196,12 +195,8 @@ public partial class AudioNormalizationTask : IScheduledTask
 
                 if (match.Success)
                 {
-                    if (waitForProcessToFinish)
-                    {
                         await process.WaitForExitAsync(cancellationToken);
-                    }
-
-                    return float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
+                        return float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
                 }
             }
 

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -195,6 +195,7 @@ public partial class AudioNormalizationTask : IScheduledTask
 
                 if (match.Success)
                 {
+                    await process.WaitForExitAsync(cancellationToken);
                     return float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
                 }
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Making the CalculateLUFSAsync method wait for the external encoder process to end, conditionally before deleting the temp file.

The audio normalization task runs the encoder as a process.
When the output matches the regex value the CalculateLUFSAsync returned.
That is however could happen before the encoder external process ends, which is still locking the temp file.
Therefore the whole task failed for trying to delete the temp file before process ends. 
So I had to make CalculateLUFSAsync wait always for the external encoder process to end

I tested this fix on Windows 11 64 bit, and it's working as expected

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #12145