### PR TITLE
Escape quotes in the subtitle path

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1104,7 +1104,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // https://ffmpeg.org/ffmpeg-filters.html#Notes-on-filtergraph-escaping
             // We need to double escape
 
-            return path.Replace('\\', '/').Replace(":", "\\:", StringComparison.Ordinal).Replace("'", @"'\\\''", StringComparison.Ordinal);
+            return path
+                .Replace('\\', '/')
+                .Replace(":", "\\:", StringComparison.Ordinal)
+                .Replace("'", @"'\\\''", StringComparison.Ordinal)
+                .Replace("\"", "\\\"", StringComparison.Ordinal);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Quick fix. Ideally, we should probably only escape quotes where value is [quoted](https://github.com/jellyfin/jellyfin/blob/aed00733f88fb9a50fc51816fd05a4438c9d5c42/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L5841-L5851).

**Changes**
Escape quotes in the subtitle path.

**Issues**
N/A

**Tests**
```
.../html"<br>/html"<br>.mp4
.../html"<br>/html"<br>.en.ass
.../html"<br>/html'<br>.mp4
.../html"<br>/html'<br>.en.ass
```