### PR TITLE
(feat) Add external JWT auth to Jellyfin

### DIFF
--- a/Jellyfin.Api/Auth/JwtAuth/JwtAuthenticationHandler.cs
+++ b/Jellyfin.Api/Auth/JwtAuth/JwtAuthenticationHandler.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Api.Auth.JwtAuth
+{
+    /// <summary>
+    /// JWT authentication handler.
+    /// </summary>
+    public class JwtAuthenticationHandler : AuthenticationHandler<JwtBearerOptions>
+    {
+        private readonly JwtOptions _jwtOptions;
+        private readonly ILogger<JwtAuthenticationHandler> _logger;
+        private ConfigurationManager<OpenIdConnectConfiguration>? _configurationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtAuthenticationHandler"/> class.
+        /// </summary>
+        /// <param name="jwtOptions">JWT options.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="encoder">The encoder.</param>
+        public JwtAuthenticationHandler(
+            IOptions<JwtOptions> jwtOptions,
+            IOptionsMonitor<JwtBearerOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+            _jwtOptions = jwtOptions.Value;
+            _logger = logger.CreateLogger<JwtAuthenticationHandler>();
+        }
+
+        /// <inheritdoc />
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            try
+            {
+                if (!_jwtOptions.IsEnabled || string.IsNullOrEmpty(_jwtOptions.JwksUrl))
+                {
+                    return AuthenticateResult.NoResult();
+                }
+
+                var token = Context.Request.Headers[_jwtOptions.AuthorizationHeader].ToString().Replace(_jwtOptions.BearerTokenPrefix, string.Empty);
+                if (string.IsNullOrEmpty(token))
+                {
+                    return AuthenticateResult.NoResult();
+                }
+
+                if (_configurationManager == null)
+                {
+                    _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                        _jwtOptions.JwksUrl,
+                        new OpenIdConnectConfigurationRetriever());
+                }
+
+                var config = await _configurationManager.GetConfigurationAsync(Context.RequestAborted).ConfigureAwait(false);
+
+                var validationParameters = _jwtOptions.ValidationParameters ?? new TokenValidationParameters();
+                validationParameters.ValidIssuer = _jwtOptions.Issuer;
+                validationParameters.ValidAudience = _jwtOptions.Audience;
+                validationParameters.IssuerSigningKeys = config.SigningKeys;
+
+                var tokenHandler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+                var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
+
+                var claims = new List<Claim>();
+                var name = claimsPrincipal.FindFirst(_jwtOptions.ClaimMappings.NameClaimType)?.Value;
+                var userId = claimsPrincipal.FindFirst(_jwtOptions.ClaimMappings.UserIdClaimType)?.Value;
+                var roles = claimsPrincipal.FindAll(_jwtOptions.ClaimMappings.RolesClaimType);
+
+                if (!string.IsNullOrEmpty(name))
+                {
+                    claims.Add(new Claim(ClaimTypes.Name, name));
+                }
+
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    claims.Add(new Claim(InternalClaimTypes.UserId, userId));
+                }
+
+                var isAdmin = false;
+                foreach (var role in roles)
+                {
+                    if (role.Value.Equals(_jwtOptions.ClaimMappings.AdminRole, StringComparison.OrdinalIgnoreCase))
+                    {
+                        isAdmin = true;
+                        break;
+                    }
+                }
+
+                claims.Add(new Claim(ClaimTypes.Role, isAdmin ? UserRoles.Administrator : UserRoles.User));
+
+                var identity = new ClaimsIdentity(claims, Scheme.Name);
+                var principal = new ClaimsPrincipal(identity);
+                var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+                return AuthenticateResult.Success(ticket);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error authenticating JWT token");
+                return AuthenticateResult.Fail(ex);
+            }
+        }
+    }
+}

