### PR TITLE
Add SUPPLEMENTAL-CODECS for Dolby Vision video with fallbacks

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -304,6 +304,8 @@ public class DynamicHlsHelper
 
         AppendPlaylistCodecsField(playlistBuilder, state);
 
+        AppendPlaylistSupplementalCodecsField(playlistBuilder, state);
+
         AppendPlaylistResolutionField(playlistBuilder, state);
 
         AppendPlaylistFramerateField(playlistBuilder, state);
@@ -404,6 +406,48 @@ public class DynamicHlsHelper
                 .Append(codecs)
                 .Append('"');
         }
+    }
+
+    /// <summary>
+    /// Appends a SUPPLEMENTAL-CODECS field containing formatted strings of
+    /// the active streams output Dolby Vision Videos.
+    /// </summary>
+    /// <seealso cref="AppendPlaylist(StringBuilder, StreamState, string, int, string)"/>
+    /// <seealso cref="GetPlaylistVideoCodecs(StreamState, string, int)"/>
+    /// <param name="builder">StringBuilder to append the field to.</param>
+    /// <param name="state">StreamState of the current stream.</param>
+    private void AppendPlaylistSupplementalCodecsField(StringBuilder builder, StreamState state)
+    {
+        // Dolby Vision currently cannot exist when transcoding
+        if (!EncodingHelper.IsCopyCodec(state.OutputVideoCodec))
+        {
+            return;
+        }
+
+        var dvProfile = state.VideoStream.DvProfile;
+        var dvLevel = state.VideoStream.DvLevel;
+        var dvRangeString = state.VideoStream.VideoRangeType switch
+        {
+            VideoRangeType.DOVIWithHDR10 => "db1p",
+            VideoRangeType.DOVIWithHLG => "db4h",
+            _ => string.Empty
+        };
+
+        if (dvProfile is null || dvLevel is null || string.IsNullOrEmpty(dvRangeString))
+        {
+            return;
+        }
+
+        var dvFourCc = string.Equals(state.ActualOutputVideoCodec, "av1", StringComparison.OrdinalIgnoreCase) ? "dav1" : "dvh1";
+        builder.Append(",SUPPLEMENTAL-CODECS=\"")
+            .Append(dvFourCc)
+            .Append('.')
+            .Append(dvProfile.Value.ToString("D2", CultureInfo.InvariantCulture))
+            .Append('.')
+            .Append(dvLevel.Value.ToString("D2", CultureInfo.InvariantCulture))
+            .Append('/')
+            .Append(dvRangeString)
+            .Append('"');
     }
 
     /// <summary>


### PR DESCRIPTION
This is a more correct way to supply Dolby Vision videos with PQ/HLG fallbacks. The `CODECS` is used to describe the base layer and this `SUPPLEMENTAL-CODECS` attribute will be used to describe the enhanced codec. Supported clients will use this field to check if the enhancement layer is available, and this attribute will simply be ignored when the client does not support that field.

One thing to note is that for Dolby Vision videos without a fallback layer, the HLS attributes generated by our current implementation are not entirely correct. If the Dolby Vision video lacks a fallback layer, the `CODECS` attribute should directly describe the Dolby Vision profile, such as `dvh1.05.09`, rather than the HEVC codec profile. However, I'm a bit concerned about compatibility if we decide to make this change. I’ve tested both HLS.js and Safari’s native HLS, and they can handle the Dolby Vision fourCC correctly, but I’m unsure about the support status on other clients. We can change that later if that becomes a problem to support `dav1` or Dolby Vision Profile 10 videos.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
