### PR TITLE
Increase password hash iterations

### DIFF
--- a/MediaBrowser.Model/Cryptography/Constants.cs
+++ b/MediaBrowser.Model/Cryptography/Constants.cs
@@ -18,6 +18,6 @@ namespace MediaBrowser.Model.Cryptography
         /// <summary>
         /// The default amount of iterations for hashing passwords.
         /// </summary>
-        public const int DefaultIterations = 120000;
+        public const int DefaultIterations = 210000;
     }
 }


### PR DESCRIPTION
It has been a while since this was last updated: https://github.com/jellyfin/jellyfin/pull/6818
Recommendations have changed since: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2

