### PR TITLE
Fix Use GetAsync to get headers for stream type check to eliminate timeout on Live TV streams

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -102,9 +102,8 @@ namespace Jellyfin.LiveTv.TunerHosts
                 {
                     try
                     {
-                        using var message = new HttpRequestMessage(HttpMethod.Head, mediaSource.Path);
                         using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
-                            .SendAsync(message, cancellationToken)
+                            .GetAsync(mediaSource.Path, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                             .ConfigureAwait(false);
 
                         if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Some IPTV proxy applications (e.g. https://github.com/xteve-project/xTeVe) do not support HTTP HEAD requests. This would cause a timeout the first time that a connection to a new channel was initiated. Clients would have to wait for 100s timeout to elapse before initiating the stream.

M3UTunerHost was making a HEAD request to check the mimetype of the stream.  This change updates M3UTunerHost to perform a GetAsync, with `HttpCompletionOption.ResponseHeadersRead` in order to quickly get the headers for the mimetype check.
