### PR TITLE
Exclude file system based library playlists from migration

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/PlaylistResolver.cs
@@ -28,7 +28,7 @@ namespace Emby.Server.Implementations.Library.Resolvers
         {
             if (args.IsDirectory)
             {
-                // It's a boxset if the path is a directory with [playlist] in its name
+                // It's a playlist if the path is a directory with [playlist] in its name
                 var filename = Path.GetFileName(Path.TrimEndingDirectorySeparator(args.Path));
                 if (string.IsNullOrEmpty(filename))
                 {

--- a/Jellyfin.Server/Migrations/Routines/RemoveDuplicatePlaylistChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/RemoveDuplicatePlaylistChildren.cs
@@ -46,6 +46,7 @@ internal class RemoveDuplicatePlaylistChildren : IMigrationRoutine
             IncludeItemTypes = [BaseItemKind.Playlist]
         })
         .Cast<Playlist>()
+        .Where(p => !p.OpenAccess || !p.OwnerUserId.Equals(Guid.Empty))
         .ToArray();
 
         if (playlists.Length > 0)


### PR DESCRIPTION
We can't update file system sourced playlists because they might be read only.

**Changes**
* Exclude file system based library playlists from migration
  * They are `OpenAccess` and have the default GUID as owner ID

**Issues**
#13057
#13048
