### PR TITLE
Always consider null char as delimiter for ID3v2

### DIFF
--- a/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
+++ b/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
@@ -18,7 +18,7 @@ public static class LibraryOptionsExtension
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        return options.CustomTagDelimiters.Select<string, char?>(x =>
+        var delimiterList = options.CustomTagDelimiters.Select<string, char?>(x =>
         {
             var isChar = char.TryParse(x, out var c);
             if (isChar)
@@ -27,6 +27,8 @@ public static class LibraryOptionsExtension
             }
 
             return null;
-        }).Where(x => x is not null).Select(x => x!.Value).ToArray();
+        }).Where(x => x is not null).Select(x => x!.Value).ToList();
+        delimiterList.Add('\0');
+        return delimiterList.ToArray();
     }
 }


### PR DESCRIPTION
This behavior is explicitly defined in ID3v2.4, but some ID3 taggers seem to apply it to ID3v2.3 as well. Hardcode this as a custom delimiter, as it is primarily used for this purpose; players like VLC also use it to split artist names on ID3v2.3.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #12957
