### PR TITLE
Update XmlTvListingsProvider.cs to fix the record series button missing on many programs

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -167,7 +167,7 @@ namespace Jellyfin.LiveTv.Listings
                 Overview = program.Description,
                 ProductionYear = program.CopyrightDate?.Year,
                 SeasonNumber = program.Episode.Series,
-                IsSeries = program.Episode.Series is not null,
+                IsSeries = EpisodeNumber is not null,
                 IsRepeat = program.IsPreviouslyShown && !program.IsNew,
                 IsPremiere = program.Premiere is not null,
                 IsKids = programCategories.Any(c => info.KidsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),

--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -167,7 +167,7 @@ namespace Jellyfin.LiveTv.Listings
                 Overview = program.Description,
                 ProductionYear = program.CopyrightDate?.Year,
                 SeasonNumber = program.Episode.Series,
-                IsSeries = EpisodeNumber is not null,
+                IsSeries = program.Episode.Episode is not null,
                 IsRepeat = program.IsPreviouslyShown && !program.IsNew,
                 IsPremiere = program.Premiere is not null,
                 IsKids = programCategories.Any(c => info.KidsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),


### PR DESCRIPTION
Fixes a bug where certain programs like the "Good Morning America" no longer have the record series button.



**Changes**
Assume that if the program has an EpisodeNumber then it is part of a series. 

**Issues**
The record series button is not displaying on many programs that are generated by zaptoxml.pl perl script.    

https://github.com/jef/zap2xml