### PR TITLE
Implement TaskTriggerInfoType enum

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -471,7 +471,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                     new()
                     {
                         IntervalTicks = TimeSpan.FromDays(1).Ticks,
-                        Type = TaskTriggerInfo.TriggerInterval
+                        Type = TaskTriggerInfoType.IntervalTrigger
                     }
                 ];
             }
@@ -616,7 +616,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 MaxRuntimeTicks = info.MaxRuntimeTicks
             };
 
-            if (info.Type.Equals(nameof(DailyTrigger), StringComparison.OrdinalIgnoreCase))
+            if (info.Type == TaskTriggerInfoType.DailyTrigger)
             {
                 if (!info.TimeOfDayTicks.HasValue)
                 {
@@ -626,7 +626,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 return new DailyTrigger(TimeSpan.FromTicks(info.TimeOfDayTicks.Value), options);
             }
 
-            if (info.Type.Equals(nameof(WeeklyTrigger), StringComparison.OrdinalIgnoreCase))
+            if (info.Type == TaskTriggerInfoType.WeeklyTrigger)
             {
                 if (!info.TimeOfDayTicks.HasValue)
                 {
@@ -641,7 +641,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 return new WeeklyTrigger(TimeSpan.FromTicks(info.TimeOfDayTicks.Value), info.DayOfWeek.Value, options);
             }
 
-            if (info.Type.Equals(nameof(IntervalTrigger), StringComparison.OrdinalIgnoreCase))
+            if (info.Type == TaskTriggerInfoType.IntervalTrigger)
             {
                 if (!info.IntervalTicks.HasValue)
                 {
@@ -651,7 +651,7 @@ namespace Emby.Server.Implementations.ScheduledTasks
                 return new IntervalTrigger(TimeSpan.FromTicks(info.IntervalTicks.Value), options);
             }
 
-            if (info.Type.Equals(nameof(StartupTrigger), StringComparison.OrdinalIgnoreCase))
+            if (info.Type == TaskTriggerInfoType.StartupTrigger)
             {
                 return new StartupTrigger(options);
             }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -156,7 +156,7 @@ public partial class AudioNormalizationTask : IScheduledTask
         [
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerInterval,
+                Type = TaskTriggerInfoType.IntervalTrigger,
                 IntervalTicks = TimeSpan.FromHours(24).Ticks
             }
         ];

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
@@ -80,7 +80,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
             [
                 new TaskTriggerInfo
                 {
-                    Type = TaskTriggerInfo.TriggerDaily,
+                    Type = TaskTriggerInfoType.DailyTrigger,
                     TimeOfDayTicks = TimeSpan.FromHours(2).Ticks,
                     MaxRuntimeTicks = TimeSpan.FromHours(4).Ticks
                 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -135,6 +135,6 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        return [new TaskTriggerInfo() { Type = TaskTriggerInfo.TriggerStartup }];
+        return [new TaskTriggerInfo() { Type = TaskTriggerInfoType.StartupTrigger }];
     }
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
@@ -73,7 +73,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
             return
             [
                 // Every so often
-                new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks }
+                new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks }
             ];
         }
 

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteLogFileTask.cs
@@ -62,7 +62,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         {
             return
             [
-                new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks }
+                new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks }
             ];
         }
 

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteTranscodeFileTask.cs
@@ -69,11 +69,11 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
             [
                 new TaskTriggerInfo
                 {
-                    Type = TaskTriggerInfo.TriggerStartup
+                    Type = TaskTriggerInfoType.StartupTrigger
                 },
                 new TaskTriggerInfo
                 {
-                    Type = TaskTriggerInfo.TriggerInterval,
+                    Type = TaskTriggerInfoType.IntervalTrigger,
                     IntervalTicks = TimeSpan.FromHours(24).Ticks
                 }
             ];

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/MediaSegmentExtractionTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/MediaSegmentExtractionTask.cs
@@ -111,7 +111,7 @@ public class MediaSegmentExtractionTask : IScheduledTask
     {
         yield return new TaskTriggerInfo
         {
-            Type = TaskTriggerInfo.TriggerInterval,
+            Type = TaskTriggerInfoType.IntervalTrigger,
             IntervalTicks = TimeSpan.FromHours(12).Ticks
         };
     }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabaseTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabaseTask.cs
@@ -62,7 +62,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
             return
             [
                 // Every so often
-                new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks }
+                new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks }
             ];
         }
 

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -58,7 +58,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
             {
                 new TaskTriggerInfo
                 {
-                    Type = TaskTriggerInfo.TriggerInterval,
+                    Type = TaskTriggerInfoType.IntervalTrigger,
                     IntervalTicks = TimeSpan.FromDays(7).Ticks
                 }
             };

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PluginUpdateTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PluginUpdateTask.cs
@@ -60,10 +60,10 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
         {
             // At startup
-            yield return new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerStartup };
+            yield return new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger };
 
             // Every so often
