### PR TITLE
Fix authenticateWithQuickConnect rethrow

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -239,6 +239,7 @@ public class UserController : BaseJellyfinApiController
     /// <param name="request">The <see cref="QuickConnectDto"/> request.</param>
     /// <response code="200">User authenticated.</response>
     /// <response code="400">Missing token.</response>
+    /// <response code="404">Token not found.</response>
     /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationRequest"/> with information about the new session.</returns>
     [HttpPost("AuthenticateWithQuickConnect")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -248,10 +249,10 @@ public class UserController : BaseJellyfinApiController
         {
             return _quickConnectManager.GetAuthorizedRequest(request.Secret);
         }
-        catch (SecurityException e)
+        catch (ResourceNotFoundException e)
         {
             // rethrow adding IP address to message
-            throw new SecurityException($"[{HttpContext.GetNormalizedRemoteIP()}] {e.Message}", e);
+            throw new ResourceNotFoundException($"[{HttpContext.GetNormalizedRemoteIP()}] {e.Message}", e);
         }
     }
 

--- a/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
+++ b/MediaBrowser.Common/Extensions/ResourceNotFoundException.cs
@@ -22,5 +22,15 @@ namespace MediaBrowser.Common.Extensions
             : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceNotFoundException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public ResourceNotFoundException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
     }
 }


### PR DESCRIPTION
The exception being rethrown when the token was not found was a different exception type than the underlying exception.

**Changes**
 - Change rethrown exception type from SecurityException to ResourceNotFoundException.
 - Add new constructor for ResourceNotFoundException to support rethrowing caught exception. Copied from SecurityException Class.
 - Add additional response StatusCode to summary for 404NotFound.
 
**Fixes**
 - The exception is now caught and rethrown.
 - 404 Response Message for /Users/authenticateWithQuickConnect
Before: Unable to find request
After: [127.0.0.1] Unable to find request
