### PR TITLE
Fix typos

### DIFF
--- a/Jellyfin.Data/Entities/PeopleBaseItemMap.cs
+++ b/Jellyfin.Data/Entities/PeopleBaseItemMap.cs
@@ -18,7 +18,7 @@ public class PeopleBaseItemMap
     public int? ListOrder { get; set; }
 
     /// <summary>
-    /// Gets or Sets the Role name the assosiated actor played in the <see cref="BaseItemEntity"/>.
+    /// Gets or Sets the Role name the associated actor played in the <see cref="BaseItemEntity"/>.
     /// </summary>
     public string? Role { get; set; }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3608,7 +3608,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return GetSwVidFilterChain(state, options, vidEncoder);
             }
 
-            // prefered nvdec/cuvid + cuda filters + nvenc pipeline
+            // preferred nvdec/cuvid + cuda filters + nvenc pipeline
             return GetNvidiaVidFiltersPrefered(state, options, vidDecoder, vidEncoder);
         }
 
@@ -3816,7 +3816,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return GetSwVidFilterChain(state, options, vidEncoder);
             }
 
-            // prefered d3d11va + opencl filters + amf pipeline
+            // preferred d3d11va + opencl filters + amf pipeline
             return GetAmdDx11VidFiltersPrefered(state, options, vidDecoder, vidEncoder);
         }
 
@@ -4042,13 +4042,13 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return GetSwVidFilterChain(state, options, vidEncoder);
             }
 
-            // prefered qsv(vaapi) + opencl filters pipeline
+            // preferred qsv(vaapi) + opencl filters pipeline
             if (isIntelVaapiOclSupported)
             {
                 return GetIntelQsvVaapiVidFiltersPrefered(state, options, vidDecoder, vidEncoder);
             }
 
-            // prefered qsv(d3d11) + opencl filters pipeline
+            // preferred qsv(d3d11) + opencl filters pipeline
             if (isIntelDx11OclSupported)
             {
                 return GetIntelQsvDx11VidFiltersPrefered(state, options, vidDecoder, vidEncoder);
@@ -4656,14 +4656,14 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return swFilterChain;
             }
 
-            // prefered vaapi + opencl filters pipeline
+            // preferred vaapi + opencl filters pipeline
             if (_mediaEncoder.IsVaapiDeviceInteliHD)
             {
                 // Intel iHD path, with extra vpp tonemap and overlay support.
                 return GetIntelVaapiFullVidFiltersPrefered(state, options, vidDecoder, vidEncoder);
             }
 
-            // prefered vaapi + vulkan filters pipeline
+            // preferred vaapi + vulkan filters pipeline
             if (_mediaEncoder.IsVaapiDeviceAmd
                 && isVaapiVkSupported
                 && _mediaEncoder.IsVaapiDeviceSupportVulkanDrmInterop
@@ -5576,7 +5576,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return GetSwVidFilterChain(state, options, vidEncoder);
             }
 
-            // prefered rkmpp + rkrga + opencl filters pipeline
+            // preferred rkmpp + rkrga + opencl filters pipeline
             if (isRkmppOclSupported)
             {
                 return GetRkmppVidFiltersPrefered(state, options, vidDecoder, vidEncoder);

--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
@@ -96,7 +96,7 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
     /// Gets the files matching a pattern and search options.
     /// </summary>
     /// <param name="searchPattern">The search pattern.</param>
-    /// <param name="searchOption">The search optin.</param>
+    /// <param name="searchOption">The search option.</param>
     /// <returns>All files of the directory matching the search pattern and options.</returns>
     public IFileInfo[] GetFiles(string searchPattern, SearchOption searchOption)
     {

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -537,7 +537,7 @@ namespace MediaBrowser.Model.Entities
             get
             {
                 // In some cases AverageFrameRate for videos will be read as 1000fps even if it is not.
-                // This is probably due to a library compatability issue.
+                // This is probably due to a library compatibility issue.
                 // See https://github.com/jellyfin/jellyfin/pull/12603#discussion_r1748044018 for more info.
                 return AverageFrameRate < 1000 ? AverageFrameRate : RealFrameRate;
             }

--- a/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonDelimitedArrayConverter.cs
@@ -52,7 +52,7 @@ namespace Jellyfin.Extensions.Json.Converters
                     }
                     catch (FormatException)
                     {
-                        // Ignore unconvertable inputs
+                        // Ignore unconvertible inputs
                     }
                 }
 


### PR DESCRIPTION
Found via `codespell -q 3 -D ../../dictionary.txt -S "./Emby.Server.Implementations/Localization" -L allready,childrens,groupe,inh,raisons,re-use,som,supercede,superceded,thirdparty,whoknows`

**Changes**
Followup to ab124bec886d90ae46c08d47922e3f080f9bd217

**Issues**
n/a


Question: there is a typo in source (not included in this PR) here:  
https://github.com/jellyfin/jellyfin/blob/0541808c256a75676909f5e6c182a9d9da12abcc/MediaBrowser.Controller/Entities/Audio/IHasAlbumArtist.cs#L25

Is this something you consider worthy of correcting (to 'Extensions') 