### PR TITLE
Migrate rating level to double

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -467,7 +467,7 @@ namespace Emby.Server.Implementations.Data
                 AddColumn(connection, "TypedBaseItems", "ExternalServiceId", "Text", existingColumnNames);
                 AddColumn(connection, "TypedBaseItems", "Tags", "Text", existingColumnNames);
                 AddColumn(connection, "TypedBaseItems", "IsFolder", "BIT", existingColumnNames);
-                AddColumn(connection, "TypedBaseItems", "InheritedParentalRatingValue", "INT", existingColumnNames);
+                AddColumn(connection, "TypedBaseItems", "InheritedParentalRatingValue", "Float", existingColumnNames);
                 AddColumn(connection, "TypedBaseItems", "UnratedType", "Text", existingColumnNames);
                 AddColumn(connection, "TypedBaseItems", "TopParentId", "Text", existingColumnNames);
                 AddColumn(connection, "TypedBaseItems", "TrailerTypes", "Text", existingColumnNames);
@@ -1746,7 +1746,7 @@ namespace Emby.Server.Implementations.Data
 
             if (HasField(query, ItemFields.InheritedParentalRatingValue))
             {
-                if (reader.TryGetInt32(index++, out var parentalRating))
+                if (reader.TryGetDouble(index++, out var parentalRating))
                 {
                     item.InheritedParentalRatingValue = parentalRating;
                 }

--- a/Emby.Server.Implementations/Sorting/OfficialRatingComparer.cs
+++ b/Emby.Server.Implementations/Sorting/OfficialRatingComparer.cs
@@ -36,8 +36,8 @@ namespace Emby.Server.Implementations.Sorting
 
             ArgumentNullException.ThrowIfNull(y);
 
-            var levelX = string.IsNullOrEmpty(x.OfficialRating) ? 0 : _localization.GetRatingLevel(x.OfficialRating) ?? 0;
-            var levelY = string.IsNullOrEmpty(y.OfficialRating) ? 0 : _localization.GetRatingLevel(y.OfficialRating) ?? 0;
+            var levelX = string.IsNullOrEmpty(x.OfficialRating) ? 0.0 : _localization.GetRatingLevel(x.OfficialRating) ?? 0.0;
+            var levelY = string.IsNullOrEmpty(y.OfficialRating) ? 0.0 : _localization.GetRatingLevel(y.OfficialRating) ?? 0.0;
 
             return levelX.CompareTo(levelY);
         }

--- a/Jellyfin.Server/Migrations/Routines/MigrateRatingLevels.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateRatingLevels.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.Server.Migrations.Routines
         }
 
         /// <inheritdoc/>
-        public Guid Id => Guid.Parse("{67445D54-B895-4B24-9F4C-35CE0690EA07}");
+        public Guid Id => Guid.Parse("{A4E4cEA6-04ED-4773-9200-5343CA223321}");
 
         /// <inheritdoc/>
         public string Name => "MigrateRatingLevels";
@@ -64,8 +64,12 @@ namespace Jellyfin.Server.Migrations.Routines
             }
 
             // Migrate parental rating strings to new levels
-            _logger.LogInformation("Recalculating parental rating levels based on rating string.");
             using var connection = new SqliteConnection($"Filename={dbPath}");
+            _logger.LogInformation("Dropping and re-creating InheritedParentalRatingValue column to change type.");
+            connection.Execute("ALTER TABLE TypedBaseItems DROP COLUMN InheritedParentalRatingValue;");
+            connection.Execute("ALTER TABLE TypedBaseItems ADD COLUMN InheritedParentalRatingValue FLOAT NULL;");
+
+            _logger.LogInformation("Populating InheritedParentalRatingValue column by re-processing rating strings.");
             connection.Open();
             using (var transaction = connection.BeginTransaction())
             {

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -570,7 +570,7 @@ namespace MediaBrowser.Controller.Entities
         public string OfficialRating { get; set; }
 
         [JsonIgnore]
-        public int? InheritedParentalRatingValue { get; set; }
+        public double? InheritedParentalRatingValue { get; set; }
 
         /// <summary>
         /// Gets or sets the critic rating.
@@ -1564,7 +1564,7 @@ namespace MediaBrowser.Controller.Entities
             return !maxAllowedRating.HasValue || value.Value <= maxAllowedRating.Value;
         }
 
