### PR TITLE
Add option to always burn in subtitles if transcoding is triggered

### DIFF
--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -109,7 +109,6 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="enableTranscoding">Whether to enable transcoding. Default: true.</param>
     /// <param name="allowVideoStreamCopy">Whether to allow to copy the video stream. Default: true.</param>
     /// <param name="allowAudioStreamCopy">Whether to allow to copy the audio stream. Default: true.</param>
-    /// <param name="alwaysBurnInSubtitleWhenTranscoding">Always burn-in subtitle when transcoding.</param>
     /// <param name="playbackInfoDto">The playback info.</param>
     /// <response code="200">Playback info returned.</response>
     /// <response code="404">Item not found.</response>
@@ -133,7 +132,6 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery, ParameterObsolete] bool? enableTranscoding,
         [FromQuery, ParameterObsolete] bool? allowVideoStreamCopy,
         [FromQuery, ParameterObsolete] bool? allowAudioStreamCopy,
-        [FromQuery, ParameterObsolete] bool? alwaysBurnInSubtitleWhenTranscoding,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] PlaybackInfoDto? playbackInfoDto)
     {
         var profile = playbackInfoDto?.DeviceProfile;
@@ -165,7 +163,6 @@ public class MediaInfoController : BaseJellyfinApiController
         enableTranscoding ??= playbackInfoDto?.EnableTranscoding ?? true;
         allowVideoStreamCopy ??= playbackInfoDto?.AllowVideoStreamCopy ?? true;
         allowAudioStreamCopy ??= playbackInfoDto?.AllowAudioStreamCopy ?? true;
-        alwaysBurnInSubtitleWhenTranscoding ??= playbackInfoDto?.AlwaysBurnInSubtitleWhenTranscoding ?? false;
 
         userId = RequestHelpers.GetUserId(User, userId);
         var user = userId.IsNullOrEmpty()
@@ -212,7 +209,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     enableTranscoding.Value,
                     allowVideoStreamCopy.Value,
                     allowAudioStreamCopy.Value,
-                    alwaysBurnInSubtitleWhenTranscoding.Value,
+                    playbackInfoDto?.AlwaysBurnInSubtitleWhenTranscoding ?? false,
                     Request.HttpContext.GetNormalizedRemoteIP());
             }
 
@@ -241,7 +238,7 @@ public class MediaInfoController : BaseJellyfinApiController
                         SubtitleStreamIndex = subtitleStreamIndex,
                         UserId = userId ?? Guid.Empty,
                         OpenToken = mediaSource.OpenToken,
-                        AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding.Value
+                        AlwaysBurnInSubtitleWhenTranscoding = playbackInfoDto?.AlwaysBurnInSubtitleWhenTranscoding ?? false
                     }).ConfigureAwait(false);
 
                 info.MediaSources = new[] { openStreamResult.MediaSource };

--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -109,6 +109,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="enableTranscoding">Whether to enable transcoding. Default: true.</param>
     /// <param name="allowVideoStreamCopy">Whether to allow to copy the video stream. Default: true.</param>
     /// <param name="allowAudioStreamCopy">Whether to allow to copy the audio stream. Default: true.</param>
+    /// <param name="alwaysBurnInSubtitleWhenTranscoding">Always burn-in subtitle when transcoding.</param>
     /// <param name="playbackInfoDto">The playback info.</param>
     /// <response code="200">Playback info returned.</response>
     /// <response code="404">Item not found.</response>
@@ -132,6 +133,7 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery, ParameterObsolete] bool? enableTranscoding,
         [FromQuery, ParameterObsolete] bool? allowVideoStreamCopy,
         [FromQuery, ParameterObsolete] bool? allowAudioStreamCopy,
