### PR TITLE
Add perf tradeoff mode to image extractor

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -21,6 +21,7 @@ namespace Emby.Server.Implementations
             { BindToUnixSocketKey, bool.FalseString },
             { SqliteCacheSizeKey, "20000" },
             { FfmpegSkipValidationKey, bool.FalseString },
+            { FfmpegImgExtractPerfTradeoffKey, bool.FalseString },
             { DetectNetworkChangeKey, bool.TrueString }
         };
     }

--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -40,6 +40,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string FfmpegAnalyzeDurationKey = "FFmpeg:analyzeduration";
 
         /// <summary>
+        /// The key for the FFmpeg image extraction performance tradeoff option.
+        /// </summary>
+        public const string FfmpegImgExtractPerfTradeoffKey = "FFmpeg:imgExtractPerfTradeoff";
+
+        /// <summary>
         /// The key for the FFmpeg path option.
         /// </summary>
         public const string FfmpegPathKey = "ffmpeg";
@@ -106,6 +111,14 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns><c>true</c> if the server should validate FFmpeg during startup, otherwise <c>false</c>.</returns>
         public static bool GetFFmpegSkipValidation(this IConfiguration configuration)
             => configuration.GetValue<bool>(FfmpegSkipValidationKey);
+
+        /// <summary>
+        /// Gets a value indicating whether the server should trade off for performance during FFmpeg image extraction.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns><c>true</c> if the server should trade off for performance during FFmpeg image extraction, otherwise <c>false</c>.</returns>
+        public static bool GetFFmpegImgExtractPerfTradeoff(this IConfiguration configuration)
+            => configuration.GetValue<bool>(FfmpegImgExtractPerfTradeoffKey);
 
         /// <summary>
         /// Gets a value indicating whether playlists should allow duplicate entries from the <see cref="IConfiguration"/>.


### PR DESCRIPTION
On low-end CPUs, image extraction can be quite slow because the CPU has to decode and analyze 24 frames to pick the best one. If the input is an HDR image, it also needs to perform tone mapping. On a Raspberry Pi 4 level of performance, this usually means more than 10 seconds per image extracted, and for 4K HDR inputs, it may even timeout. This PR adds a tradeoff mode where the extracted image is the single frame that was picked. Ideally it would come from one of the key frame which is very fast to extract, but if that failed it will fallback to extract the slower normal frame. The frame picked by this mode is worse and less representative, but the process is significantly faster.

Another benefit of this mode is that there is no longer the need to pool and cache lots of frames in the memory, which might also be helpful in low-memory scenarios.

Users can activate this mode by export env var:

```
export JELLYFIN_FFMPEG__ImgExtractPerfTradeoff=true
```

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Might make users like #12740 happier.
