### PR TITLE
Improve error message when image extraction times out

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncodingUtils.cs
@@ -42,7 +42,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // If there's more than one we'll need to use the concat command
             if (inputFiles.Count > 1)
             {
-                var files = string.Join("|", inputFiles.Select(NormalizePath));
+                var files = string.Join('|', inputFiles.Select(NormalizePath));
 
                 return string.Format(CultureInfo.InvariantCulture, "concat:\"{0}\"", files);
             }


### PR DESCRIPTION
The exception will get logged higher up the call stack.