### PR TITLE
Only sort item by width when they have the same path

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1087,12 +1087,7 @@ namespace MediaBrowser.Controller.Entities
 
                 return 1;
             }).ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
-            .ThenByDescending(i =>
-            {
-                var stream = i.VideoStream;
-
-                return stream is null || stream.Width is null ? 0 : stream.Width.Value;
-            })
+            .ThenByDescending(i => i, new MediaSourceWidthComparator())
             .ToList();
         }
 

--- a/MediaBrowser.Controller/Entities/MediaSourceWidthComparator.cs
+++ b/MediaBrowser.Controller/Entities/MediaSourceWidthComparator.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Dto;
 namespace MediaBrowser.Controller.Entities;
 
 /// <summary>
-/// Alphanumeric <see cref="IComparer{T}" />.
+/// Compare MediaSource of the same file by Video width <see cref="IComparer{T}" />.
 /// </summary>
 public class MediaSourceWidthComparator : IComparer<MediaSourceInfo>
 {

--- a/MediaBrowser.Controller/Entities/MediaSourceWidthComparator.cs
+++ b/MediaBrowser.Controller/Entities/MediaSourceWidthComparator.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Intrinsics.X86;
+using MediaBrowser.Model.Dto;
+
+namespace MediaBrowser.Controller.Entities;
+
+/// <summary>
+/// Alphanumeric <see cref="IComparer{T}" />.
+/// </summary>
+public class MediaSourceWidthComparator : IComparer<MediaSourceInfo>
+{
+    /// <inheritdoc />
+    public int Compare(MediaSourceInfo? x, MediaSourceInfo? y)
+    {
+        if (x is null && y is null)
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        if (string.Equals(x.Path, y.Path, StringComparison.OrdinalIgnoreCase))
+        {
+            if (x.VideoStream is null && y.VideoStream is null)
+            {
+                return 0;
+            }
+
+            if (x.VideoStream is null)
+            {
+                return -1;
+            }
+
+            if (y.VideoStream is null)
+            {
+                return 1;
+            }
+
+            var xWidth = x.VideoStream.Width ?? 0;
+            var yWidth = y.VideoStream.Width ?? 0;
+
+            return xWidth - yWidth;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Since emby era we are re-ordering all media sources by its width when reading from database. However, that would break the sorting made by the media prober when resolving multiple versions from different files. Only do such sorting when media streams share the same path to respect the filename based sorting done by the multi version resolver.

This should have little to no impact for most cases are most of the files will only have strictly one video stream.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12129