### PR TITLE
Fix RKMPP-DRM-OpenCL mapping

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -5669,7 +5669,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             if (doOclTonemap && isRkmppDecoder)
             {
                 // map from rkmpp/drm to opencl via drm-opencl interop.
-                mainFilters.Add("hwmap=derive_device=opencl:mode=read");
+                mainFilters.Add("hwmap=derive_device=opencl");
             }
 
             // ocl tonemap
@@ -5712,7 +5712,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 {
                     // OUTPUT drm(nv12) surface(gem/dma-heap)
                     // reverse-mapping via drm-opencl interop.
-                    mainFilters.Add("hwmap=derive_device=rkmpp:mode=write:reverse=1");
+                    mainFilters.Add("hwmap=derive_device=rkmpp:reverse=1");
                     mainFilters.Add("format=drm_prime");
                 }
             }


### PR DESCRIPTION
Unlike vaapi/d3d11->ocl, drm->ocl requires read+write permissions.

**Changes**
- Fix RKMPP-DRM-OpenCL mapping

**Issues**
- Fixes f4d5538

```
[  143.867208] rk_vcodec: mpp_task_attach_fd:1760: can't import dma-buf 122
[  143.867220] rk_vcodec: mpp_translate_reg_address:1816: reg[  0]: 0x0000007a fd 122 failed
[  143.867223] rk_vcodec: mpp_task_dump_mem_region:2003: --- dump task 0 mem region ---
[  143.867228] mpp_rkvenc2 fdbd0000.rkvenc-core: no memory region mapped
[  143.867236] rk_vcodec: mpp_process_task_default:614: alloc_task failed.
[  143.873903] rkvenc2_wait_result:2064: session 0000000028e16dd5 pending list is empty!
[  143.873910] rk_vcodec: mpp_msgs_wait:1612: session 1 wait result ret -5
```