### PR TITLE
Don't force non-virtual when all episodes in season are isMissing=true

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -211,8 +211,12 @@ namespace MediaBrowser.Providers.TV
                 }
                 else if (existingSeason.IsVirtualItem)
                 {
-                    existingSeason.IsVirtualItem = false;
-                    await existingSeason.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                    var episodeCount = seriesChildren.OfType<Episode>().Count(e => e.ParentIndexNumber == seasonNumber && !e.IsMissingEpisode);
+                    if (episodeCount > 0)
+                    {
+                        existingSeason.IsVirtualItem = false;
+                        await existingSeason.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Virtual seasons created by Missing Episode Provider are being forced to be non-virtual, which results in ghost seasons when when "Display missing episodes within their series" is unchecked. This change prevents conversion to non-virtual if all episodes for the season have isMissing=true.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin/issues/12208 caused by Missing Episode Provider (Requires recreation of the season)