-            yield return new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks };
+            yield return new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks };
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/RefreshMediaLibraryTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/RefreshMediaLibraryTask.cs
@@ -48,7 +48,7 @@ namespace Emby.Server.Implementations.ScheduledTasks.Tasks
         {
             yield return new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerInterval,
+                Type = TaskTriggerInfoType.IntervalTrigger,
                 IntervalTicks = TimeSpan.FromHours(12).Ticks
             };
         }

--- a/MediaBrowser.Model/Tasks/TaskTriggerInfo.cs
+++ b/MediaBrowser.Model/Tasks/TaskTriggerInfo.cs
@@ -9,30 +9,10 @@ namespace MediaBrowser.Model.Tasks
     public class TaskTriggerInfo
     {
         /// <summary>
-        /// The daily trigger.
-        /// </summary>
-        public const string TriggerDaily = "DailyTrigger";
-
-        /// <summary>
-        /// The weekly trigger.
-        /// </summary>
-        public const string TriggerWeekly = "WeeklyTrigger";
-
-        /// <summary>
-        /// The interval trigger.
-        /// </summary>
-        public const string TriggerInterval = "IntervalTrigger";
-
-        /// <summary>
-        /// The startup trigger.
-        /// </summary>
-        public const string TriggerStartup = "StartupTrigger";
-
-        /// <summary>
         /// Gets or sets the type.
         /// </summary>
         /// <value>The type.</value>
-        public string Type { get; set; }
+        public TaskTriggerInfoType Type { get; set; }
 
         /// <summary>
         /// Gets or sets the time of day.

--- a/MediaBrowser.Model/Tasks/TaskTriggerInfoType.cs
+++ b/MediaBrowser.Model/Tasks/TaskTriggerInfoType.cs
@@ -1,0 +1,28 @@
+namespace MediaBrowser.Model.Tasks
+{
+    /// <summary>
+    /// Enum TaskTriggerInfoType.
+    /// </summary>
+    public enum TaskTriggerInfoType
+    {
+        /// <summary>
+        /// The daily trigger.
+        /// </summary>
+        DailyTrigger,
+
+        /// <summary>
+        /// The weekly trigger.
+        /// </summary>
+        WeeklyTrigger,
+
+        /// <summary>
+        /// The interval trigger.
+        /// </summary>
+        IntervalTrigger,
+
+        /// <summary>
+        /// The startup trigger.
+        /// </summary>
+        StartupTrigger
+    }
+}

--- a/MediaBrowser.Providers/Lyric/LyricScheduledTask.cs
+++ b/MediaBrowser.Providers/Lyric/LyricScheduledTask.cs
@@ -162,7 +162,7 @@ public class LyricScheduledTask : IScheduledTask
         [
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerInterval,
+                Type = TaskTriggerInfoType.IntervalTrigger,
                 IntervalTicks = TimeSpan.FromHours(24).Ticks
             }
         ];

--- a/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
@@ -217,7 +217,7 @@ namespace MediaBrowser.Providers.MediaInfo
             return new[]
             {
                 // Every so often
-                new TaskTriggerInfo { Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks }
+                new TaskTriggerInfo { Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks }
             };
         }
     }

--- a/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
@@ -63,7 +63,7 @@ public class TrickplayImagesTask : IScheduledTask
         {
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerDaily,
+                Type = TaskTriggerInfoType.DailyTrigger,
                 TimeOfDayTicks = TimeSpan.FromHours(3).Ticks
             }
         };

--- a/src/Jellyfin.LiveTv/Channels/RefreshChannelsScheduledTask.cs
+++ b/src/Jellyfin.LiveTv/Channels/RefreshChannelsScheduledTask.cs
@@ -79,7 +79,7 @@ namespace Jellyfin.LiveTv.Channels
                 // Every so often
                 new TaskTriggerInfo
                 {
-                    Type = TaskTriggerInfo.TriggerInterval, IntervalTicks = TimeSpan.FromHours(24).Ticks
+                    Type = TaskTriggerInfoType.IntervalTrigger, IntervalTicks = TimeSpan.FromHours(24).Ticks
                 }
             };
         }

--- a/src/Jellyfin.LiveTv/Guide/RefreshGuideScheduledTask.cs
+++ b/src/Jellyfin.LiveTv/Guide/RefreshGuideScheduledTask.cs
@@ -66,7 +66,7 @@ public class RefreshGuideScheduledTask : IScheduledTask, IConfigurableScheduledT
         {
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerInterval,
+                Type = TaskTriggerInfoType.IntervalTrigger,
                 IntervalTicks = TimeSpan.FromHours(24).Ticks
             }
         };


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

Just something I noticed while we're implementing tasks in Swiftfin. Not necessary for 10.10.

**Changes**
Implements `TaskTriggerInfoType` for the `TaskTriggerInfo.Type` field.