### PR TITLE
Catch IOExceptions for GetFileSystemMetadata

### DIFF
--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -276,6 +276,13 @@ namespace Emby.Server.Implementations.IO
                         {
                             _logger.LogError(ex, "Reading the file at {Path} failed due to a permissions exception.", fileInfo.FullName);
                         }
+                        catch (IOException ex)
+                        {
+                            // IOException generally means the file is not accessible due to filesystem issues
+                            // Catch this exception and mark the file as not exist to ignore it
+                            _logger.LogError(ex, "Reading the file at {Path} failed due to an IO Exception. Marking the file as not existing", fileInfo.FullName);
+                            result.Exists = false;
+                        }
                     }
                 }
 
@@ -590,6 +597,9 @@ namespace Emby.Server.Implementations.IO
         /// <inheritdoc />
         public virtual IEnumerable<FileSystemMetadata> GetFileSystemEntries(string path, bool recursive = false)
         {
+            // Note: any of unhandled exceptions thrown by this method may cause the caller to believe the whole path is not accessible.
+            // But what causing the exception may be a single file under that path. This could lead to unexpected behavior.
+            // For example, the scanner will remove everything in that path due to unhandled errors.
             var directoryInfo = new DirectoryInfo(path);
             var enumerationOptions = GetEnumerationOptions(recursive);
 


### PR DESCRIPTION
Our `GetFileSystemEntries` method will throw when enumerating the file system, but its callers might consider the unhandled exceptions as the whole path is not available. This would cause a single problematic file to fail the enumeration, and could lead to unexpected side effects.

HandleIOException gracefully by marking the files throwing as not exist to let the caller skip that file.

Note that the dotnet's method `EnumerateFileSystemInfos` may also throw and failed to build the file list. We can do little in this case. See #13093 for more info for this kind of issue.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13389
