### PR TITLE
Add FamilyName field to FontFile class and /FallbackFont/Fonts API call

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,7 @@
     <PackageVersion Include="Serilog.Sinks.Graylog" Version="3.1.1" />
     <PackageVersion Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageVersion Include="SharpFuzz" Version="2.1.1" />
+    <PackageVersion Include="SixLabors.Fonts" Version="2.0.4" />
     <PackageVersion Include="SkiaSharp" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,6 +76,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageVersion Include="System.Globalization" Version="4.3.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -80,6 +80,8 @@
     "SubtitleDownloadFailureFromForItem": "Subtitles failed to download from {0} for {1}",
     "Sync": "Sync",
     "System": "System",
+    "TaskSubtitleFallbackFontListPrecache": "Preload fallback subtitles font names",
+    "TaskSubtitleFallbackFontListPrecacheDescription": "Preloads the font family names for fallback subtitles fonts",
     "TvShows": "TV Shows",
     "Undefined": "Undefined",
     "User": "User",

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/SubtitleFallbackFontListPrecacheTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/SubtitleFallbackFontListPrecacheTask.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Subtitles;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Emby.Server.Implementations.ScheduledTasks.Tasks;
+
+/// <summary>
+/// Precaches the mapping of fallback font file to font family name.
+/// </summary>
+public class SubtitleFallbackFontListPrecacheTask : IScheduledTask, IConfigurableScheduledTask
+{
+    private readonly ILocalizationManager _localization;
+    private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly ISubtitleManager _subtitleManager;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<SubtitleFallbackFontListPrecacheTask> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubtitleFallbackFontListPrecacheTask"/> class.
+    /// </summary>
+    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="subtitleManager">Instance of the <see cref="ISubtitleManager"/> interface.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileSystem">The filesystem.</param>
+    public SubtitleFallbackFontListPrecacheTask(
+        ILocalizationManager localization,
+        IServerConfigurationManager serverConfigurationManager,
+        ISubtitleManager subtitleManager,
+        IFileSystem fileSystem,
+        ILogger<SubtitleFallbackFontListPrecacheTask> logger)
+    {
+        _localization = localization;
+        _serverConfigurationManager = serverConfigurationManager;
+        _subtitleManager = subtitleManager;
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => _localization.GetLocalizedString("TaskSubtitleFallbackFontListPrecache");
+
+    /// <inheritdoc />
+    public string Key => "SubtitleFallbackFontListPrecache";
+
+    /// <inheritdoc />
+    public string Description => _localization.GetLocalizedString("TaskSubtitleFallbackFontListPrecacheDescription");
+
+    /// <inheritdoc />
+    public string Category => _localization.GetLocalizedString("TasksLibraryCategory");
+
+    /// <inheritdoc />
+    public bool IsHidden => true;
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public bool IsLogged => true;
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var fonts = _subtitleManager.GetFallbackFontList(progress, cancellationToken);
+        _logger.LogDebug("Precached {Count} fallback font family names", fonts.Count());
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        return new[] { new TaskTriggerInfo() { Type = TaskTriggerInfo.TriggerStartup } };
+    }
+}

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Api.Helpers;
 using Jellyfin.Api.Models.SubtitleDtos;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Configuration;
@@ -31,7 +30,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using SixLabors.Fonts;
 
 namespace Jellyfin.Api.Controllers;
 
