### PR TITLE
Enable the new BWDIF CUDA deint filter when available

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3234,14 +3234,18 @@ namespace MediaBrowser.Controller.MediaEncoding
                 doubleRateDeint ? "1" : "0");
         }
 
-        public static string GetHwDeinterlaceFilter(EncodingJobInfo state, EncodingOptions options, string hwDeintSuffix)
+        public string GetHwDeinterlaceFilter(EncodingJobInfo state, EncodingOptions options, string hwDeintSuffix)
         {
             var doubleRateDeint = options.DeinterlaceDoubleRate && (state.VideoStream?.AverageFrameRate ?? 60) <= 30;
             if (hwDeintSuffix.Contains("cuda", StringComparison.OrdinalIgnoreCase))
             {
+                var useBwdif = string.Equals(options.DeinterlaceMethod, "bwdif", StringComparison.OrdinalIgnoreCase)
+                    && _mediaEncoder.SupportsFilter("bwdif_cuda");
+
                 return string.Format(
                     CultureInfo.InvariantCulture,
-                    "yadif_cuda={0}:-1:0",
+                    "{0}_cuda={1}:-1:0",
+                    useBwdif ? "bwdif" : "yadif",
                     doubleRateDeint ? "1" : "0");
             }
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -110,6 +110,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // cuda
             "scale_cuda",
             "yadif_cuda",
+            "bwdif_cuda",
             "tonemap_cuda",
             "overlay_cuda",
             "transpose_cuda",


### PR DESCRIPTION
**Changes**
- Enable the new BWDIF CUDA deint filter when available (This requires jellyfin-ffmpeg7)

Conflict with #12561