### PR TITLE
Fix OnPlaybackStopped task erroring out when closing a browser tab with a livestream that is transcoding

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -782,9 +782,13 @@ namespace Emby.Server.Implementations.Library
         {
             ArgumentException.ThrowIfNullOrEmpty(id);
 
-            // TODO probably shouldn't throw here but it is kept for "backwards compatibility"
-            var info = GetLiveStreamInfo(id) ?? throw new ResourceNotFoundException();
-            return Task.FromResult(new Tuple<MediaSourceInfo, IDirectStreamProvider>(info.MediaSource, info as IDirectStreamProvider));
+            var info = GetLiveStreamInfo(id);
+            if (info is null)
+            {
+                return Task.FromResult<Tuple<MediaSourceInfo, IDirectStreamProvider>>(new Tuple<MediaSourceInfo, IDirectStreamProvider>(null, null));
+            }
+
+            return Task.FromResult<Tuple<MediaSourceInfo, IDirectStreamProvider>>(new Tuple<MediaSourceInfo, IDirectStreamProvider>(info.MediaSource, info as IDirectStreamProvider));
         }
 
         public ILiveStream GetLiveStreamInfo(string id)

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -343,6 +343,11 @@ namespace Emby.Server.Implementations.Session
         /// <returns>Task.</returns>
         private async Task UpdateNowPlayingItem(SessionInfo session, PlaybackProgressInfo info, BaseItem libraryItem, bool updateLastCheckInTime)
         {
+            if (session is null)
+            {
+               return;
+            }
+
             if (string.IsNullOrEmpty(info.MediaSourceId))
             {
                 info.MediaSourceId = info.ItemId.ToString("N", CultureInfo.InvariantCulture);
@@ -675,6 +680,11 @@ namespace Emby.Server.Implementations.Session
 
         private BaseItem GetNowPlayingItem(SessionInfo session, Guid itemId)
         {
+            if (session is null)
+            {
+                return null;
+            }
+
             var item = session.FullNowPlayingItem;
             if (item is not null && item.Id.Equals(itemId))
             {
@@ -794,7 +804,11 @@ namespace Emby.Server.Implementations.Session
 
             ArgumentNullException.ThrowIfNull(info);
 
-            var session = GetSession(info.SessionId);
+            var session = GetSession(info.SessionId, false);
+            if (session is null)
+            {
+                return;
+            }
 
             var libraryItem = info.ItemId.IsEmpty()
                 ? null


### PR DESCRIPTION
This PR solves an issue where the OnPlaybackStopped task inside the SessionManager errors out as described in Issue #13225.

Changes:
This is done by adding a try-catch-block around the problematic function call. This should not result in any other issues when the task runs without this call succeeding. 

Issues:
Fixes #13225 
