### PR TITLE
Downgrade minimum sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.404",
+        "version": "8.0.0",
         "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin/pull/13038#issuecomment-2481505391

We avoided updating global.json in the past for exactly this reason but attempted to fix codeql ci issues. 