### PR TITLE
Extract subtitles of MKS aux files if they're extractable.

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -612,7 +612,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
-                if (streamIndex == -1 || subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                if (subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogDebug("Subtitle {Index} for file {InputPath} is part in an MKS file. Skipping", inputPath, subtitleStream.Index);
+                    continue;
+                }
+
+                if (streamIndex == -1)
                 {
                     _logger.LogError("Cannot find subtitle stream index for {InputPath} ({Index}), skipping this stream", inputPath, subtitleStream.Index);
                     continue;

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -489,10 +489,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             try
             {
                 var subtitleStreams = mediaSource.MediaStreams
-                    .Where(stream => stream is { IsExtractableSubtitleStream: true, SupportsExternalStream: true, IsExternal: false });
+                    .Where(stream => stream is { IsExtractableSubtitleStream: true, SupportsExternalStream: true });
 
                 foreach (var subtitleStream in subtitleStreams)
                 {
+                    if (subtitleStream.IsExternal && !subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
 
                     var releaser = await _semaphoreLocks.LockAsync(outputPath, cancellationToken).ConfigureAwait(false);
@@ -510,6 +515,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 if (extractableStreams.Count > 0)
                 {
                     await ExtractAllExtractableSubtitlesInternal(mediaSource, extractableStreams, cancellationToken).ConfigureAwait(false);
+                    await ExtractAllExtractableSubtitlesMKS(mediaSource, extractableStreams, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -519,6 +525,72 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             finally
             {
                 locks.ForEach(x => x.Dispose());
+            }
+        }
+
+        private async Task ExtractAllExtractableSubtitlesMKS(
+           MediaSourceInfo mediaSource,
+           List<MediaStream> subtitleStreams,
+           CancellationToken cancellationToken)
+        {
+            var mksFiles = new List<string>();
+
+            foreach (var subtitleStream in subtitleStreams)
+            {
+                if (!subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!mksFiles.Contains(subtitleStream.Path))
+                {
+                    mksFiles.Add(subtitleStream.Path);
+                }
+            }
+
+            if (mksFiles.Count == 0)
+            {
+                return;
+            }
+
+            foreach (string mksFile in mksFiles)
+            {
+                var inputPath = _mediaEncoder.GetInputArgument(mksFile, mediaSource);
+                var outputPaths = new List<string>();
+                var args = string.Format(
+                CultureInfo.InvariantCulture,
+                "-i {0} -copyts",
+                inputPath);
+
+                foreach (var subtitleStream in subtitleStreams)
+                {
+                    if (!subtitleStream.Path.Equals(mksFile, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                    var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
+                    var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
+
+                    if (streamIndex == -1)
+                    {
+                        _logger.LogError("Cannot find subtitle stream index for {InputPath} ({Index}), skipping this stream", inputPath, subtitleStream.Index);
+                        continue;
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
+
+                    outputPaths.Add(outputPath);
+                    args += string.Format(
+                        CultureInfo.InvariantCulture,
+                        " -map 0:{0} -an -vn -c:s {1} \"{2}\"",
+                        streamIndex,
+                        outputCodec,
+                        outputPath);
+                }
+
+                await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -540,7 +612,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
-                if (streamIndex == -1)
+                if (streamIndex == -1 || subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogError("Cannot find subtitle stream index for {InputPath} ({Index}), skipping this stream", inputPath, subtitleStream.Index);
                     continue;
@@ -557,6 +629,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     outputPath);
             }
 
+            await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task ExtractSubtitlesForFile(
+            string inputPath,
+            string args,
+            List<string> outputPaths,
+            CancellationToken cancellationToken)
+        {
             int exitCode;
 
             using (var process = new Process

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -635,6 +635,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     outputPath);
             }
 
+            if (outputPaths.Count == 0)
+            {
+                return;
+            }
+
             await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
         }
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -608,15 +608,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             foreach (var subtitleStream in subtitleStreams)
             {
-                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
-                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
-                var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
-
                 if (subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Subtitle {Index} for file {InputPath} is part in an MKS file. Skipping", inputPath, subtitleStream.Index);
                     continue;
                 }
+
+                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
+                var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
                 if (streamIndex == -1)
                 {

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -558,9 +558,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var inputPath = _mediaEncoder.GetInputArgument(mksFile, mediaSource);
                 var outputPaths = new List<string>();
                 var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-i {0} -copyts",
-                inputPath);
+                    CultureInfo.InvariantCulture,
+                    "-i {0} -copyts",
+                    inputPath);
 
                 foreach (var subtitleStream in subtitleStreams)
                 {

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -537,7 +537,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             foreach (var subtitleStream in subtitleStreams)
             {
-                if (subtitleStream.Path is null || !subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                if (string.IsNullOrEmpty(subtitleStream.Path) || !subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -608,7 +608,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             foreach (var subtitleStream in subtitleStreams)
             {
-                if (subtitleStream.Path is not null && subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(subtitleStream.Path) && subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Subtitle {Index} for file {InputPath} is part in an MKS file. Skipping", inputPath, subtitleStream.Index);
                     continue;

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -537,7 +537,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             foreach (var subtitleStream in subtitleStreams)
             {
-                if (!subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                if (subtitleStream.Path is null || !subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -608,7 +608,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             foreach (var subtitleStream in subtitleStreams)
             {
-                if (subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
+                if (subtitleStream.Path is not null && subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Subtitle {Index} for file {InputPath} is part in an MKS file. Skipping", inputPath, subtitleStream.Index);
                     continue;


### PR DESCRIPTION
The current implementation only extracts from the main container. This makes SRT/ASS subtitles from MKS files unusable (except when burning them in), because the server expects to retrieve them from the subtitles directory.

This change also extracts subtitles from MKS files that are associated with the video file and stores them in their appropriate location, so the client can request and render them.


**Changes**
Adds additional subtitle extractor logic for MKS file(s).

**Issues**
https://github.com/jellyfin/jellyfin/issues/12236
