### PR TITLE
Fix media segment operation name

### DIFF
--- a/Jellyfin.Api/Controllers/MediaSegmentsController.cs
+++ b/Jellyfin.Api/Controllers/MediaSegmentsController.cs
@@ -45,7 +45,7 @@ public class MediaSegmentsController : BaseJellyfinApiController
     [HttpGet("{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<QueryResult<MediaSegmentDto>>> GetSegmentsAsync(
+    public async Task<ActionResult<QueryResult<MediaSegmentDto>>> GetItemSegments(
         [FromRoute, Required] Guid itemId,
         [FromQuery] IEnumerable<MediaSegmentType>? includeSegmentTypes = null)
     {


### PR DESCRIPTION
Similar to #12681 

**Changes**
- Rename newly added `GetSegmentsAsync` operation to more descriptive `GetItemSegments`
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