+        [FromQuery, ParameterObsolete] bool? alwaysBurnInSubtitleWhenTranscoding,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] PlaybackInfoDto? playbackInfoDto)
     {
         var profile = playbackInfoDto?.DeviceProfile;
@@ -163,6 +165,7 @@ public class MediaInfoController : BaseJellyfinApiController
         enableTranscoding ??= playbackInfoDto?.EnableTranscoding ?? true;
         allowVideoStreamCopy ??= playbackInfoDto?.AllowVideoStreamCopy ?? true;
         allowAudioStreamCopy ??= playbackInfoDto?.AllowAudioStreamCopy ?? true;
+        alwaysBurnInSubtitleWhenTranscoding ??= playbackInfoDto?.AlwaysBurnInSubtitleWhenTranscoding ?? false;
 
         userId = RequestHelpers.GetUserId(User, userId);
         var user = userId.IsNullOrEmpty()
@@ -209,6 +212,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     enableTranscoding.Value,
                     allowVideoStreamCopy.Value,
                     allowAudioStreamCopy.Value,
+                    alwaysBurnInSubtitleWhenTranscoding.Value,
                     Request.HttpContext.GetNormalizedRemoteIP());
             }
 
@@ -236,7 +240,8 @@ public class MediaInfoController : BaseJellyfinApiController
                         StartTimeTicks = startTimeTicks,
                         SubtitleStreamIndex = subtitleStreamIndex,
                         UserId = userId ?? Guid.Empty,
-                        OpenToken = mediaSource.OpenToken
+                        OpenToken = mediaSource.OpenToken,
+                        AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding.Value
                     }).ConfigureAwait(false);
 
                 info.MediaSources = new[] { openStreamResult.MediaSource };
@@ -261,6 +266,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="openLiveStreamDto">The open live stream dto.</param>
     /// <param name="enableDirectPlay">Whether to enable direct play. Default: true.</param>
     /// <param name="enableDirectStream">Whether to enable direct stream. Default: true.</param>
+    /// <param name="alwaysBurnInSubtitleWhenTranscoding">Always burn-in subtitle when transcoding.</param>
     /// <response code="200">Media source opened.</response>
     /// <returns>A <see cref="Task"/> containing a <see cref="LiveStreamResponse"/>.</returns>
     [HttpPost("LiveStreams/Open")]
@@ -277,7 +283,8 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery] Guid? itemId,
         [FromBody] OpenLiveStreamDto? openLiveStreamDto,
         [FromQuery] bool? enableDirectPlay,
-        [FromQuery] bool? enableDirectStream)
+        [FromQuery] bool? enableDirectStream,
+        [FromQuery] bool? alwaysBurnInSubtitleWhenTranscoding)
     {
         userId ??= openLiveStreamDto?.UserId;
         userId = RequestHelpers.GetUserId(User, userId);
@@ -295,7 +302,8 @@ public class MediaInfoController : BaseJellyfinApiController
             DeviceProfile = openLiveStreamDto?.DeviceProfile,
             EnableDirectPlay = enableDirectPlay ?? openLiveStreamDto?.EnableDirectPlay ?? true,
             EnableDirectStream = enableDirectStream ?? openLiveStreamDto?.EnableDirectStream ?? true,
-            DirectPlayProtocols = openLiveStreamDto?.DirectPlayProtocols ?? new[] { MediaProtocol.Http }
+            DirectPlayProtocols = openLiveStreamDto?.DirectPlayProtocols ?? new[] { MediaProtocol.Http },
+            AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding ?? openLiveStreamDto?.AlwaysBurnInSubtitleWhenTranscoding ?? false
         };
         return await _mediaInfoHelper.OpenMediaSource(HttpContext, request).ConfigureAwait(false);
     }

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -160,6 +160,7 @@ public class UniversalAudioController : BaseJellyfinApiController
                 true,
                 true,
                 true,
+                false,
                 Request.HttpContext.GetNormalizedRemoteIP());
         }
 

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -156,6 +156,7 @@ public class MediaInfoHelper
     /// <param name="enableTranscoding">Enable transcoding.</param>
     /// <param name="allowVideoStreamCopy">Allow video stream copy.</param>
     /// <param name="allowAudioStreamCopy">Allow audio stream copy.</param>
