### PR TITLE
[WIP] Smart font streaming for external ASS subtitles

### DIFF
--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -45,4 +45,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Jellyfin.LibAssUtils">
+      <HintPath>..\..\..\..\Downloads\libass\Jellyfin.LibAssUtils\bin\Debug\net8.0\Jellyfin.LibAssUtils.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/MediaBrowser.Model/Subtitles/FontStreamInfo.cs
+++ b/MediaBrowser.Model/Subtitles/FontStreamInfo.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace MediaBrowser.Model.Subtitles
+{
+    /// <summary>
+    /// Class FontStreamInfo.
+    /// </summary>
+    public class FontStreamInfo
+    {
+        /// <summary>
+        /// Gets or sets the filesystem path of the font file.
+        /// </summary>
+        /// <value>The filesystem path.</value>
+        public required string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lookup key that can be used to grab the underlying font file from Jellyfin API.
+        /// </summary>
+        /// <value>The lookup key.</value>
+        public required string Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the font name as specified in the subtitle file that referenced it.
+        /// This might be either family name, full name or PostScript name.
+        /// It does not uniquely identify the font on its own.
+        /// Any given font file may match multiple names.
+        /// </summary>
+        /// <value>The name.</value>
+        public string? FontName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the PostScript name of the font.
+        /// The PostScript font name is supposed to be unique, locale-independent
+        /// and abide by certain restrictions to allowed format.
+        /// Unfortunately, not all font files out there physically abide by these standards.
+        /// </summary>
+        /// <value>The PostScript name.</value>
+        public string? PostScriptName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Bold score.
+        /// </summary>
+        /// <value>The Bold.</value>
+        public int Bold { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Italic score.
+        /// </summary>
+        /// <value>The Italic.</value>
+        public int Italic { get; set; }
+    }
+}


### PR DESCRIPTION
This is new feature based on discussion under #12511 that proposed this general idea instead.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Background/reasoning** (as short and concise as I could :sob:)

Currently there is no way to stream fonts from server for loose .ass files next to the video files. The fonts either need to be (a) bundled inside of .mkv or (b) pre-installed on the clients. Some people (c) misused the fallback fonts feature to make the web client load up the fonts they wanted, abusing that it'd preload them all to the browser.

These existing options sucked because:
- (a) it's not desirable to re-bake the existing MKV file, as that both requires work + you don't keep original for example seed such original file anymore, or for archival reasons
- (b) impossible on TVs, phones, consoles, even on web client, so basically possible just for PC clients
- (c) fallback fonts preload ALL of the fonts there up to 20 MB limit, this causes huge unnecessary strain on the browser if used this way, plus delays subtitle viewing by a good couple of seconds on LAN!

I attempted a PR #12511, but it'd break existing original use-case of fallback fonts, plus it wasn't desirable by the contributors to send full list of fonts (could be many of them), plus the naive approach of mapping just font name from .ass to font file could NOT actually work reliably due to more complicated logic of font-picking, as used by libass for example (most popular library).

It was concluded that server should decide and filter what fonts should be loaded for a given subtitles file. That approach makes perfect sense, since the server is then just one place that has to parse the file and run selection logic, while clients can then just load the fonts. Then the fonts should all be preloaded into video backend and the embedded library such as libass will match them up with its extended logic.

The source of fonts will be server-side fonts installed on the system. This creates a common single source of extra fonts for videos, since those fonts are already used for server-side subtitle burn-in automatically by ffmpeg now, plus there's now instructions how to install extra fonts in Docker in docs now. Alternative of adding 4th source of fonts as a streamable folder similar to fallback fonts would be bad on the other hand.

**Implementation**

My implementation idea boils down to just using libass (modified and wrapped into C# module) to parse and select a list of needed fonts.

Why libass:
- guarantees proper and consistent parsing of .ass file
- exact same consistent logic for matching up fonts as on the client, meaning the client-side will be happy with the fonts it gets (and the logic isn't as simple as name -> file turns out)
- libass happens to already have integration of native system font provider APIs of three major systems: Linux (fontconfig), Windows (directwrite), macOS (CoreText), this means no need to reinvent the wheel for us all while taking advantage of system's existing font cache to make the picking faster

I spent actually a lot of time and effort to get a minimal version of libass built (without rendering features and thus without having to link some unneeded libs). It works pretty well now. Two levels of caching (fontselect caches font info, I cache params->font info mapping) make the thing very reasonably fast. The advantage of this approach is that it also doesn't require advanced changes in Jellyfin codebase.

Also getting just a list of needed fonts instead of a map (that was flawed anyways, as Subtitle Octopus would just simply download all fonts it saw in Styles with no further checks!) will allow many clients to very easily support it. If you have clients that expect a dir with fonts and you already create a temp dir and download MediaAttachments fonts there, it should be trivial for you to also download these fonts there too. Peace of cake, and this will allow the adoption to be more than just the web client...

⚠️ [**WIP part**]: I still need to figure out CI building of the modified libass and packaging it into NuGet... I named my prototype package **`Jellyfin.LibAssTools`**, code-wise it works already but I still need to figure out some things like logging redirection maybe. It's not a full libass wrapper by any means, wraps just the interface created for Jellyfin's needed functionality to remain minimalistic.

And so I think we should move it under Jellyfin org once it's ready, similarly to a helper module like: https://github.com/jellyfin/Jellyfin.XmlTv

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

1. Adds following API endpoints:
- `Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Fonts` -> get FontStreamInfo[]
- `Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Fonts` -> get FontStreamInfo[]
- `Fonts/{family},{bold},{italic}` -> get font file (the key to use as params will be returned in items from above^)
- `Fonts/{family}` -> get font file (easy version of above, less precise)

on `{routeStartPositionTicks}`:
The first two routes have two variants exactly like the one ending with `/Stream.ass`. Right now the variant with `{routeStartPositionTicks}` is kinda useless, but: for one, it can be used more consistently since for font /Stream.ass always the longer version is used; secondly, if someone ever implements it properly in the future that events before start tick are filtered out even when subtitles are not converted between formats (right now they're streamed directly if same format, converted with dropping otherwise). And if that was to happen, the library would already filter out the fonts that are only used by the dropped events. So that's kinda future-proofing it, since the intended interface is already there I guess?

2. Adds following schema:
- `MediaBrowser.Model/Subtitles/FontStreamInfo`

⚠️ **TODO**

Todo:
- module `Jellyfin.LibAssTools` is missing currently!!! (see above)
- PR to support it in jellyfin-web at least
- PRs to support it in some other clients (I'll look into some of them after we merge the baseline of server+web I think)

Questions:
- should the link to /Fonts list be next to `DeliveryUrl` that's consumed by clients, or should the client take DeliveryUrl and figure out path to /Fonts endpoint on its own (with regex?)? clearly at least having it there would make it less error-prone for clients plus easier to feature-detect it's not yet supported on old server; but that'd require adding a new field to class MediaStream if that's okay (like `FontsUrl`)
- is API endpoint prefix `Fonts/...` for the last two endpoints ok? Fallback fonts have `FallbackFont/Fonts/`, and my logic was "okay, and these are *just* fonts". But some alternatives could include something like `StreamableFont/Fonts/`, `ServerFont/Fonts/`, `ServerSideFont/Fonts/` idk!!
- should enablement of this be configurable (on server?)? if yes then enabled or disabled by default?
- should some API feedback also be returned for fonts that couldn't be found installed on the server?

Possible enhancements:
- if the above with `FontsUrl` on MediaStream is answered "yes", then server could maybe list fonts in advance and only add the `FontsUrl` or something if there's >0 fonts available, so that the client wouldn't have to bother with round-trip to `.../Fonts`
- currently fonts existing in MediaAttachments of MKV aren't filtered out. It's TBD whether clients should attempt loading external fonts if they stream non-external subtitles. Simple option for now is to not do that and assume that .ass in MKV will have corresponding font files attached all in the MKV. While also assuming that an .ass outside will likely not and hence the new feature.
- maybe the last two endpoints could be combined into one with `bold` and `italic` as optional query params...

Problems:
- ideally we'd want a way on the SubtitleEncoder interface to grab either ssa/ass if available, else bail out; currently something like "ssa" will probably be converted to "ass" and throw out Styles; and something like .srt would be converted to generic .ass and then it'd stream Default font from converter (Arial or whatever)
- I need to wait for libass contribs to answer me point 2 in libass/libass#843 so that I know if I can simplify Bold and Italic parameters into booleans or not... (I already realized I don't need Vertical right before making the PR)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Supersedes these old PRs that were based on the old idea:
Closes #12511
Closes jellyfin/jellyfin-web#5960

So yeah this isn't finished yet, but I wanna start gathering some feedback already if people have some. Working on it slowly while Jellyfin is in its lock phase before release. Maybe we could get this in after lifting the lock and at least there'd be plenty of time for interested clients to start supporting it then. Hope I didn't type out too much text :sob: