### PR TITLE
Don't use custom params on ultrafast x265 preset

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2056,13 +2056,18 @@ namespace MediaBrowser.Controller.MediaEncoding
                 param += " -x264opts:0 subme=0:me_range=16:rc_lookahead=10:me=hex:open_gop=0";
             }
 
-            if (string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase) && encodingOptions.EncoderPreset < EncoderPreset.ultrafast)
+            if (string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase))
             {
                 // libx265 only accept level option in -x265-params.
                 // level option may cause libx265 to fail.
                 // libx265 cannot adjust the given level, just throw an error.
-                // The following params are slower than the ultrafast preset, don't use when ultrafast is selected.
-                param += " -x265-params:0 subme=3:merange=25:rc-lookahead=10:me=star:ctu=32:max-tu-size=32:min-cu-size=16:rskip=2:rskip-edge-threshold=2:no-sao=1:no-strong-intra-smoothing=1:no-scenecut=1:no-open-gop=1:no-info=1";
+                param += " -x265-params:0 no-scenecut=1:no-open-gop=1:no-info=1";
+
+                if (encodingOptions.EncoderPreset < EncoderPreset.ultrafast)
+                {
+                    // The following params are slower than the ultrafast preset, don't use when ultrafast is selected.
+                    param += ":subme=3:merange=25:rc-lookahead=10:me=star:ctu=32:max-tu-size=32:min-cu-size=16:rskip=2:rskip-edge-threshold=2:no-sao=1:no-strong-intra-smoothing=1";
+                }
             }
 
             if (string.Equals(videoEncoder, "libsvtav1", StringComparison.OrdinalIgnoreCase)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2056,11 +2056,12 @@ namespace MediaBrowser.Controller.MediaEncoding
                 param += " -x264opts:0 subme=0:me_range=16:rc_lookahead=10:me=hex:open_gop=0";
             }
 
-            if (string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase) && encodingOptions.EncoderPreset < EncoderPreset.ultrafast)
             {
                 // libx265 only accept level option in -x265-params.
                 // level option may cause libx265 to fail.
                 // libx265 cannot adjust the given level, just throw an error.
+                // The following params are slower than the ultrafast preset, don't use when ultrafast is selected.
                 param += " -x265-params:0 subme=3:merange=25:rc-lookahead=10:me=star:ctu=32:max-tu-size=32:min-cu-size=16:rskip=2:rskip-edge-threshold=2:no-sao=1:no-strong-intra-smoothing=1:no-scenecut=1:no-open-gop=1:no-info=1";
             }
 


### PR DESCRIPTION
Our custom parameters are slower than the ultrafast preset, but users would expect encoding to be as fast as possible when selecting ultrafast. Only apply those parameters to superfast and slower presets.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
