### PR TITLE
Add channel queries to series

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -23,6 +23,7 @@ using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
@@ -1683,7 +1684,7 @@ namespace MediaBrowser.Controller.Entities
 
         public virtual string GetClientTypeName()
         {
-            if (IsFolder && SourceType == SourceType.Channel && this is not Channel)
+            if (IsFolder && SourceType == SourceType.Channel && this is not Channel && this is not Season && this is not Series)
             {
                 return "ChannelFolderItem";
             }

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -226,6 +226,21 @@ namespace MediaBrowser.Controller.Entities.TV
         {
             var user = query.User;
 
+            if (SourceType == SourceType.Channel)
+            {
+                try
+                {
+                    query.Parent = this;
+                    query.ChannelIds = [ChannelId];
+                    return ChannelManager.GetChannelItemsInternal(query, new Progress<double>(), CancellationToken.None).GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // Already logged at lower levels
+                    return new QueryResult<BaseItem>();
+                }
+            }
+
             if (query.Recursive)
             {
                 var seriesKey = GetUniqueSeriesKey(this);
@@ -372,7 +387,25 @@ namespace MediaBrowser.Controller.Entities.TV
                 query.IsMissing = false;
             }
 
-            var allItems = LibraryManager.GetItemList(query);
+            IReadOnlyList<BaseItem> allItems;
+            if (SourceType == SourceType.Channel)
+            {
+                try
+                {
+                    query.Parent = parentSeason;
+                    query.ChannelIds = [ChannelId];
+                    allItems = [.. ChannelManager.GetChannelItemsInternal(query, new Progress<double>(), CancellationToken.None).GetAwaiter().GetResult().Items];
+                }
+                catch
+                {
+                    // Already logged at lower levels
+                    return [];
+                }
+            }
+            else
+            {
+                allItems = LibraryManager.GetItemList(query);
+            }
 
             return GetSeasonEpisodes(parentSeason, user, allItems, options, shouldIncludeMissingEpisodes);
         }


### PR DESCRIPTION
Currently, the IChannel interface can deliver channel result folders which are interpreted as series and seasons. However, Jellyfin does not query for the contents of these folders when viewing said serie of season. This results in empty series in the API.

The parsing of series and seasons is implemented in the [ChannelManager](https://github.com/jellyfin/jellyfin/blob/v10.10.3/src/Jellyfin.LiveTv/Channels/ChannelManager.cs#L973). The `IChannel` implementation is never queried for the contents of said series and seasons.
Looking at the implementation of channel [Folders](https://github.com/jellyfin/jellyfin/blob/v10.10.3/MediaBrowser.Controller/Entities/Folder.cs#L951), this implementation for series and seasons seems to fit in the structure of Jellyfin and works with my testing.

**Changes**
- Add query for seasons in series in case the series originates from a channel.
- Add query for episodes in season in case the series originates from a channel.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
