### PR TITLE
Add SubContainer support to CodecProfile

### DIFF
--- a/MediaBrowser.Model/Dlna/CodecProfile.cs
+++ b/MediaBrowser.Model/Dlna/CodecProfile.cs
@@ -28,7 +28,7 @@ namespace MediaBrowser.Model.Dlna
         [XmlAttribute("container")]
         public string Container { get; set; }
 
-        [XmlAttribute("container")]
+        [XmlAttribute("subcontainer")]
         public string SubContainer { get; set; }
 
         public string[] GetCodecs()

--- a/MediaBrowser.Model/Dlna/CodecProfile.cs
+++ b/MediaBrowser.Model/Dlna/CodecProfile.cs
@@ -28,24 +28,28 @@ namespace MediaBrowser.Model.Dlna
         [XmlAttribute("container")]
         public string Container { get; set; }
 
+        [XmlAttribute("container")]
+        public string SubContainer { get; set; }
+
         public string[] GetCodecs()
         {
             return ContainerProfile.SplitValue(Codec);
         }
 
-        private bool ContainsContainer(string container)
+        private bool ContainsContainer(string container, bool useSubContainer = false)
         {
-            return ContainerProfile.ContainsContainer(Container, container);
+            var containerToCheck = useSubContainer && string.Equals(Container, "hls", StringComparison.OrdinalIgnoreCase) ? SubContainer : Container;
+            return ContainerProfile.ContainsContainer(containerToCheck, container);
         }
 
-        public bool ContainsAnyCodec(string codec, string container)
+        public bool ContainsAnyCodec(string codec, string container, bool useSubContainer = false)
         {
-            return ContainsAnyCodec(ContainerProfile.SplitValue(codec), container);
+            return ContainsAnyCodec(ContainerProfile.SplitValue(codec), container, useSubContainer);
         }
 
-        public bool ContainsAnyCodec(string[] codec, string container)
+        public bool ContainsAnyCodec(string[] codec, string container, bool useSubContainer = false)
         {
-            if (!ContainsContainer(container))
+            if (!ContainsContainer(container, useSubContainer))
             {
                 return false;
             }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -962,9 +962,11 @@ namespace MediaBrowser.Model.Dlna
             int? numAudioStreams = item.GetStreamCount(MediaStreamType.Audio);
             int? numVideoStreams = item.GetStreamCount(MediaStreamType.Video);
 
+            var useSubContainer = playlistItem.SubProtocol == MediaStreamProtocol.hls;
+
             var appliedVideoConditions = options.Profile.CodecProfiles
                 .Where(i => i.Type == CodecType.Video &&
-                    i.ContainsAnyCodec(videoStream?.Codec, container) &&
+                    i.ContainsAnyCodec(videoStream?.Codec, container, useSubContainer) &&
                     i.ApplyConditions.All(applyCondition => ConditionProcessor.IsVideoConditionSatisfied(applyCondition, width, height, bitDepth, videoBitrate, videoProfile, videoRangeType, videoLevel, videoFramerate, packetLength, timestamp, isAnamorphic, isInterlaced, refFrames, numVideoStreams, numAudioStreams, videoCodecTag, isAvc)))
                 // Reverse codec profiles for backward compatibility - first codec profile has higher priority
                 .Reverse();
@@ -974,7 +976,7 @@ namespace MediaBrowser.Model.Dlna
                 var transcodingVideoCodecs = ContainerProfile.SplitValue(videoCodec);
                 foreach (var transcodingVideoCodec in transcodingVideoCodecs)
                 {
-                    if (i.ContainsAnyCodec(transcodingVideoCodec, container))
+                    if (i.ContainsAnyCodec(transcodingVideoCodec, container, useSubContainer))
                     {
                         ApplyTranscodingConditions(playlistItem, i.Conditions, transcodingVideoCodec, true, true);
                         continue;


### PR DESCRIPTION
Currently, when specifying codec profiles, the client can only specify profiles applied to direct containers, with no way to apply a profile specifically to HLS or a specific HLS container. This limitation is not suitable for more complex client codec support scenarios.

To address this, a SubContainer field is added to CodecProfile. The client can now specify the main container as "hls" to apply the profile exclusively to HLS streams. Additionally, the SubContainer field allows the profile to be applied to a specific HLS container.

Currently, this is only used in StreamBuilder for HLS streams. Further changes may be required to extend its usage.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
