### PR TITLE
Make Live TV compatibility profiles customizable

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -142,28 +142,15 @@ public static class StreamingHelpers
         }
         else
         {
-            // Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
-            // Cap the MaxStreamingBitrate to 30Mbps, because we are unable to reliably probe source bitrate,
-            // which will cause the client to request extremely high bitrate that may fail the player/encoder
-            streamingRequest.VideoBitRate = streamingRequest.VideoBitRate > 30000000 ? 30000000 : streamingRequest.VideoBitRate;
-
-            if (streamingRequest.SegmentContainer is not null)
-            {
-                // Remove all fmp4 transcoding profiles, because it causes playback error and/or A/V sync issues
-                // Notably: Some channels won't play on FireFox and LG webOS
-                // Some channels from HDHomerun will experience A/V sync issues
-                streamingRequest.SegmentContainer = "ts";
-                streamingRequest.VideoCodec = "h264";
-                streamingRequest.AudioCodec = "aac";
-                state.SupportedVideoCodecs = ["h264"];
-                state.Request.VideoCodec = "h264";
-                state.SupportedAudioCodecs = ["aac"];
-                state.Request.AudioCodec = "aac";
-            }
-
             var liveStreamInfo = await mediaSourceManager.GetLiveStreamWithDirectStreamProvider(streamingRequest.LiveStreamId, cancellationToken).ConfigureAwait(false);
             mediaSource = liveStreamInfo.Item1;
             state.DirectStreamProvider = liveStreamInfo.Item2;
+
+            // Cap the max bitrate when it is too high. This is usually due to ffmpeg is unable to probe the source liveTV streams' bitrate.
+            if (mediaSource.FallbackMaxStreamingBitrate is not null)
+            {
+                streamingRequest.VideoBitRate = streamingRequest.VideoBitRate > mediaSource.FallbackMaxStreamingBitrate ? mediaSource.FallbackMaxStreamingBitrate : streamingRequest.VideoBitRate;
+            }
         }
 
         var encodingOptions = serverConfigurationManager.GetEncodingOptions();

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -149,7 +149,7 @@ public static class StreamingHelpers
             // Cap the max bitrate when it is too high. This is usually due to ffmpeg is unable to probe the source liveTV streams' bitrate.
             if (mediaSource.FallbackMaxStreamingBitrate is not null)
             {
-                streamingRequest.VideoBitRate = streamingRequest.VideoBitRate > mediaSource.FallbackMaxStreamingBitrate ? mediaSource.FallbackMaxStreamingBitrate : streamingRequest.VideoBitRate;
+                streamingRequest.VideoBitRate = Math.Min(streamingRequest.VideoBitRate, mediaSource.FallbackMaxStreamingBitrate);
             }
         }
 

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -147,9 +147,9 @@ public static class StreamingHelpers
             state.DirectStreamProvider = liveStreamInfo.Item2;
 
             // Cap the max bitrate when it is too high. This is usually due to ffmpeg is unable to probe the source liveTV streams' bitrate.
-            if (mediaSource.FallbackMaxStreamingBitrate is not null)
+            if (mediaSource.FallbackMaxStreamingBitrate is not null && streamingRequest.VideoBitRate is not null)
             {
-                streamingRequest.VideoBitRate = Math.Min(streamingRequest.VideoBitRate, mediaSource.FallbackMaxStreamingBitrate);
+                streamingRequest.VideoBitRate = Math.Min(streamingRequest.VideoBitRate.Value, mediaSource.FallbackMaxStreamingBitrate.Value);
             }
         }
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -805,7 +805,7 @@ namespace MediaBrowser.Model.Dlna
             }
 
             var transcodingProfiles = options.Profile.TranscodingProfiles
-                .Where(i => !item.RequiresTsContainerTranscoding || string.Equals(i.Container, "ts", StringComparison.OrdinalIgnoreCase))
+                .Where(i => !item.UseMostCompatibleTranscodingProfile || string.Equals(i.Container, "ts", StringComparison.OrdinalIgnoreCase))
                 .Where(i => i.Type == playlistItem.MediaType && i.Context == options.Context);
 
             if (options.AllowVideoStreamCopy)

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -805,6 +805,7 @@ namespace MediaBrowser.Model.Dlna
             }
 
             var transcodingProfiles = options.Profile.TranscodingProfiles
+                .Where(i => !item.RequiresTsContainerTranscoding || string.Equals(i.Container, "ts", StringComparison.OrdinalIgnoreCase))
                 .Where(i => i.Type == playlistItem.MediaType && i.Context == options.Context);
 
             if (options.AllowVideoStreamCopy)

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Dlna;
@@ -24,6 +25,7 @@ namespace MediaBrowser.Model.Dto
             SupportsDirectStream = true;
             SupportsDirectPlay = true;
             SupportsProbing = true;
+            UseMostCompatibleTranscodingProfile = false;
         }
 
         public MediaProtocol Protocol { get; set; }
@@ -70,6 +72,7 @@ namespace MediaBrowser.Model.Dto
 
         public bool IsInfiniteStream { get; set; }
 
+        [DefaultValue(false)]
         public bool UseMostCompatibleTranscodingProfile { get; set; }
 
         public bool RequiresOpening { get; set; }

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -70,6 +70,8 @@ namespace MediaBrowser.Model.Dto
 
         public bool IsInfiniteStream { get; set; }
 
