### PR TITLE
Order using production year when premiere date is not available

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -265,3 +265,4 @@
  - [0x25CBFC4F](https://github.com/0x25CBFC4F)
  - [Robert Lützner](https://github.com/rluetzner)
  - [Nathan McCrina](https://github.com/nfmccrina)
+ - [Yutong Luo](https://github.com/yutongluo)

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -2866,7 +2866,7 @@ namespace Emby.Server.Implementations.Data
                 ItemSortBy.AiredEpisodeOrder => "AiredEpisodeOrder",
                 ItemSortBy.Album => "Album",
                 ItemSortBy.DateCreated => "DateCreated",
-                ItemSortBy.PremiereDate => "PremiereDate",
+                ItemSortBy.PremiereDate => "COALESCE(PremiereDate, DATE(ProductionYear||'-01-01'))",
                 ItemSortBy.StartDate => "StartDate",
                 ItemSortBy.Name => "Name",
                 ItemSortBy.CommunityRating => "CommunityRating",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->



**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add coalesce clause to use production year to sort when premiere date is not available. Behavior is as follows
- Use Premiere Date if not null
- else use `date(ProductionYear||'-01-01')`
- if `ProductionYear` is also null, date will return null since '-01-01' is invalid, and sort will be using NULL (expected behavior)

Could not find where to add a test, if folks more familiar could help point it out that'd be great. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#12101