--- a/Jellyfin.Api/Auth/JwtAuth/JwtAuthenticationOptions.cs
+++ b/Jellyfin.Api/Auth/JwtAuth/JwtAuthenticationOptions.cs
@@ -1,0 +1,69 @@
+namespace Jellyfin.Api.Auth.JwtAuth
+{
+    /// <summary>
+    /// JWT authentication configuration options.
+    /// </summary>
+    public class JwtAuthenticationOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether JWT authentication is enabled.
+        /// </summary>
+        public bool Enable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JWKS endpoint URL.
+        /// </summary>
+        public string? JwksUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authorization header name.
+        /// </summary>
+        public string AuthorizationHeader { get; set; } = "Authorization";
+
+        /// <summary>
+        /// Gets or sets the bearer token prefix.
+        /// </summary>
+        public string BearerTokenPrefix { get; set; } = "Bearer ";
+
+        /// <summary>
+        /// Gets or sets the expected audience.
+        /// </summary>
+        public string? Audience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issuer.
+        /// </summary>
+        public string? Issuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the claim mappings.
+        /// </summary>
+        public JwtClaimMappingOptions ClaimMappings { get; set; } = new JwtClaimMappingOptions();
+    }
+
+    /// <summary>
+    /// JWT claim mapping configuration options.
+    /// </summary>
+    public class JwtClaimMappingOptions
+    {
+        /// <summary>
+        /// Gets or sets the name claim mapping.
+        /// </summary>
+        public string NameClaimType { get; set; } = "name";
+
+        /// <summary>
+        /// Gets or sets the user ID claim mapping.
+        /// </summary>
+        public string UserIdClaimType { get; set; } = "sub";
+
+        /// <summary>
+        /// Gets or sets the admin role value.
+        /// </summary>
+        public string AdminRole { get; set; } = "admin";
+
+        /// <summary>
+        /// Gets or sets the roles claim type.
+        /// </summary>
+        public string RolesClaimType { get; set; } = "roles";
+    }
+}

--- a/Jellyfin.Api/Auth/JwtAuth/JwtOptions.cs
+++ b/Jellyfin.Api/Auth/JwtAuth/JwtOptions.cs
@@ -1,0 +1,99 @@
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Api.Auth.JwtAuth
+{
+    /// <summary>
+    /// JWT runtime options.
+    /// </summary>
+    public class JwtOptions
+    {
+        private readonly JwtAuthenticationOptions _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtOptions"/> class.
+        /// </summary>
+        /// <param name="config">The JWT authentication configuration.</param>
+        public JwtOptions(JwtAuthenticationOptions config)
+        {
+            _config = config;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether JWT authentication is enabled.
+        /// </summary>
+        public bool IsEnabled => _config.Enable;
+
+        /// <summary>
+        /// Gets the JWKS endpoint URL.
+        /// </summary>
+        public string? JwksUrl => _config.JwksUrl;
+
+        /// <summary>
+        /// Gets the authorization header name.
+        /// </summary>
+        public string AuthorizationHeader => _config.AuthorizationHeader;
+
+        /// <summary>
+        /// Gets the bearer token prefix.
+        /// </summary>
+        public string BearerTokenPrefix => _config.BearerTokenPrefix;
+
+        /// <summary>
+        /// Gets the expected audience.
+        /// </summary>
+        public string? Audience => _config.Audience;
+
+        /// <summary>
+        /// Gets the issuer.
+        /// </summary>
+        public string? Issuer => _config.Issuer;
+
+        /// <summary>
+        /// Gets the claim mappings.
+        /// </summary>
+        public JwtClaimMappings ClaimMappings { get; } = new JwtClaimMappings();
+
+        /// <summary>
+        /// Gets or sets the token validation parameters.
+        /// </summary>
+        public TokenValidationParameters? ValidationParameters { get; set; }
+    }
+
+    /// <summary>
+    /// JWT claim mapping configuration.
+    /// </summary>
+    public class JwtClaimMappings
+    {
+        private readonly JwtClaimMappingOptions _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtClaimMappings"/> class.
+        /// </summary>
+        /// <param name="config">The claim mapping configuration.</param>
+        public JwtClaimMappings(JwtClaimMappingOptions config)
+        {
+            _config = config;
+        }
+
+        /// <summary>
+        /// Gets the name claim mapping.
+        /// </summary>
+        public string NameClaimType => _config.NameClaimType;
+
+        /// <summary>
+        /// Gets the user ID claim mapping.
+        /// </summary>
+        public string UserIdClaimType => _config.UserIdClaimType;
+
+        /// <summary>
+        /// Gets the admin role value.
+        /// </summary>
+        public string AdminRole => _config.AdminRole;
+
+        /// <summary>
+        /// Gets the roles claim type.
+        /// </summary>
+        public string RolesClaimType => _config.RolesClaimType;
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This adds the ability to use external JWT auth in Jellyfin. This allows Jellyfin to be used in conjunction with Identity Aware Proxies, like [Pomerium](https://github.com/pomerium/pomerium). 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None found. 
