### PR TITLE
Use FileStream to read static media files

### DIFF
--- a/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
+++ b/Jellyfin.Api/Helpers/FileStreamResponseHelpers.cs
@@ -56,7 +56,8 @@ public static class FileStreamResponseHelpers
         string path,
         string contentType)
     {
-        return new PhysicalFileResult(path, contentType) { EnableRangeProcessing = true };
+        FileStream fs = File.OpenRead(path);
+        return new FileStreamResult(fs, contentType) { EnableRangeProcessing = true };
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Use a `FileStream` to read static media files.

This solves three issues when reading from slow I/O sources:
1. Current implementation uses maximum available bandwidth to download files from slow I/O sources even if the media doesn't require it. For example using DirectPlay on a file with ~15Mbit average bitrate would cause the read with network I/O to saturate the 100Mbps link. With this change the bandwidth used is appropriate for the bitrate required.
2. Current implementation would not stop downloading from source when streaming from client was stopped, using data unnecessarily.
3. File handles were not released when streaming stopped.

I don't have .NET experience so apologies if this causes unintended issues but in local testing it solves the issues with current implementation.

**Issues**
#11343 
