### PR TITLE
Fix libx264/libx265 auto preset

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1441,7 +1441,13 @@ namespace MediaBrowser.Controller.MediaEncoding
             var encoderPreset = preset ?? defaultPreset;
             if (string.Equals(videoEncoder, "libx264", StringComparison.OrdinalIgnoreCase) || isLibX265)
             {
-                param += " -preset " + encoderPreset.ToString().ToLowerInvariant();
+                var presetString = encoderPreset switch
+                {
+                    EncoderPreset.auto => EncoderPreset.veryfast.ToString().ToLowerInvariant(),
+                    _ => encoderPreset.ToString().ToLowerInvariant()
+                };
+
+                param += " -preset " + presetString;
 
                 int encodeCrf = encodingOptions.H264Crf;
                 if (isLibX265)


### PR DESCRIPTION
We need to normalize auto to veryfast instead of convert it so string directly. `auto` is not a valid preset.

In my opinion just using the enum `ToString` failed for all our use cases now and all code path requires extra normalization. I plan to add an extension to have our own `ToString` method to turn this into CLI parameters. But that would break the ABI so not for now.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Fix software transcoding with auto preset.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
