### PR TITLE
Better bitrate and resolution normalization

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -219,11 +219,17 @@ public static class StreamingHelpers
                 }
                 else
                 {
+                    var h264EquivalentBitrate = EncodingHelper.ScaleBitrate(
+                        state.OutputVideoBitrate.Value,
+                        state.ActualOutputVideoCodec,
+                        "h264");
                     var resolution = ResolutionNormalizer.Normalize(
                         state.VideoStream?.BitRate,
                         state.OutputVideoBitrate.Value,
+                        h264EquivalentBitrate,
                         state.VideoRequest.MaxWidth,
-                        state.VideoRequest.MaxHeight);
+                        state.VideoRequest.MaxHeight,
+                        state.TargetFramerate);
 
                     state.VideoRequest.MaxWidth = resolution.MaxWidth;
                     state.VideoRequest.MaxHeight = resolution.MaxHeight;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2381,7 +2381,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             return 1;
         }
 
-        private static int ScaleBitrate(int bitrate, string inputVideoCodec, string outputVideoCodec)
+        public static int ScaleBitrate(int bitrate, string inputVideoCodec, string outputVideoCodec)
         {
             var inputScaleFactor = GetVideoBitrateScaleFactor(inputVideoCodec);
             var outputScaleFactor = GetVideoBitrateScaleFactor(outputVideoCodec);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2405,6 +2405,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 scaleFactor = Math.Max(scaleFactor, 2);
             }
+            else if (bitrate >= 30000000)
+            {
+                // Don't scale beyond 30Mbps, it is hardly visually noticeable for most codecs with our prefer speed encoding
+                // and will cause extremely high bitrate to be used for av1->h264 transcoding that will overload clients and encoders
+                scaleFactor = 1;
+            }
 
             return Convert.ToInt32(scaleFactor * bitrate);
         }

--- a/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
@@ -47,7 +47,7 @@ namespace MediaBrowser.Model.Dlna
 
             if (isHdr)
             {
-                referenceBitrate *= 1.2f;
+                referenceBitrate *= 0.8f;
             }
 
             var resolutionConfig = GetResolutionConfiguration(Convert.ToInt32(referenceBitrate));

--- a/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
@@ -2,28 +2,33 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Linq;
 
 namespace MediaBrowser.Model.Dlna
 {
     public static class ResolutionNormalizer
     {
-        private static readonly ResolutionConfiguration[] Configurations =
-            new[]
-            {
-                new ResolutionConfiguration(426, 320000),
-                new ResolutionConfiguration(640, 400000),
-                new ResolutionConfiguration(720, 950000),
-                new ResolutionConfiguration(1280, 2500000),
-                new ResolutionConfiguration(1920, 4000000),
-                new ResolutionConfiguration(2560, 20000000),
-                new ResolutionConfiguration(3840, 35000000)
-            };
+        // Please note: all bitrate here are in the scale of SDR h264 bitrate at 30fps
+        private static readonly ResolutionConfiguration[] _configurations =
+        [
+            new ResolutionConfiguration(416, 365000),
+            new ResolutionConfiguration(640, 730000),
+            new ResolutionConfiguration(768, 1100000),
+            new ResolutionConfiguration(960, 3000000),
+            new ResolutionConfiguration(1280, 6000000),
+            new ResolutionConfiguration(1920, 13500000),
+            new ResolutionConfiguration(2560, 28000000),
+            new ResolutionConfiguration(3840, 50000000)
+        ];
 
         public static ResolutionOptions Normalize(
             int? inputBitrate,
             int outputBitrate,
+            int h264EquivalentOutputBitrate,
             int? maxWidth,
-            int? maxHeight)
+            int? maxHeight,
+            float? targetFps,
+            bool isHdr = false) // We are not doing HDR transcoding for now, leave for future use
         {
             // If the bitrate isn't changing, then don't downscale the resolution
             if (inputBitrate.HasValue && outputBitrate >= inputBitrate.Value)
@@ -38,16 +43,26 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
-            var resolutionConfig = GetResolutionConfiguration(outputBitrate);
-            if (resolutionConfig is not null)
-            {
-                var originvalValue = maxWidth;
+            var referenceBitrate = h264EquivalentOutputBitrate * (30.0f / (targetFps ?? 30.0f));
 
-                maxWidth = Math.Min(resolutionConfig.MaxWidth, maxWidth ?? resolutionConfig.MaxWidth);
-                if (!originvalValue.HasValue || originvalValue.Value != maxWidth.Value)
-                {
-                    maxHeight = null;
-                }
+            if (isHdr)
+            {
+                referenceBitrate *= 1.2f;
+            }
+
+            var resolutionConfig = GetResolutionConfiguration(Convert.ToInt32(referenceBitrate));
+
+            if (resolutionConfig is null)
+            {
+                return new ResolutionOptions { MaxWidth = maxWidth, MaxHeight = maxHeight };
+            }
+
+            var originWidthValue = maxWidth;
+
+            maxWidth = Math.Min(resolutionConfig.MaxWidth, maxWidth ?? resolutionConfig.MaxWidth);
+            if (!originWidthValue.HasValue || originWidthValue.Value != maxWidth.Value)
+            {
+                maxHeight = null;
             }
 
             return new ResolutionOptions
@@ -59,19 +74,7 @@ namespace MediaBrowser.Model.Dlna
 
         private static ResolutionConfiguration GetResolutionConfiguration(int outputBitrate)
         {
-            ResolutionConfiguration previousOption = null;
-
-            foreach (var config in Configurations)
-            {
-                if (outputBitrate <= config.MaxBitrate)
-                {
-                    return previousOption ?? config;
-                }
-
-                previousOption = config;
-            }
-
-            return null;
+            return _configurations.FirstOrDefault(config => outputBitrate <= config.MaxBitrate);
         }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

Previously we don't cap how much we want to scale the bitrate when transcoding to a less efficient codec like h264, resulting in extremely undesired high bitrate from high bitrate original videos, for example 80M AV1 will produce 120M H.264 file which overloads the server encoder, the client decoder and probably also the network. This set a scaling cap at 30Mbit, which means we don't scale up bitrate after 30M anymore, so that the bitrate will not be significantly larger than original if the original video has a high enough bitrate. For videos at such high bitrate the result is hardly noticeable (or not noticeable at all) with our current prefer speed encoding presets.

The previous resolution normalization is also outdated and not well-suited for modern advanced codecs and UHD videos. It is overly conservative with the use of high resolutions. This normalizes resolution while taking into account codec efficiency, frame rate, and dynamic range, providing in a more appropriate resolution config. All resolution configurations are now normalized based on the bitrate for H.264 in SDR at 30fps. The reference bitrate used to determine the resolution will be adjusted accordingly for codec, frame rate, and dynamic range (HDR reserved for future use, we are not doing HDR transcoding now). As a result, users will see higher resolutions more frequently when bitrate caps are applied.

The old logic of "using the previous configuration if the max bitrate is reached," inherited from Emby also didn't make much sense to me. I've changed it to "if the reference bitrate is below this configuration's max value, then use this configuration" which makes more sense for a "maxBitrate".

We probably also want to change the web texts based on this change as the resolution texts on web will now make almost no sense and even more wrong. In extreme condition now the text can say 720p 8Mbps on web and the video is streamed in 1440p which is a 2x resolution difference.

The new resolution config's max bitrate is taken from [Apple's HLS document](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Video) with modifications to fit our own scaling. 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Don't scale bitrate >= 30Mbps
- Normalize Resolution better

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See recent post on forum: https://forum.jellyfin.org/t-solved-jellyfin-bitrate-is-way-to-high-on-firefox
