### PR TITLE
Fix only returning one item from /Item/Latest api.

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1362,6 +1362,21 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetItemList(query);
         }
 
+        public IReadOnlyList<BaseItem> GetLatestItemList(InternalItemsQuery query, IReadOnlyList<BaseItem> parents, CollectionType collectionType)
+        {
+            SetTopParentIdsOrAncestors(query, parents);
+
+            if (query.AncestorIds.Length == 0 && query.TopParentIds.Length == 0)
+            {
+                if (query.User is not null)
+                {
+                    AddUserToQuery(query, query.User);
+                }
+            }
+
+            return _itemRepository.GetLatestItemList(query, collectionType);
+        }
+
         public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents, DateTime dateCutoff)
         {
             SetTopParentIdsOrAncestors(query, parents);

--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -370,6 +370,21 @@ namespace Emby.Server.Implementations.Library
                 MediaTypes = mediaTypes
             };
 
+            if (request.GroupItems)
+            {
+                if (parents.OfType<ICollectionFolder>().All(i => i.CollectionType == CollectionType.tvshows))
+                {
+                    query.Limit = limit;
+                    return _libraryManager.GetLatestItemList(query, parents, CollectionType.tvshows);
+                }
+
+                if (parents.OfType<ICollectionFolder>().All(i => i.CollectionType == CollectionType.music))
+                {
+                    query.Limit = limit;
+                    return _libraryManager.GetLatestItemList(query, parents, CollectionType.music);
+                }
+            }
+
             return _libraryManager.GetItemList(query, parents);
         }
     }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -279,7 +279,7 @@ public sealed class BaseItemRepository
         // Subquery to group by SeriesNames/Album and get the max Date Created for each group.
         var subquery = PrepareItemQuery(context, filter);
         subquery = TranslateQuery(subquery, context, filter);
-        var subqueryGrouped = subquery.GroupBy(e => e.SeriesName)
+        var subqueryGrouped = subquery.GroupBy(g => collectionType == CollectionType.tvshows ? g.SeriesName : g.Album)
             .Select(g => new
             {
                 Key = g.Key,

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -280,6 +280,7 @@ public sealed class BaseItemRepository
         var subquery = context.BaseItems
             .AsNoTracking()
             .Where(b => !b.IsVirtualItem)
+            .Where(b => b.MediaType != MediaType.Unknown.ToString())
             .GroupBy(g => collectionType == CollectionType.tvshows ? g.SeriesName : g.Album)
             .Select(g => new
             {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -35,7 +35,6 @@ using MediaBrowser.Model.LiveTv;
 using MediaBrowser.Model.Querying;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 using BaseItemDto = MediaBrowser.Controller.Entities.BaseItem;
 using BaseItemEntity = Jellyfin.Data.Entities.BaseItemEntity;
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -567,6 +567,15 @@ namespace MediaBrowser.Controller.Library
         IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, List<BaseItem> parents);
 
         /// <summary>
+        /// Gets the TVShow/Album items for Latest api.
+        /// </summary>
+        /// <param name="query">The query to use.</param>
+        /// <param name="parents">Items to use for query.</param>
+        /// <param name="collectionType">Collection Type.</param>
+        /// <returns>List of items.</returns>
+        IReadOnlyList<BaseItem> GetLatestItemList(InternalItemsQuery query, IReadOnlyList<BaseItem> parents, CollectionType collectionType);
+
+        /// <summary>
         /// Gets the list of series presentation keys for next up.
         /// </summary>
         /// <param name="query">The query to use.</param>

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Querying;
@@ -58,6 +59,14 @@ public interface IItemRepository
     /// <param name="filter">The query.</param>
     /// <returns>List&lt;BaseItem&gt;.</returns>
     IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery filter);
+
+    /// <summary>
+    /// Gets the item list. Used mainly by the Latest api endpoint.
+    /// </summary>
+    /// <param name="filter">The query.</param>
+    /// <param name="collectionType">Collection Type.</param>
+    /// <returns>List&lt;BaseItem&gt;.</returns>
+    IReadOnlyList<BaseItem> GetLatestItemList(InternalItemsQuery filter, CollectionType collectionType);
 
     /// <summary>
     /// Gets the list of series presentation keys for next up.


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Adds an extra function to the SqliteItemRepository to do a sub query to get the top N number of unique series/albums names sorted by datecreated. The min value of the datecreated from the subquery is then used to retrieve the rows for use for the /item/latest api. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin/issues/10993
Fixes https://github.com/jellyfin/jellyfin/issues/1880
