### PR TITLE
chore(ci): Add permissions grant

### DIFF
--- a/.github/workflows/ci-codeql-analysis.yml
+++ b/.github/workflows/ci-codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '24 2 * * 4'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
**Changes**
Add permissions grant to ci-codeql-analysis.yml

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Without this fix, repositories/organizations that are configured to with restrictive permissions (and all repositories/orgs should be) fail like this:
https://github.com/jsoref/jellyfin/actions/runs/12976527234