### PR TITLE
Fix: handling of <set> elements in NfoParser

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
@@ -82,21 +82,13 @@ namespace MediaBrowser.XbmcMetadata.Parsers
 
                         if (!string.IsNullOrWhiteSpace(val) && movie is not null)
                         {
-                            // TODO Handle this better later
-                            if (!val.Contains('<', StringComparison.Ordinal))
+                            try
                             {
-                                movie.CollectionName = val;
+                                ParseSetXml(val, movie);
                             }
-                            else
+                            catch (Exception ex)
                             {
-                                try
-                                {
-                                    ParseSetXml(val, movie);
-                                }
-                                catch (Exception ex)
-                                {
-                                    Logger.LogError(ex, "Error parsing set node");
-                                }
+                                Logger.LogError(ex, "Error parsing set node");
                             }
                         }
 
@@ -139,7 +131,12 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     // Loop through each element
                     while (!reader.EOF && reader.ReadState == ReadState.Interactive)
                     {
-                        if (reader.NodeType == XmlNodeType.Element)
+                        if (reader.NodeType == XmlNodeType.Text && reader.Depth == 1)
+                        {
+                            movie.CollectionName = reader.Value;
+                            break;
+                        }
+                        else if (reader.NodeType == XmlNodeType.Element)
                         {
                             switch (reader.Name)
                             {

--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -115,7 +115,9 @@ namespace MediaBrowser.XbmcMetadata.Savers
             {
                 if (!string.IsNullOrEmpty(movie.CollectionName))
                 {
-                    writer.WriteElementString("set", movie.CollectionName);
+                    writer.WriteStartElement("set");
+                    writer.WriteElementString("name", movie.CollectionName);
+                    writer.WriteEndElement();
                 }
             }
         }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -257,5 +257,23 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
 
             Assert.Throws<ArgumentException>(() => _parser.Fetch(result, string.Empty, CancellationToken.None));
         }
+
+        [Fact]
+        public void Parsing_Fields_With_Escaped_Xml_Special_Characters_Success()
+        {
+            var result = new MetadataResult<Video>()
+            {
+                Item = new Movie()
+            };
+
+            _parser.Fetch(result, "Test Data/Lilo & Stitch.nfo", CancellationToken.None);
+            var item = (Movie)result.Item;
+
+            Assert.Equal("Lilo & Stitch", item.Name);
+            Assert.Equal("Lilo & Stitch", item.OriginalTitle);
+            Assert.Equal("Lilo & Stitch Collection", item.CollectionName);
+            Assert.StartsWith(">>", item.Overview, StringComparison.InvariantCulture);
+            Assert.EndsWith("<<", item.Overview, StringComparison.InvariantCulture);
+        }
     }
 }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Lilo & Stitch.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/Lilo & Stitch.nfo
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<movie>
+  <title>Lilo &amp; Stitch</title>
+  <originaltitle>Lilo &amp; Stitch</originaltitle>
+  <set>Lilo &amp; Stitch Collection</set>
+  <plot>&gt;&gt;As Stitch, a runaway genetic experiment from a faraway planet, wreaks havoc on the Hawaiian Islands, he becomes the mischievous adopted alien "puppy" of an independent little girl named Lilo and learns about loyalty, friendship, and ʻohana, the Hawaiian tradition of family.&lt;&lt;</plot>
+</movie>


### PR DESCRIPTION
**Changes**
- moved parsing of `<set>` elements without sub elements to `ParseSetXml`method
- use method to retrieve value that uses proper unescaping of special characters
- added new test to check unescaping works properly

**Issues**
Fixes #10767
