### PR TITLE
Determine tv image type by extension if content-type is unavailable

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -200,11 +200,25 @@ namespace MediaBrowser.Providers.Manager
                 // TODO: Isolate this hack into the tvh plugin
                 if (string.IsNullOrEmpty(contentType))
                 {
+                    // First, check for imagecache special case
                     if (url.Contains("/imagecache/", StringComparison.OrdinalIgnoreCase))
                     {
-                        contentType = MediaTypeNames.Image.Png;
+                        contentType = "image/png";
+                        return;
                     }
-                    else
+
+                    // Deduce content type from file extension
+                    var fileExtension = Path.GetExtension(url)?.ToLowerInvariant();
+                    contentType = fileExtension switch
+                    {
+                        ".jpg" or ".jpeg" => "image/jpeg",
+                        ".png" => "image/png",
+                        ".gif" => "image/gif",
+                        ".webp" => "image/webp",
+                        _ => null
+                    };
+
+                    if (string.IsNullOrEmpty(contentType))
                     {
                         throw new HttpRequestException("Invalid image received: contentType not set.", null, response.StatusCode);
                     }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -208,15 +208,8 @@ namespace MediaBrowser.Providers.Manager
                     }
 
                     // Deduce content type from file extension
-                    var fileExtension = Path.GetExtension(url)?.ToLowerInvariant();
-                    contentType = fileExtension switch
-                    {
-                        ".jpg" or ".jpeg" => MediaTypeNames.Image.Jpeg,
-                        ".png" => MediaTypeNames.Image.Png,
-                        ".gif" => MediaTypeNames.Image.Gif,
-                        ".webp" => "image/webp",
-                        _ => null
-                    };
+                    var fileExtension = MimeTypes.GetMimeType(new Uri(url).GetLeftPart(UriPartial.Path));
+                    contentType = fileExtension;
 
                     if (string.IsNullOrEmpty(contentType))
                     {

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -203,7 +203,7 @@ namespace MediaBrowser.Providers.Manager
                     // First, check for imagecache special case
                     if (url.Contains("/imagecache/", StringComparison.OrdinalIgnoreCase))
                     {
-                        contentType = "image/png";
+                        contentType = MediaTypeNames.Image.Png;
                         return;
                     }
 
@@ -211,9 +211,9 @@ namespace MediaBrowser.Providers.Manager
                     var fileExtension = Path.GetExtension(url)?.ToLowerInvariant();
                     contentType = fileExtension switch
                     {
-                        ".jpg" or ".jpeg" => "image/jpeg",
-                        ".png" => "image/png",
-                        ".gif" => "image/gif",
+                        ".jpg" or ".jpeg" => MediaTypeNames.Image.Jpeg,
+                        ".png" => MediaTypeNames.Image.Png,
+                        ".gif" => MediaTypeNames.Image.Gif,
                         ".webp" => "image/webp",
                         _ => null
                     };

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -200,17 +200,18 @@ namespace MediaBrowser.Providers.Manager
                 // TODO: Isolate this hack into the tvh plugin
                 if (string.IsNullOrEmpty(contentType))
                 {
-                    // First, check for imagecache special case
+                    // Special case for imagecache
                     if (url.Contains("/imagecache/", StringComparison.OrdinalIgnoreCase))
                     {
                         contentType = MediaTypeNames.Image.Png;
-                        return;
+                    }
+                    else
+                    {
+                        // Deduce content type from file extension
+                        contentType = MimeTypes.GetMimeType(new Uri(url).GetLeftPart(UriPartial.Path));
                     }
 
-                    // Deduce content type from file extension
-                    var fileExtension = MimeTypes.GetMimeType(new Uri(url).GetLeftPart(UriPartial.Path));
-                    contentType = fileExtension;
-
+                    // Throw if we still can't determine the content type
                     if (string.IsNullOrEmpty(contentType))
                     {
                         throw new HttpRequestException("Invalid image received: contentType not set.", null, response.StatusCode);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added logic to determine the TV image type based on the file extension if the Content-Type header is null or empty.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> Fixes #13075 #11703 #11824
