### PR TITLE
Set `-copytb 1` in ffmpeg when creating an HLS stream, to fix "non-monotonic DTS" time breakage when remuxing.

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1645,7 +1645,7 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
+            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -copytb 1 -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
             inputModifier,
             _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer),
             threads,


### PR DESCRIPTION
Set `-copytb 1` which "is sometimes required to avoid non monotonically increasing timestamps when copying video streams with variable frame rate."

**Does this adversely affect non-copy (transcode) streams?** ... is an excellent question. :)  In my limited testing, I don't think it does, though admittedly I don't have a ton of domain knowledge or relevant testing material.

**Changes**
This change simply adds `-copytb 1` to ffmpeg's command-line arguments when creating an HLS stream.  As ffmpeg documentation mentions: https://ffmpeg.org/ffmpeg.html

> -copytb mode
Specify how to set the encoder timebase when stream copying. mode is an integer numeric value, and can assume one of the following values:

> 1
Use the demuxer timebase.

> The time base is copied to the output encoder from the corresponding input demuxer. This is sometimes required to avoid non monotonically increasing timestamps when copying video streams with variable frame rate.

> 0
Use the decoder timebase.

> The time base is copied to the output encoder from the corresponding input decoder.

> -1
Try to make the choice automatically, in order to generate a sane output.

> Default value is -1.

Like the doc says, when a source video has "non monotonically increasing timestamps," this setting appears necessary to ensure that a remux operation outputs frames with the source's intended timings.

Otherwise an HLS remux stream will adjust those non-monotonic timestamps, and produce a video which appears to miss or skip frames.  This results in warnings logged by ffmpeg such as:

> [vost#0:0/copy @ 0x56517bc84400] Non-monotonic DTS; previous: -1001, current: -1001; changing to -1000. This may result in incorrect timestamps in the output file.
[vost#0:0/copy @ 0x56517bc84400] Non-monotonic DTS; previous: 2002, current: 2002; changing to 2003. This may result in incorrect timestamps in the output file.
[vost#0:0/copy @ 0x56517bc84400] Non-monotonic DTS; previous: 6006, current: 6006; changing to 6007. This may result in incorrect timestamps in the output file.
[vost#0:0/copy @ 0x56517bc84400] Non-monotonic DTS; previous: 9009, current: 9009; changing to 9010. This may result in incorrect timestamps in the output file.
[vost#0:0/copy @ 0x56517bc84400] Non-monotonic DTS; previous: 13013, current: 13013; changing to 13014. This may result in incorrect timestamps in the output file.
...

**Issues**
* https://github.com/jellyfin/jellyfin/issues/13052
