### PR TITLE
Set Content-Disposition header to attachment for image endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -2089,6 +2089,8 @@ public class ImageController : BaseJellyfinApiController
         Response.Headers.Append(HeaderNames.Age, Convert.ToInt64((DateTime.UtcNow - dateImageModified).TotalSeconds).ToString(CultureInfo.InvariantCulture));
         Response.Headers.Append(HeaderNames.Vary, HeaderNames.Accept);
 
+        Response.Headers.ContentDisposition = "attachment";
+
         if (disableCaching)
         {
             Response.Headers.Append(HeaderNames.CacheControl, "no-cache, no-store, must-revalidate");

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -233,6 +233,8 @@ public class PluginsController : BaseJellyfinApiController
             return NotFound();
         }
 
+        Response.Headers.ContentDisposition = "attachment";
+
         imagePath = Path.Combine(plugin.Path, plugin.Manifest.ImagePath);
         return PhysicalFile(imagePath, MimeTypes.GetMimeType(imagePath));
     }

--- a/Jellyfin.Api/Controllers/TrickplayController.cs
+++ b/Jellyfin.Api/Controllers/TrickplayController.cs
@@ -95,6 +95,7 @@ public class TrickplayController : BaseJellyfinApiController
         var path = _trickplayManager.GetTrickplayTilePath(item, width, index);
         if (System.IO.File.Exists(path))
         {
+            Response.Headers.ContentDisposition = "attachment";
             return PhysicalFile(path, MediaTypeNames.Image.Jpeg);
         }
 


### PR DESCRIPTION
The server serves images in various endpoints, those are meant to be displayed in the various clients and not for sharing. Setting the content disposition header to `attachment` will force a browser to download the images when opened directly instead of displaying them in the browser.

**Changes**
- Update item image endpoints
- Update plugin image endpoint
- Update user image endpoints
- Update splashscreen image endpoint

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
