### PR TITLE
Fix allow inputContainer to be null for Live TV

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -392,7 +392,7 @@ namespace MediaBrowser.Model.Dlna
         public static string? NormalizeMediaSourceFormatIntoSingleContainer(string inputContainer, DeviceProfile? profile, DlnaProfileType type, DirectPlayProfile? playProfile = null)
         {
             // If the source is Live TV the inputContainer will be null until the mediasource is probed on first access
-            if (profile is null || inputContainer is null || !inputContainer.Contains(',', StringComparison.OrdinalIgnoreCase))
+            if (profile is null || string.IsNullOrEmpty(inputContainer) || !inputContainer.Contains(',', StringComparison.OrdinalIgnoreCase))
             {
                 return inputContainer;
             }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -389,9 +389,10 @@ namespace MediaBrowser.Model.Dlna
         /// <param name="type">The <see cref="DlnaProfileType"/>.</param>
         /// <param name="playProfile">The <see cref="DirectPlayProfile"/> object to get the video stream from.</param>
         /// <returns>The normalized input container.</returns>
-        public static string NormalizeMediaSourceFormatIntoSingleContainer(string inputContainer, DeviceProfile? profile, DlnaProfileType type, DirectPlayProfile? playProfile = null)
+        public static string? NormalizeMediaSourceFormatIntoSingleContainer(string inputContainer, DeviceProfile? profile, DlnaProfileType type, DirectPlayProfile? playProfile = null)
         {
-            if (profile is null || !inputContainer.Contains(',', StringComparison.OrdinalIgnoreCase))
+            // If the source is Live TV the inputContainer will be null until the mediasource is probed on first access
+            if (profile is null || inputContainer is null || !inputContainer.Contains(',', StringComparison.OrdinalIgnoreCase))
             {
                 return inputContainer;
             }


### PR DESCRIPTION
**Changes**
The refactoring for https://github.com/jellyfin/jellyfin/pull/9374 did not allow for a null inputContainer. When Live TV is the source, the inputContainer will be null until the initial connection happens.
