### PR TITLE
Fix SQLite error with large playlist

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -265,3 +265,4 @@
  - [0x25CBFC4F](https://github.com/0x25CBFC4F)
  - [Robert Lützner](https://github.com/rluetzner)
  - [Nathan McCrina](https://github.com/nfmccrina)
+ - [breakid](https://github.com/breakid)


### PR DESCRIPTION
**Bug Description**

By default, SQLite supports a maximum of 1000 expressions per query. When called from `GetItemList()`, `GetWhereClauses()` adds a separate check for the `Guid` of each playlist item. For large playlists, the number of these expressions can exceed the maximum, resulting in an `Expression tree is too large` error that prevents the `VideoPlayback` event from being published. This means that affected media items do not appear in the Activity view or get logged to the Playback Reporting database.

**Changes**

- Reduced the number of query expressions by using `IN` rather than `OR`-ing a sequence of `GUID = ...` expressions
- Added error handling to `GetItemList()` to allow execution to continue in the event other query errors occur

**Issues**
Fixes #12219