### PR TITLE
Fix NFO ID parsing

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/MovieNfoParser.cs
@@ -50,23 +50,20 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             {
                 case "id":
                     {
-                        // get ids from attributes
+                        // Get ids from attributes
+                        item.TrySetProviderId(MetadataProvider.Tmdb, reader.GetAttribute("TMDB"));
+                        item.TrySetProviderId(MetadataProvider.Tvdb, reader.GetAttribute("TVDB"));
                         string? imdbId = reader.GetAttribute("IMDB");
-                        string? tmdbId = reader.GetAttribute("TMDB");
 
-                        // read id from content
+                        // Read id from content
+                        // Content can be arbitrary according to Kodi wiki, so only parse if we are sure it matches a provider-specific schema
                         var contentId = reader.ReadElementContentAsString();
-                        if (contentId.Contains("tt", StringComparison.Ordinal) && string.IsNullOrEmpty(imdbId))
+                        if (string.IsNullOrEmpty(imdbId) && contentId.StartsWith("tt", StringComparison.Ordinal))
                         {
                             imdbId = contentId;
                         }
-                        else if (string.IsNullOrEmpty(tmdbId))
-                        {
-                            tmdbId = contentId;
-                        }
 
                         item.TrySetProviderId(MetadataProvider.Imdb, imdbId);
-                        item.TrySetProviderId(MetadataProvider.Tmdb, tmdbId);
 
                         break;
                     }

--- a/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/SeriesNfoParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Xml;
 using Emby.Naming.TV;
@@ -48,16 +49,20 @@ namespace MediaBrowser.XbmcMetadata.Parsers
             {
                 case "id":
                     {
-                        item.TrySetProviderId(MetadataProvider.Imdb, reader.GetAttribute("IMDB"));
+                        // Get ids from attributes
                         item.TrySetProviderId(MetadataProvider.Tmdb, reader.GetAttribute("TMDB"));
+                        item.TrySetProviderId(MetadataProvider.Tvdb, reader.GetAttribute("TVDB"));
+                        string? imdbId = reader.GetAttribute("IMDB");
 
-                        string? tvdbId = reader.GetAttribute("TVDB");
-                        if (string.IsNullOrWhiteSpace(tvdbId))
+                        // Read id from content
+                        // Content can be arbitrary according to Kodi wiki, so only parse if we are sure it matches a provider-specific schema
+                        var contentId = reader.ReadElementContentAsString();
+                        if (string.IsNullOrEmpty(imdbId) && contentId.StartsWith("tt", StringComparison.Ordinal))
                         {
-                            tvdbId = reader.ReadElementContentAsString();
+                            imdbId = contentId;
                         }
 
-                        item.TrySetProviderId(MetadataProvider.Tvdb, tvdbId);
+                        item.TrySetProviderId(MetadataProvider.Imdb, imdbId);
 
                         break;
                     }


### PR DESCRIPTION
For some reason we assume that the `id` tag of an NFO always includes the TVDB id for series and IMDB id for movies.

According to the [Kodi Wiki](https://kodi.wiki/view/NFO_files/Movies) this is false. The `id` tag usually includes the value of the `uniqueId` tag which is set as `default`. This can be any kind of provider ID.

**Changes**
* Do not assume the extracted id is associated to a specific provider
* Only use the extracted ID if we're somewhat sure it is for a specific provider

**Issues**
* Id extracted from unreliable `id` tag overrides correct id extracted from `uniqueId` tag