### PR TITLE
Prevent server from starting if the ffmpeg path is invalid

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -402,7 +402,12 @@ namespace Emby.Server.Implementations
             ConfigurationManager.ConfigurationUpdated += OnConfigurationUpdated;
             ConfigurationManager.NamedConfigurationUpdated += OnConfigurationUpdated;
 
-            Resolve<IMediaEncoder>().SetFFmpegPath();
+            var ffmpegValid = Resolve<IMediaEncoder>().SetFFmpegPath();
+
+            if (!ffmpegValid)
+            {
+                throw new FfmpegException("Failed to find valid ffmpeg");
+            }
 
             Logger.LogInformation("ServerId: {ServerId}", SystemId);
             Logger.LogInformation("Core startup complete");

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -403,9 +403,9 @@ namespace Emby.Server.Implementations
             ConfigurationManager.NamedConfigurationUpdated += OnConfigurationUpdated;
 
             var ffmpegValid = Resolve<IMediaEncoder>().SetFFmpegPath();
-            var isRunningInCi = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+            var skipFfmpegCheck = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("JELLYFIN_DEBUG_NO_FFMPEG"));
 
-            if (!ffmpegValid && !isRunningInCi)
+            if (!skipFfmpegCheck && !ffmpegValid)
             {
                 throw new FfmpegException("Failed to find valid ffmpeg");
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -403,9 +403,8 @@ namespace Emby.Server.Implementations
             ConfigurationManager.NamedConfigurationUpdated += OnConfigurationUpdated;
 
             var ffmpegValid = Resolve<IMediaEncoder>().SetFFmpegPath();
-            var skipFfmpegCheck = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("JELLYFIN_DEBUG_NO_FFMPEG"));
 
-            if (!skipFfmpegCheck && !ffmpegValid)
+            if (!ffmpegValid)
             {
                 throw new FfmpegException("Failed to find valid ffmpeg");
             }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -403,8 +403,9 @@ namespace Emby.Server.Implementations
             ConfigurationManager.NamedConfigurationUpdated += OnConfigurationUpdated;
 
             var ffmpegValid = Resolve<IMediaEncoder>().SetFFmpegPath();
+            var isRunningInCi = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
-            if (!ffmpegValid)
+            if (!ffmpegValid && !isRunningInCi)
             {
                 throw new FfmpegException("Failed to find valid ffmpeg");
             }

--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -19,7 +19,8 @@ namespace Emby.Server.Implementations
             { FfmpegAnalyzeDurationKey, "200M" },
             { PlaylistsAllowDuplicatesKey, bool.FalseString },
             { BindToUnixSocketKey, bool.FalseString },
-            { SqliteCacheSizeKey, "20000" }
+            { SqliteCacheSizeKey, "20000" },
+            { FfmpegSkipValidationKey, bool.FalseString }
         };
     }
 }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -30,6 +30,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string FfmpegProbeSizeKey = "FFmpeg:probesize";
 
         /// <summary>
+        /// The key for the skipping FFmpeg validation.
+        /// </summary>
+        public const string FfmpegSkipValidationKey = "FFmpeg:novalidation";
+
+        /// <summary>
         /// The key for the FFmpeg analyze duration option.
         /// </summary>
         public const string FfmpegAnalyzeDurationKey = "FFmpeg:analyzeduration";
@@ -88,6 +93,14 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The FFmpeg analyze duration option.</returns>
         public static string? GetFFmpegAnalyzeDuration(this IConfiguration configuration)
             => configuration[FfmpegAnalyzeDurationKey];
+
+        /// <summary>
+        /// Gets a value indicating whether the server should validate FFmpeg during startup.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns><c>true</c> if the server should validate FFmpeg during startup, otherwise <c>false</c>.</returns>
+        public static bool GetFFmpegSkipValidation(this IConfiguration configuration)
+            => configuration.GetValue<bool>(FfmpegSkipValidationKey);
 
         /// <summary>
         /// Gets a value indicating whether playlists should allow duplicate entries from the <see cref="IConfiguration"/>.

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -223,14 +223,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Sets the path to find FFmpeg.
         /// </summary>
-        void SetFFmpegPath();
-
-        /// <summary>
-        /// Updates the encoder path.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <param name="pathType">The type of path.</param>
-        void UpdateEncoderPath(string path, string pathType);
+        /// <returns>bool indicates whether a valid ffmpeg is found.</returns>
+        bool SetFFmpegPath();
 
         /// <summary>
         /// Gets the primary playlist of .vob files.

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -154,6 +154,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <returns>bool indicates whether a valid ffmpeg is found.</returns>
         public bool SetFFmpegPath()
         {
+            var skipValidation = _config.GetFFmpegSkipValidation();
+            if (skipValidation)
+            {
+                _logger.LogWarning("FFmpeg: Skipping FFmpeg Validation due to FFmpeg:novalidation set to true");
+                return true;
+            }
+
             // 1) Check if the --ffmpeg CLI switch has been given
             var ffmpegPath = _startupOptionFFmpegPath;
             string ffmpegPathSetMethodText = "command line or environment variable";

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -47,7 +47,7 @@ namespace Jellyfin.Server.Integration.Tests
         /// <inheritdoc/>
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            // Tell skip ffmpeg check
+            // Skip ffmpeg check for testing
             Environment.SetEnvironmentVariable("JELLYFIN_DEBUG_NO_FFMPEG", "1");
             // Specify the startup command line options
             var commandLineOpts = new StartupOptions();

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -48,7 +48,7 @@ namespace Jellyfin.Server.Integration.Tests
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             // Skip ffmpeg check for testing
-            Environment.SetEnvironmentVariable("JELLYFIN_DEBUG_NO_FFMPEG", "1");
+            Environment.SetEnvironmentVariable("JELLYFIN_FFMPEG__NOVALIDATION", "true");
             // Specify the startup command line options
             var commandLineOpts = new StartupOptions();
 

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -47,6 +47,8 @@ namespace Jellyfin.Server.Integration.Tests
         /// <inheritdoc/>
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
+            // Tell skip ffmpeg check
+            Environment.SetEnvironmentVariable("JELLYFIN_DEBUG_NO_FFMPEG", "1");
             // Specify the startup command line options
             var commandLineOpts = new StartupOptions();
 


### PR DESCRIPTION
We've received numerous reports from users that Jellyfin is failing to play certain files, and it turns out that many of these issues are due to invalid FFmpeg configurations, such as incorrect installation, stale configuration values, or an unsupported FFmpeg version. The server currently still starts in this situation, leading users to mistakenly believe it's a server bug rather than a configuration error.

This PR makes the server be prevented from starting and print a helper text to help the user fix the installation if the FFmpeg path is not found, not supported, or not executable.

This also removed the internal logic to update the config file's ffmpeg path as we are no longer using that.

For debug purposes that want to run jellyfin without ffmpeg, set the env var `JELLYFIN_FFMPEG__NOVALIDATION=true` to bypass this check.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Some of the reports that turns out to be a config/installation issue. These might not be all of them:

#11543
#11577
#11696
#12042
#12411
#12458
