### PR TITLE
Add MaxActiveStreams functionality

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -726,15 +726,19 @@ namespace Emby.Server.Implementations.Session
                             && i.DeviceId != session.DeviceId
                             && i.NowPlayingItem is not null)
                         .ToList();
+
                     int maxActiveStreams = user.MaxActiveStreams;
+
                     _logger.LogInformation("Current/Max streams for user {User}: {Streams}/{Max}", user.Username, activeStreams.Count(), maxActiveStreams);
+
                     while (maxActiveStreams >= 1 && activeStreams.Count() >= maxActiveStreams)
                     {
+                        var activeStream = activeStreams.First();
+
                         try
                         {
-                            var activeStream = activeStreams.First();
                             await SendPlaystateCommand(
-                                activeStream.Id,
+                                session.Id,
                                 activeStream.Id,
                                 new PlaystateRequest()
                                 {
@@ -743,12 +747,13 @@ namespace Emby.Server.Implementations.Session
                                     SeekPositionTicks = activeStream.PlayState?.PositionTicks
                                 },
                                 CancellationToken.None).ConfigureAwait(true);
-                            activeStreams.RemoveAt(0);
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogDebug(ex, "Error calling SendPlaystateCommand for stopping max active session {Session}.", session.Id);
+                            _logger.LogDebug(ex, "Error calling SendPlaystateCommand for stopping max active session {Session}.", activeStream.Id);
                         }
+
+                        activeStreams.RemoveAt(0);
                     }
 
                     OnPlaybackStart(user, libraryItem);

--- a/Jellyfin.Data/Entities/User.cs
+++ b/Jellyfin.Data/Entities/User.cs
@@ -158,6 +158,11 @@ namespace Jellyfin.Data.Entities
         public int MaxActiveSessions { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of active streams the user can have at once.
+        /// </summary>
+        public int MaxActiveStreams { get; set; }
+
+        /// <summary>
         /// Gets or sets the subtitle mode.
         /// </summary>
         /// <remarks>

--- a/Jellyfin.Server.Implementations/Migrations/20241017013200_AddMaxActiveStreams.Designer.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20241017013200_AddMaxActiveStreams.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Server.Implementations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Server.Implementations.Migrations
 {
     [DbContext(typeof(JellyfinDbContext))]
-    partial class JellyfinDbModelSnapshot : ModelSnapshot
+    [Migration("20241017013200_AddMaxActiveStreams")]
+    partial class AddMaxActiveStreams
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.8");

--- a/Jellyfin.Server.Implementations/Migrations/20241017013200_AddMaxActiveStreams.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20241017013200_AddMaxActiveStreams.cs
@@ -1,0 +1,28 @@
+#pragma warning disable CS1591
+#pragma warning disable SA1601
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Jellyfin.Server.Implementations.Migrations
+{
+    public partial class AddMaxActiveStreams : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxActiveStreams",
+                schema: "jellyfin",
+                table: "Users",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxActiveStreams",
+                schema: "jellyfin",
+                table: "Users");
+        }
+    }
+}

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -342,6 +342,7 @@ namespace Jellyfin.Server.Implementations.Users
                     InvalidLoginAttemptCount = user.InvalidLoginAttemptCount,
                     LoginAttemptsBeforeLockout = user.LoginAttemptsBeforeLockout ?? -1,
                     MaxActiveSessions = user.MaxActiveSessions,
+                    MaxActiveStreams = user.MaxActiveStreams,
                     IsAdministrator = user.HasPermission(PermissionKind.IsAdministrator),
                     IsHidden = user.HasPermission(PermissionKind.IsHidden),
                     IsDisabled = user.HasPermission(PermissionKind.IsDisabled),
@@ -667,6 +668,7 @@ namespace Jellyfin.Server.Implementations.Users
                 user.InvalidLoginAttemptCount = policy.InvalidLoginAttemptCount;
                 user.LoginAttemptsBeforeLockout = maxLoginAttempts;
                 user.MaxActiveSessions = policy.MaxActiveSessions;
+                user.MaxActiveStreams = policy.MaxActiveStreams;
                 user.SyncPlayAccess = policy.SyncPlayAccess;
                 user.SetPermission(PermissionKind.IsAdministrator, policy.IsAdministrator);
                 user.SetPermission(PermissionKind.IsHidden, policy.IsHidden);

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -49,6 +49,7 @@ namespace MediaBrowser.Model.Users
             LoginAttemptsBeforeLockout = -1;
 
             MaxActiveSessions = 0;
+            MaxActiveStreams = 0;
             MaxParentalRating = null;
 
             EnableAllChannels = true;
@@ -171,6 +172,8 @@ namespace MediaBrowser.Model.Users
         public int LoginAttemptsBeforeLockout { get; set; }
 
         public int MaxActiveSessions { get; set; }
+
+        public int MaxActiveStreams { get; set; }
 
         public bool EnablePublicSharing { get; set; }
 


### PR DESCRIPTION
Feature Add: Adding the functionality to limit Active Streams per user by a configurable number.

**Changes**
This adds a configurable number that, if a user exceeds by starting a new stream, will issue a stop command to another active stream, which will then effectively limit the number of active streams per user.
This piggybacks onto OnPlaybackStarted in SessionManager to check Sessions for active sessions for the user (NowPlayingItem) and then Issue a Stop command to as many Sessions as needed to be within the users' configured Max allowed Active Streams count.

NOTES:
1.) This is not "fully" tested. (I have only tested using jellyfin-web, not against other clients)
2.) The .First() doesn't seem to be working as I originally intended.  I think the desire would be to stop the "oldest" Session, but this doesn't seem to work as expected, not sure if this is important or not at this juncture.
3.) This adds MaxActiveStreams to the User Policy.  Requiring a db update (included) and client/sdk updates (below)
4.) This depends on the ability to update the value through a UI/client which I've done for [jellyfin-web here](https://github.com/Migs3/jellyfin-web/commit/50a00aea169f0a45ec2b2b40b0554c1b4d79bd7a):  but other languages will also need updates (Sorry, I only know English) and other clients will need updated as well to show the properly display the setting in their UI.
5.) This also then depends on [updating the sdk](https://github.com/Migs3/jellyfin-sdk-typescript/commit/4173bc44fe2966625d5b67cbf6610daac4b2be95).
6.) I would assume that this number should not exceed the MaxActiveSessions number, but I haven't implemented any checks to ensure it doesn't.  Not sure if this is needed?

**Issues**
This addresses functionality request here: https://features.jellyfin.org/posts/1444/limit-the-number-of-simultaneous-streams-per-user