### PR TITLE
Always do tone-mapping for HDR transcoding when software pipeline is used

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -309,7 +309,6 @@ namespace MediaBrowser.Controller.MediaEncoding
         private bool IsSwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
         {
             if (state.VideoStream is null
-                || !options.EnableTonemapping
                 || GetVideoColorBitDepth(state) < 10
                 || !_mediaEncoder.SupportsFilter("tonemapx"))
             {


### PR DESCRIPTION
**Changes**
- Enable software tone-mapping by default
  (Web https://github.com/jellyfin/jellyfin-web/pull/6362)

**Issues**
- Transcoding HDR video without tonemapping results in an unacceptable viewing experience.
  Many users are not even aware of the option and therefore we should always enable the software tonemapx filter.
