### PR TITLE
Refactoring of DirectoryService: change all direct creation to Depend…

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -636,6 +636,7 @@ namespace Emby.Server.Implementations
             BaseItem.LocalizationManager = Resolve<ILocalizationManager>();
             BaseItem.ItemRepository = Resolve<IItemRepository>();
             BaseItem.FileSystem = Resolve<IFileSystem>();
+            BaseItem.DirectoryService = Resolve<IDirectoryService>();
             BaseItem.UserDataManager = Resolve<IUserDataManager>();
             BaseItem.ChannelManager = Resolve<IChannelManager>();
             Video.RecordingsManager = Resolve<IRecordingsManager>();

--- a/Jellyfin.Api/Controllers/ItemLookupController.cs
+++ b/Jellyfin.Api/Controllers/ItemLookupController.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.Api.Controllers;
 public class ItemLookupController : BaseJellyfinApiController
 {
     private readonly IProviderManager _providerManager;
-    private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
     private readonly ILibraryManager _libraryManager;
     private readonly ILogger<ItemLookupController> _logger;
 
@@ -38,18 +38,18 @@ public class ItemLookupController : BaseJellyfinApiController
     /// Initializes a new instance of the <see cref="ItemLookupController"/> class.
     /// </summary>
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
-    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+    /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{ItemLookupController}"/> interface.</param>
     public ItemLookupController(
         IProviderManager providerManager,
-        IFileSystem fileSystem,
+        IDirectoryService directoryService,
         ILibraryManager libraryManager,
         ILogger<ItemLookupController> logger)
     {
         _providerManager = providerManager;
-        _fileSystem = fileSystem;
         _libraryManager = libraryManager;
+        _directoryService = directoryService;
         _logger = logger;
     }
 
@@ -266,7 +266,7 @@ public class ItemLookupController : BaseJellyfinApiController
         item.ProviderIds = searchResult.ProviderIds;
         await _providerManager.RefreshFullItem(
             item,
-            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            new MetadataRefreshOptions(_directoryService)
             {
                 MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
                 ImageRefreshMode = MetadataRefreshMode.FullRefresh,

--- a/Jellyfin.Api/Controllers/ItemRefreshController.cs
+++ b/Jellyfin.Api/Controllers/ItemRefreshController.cs
@@ -1,14 +1,11 @@
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Api.Helpers;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -24,22 +21,22 @@ public class ItemRefreshController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IProviderManager _providerManager;
-    private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemRefreshController"/> class.
     /// </summary>
     /// <param name="libraryManager">Instance of <see cref="ILibraryManager"/> interface.</param>
     /// <param name="providerManager">Instance of <see cref="IProviderManager"/> interface.</param>
-    /// <param name="fileSystem">Instance of <see cref="IFileSystem"/> interface.</param>
+    /// <param name="directoryService">Instance of <see cref="IDirectoryService"/> interface.</param>
     public ItemRefreshController(
         ILibraryManager libraryManager,
         IProviderManager providerManager,
-        IFileSystem fileSystem)
+        IDirectoryService directoryService)
     {
         _libraryManager = libraryManager;
         _providerManager = providerManager;
-        _fileSystem = fileSystem;
+        _directoryService = directoryService;
     }
 
     /// <summary>
@@ -72,7 +69,7 @@ public class ItemRefreshController : BaseJellyfinApiController
             return NotFound();
         }
 
-        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+        var refreshOptions = new MetadataRefreshOptions(_directoryService)
         {
             MetadataRefreshMode = metadataRefreshMode,
             ImageRefreshMode = imageRefreshMode,

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -36,29 +36,29 @@ public class ItemUpdateController : BaseJellyfinApiController
     private readonly ILibraryManager _libraryManager;
     private readonly IProviderManager _providerManager;
     private readonly ILocalizationManager _localizationManager;
-    private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
     private readonly IServerConfigurationManager _serverConfigurationManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemUpdateController"/> class.
     /// </summary>
-    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+    /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
     /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
     public ItemUpdateController(
-        IFileSystem fileSystem,
         ILibraryManager libraryManager,
         IProviderManager providerManager,
+        IDirectoryService directoryService,
         ILocalizationManager localizationManager,
         IServerConfigurationManager serverConfigurationManager)
     {
         _libraryManager = libraryManager;
         _providerManager = providerManager;
         _localizationManager = localizationManager;
-        _fileSystem = fileSystem;
         _serverConfigurationManager = serverConfigurationManager;
+        _directoryService = directoryService;
     }
 
     /// <summary>
@@ -123,7 +123,7 @@ public class ItemUpdateController : BaseJellyfinApiController
         {
             _providerManager.QueueRefresh(
                 series!.Id,
-                new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                new MetadataRefreshOptions(_directoryService)
                 {
                     MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
                     ImageRefreshMode = MetadataRefreshMode.FullRefresh,

--- a/Jellyfin.Api/Controllers/LyricsController.cs
+++ b/Jellyfin.Api/Controllers/LyricsController.cs
@@ -32,8 +32,7 @@ public class LyricsController : BaseJellyfinApiController
     private readonly ILibraryManager _libraryManager;
     private readonly ILyricManager _lyricManager;
     private readonly IProviderManager _providerManager;
-    private readonly IFileSystem _fileSystem;
-    private readonly IUserManager _userManager;
+    private readonly IDirectoryService _directoryService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LyricsController"/> class.
@@ -41,20 +40,17 @@ public class LyricsController : BaseJellyfinApiController
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="lyricManager">Instance of the <see cref="ILyricManager"/> interface.</param>
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
-    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
-    /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+    /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
     public LyricsController(
         ILibraryManager libraryManager,
         ILyricManager lyricManager,
         IProviderManager providerManager,
-        IFileSystem fileSystem,
-        IUserManager userManager)
+        IDirectoryService directoryService)
     {
         _libraryManager = libraryManager;
         _lyricManager = lyricManager;
         _providerManager = providerManager;
-        _fileSystem = fileSystem;
-        _userManager = userManager;
+        _directoryService = directoryService;
     }
 
     /// <summary>
@@ -137,7 +133,7 @@ public class LyricsController : BaseJellyfinApiController
                 return BadRequest();
             }
 
-            _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.High);
+            _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(_directoryService), RefreshPriority.High);
             return Ok(uploadedLyric);
         }
     }
