### PR TITLE
Fallback to lossy audio codec for bitrate limit

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -236,7 +236,7 @@ public static class StreamingHelpers
                 }
             }
 
-            if (!EncodingHelper.IsCopyCodec(state.OutputAudioCodec) && EncodingHelper.LosslessAudioCodecs.Contains(state.OutputAudioCodec) && state.OutputAudioBitrate.HasValue)
+            if (!EncodingHelper.IsCopyCodec(state.OutputAudioCodec) && string.Equals(state.AudioStream.Codec, state.OutputAudioCodec, StringComparison.OrdinalIgnoreCase) && state.OutputAudioBitrate.HasValue)
             {
                 state.OutputAudioCodec = state.SupportedAudioCodecs.Where(c => !EncodingHelper.LosslessAudioCodecs.Contains(c)).FirstOrDefault(mediaEncoder.CanEncodeToAudioCodec);
             }

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -238,7 +238,7 @@ public static class StreamingHelpers
 
             if (!EncodingHelper.IsCopyCodec(state.OutputAudioCodec) && EncodingHelper.LosslessAudioCodecs.Contains(state.OutputAudioCodec) && state.OutputAudioBitrate.HasValue)
             {
-                state.OutputAudioCodec = state.SupportedAudioCodecs.FirstOrDefault(c => !EncodingHelper.LosslessAudioCodecs.Contains(c));
+                state.OutputAudioCodec = state.SupportedAudioCodecs.Where(c => !EncodingHelper.LosslessAudioCodecs.Contains(c)).FirstOrDefault(mediaEncoder.CanEncodeToAudioCodec);
             }
         }
 

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -235,6 +235,11 @@ public static class StreamingHelpers
                     state.VideoRequest.MaxHeight = resolution.MaxHeight;
                 }
             }
+
+            if (!EncodingHelper.IsCopyCodec(state.OutputAudioCodec) && EncodingHelper.LosslessAudioCodecs.Contains(state.OutputAudioCodec) && state.OutputAudioBitrate.HasValue)
+            {
+                state.OutputAudioCodec = state.SupportedAudioCodecs.FirstOrDefault(c => !EncodingHelper.LosslessAudioCodecs.Contains(c));
+            }
         }
 
         var ext = string.IsNullOrWhiteSpace(state.OutputContainer)


### PR DESCRIPTION
When the stream is bitrate limited, and we’re not directly coping the audio stream, we should use the first supported lossy codec reported by the client to apply the bitrate to the encoder instead of transcoding using the lossless encoder without bitrate limit.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13126

