### PR TITLE
Enable VideoToolbox AV1 decode

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6610,6 +6610,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 || string.Equals("yuv420p12le", videoStream.PixelFormat, StringComparison.OrdinalIgnoreCase)
                 || string.Equals("yuv422p12le", videoStream.PixelFormat, StringComparison.OrdinalIgnoreCase)
                 || string.Equals("yuv444p12le", videoStream.PixelFormat, StringComparison.OrdinalIgnoreCase);
+            var isAv1SupportedSwFormatsVt = is8_10bitSwFormatsVt || string.Equals("yuv420p12le", videoStream.PixelFormat, StringComparison.OrdinalIgnoreCase);
 
             // The related patches make videotoolbox hardware surface working is only available in jellyfin-ffmpeg 7.0.1 at the moment.
             bool useHwSurface = (_mediaEncoder.EncoderVersion >= _minFFmpegWorkingVtHwSurface) && IsVideoToolboxFullSupported();
@@ -6642,6 +6643,13 @@ namespace MediaBrowser.Controller.MediaEncoding
                     || string.Equals("h265", videoStream.Codec, StringComparison.OrdinalIgnoreCase))
                 {
                     return GetHwaccelType(state, options, "hevc", bitDepth, useHwSurface);
+                }
+
+                if (string.Equals("av1", videoStream.Codec, StringComparison.OrdinalIgnoreCase)
+                    && isAv1SupportedSwFormatsVt
+                    && _mediaEncoder.IsVideoToolboxAv1DecodeAvailable)
+                {
+                    return GetHwaccelType(state, options, "av1", bitDepth, useHwSurface);
                 }
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -76,6 +76,12 @@ namespace MediaBrowser.Controller.MediaEncoding
         bool IsVaapiDeviceSupportVulkanDrmInterop { get; }
 
         /// <summary>
+        /// Gets a value indicating whether av1 decoding is available via VideoToolbox.
+        /// </summary>
+        /// <value><c>true</c> if the av1 is available via VideoToolbox, <c>false</c> otherwise.</value>
+        bool IsVideoToolboxAv1DecodeAvailable { get; }
+
+        /// <summary>
         /// Whether given encoder codec is supported.
         /// </summary>
         /// <param name="encoder">The encoder.</param>

--- a/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
@@ -1,0 +1,85 @@
+#pragma warning disable CA1031
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.MediaEncoding.Encoder;
+
+/// <summary>
+/// Helper class for Apple platform specific operations.
+/// </summary>
+public static class ApplePlatformHelper
+{
+    private static readonly string[] _av1DecodeBlacklistedCpuClass = ["M1", "M2"];
+
+    private static string GetSysctlValue(string name)
+    {
+        IntPtr length = IntPtr.Zero;
+        // Get length of the value
+        int osStatus = SysctlByName(name, IntPtr.Zero, ref length, IntPtr.Zero, 0);
+
+        if (osStatus != 0)
+        {
+            throw new NotSupportedException($"Failed to get sysctl value for {name} with error {osStatus}");
+        }
+
+        IntPtr buffer = Marshal.AllocHGlobal(length.ToInt32());
+        try
+        {
+            osStatus = SysctlByName(name, buffer, ref length, IntPtr.Zero, 0);
+            if (osStatus != 0)
+            {
+                throw new NotSupportedException($"Failed to get sysctl value for {name} with error {osStatus}");
+            }
+
+            return Marshal.PtrToStringAnsi(buffer) ?? string.Empty;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static int SysctlByName(string name, IntPtr oldp, ref IntPtr oldlenp, IntPtr newp, uint newlen)
+    {
+        return NativeMethods.SysctlByName(System.Text.Encoding.ASCII.GetBytes(name), oldp, ref oldlenp, newp, newlen);
+    }
+
+    /// <summary>
+    /// Check if the current system has hardware acceleration for AV1 decoding.
+    /// </summary>
+    /// <param name="logger">The logger used for error logging.</param>
+    /// <returns>Boolean indicates the hwaccel support.</returns>
+    public static bool HasAv1HardwareAccel(ILogger logger)
+    {
+        if (!RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
+        {
+            return false;
+        }
+
+        try
+        {
+            string cpuBrandString = GetSysctlValue("machdep.cpu.brand_string");
+            return !_av1DecodeBlacklistedCpuClass.Any(blacklistedCpuClass => cpuBrandString.Contains(blacklistedCpuClass, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (NotSupportedException e)
+        {
+            logger.LogError("Error getting CPU brand string: {Message}", e.Message);
+        }
+        catch (Exception e)
+        {
+            logger.LogError("Unknown error occured: {Exception}", e);
+        }
+
+        return false;
+    }
+
+    private static class NativeMethods
+    {
+        [DllImport("libc", EntryPoint = "sysctlbyname", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        internal static extern int SysctlByName(byte[] name, IntPtr oldp, ref IntPtr oldlenp, IntPtr newp, uint newlen);
+    }
+}

--- a/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.MediaEncoding.Encoder;
@@ -10,6 +11,7 @@ namespace MediaBrowser.MediaEncoding.Encoder;
 /// <summary>
 /// Helper class for Apple platform specific operations.
 /// </summary>
+[SupportedOSPlatform("macos")]
 public static class ApplePlatformHelper
 {
     private static readonly string[] _av1DecodeBlacklistedCpuClass = ["M1", "M2"];

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -437,6 +437,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
         }
 
+        public bool CheckIsVideoToolboxAv1DecodeAvailable()
+        {
+            return ApplePlatformHelper.HasAv1HardwareAccel(_logger);
+        }
+
         private IEnumerable<string> GetHwaccelTypes()
         {
             string? output = null;

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -437,6 +438,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
         }
 
+        [SupportedOSPlatform("macos")]
         public bool CheckIsVideoToolboxAv1DecodeAvailable()
         {
             return ApplePlatformHelper.HasAv1HardwareAccel(_logger);

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -83,6 +83,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private bool _isVaapiDeviceSupportVulkanDrmModifier = false;
         private bool _isVaapiDeviceSupportVulkanDrmInterop = false;
 
+        private bool _isVideoToolboxAv1DecodeAvailable = false;
+
         private static string[] _vulkanImageDrmFmtModifierExts =
         {
             "VK_EXT_image_drm_format_modifier",
@@ -152,6 +154,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         /// <inheritdoc />
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
+
+        public bool IsVideoToolboxAv1DecodeAvailable => _isVideoToolboxAv1DecodeAvailable;
 
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
@@ -254,6 +258,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     {
                         _logger.LogInformation("VAAPI device {RenderNodePath} supports Vulkan DRM interop", options.VaapiDevice);
                     }
+                }
+
+                // Check if VideoToolbox supports AV1 decode
+                if (OperatingSystem.IsMacOS() && SupportsHwaccel("videotoolbox"))
+                {
+                    _isVideoToolboxAv1DecodeAvailable = validator.CheckIsVideoToolboxAv1DecodeAvailable();
                 }
             }
 


### PR DESCRIPTION
This decoder differs from others provided by VideoToolbox in that it lacks any software fallback. To achieve consistent behavior with other VideoToolbox decoders, this PR implemented additional checking on the server to simulate the software fallback provided by VideoToolbox.

The current fallback checking mechanism is a temporary solution. In the long term, it should be replaced with a more capable hardware capability checking system.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Required ffmpeg change is already backported here: https://github.com/jellyfin/jellyfin-ffmpeg/pull/500

The upstream has not released tagged version with VideoToolbox AV1 yet. Jellyfin-ffmpeg is required for now.
