### PR TITLE
Don't generate trickplay for backdrops

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -194,6 +194,14 @@ public class TrickplayManager : ITrickplayManager
                     return;
                 }
 
+                // We support video backdrops, but we should not generate trickplay images for them
+                var parentDirectory = Directory.GetParent(mediaPath);
+                if (parentDirectory is not null && string.Equals(parentDirectory.Name, "backdrops", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogDebug("Ignoring backdrop media found at {Path} for item {ItemID}", mediaPath, video.Id);
+                    return;
+                }
+
                 // The width has to be even, otherwise a lot of filters will not be able to sample it
                 var actualWidth = 2 * (width / 2);
 


### PR DESCRIPTION
Trickplay images should not be generated for backdrops as backdrops are not seekable at all.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13099
