### PR TITLE
Fix subtitle and attachment extraction when input path contains quotes

### DIFF
--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -284,7 +284,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
                 if (extractableAttachmentIds.Count > 0)
                 {
-                    await CacheAllAttachmentsInternal(mediaPath, inputFile, mediaSource, extractableAttachmentIds, cancellationToken).ConfigureAwait(false);
+                    await CacheAllAttachmentsInternal(mediaPath, _mediaEncoder.GetInputArgument(inputFile, mediaSource), mediaSource, extractableAttachmentIds, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -323,7 +323,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
             processArgs += string.Format(
                 CultureInfo.InvariantCulture,
-                " -i \"{0}\" -t 0 -f null null",
+                " -i {0} -t 0 -f null null",
                 inputFile);
 
             int exitCode;

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -501,11 +501,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             List<MediaStream> subtitleStreams,
             CancellationToken cancellationToken)
         {
-            var inputPath = mediaSource.Path;
+            var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
             var outputPaths = new List<string>();
             var args = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i \"{0}\" -copyts",
+                "-i {0} -copyts",
                 inputPath);
 
             foreach (var subtitleStream in subtitleStreams)
@@ -676,7 +676,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             var processArgs = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i \"{0}\" -copyts -map 0:{1} -an -vn -c:s {2} \"{3}\"",
+                "-i {0} -copyts -map 0:{1} -an -vn -c:s {2} \"{3}\"",
                 inputPath,
                 subtitleStreamIndex,
                 outputCodec,


### PR DESCRIPTION
**Changes**
- [Use `IMediaEncoder.GetInputArgument`](https://github.com/jellyfin/jellyfin/blob/8c4d23435e6e0206e36e2120029697bb92714ec3/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L504) to escape input path, as in [`ExtractTextSubtitle`](https://github.com/jellyfin/jellyfin/blob/b3efae71c0c5b01c762695156aa3bd61a7e8afb9/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L647).
- Remove extra quotes from command (https://github.com/jellyfin/jellyfin/pull/10992).
[`inputPath` in `ExtractTextSubtitleInternal`](https://github.com/jellyfin/jellyfin/blob/b3efae71c0c5b01c762695156aa3bd61a7e8afb9/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L680) is already [escaped](https://github.com/jellyfin/jellyfin/blob/b3efae71c0c5b01c762695156aa3bd61a7e8afb9/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L647).
- [Use `IMediaEncoder.GetInputArgument`](https://github.com/jellyfin/jellyfin/blob/8c4d23435e6e0206e36e2120029697bb92714ec3/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs#L287) to escape input path, as in [`ExtractAttachment`](https://github.com/jellyfin/jellyfin/blob/b3efae71c0c5b01c762695156aa3bd61a7e8afb9/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs#L419).

**Issues**
Fixes #10991
#12450
Fixes #12570
