### PR TITLE
Never set RemoveOldMetadata when replacing all metadata.

### DIFF
--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -80,8 +80,7 @@ public class ItemRefreshController : BaseJellyfinApiController
                 || imageRefreshMode == MetadataRefreshMode.FullRefresh
                 || replaceAllImages
                 || replaceAllMetadata,
-            IsAutomated = false,
-            RemoveOldMetadata = replaceAllMetadata
+            IsAutomated = false
         };
 
         _providerManager.QueueRefresh(item.Id, refreshOptions, RefreshPriority.High);


### PR DESCRIPTION
When RemoveOldMetadata is set it will clear all existing metadata from items before applying the new information. This breaks virtual seasons as episodes will never have a ParentIndexNumber set unless the season is part of the episode file name (which in a lot of cases, it is not). The fallback to "season 1" is only available in EpisodeResolver which is not called during metadata refresh. When the ParentIndexId is reset to null the RemoveObsoleteSeasons method in SeriesMetadataService will remove the virtual season(s) as it thinks there are no episodes in them.

This change only affects the behavior when using a full metadata refresh, other cases of the season unknown issue have been fixed in my previous fixes (#12240 and #12356) in 10.9.z releases.

**Changes**

- Never set RemoveOldMetadata when replacing all metadata.
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