@@ -217,7 +213,7 @@ public class LyricsController : BaseJellyfinApiController
             return NotFound();
         }
 
-        _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.High);
+        _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(_directoryService), RefreshPriority.High);
         return Ok(downloadedLyrics);
     }
 

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -47,6 +47,7 @@ public class SubtitleController : BaseJellyfinApiController
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IProviderManager _providerManager;
     private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
     private readonly ILogger<SubtitleController> _logger;
 
     /// <summary>
@@ -59,6 +60,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <param name="mediaSourceManager">Instance of <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="providerManager">Instance of <see cref="IProviderManager"/> interface.</param>
     /// <param name="fileSystem">Instance of <see cref="IFileSystem"/> interface.</param>
+    /// <param name="directoryService">Instance of <see cref="IDirectoryService"/> interface.</param>
     /// <param name="logger">Instance of <see cref="ILogger{SubtitleController}"/> interface.</param>
     public SubtitleController(
         IServerConfigurationManager serverConfigurationManager,
@@ -68,6 +70,7 @@ public class SubtitleController : BaseJellyfinApiController
         IMediaSourceManager mediaSourceManager,
         IProviderManager providerManager,
         IFileSystem fileSystem,
+        IDirectoryService directoryService,
         ILogger<SubtitleController> logger)
     {
         _serverConfigurationManager = serverConfigurationManager;
@@ -78,6 +81,7 @@ public class SubtitleController : BaseJellyfinApiController
         _providerManager = providerManager;
         _fileSystem = fileSystem;
         _logger = logger;
+        _directoryService = directoryService;
     }
 
     /// <summary>
@@ -160,7 +164,7 @@ public class SubtitleController : BaseJellyfinApiController
             await _subtitleManager.DownloadSubtitles(item, subtitleId, CancellationToken.None)
                 .ConfigureAwait(false);
 
-            _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.High);
+            _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(_directoryService), RefreshPriority.High);
         }
         catch (Exception ex)
         {
@@ -449,7 +453,7 @@ public class SubtitleController : BaseJellyfinApiController
                         IsHearingImpaired = body.IsHearingImpaired,
                         Stream = stream
                     }).ConfigureAwait(false);
-                _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.High);
+                _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(_directoryService), RefreshPriority.High);
 
                 return NoContent();
             }

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -38,6 +38,7 @@ public class UserLibraryController : BaseJellyfinApiController
     private readonly IDtoService _dtoService;
     private readonly IUserViewManager _userViewManager;
     private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UserLibraryController"/> class.
