### PR TITLE
Add option to disable deprecated legacy authorization options

### DIFF
--- a/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Queries;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Devices;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
@@ -22,17 +23,20 @@ namespace Jellyfin.Server.Implementations.Security
         private readonly IUserManager _userManager;
         private readonly IDeviceManager _deviceManager;
         private readonly IServerApplicationHost _serverApplicationHost;
+        private readonly IServerConfigurationManager _configurationManager;
 
         public AuthorizationContext(
             IDbContextFactory<JellyfinDbContext> jellyfinDb,
             IUserManager userManager,
             IDeviceManager deviceManager,
-            IServerApplicationHost serverApplicationHost)
+            IServerApplicationHost serverApplicationHost,
+            IServerConfigurationManager configurationManager)
         {
             _jellyfinDbProvider = jellyfinDb;
             _userManager = userManager;
             _deviceManager = deviceManager;
             _serverApplicationHost = serverApplicationHost;
+            _configurationManager = configurationManager;
         }
 
         public Task<AuthorizationInfo> GetAuthorizationInfo(HttpContext requestContext)
@@ -85,12 +89,12 @@ namespace Jellyfin.Server.Implementations.Security
                 auth.TryGetValue("Token", out token);
             }
 
-            if (string.IsNullOrEmpty(token))
+            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = headers["X-Emby-Token"];
             }
 
-            if (string.IsNullOrEmpty(token))
+            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = headers["X-MediaBrowser-Token"];
             }
@@ -100,8 +104,7 @@ namespace Jellyfin.Server.Implementations.Security
                 token = queryString["ApiKey"];
             }
 
-            // TODO deprecate this query parameter.
-            if (string.IsNullOrEmpty(token))
+            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = queryString["api_key"];
             }
@@ -128,10 +131,7 @@ namespace Jellyfin.Server.Implementations.Security
             await using (dbContext.ConfigureAwait(false))
             {
                 var device = _deviceManager.GetDevices(
-                    new DeviceQuery
-                    {
-                        AccessToken = token
-                    }).Items.FirstOrDefault();
+                    new DeviceQuery { AccessToken = token }).Items.FirstOrDefault();
 
                 if (device is not null)
                 {
@@ -227,13 +227,13 @@ namespace Jellyfin.Server.Implementations.Security
         /// </summary>
         /// <param name="httpReq">The HTTP request.</param>
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
-        private static Dictionary<string, string>? GetAuthorizationDictionary(HttpRequest httpReq)
+        private Dictionary<string, string>? GetAuthorizationDictionary(HttpRequest httpReq)
         {
-            var auth = httpReq.Headers["X-Emby-Authorization"];
+            var auth = httpReq.Headers[HeaderNames.Authorization];
 
-            if (string.IsNullOrEmpty(auth))
+            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(auth))
             {
-                auth = httpReq.Headers[HeaderNames.Authorization];
+                auth = httpReq.Headers["X-Emby-Authorization"];
             }
 
             return auth.Count > 0 ? GetAuthorization(auth[0]) : null;
@@ -244,7 +244,7 @@ namespace Jellyfin.Server.Implementations.Security
         /// </summary>
         /// <param name="authorizationHeader">The authorization header.</param>
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
-        private static Dictionary<string, string>? GetAuthorization(ReadOnlySpan<char> authorizationHeader)
+        private Dictionary<string, string>? GetAuthorization(ReadOnlySpan<char> authorizationHeader)
         {
             var firstSpace = authorizationHeader.IndexOf(' ');
 
@@ -256,8 +256,10 @@ namespace Jellyfin.Server.Implementations.Security
 
             var name = authorizationHeader[..firstSpace];
 
-            if (!name.Equals("MediaBrowser", StringComparison.OrdinalIgnoreCase)
-                && !name.Equals("Emby", StringComparison.OrdinalIgnoreCase))
+            var validName = name.Equals("MediaBrowser", StringComparison.OrdinalIgnoreCase);
+            validName = validName || (_configurationManager.Configuration.EnableLegacyAuthorization && name.Equals("Emby", StringComparison.OrdinalIgnoreCase));
+
+            if (!validName)
             {
                 return null;
             }

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -276,4 +276,9 @@ public class ServerConfiguration : BaseApplicationConfiguration
     /// </summary>
     /// <value>The trickplay options.</value>
     public TrickplayOptions TrickplayOptions { get; set; } = new TrickplayOptions();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether old authorization methods are allowed.
+    /// </summary>
+    public bool EnableLegacyAuthorization { get; set; } = true;
 }


### PR DESCRIPTION
**Changes**

Adds a new `EnableLegacyAuthorization` configuration option to `system.xml`. It defaults to `true` (keep legacy methods working) but we will add a migration to change it to `false` in the future before entirely removing the old authorization methods.

For now the option can be used by (client-)developers to find network requests using a wrong authorization method.

The only method we'll allow is the `Authorization` header with `MediaBrowser` scheme and the `ApiKey` query parameter. The other headers (`X-Emby-Authorization`, `X-Emby-Token`, `X-MediaBrowser-Token`), query parameter (`api_key`) and authorization scheme (`Emby`) are all deprecated.

We've warned for these changes for almost 2 years using [this gist](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f) we share almost weekly to people developing for Jellyfin.

Note: It is currently not possible to use jellyfin-web without legacy authorization (unable to sign in due to [this line](https://github.com/jellyfin-archive/jellyfin-apiclient-javascript/blob/master/src/connectionManager.js#L380) in the archived JS apiclient).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
