### PR TITLE
make playlist creation private by default

### DIFF
--- a/MediaBrowser.Model/Playlists/PlaylistCreationRequest.cs
+++ b/MediaBrowser.Model/Playlists/PlaylistCreationRequest.cs
@@ -38,5 +38,5 @@ public class PlaylistCreationRequest
     /// <summary>
     /// Gets or sets a value indicating whether the playlist is public.
     /// </summary>
-    public bool? Public { get; set; } = true;
+    public bool? Public { get; set; } = false;
 }


### PR DESCRIPTION
@nielsvanvelzen you requested the current behavior but it would change the status quo for existing clients.

**Changes**

Invert public boolean for backwards compatibility on clients that don't currently support this attribute. Currently untested so don't merge this unless it looks correct.

**Issues**

#12835