### PR TITLE
Fix DeviceProfile.Id should be nullable

### DIFF
--- a/MediaBrowser.Model/Dlna/DeviceProfile.cs
+++ b/MediaBrowser.Model/Dlna/DeviceProfile.cs
@@ -22,7 +22,7 @@ public class DeviceProfile
     /// <summary>
     /// Gets or sets the unique internal identifier.
     /// </summary>
-    public Guid Id { get; set; }
+    public Guid? Id { get; set; }
 
     /// <summary>
     /// Gets or sets the maximum allowed bitrate for all streamed content.

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -65,7 +65,7 @@ namespace MediaBrowser.Model.Dlna
                 if (streamInfo is not null)
                 {
                     streamInfo.DeviceId = options.DeviceId;
-                    streamInfo.DeviceProfileId = options.Profile.Id.ToString("N", CultureInfo.InvariantCulture);
+                    streamInfo.DeviceProfileId = options.Profile.Id?.ToString("N", CultureInfo.InvariantCulture);
                     streams.Add(streamInfo);
                 }
             }
@@ -240,7 +240,7 @@ namespace MediaBrowser.Model.Dlna
             foreach (var stream in streams)
             {
                 stream.DeviceId = options.DeviceId;
-                stream.DeviceProfileId = options.Profile.Id.ToString("N", CultureInfo.InvariantCulture);
+                stream.DeviceProfileId = options.Profile.Id?.ToString("N", CultureInfo.InvariantCulture);
             }
 
             return GetOptimalStream(streams, options.GetMaxBitrate(false) ?? 0);


### PR DESCRIPTION
Previously (10.9<=) the id of a device profile was a nullable string. This was changed to a GUID during the 10.10 development but with this change the nullability was removed. A lot of clients (Android TV included) do not set a id so this is was a breaking change. The only 2 usages of the id still accept null so I've made the id nullable to keep compatibility.

**Changes**
- Fix DeviceProfile.Id should be nullable
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