@@ -48,13 +49,15 @@ public class UserLibraryController : BaseJellyfinApiController
     /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
     /// <param name="userViewManager">Instance of the <see cref="IUserViewManager"/> interface.</param>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+    /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
     public UserLibraryController(
         IUserManager userManager,
         IUserDataManager userDataRepository,
         ILibraryManager libraryManager,
         IDtoService dtoService,
         IUserViewManager userViewManager,
-        IFileSystem fileSystem)
+        IFileSystem fileSystem,
+        IDirectoryService directoryService)
     {
         _userManager = userManager;
         _userDataRepository = userDataRepository;
@@ -62,6 +65,7 @@ public class UserLibraryController : BaseJellyfinApiController
         _dtoService = dtoService;
         _userViewManager = userViewManager;
         _fileSystem = fileSystem;
+        _directoryService = directoryService;
     }
 
     /// <summary>
@@ -639,7 +643,7 @@ public class UserLibraryController : BaseJellyfinApiController
 
             if (!hasMetdata)
             {
-                var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                var options = new MetadataRefreshOptions(_directoryService)
                 {
                     MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
                     ImageRefreshMode = MetadataRefreshMode.FullRefresh,

--- a/MediaBrowser.Controller/Entities/AggregateFolder.cs
+++ b/MediaBrowser.Controller/Entities/AggregateFolder.cs
@@ -95,7 +95,7 @@ namespace MediaBrowser.Controller.Entities
             {
                 var locations = PhysicalLocations;
 
-                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations;
+                var newLocations = CreateResolveArgs(DirectoryService, false).PhysicalLocations;
 
                 if (!locations.SequenceEqual(newLocations))
                 {

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -481,6 +481,8 @@ namespace MediaBrowser.Controller.Entities
 
         public static IFileSystem FileSystem { get; set; }
 
+        public static IDirectoryService DirectoryService { get; set; }
+
         public static IUserDataManager UserDataManager { get; set; }
 
         public static IChannelManager ChannelManager { get; set; }
@@ -1252,7 +1254,7 @@ namespace MediaBrowser.Controller.Entities
 
         public Task RefreshMetadata(CancellationToken cancellationToken)
         {
-            return RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken);
+            return RefreshMetadata(new MetadataRefreshOptions(DirectoryService), cancellationToken);
         }
 
         /// <summary>
@@ -1870,7 +1872,7 @@ namespace MediaBrowser.Controller.Entities
         /// </summary>
         public virtual void ChangedExternally()
         {
-            ProviderManager.QueueRefresh(Id, new MetadataRefreshOptions(new DirectoryService(FileSystem)), RefreshPriority.High);
+            ProviderManager.QueueRefresh(Id, new MetadataRefreshOptions(DirectoryService), RefreshPriority.High);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -191,7 +191,7 @@ namespace MediaBrowser.Controller.Entities
             {
                 var locations = PhysicalLocations;
 
-                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations;
+                var newLocations = CreateResolveArgs(DirectoryService, false).PhysicalLocations;
 
                 if (!locations.SequenceEqual(newLocations))
                 {

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -261,7 +261,7 @@ namespace MediaBrowser.Controller.Entities
 
         public Task ValidateChildren(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            return ValidateChildren(progress, new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken: cancellationToken);
+            return ValidateChildren(progress, new MetadataRefreshOptions(DirectoryService), cancellationToken: cancellationToken);
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -53,6 +53,7 @@ namespace MediaBrowser.Providers.Manager
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly IFileSystem _fileSystem;
+        private readonly IDirectoryService _directoryService;
         private readonly IServerApplicationPaths _appPaths;
         private readonly ILibraryManager _libraryManager;
         private readonly ISubtitleManager _subtitleManager;
@@ -88,6 +89,7 @@ namespace MediaBrowser.Providers.Manager
         /// <param name="libraryMonitor">The library monitor.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="fileSystem">The filesystem.</param>
+        /// <param name="directoryService">The directories.</param>
         /// <param name="appPaths">The server application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="baseItemManager">The BaseItem manager.</param>
@@ -101,6 +103,7 @@ namespace MediaBrowser.Providers.Manager
             ILibraryMonitor libraryMonitor,
             ILogger<ProviderManager> logger,
             IFileSystem fileSystem,
+            IDirectoryService directoryService,
             IServerApplicationPaths appPaths,
             ILibraryManager libraryManager,
             IBaseItemManager baseItemManager,
@@ -113,6 +116,7 @@ namespace MediaBrowser.Providers.Manager
             _configurationManager = configurationManager;
             _libraryMonitor = libraryMonitor;
             _fileSystem = fileSystem;
+            _directoryService = directoryService;
             _appPaths = appPaths;
             _libraryManager = libraryManager;
             _subtitleManager = subtitleManager;
@@ -385,7 +389,7 @@ namespace MediaBrowser.Providers.Manager
                 item,
                 libraryOptions,
                 options,
-                new ImageRefreshOptions(new DirectoryService(_fileSystem)),
+                new ImageRefreshOptions(_directoryService),
                 includeDisabled).OfType<IRemoteImageProvider>();
         }
 
@@ -574,7 +578,7 @@ namespace MediaBrowser.Providers.Manager
                 dummy,
                 libraryOptions,
                 options,
-                new ImageRefreshOptions(new DirectoryService(_fileSystem)),
+                new ImageRefreshOptions(_directoryService),
                 true).ToList();
 
             var pluginList = summary.Plugins.ToList();

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -23,6 +23,7 @@ namespace MediaBrowser.Providers.TV
     /// </summary>
     public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
     {
+        private readonly IDirectoryService _directoryService;
         private readonly ILocalizationManager _localizationManager;
 
         /// <summary>
@@ -32,6 +33,7 @@ namespace MediaBrowser.Providers.TV
         /// <param name="logger">Instance of the <see cref="ILogger{SeasonMetadataService}"/> interface.</param>
         /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+        /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
         /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
         public SeriesMetadataService(
@@ -39,10 +41,12 @@ namespace MediaBrowser.Providers.TV
             ILogger<SeriesMetadataService> logger,
             IProviderManager providerManager,
             IFileSystem fileSystem,
+            IDirectoryService directoryService,
             ILibraryManager libraryManager,
             ILocalizationManager localizationManager)
             : base(serverConfigurationManager, logger, providerManager, fileSystem, libraryManager)
         {
+            _directoryService = directoryService;
             _localizationManager = localizationManager;
         }
 
@@ -262,7 +266,7 @@ namespace MediaBrowser.Providers.TV
             };
 
             series.AddChild(season);
-            await season.RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken).ConfigureAwait(false);
+            await season.RefreshMetadata(new MetadataRefreshOptions(_directoryService), cancellationToken).ConfigureAwait(false);
         }
 
         private string GetValidSeasonNameForSeries(Series series, string? seasonName, int? seasonNumber)

--- a/src/Jellyfin.LiveTv/Channels/ChannelManager.cs
+++ b/src/Jellyfin.LiveTv/Channels/ChannelManager.cs
@@ -48,6 +48,7 @@ namespace Jellyfin.LiveTv.Channels
         private readonly ILogger<ChannelManager> _logger;
         private readonly IServerConfigurationManager _config;
         private readonly IFileSystem _fileSystem;
+        private readonly IDirectoryService _directoryService;
         private readonly IProviderManager _providerManager;
         private readonly IMemoryCache _memoryCache;
         private readonly AsyncNonKeyedLocker _resourcePool = new(1);
@@ -63,6 +64,7 @@ namespace Jellyfin.LiveTv.Channels
         /// <param name="logger">The logger.</param>
         /// <param name="config">The server configuration manager.</param>
         /// <param name="fileSystem">The filesystem.</param>
+        /// <param name="directoryService">The directory service.</param>
         /// <param name="userDataManager">The user data manager.</param>
         /// <param name="providerManager">The provider manager.</param>
         /// <param name="memoryCache">The memory cache.</param>
@@ -74,6 +76,7 @@ namespace Jellyfin.LiveTv.Channels
             ILogger<ChannelManager> logger,
             IServerConfigurationManager config,
             IFileSystem fileSystem,
+            IDirectoryService directoryService,
             IUserDataManager userDataManager,
             IProviderManager providerManager,
             IMemoryCache memoryCache,
@@ -88,6 +91,7 @@ namespace Jellyfin.LiveTv.Channels
             _userDataManager = userDataManager;
             _providerManager = providerManager;
             _memoryCache = memoryCache;
+            _directoryService = directoryService;
             Channels = channels.ToArray();
         }
 
@@ -491,7 +495,7 @@ namespace Jellyfin.LiveTv.Channels
             }
 
             await item.RefreshMetadata(
-                new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                new MetadataRefreshOptions(_directoryService)
                 {
                     ForceSave = !isNew && forceUpdate
                 },
@@ -1166,7 +1170,7 @@ namespace Jellyfin.LiveTv.Channels
 
             if (isNew || forceUpdate || item.DateLastRefreshed == default)
             {
-                _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(new DirectoryService(_fileSystem)), RefreshPriority.Normal);
+                _providerManager.QueueRefresh(item.Id, new MetadataRefreshOptions(_directoryService), RefreshPriority.Normal);
             }
 
             return item;

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -31,7 +31,7 @@ public class GuideManager : IGuideManager
 
     private readonly ILogger<GuideManager> _logger;
     private readonly IConfigurationManager _config;