@@ -500,38 +498,7 @@ public class SubtitleController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public IEnumerable<FontFile> GetFallbackFontList()
     {
-        var encodingOptions = _serverConfigurationManager.GetEncodingOptions();
-        var fallbackFontPath = encodingOptions.FallbackFontPath;
-
-        if (!string.IsNullOrEmpty(fallbackFontPath))
-        {
-            var files = _fileSystem.GetFiles(fallbackFontPath, new[] { ".woff", ".woff2", ".ttf", ".otf" }, false, false);
-            var fontFiles = files
-                .Select(i => new FontFile
-                {
-                    Name = i.Name,
-                    Size = i.Length,
-                    DateCreated = _fileSystem.GetCreationTimeUtc(i),
-                    DateModified = _fileSystem.GetLastWriteTimeUtc(i)
-                })
-                .OrderBy(i => i.Size)
-                .ThenBy(i => i.Name)
-                .ThenByDescending(i => i.DateModified)
-                .ThenByDescending(i => i.DateCreated);
-            foreach (var fontFile in fontFiles)
-            {
-                FontCollection collection = new();
-                FontFamily family = collection.Add(fallbackFontPath + "/" + fontFile.Name, CultureInfo.InvariantCulture);
-                fontFile.FamilyName = family.Name;
-
-                yield return fontFile;
-            }
-        }
-        else
-        {
-            _logger.LogWarning("The path of fallback font folder has not been set");
-            encodingOptions.EnableFallbackFont = false;
-        }
+        return _subtitleManager.GetFallbackFontList();
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -31,6 +31,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using SixLabors.Fonts;
 
 namespace Jellyfin.Api.Controllers;
 
@@ -517,17 +518,11 @@ public class SubtitleController : BaseJellyfinApiController
                 .ThenBy(i => i.Name)
                 .ThenByDescending(i => i.DateModified)
                 .ThenByDescending(i => i.DateCreated);
-            // max total size 20M
-            const int MaxSize = 20971520;
-            var sizeCounter = 0L;
             foreach (var fontFile in fontFiles)
             {
-                sizeCounter += fontFile.Size;
-                if (sizeCounter >= MaxSize)
-                {
-                    _logger.LogWarning("Some fonts will not be sent due to size limitations");
-                    yield break;
-                }
+                FontCollection collection = new();
+                FontFamily family = collection.Add(fallbackFontPath + "/" + fontFile.Name, CultureInfo.InvariantCulture);
+                fontFile.FamilyName = family.Name;
 
                 yield return fontFile;
             }

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="SixLabors.Fonts" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" />
   </ItemGroup>

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="SixLabors.Fonts" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" />
   </ItemGroup>

--- a/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
+++ b/MediaBrowser.Controller/Subtitles/ISubtitleManager.cs
@@ -1,11 +1,13 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Model.Subtitles;
 
 namespace MediaBrowser.Controller.Subtitles
 {
@@ -91,5 +93,13 @@ namespace MediaBrowser.Controller.Subtitles
         /// <param name="item">The media item.</param>
         /// <returns>Subtitles providers.</returns>
         SubtitleProviderInfo[] GetSupportedProviders(BaseItem item);
+
+        /// <summary>
+        /// Gets the fallback font list.
+        /// </summary>
+        /// <param name="progress">The progress of font family name extraction.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns><see cref="IEnumerable{FontFile}" />.</returns>
+        IEnumerable<FontFile> GetFallbackFontList(IProgress<double>? progress = null, CancellationToken cancellationToken = default);
     }
 }

--- a/MediaBrowser.Model/Subtitles/FontFile.cs
+++ b/MediaBrowser.Model/Subtitles/FontFile.cs
@@ -14,6 +14,12 @@ namespace MediaBrowser.Model.Subtitles
         public string? Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the font family name.
+        /// </summary>
+        /// <value>The font family name.</value>
+        public string? FamilyName { get; set; }
+
+        /// <summary>
         /// Gets or sets the size.
         /// </summary>
         /// <value>The size.</value>

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -23,7 +23,9 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="PlaylistsNET" />
-    <PackageReference Include="z440.atl.core"/>
+    <PackageReference Include="SixLabors.Fonts" />
+    <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Include="z440.atl.core" />
     <PackageReference Include="TMDbLib" />
   </ItemGroup>
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This adds the FamilyName field to the fallback fonts API, which is required to be able to load fonts on-demand in client.

Currently the way fallback fonts work is that they load **all** the fonts into browser before starting playback (up to the arbitrary 20 MB limit), which for obvious reasons sucks. Subtitle Octopus library has a feature where you can define a map of font family to URL to have it only load the required fonts used by particular .ASS file on-demand instead of preloading them all and then figuring out what's gonna be used, which is infinitely better.

However I currently create this as draft PR, because the current naive simple approach requires opening all the font files, which takes 10+ seconds with 1000 font files and on HDD (which is my real use-case that I have right now...). At the very least probably thus the font file path to font family name should be cached somewhere, and possibly precached on both server startup and when the font preloading preference is turned on in admin settings during runtime, if it was off before. I would welcome feedback on what would be the best way of going about this...

Btw it adds a dependency on new library, according to my research it's the only pain-free and cross-platform library for fonts that also supports all the required formats. It's dual-licensed, but Jellyfin as open-source projects falls into the allowance of using Apache2 license of it. So hopefully that's okay?

Also future work TODO: should also make fallback fonts work with transcoding (afaik currently they're completely ignored for burn-in? but that's a matter for separate issue and PR; related to #7275 that currently only supports subtitles from MKV attachments afaik)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
didn't create one for this :/

related jellyfin-web PR that follows this: jellyfin/jellyfin-web#5960

I also have hopes to add support for this to some other clients afterwards in some way...