### PR TITLE
Enable tone-mapping and HLS remuxing for DoVi Profile 10 in AV1

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -315,8 +315,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return false;
             }
 
-            if (string.Equals(state.VideoStream.Codec, "hevc", StringComparison.OrdinalIgnoreCase)
-                && state.VideoStream.VideoRange == VideoRange.HDR
+            if (state.VideoStream.VideoRange == VideoRange.HDR
                 && state.VideoStream.VideoRangeType == VideoRangeType.DOVI)
             {
                 // Only native SW decoder and HW accelerator can parse dovi rpu.


### PR DESCRIPTION
Together with #11559 and jellyfin-ffmpeg7, we can enable DoVi Profile 10.

**Changes**
- Enable hardware tone-mapping for DoVi Profile 10
- Add HLS remuxing support for DoVi Profile 10

<img src="https://github.com/user-attachments/assets/f3b56430-8c80-4953-b629-beb437771354" height="300">