### PR TITLE
Enable software tonemap for dolby vision

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3491,13 +3491,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 mainFilters.Add(tonemapArgs);
-
-                // convert back to nv12 for VAAPI encoders
-                // Q: Is this still being used?
-                if (requireDoviReshaping && isVaapiEncoder)
-                {
-                    mainFilters.Add("format=" + outFormat);
-                }
             }
             else
             {


### PR DESCRIPTION
This applies software tonemapx filter for dolby vision videos that have no compatability fallback.

Due to the complexity of the reshaping process, this is quite CPU-intensive. For real-time transcoding and tonemapping of 4K 60fps content, a CPU with 16 cores of Zen3-level performance is recommended.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Relies on https://github.com/jellyfin/jellyfin-ffmpeg/pull/447

Fixes #9877
