### PR TITLE
Ensure user's own playlists are accessible regardless of allowed tags

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4203,6 +4203,15 @@ namespace Emby.Server.Implementations.Data
                                           OR (select CleanValue from ItemValues where ItemId=ParentId and Type=6 and CleanValue in ({includedTags})) is not null)
                                           """);
                     }
+
+                    // A playlist should be accessible to its owner regardless of allowed tags.
+                    else if (includeTypes.Length == 1 && includeTypes.FirstOrDefault() is BaseItemKind.Playlist)
+                    {
+                        whereClauses.Add($"""
+                                          ((select CleanValue from ItemValues where ItemId=Guid and Type=6 and CleanValue in ({includedTags})) is not null
+                                          OR data like @PlaylistOwnerUserId)
+                                          """);
+                    }
                     else
                     {
                         whereClauses.Add("((select CleanValue from ItemValues where ItemId=Guid and Type=6 and cleanvalue in (" + includedTags + ")) is not null)");
@@ -4213,6 +4222,11 @@ namespace Emby.Server.Implementations.Data
                     for (int index = 0; index < query.IncludeInheritedTags.Length; index++)
                     {
                         statement.TryBind(paramName + index, GetCleanValue(query.IncludeInheritedTags[index]));
+                    }
+
+                    if (query.User != null)
+                    {
+                        statement.TryBind("@PlaylistOwnerUserId", $"""%"OwnerUserId":"{query.User.Id.ToString("N")}"%""");
                     }
                 }
             }

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4224,7 +4224,7 @@ namespace Emby.Server.Implementations.Data
                         statement.TryBind(paramName + index, GetCleanValue(query.IncludeInheritedTags[index]));
                     }
 
-                    if (query.User != null)
+                    if (query.User is not null)
                     {
                         statement.TryBind("@PlaylistOwnerUserId", $"""%"OwnerUserId":"{query.User.Id.ToString("N")}"%""");
                     }


### PR DESCRIPTION
The current logic for querying items with allowed tags prevents even the user that created the playlist from seeing it.

**Changes**
In addition to allowed tags, expand the where clause to include playlists owned by the current user.

**Issues**
Fixes #12699
