### PR TITLE
Only run merge conflict labler action on pull requests

### DIFF
--- a/.github/workflows/pull-request-conflict.yml
+++ b/.github/workflows/pull-request-conflict.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     name: Labeling
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'jellyfin/jellyfin' }}
+    if: ${{ github.repository == 'jellyfin/jellyfin' && github.event.issue.pull_request }}
     steps:
       - name: Apply label
         uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3


### PR DESCRIPTION
Currently, looking at the actions log of this repo, the merge conflict labeler is run on all comments, including issues. Changes the GHA file to only run it on PRs.

**Changes**
Add a condition to only run the GHA on pull requests

**Issues**
None
