### PR TITLE
Round RemoteImage CommunityRating to nearest tenths when sorting

### DIFF
--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -50,7 +50,7 @@ namespace MediaBrowser.Model.Extensions
 
                     return 0;
                 })
-                .ThenByDescending(i => i.CommunityRating ?? 0)
+                .ThenByDescending(i => Math.Round(i.CommunityRating ?? 0, 1) )
                 .ThenByDescending(i => i.VoteCount ?? 0);
         }
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Some Movies/series images on TMDB have very close ratings (differing by hundredths) but the JF UI only displays rating to the tenths. This results in seemingly out of order images. 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Community Rating is rounded to nearest tenths when sorting, hundredths are not significant IMO. This results in a more intuitive display. Now number of votes has the proper weight when rating is so close.

**Before**
![image](https://github.com/user-attachments/assets/945ff100-9549-4ba6-b033-e47b570233ba)

**After**
![image](https://github.com/user-attachments/assets/ee795e1a-e291-4ae7-8d6e-7b780c45a510)
