### PR TITLE
Set segmentFormat for mpegts container

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1569,7 +1569,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         var segmentContainer = outputExtension.TrimStart('.');
         var inputModifier = _encodingHelper.GetInputModifier(state, _encodingOptions, segmentContainer);
 
-        if (string.Equals(segmentContainer, "ts", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(segmentContainer, "ts", StringComparison.OrdinalIgnoreCase) || string.Equals(segmentContainer, "mpegts", StringComparison.OrdinalIgnoreCase))
         {
             segmentFormat = "mpegts";
         }


### PR DESCRIPTION
Fixes the need to disable "Prefer fMP4-HLS Media Container" when using the TVHeadend plugin (and playback of a TS recording) as part of the issue https://github.com/jellyfin/jellyfin-plugin-tvheadend/issues/89. 

**Changes**
The current code sets the segmentFormat to mpegts for container "ts". This PR also includes container "mpegts".

**Issues**
Backend part of https://github.com/jellyfin/jellyfin-plugin-tvheadend/issues/89
