### PR TITLE
Change the order of the iso6392.txt file

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -10,7 +10,7 @@ afr||af|Afrikaans|afrikaans
 ain|||Ainu|aïnou
 aka||ak|Akan|akan
 akk|||Akkadian|akkadien
-alb|sqi|sq|Albanian|albanais
+sqi|alb|sq|Albanian|albanais
 ale|||Aleut|aléoute
 alg|||Algonquian languages|algonquines, langues
 alt|||Southern Altai|altai du Sud
@@ -21,7 +21,7 @@ apa|||Apache languages|apaches, langues
 ara||ar|Arabic|arabe
 arc|||Official Aramaic (700-300 BCE); Imperial Aramaic (700-300 BCE)|araméen d'empire (700-300 BCE)
 arg||an|Aragonese|aragonais
-arm|hye|hy|Armenian|arménien
+hye|arm|hy|Armenian|arménien
 arn|||Mapudungun; Mapuche|mapudungun; mapuche; mapuce
 arp|||Arapaho|arapaho
 art|||Artificial languages|artificielles, langues
@@ -41,7 +41,7 @@ bak||ba|Bashkir|bachkir
 bal|||Baluchi|baloutchi
 bam||bm|Bambara|bambara
 ban|||Balinese|balinais
-baq|eus|eu|Basque|basque
+eus|baq|eu|Basque|basque
 bas|||Basa|basa
 bat|||Baltic languages|baltes, langues
 bej|||Beja; Bedawiyet|bedja
@@ -63,7 +63,7 @@ btk|||Batak languages|batak, langues
 bua|||Buriat|bouriate
 bug|||Buginese|bugi
 bul||bg|Bulgarian|bulgare
-bur|mya|my|Burmese|birman
+mya|bur|my|Burmese|birman
 byn|||Blin; Bilin|blin; bilen
 cad|||Caddo|caddo
 cai|||Central American Indian languages|amérindiennes de L'Amérique centrale, langues
@@ -76,10 +76,10 @@ cha||ch|Chamorro|chamorro
 chb|||Chibcha|chibcha
 che||ce|Chechen|tchétchène
 chg|||Chagatai|djaghataï
-chi|zho|zh|Chinese|chinois
-chi|zho|ze|Chinese; Bilingual|chinois
-chi|zho|zh-tw|Chinese; Traditional|chinois
-chi|zho|zh-hk|Chinese; Hong Kong|chinois
+zho|chi|zh|Chinese|chinois
+zho|chi|ze|Chinese; Bilingual|chinois
+zho|chi|zh-tw|Chinese; Traditional|chinois
+zho|chi|zh-hk|Chinese; Hong Kong|chinois
 chk|||Chuukese|chuuk
 chm|||Mari|mari
 chn|||Chinook jargon|chinook, jargon
@@ -101,7 +101,7 @@ crh|||Crimean Tatar; Crimean Turkish|tatar de Crimé
 crp|||Creoles and pidgins |créoles et pidgins
 csb|||Kashubian|kachoube
 cus|||Cushitic languages|couchitiques, langues
-cze|ces|cs|Czech|tchèque
+ces|cze|cs|Czech|tchèque
 dak|||Dakota|dakota
 dan||da|Danish|danois
 dar|||Dargwa|dargwa
@@ -116,7 +116,7 @@ dra|||Dravidian languages|dravidiennes, langues
 dsb|||Lower Sorbian|bas-sorabe
 dua|||Duala|douala
 dum|||Dutch, Middle (ca.1050-1350)|néerlandais moyen (ca. 1050-1350)
-dut|nld|nl|Dutch; Flemish|néerlandais; flamand
+nld|dut|nl|Dutch; Flemish|néerlandais; flamand
 dyu|||Dyula|dioula
 dzo||dz|Dzongkha|dzongkha
 efi|||Efik|efik
@@ -137,7 +137,7 @@ fil|||Filipino; Pilipino|filipino; pilipino
 fin||fi|Finnish|finnois
 fiu|||Finno-Ugrian languages|finno-ougriennes, langues
 fon|||Fon|fon
