### PR TITLE
Fix some analyzer IDisposable warnings

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -608,6 +608,7 @@ namespace Emby.Server.Implementations
                 var localCert = new X509Certificate2(path, password, X509KeyStorageFlags.UserKeySet);
                 if (!localCert.HasPrivateKey)
                 {
+                    localCert.Dispose();
                     Logger.LogError("No private key included in SSL cert {CertificateLocation}.", path);
                     return null;
                 }

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -161,8 +161,6 @@ namespace Emby.Server.Implementations
                 ConfigurationManager.Configuration,
                 ApplicationPaths.PluginsPath,
                 ApplicationVersion);
-
-            _disposableParts.Add(_pluginManager);
         }
 
         /// <summary>
@@ -971,6 +969,7 @@ namespace Emby.Server.Implementations
 
             if (dispose)
             {
+                _pluginManager?.Dispose();
                 var type = GetType();
 
                 Logger.LogInformation("Disposing {Type}", type.Name);

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -425,7 +425,7 @@ public class VideosController : BaseJellyfinApiController
             EnableAudioVbrEncoding = enableAudioVbrEncoding
         };
 
-        var state = await StreamingHelpers.GetStreamingState(
+        using var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
                 HttpContext,
                 _mediaSourceManager,

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -124,7 +124,8 @@ namespace MediaBrowser.MediaEncoding.Attachments
         {
             using (await _semaphoreLocks.LockAsync(outputPath, cancellationToken).ConfigureAwait(false))
             {
-                if (!File.Exists(Path.Join(outputPath, id)))
+                var outputIdPath = Path.Join(outputPath, id);
+                if (!File.Exists(outputIdPath))
                 {
                     await ExtractAllAttachmentsInternal(
                         inputArgument,
@@ -134,7 +135,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
                     if (Directory.Exists(outputPath))
                     {
-                        File.Create(Path.Join(outputPath, id));
+                        await File.Create(outputIdPath).DisposeAsync().ConfigureAwait(false);
                     }
                 }
             }

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -132,6 +132,8 @@
     <Rule Id="CA2016" Action="Error" />
     <!-- error on CA2201: Exception type System.Exception is not sufficiently specific -->
     <Rule Id="CA2201" Action="Error" />
+    <!-- error on CA2213: Disposable fields should be disposed -->
+    <Rule Id="CA2213" Action="Error" />
     <!-- error on CA2215: Dispose methods should call base class dispose -->
     <Rule Id="CA2215" Action="Error" />
     <!-- error on CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability -->

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -93,6 +93,8 @@
     <Rule Id="CA1727" Action="Error" />
     <!-- error on CA1813: Avoid unsealed attributes -->
     <Rule Id="CA1813" Action="Error" />
+    <!-- error on CA1816: Call GC.SuppressFinalize correctly -->
+    <Rule Id="CA1816" Action="Error" />
     <!-- error on CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string -->
     <Rule Id="CA1834" Action="Error" />
     <!-- error on CA1843: Do not use 'WaitAll' with a single task -->
@@ -136,6 +138,8 @@
     <Rule Id="CA2213" Action="Error" />
     <!-- error on CA2215: Dispose methods should call base class dispose -->
     <Rule Id="CA2215" Action="Error" />
+    <!-- error on CA2216: Disposable types should declare finalizer -->
+    <Rule Id="CA2216" Action="Error" />
     <!-- error on CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability -->
     <Rule Id="CA2249" Action="Error" />
     <!-- error on CA2254: Template should be a static expression -->

--- a/tests/Jellyfin.LiveTv.Tests/HdHomerunHostTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/HdHomerunHostTests.cs
@@ -14,10 +14,13 @@ using Xunit;
 
 namespace Jellyfin.LiveTv.Tests
 {
-    public class HdHomerunHostTests
+    public sealed class HdHomerunHostTests : IDisposable
     {
         private readonly Fixture _fixture;
         private readonly HdHomerunHost _hdHomerunHost;
+        private readonly HttpClient _httpClient;
+
+        private bool _disposed;
 
         public HdHomerunHostTests()
         {
@@ -33,9 +36,10 @@ namespace Jellyfin.LiveTv.Tests
                         });
                     });
 
+            _httpClient = new HttpClient(messageHandler.Object);
             var http = new Mock<IHttpClientFactory>();
             http.Setup(x => x.CreateClient(It.IsAny<string>()))
-                .Returns(new HttpClient(messageHandler.Object));
+                .Returns(_httpClient);
             _fixture = new Fixture();
             _fixture.Customize(new AutoMoqCustomization
             {
@@ -151,6 +155,17 @@ namespace Jellyfin.LiveTv.Tests
             Assert.Equal("HDHomeRun PRIME", host.FriendlyName);
             Assert.Equal("FFFFFFFF", host.DeviceId);
             Assert.Equal(3, host.TunerCount);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _httpClient.Dispose();
+            _disposed = true;
         }
     }
 }

--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
@@ -14,10 +14,13 @@ using Xunit;
 
 namespace Jellyfin.LiveTv.Tests.Listings;
 
-public class XmlTvListingsProviderTests
+public sealed class XmlTvListingsProviderTests : IDisposable
 {
     private readonly Fixture _fixture;
     private readonly XmlTvListingsProvider _xmlTvListingsProvider;
+    private readonly HttpClient _httpClient;
+
+    private bool _disposed;
 
     public XmlTvListingsProviderTests()
     {
@@ -33,9 +36,10 @@ public class XmlTvListingsProviderTests
                     });
                 });
 
