### PR TITLE
Fix subtitle dar comparison when number not exact

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3015,7 +3015,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var subtitleDar = (double)subtitleWidth.Value / subtitleHeight.Value;
 
                 // No need to add padding when DAR is the same -> 1080p PGSSUB on 2160p video
-                if (videoDar == subtitleDar)
+                if (Math.Abs(videoDar - subtitleDar) < 0.01f)
                 {
                     filters = @"scale,scale={0}:{1}:fast_bilinear";
                 }


### PR DESCRIPTION
Due to precision issue the dar value should be same might not be exactly equal. Lower the precision requirement to allow more subtitles not be padded.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
