### PR TITLE
Auto update issue template version on new release

### DIFF
--- a/bump_version
+++ b/bump_version
@@ -28,6 +28,7 @@ jellyfin_subprojects=(
   Emby.Naming/Emby.Naming.csproj
   src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
 )
+issue_template_file="./.github/ISSUE_TEMPLATE/issue report.yml"
 
 new_version="$1"
 new_version_sed="$( cut -f1 -d'-' <<<"${new_version}" )"
@@ -55,6 +56,9 @@ for subproject in ${jellyfin_subprojects[@]}; do
     # Set the nuget version to the specified new_version
     sed -i "s|${old_version}|${new_version_sed}|g" ${subproject}
 done
+
+# Set the version in the GitHub issue template file
+sed -i "s|${old_version}|${new_version_sed}|g" ${issue_template_file}
 
 # Stage the changed files for commit
 git add .


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

Extend the existing `bump_version` script to also update the jellyfin version in the github issue template file so if is no longer necessary to manually update it on every new release.

I tested that the script does behave as expected with the issue template file that contains a space character in its filename.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Context/motivation: https://github.com/jellyfin/jellyfin/pull/12613#pullrequestreview-2288536359

