### PR TITLE
Userdatakey fix

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -178,7 +178,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
             if (this.TryGetProviderId(MetadataProvider.Tvdb, out key))
             {
-                list.Insert(0, key);
+                list.Insert(0, "tvdb-" + key);
             }
 
             if (this.TryGetProviderId(MetadataProvider.Custom, out key))

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -270,7 +270,7 @@ namespace MediaBrowser.Controller.Entities
                     var key = this.GetProviderId(MetadataProvider.Tmdb);
                     if (!string.IsNullOrEmpty(key))
                     {
-                        list.Insert(0, GetUserDataKey(key));
+                        list.Insert(0, "tmdb-" + GetUserDataKey(key));
                     }
 
                     key = this.GetProviderId(MetadataProvider.Imdb);
@@ -290,7 +290,7 @@ namespace MediaBrowser.Controller.Entities
                     key = this.GetProviderId(MetadataProvider.Tmdb);
                     if (!string.IsNullOrEmpty(key))
                     {
-                        list.Insert(0, key);
+                        list.Insert(0, "tmdb-" + key);
                     }
                 }
             }


### PR DESCRIPTION
**[DRAFT]**
**[DRAFT]**
**[DRAFT]**

Currently tmdb and tvdb userdatakeys are added as digits only. This has caused confusion especially when marking favorites.
This fixes the issue by adding a prefix for each case. IMDB userdatakeys already have a "tt" prefix that differentiates them.

I have tested this in a personal instance and it works.


**Changes**
The column "UserDataKey" in table "TypedBaseItems" of library.db  will now have "tvdb-" appended if the userdatakey is derived from the tvdb id, and "tmdb-" appended if derived from a tmdb id. 

**Issues**
Fixes #11840  

**Problems**
This fixes the issue completely going forward. However, the current watch history data in the "key" column in "Userdatas" table will not match. The current data needs to be migrated. Proposed migration method is to:
- for any UserDatas.key = TypedBaseItems.UserDataKey AND only digits, check TypedBaseItems.UnratedType. 
- if TypedBaseItems.UnratedType is "Series", add "tvdb-" prefix to both UserDatas.key and TypedBaseItems.UserDataKey
- if TypedBaseItems.UnratedType is "Movie", add "tmdb-" prefix to both UserDatas.key and TypedBaseItems.UserDataKey

Unfortunately i dont know to put in a migration script. This would need someone else's help.
Thus, this PR is still in [DRAFT].
 Please give any comments.