### PR TITLE
Update PluginPageInfo.cs summary.

### DIFF
--- a/MediaBrowser.Model/Plugins/PluginPageInfo.cs
+++ b/MediaBrowser.Model/Plugins/PluginPageInfo.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Model.Plugins
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the display name of the plugin/
+        /// Gets or sets the display name of the plugin.
         /// </summary>
         public string? DisplayName { get; set; }
 

--- a/MediaBrowser.Model/Plugins/PluginPageInfo.cs
+++ b/MediaBrowser.Model/Plugins/PluginPageInfo.cs
@@ -6,12 +6,12 @@ namespace MediaBrowser.Model.Plugins
     public class PluginPageInfo
     {
         /// <summary>
-        /// Gets or sets the name.
+        /// Gets or sets the name of the plugin.
         /// </summary>
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the display name.
+        /// Gets or sets the display name of the plugin/
         /// </summary>
         public string? DisplayName { get; set; }
 


### PR DESCRIPTION
**Description**
A small addition to the summary of the plugin’s Name and DisplayName, making it much easier to understand what the getters and setters actually mean.

**Changes**
 i added a bit more explanation to the summary of Name and DisplayName.
Mainly, I explained that they are the names of the plugin. 