### PR TITLE
Fix json array string writer in JsonDelimitedArrayConverter

### DIFF
--- a/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
@@ -71,24 +71,11 @@ namespace Jellyfin.Extensions.Json.Converters
                 writer.WriteStartArray();
                 if (value.Length > 0)
                 {
-                    var toWrite = value.Length - 1;
                     foreach (var it in value)
                     {
-                        var wrote = false;
                         if (it is not null)
                         {
                             writer.WriteStringValue(it.ToString());
-                            wrote = true;
-                        }
-
-                        if (toWrite > 0)
-                        {
-                            if (wrote)
-                            {
-                                writer.WriteStringValue(Delimiter.ToString());
-                            }
-
-                            toWrite--;
                         }
                     }
                 }


### PR DESCRIPTION
The `Utf8JsonWriter.WriteStringValue` method writes the provided string as an element of a JSON array, so we shouldn't manually add delimiters. If we do, the delimiters will be treated as separate array elements.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12948