### PR TITLE
Only remove images in metadata folder by default

### DIFF
--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -68,16 +68,22 @@ namespace MediaBrowser.Providers.Manager
         /// Removes all existing images from the provided item.
         /// </summary>
         /// <param name="item">The <see cref="BaseItem"/> to remove images from.</param>
+        /// <param name="canDeleteLocal">Whether removing images outside metadata folder is allowed.</param>
         /// <returns><c>true</c> if changes were made to the item; otherwise <c>false</c>.</returns>
-        public bool RemoveImages(BaseItem item)
+        public bool RemoveImages(BaseItem item, bool canDeleteLocal = false)
         {
             var singular = new List<ItemImageInfo>();
+            var itemMetadataPath = item.GetInternalMetadataPath();
             for (var i = 0; i < _singularImages.Length; i++)
             {
                 var currentImage = item.GetImageInfo(_singularImages[i], 0);
                 if (currentImage is not null)
                 {
-                    singular.Add(currentImage);
+                    var imageInMetadataFolder = currentImage.Path.StartsWith(itemMetadataPath, StringComparison.OrdinalIgnoreCase);
+                    if (imageInMetadataFolder || canDeleteLocal || item.IsSaveLocalMetadataEnabled())
+                    {
+                        singular.Add(currentImage);
+                    }
                 }
             }
 

--- a/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
@@ -580,6 +580,7 @@ namespace Jellyfin.Providers.Tests.Manager
                 CallBase = true
             };
             item.Setup(m => m.IsSaveLocalMetadataEnabled()).Returns(false);
+            item.Setup(m => m.GetInternalMetadataPath()).Returns(string.Empty);
 
             var path = validPaths ? _testDataImagePath.Format : "invalid path {0}";
             for (int i = 0; i < count; i++)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Currently, images in the media folder are being removed during replace all images scan without verifying if they were saved by jellyfin. This PR changes the default behavior to only remove images in the metadata folder, unless the user explicitly enables the option to save metadata with media files.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12629
