### PR TITLE
Fix typo in LibraryOptions

### DIFF
--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -61,7 +61,7 @@ public class MediaSegmentManager : IMediaSegmentManager
             .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
             .OrderBy(i =>
                 {
-                    var index = libraryOptions.MediaSegmentProvideOrder.IndexOf(i.Name);
+                    var index = libraryOptions.MediaSegmentProviderOrder.IndexOf(i.Name);
                     return index == -1 ? int.MaxValue : index;
                 })
             .ToList();

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -15,7 +15,7 @@ namespace MediaBrowser.Model.Configuration
             TypeOptions = Array.Empty<TypeOptions>();
             DisabledSubtitleFetchers = Array.Empty<string>();
             DisabledMediaSegmentProviders = Array.Empty<string>();
-            MediaSegmentProvideOrder = Array.Empty<string>();
+            MediaSegmentProviderOrder = Array.Empty<string>();
             SubtitleFetcherOrder = Array.Empty<string>();
             DisabledLocalMetadataReaders = Array.Empty<string>();
             DisabledLyricFetchers = Array.Empty<string>();
@@ -99,7 +99,7 @@ namespace MediaBrowser.Model.Configuration
 
         public string[] DisabledMediaSegmentProviders { get; set; }
 
-        public string[] MediaSegmentProvideOrder { get; set; }
+        public string[] MediaSegmentProviderOrder { get; set; }
 
         public bool SkipSubtitlesIfEmbeddedSubtitlesPresent { get; set; }
 


### PR DESCRIPTION
This option is not implemented in any of our clients in 10.10 so no migrations required. By default this value is empty which basically means no-op.

**Changes**
- Fix typo in LibraryOptions
  - `MediaSegmentProvideOrder` -> `MediaSegmentProviderOrder`
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