+        _httpClient = new HttpClient(messageHandler.Object);
         var http = new Mock<IHttpClientFactory>();
         http.Setup(x => x.CreateClient(It.IsAny<string>()))
-            .Returns(new HttpClient(messageHandler.Object));
+            .Returns(_httpClient);
         _fixture = new Fixture();
         _fixture.Customize(new AutoMoqCustomization
         {
@@ -85,5 +89,16 @@ public class XmlTvListingsProviderTests
         var program = programsList[0];
         Assert.DoesNotContain(program.Genres, g => string.IsNullOrEmpty(g));
         Assert.Equal("3297", program.ChannelId);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _httpClient.Dispose();
+        _disposed = true;
     }
 }

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
         [Fact]
         public void GetExtraArguments_Forwards_UserAgent()
         {
-            var encoder = new MediaEncoder(
+            using var encoder = new MediaEncoder(
                 Mock.Of<ILogger<MediaEncoder>>(),
                 Mock.Of<IServerConfigurationManager>(),
                 Mock.Of<IFileSystem>(),

--- a/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
@@ -96,7 +96,7 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
         public async Task GetReadableFile_Valid_Success(MediaSourceInfo mediaSource, MediaStream subtitleStream, SubtitleEncoder.SubtitleInfo subtitleInfo)
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
-            var subtitleEncoder = fixture.Create<SubtitleEncoder>();
+            using var subtitleEncoder = fixture.Create<SubtitleEncoder>();
             var result = await subtitleEncoder.GetReadableFile(mediaSource, subtitleStream, CancellationToken.None);
             Assert.Equal(subtitleInfo.Path, result.Path);
             Assert.Equal(subtitleInfo.Protocol, result.Protocol);

--- a/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
@@ -38,7 +38,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
         [Fact]
         public void SaveManifest_RoundTrip_Success()
         {
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, null!, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager(null);
             var manifest = new PluginManifest()
             {
                 Version = "1.0"
@@ -85,12 +85,12 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var dllPath = Path.GetDirectoryName(Path.Combine(_pluginPath, dllFile))!;
 
             Directory.CreateDirectory(dllPath);
-            File.Create(Path.Combine(dllPath, filename));
+            File.Create(Path.Combine(dllPath, filename)).Dispose();
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
 
             File.WriteAllText(metafilePath, JsonSerializer.Serialize(manifest, _options));
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, _tempPath, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager();
 
             var res = JsonSerializer.Deserialize<PluginManifest>(File.ReadAllText(metafilePath), _options);
 
@@ -141,14 +141,14 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
 
             foreach (var file in files)
             {
-                File.Create(Path.Combine(_pluginPath, file));
+                File.Create(Path.Combine(_pluginPath, file)).Dispose();
             }
 
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
 
             File.WriteAllText(metafilePath, JsonSerializer.Serialize(manifest, _options));
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, _tempPath, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager();
 
             var res = JsonSerializer.Deserialize<PluginManifest>(File.ReadAllText(metafilePath), _options);
 
@@ -193,7 +193,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
             await File.WriteAllTextAsync(metafilePath, JsonSerializer.Serialize(partial, _options));
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, _tempPath, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager();
 
             await pluginManager.PopulateManifest(packageInfo, new Version(1, 0), _pluginPath, PluginStatus.Active);
 
@@ -226,7 +226,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
                 ImagePath = string.Empty
             };
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, null!, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager(null);
 
             await pluginManager.PopulateManifest(packageInfo, new Version(1, 0), _pluginPath, PluginStatus.Active);
 
@@ -253,7 +253,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
             await File.WriteAllTextAsync(metafilePath, JsonSerializer.Serialize(partial, _options));
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, _tempPath, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager();
 
             await pluginManager.PopulateManifest(packageInfo, new Version(1, 0), _pluginPath, PluginStatus.Active);
 
@@ -279,7 +279,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
             await File.WriteAllTextAsync(metafilePath, JsonSerializer.Serialize(partial, _options));
 
-            var pluginManager = new PluginManager(new NullLogger<PluginManager>(), null!, null!, _tempPath, new Version(1, 0));
+            using var pluginManager = GetTestPluginManager();
 
             await pluginManager.PopulateManifest(packageInfo, new Version(1, 0), _pluginPath, PluginStatus.Active);
 
@@ -334,5 +334,12 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
 
             return (tempPath, pluginPath);
         }
+
+        private static PluginManager GetTestPluginManager(string? pluginsPath)
+        {
+            return new PluginManager(new NullLogger<PluginManager>(), null!, null!, pluginsPath!, new Version(1, 0));
+        }
+
+        private PluginManager GetTestPluginManager() => GetTestPluginManager(_tempPath);
     }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Server.Integration.Tests
             var userResponse = await client.GetByteArrayAsync("/Startup/User");
             var user = JsonSerializer.Deserialize<StartupUserDto>(userResponse, jsonOptions);
 
-            using var completeResponse = await client.PostAsync("/Startup/Complete", new ByteArrayContent(Array.Empty<byte>()));
+            using var completeResponse = await client.PostAsync("/Startup/Complete", null);
             Assert.Equal(HttpStatusCode.NoContent, completeResponse.StatusCode);
 
             using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/Users/AuthenticateByName");

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/DashboardControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/DashboardControllerTests.cs
@@ -41,7 +41,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(MediaTypeNames.Text.Html, response.Content.Headers.ContentType?.MediaType);
-            StreamReader reader = new StreamReader(typeof(TestPlugin).Assembly.GetManifestResourceStream("Jellyfin.Server.Integration.Tests.TestPage.html")!);
+            using StreamReader reader = new StreamReader(typeof(TestPlugin).Assembly.GetManifestResourceStream("Jellyfin.Server.Integration.Tests.TestPage.html")!);
             Assert.Equal(await response.Content.ReadAsStringAsync(), await reader.ReadToEndAsync());
         }
 

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/StartupControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/StartupControllerTests.cs
@@ -99,7 +99,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
         {
             var client = _factory.CreateClient();
 
-            var response = await client.PostAsync("/Startup/Complete", new ByteArrayContent(Array.Empty<byte>()));
+            var response = await client.PostAsync("/Startup/Complete", null);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
I haven't had much experience with C#, so I decided to start with fixing some of what the IDE analyzers were yelling about.

There are still remaining CA2000 violations, which fall into several categories:

* Required touching larger portions of code (such as `SKBitMap`)
* Not sure if a simple `(await) using` is appropriate (such as `CancellationTokenSource` and the log `Stream` for FFmpeg)
* Fixing the "recommended way" introduces an IDISP003 warning, though I believe it's an analyzer bug (`FromBase64Transform`, `Socket`)
* False positives (analyzer bugs for CA2000) (such as not recognizing that `ControllerBase.File` disposes its `Stream` argument, and something weird with `GetBitmapFromSvg` being part of a conditional expression).

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
These bring down the number of CA2000 violations that VS reports from 47 to 22, as well as remove the only CA2213 violation and add CA2213+CA2216 as build errors.