### PR TITLE
Don't try to prune images for virtual episodes.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -193,6 +193,7 @@
  - [oxixes](https://github.com/oxixes)
  - [elfalem](https://github.com/elfalem)
  - [benedikt257](https://github.com/benedikt257)
+ - [revam](https://github.com/revam)
 
 # Emby Contributors
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -387,8 +387,8 @@ namespace MediaBrowser.Providers.Manager
 
             item.RemoveImages(images);
 
-            // Cleanup old metadata directory for episodes if empty
-            if (item is Episode)
+            // Cleanup old metadata directory for episodes if empty, as long as it's not a virtual item
+            if (item is Episode && !item.IsVirtualItem)
             {
                 var oldLocalMetadataDirectory = Path.Combine(item.ContainingFolderPath, "metadata");
                 if (_fileSystem.DirectoryExists(oldLocalMetadataDirectory) && !_fileSystem.GetFiles(oldLocalMetadataDirectory).Any())


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Don't try to prune images for virtual episodes, since they don't have a containing folder path to look for metadata in. This was causing issues when attempting to refresh a library, series or episode with replace all and replace images enabled.

I also added myself to the contributors file since I've forgotten to do that in previous PRs.

**Issues**
Didn't make one, but it will prevent these kinds of stack traces from stopping a refresh or library scan when it tries to prune images for a virtual episode;
```log
[XX:XX:XX] [ERR] [XX] MediaBrowser.Providers.Manager.ProviderManager: Error refreshing item
System.ArgumentNullException: Value cannot be null. (Parameter 'path1')
   at System.ArgumentNullException.Throw(String paramName)
   at System.IO.Path.Combine(String path1, String path2)
   at MediaBrowser.Providers.Manager.ItemImageProvider.PruneImages(BaseItem item, IReadOnlyList`1 images)
   at MediaBrowser.Providers.Manager.ItemImageProvider.RemoveImages(BaseItem item, Boolean canDeleteLocal)
   at MediaBrowser.Providers.Manager.MetadataService`2.RefreshMetadata(BaseItem item, MetadataRefreshOptions refreshOptions, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.BaseItem.RefreshMetadata(MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.TV.Series.RefreshAllMetadata(MetadataRefreshOptions refreshOptions, IProgress`1 progress, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.RefreshAllMetadataForContainer(IMetadataContainer container, MetadataRefreshOptions refreshOptions, IProgress`1 progress, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.RefreshChildMetadata(BaseItem child, MetadataRefreshOptions refreshOptions, Boolean recursive, IProgress`1 progress, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.<>c__DisplayClass69_0`1.<<RunTasks>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at MediaBrowser.Controller.Entities.Folder.RunTasks[T](Func`3 task, IList`1 children, IProgress`1 progress, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.ValidateChildrenInternal2(IProgress`1 progress, Boolean recursive, Boolean refreshChildMetadata, Boolean allowRemoveRoot, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService, CancellationToken cancellationToken)
   at MediaBrowser.Controller.Entities.Folder.ValidateChildrenInternal(IProgress`1 progress, Boolean recursive, Boolean refreshChildMetadata, Boolean allowRemoveRoot, MetadataRefreshOptions refreshOptions, IDirectoryService directoryService, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.ProviderManager.RefreshCollectionFolderChildren(MetadataRefreshOptions options, CollectionFolder collectionFolder, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.ProviderManager.RefreshItem(BaseItem item, MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.ProviderManager.StartProcessingRefreshQueue()
```

Example of it attempting to prune the images of a virtual episode right before it will throw the above error;
![image](https://github.com/user-attachments/assets/30a9a042-4584-424d-8152-6b399608ee70)
