### PR TITLE
Migrate keyframes to configured cache directory

### DIFF
--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -51,6 +51,11 @@ public class CacheDecorator : IKeyframeExtractor
         var cachePath = GetCachePath(_keyframeCachePath, filePath);
         if (TryReadFromCache(cachePath, out var cachedResult))
         {
+            // touch the used files to avoid cleanup
+            // unreferenced files should be cleaned up eventually
+            var fi = new FileInfo(cachePath);
+            fi.LastWriteTime = DateTime.Now;
+
             keyframeData = cachedResult;
             return true;
         }

--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -54,7 +54,7 @@ public class CacheDecorator : IKeyframeExtractor
             keyframeData = cachedResult;
             return true;
         }
-        
+
         // TODO remove when reading old json files is no longer wanted
         var cachePathData = GetCachePath(_keyframeDataPath, filePath);
         if (TryReadFromCache(cachePathData, out var cachedResultData))

--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -48,14 +48,14 @@ public class CacheDecorator : IKeyframeExtractor
     public bool TryExtractKeyframes(string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
     {
         keyframeData = null;
-        var cachePath = GetCachePath(_keyframeDataPath, filePath);
-        if (TryReadFromCache(cachePath, out var cachedResult))
+        var cachePathData = GetCachePath(_keyframeDataPath, filePath);
+        if (TryReadFromCache(cachePathData, out var cachedResultData))
         {
-            keyframeData = cachedResult;
+            keyframeData = cachedResultData;
             return true;
         }
 
-        cachePath = GetCachePath(_keyframeCachePath, filePath);
+        var cachePath = GetCachePath(_keyframeCachePath, filePath);
         if (TryReadFromCache(cachePath, out var cachedResult))
         {
             keyframeData = cachedResult;

--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -48,17 +48,19 @@ public class CacheDecorator : IKeyframeExtractor
     public bool TryExtractKeyframes(string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
     {
         keyframeData = null;
-        var cachePathData = GetCachePath(_keyframeDataPath, filePath);
-        if (TryReadFromCache(cachePathData, out var cachedResultData))
-        {
-            keyframeData = cachedResultData;
-            return true;
-        }
-
         var cachePath = GetCachePath(_keyframeCachePath, filePath);
         if (TryReadFromCache(cachePath, out var cachedResult))
         {
             keyframeData = cachedResult;
+            return true;
+        }
+        
+        // TODO remove when reading old json files is no longer wanted
+        var cachePathData = GetCachePath(_keyframeDataPath, filePath);
+        if (TryReadFromCache(cachePathData, out var cachedResultData))
+        {
+            _logger.LogDebug("Used cached keyframes result from data path.");
+            keyframeData = cachedResultData;
             return true;
         }
 

--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -20,6 +20,7 @@ public class CacheDecorator : IKeyframeExtractor
     private readonly string _keyframeExtractorName;
     private static readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
     private readonly string _keyframeCachePath;
+    private readonly string _keyframeDataPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CacheDecorator"/> class.
@@ -36,7 +37,8 @@ public class CacheDecorator : IKeyframeExtractor
         _logger = logger;
         _keyframeExtractorName = keyframeExtractor.GetType().Name;
         // TODO make the dir configurable
-        _keyframeCachePath = Path.Combine(applicationPaths.DataPath, "keyframes");
+        _keyframeCachePath = Path.Combine(applicationPaths.CachePath, "keyframes");
+        _keyframeDataPath = Path.Combine(applicationPaths.DataPath, "keyframes");
     }
 
     /// <inheritdoc />
@@ -46,7 +48,14 @@ public class CacheDecorator : IKeyframeExtractor
     public bool TryExtractKeyframes(string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
     {
         keyframeData = null;
-        var cachePath = GetCachePath(_keyframeCachePath, filePath);
+        var cachePath = GetCachePath(_keyframeDataPath, filePath);
+        if (TryReadFromCache(cachePath, out var cachedResult))
+        {
+            keyframeData = cachedResult;
+            return true;
+        }
+
+        cachePath = GetCachePath(_keyframeCachePath, filePath);
         if (TryReadFromCache(cachePath, out var cachedResult))
         {
             keyframeData = cachedResult;


### PR DESCRIPTION
I'm not sure why these were put into the data directory in the first place.

The TODO comment about making it configurable is satisfied, for me, by using the already configurable cache directory instead.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Check for old keyframes json files in the data directory.
Only write new files to the cache directory.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
