### PR TITLE
NetworkManager: Use MemberNotNull attribute

### DIFF
--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -81,7 +81,6 @@ public class NetworkManager : INetworkManager, IDisposable
     /// <param name="configurationManager">The <see cref="IConfigurationManager"/> instance.</param>
     /// <param name="startupConfig">The <see cref="IConfiguration"/> instance holding startup parameters.</param>
     /// <param name="logger">Logger to use for messages.</param>
-#pragma warning disable CS8618 // Non-nullable field is uninitialized. : Values are set in UpdateSettings function. Compiler doesn't yet recognise this.
     public NetworkManager(IConfigurationManager configurationManager, IConfiguration startupConfig, ILogger<NetworkManager> logger)
     {
         ArgumentNullException.ThrowIfNull(logger);
@@ -109,7 +108,6 @@ public class NetworkManager : INetworkManager, IDisposable
 
         _configurationManager.NamedConfigurationUpdated += ConfigurationUpdated;
     }
-#pragma warning restore CS8618 // Non-nullable field is uninitialized.
 
     /// <summary>
     /// Event triggered on network changes.
@@ -312,6 +310,7 @@ public class NetworkManager : INetworkManager, IDisposable
     /// <summary>
     /// Initializes internal LAN cache.
     /// </summary>
+    [MemberNotNull(nameof(_lanSubnets), nameof(_excludedSubnets))]
     private void InitializeLan(NetworkConfiguration config)
     {
         lock (_initLock)
@@ -591,6 +590,7 @@ public class NetworkManager : INetworkManager, IDisposable
     /// Reloads all settings and re-Initializes the instance.
     /// </summary>
     /// <param name="configuration">The <see cref="NetworkConfiguration"/> to use.</param>
+    [MemberNotNull(nameof(_lanSubnets), nameof(_excludedSubnets))]
     public void UpdateSettings(object configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);


### PR DESCRIPTION
Added in .NET 5, [this attribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.membernotnullattribute) allows for the compiler to recognize that InitializeLan (and by extension, UpdateSettings) will initialize the specified fields to non-null values.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The `#pragma warning disable` is replaced with the appropriate `MemberNotNull` attributes. If the methods are changed in the future to not initialize the fields, then the compiler will issue a [`CS8774`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#code-doesnt-match-attribute-declaration) error.