### PR TITLE
Properly handle null values in PlaylistManager.cs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -187,6 +187,7 @@
  - [HonestlyWhoKnows](https://github.com/honestlywhoknows)
  - [TheMelmacian](https://github.com/TheMelmacian)
  - [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
+ - [phito](https://github.com/phito)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -590,7 +590,12 @@ namespace Emby.Server.Implementations.Playlists
                     EnableImages = true
                 }).ConfigureAwait(false);
 
-                playlist = GetPlaylistForUser(request.Id, request.UserId)!;
+                playlist = GetPlaylistForUser(request.Id, request.UserId);
+            }
+
+            if (playlist is null)
+            {
+                throw new ArgumentException($"No playlist exists with Id {request.Id}");
             }
 
             if (request.Name is not null)

--- a/MediaBrowser.Controller/Playlists/IPlaylistManager.cs
+++ b/MediaBrowser.Controller/Playlists/IPlaylistManager.cs
@@ -17,7 +17,7 @@ namespace MediaBrowser.Controller.Playlists
         /// <param name="playlistId">The playlist identifier.</param>
         /// <param name="userId">The user identifier.</param>
         /// <returns>Playlist.</returns>
-        Playlist GetPlaylistForUser(Guid playlistId, Guid userId);
+        Playlist? GetPlaylistForUser(Guid playlistId, Guid userId);
 
         /// <summary>
         /// Creates the playlist.
@@ -77,14 +77,14 @@ namespace MediaBrowser.Controller.Playlists
         /// Gets the playlists folder.
         /// </summary>
         /// <returns>Folder.</returns>
-        Folder GetPlaylistsFolder();
+        Folder? GetPlaylistsFolder();
 
         /// <summary>
         /// Gets the playlists folder for a user.
         /// </summary>
         /// <param name="userId">The user identifier.</param>
         /// <returns>Folder.</returns>
-        Folder GetPlaylistsFolder(Guid userId);
+        Folder? GetPlaylistsFolder(Guid userId);
 
         /// <summary>
         /// Moves the item.


### PR DESCRIPTION
`PlaylistManager.cs` had a #nullable disable declaration, which lead to NullReferenceException  when dependencies are return null values.

**Changes**
Removed `#nullable disable` and properly handling null values in `PlaylistManager.cs`.

**Issues**
529d24ec308645e92839b216fd0b52acd4ad62a2

#11854 was definitely cause by this, and I believe it has already been fixed by [this commit](https://github.com/jellyfin/jellyfin/commit/529d24ec308645e92839b216fd0b52acd4ad62a2), but it did not address the root cause.

(this is also practice for my first contribution, thanks all of you for this awesome software, I am looking forward to contribute more)