### PR TITLE
Fixed the issue that Blu-ray movies cannot get external subtitles

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -323,9 +323,17 @@ namespace MediaBrowser.Providers.MediaInfo
 
             var ffmpegVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
 
+            List<MediaStream> externalStreams = mediaStreams.FindAll(s => s.IsExternal);
             // Fill video properties from the BDInfo result
             mediaStreams.Clear();
             mediaStreams.AddRange(blurayInfo.MediaStreams);
+            // Fill video properties from external stream
+            var startIndex = mediaStreams.Count;
+            foreach (var externalStream in externalStreams)
+            {
+                externalStream.Index = startIndex++;
+                mediaStreams.Add(externalStream);
+            }
 
             if (blurayInfo.RunTimeTicks.HasValue && blurayInfo.RunTimeTicks.Value > 0)
             {


### PR DESCRIPTION
resolve the issues https://github.com/jellyfin/jellyfin/issues/12738, Fixed the issue that Blu-ray movies cannot get external subtitles.

**Changes**
Keep the external stream, add them after adding the blurayInfo stream.

**Issues**
https://github.com/jellyfin/jellyfin/issues/12738
