### PR TITLE
Allow Playlists access for users with allowed tags configured

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -191,6 +191,7 @@
  - [pret0rian8](https://github.com/pret0rian)
  - [jaina heartles](https://github.com/heartles)
  - [oxixes](https://github.com/oxixes)
+ - [elfalem](https://github.com/elfalem)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1608,7 +1608,7 @@ namespace MediaBrowser.Controller.Entities
             }
 
             var parent = GetParents().FirstOrDefault() ?? this;
-            if (parent is UserRootFolder or AggregateFolder)
+            if (parent is UserRootFolder or AggregateFolder or UserView)
             {
                 return true;
             }


### PR DESCRIPTION
The current logic prevents "Playlists" user view from being accessed by a user with allowed tags. It tries to check if the view has the tag and fails as a result.

**Changes**
Avoids checking allowed tags on UserView items. 

**Issues**
Fixes #12685 