+        public bool RequiresTsContainerTranscoding { get; set; }
+
         public bool RequiresOpening { get; set; }
 
         public string OpenToken { get; set; }
@@ -97,6 +99,8 @@ namespace MediaBrowser.Model.Dto
         public string[] Formats { get; set; }
 
         public int? Bitrate { get; set; }
+
+        public int? FallbackMaxStreamingBitrate { get; set; }
 
         public TransportStreamTimestamp? Timestamp { get; set; }
 

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -70,7 +70,7 @@ namespace MediaBrowser.Model.Dto
 
         public bool IsInfiniteStream { get; set; }
 
-        public bool RequiresTsContainerTranscoding { get; set; }
+        public bool UseMostCompatibleTranscodingProfile { get; set; }
 
         public bool RequiresOpening { get; set; }
 

--- a/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
+++ b/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
@@ -9,6 +9,9 @@ namespace MediaBrowser.Model.LiveTv
         {
             AllowHWTranscoding = true;
             IgnoreDts = true;
+            AllowStreamSharing = true;
+            AllowFmp4TranscodingContainer = false;
+            FallbackMaxStreamingBitrate = 30000000;
         }
 
         public string Id { get; set; }
@@ -24,6 +27,12 @@ namespace MediaBrowser.Model.LiveTv
         public bool ImportFavoritesOnly { get; set; }
 
         public bool AllowHWTranscoding { get; set; }
+
+        public bool AllowFmp4TranscodingContainer { get; set; }
+
+        public bool AllowStreamSharing { get; set; }
+
+        public int FallbackMaxStreamingBitrate { get; set; }
 
         public bool EnableStreamLooping { get; set; }
 

--- a/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -331,6 +331,8 @@ namespace Jellyfin.LiveTv.TunerHosts.HdHomerun
                 SupportsTranscoding = true,
                 IsInfiniteStream = true,
                 IgnoreDts = true,
+                RequiresTsContainerTranscoding = true, // All HDHR tuners require this
+                FallbackMaxStreamingBitrate = info.FallbackMaxStreamingBitrate,
                 // IgnoreIndex = true,
                 // ReadAtNativeFramerate = true
             };

--- a/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -331,7 +331,7 @@ namespace Jellyfin.LiveTv.TunerHosts.HdHomerun
                 SupportsTranscoding = true,
                 IsInfiniteStream = true,
                 IgnoreDts = true,
-                RequiresTsContainerTranscoding = true, // All HDHR tuners require this
+                UseMostCompatibleTranscodingProfile = true, // All HDHR tuners require this
                 FallbackMaxStreamingBitrate = info.FallbackMaxStreamingBitrate,
                 // IgnoreIndex = true,
                 // ReadAtNativeFramerate = true

--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -94,7 +94,7 @@ namespace Jellyfin.LiveTv.TunerHosts
 
             var mediaSource = sources[0];
 
-            if (mediaSource.Protocol == MediaProtocol.Http && !mediaSource.RequiresLooping)
+            if (tunerHost.AllowStreamSharing && mediaSource.Protocol == MediaProtocol.Http && !mediaSource.RequiresLooping)
             {
                 var extension = Path.GetExtension(new UriBuilder(mediaSource.Path).Path);
 
@@ -200,7 +200,9 @@ namespace Jellyfin.LiveTv.TunerHosts
                 SupportsDirectPlay = supportsDirectPlay,
                 SupportsDirectStream = supportsDirectStream,
 
-                RequiredHttpHeaders = httpHeaders
+                RequiredHttpHeaders = httpHeaders,
+                RequiresTsContainerTranscoding = !info.AllowFmp4TranscodingContainer,
+                FallbackMaxStreamingBitrate = info.FallbackMaxStreamingBitrate
             };
 
             mediaSource.InferTotalBitrate();

--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -201,7 +201,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                 SupportsDirectStream = supportsDirectStream,
 
                 RequiredHttpHeaders = httpHeaders,
-                RequiresTsContainerTranscoding = !info.AllowFmp4TranscodingContainer,
+                UseMostCompatibleTranscodingProfile = !info.AllowFmp4TranscodingContainer,
                 FallbackMaxStreamingBitrate = info.FallbackMaxStreamingBitrate
             };
 


### PR DESCRIPTION
This allows the previously hard-coded compatibility profiles for Live TV to be customizable on a per-tuner basis. Notably:

- Selective enabling of the fMP4 transcoding container to support HEVC and HDR content if the tuner is compatible and will not cause playback issues like A/V out of sync.

- Option to enable or disable HTTP shared streaming (one stream from Jellyfin to the tuner, with multiple clients from Jellyfin). This is useful when the tuner has a stream count limit, but it also caused a lot of playback issues as not all tuners/streams are happy with this.

- User-customizable fallback streaming bitrate. This is particularly helpful when `ffprobe` cannot reliably determine the source stream bitrate, making the client request an excessively high transcoding bitrate that could overload the hardware encoder.

These changes also allow the plugins that implements `ILiveTvService` that can only supply a `MedaSourceInfo` to use the compatibility profiles. By specifying `UseMostCompatibleTranscodingProfile` and `FallbackMaxStreamingBitrate`.



<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Replaces #12483 but this is for 10.10

Fixes #11847
