### PR TITLE
Fix trickplay migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MoveTrickplayFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/MoveTrickplayFiles.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Globalization;
 using System.IO;
-using DiscUtils;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Trickplay;
+using MediaBrowser.Model.IO;
 
 namespace Jellyfin.Server.Migrations.Routines;
 


### PR DESCRIPTION
The auto import generated by IDE used wrong namespace

The CI is expected to fail until rebase on #12607 

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
