### PR TITLE
Fix metadata merge for BoxSets

### DIFF
--- a/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
+++ b/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
@@ -54,7 +54,14 @@ namespace MediaBrowser.Providers.BoxSets
 
             if (mergeMetadataSettings)
             {
-                targetItem.LinkedChildren = sourceItem.LinkedChildren;
+                if (replaceData || targetItem.LinkedChildren.Length == 0)
+                {
+                    targetItem.LinkedChildren = sourceItem.LinkedChildren;
+                }
+                else
+                {
+                    targetItem.LinkedChildren = sourceItem.LinkedChildren.Concat(targetItem.LinkedChildren).Distinct().ToArray();
+                }
             }
         }
 


### PR DESCRIPTION
When updating BoxSets, we don't merge but replace the `LinkedChildren`.

**Changes**
* Actually merge and not replace `LinkedChildren` on BoxSets.

**Issues**
Fixes #12155
