### PR TITLE
Add support for ItemSortBy values in BoxSet

### DIFF
--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -114,26 +114,19 @@ namespace MediaBrowser.Controller.Entities.Movies
 
         public IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user)
         {
-            var sortBy = new[]
-            {
-               ItemSortBy.ProductionYear,
-               ItemSortBy.PremiereDate,
-               ItemSortBy.SortName
-            };
+            var sortBy = ItemSortBy.PremiereDate;
+
             if (!string.IsNullOrEmpty(DisplayOrder))
             {
-              if (DisplayOrder == "InsertDate")
-              {
-                 return items;
-              }
-
-              sortBy = new[]
-                {
-                    Enum.Parse<ItemSortBy>(DisplayOrder)
-                };
+                sortBy = Enum.Parse<ItemSortBy>(DisplayOrder);
             }
 
-            return LibraryManager.Sort(items, user, sortBy, SortOrder.Ascending);
+            if (sortBy == ItemSortBy.Default)
+            {
+              return items;
+            }
+
+            return LibraryManager.Sort(items, user, new[] { sortBy }, SortOrder.Ascending);
         }
 
         public override List<BaseItem> GetChildren(User user, bool includeLinkedChildren, InternalItemsQuery query)

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -122,6 +122,11 @@ namespace MediaBrowser.Controller.Entities.Movies
             };
             if (!string.IsNullOrEmpty(DisplayOrder))
             {
+              if (DisplayOrder == "InsertDate")
+              {
+                 return items;
+              }
+
               sortBy = new[]
                 {
                     Enum.Parse<ItemSortBy>(DisplayOrder)

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -112,13 +112,11 @@ namespace MediaBrowser.Controller.Entities.Movies
             return true;
         }
 
-        public IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user)
+        private IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user)
         {
-            var sortBy = ItemSortBy.PremiereDate;
-
-            if (!string.IsNullOrEmpty(DisplayOrder))
+            if (!Enum.TryParse<ItemSortBy>(DisplayOrder, out var sortBy))
             {
-                sortBy = Enum.Parse<ItemSortBy>(DisplayOrder);
+                sortBy = ItemSortBy.PremiereDate;
             }
 
             if (sortBy == ItemSortBy.Default)

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -112,37 +112,35 @@ namespace MediaBrowser.Controller.Entities.Movies
             return true;
         }
 
+        public IEnumerable<BaseItem> Sort(IEnumerable<BaseItem> items, User user)
+        {
+            var sortBy = new[]
+            {
+               ItemSortBy.ProductionYear,
+               ItemSortBy.PremiereDate,
+               ItemSortBy.SortName
+            };
+            if (!string.IsNullOrEmpty(DisplayOrder))
+            {
+              sortBy = new[]
+                {
+                    Enum.Parse<ItemSortBy>(DisplayOrder)
+                };
+            }
+
+            return LibraryManager.Sort(items, user, sortBy, SortOrder.Ascending);
+        }
+
         public override List<BaseItem> GetChildren(User user, bool includeLinkedChildren, InternalItemsQuery query)
         {
             var children = base.GetChildren(user, includeLinkedChildren, query);
-
-            if (string.Equals(DisplayOrder, "SortName", StringComparison.OrdinalIgnoreCase))
-            {
-                // Sort by name
-                return LibraryManager.Sort(children, user, new[] { ItemSortBy.SortName }, SortOrder.Ascending).ToList();
-            }
-
-            if (string.Equals(DisplayOrder, "PremiereDate", StringComparison.OrdinalIgnoreCase))
-            {
-                // Sort by release date
-                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Ascending).ToList();
-            }
-
-            // Default sorting
-            return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Ascending).ToList();
+            return Sort(children, user).ToList();
         }
 
         public override IEnumerable<BaseItem> GetRecursiveChildren(User user, InternalItemsQuery query)
         {
             var children = base.GetRecursiveChildren(user, query);
-
-            if (string.Equals(DisplayOrder, "PremiereDate", StringComparison.OrdinalIgnoreCase))
-            {
-                // Sort by release date
-                return LibraryManager.Sort(children, user, new[] { ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName }, SortOrder.Ascending).ToList();
-            }
-
-            return children;
+            return Sort(children, user).ToList();
         }
 
         public BoxSetInfo GetLookupInfo()


### PR DESCRIPTION
GetChildren and GetRecursiveChildren on the BoxSet class now support all values from ItemSortBy.

This opens up the possibility to add more sorting options for collections in the web ui. (if a sorting comparer exists for it)

for my usercase i want the sorting to be the original insert order.

I settled on using the Default enum for this. Could call it different in the ui if needed.