### PR TITLE
Fallback to URL extension for image type when content header is invalid

### DIFF
--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -548,13 +548,26 @@ namespace MediaBrowser.Providers.Manager
                         break;
                     }
 
+                    var contentType = response.Content.Headers.ContentType?.MediaType;
+
+                    if (!contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                    {
+                    contentType = MimeTypes.GetMimeType(new Uri(url).GetLeftPart(UriPartial.Path));
+
+                    if (!contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogWarning("Unable to determine content type for {Url}. Defaulting to jpeg", url);
+                        contentType = "image/jpeg";
+                    }
+                    }
+
                     var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                     await using (stream.ConfigureAwait(false))
                     {
                         await _providerManager.SaveImage(
                             item,
                             stream,
-                            response.Content.Headers.ContentType?.MediaType,
+                            contentType,
                             type,
                             null,
                             cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR modifies the `DownloadImage` method in` ItemImageProvider` to handle cases where the image's content header does not indicate a valid image type. In these cases, the extension of the image URL is used to infer the content type. If the content type still cannot be determined by either the content header or the URL extension, it defaults to `image/jpeg`. This ensures that images are correctly downloaded with the appropriate extension and prevents them from being mistakenly downloaded as binary files.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->#12593
