### PR TITLE
Disable CA1008 for ImageOrientation.cs; Remove CA1815 for ImageDimensions.cs

### DIFF
--- a/MediaBrowser.Model/Drawing/ImageDimensions.cs
+++ b/MediaBrowser.Model/Drawing/ImageDimensions.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using System.Globalization;
 
 namespace MediaBrowser.Model.Drawing
@@ -7,7 +8,7 @@ namespace MediaBrowser.Model.Drawing
     /// <summary>
     /// Struct ImageDimensions.
     /// </summary>
-    public readonly struct ImageDimensions
+    public readonly struct ImageDimensions : IEquatable<ImageDimensions>
     {
         public ImageDimensions(int width, int height)
         {
@@ -27,9 +28,19 @@ namespace MediaBrowser.Model.Drawing
         /// <value>The width.</value>
         public int Width { get; }
 
-        public bool Equals(ImageDimensions size)
+        public static bool operator ==(ImageDimensions left, ImageDimensions right)
         {
-            return Width.Equals(size.Width) && Height.Equals(size.Height);
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ImageDimensions left, ImageDimensions right)
+        {
+            return !(left == right);
+        }
+
+        public bool Equals(ImageDimensions other)
+        {
+            return Width.Equals(other.Width) && Height.Equals(other.Height);
         }
 
         /// <inheritdoc />
@@ -40,6 +51,16 @@ namespace MediaBrowser.Model.Drawing
                 "{0}-{1}",
                 Width,
                 Height);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ImageDimensions other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Height, Width);
         }
     }
 }

--- a/MediaBrowser.Model/Drawing/ImageOrientation.cs
+++ b/MediaBrowser.Model/Drawing/ImageOrientation.cs
@@ -1,8 +1,8 @@
 #pragma warning disable CS1591
+#pragma warning disable CA1008 // Disabling Null default rule check since the enum is already shipped and default is handled in GetSKEncodedOrigin()
 
 namespace MediaBrowser.Model.Drawing
 {
-#pragma warning disable CA1008 // Disabling Null default rule check since the enum is already shipped and default is handled in GetSKEncodedOrigin()
     public enum ImageOrientation
     {
         TopLeft = 1,
@@ -14,5 +14,4 @@ namespace MediaBrowser.Model.Drawing
         RightBottom = 7,
         LeftBottom = 8,
     }
-#pragma warning restore CA1008
 }

--- a/MediaBrowser.Model/Drawing/ImageOrientation.cs
+++ b/MediaBrowser.Model/Drawing/ImageOrientation.cs
@@ -2,6 +2,7 @@
 
 namespace MediaBrowser.Model.Drawing
 {
+#pragma warning disable CA1008 // Disabling Null default rule check since the enum is already shipped and default is handled in GetSKEncodedOrigin()
     public enum ImageOrientation
     {
         TopLeft = 1,
@@ -13,4 +14,5 @@ namespace MediaBrowser.Model.Drawing
         RightBottom = 7,
         LeftBottom = 8,
     }
+#pragma warning restore CA1008
 }


### PR DESCRIPTION
Disable CA1008 for ImageOrientation.cs; Remove CA1815 for ImageDimensions.cs

**Changes**
As per the rule CA1008 [documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1008)
"When to suppress warnings
 Do not suppress a warning from this rule except for flags-attributed enumerations that have previously shipped."

 And this enum has already been shipped. And default value is handed in the GetSKEncodedOrigin() method.
 Added comment RE the same.

For CA1815 for ImageDimensions.cs
Added relevant operators, hash methods and implemented IEquatable to address the CA1815 rule.

 Ran unit tests.

**Issues**
Fixes #2149