-    private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
     private readonly IItemRepository _itemRepo;
     private readonly ILibraryManager _libraryManager;
     private readonly ILiveTvManager _liveTvManager;
@@ -44,7 +44,7 @@ public class GuideManager : IGuideManager
     /// </summary>
     /// <param name="logger">The <see cref="ILogger{TCategoryName}"/>.</param>
     /// <param name="config">The <see cref="IConfigurationManager"/>.</param>
-    /// <param name="fileSystem">The <see cref="IFileSystem"/>.</param>
+    /// <param name="directoryService">The <see cref="IDirectoryService"/>.</param>
     /// <param name="itemRepo">The <see cref="IItemRepository"/>.</param>
     /// <param name="libraryManager">The <see cref="ILibraryManager"/>.</param>
     /// <param name="liveTvManager">The <see cref="ILiveTvManager"/>.</param>
@@ -54,7 +54,7 @@ public class GuideManager : IGuideManager
     public GuideManager(
         ILogger<GuideManager> logger,
         IConfigurationManager config,
-        IFileSystem fileSystem,
+        IDirectoryService directoryService,
         IItemRepository itemRepo,
         ILibraryManager libraryManager,
         ILiveTvManager liveTvManager,
@@ -64,7 +64,7 @@ public class GuideManager : IGuideManager
     {
         _logger = logger;
         _config = config;
-        _fileSystem = fileSystem;
+        _directoryService = directoryService;
         _itemRepo = itemRepo;
         _libraryManager = libraryManager;
         _liveTvManager = liveTvManager;
@@ -291,7 +291,7 @@ public class GuideManager : IGuideManager
 
                 await currentChannel.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
                 await currentChannel.RefreshMetadata(
-                    new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                    new MetadataRefreshOptions(_directoryService)
                     {
                         ForceSave = true
                     },

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -40,6 +40,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     private readonly IServerConfigurationManager _config;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IFileSystem _fileSystem;
+    private readonly IDirectoryService _directoryService;
     private readonly ILibraryManager _libraryManager;
     private readonly ILibraryMonitor _libraryMonitor;
     private readonly IProviderManager _providerManager;
@@ -61,6 +62,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     /// <param name="config">The <see cref="IServerConfigurationManager"/>.</param>
     /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
     /// <param name="fileSystem">The <see cref="IFileSystem"/>.</param>
+    /// <param name="directoryService">The <see cref="IDirectoryService"/>.</param>
     /// <param name="libraryManager">The <see cref="ILibraryManager"/>.</param>
     /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
     /// <param name="providerManager">The <see cref="IProviderManager"/>.</param>
@@ -75,6 +77,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         IServerConfigurationManager config,
         IHttpClientFactory httpClientFactory,
         IFileSystem fileSystem,
+        IDirectoryService directoryService,
         ILibraryManager libraryManager,
         ILibraryMonitor libraryMonitor,
         IProviderManager providerManager,
@@ -98,6 +101,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         _timerManager = timerManager;
         _seriesTimerManager = seriesTimerManager;
         _recordingsMetadataManager = recordingsMetadataManager;
+        _directoryService = directoryService;
 
         _config.NamedConfigurationUpdated += OnNamedConfigurationUpdated;
     }
@@ -613,7 +617,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         _logger.LogInformation("Refreshing recording parent {Path}", item.Path);
         _providerManager.QueueRefresh(
             item.Id,
-            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            new MetadataRefreshOptions(_directoryService)
             {
                 RefreshPaths =
                 [

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -570,6 +570,7 @@ namespace Jellyfin.Providers.Tests.Manager
                 Mock.Of<ILibraryMonitor>(),
                 _logger,
                 Mock.Of<IFileSystem>(),
+                Mock.Of<IDirectoryService>(),
                 Mock.Of<IServerApplicationPaths>(),
                 libraryManager.Object,
                 baseItemManager!,


### PR DESCRIPTION
Hi friends!

I did a little refactoring for removing direct creation of DirectoryService, like 
`new DirectoryService(FileSystem)`

I guess it help reduce strong dependencies and help jellyfin code more flexibility
Also I tried to create plugin whats implement my own DirectoryService and it has problem what it can be injected

please review code
