### PR TITLE
Add new permission to allow users to set empty passwords

### DIFF
--- a/Jellyfin.Data/Enums/PermissionKind.cs
+++ b/Jellyfin.Data/Enums/PermissionKind.cs
@@ -124,5 +124,10 @@ namespace Jellyfin.Data.Enums
         /// Whether the user can edit lyrics.
         /// </summary>
         EnableLyricManagement = 23,
+
+        /// <summary>
+        /// Whether the user can log without a password.
+        /// </summary>
+        EnableNoPassword = 24,
     }
 }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -287,6 +287,11 @@ namespace Jellyfin.Server.Implementations.Users
                 throw new ArgumentException("Admin user passwords must not be empty", nameof(newPassword));
             }
 
+            if (!user.HasPermission(PermissionKind.EnableNoPassword) && string.IsNullOrWhiteSpace(newPassword))
+            {
+                throw new ArgumentException("This user is not allowed to have an empty password", nameof(newPassword));
+            }
+
             await GetAuthenticationProvider(user).ChangePassword(user, newPassword).ConfigureAwait(false);
             await UpdateUserAsync(user).ConfigureAwait(false);
 
@@ -364,6 +369,7 @@ namespace Jellyfin.Server.Implementations.Users
                     EnablePublicSharing = user.HasPermission(PermissionKind.EnablePublicSharing),
                     EnableCollectionManagement = user.HasPermission(PermissionKind.EnableCollectionManagement),
                     EnableSubtitleManagement = user.HasPermission(PermissionKind.EnableSubtitleManagement),
+                    EnableNoPassword = user.HasPermission(PermissionKind.EnableNoPassword),
                     AccessSchedules = user.AccessSchedules.ToArray(),
                     BlockedTags = user.GetPreference(PreferenceKind.BlockedTags),
                     AllowedTags = user.GetPreference(PreferenceKind.AllowedTags),
@@ -692,6 +698,7 @@ namespace Jellyfin.Server.Implementations.Users
                 user.SetPermission(PermissionKind.EnableLyricManagement, policy.EnableLyricManagement);
                 user.SetPermission(PermissionKind.ForceRemoteSourceTranscoding, policy.ForceRemoteSourceTranscoding);
                 user.SetPermission(PermissionKind.EnablePublicSharing, policy.EnablePublicSharing);
+                user.SetPermission(PermissionKind.EnableNoPassword, policy.EnableNoPassword);
 
                 user.AccessSchedules.Clear();
                 foreach (var policyAccessSchedule in policy.AccessSchedules)

--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -147,6 +147,7 @@ namespace Jellyfin.Server.Migrations.Routines
                     user.SetPermission(PermissionKind.IsDisabled, policy.IsDisabled);
                     user.SetPermission(PermissionKind.EnableSharedDeviceControl, policy.EnableSharedDeviceControl);
                     user.SetPermission(PermissionKind.EnableRemoteAccess, policy.EnableRemoteAccess);
+                    user.SetPermission(PermissionKind.EnableNoPassword, policy.EnableNoPassword);
                     user.SetPermission(PermissionKind.EnableLiveTvManagement, policy.EnableLiveTvManagement);
                     user.SetPermission(PermissionKind.EnableLiveTvAccess, policy.EnableLiveTvAccess);
                     user.SetPermission(PermissionKind.EnableMediaPlayback, policy.EnableMediaPlayback);

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -63,6 +63,7 @@ namespace MediaBrowser.Model.Users
             EnableContentDownloading = true;
             EnablePublicSharing = true;
             EnableRemoteAccess = true;
+            EnableNoPassword = true;
             SyncPlayAccess = SyncPlayUserAccessType.CreateAndJoinGroups;
         }
 
@@ -125,6 +126,8 @@ namespace MediaBrowser.Model.Users
         public bool EnableSharedDeviceControl { get; set; }
 
         public bool EnableRemoteAccess { get; set; }
+
+        public bool EnableNoPassword { get; set; }
 
         public bool EnableLiveTvManagement { get; set; }
 


### PR DESCRIPTION
I'm adressing the old Issue #2658 by setting a new permission. Not sure if it's the best aproach, but I'm open for advices

**Changes**

- Added a new Permission `EnableNoPassword` with default being `true`
- Added a validation on `Usermanager` to only change the password to nothing when the user has this permission

**Issues**
Fixes #2658 
