### PR TITLE
Don't resolve trickplay folder during media scanning

### DIFF
--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -50,6 +50,10 @@ namespace Emby.Server.Implementations.Library
             "**/lost+found/**",
             "**/lost+found",
 
+            // Trickplay files
+            "**/*.trickplay",
+            "**/*.trickplay/**",
+
             // WMC temp recording directories that will constantly be written to
             "**/TempRec/**",
             "**/TempRec",

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -649,9 +649,7 @@ namespace Emby.Server.Implementations.Library
         private static bool ShouldResolvePathContents(ItemResolveArgs args)
         {
             // Ignore any folders containing a file called .ignore
-            return !args.ContainsFileSystemEntryByName(".ignore")
-                   // Ignore trickplay folders
-                || !(args.IsDirectory && args.Path.EndsWith(".trickplay", StringComparison.OrdinalIgnoreCase));
+            return !args.ContainsFileSystemEntryByName(".ignore");
         }
 
         public IEnumerable<BaseItem> ResolvePaths(IEnumerable<FileSystemMetadata> files, IDirectoryService directoryService, Folder parent, LibraryOptions libraryOptions, CollectionType? collectionType = null)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -649,7 +649,9 @@ namespace Emby.Server.Implementations.Library
         private static bool ShouldResolvePathContents(ItemResolveArgs args)
         {
             // Ignore any folders containing a file called .ignore
-            return !args.ContainsFileSystemEntryByName(".ignore");
+            return !args.ContainsFileSystemEntryByName(".ignore")
+                   // Ignore trickplay folders
+                || !(args.IsDirectory && args.Path.EndsWith(".trickplay", StringComparison.OrdinalIgnoreCase));
         }
 
         public IEnumerable<BaseItem> ResolvePaths(IEnumerable<FileSystemMetadata> files, IDirectoryService directoryService, Folder parent, LibraryOptions libraryOptions, CollectionType? collectionType = null)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

The trickplay file folder is now scanned for media after moving to media folder, but those should be ignored.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
