### PR TITLE
Fix SessionInfoDto (de)serialization

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1098,10 +1098,10 @@ namespace Emby.Server.Implementations.Session
             return new SessionInfoDto
             {
                 PlayState = sessionInfo.PlayState,
-                AdditionalUsers = sessionInfo.AdditionalUsers,
+                AdditionalUsers = sessionInfo.AdditionalUsers.ToArray(),
                 Capabilities = _deviceManager.ToClientCapabilitiesDto(sessionInfo.Capabilities),
                 RemoteEndPoint = sessionInfo.RemoteEndPoint,
-                PlayableMediaTypes = sessionInfo.PlayableMediaTypes,
+                PlayableMediaTypes = sessionInfo.PlayableMediaTypes.ToArray(),
                 Id = sessionInfo.Id,
                 UserId = sessionInfo.UserId,
                 UserName = sessionInfo.UserName,
@@ -1119,13 +1119,13 @@ namespace Emby.Server.Implementations.Session
                 IsActive = sessionInfo.IsActive,
                 SupportsMediaControl = sessionInfo.SupportsMediaControl,
                 SupportsRemoteControl = sessionInfo.SupportsRemoteControl,
-                NowPlayingQueue = sessionInfo.NowPlayingQueue,
-                NowPlayingQueueFullItems = sessionInfo.NowPlayingQueueFullItems,
+                NowPlayingQueue = sessionInfo.NowPlayingQueue.ToArray(),
+                NowPlayingQueueFullItems = sessionInfo.NowPlayingQueueFullItems.ToArray(),
                 HasCustomDeviceName = sessionInfo.HasCustomDeviceName,
                 PlaylistItemId = sessionInfo.PlaylistItemId,
                 ServerId = sessionInfo.ServerId,
                 UserPrimaryImageTag = sessionInfo.UserPrimaryImageTag,
-                SupportedCommands = sessionInfo.SupportedCommands
+                SupportedCommands = sessionInfo.SupportedCommands.ToArray()
             };
         }
 

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1098,10 +1098,10 @@ namespace Emby.Server.Implementations.Session
             return new SessionInfoDto
             {
                 PlayState = sessionInfo.PlayState,
-                AdditionalUsers = sessionInfo.AdditionalUsers.ToArray(),
+                AdditionalUsers = sessionInfo.AdditionalUsers?.ToArray(),
                 Capabilities = _deviceManager.ToClientCapabilitiesDto(sessionInfo.Capabilities),
                 RemoteEndPoint = sessionInfo.RemoteEndPoint,
-                PlayableMediaTypes = sessionInfo.PlayableMediaTypes.ToArray(),
+                PlayableMediaTypes = sessionInfo.PlayableMediaTypes?.ToArray() ?? [],
                 Id = sessionInfo.Id,
                 UserId = sessionInfo.UserId,
                 UserName = sessionInfo.UserName,
@@ -1119,13 +1119,13 @@ namespace Emby.Server.Implementations.Session
                 IsActive = sessionInfo.IsActive,
                 SupportsMediaControl = sessionInfo.SupportsMediaControl,
                 SupportsRemoteControl = sessionInfo.SupportsRemoteControl,
-                NowPlayingQueue = sessionInfo.NowPlayingQueue.ToArray(),
-                NowPlayingQueueFullItems = sessionInfo.NowPlayingQueueFullItems.ToArray(),
+                NowPlayingQueue = sessionInfo.NowPlayingQueue?.ToArray(),
+                NowPlayingQueueFullItems = sessionInfo.NowPlayingQueueFullItems?.ToArray(),
                 HasCustomDeviceName = sessionInfo.HasCustomDeviceName,
                 PlaylistItemId = sessionInfo.PlaylistItemId,
                 ServerId = sessionInfo.ServerId,
                 UserPrimaryImageTag = sessionInfo.UserPrimaryImageTag,
-                SupportedCommands = sessionInfo.SupportedCommands.ToArray()
+                SupportedCommands = sessionInfo.SupportedCommands?.ToArray() ?? []
             };
         }
 

