### PR TITLE
Only move trickplay file should not be saved with media to metadata dir

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -105,7 +105,7 @@ public class TrickplayManager : ITrickplayManager
                     _logger.LogInformation("Moved trickplay images for {ItemName} to {Location}", video.Name, mediaOutputDir);
                 }
             }
-            else if (Directory.Exists(mediaOutputDir))
+            else if (!shouldBeSavedWithMedia && Directory.Exists(mediaOutputDir))
             {
                 var mediaDirFiles = Directory.GetFiles(mediaOutputDir);
                 var localDirExists = Directory.Exists(localOutputDir);


### PR DESCRIPTION
Some users report such behavior is more straightforward and will fit more use cases. In my opinion if this task is intended to be run multiple times it should not move files like its old behavior which moves everything back to metadata.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12703 
