### PR TITLE
Fix trickplay images never being replaced

### DIFF
--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -50,6 +50,7 @@ public class ItemRefreshController : BaseJellyfinApiController
     /// <param name="imageRefreshMode">(Optional) Specifies the image refresh mode.</param>
     /// <param name="replaceAllMetadata">(Optional) Determines if metadata should be replaced. Only applicable if mode is FullRefresh.</param>
     /// <param name="replaceAllImages">(Optional) Determines if images should be replaced. Only applicable if mode is FullRefresh.</param>
+    /// <param name="regenerateTrickplay">(Optional) Determines if trickplay images should be replaced. Only applicable if mode is FullRefresh.</param>
     /// <response code="204">Item metadata refresh queued.</response>
     /// <response code="404">Item to refresh not found.</response>
     /// <returns>An <see cref="NoContentResult"/> on success, or a <see cref="NotFoundResult"/> if the item could not be found.</returns>
@@ -62,7 +63,8 @@ public class ItemRefreshController : BaseJellyfinApiController
         [FromQuery] MetadataRefreshMode metadataRefreshMode = MetadataRefreshMode.None,
         [FromQuery] MetadataRefreshMode imageRefreshMode = MetadataRefreshMode.None,
         [FromQuery] bool replaceAllMetadata = false,
-        [FromQuery] bool replaceAllImages = false)
+        [FromQuery] bool replaceAllImages = false,
+        [FromQuery] bool regenerateTrickplay = false)
     {
         var item = _libraryManager.GetItemById<BaseItem>(itemId, User.GetUserId());
         if (item is null)
@@ -81,7 +83,8 @@ public class ItemRefreshController : BaseJellyfinApiController
                 || replaceAllImages
                 || replaceAllMetadata,
             IsAutomated = false,
-            RemoveOldMetadata = replaceAllMetadata
+            RemoveOldMetadata = replaceAllMetadata,
+            RegenerateTrickplay = regenerateTrickplay
         };
 
         _providerManager.QueueRefresh(item.Id, refreshOptions, RefreshPriority.High);


### PR DESCRIPTION
The Refresh API controller did not pass the query parameter from the client to MetadataRefreshOptions and the old trickplay files never got replaced.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