--- a/MediaBrowser.Model/Dto/SessionInfoDto.cs
+++ b/MediaBrowser.Model/Dto/SessionInfoDto.cs
@@ -1,6 +1,10 @@
+#pragma warning disable CA1819 // Properties should not return arrays
+
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions.Json.Converters;
 using MediaBrowser.Model.Session;
 
 namespace MediaBrowser.Model.Dto;
@@ -20,7 +24,7 @@ public class SessionInfoDto
     /// Gets or sets the additional users.
     /// </summary>
     /// <value>The additional users.</value>
-    public IReadOnlyList<SessionUserInfo>? AdditionalUsers { get; set; }
+    public SessionUserInfo[]? AdditionalUsers { get; set; }
 
     /// <summary>
     /// Gets or sets the client capabilities.
@@ -38,7 +42,7 @@ public class SessionInfoDto
     /// Gets or sets the playable media types.
     /// </summary>
     /// <value>The playable media types.</value>
-    public IReadOnlyList<MediaType> PlayableMediaTypes { get; set; } = [];
+    public MediaType[] PlayableMediaTypes { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the id.
@@ -146,13 +150,13 @@ public class SessionInfoDto
     /// Gets or sets the now playing queue.
     /// </summary>
     /// <value>The now playing queue.</value>
-    public IReadOnlyList<QueueItem>? NowPlayingQueue { get; set; }
+    public QueueItem[]? NowPlayingQueue { get; set; }
 
     /// <summary>
     /// Gets or sets the now playing queue full items.
     /// </summary>
     /// <value>The now playing queue full items.</value>
-    public IReadOnlyList<BaseItemDto>? NowPlayingQueueFullItems { get; set; }
+    public BaseItemDto[]? NowPlayingQueueFullItems { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the session has a custom device name.
@@ -182,5 +186,5 @@ public class SessionInfoDto
     /// Gets or sets the supported commands.
     /// </summary>
     /// <value>The supported commands.</value>
-    public IReadOnlyList<GeneralCommandType> SupportedCommands { get; set; } = [];
+    public GeneralCommandType[] SupportedCommands { get; set; } = [];
 }


### PR DESCRIPTION
I got some serialization errors because of failed `IReadonlyList` JSON conversion, this PR fixes it.

```
Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL "GET" "/sessions".
System.InvalidCastException: Unable to cast object of type '<>z__ReadOnlyArray`1[MediaBrowser.Model.Session.GeneralCommandType]' to type 'MediaBrowser.Model.Session.GeneralCommandType[]'.
   at System.Text.Json.JsonSerializer.UnboxOnWrite[T](Object value)
   at System.Text.Json.Serialization.JsonConverter`1.WriteAsObject(Utf8JsonWriter writer, Object value, JsonSerializerOptions options)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(Object obj, WriteStack& state, Utf8JsonWriter writer)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(Object obj, WriteStack& state, Utf8JsonWriter writer)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Converters.ListOfTConverter`2.OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryWrite(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.SerializeAsync(Stream utf8Json, T rootValue, CancellationToken cancellationToken, Object rootValueBoxed)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.SerializeAsync(Stream utf8Json, T rootValue, CancellationToken cancellationToken, Object rootValueBoxed)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.SerializeAsync(Stream utf8Json, T rootValue, CancellationToken cancellationToken, Object rootValueBoxed)
   at Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter.WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResultFilterAsync>g__Awaited|30_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state,>
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Jellyfin.Api.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager)
   at Jellyfin.Api.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager)
   at Jellyfin.Api.Middleware.IPBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager)
   at Jellyfin.Api.Middleware.LanFilteringMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager, IServerConfigurationManager serverConfigurationManager)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext)
   at Jellyfin.Api.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Jellyfin.Api.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context, IServerConfigurationManager serverConfigurationManager)
   at Jellyfin.Api.Middleware.ExceptionMiddleware.Invoke(HttpContext context)
``` 

Not sure if we should get rid of `IReadonlyList` on any DTOs and structure returned by the API just to be safe.

**Changes**
* Use Arrays instead of `IReadonlyList` on DTOs to allow proper (de)serialization