-        public int? GetInheritedParentalRatingValue()
+        public double? GetInheritedParentalRatingValue()
         {
             var rating = CustomRatingForComparison;
 

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -233,9 +233,9 @@ namespace MediaBrowser.Controller.Entities
 
         public int? IndexNumber { get; set; }
 
-        public int? MinParentalRating { get; set; }
+        public double? MinParentalRating { get; set; }
 
-        public int? MaxParentalRating { get; set; }
+        public double? MaxParentalRating { get; set; }
 
         public bool? HasDeadParentId { get; set; }
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1208,7 +1208,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             // Generate concat configuration entries for each file and write to file
             Directory.CreateDirectory(Path.GetDirectoryName(concatFilePath));
-            using StreamWriter sw = new FormattingStreamWriter(concatFilePath, CultureInfo.InvariantCulture);
+            using FormattingStreamWriter sw = new FormattingStreamWriter(concatFilePath, CultureInfo.InvariantCulture);
             foreach (var path in files)
             {
                 var mediaInfoResult = GetMediaInfo(

--- a/MediaBrowser.Model/Entities/ParentalRating.cs
+++ b/MediaBrowser.Model/Entities/ParentalRating.cs
@@ -1,33 +1,39 @@
 #nullable disable
-#pragma warning disable CS1591
 
-namespace MediaBrowser.Model.Entities
+namespace MediaBrowser.Model.Entities;
+
+/// <summary>
+/// Class ParentalRating.
+/// </summary>
+public class ParentalRating
 {
     /// <summary>
-    /// Class ParentalRating.
+    /// Initializes a new instance of the <see cref="ParentalRating"/> class.
     /// </summary>
-    public class ParentalRating
+    public ParentalRating()
     {
-        public ParentalRating()
-        {
-        }
-
-        public ParentalRating(string name, int? value)
-        {
-            Name = name;
-            Value = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the name.
-        /// </summary>
-        /// <value>The name.</value>
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value.
-        /// </summary>
-        /// <value>The value.</value>
-        public int? Value { get; set; }
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParentalRating"/> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="value">The value.</param>
+    public ParentalRating(string name, double? value)
+    {
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    /// <value>The name.</value>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value.
+    /// </summary>
+    /// <value>The value.</value>
+    public double? Value { get; set; }
 }

--- a/MediaBrowser.Model/Globalization/ILocalizationManager.cs
+++ b/MediaBrowser.Model/Globalization/ILocalizationManager.cs
@@ -31,8 +31,8 @@ namespace MediaBrowser.Model.Globalization
         /// </summary>
         /// <param name="rating">The rating.</param>
         /// <param name="countryCode">The optional two letter ISO language string.</param>
-        /// <returns><see cref="int" /> or <c>null</c>.</returns>
-        int? GetRatingLevel(string rating, string? countryCode = null);
+        /// <returns><see cref="double" /> or <c>null</c>.</returns>
+        double? GetRatingLevel(string rating, string? countryCode = null);
 
         /// <summary>
         /// Gets the localized string.

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Emby.Server.Implementations.Localization;
 using MediaBrowser.Controller.Configuration;
@@ -109,14 +108,14 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         }
 
         [Theory]
-        [InlineData("CA-R", "CA", 18)]
-        [InlineData("FSK-16", "DE", 16)]
-        [InlineData("FSK-18", "DE", 18)]
-        [InlineData("FSK-18", "US", 18)]
-        [InlineData("TV-MA", "US", 17)]
-        [InlineData("XXX", "asdf", 1000)]
-        [InlineData("Germany: FSK-18", "DE", 18)]
-        public async Task GetRatingLevel_GivenValidString_Success(string value, string countryCode, int expectedLevel)
+        [InlineData("CA-R", "CA", 18.0)]
+        [InlineData("FSK-16", "DE", 16.0)]
+        [InlineData("FSK-18", "DE", 18.0)]
+        [InlineData("FSK-18", "US", 18.0)]
+        [InlineData("TV-MA", "US", 17.0)]
+        [InlineData("XXX", "asdf", 1000.0)]
+        [InlineData("Germany: FSK-18", "DE", 18.0)]
+        public async Task GetRatingLevel_GivenValidString_Success(string value, string countryCode, double expectedLevel)
         {
             var localizationManager = Setup(new ServerConfiguration()
             {
@@ -129,13 +128,13 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         }
 
         [Theory]
-        [InlineData("0", 0)]
-        [InlineData("1", 1)]
-        [InlineData("6", 6)]
-        [InlineData("12", 12)]
-        [InlineData("42", 42)]
-        [InlineData("9999", 9999)]
-        public async Task GetRatingLevel_GivenValidAge_Success(string value, int expectedLevel)
+        [InlineData("0", 0.0)]
+        [InlineData("1", 1.0)]
+        [InlineData("6", 6.0)]
+        [InlineData("12", 12.0)]
+        [InlineData("42", 42.0)]
+        [InlineData("9999", 9999.0)]
+        public async Task GetRatingLevel_GivenValidAge_Success(string value, double expectedLevel)
         {
             var localizationManager = Setup(new ServerConfiguration { MetadataCountryCode = "nl" });
             await localizationManager.LoadAll();


### PR DESCRIPTION
We need to have more granular control if we have rating strings which map to the same age.

**Changes**
* Switch all rating level related logic to double
* Re-enable migration to re-create and re-populate changed column

**Issues**
Prerequisite to fix #11650
