### PR TITLE
Fix GetTrickplayTileImage operation name

### DIFF
--- a/Jellyfin.Api/Controllers/TrickplayController.cs
+++ b/Jellyfin.Api/Controllers/TrickplayController.cs
@@ -80,7 +80,7 @@ public class TrickplayController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesImageFile]
-    public async Task<ActionResult> GetTrickplayTileImageAsync(
+    public async Task<ActionResult> GetTrickplayTileImage(
         [FromRoute, Required] Guid itemId,
         [FromRoute, Required] int width,
         [FromRoute, Required] int index,


### PR DESCRIPTION
The method names in controllers are directly used as operation id unless specified otherwise. In 10.10 the name of the `GetTrickplayTileImage` operation was changed to `GetTrickplayTileImageAsync`. While not really a breaking change, it's not a proper operation name as the "async" part has no meaning in the API.

**Changes**
- Fix GetTrickplayTileImage operation name
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
