### PR TITLE
Fix consumer count off by one when closing a browser tab with a livestream that is transcoding

### DIFF
--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -341,5 +341,13 @@ namespace MediaBrowser.Controller.Session
         Task RevokeUserTokens(Guid userId, string currentAccessToken);
 
         Task CloseIfNeededAsync(SessionInfo session);
+
+        /// <summary>
+        /// Used to close the livestream if needed.
+        /// </summary>
+        /// <param name="liveStreamId">The livestream id.</param>
+        /// <param name="sessionIdOrPlaySessionId">The session id or playsession id.</param>
+        /// <returns>Task.</returns>
+        Task CloseLiveStreamIfNeededAsync(string liveStreamId, string sessionIdOrPlaySessionId);
     }
 }

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -241,14 +241,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
 
         if (closeLiveStream && !string.IsNullOrWhiteSpace(job.LiveStreamId))
         {
-            try
-            {
-                await _mediaSourceManager.CloseLiveStream(job.LiveStreamId).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error closing live stream for {Path}", job.Path);
-            }
+            await _sessionManager.CloseLiveStreamIfNeededAsync(job.LiveStreamId, job.PlaySessionId).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
This PR solves an issue where the consumer count is off by one when closing a browser tab with a livestream that is transcoding as described in Issue #13219. The task "CloseLivestream" is called twice in this case.

I resolved this issue by modifying the if-statement in the "CloseIfNeededAsync" task that determines if the "CloseLivestream" task is run or not. In my updated version it is not run if the livestream is transcoded, which resolves the aforementioned issue.
The consumer ount is then reduced by one when PlaybackStopped is reported, which is the expected behavior that is also seen by quitting the stream via the back button instead of closing the browser tab.

Issues:
Fixes #13219 
Fixes #13721 
Fixes #13684 
