### PR TITLE
Infer more audio codec from containers

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -629,49 +629,21 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <returns>Codec string.</returns>
         public string InferAudioCodec(string container)
         {
-            var ext = "." + (container ?? string.Empty);
-
-            if (string.Equals(ext, ".mp3", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(container))
             {
-                return "mp3";
-            }
-
-            if (string.Equals(ext, ".aac", StringComparison.OrdinalIgnoreCase))
-            {
+                // this may not work, but if the client is that broken we can not do anything better
                 return "aac";
             }
 
-            if (string.Equals(ext, ".wma", StringComparison.OrdinalIgnoreCase))
-            {
-                return "wma";
-            }
+            var inferredCodec = container.ToLowerInvariant();
 
-            if (string.Equals(ext, ".ogg", StringComparison.OrdinalIgnoreCase))
+            return inferredCodec switch
             {
-                return "vorbis";
-            }
-
-            if (string.Equals(ext, ".oga", StringComparison.OrdinalIgnoreCase))
-            {
-                return "vorbis";
-            }
-
-            if (string.Equals(ext, ".ogv", StringComparison.OrdinalIgnoreCase))
-            {
-                return "vorbis";
-            }
-
-            if (string.Equals(ext, ".webm", StringComparison.OrdinalIgnoreCase))
-            {
-                return "vorbis";
-            }
-
-            if (string.Equals(ext, ".webma", StringComparison.OrdinalIgnoreCase))
-            {
-                return "vorbis";
-            }
-
-            return "copy";
+                "ogg" or "oga" or "ogv" or "webm" or "webma" => "opus",
+                "m4a" or "m4b" or "mp4" or "mov" or "mkv" or "mka" => "aac",
+                "ts" or "avi" or "flv" or "f4v" or "swf" => "mp3",
+                _ => inferredCodec
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
This is mainly for some broken legacy clients that will unlikely to receive proper fix for audio transcoding profile and migrate to our new universal audio controller anytime soon. These legacy clients used an outdated Emby-era audio transcoding pipeline, where the client neither explicitly specifies the desired transcoding formats nor properly indicates the supported audio codecs in its request. Instead, they rely on just providing a container name in the request URL, hoping the server can guess the correct audio codec. However, this guessing is often inaccurate as the container-to-codec mapping has been hard-coded and outdated for six years. When the server cannot guess it will just return "copy" which will obviously fail because the client is requesting transcoding. This PR makes the infer logic more robust to only infer from containers that does not have the same name as the audio codec, and pick the "should be compatible" codec for the container. This may still fail in edge cases if the client is weird enough, but should cover most use cases.

Please note that some clients (like JMP) always requests the container same as the source audio (like from flac to flac) which might make the transcoding behavior weird, this has to be fixed on the client side.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Pick the in-theory compatible audio codec for requested container
- If the container is not empty, default to just return the container name as codec

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12822
