### PR TITLE
Use subtitle cache when burning subtitles in

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -189,6 +189,7 @@
  - [TheMelmacian](https://github.com/TheMelmacian)
  - [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
  - [pret0rian8](https://github.com/pret0rian)
+ - [jaina heartles](https://github.com/heartles)
 
 # Emby Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -190,6 +190,7 @@
  - [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
  - [pret0rian8](https://github.com/pret0rian)
  - [jaina heartles](https://github.com/heartles)
+ - [oxixes](https://github.com/oxixes)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1652,13 +1652,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                     setPtsParam);
             }
 
-            var mediaPath = state.MediaPath ?? string.Empty;
+            var subtitlePath = _subtitleEncoder.GetSubtitleFilePath(
+                    state.SubtitleStream,
+                    state.MediaSource,
+                    CancellationToken.None).GetAwaiter().GetResult();
 
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "subtitles=f='{0}':si={1}{2}{3}{4}{5}",
-                _mediaEncoder.EscapeSubtitleFilterPath(mediaPath),
-                state.InternalSubtitleStreamOffset.ToString(CultureInfo.InvariantCulture),
+                "subtitles=f='{0}'{1}{2}{3}{4}",
+                _mediaEncoder.EscapeSubtitleFilterPath(subtitlePath),
                 alphaParam,
                 sub2videoParam,
                 fontParam,

--- a/MediaBrowser.Controller/MediaEncoding/ISubtitleEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/ISubtitleEncoder.cs
@@ -44,5 +44,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>System.String.</returns>
         Task<string> GetSubtitleFileCharacterSet(MediaStream subtitleStream, string language, MediaSourceInfo mediaSource, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the path to a subtitle file.
+        /// </summary>
+        /// <param name="subtitleStream">The subtitle stream.</param>
+        /// <param name="mediaSource">The media source.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>System.String.</returns>
+        Task<string> GetSubtitleFilePath(MediaStream subtitleStream, MediaSourceInfo mediaSource, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -902,6 +902,12 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
+        public async Task<string> GetSubtitleFilePath(MediaStream subtitleStream, MediaSourceInfo mediaSource, CancellationToken cancellationToken)
+        {
+            var info = await GetReadableFile(mediaSource, subtitleStream, cancellationToken);
+            return info.Path;
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -904,7 +904,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
         public async Task<string> GetSubtitleFilePath(MediaStream subtitleStream, MediaSourceInfo mediaSource, CancellationToken cancellationToken)
         {
-            var info = await GetReadableFile(mediaSource, subtitleStream, cancellationToken);
+            var info = await GetReadableFile(mediaSource, subtitleStream, cancellationToken)
+                .ConfigureAwait(false);
             return info.Path;
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR is based off of #12373.

*From the original PR*
This PR adds a method to MediaBrowser.Controller.MediaEncoding.ISubtitleEncoder to get the path of the extracted subtitle. MediaBrowser.Controller.MediaEncoding.EncodingHelper is modified to call this method instead of getting the subtitle directly from the media file itself.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #11938. If the subtitles are already extracted (by a previous extraction done by a user, or by SubtitleExtract) they will be used. If not, they will be extracted and added to the cache, which will take almost the same time as the previous solution, though it will only need to be done once (this is because `GetReadableFile` already does the extraction automatically).