-fre|fra|fr|French|français
+fra|fre|fr|French|français
 frm|||French, Middle (ca.1400-1600)|français moyen (1400-1600)
 fro|||French, Old (842-ca.1400)|français ancien (842-ca.1400)
 frc||fr-ca|French (Canada)|french
@@ -150,8 +150,8 @@ gaa|||Ga|ga
 gay|||Gayo|gayo
 gba|||Gbaya|gbaya
 gem|||Germanic languages|germaniques, langues
-geo|kat|ka|Georgian|géorgien
-ger|deu|de|German|allemand
+kat|geo|ka|Georgian|géorgien
+deu|ger|de|German|allemand
 gez|||Geez|guèze
 gil|||Gilbertese|kiribati
 gla||gd|Gaelic; Scottish Gaelic|gaélique; gaélique écossais
@@ -165,7 +165,7 @@ gor|||Gorontalo|gorontalo
 got|||Gothic|gothique
 grb|||Grebo|grebo
 grc|||Greek, Ancient (to 1453)|grec ancien (jusqu'à 1453)
-gre|ell|el|Greek, Modern (1453-)|grec moderne (après 1453)
+ell|gre|el|Greek, Modern (1453-)|grec moderne (après 1453)
 grn||gn|Guarani|guarani
 gsw|||Swiss German; Alemannic; Alsatian|suisse alémanique; alémanique; alsacien
 guj||gu|Gujarati|goudjrati
@@ -188,7 +188,7 @@ hun||hu|Hungarian|hongrois
 hup|||Hupa|hupa
 iba|||Iban|iban
 ibo||ig|Igbo|igbo
-ice|isl|is|Icelandic|islandais
+isl|ice|is|Icelandic|islandais
 ido||io|Ido|ido
 iii||ii|Sichuan Yi; Nuosu|yi de Sichuan
 ijo|||Ijo languages|ijo, langues
@@ -263,7 +263,7 @@ lui|||Luiseno|luiseno
 lun|||Lunda|lunda
 luo|||Luo (Kenya and Tanzania)|luo (Kenya et Tanzanie)
 lus|||Lushai|lushai
-mac|mkd|mk|Macedonian|macédonien
+mkd|mac|mk|Macedonian|macédonien
 mad|||Madurese|madourais
 mag|||Magahi|magahi
 mah||mh|Marshallese|marshall
@@ -271,11 +271,11 @@ mai|||Maithili|maithili
 mak|||Makasar|makassar
 mal||ml|Malayalam|malayalam
 man|||Mandingo|mandingue
-mao|mri|mi|Maori|maori
+mri|mao|mi|Maori|maori
 map|||Austronesian languages|austronésiennes, langues
 mar||mr|Marathi|marathe
 mas|||Masai|massaï
-may|msa|ms|Malay|malais
+msa|may|ms|Malay|malais
 mdf|||Moksha|moksa
 mdr|||Mandar|mandar
 men|||Mende|mendé
@@ -343,7 +343,7 @@ pan||pa|Panjabi; Punjabi|pendjabi
 pap|||Papiamento|papiamento
 pau|||Palauan|palau
 peo|||Persian, Old (ca.600-400 B.C.)|perse, vieux (ca. 600-400 av. J.-C.)
-per|fas|fa|Persian|persan
+fas|per|fa|Persian|persan
 phi|||Philippine languages|philippines, langues
 phn|||Phoenician|phénicien
 pli||pi|Pali|pali
@@ -363,7 +363,7 @@ rar|||Rarotongan; Cook Islands Maori|rarotonga; maori des îles Cook
 roa|||Romance languages|romanes, langues
 roh||rm|Romansh|romanche
 rom|||Romany|tsigane
-rum|ron|ro|Romanian; Moldavian; Moldovan|roumain; moldave
+ron|rum|ro|Romanian; Moldavian; Moldovan|roumain; moldave
 run||rn|Rundi|rundi
 rup|||Aromanian; Arumanian; Macedo-Romanian|aroumain; macédo-roumain
 rus||ru|Russian|russe
@@ -388,7 +388,7 @@ sin||si|Sinhala; Sinhalese|singhalais
 sio|||Siouan languages|sioux, langues
 sit|||Sino-Tibetan languages|sino-tibétaines, langues
 sla|||Slavic languages|slaves, langues
-slo|slk|sk|Slovak|slovaque
+slk|slo|sk|Slovak|slovaque
 slv||sl|Slovenian|slovène
 sma|||Southern Sami|sami du Sud
 sme||se|Northern Sami|sami du Nord
@@ -408,7 +408,7 @@ spa||es-mx|Spanish; Latin|espagnol; Latin
 spa||es|Spanish; Castilian|espagnol; castillan
 srd||sc|Sardinian|sarde
 srn|||Sranan Tongo|sranan tongo
-srp|scc|sr|Serbian|serbe
+scc|srp|sr|Serbian|serbe
 srr|||Serer|sérère
 ssa|||Nilo-Saharan languages|nilo-sahariennes, langues
 ssw||ss|Swati|swati
@@ -431,7 +431,7 @@ tet|||Tetum|tetum
 tgk||tg|Tajik|tadjik
 tgl||tl|Tagalog|tagalog
 tha||th|Thai|thaï
-tib|bod|bo|Tibetan|tibétain
+bod|tib|bo|Tibetan|tibétain
 tig|||Tigre|tigré
 tir||ti|Tigrinya|tigrigna
 tiv|||Tiv|tiv
@@ -470,7 +470,7 @@ wak|||Wakashan languages|wakashanes, langues
 wal|||Walamo|walamo
 war|||Waray|waray
 was|||Washo|washo
-wel|cym|cy|Welsh|gallois
+cym|wel|cy|Welsh|gallois
 wen|||Sorbian languages|sorabes, langues
 wln||wa|Walloon|wallon
 wol||wo|Wolof|wolof

--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -10,7 +10,6 @@ afr||af|Afrikaans|afrikaans
 ain|||Ainu|aïnou
 aka||ak|Akan|akan
 akk|||Akkadian|akkadien
-sqi|alb|sq|Albanian|albanais
 ale|||Aleut|aléoute
 alg|||Algonquian languages|algonquines, langues
 alt|||Southern Altai|altai du Sud
@@ -21,7 +20,6 @@ apa|||Apache languages|apaches, langues
 ara||ar|Arabic|arabe
 arc|||Official Aramaic (700-300 BCE); Imperial Aramaic (700-300 BCE)|araméen d'empire (700-300 BCE)
 arg||an|Aragonese|aragonais
-hye|arm|hy|Armenian|arménien
 arn|||Mapudungun; Mapuche|mapudungun; mapuche; mapuce
 arp|||Arapaho|arapaho
 art|||Artificial languages|artificielles, langues
@@ -41,7 +39,6 @@ bak||ba|Bashkir|bachkir
 bal|||Baluchi|baloutchi
 bam||bm|Bambara|bambara
 ban|||Balinese|balinais
-eus|baq|eu|Basque|basque
 bas|||Basa|basa
 bat|||Baltic languages|baltes, langues
 bej|||Beja; Bedawiyet|bedja
@@ -56,6 +53,7 @@ bin|||Bini; Edo|bini; edo
 bis||bi|Bislama|bichlamar
 bla|||Siksika|blackfoot
 bnt|||Bantu (Other)|bantoues, autres langues
+bod|tib|bo|Tibetan|tibétain
 bos||bs|Bosnian|bosniaque
 bra|||Braj|braj
 bre||br|Breton|breton
@@ -63,7 +61,6 @@ btk|||Batak languages|batak, langues
 bua|||Buriat|bouriate
 bug|||Buginese|bugi
 bul||bg|Bulgarian|bulgare
-mya|bur|my|Burmese|birman
 byn|||Blin; Bilin|blin; bilen
 cad|||Caddo|caddo
 cai|||Central American Indian languages|amérindiennes de L'Amérique centrale, langues
@@ -72,14 +69,11 @@ cat||ca|Catalan; Valencian|catalan; valencien
 cau|||Caucasian languages|caucasiennes, langues
 ceb|||Cebuano|cebuano
 cel|||Celtic languages|celtiques, langues; celtes, langues
+ces|cze|cs|Czech|tchèque
 cha||ch|Chamorro|chamorro
 chb|||Chibcha|chibcha
 che||ce|Chechen|tchétchène
 chg|||Chagatai|djaghataï
-zho|chi|zh|Chinese|chinois
-zho|chi|ze|Chinese; Bilingual|chinois
-zho|chi|zh-tw|Chinese; Traditional|chinois
-zho|chi|zh-hk|Chinese; Hong Kong|chinois
 chk|||Chuukese|chuuk
 chm|||Mari|mari
 chn|||Chinook jargon|chinook, jargon
@@ -101,13 +95,14 @@ crh|||Crimean Tatar; Crimean Turkish|tatar de Crimé
 crp|||Creoles and pidgins |créoles et pidgins
 csb|||Kashubian|kachoube
 cus|||Cushitic languages|couchitiques, langues
-ces|cze|cs|Czech|tchèque
+cym|wel|cy|Welsh|gallois
 dak|||Dakota|dakota
 dan||da|Danish|danois
 dar|||Dargwa|dargwa
 day|||Land Dayak languages|dayak, langues
 del|||Delaware|delaware
 den|||Slave (Athapascan)|esclave (athapascan)
+deu|ger|de|German|allemand
 dgr|||Dogrib|dogrib
 din|||Dinka|dinka
 div||dv|Divehi; Dhivehi; Maldivian|maldivien
@@ -116,21 +111,23 @@ dra|||Dravidian languages|dravidiennes, langues
 dsb|||Lower Sorbian|bas-sorabe
 dua|||Duala|douala
 dum|||Dutch, Middle (ca.1050-1350)|néerlandais moyen (ca. 1050-1350)
-nld|dut|nl|Dutch; Flemish|néerlandais; flamand
 dyu|||Dyula|dioula
 dzo||dz|Dzongkha|dzongkha
 efi|||Efik|efik
 egy|||Egyptian (Ancient)|égyptien
 eka|||Ekajuk|ekajuk
+ell|gre|el|Greek, Modern (1453-)|grec moderne (après 1453)
 elx|||Elamite|élamite
 eng||en|English|anglais
 enm|||English, Middle (1100-1500)|anglais moyen (1100-1500)
 epo||eo|Esperanto|espéranto
 est||et|Estonian|estonien
+eus|baq|eu|Basque|basque
 ewe||ee|Ewe|éwé
 ewo|||Ewondo|éwondo
 fan|||Fang|fang
 fao||fo|Faroese|féroïen
+fas|per|fa|Persian|persan
 fat|||Fanti|fanti
 fij||fj|Fijian|fidjien
 fil|||Filipino; Pilipino|filipino; pilipino
@@ -150,8 +147,6 @@ gaa|||Ga|ga
 gay|||Gayo|gayo
 gba|||Gbaya|gbaya
 gem|||Germanic languages|germaniques, langues
-kat|geo|ka|Georgian|géorgien
-deu|ger|de|German|allemand
 gez|||Geez|guèze
 gil|||Gilbertese|kiribati
 gla||gd|Gaelic; Scottish Gaelic|gaélique; gaélique écossais
@@ -165,7 +160,6 @@ gor|||Gorontalo|gorontalo
 got|||Gothic|gothique
 grb|||Grebo|grebo
 grc|||Greek, Ancient (to 1453)|grec ancien (jusqu'à 1453)
-ell|gre|el|Greek, Modern (1453-)|grec moderne (après 1453)
 grn||gn|Guarani|guarani
 gsw|||Swiss German; Alemannic; Alsatian|suisse alémanique; alémanique; alsacien
 guj||gu|Gujarati|goudjrati
@@ -186,6 +180,7 @@ hrv||hr|Croatian|croate
 hsb|||Upper Sorbian|haut-sorabe
 hun||hu|Hungarian|hongrois
 hup|||Hupa|hupa
+hye|arm|hy|Armenian|arménien
 iba|||Iban|iban
 ibo||ig|Igbo|igbo
 isl|ice|is|Icelandic|islandais
@@ -217,6 +212,7 @@ kam|||Kamba|kamba
 kan||kn|Kannada|kannada
 kar|||Karen languages|karen, langues
 kas||ks|Kashmiri|kashmiri
+kat|geo|ka|Georgian|géorgien
 kau||kr|Kanuri|kanouri
 kaw|||Kawi|kawi
 kaz||kk|Kazakh|kazakh
@@ -263,7 +259,6 @@ lui|||Luiseno|luiseno
 lun|||Lunda|lunda
 luo|||Luo (Kenya and Tanzania)|luo (Kenya et Tanzanie)
 lus|||Lushai|lushai
-mkd|mac|mk|Macedonian|macédonien
 mad|||Madurese|madourais
 mag|||Magahi|magahi
 mah||mh|Marshallese|marshall
@@ -271,11 +266,9 @@ mai|||Maithili|maithili
 mak|||Makasar|makassar
 mal||ml|Malayalam|malayalam
 man|||Mandingo|mandingue
-mri|mao|mi|Maori|maori
 map|||Austronesian languages|austronésiennes, langues
 mar||mr|Marathi|marathe
 mas|||Masai|massaï
-msa|may|ms|Malay|malais
 mdf|||Moksha|moksa
 mdr|||Mandar|mandar
 men|||Mende|mendé
@@ -283,6 +276,7 @@ mga|||Irish, Middle (900-1200)|irlandais moyen (900-1200)
 mic|||Mi'kmaq; Micmac|mi'kmaq; micmac
 min|||Minangkabau|minangkabau
 mis|||Uncoded languages|langues non codées
+mkd|mac|mk|Macedonian|macédonien
 mkh|||Mon-Khmer languages|môn-khmer, langues
 mlg||mg|Malagasy|malgache
 mlt||mt|Maltese|maltais
@@ -292,11 +286,14 @@ mno|||Manobo languages|manobo, langues
 moh|||Mohawk|mohawk
 mon||mn|Mongolian|mongol
 mos|||Mossi|moré
+mri|mao|mi|Maori|maori
+msa|may|ms|Malay|malais
 mul|||Multiple languages|multilingue
 mun|||Munda languages|mounda, langues
 mus|||Creek|muskogee
 mwl|||Mirandese|mirandais
 mwr|||Marwari|marvari
+mya|bur|my|Burmese|birman
 myn|||Mayan languages|maya, langues
 myv|||Erzya|erza
 nah|||Nahuatl languages|nahuatl, langues
@@ -313,6 +310,7 @@ new|||Nepal Bhasa; Newari|nepal bhasa; newari
 nia|||Nias|nias
 nic|||Niger-Kordofanian languages|nigéro-kordofaniennes, langues
 niu|||Niuean|niué
+nld|dut|nl|Dutch; Flemish|néerlandais; flamand
 nno||nn|Norwegian Nynorsk; Nynorsk, Norwegian|norvégien nynorsk; nynorsk, norvégien
 nob||nb|Bokmål, Norwegian; Norwegian Bokmål|norvégien bokmål
 nog|||Nogai|nogaï; nogay
@@ -343,7 +341,6 @@ pan||pa|Panjabi; Punjabi|pendjabi
 pap|||Papiamento|papiamento
 pau|||Palauan|palau
 peo|||Persian, Old (ca.600-400 B.C.)|perse, vieux (ca. 600-400 av. J.-C.)
-fas|per|fa|Persian|persan
 phi|||Philippine languages|philippines, langues
 phn|||Phoenician|phénicien
 pli||pi|Pali|pali
@@ -376,6 +373,7 @@ sam|||Samaritan Aramaic|samaritain
 san||sa|Sanskrit|sanskrit
 sas|||Sasak|sasak
 sat|||Santali|santal
+scc|srp|sr|Serbian|serbe
 scn|||Sicilian|sicilien
 sco|||Scots|écossais
 sel|||Selkup|selkoupe
@@ -406,9 +404,9 @@ son|||Songhai languages|songhai, langues
 sot||st|Sotho, Southern|sotho du Sud
 spa||es-mx|Spanish; Latin|espagnol; Latin
 spa||es|Spanish; Castilian|espagnol; castillan
+sqi|alb|sq|Albanian|albanais
 srd||sc|Sardinian|sarde
 srn|||Sranan Tongo|sranan tongo
-scc|srp|sr|Serbian|serbe
 srr|||Serer|sérère
 ssa|||Nilo-Saharan languages|nilo-sahariennes, langues
 ssw||ss|Swati|swati
@@ -431,7 +429,6 @@ tet|||Tetum|tetum
 tgk||tg|Tajik|tadjik
 tgl||tl|Tagalog|tagalog
 tha||th|Thai|thaï
-bod|tib|bo|Tibetan|tibétain
 tig|||Tigre|tigré
 tir||ti|Tigrinya|tigrigna
 tiv|||Tiv|tiv
@@ -470,7 +467,6 @@ wak|||Wakashan languages|wakashanes, langues
 wal|||Walamo|walamo
 war|||Waray|waray
 was|||Washo|washo
-cym|wel|cy|Welsh|gallois
 wen|||Sorbian languages|sorabes, langues
 wln||wa|Walloon|wallon
 wol||wo|Wolof|wolof
@@ -486,6 +482,10 @@ zbl|||Blissymbols; Blissymbolics; Bliss|symboles Bliss; Bliss
 zen|||Zenaga|zenaga
 zgh|||Standard Moroccan Tamazight|amazighe standard marocain
 zha||za|Zhuang; Chuang|zhuang; chuang
+zho|chi|zh|Chinese|chinois
+zho|chi|ze|Chinese; Bilingual|chinois
+zho|chi|zh-tw|Chinese; Traditional|chinois
+zho|chi|zh-hk|Chinese; Hong Kong|chinois
 znd|||Zande languages|zandé, langues
 zul||zu|Zulu|zoulou
 zun|||Zuni|zuni

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -45,7 +45,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
 
             var germany = cultures.FirstOrDefault(x => x.TwoLetterISOLanguageName.Equals("de", StringComparison.Ordinal));
             Assert.NotNull(germany);
-            Assert.Equal("ger", germany!.ThreeLetterISOLanguageName);
+            Assert.Equal("deu", germany!.ThreeLetterISOLanguageName);
             Assert.Equal("German", germany.DisplayName);
             Assert.Equal("German", germany.Name);
             Assert.Contains("deu", germany.ThreeLetterISOLanguageNames);
@@ -54,6 +54,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
 
         [Theory]
         [InlineData("de")]
+        [InlineData("deu")]
         [InlineData("ger")]
         [InlineData("german")]
         public async Task FindLanguageInfo_Valid_Success(string identifier)
@@ -67,7 +68,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             var germany = localizationManager.FindLanguageInfo(identifier);
             Assert.NotNull(germany);
 
-            Assert.Equal("ger", germany!.ThreeLetterISOLanguageName);
+            Assert.Equal("deu", germany!.ThreeLetterISOLanguageName);
             Assert.Equal("German", germany.DisplayName);
             Assert.Equal("German", germany.Name);
             Assert.Contains("deu", germany.ThreeLetterISOLanguageNames);


### PR DESCRIPTION
Now the ISO 639-2/T (terminological) comes first (which is the same as the ISO 639-3 code) and the second column is for the ISO 639-2/B (bibliograpihc) code.
The terminological code is derived from the native name for the language while the bibliographic code is more of a "legacy feature" (see https://en.wikipedia.org/wiki/ISO_639-2#B_and_T_codes) where the code is derived from the English name for the language.

The format of the file is now

``ISO 639-2/T (or ISO 639-3) | ISO 639-2/B (where applicable) | ISO 639-1 (two-letter code) | English name | French name``

**Changes**
There are no functional changes, but the unit test for the German language needed to be changed.