### PR TITLE
Don't select audio stream and codec explicitly for copy when bitrate exceeds limit

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1001,8 +1001,7 @@ namespace MediaBrowser.Model.Dlna
                     }))
                     .All(satisfied => satisfied);
 
-            var containerBitrateExceed = (playlistItem.TranscodeReasons & TranscodeReason.ContainerBitrateExceedsLimit) != 0;
-            directAudioStreamSatisfied = directAudioStreamSatisfied && !containerBitrateExceed;
+            directAudioStreamSatisfied = directAudioStreamSatisfied && !playlistItem.TranscodeReasons.HasFlag(TranscodeReason.ContainerBitrateExceedsLimit);
 
             var directAudioStream = directAudioStreamSatisfied ? audioStreamWithSupportedCodec : null;
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1001,6 +1001,9 @@ namespace MediaBrowser.Model.Dlna
                     }))
                     .All(satisfied => satisfied);
 
+            var containerBitrateExceed = (playlistItem.TranscodeReasons & TranscodeReason.ContainerBitrateExceedsLimit) != 0;
+            directAudioStreamSatisfied = directAudioStreamSatisfied && !containerBitrateExceed;
+
             var directAudioStream = directAudioStreamSatisfied ? audioStreamWithSupportedCodec : null;
 
             if (channelsExceedsLimit && playlistItem.TargetAudioStream is not null)


### PR DESCRIPTION
Stream copy cannot be guaranteed when bitrate limit is exceeded, and the actual transcoding or copy is at best effort. The explicit selection may result in a wrong fallback codec being picked up when a transcode has to happen.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13416

Though I don't understand the reason why mp3 cannot be played on Android TV as the stream looks normal. This PR will make the fallback to pick AAC which should be played fine as verified by user.
