### PR TITLE
Remove DynamicImageResponse local image after saved to metadata folder

### DIFF
--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -122,7 +122,6 @@ namespace Emby.Server.Implementations.Images
             }
 
             await ProviderManager.SaveImage(item, outputPath, mimeType, imageType, null, false, cancellationToken).ConfigureAwait(false);
-            File.Delete(outputPath);
 
             return ItemUpdateType.ImageUpdate;
         }

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -77,7 +77,8 @@ namespace MediaBrowser.Controller.Providers
         Task SaveImage(BaseItem item, Stream source, string mimeType, ImageType type, int? imageIndex, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Saves the image.
+        /// Saves the image by giving the image path on filesystem.
+        /// This method will remove the image on the source path after saving it to the destination.
         /// </summary>
         /// <param name="item">Image to save.</param>
         /// <param name="source">Source of image.</param>

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -229,11 +229,7 @@ namespace MediaBrowser.Providers.Manager
                                 {
                                     var mimeType = MimeTypes.GetMimeType(response.Path);
 
-                                    var stream = AsyncFile.OpenRead(response.Path);
-
-                                    await _providerManager.SaveImage(item, stream, mimeType, imageType, null, cancellationToken).ConfigureAwait(false);
-
-                                    File.Delete(response.Path);
+                                    await _providerManager.SaveImage(item, response.Path, mimeType, imageType, null, null, cancellationToken).ConfigureAwait(false);
                                 }
                             }
 

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -232,6 +232,8 @@ namespace MediaBrowser.Providers.Manager
                                     var stream = AsyncFile.OpenRead(response.Path);
 
                                     await _providerManager.SaveImage(item, stream, mimeType, imageType, null, cancellationToken).ConfigureAwait(false);
+
+                                    File.Delete(response.Path);
                                 }
                             }
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncKeyedLock;
@@ -258,7 +259,7 @@ namespace MediaBrowser.Providers.Manager
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Exception? saveException = null;
+            ExceptionDispatchInfo? saveException = null;
 
             try
             {
@@ -267,7 +268,7 @@ namespace MediaBrowser.Providers.Manager
             }
             catch (Exception ex)
             {
-                saveException = ex;
+                saveException = ExceptionDispatchInfo.Capture(ex);
                 _logger.LogError(ex, "Unable to save image {Source}", source);
             }
             finally
@@ -282,14 +283,11 @@ namespace MediaBrowser.Providers.Manager
                 }
                 catch (Exception ex)
                 {
-                    saveException ??= ex;
+                    saveException ??= ExceptionDispatchInfo.Capture(ex);
                 }
             }
 
-            if (saveException is not null)
-            {
-                throw saveException;
-            }
+            saveException?.Throw();
         }
 
         /// <inheritdoc/>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -270,7 +270,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                     File.Delete(source);
                 }
-                catch (IOException ex)
+                catch (Exception ex)
                 {
                     _logger.LogError(ex, "Source file {Source} not found or in use, skip removing", source);
                 }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -251,7 +251,7 @@ namespace MediaBrowser.Providers.Manager
         }
 
         /// <inheritdoc/>
-        public Task SaveImage(BaseItem item, string source, string mimeType, ImageType type, int? imageIndex, bool? saveLocallyWithMedia, CancellationToken cancellationToken)
+        public async Task SaveImage(BaseItem item, string source, string mimeType, ImageType type, int? imageIndex, bool? saveLocallyWithMedia, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(source))
             {
@@ -259,7 +259,15 @@ namespace MediaBrowser.Providers.Manager
             }
 
             var fileStream = AsyncFile.OpenRead(source);
-            return new ImageSaver(_configurationManager, _libraryMonitor, _fileSystem, _logger).SaveImage(item, fileStream, mimeType, type, imageIndex, saveLocallyWithMedia, cancellationToken);
+            await new ImageSaver(_configurationManager, _libraryMonitor, _fileSystem, _logger).SaveImage(item, fileStream, mimeType, type, imageIndex, saveLocallyWithMedia, cancellationToken);
+            try
+            {
+                File.Delete(source);
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "Source file {Source} not found or in use, skip removing", source);
+            }
         }
 
         /// <inheritdoc/>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -259,17 +259,10 @@ namespace MediaBrowser.Providers.Manager
                 throw new ArgumentNullException(nameof(source));
             }
 
-            ExceptionDispatchInfo? saveException = null;
-
             try
             {
                 var fileStream = AsyncFile.OpenRead(source);
                 await new ImageSaver(_configurationManager, _libraryMonitor, _fileSystem, _logger).SaveImage(item, fileStream, mimeType, type, imageIndex, saveLocallyWithMedia, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                saveException = ExceptionDispatchInfo.Capture(ex);
-                _logger.LogError(ex, "Unable to save image {Source}", source);
             }
             finally
             {
@@ -281,13 +274,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                     _logger.LogError(ex, "Source file {Source} not found or in use, skip removing", source);
                 }
-                catch (Exception ex)
-                {
-                    saveException ??= ExceptionDispatchInfo.Capture(ex);
-                }
             }
-
-            saveException?.Throw();
         }
 
         /// <inheritdoc/>

--- a/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
@@ -292,6 +292,9 @@ namespace Jellyfin.Providers.Tests.Manager
             providerManager.Setup(pm => pm.SaveImage(item, It.IsAny<Stream>(), It.IsAny<string>(), imageType, null, It.IsAny<CancellationToken>()))
                 .Callback<BaseItem, Stream, string, ImageType, int?, CancellationToken>((callbackItem, _, _, callbackType, _, _) => callbackItem.SetImagePath(callbackType, 0, new FileSystemMetadata()))
                 .Returns(Task.CompletedTask);
+            providerManager.Setup(pm => pm.SaveImage(item, It.IsAny<string>(), It.IsAny<string>(), imageType, null, null, It.IsAny<CancellationToken>()))
+                .Callback<BaseItem, string, string, ImageType, int?, bool?, CancellationToken>((callbackItem, _, _, callbackType, _, _, _) => callbackItem.SetImagePath(callbackType, 0, new FileSystemMetadata()))
+                .Returns(Task.CompletedTask);
             var itemImageProvider = GetItemImageProvider(providerManager.Object, null);
             var result = await itemImageProvider.RefreshImages(item, libraryOptions, new List<IImageProvider> { dynamicProvider.Object }, refreshOptions, CancellationToken.None);
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Previously, local images provided by DynamicImageResponse were never cleaned up until the server was restarted. This issue has become more severe in 10.10, as the default is now set to use the system's native temp folder, which might be a RAM backed tmpfs. This behavior could lead to resource starvation for long-running servers performing multiple library scans.

Metadata plugins prefer the old behavior should do its own backup.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12937