### PR TITLE
Have device deletion take list of ids

### DIFF
--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -1,7 +1,10 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
+using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Helpers;
+using Jellyfin.Api.ModelBinders;
 using Jellyfin.Data.Dtos;
 using Jellyfin.Data.Queries;
 using MediaBrowser.Common.Api;
@@ -111,28 +114,34 @@ public class DevicesController : BaseJellyfinApiController
     }
 
     /// <summary>
-    /// Deletes a device.
+    /// Deletes devices.
     /// </summary>
-    /// <param name="id">Device Id.</param>
+    /// <param name="id">Optional. Device Id.</param>
+    /// <param name="ids">Device Ids.</param>
     /// <response code="204">Device deleted.</response>
     /// <response code="404">Device not found.</response>
-    /// <returns>A <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the device could not be found.</returns>
+    /// <returns>A <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if a device could not be found.</returns>
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DeleteDevice([FromQuery, Required] string id)
+    public async Task<ActionResult> DeleteDevice([FromQuery, ParameterObsolete] string? id, [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] ids)
     {
-        var existingDevice = _deviceManager.GetDevice(id);
-        if (existingDevice is null)
-        {
-            return NotFound();
-        }
+        string[] allIDs = ids.Concat(id != null ? [id] : Array.Empty<string>()).ToArray();
 
-        var sessions = _deviceManager.GetDevices(new DeviceQuery { DeviceId = id });
-
-        foreach (var session in sessions.Items)
+        foreach (var i in allIDs)
         {
-            await _sessionManager.Logout(session).ConfigureAwait(false);
+            var existingDevice = _deviceManager.GetDevice(i);
+            if (existingDevice is null)
+            {
+                return NotFound();
+            }
+
+            var sessions = _deviceManager.GetDevices(new DeviceQuery { DeviceId = i });
+
+            foreach (var session in sessions.Items)
+            {
+                await _sessionManager.Logout(session).ConfigureAwait(false);
+            }
         }
 
         return NoContent();

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -126,7 +126,11 @@ public class DevicesController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteDevice([FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] ids)
     {
-        List<DeviceInfoDto> devices = new List<DeviceInfoDto>();
+        var devices = ids.Select(_deviceManager.GetDevice).ToArray();
+        if (devices.Any(f => f is null))
+        {
+        	return NotFound();
+        }
 
         foreach (var id in ids)
         {

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -124,28 +124,17 @@ public class DevicesController : BaseJellyfinApiController
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DeleteDevice([FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] ids)
+    public async Task<ActionResult> DeleteDevice([FromQuery] string[] ids)
     {
         var devices = ids.Select(_deviceManager.GetDevice).ToArray();
         if (devices.Any(f => f is null))
         {
-        	return NotFound();
-        }
-
-        foreach (var id in ids)
-        {
-            var existingDevice = _deviceManager.GetDevice(id);
-            if (existingDevice is null)
-            {
-                return NotFound();
-            }
-
-            devices.Add(existingDevice);
+            return NotFound();
         }
 
         foreach (var device in devices)
         {
-            var sessions = _deviceManager.GetDevices(new DeviceQuery { DeviceId = device.Id });
+            var sessions = _deviceManager.GetDevices(new DeviceQuery { DeviceId = device!.Id });
 
             foreach (var session in sessions.Items)
             {

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -117,16 +117,16 @@ public class DevicesController : BaseJellyfinApiController
     /// <summary>
     /// Deletes devices.
     /// </summary>
-    /// <param name="ids">Device Ids.</param>
+    /// <param name="id">Device Ids.</param>
     /// <response code="204">Device deleted.</response>
     /// <response code="404">Device not found.</response>
     /// <returns>A <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if a device could not be found.</returns>
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DeleteDevice([FromQuery] string[] ids)
+    public async Task<ActionResult> DeleteDevice([FromQuery] string[] id)
     {
-        var devices = ids.Select(_deviceManager.GetDevice).ToArray();
+        var devices = id.Select(_deviceManager.GetDevice).ToArray();
         if (devices.Any(f => f is null))
         {
             return NotFound();

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -136,7 +136,7 @@ public class DevicesController : BaseJellyfinApiController
                 return NotFound();
             }
 
-            devices.Append(existingDevice);
+            devices.Add(existingDevice);
         }
 
         foreach (var device in devices)

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -119,17 +119,17 @@ public class DevicesController : BaseJellyfinApiController
     /// </summary>
     /// <param name="id">Device Ids.</param>
     /// <response code="204">Device deleted.</response>
-    /// <response code="404">Device not found.</response>
-    /// <returns>A <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if a device could not be found.</returns>
+    /// <response code="400">A requested device is invalid.</response>
+    /// <returns>A <see cref="NoContentResult"/> on success, or a <see cref="BadRequestResult"/> if a requested device is invalid.</returns>
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteDevice([FromQuery] string[] id)
     {
         var devices = id.Select(_deviceManager.GetDevice).ToArray();
         if (devices.Any(f => f is null))
         {
-            return NotFound();
+            return BadRequest();
         }
 
         foreach (var device in devices)


### PR DESCRIPTION
While we're implementing administrative tasks in Swiftfin, I noticed that the endpoint for device deletion only takes a single id. The web performs "delete all" by iteratively calling the endpoint. This could be problematic for larger device counts and was just easy an easy optimization.

**Changes**

Changes the `id` parameter to accept a list of items, which occur through parameter repetition. This is not a breaking change.

My only concern is that trying to delete too many devices will create long URLs that may cause other issues. So, an implementation by falling back to the body if parameters weren't present may be warranted.