### PR TITLE
Add EpisodeExpression for anime file names

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -471,7 +471,7 @@ namespace Emby.Naming.Common
                 // Anime style expression
                 // "[Group][Series Name][21][1080p][FLAC][HASH]"
                 // "[Group] Series Name [04][BDRIP]"
-                new EpisodeExpression(@"(?:\[(?:[^\]]+)\]\s*)?(?<seriesname>\[[^\]]+\]|[^[\]]+)\s*\[(?<epnumber>\d+)\]")
+                new EpisodeExpression(@"(?:\[(?:[^\]]+)\]\s*)?(?<seriesname>\[[^\]]+\]|[^[\]]+)\s*\[(?<epnumber>[0-9]+)\]")
                 {
                     IsNamed = true
                 },

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -467,6 +467,14 @@ namespace Emby.Naming.Common
                 {
                     IsNamed = true
                 },
+
+                // Anime style expression
+                // "[Group][Series Name][21][1080p][FLAC][HASH]"
+                // "[Group] Series Name [04][BDRIP]"
+                new EpisodeExpression(@"(?:\[(?:[^\]]+)\]\s*)?(?<seriesname>\[[^\]]+\]|[^[\]]+)\s*\[(?<epnumber>\d+)\]")
+                {
+                    IsNamed = true
+                },
             };
 
             VideoExtraRules = new[]

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
@@ -77,6 +77,8 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("Season 3/The Series S3 E9 - The title.avi", 9)]
         [InlineData("Season 3/S003 E009.avi", 9)]
         [InlineData("Season 3/Season 3 Episode 9.avi", 9)]
+        [InlineData("[VCB-Studio] Re Zero kara Hajimeru Isekai Seikatsu [21][Ma10p_1080p][x265_flac].mkv", 21)]
+        [InlineData("[CASO&Sumisora][Oda_Nobuna_no_Yabou][04][BDRIP][1920x1080][x264_AAC][7620E503].mp4", 4)]
 
         // [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", 317)] // triple digit episode number
         // TODO: [InlineData("Season 2/16 12 Some Title.avi", 16)]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Add an EpisodeExpression to extract episode number from anime style file names like `[VCB-Studio] Re Zero kara Hajimeru Isekai Seikatsu [21][Ma10p_1080p][x265_flac]` and `[CASO&Sumisora][Oda_Nobuna_no_Yabou][04][BDRIP][1920x1080][x264_AAC][7620E503]`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
fixes issue #9332