+    /// <param name="alwaysBurnInSubtitleWhenTranscoding">Always burn-in subtitle when transcoding.</param>
     /// <param name="ipAddress">Requesting IP address.</param>
     public void SetDeviceSpecificData(
         BaseItem item,
@@ -175,6 +176,7 @@ public class MediaInfoHelper
         bool enableTranscoding,
         bool allowVideoStreamCopy,
         bool allowAudioStreamCopy,
+        bool alwaysBurnInSubtitleWhenTranscoding,
         IPAddress ipAddress)
     {
         var streamBuilder = new StreamBuilder(_mediaEncoder, _logger);
@@ -188,7 +190,8 @@ public class MediaInfoHelper
             Profile = profile,
             MaxAudioChannels = maxAudioChannels,
             AllowAudioStreamCopy = allowAudioStreamCopy,
-            AllowVideoStreamCopy = allowVideoStreamCopy
+            AllowVideoStreamCopy = allowVideoStreamCopy,
+            AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding,
         };
 
         if (string.Equals(mediaSourceId, mediaSource.Id, StringComparison.OrdinalIgnoreCase))
@@ -420,6 +423,7 @@ public class MediaInfoHelper
                 true,
                 true,
                 true,
+                request.AlwaysBurnInSubtitleWhenTranscoding,
                 httpContext.GetNormalizedRemoteIP());
         }
         else

