### PR TITLE
Clean up deprecated -vsync option

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1908,7 +1908,7 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         if (!string.IsNullOrEmpty(state.OutputVideoSync))
         {
-            args += " -vsync " + state.OutputVideoSync;
+            args += EncodingHelper.GetVideoSyncOption(state.OutputVideoSync, _mediaEncoder.EncoderVersion);
         }
 
         args += _encodingHelper.GetOutputFFlags(state);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -945,7 +945,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 vidEncoder,
                 encoderQualityOption + encoderQuality + " ",
                 vidEncoder.Contains("videotoolbox", StringComparison.InvariantCultureIgnoreCase) ? "-allow_sw 1 " : string.Empty, // allow_sw fallback for some intel macs
-                EncoderVersion >= new Version(5, 1) ? "-fps_mode passthrough " : "-vsync passthrough ", // passthrough timestamp
+                EncodingHelper.GetVideoSyncOption("0", EncoderVersion).Trim() + " ", // passthrough timestamp
                 "image2",
                 outputPath);
 

--- a/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
@@ -130,7 +130,7 @@ namespace Jellyfin.LiveTv.IO
                 const int MaxBitrate = 25000000;
                 videoArgs = string.Format(
                     CultureInfo.InvariantCulture,
-                    "-codec:v:0 libx264 -force_key_frames \"expr:gte(t,n_forced*5)\" {0} -pix_fmt yuv420p -preset superfast -crf 23 -b:v {1} -maxrate {1} -bufsize ({1}*2) -vsync -1 -profile:v high -level 41",
+                    "-codec:v:0 libx264 -force_key_frames \"expr:gte(t,n_forced*5)\" {0} -pix_fmt yuv420p -preset superfast -crf 23 -b:v {1} -maxrate {1} -bufsize ({1}*2) -profile:v high -level 41",
                     GetOutputSizeParam(),
                     MaxBitrate);
             }
@@ -157,7 +157,7 @@ namespace Jellyfin.LiveTv.IO
                 flags.Add("+genpts");
             }
 
-            var inputModifier = "-async 1 -vsync -1";
+            var inputModifier = "-async 1";
 
             if (flags.Count > 0)
             {


### PR DESCRIPTION
**Changes**
- Clean up deprecated `-vsync` option

**Issues**
- `-vsync` is deprecated in FFmpeg 5.1 and will be removed in the future.

   ref: https://ffmpeg.org/ffmpeg-all.html#toc-Advanced-options
