### PR TITLE
Revert "NextUp query respects Limit (#11956)"

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -91,7 +91,7 @@ namespace Emby.Server.Implementations.TV
             }
 
             string? presentationUniqueKey = null;
-            int? limit = request.Limit;
+            int? limit = null;
             if (!request.SeriesId.IsNullOrEmpty())
             {
                 if (_libraryManager.GetItemById(request.SeriesId.Value) is Series series)


### PR DESCRIPTION
This reverts commit 484aea1cdb93804b8388cdf3dfa3344942ad9119.

Turns out this fix from PR #11956 leads to unexpected behaviour as described in issue #12367.

Fixes: #12367

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Setting the limit here limits how many series is considered watching; not how many items to return to the client. For a proper fix of the original performance issue I think either the query needs to be redesigned or the [post-processing](https://github.com/jellyfin/jellyfin/blob/d4eeafe53ff8ae2f287f5dca49a873cd71f4c3da/Emby.Server.Implementations/TV/TVSeriesManager.cs#L187C79-L187C88) of the result from this query needs to be smarter somehow...

Note that this PR is against 10.9.z (as that was where the original PR was), but it looks like the original commit was backported to master as well, so it should probably be reverted there as well.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #12367
Possibly re-opens #11888 #11316