### PR TITLE
Include AVIF extension for support images

### DIFF
--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -103,7 +103,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
             "ktx",
             "pkm",
             "wbmp",
-	    "avif"
+            "avif"
         };
 
     /// <inheritdoc />

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -102,7 +102,8 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
             "astc",
             "ktx",
             "pkm",
-            "wbmp"
+            "wbmp",
+	    "avif"
         };
 
     /// <inheritdoc />


### PR DESCRIPTION
Jellyfin will currently process avif files (as demonstrated by renaming a valid `.avif` file to `.jpg`, and jellyfin indexing and displaying it perfectly) but currently does not try processing for some reason.

**Changes**
Adds the AVIF extension to the list of supported image types.

**Issues**
Close #12412