### PR TITLE
Sanitize CustomTagDelimiters server side

### DIFF
--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -149,19 +149,5 @@ namespace MediaBrowser.Model.Configuration
 
             return null;
         }
-
-        public char[] GetCustomTagDelimiters()
-        {
-            return CustomTagDelimiters.Select<string, char?>(x =>
-            {
-                var isChar = char.TryParse(x, out var c);
-                if (isChar)
-                {
-                    return c;
-                }
-
-                return null;
-            }).Where(x => x is not null).Select(x => x!.Value).ToArray();
-        }
     }
 }

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -2,12 +2,13 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 
 namespace MediaBrowser.Model.Configuration
 {
     public class LibraryOptions
     {
-        private static readonly char[] _defaultTagDelimiters = ['/', '|', ';', '\\'];
+        private static readonly string[] _defaultTagDelimiters = ["/", "|", ";", "\\"];
 
         public LibraryOptions()
         {
@@ -126,8 +127,7 @@ namespace MediaBrowser.Model.Configuration
         [DefaultValue(false)]
         public bool UseCustomTagDelimiters { get; set; }
 
-        [DefaultValue(typeof(LibraryOptions), nameof(_defaultTagDelimiters))]
-        public char[] CustomTagDelimiters { get; set; }
+        public string[] CustomTagDelimiters { get; set; }
 
         public string[] DelimiterWhitelist { get; set; }
 
@@ -148,6 +148,20 @@ namespace MediaBrowser.Model.Configuration
             }
 
             return null;
+        }
+
+        public char[] GetCustomTagDelimiters()
+        {
+            return CustomTagDelimiters.Select<string, char?>(x =>
+            {
+                var isChar = char.TryParse(x, out var c);
+                if (isChar)
+                {
+                    return c;
+                }
+
+                return null;
+            }).Where(x => x is not null).Select(x => x!.Value).ToArray();
         }
     }
 }

--- a/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
+++ b/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using MediaBrowser.Model.Configuration;
+
+namespace MediaBrowser.Model.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="LibraryOptions"/>.
+/// </summary>
+public static class LibraryOptionsExtension
+{
+    /// <summary>
+    /// Get the custom tag delimiters.
+    /// </summary>
+    /// <param name="options">This LibraryOptions.</param>
+    /// <returns>CustomTagDelimiters in char[].</returns>
+    public static char[] GetCustomTagDelimiters(this LibraryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return options.CustomTagDelimiters.Select<string, char?>(x =>
+        {
+            var isChar = char.TryParse(x, out var c);
+            if (isChar)
+            {
+                return c;
+            }
+
+            return null;
+        }).Where(x => x is not null).Select(x => x!.Value).ToArray();
+    }
+}

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -178,7 +178,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (libraryOptions.UseCustomTagDelimiters)
                 {
-                    albumArtists = albumArtists.SelectMany(a => SplitWithCustomDelimiter(a, libraryOptions.CustomTagDelimiters, libraryOptions.DelimiterWhitelist)).ToArray();
+                    albumArtists = albumArtists.SelectMany(a => SplitWithCustomDelimiter(a, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
 
                 foreach (var albumArtist in albumArtists)
@@ -210,7 +210,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (libraryOptions.UseCustomTagDelimiters)
                 {
-                    performers = performers.SelectMany(p => SplitWithCustomDelimiter(p, libraryOptions.CustomTagDelimiters, libraryOptions.DelimiterWhitelist)).ToArray();
+                    performers = performers.SelectMany(p => SplitWithCustomDelimiter(p, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
 
                 foreach (var performer in performers)
@@ -313,7 +313,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (libraryOptions.UseCustomTagDelimiters)
                 {
-                    genres = genres.SelectMany(g => SplitWithCustomDelimiter(g, libraryOptions.CustomTagDelimiters, libraryOptions.DelimiterWhitelist)).ToArray();
+                    genres = genres.SelectMany(g => SplitWithCustomDelimiter(g, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
 
                 audio.Genres = options.ReplaceAllMetadata || audio.Genres is null || audio.Genres.Length == 0

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -16,6 +16,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
The API requires an array type and does not support runtime generated default value. Use server side helper function to sanitize it into char.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