--- a/Jellyfin.Api/Models/MediaInfoDtos/OpenLiveStreamDto.cs
+++ b/Jellyfin.Api/Models/MediaInfoDtos/OpenLiveStreamDto.cs
@@ -66,6 +66,11 @@ public class OpenLiveStreamDto
     public bool? EnableDirectStream { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether always burn in subtitles when transcoding.
+    /// </summary>
+    public bool? AlwaysBurnInSubtitleWhenTranscoding { get; set; }
+
+    /// <summary>
     /// Gets or sets the device profile.
     /// </summary>
     public DeviceProfile? DeviceProfile { get; set; }

--- a/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
+++ b/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
@@ -82,4 +82,9 @@ public class PlaybackInfoDto
     /// Gets or sets a value indicating whether to auto open the live stream.
     /// </summary>
     public bool? AutoOpenLiveStream { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether always burn in subtitles when transcoding.
+    /// </summary>
+    public bool? AlwaysBurnInSubtitleWhenTranscoding { get; set; }
 }

--- a/MediaBrowser.Model/Dlna/MediaOptions.cs
+++ b/MediaBrowser.Model/Dlna/MediaOptions.cs
@@ -50,6 +50,11 @@ namespace MediaBrowser.Model.Dlna
         public bool AllowVideoStreamCopy { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether always burn in subtitles when transcoding.
+        /// </summary>
+        public bool AlwaysBurnInSubtitleWhenTranscoding { get; set; }
+
+        /// <summary>
         /// Gets or sets the item id.
         /// </summary>
         public Guid ItemId { get; set; }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -764,7 +764,19 @@ namespace MediaBrowser.Model.Dlna
                     {
                         var subtitleProfile = GetSubtitleProfile(item, subtitleStream, options.Profile.SubtitleProfiles, PlayMethod.Transcode, _transcoderSupport, transcodingProfile.Container, transcodingProfile.Protocol);
 
-                        playlistItem.SubtitleDeliveryMethod = subtitleProfile.Method;
+                        if (options.AlwaysBurnInSubtitleWhenTranscoding && (playlistItem.TranscodeReasons & (VideoReasons | TranscodeReason.ContainerBitrateExceedsLimit)) != 0)
+                        {
+                            playlistItem.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Encode;
+                            foreach (SubtitleProfile profile in options.Profile.SubtitleProfiles)
+                            {
+                                profile.Method = SubtitleDeliveryMethod.Encode;
+                            }
+                        }
+                        else
+                        {
+                            playlistItem.SubtitleDeliveryMethod = subtitleProfile.Method;
+                        }
+
                         playlistItem.SubtitleFormat = subtitleProfile.Format;
                         playlistItem.SubtitleCodecs = new[] { subtitleProfile.Format };
                     }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -352,7 +352,7 @@ namespace MediaBrowser.Model.Dlna
                     return TranscodeReason.VideoBitrateNotSupported;
 
                 case ProfileConditionValue.VideoCodecTag:
-                    return TranscodeReason.VideoCodecNotSupported;
+                    return TranscodeReason.VideoCodecTagNotSupported;
 
                 case ProfileConditionValue.VideoFramerate:
                     return TranscodeReason.VideoFramerateNotSupported;

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -20,8 +20,8 @@ namespace MediaBrowser.Model.Dlna
         // Aliases
         internal const TranscodeReason ContainerReasons = TranscodeReason.ContainerNotSupported | TranscodeReason.ContainerBitrateExceedsLimit;
         internal const TranscodeReason AudioReasons = TranscodeReason.AudioCodecNotSupported | TranscodeReason.AudioBitrateNotSupported | TranscodeReason.AudioChannelsNotSupported | TranscodeReason.AudioProfileNotSupported | TranscodeReason.AudioSampleRateNotSupported | TranscodeReason.SecondaryAudioNotSupported | TranscodeReason.AudioBitDepthNotSupported | TranscodeReason.AudioIsExternal;
-        internal const TranscodeReason VideoReasons = TranscodeReason.VideoCodecNotSupported | TranscodeReason.VideoResolutionNotSupported | TranscodeReason.AnamorphicVideoNotSupported | TranscodeReason.InterlacedVideoNotSupported | TranscodeReason.VideoBitDepthNotSupported | TranscodeReason.VideoBitrateNotSupported | TranscodeReason.VideoFramerateNotSupported | TranscodeReason.VideoLevelNotSupported | TranscodeReason.RefFramesNotSupported;
-        internal const TranscodeReason DirectStreamReasons = AudioReasons | TranscodeReason.ContainerNotSupported;
+        internal const TranscodeReason VideoReasons = TranscodeReason.VideoCodecNotSupported | TranscodeReason.VideoResolutionNotSupported | TranscodeReason.AnamorphicVideoNotSupported | TranscodeReason.InterlacedVideoNotSupported | TranscodeReason.VideoBitDepthNotSupported | TranscodeReason.VideoBitrateNotSupported | TranscodeReason.VideoFramerateNotSupported | TranscodeReason.VideoLevelNotSupported | TranscodeReason.RefFramesNotSupported | TranscodeReason.VideoRangeTypeNotSupported | TranscodeReason.VideoProfileNotSupported;
+        internal const TranscodeReason DirectStreamReasons = AudioReasons | TranscodeReason.ContainerNotSupported | TranscodeReason.VideoCodecTagNotSupported;
 
         private readonly ILogger _logger;
         private readonly ITranscoderSupport _transcoderSupport;

--- a/MediaBrowser.Model/MediaInfo/LiveStreamRequest.cs
+++ b/MediaBrowser.Model/MediaInfo/LiveStreamRequest.cs
@@ -13,6 +13,7 @@ namespace MediaBrowser.Model.MediaInfo
         {
             EnableDirectPlay = true;
             EnableDirectStream = true;
+            AlwaysBurnInSubtitleWhenTranscoding = false;
             DirectPlayProtocols = new MediaProtocol[] { MediaProtocol.Http };
         }
 
@@ -39,6 +40,8 @@ namespace MediaBrowser.Model.MediaInfo
         public bool EnableDirectPlay { get; set; }
 
         public bool EnableDirectStream { get; set; }
+
+        public bool AlwaysBurnInSubtitleWhenTranscoding { get; set; }
 
         public IReadOnlyList<MediaProtocol> DirectPlayProtocols { get; set; }
     }

--- a/MediaBrowser.Model/Session/TranscodeReason.cs
+++ b/MediaBrowser.Model/Session/TranscodeReason.cs
@@ -18,6 +18,7 @@ namespace MediaBrowser.Model.Session
         // Video Constraints
         VideoProfileNotSupported = 1 << 6,
         VideoRangeTypeNotSupported = 1 << 24,
+        VideoCodecTagNotSupported = 1 << 25,
         VideoLevelNotSupported = 1 << 7,
         VideoResolutionNotSupported = 1 << 8,
         VideoBitDepthNotSupported = 1 << 9,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Subtitles often have synchronization issues after video transcoding. This option allows the client to opt-in to always burn in all subtitles, preventing out-of-sync subtitles at the cost of transcoding performance.

To support this feature, the `TranscodeReason` has been extended to accurately determine if a stream can be remuxed.

Notably:

- `VideoCodecTag` now has its own transcode reason instead of sharing one with `VideoCodec`. The former can be fixed by remuxing, while the latter always triggers a full transcode.
- The `VideoReasons` have been updated to check for profile mismatches, as these will also require transcoding.
- `DirectStreamingReasons` now includes the new `VideoCodecTagNotSupported` reason.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
