### PR TITLE
Fix .gzip handling and URL redirection for XML TV guide parsing

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -84,10 +84,11 @@ namespace Jellyfin.LiveTv.Listings
                 _logger.LogInformation("Downloading xmltv listings from {Path}", info.Path);
 
                 using var response = await _httpClientFactory.CreateClient(NamedClient.Default).GetAsync(info.Path, cancellationToken).ConfigureAwait(false);
+                var redirectedUrl = response.RequestMessage?.RequestUri?.ToString() ?? info.Path;
                 var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 await using (stream.ConfigureAwait(false))
                 {
-                    return await UnzipIfNeededAndCopy(info.Path, stream, cacheFile, cancellationToken).ConfigureAwait(false);
+                    return await UnzipIfNeededAndCopy(redirectedUrl, stream, cacheFile, cancellationToken).ConfigureAwait(false);
                 }
             }
             else
@@ -112,7 +113,8 @@ namespace Jellyfin.LiveTv.Listings
 
             await using (fileStream.ConfigureAwait(false))
             {
-                if (Path.GetExtension(originalUrl.AsSpan().LeftPart('?')).Equals(".gz", StringComparison.OrdinalIgnoreCase))
+                if (Path.GetExtension(originalUrl.AsSpan().LeftPart('?')).Equals(".gz", StringComparison.OrdinalIgnoreCase) ||
+                    Path.GetExtension(originalUrl.AsSpan().LeftPart('?')).Equals(".gzip", StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Added support for handling .gzip compressed XML files in addition to .gz files. Updated the GetXml method to follow URL redirections and use the final redirected URL for processing.

**Issues**
 Fixes #13249 & #12413
