### PR TITLE
Transcode to audio codec satisfied other conditions when copy check failed.

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -872,8 +872,8 @@ namespace MediaBrowser.Model.Dlna
                         {
                             var appliedVideoConditions = options.Profile.CodecProfiles
                                 .Where(i => i.Type == CodecType.VideoAudio &&
-                                            i.ContainsAnyCodec(transcodingAudioCodec, container) &&
-                                            i.ApplyConditions.All(applyCondition => ConditionProcessor.IsVideoAudioConditionSatisfied(applyCondition, audioChannels, audioBitrate, audioSampleRate, audioBitDepth, audioProfile, false)))
+                                    i.ContainsAnyCodec(transcodingAudioCodec, container) &&
+                                    i.ApplyConditions.All(applyCondition => ConditionProcessor.IsVideoAudioConditionSatisfied(applyCondition, audioChannels, audioBitrate, audioSampleRate, audioBitDepth, audioProfile, false)))
                                 .Select(i =>
                                     i.Conditions.All(condition => ConditionProcessor.IsVideoAudioConditionSatisfied(condition, audioChannels, audioBitrate, audioSampleRate, audioBitDepth, audioProfile, false)));
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -846,6 +846,12 @@ namespace MediaBrowser.Model.Dlna
                         return transcodingProfile;
                     }
 
+                    // Directly return the transcoding profile if the audio codec is already on its own
+                    if (string.Equals(transcodingProfile.AudioCodec, audioStream.Codec, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return transcodingProfile;
+                    }
+
                     var targetAudioCodecTranscodingProfile = new TranscodingProfile(transcodingProfile)
                     {
                         AudioCodec = audioStream.Codec
@@ -2297,6 +2303,11 @@ namespace MediaBrowser.Model.Dlna
                 if (string.Equals(profile.AudioCodec, audioCodec, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(profile.Container, audioCodec, StringComparison.OrdinalIgnoreCase))
                 {
+                    if (string.Equals("opus", audioCodec, StringComparison.OrdinalIgnoreCase) && audioStream?.Channels > 2)
+                    {
+                        return false;
+                    }
+
                     return true;
                 }
             }

--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
 using Jellyfin.Data.Enums;
@@ -6,6 +7,7 @@ namespace MediaBrowser.Model.Dlna;
 
 /// <summary>
 /// A class for transcoding profile information.
+/// Note for client developers: Conditions defined in <see cref="CodecProfile"/> has higher priority and can override values defined here.
 /// </summary>
 public class TranscodingProfile
 {
@@ -15,6 +17,33 @@ public class TranscodingProfile
     public TranscodingProfile()
     {
         Conditions = [];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TranscodingProfile" /> class copying the values from another instance.
+    /// </summary>
+    /// <param name="other">Another instance of <see cref="TranscodingProfile" /> to be copied.</param>
+    public TranscodingProfile(TranscodingProfile other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        Container = other.Container;
+        Type = other.Type;
+        VideoCodec = other.VideoCodec;
+        AudioCodec = other.AudioCodec;
+        Protocol = other.Protocol;
+        EstimateContentLength = other.EstimateContentLength;
+        EnableMpegtsM2TsMode = other.EnableMpegtsM2TsMode;
+        TranscodeSeekInfo = other.TranscodeSeekInfo;
+        CopyTimestamps = other.CopyTimestamps;
+        Context = other.Context;
+        EnableSubtitlesInManifest = other.EnableSubtitlesInManifest;
+        MaxAudioChannels = other.MaxAudioChannels;
+        MinSegments = other.MinSegments;
+        SegmentLength = other.SegmentLength;
+        BreakOnNonKeyFrames = other.BreakOnNonKeyFrames;
+        Conditions = other.Conditions;
+        EnableAudioVbrEncoding = other.EnableAudioVbrEncoding;
     }
 
     /// <summary>


### PR DESCRIPTION
Some clients may have specific requirements for audio codec support. For instance, WebOS only supports flac in stereo, while Safari only supports opus in stereo. When attempting to check the validity for remuxing fails for such clients, we should instead fallback to alternative codecs that support other transcoding conditions, instead of forcing a downmix in the source codec.

If this change is considered too much for a bug fix release, I will rebase this to target master.
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
