### PR TITLE
Fix spelling

### DIFF
--- a/Emby.Naming/TV/SeriesResolver.cs
+++ b/Emby.Naming/TV/SeriesResolver.cs
@@ -12,7 +12,7 @@ namespace Emby.Naming.TV
         /// <summary>
         /// Regex that matches strings of at least 2 characters separated by a dot or underscore.
         /// Used for removing separators between words, i.e turns "The_show" into "The show" while
-        /// preserving namings like "S.H.O.W".
+        /// preserving names like "S.H.O.W".
         /// </summary>
         [GeneratedRegex(@"((?<a>[^\._]{2,})[\._]*)|([\._](?<b>[^\._]{2,}))")]
         private static partial Regex SeriesNameRegex();

--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -238,7 +238,7 @@ public class AudioController : BaseJellyfinApiController
     /// <param name="maxVideoBitDepth">Optional. The maximum video bit depth.</param>
     /// <param name="requireAvc">Optional. Whether to require avc.</param>
     /// <param name="deInterlace">Optional. Whether to deinterlace the video.</param>
-    /// <param name="requireNonAnamorphic">Optional. Whether to require a non anamporphic stream.</param>
+    /// <param name="requireNonAnamorphic">Optional. Whether to require a non anamorphic stream.</param>
     /// <param name="transcodingMaxAudioChannels">Optional. The maximum number of audio channels to transcode.</param>
     /// <param name="cpuCoreLimit">Optional. The limit of how many cpu cores to use.</param>
     /// <param name="liveStreamId">The live stream id.</param>

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -210,7 +210,7 @@ public static class StreamingHelpers
                     && state.VideoRequest.VideoBitRate.Value >= state.VideoStream.BitRate.Value)
                 {
                     // Don't downscale the resolution if the width/height/MaxWidth/MaxHeight is not requested,
-                    // and the requested video bitrate is higher than source video bitrate.
+                    // and the requested video bitrate is greater than source video bitrate.
                     if (state.VideoStream.Width.HasValue || state.VideoStream.Height.HasValue)
                     {
                         state.VideoRequest.MaxWidth = state.VideoStream?.Width;

--- a/Jellyfin.Data/Entities/BaseItemMetadataField.cs
+++ b/Jellyfin.Data/Entities/BaseItemMetadataField.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.Data.Entities;
 public class BaseItemMetadataField
 {
     /// <summary>
-    /// Gets or Sets Numerical ID of this enumeratable.
+    /// Gets or Sets Numerical ID of this enumerable.
     /// </summary>
     public required int Id { get; set; }
 

--- a/Jellyfin.Data/Entities/BaseItemTrailerType.cs
+++ b/Jellyfin.Data/Entities/BaseItemTrailerType.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.Data.Entities;
 public class BaseItemTrailerType
 {
     /// <summary>
-    /// Gets or Sets Numerical ID of this enumeratable.
+    /// Gets or Sets Numerical ID of this enumerable.
     /// </summary>
     public required int Id { get; set; }
 

--- a/Jellyfin.Data/Entities/ItemValue.cs
+++ b/Jellyfin.Data/Entities/ItemValue.cs
@@ -24,7 +24,7 @@ public class ItemValue
     public required string Value { get; set; }
 
     /// <summary>
-    /// Gets or Sets the sanatised Value.
+    /// Gets or Sets the sanitized Value.
     /// </summary>
     public required string CleanValue { get; set; }
 

--- a/Jellyfin.Data/Entities/PeopleBaseItemMap.cs
+++ b/Jellyfin.Data/Entities/PeopleBaseItemMap.cs
@@ -18,7 +18,7 @@ public class PeopleBaseItemMap
     public int? ListOrder { get; set; }
 
     /// <summary>
-    /// Gets or Sets the Role name the assosiated actor played in the <see cref="BaseItemEntity"/>.
+    /// Gets or Sets the Role name the associated actor played in the <see cref="BaseItemEntity"/>.
     /// </summary>
     public string? Role { get; set; }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -231,7 +231,7 @@ public sealed class BaseItemRepository
         }
 
         dbQuery = ApplyGroupingFilter(dbQuery, filter);
-        dbQuery = ApplyQueryPageing(dbQuery, filter);
+        dbQuery = ApplyQueryPaging(dbQuery, filter);
 
         result.Items = dbQuery.AsEnumerable().Where(e => e is not null).Select(w => DeserialiseBaseItem(w, filter.SkipDeserialization)).ToArray();
         result.StartIndex = filter.StartIndex ?? 0;
@@ -250,7 +250,7 @@ public sealed class BaseItemRepository
         dbQuery = TranslateQuery(dbQuery, context, filter);
 
         dbQuery = ApplyGroupingFilter(dbQuery, filter);
-        dbQuery = ApplyQueryPageing(dbQuery, filter);
+        dbQuery = ApplyQueryPaging(dbQuery, filter);
 
         return dbQuery.AsEnumerable().Where(e => e is not null).Select(w => DeserialiseBaseItem(w, filter.SkipDeserialization)).ToArray();
     }
@@ -289,7 +289,7 @@ public sealed class BaseItemRepository
         return dbQuery;
     }
 
-    private IQueryable<BaseItemEntity> ApplyQueryPageing(IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
+    private IQueryable<BaseItemEntity> ApplyQueryPaging(IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
     {
         if (filter.Limit.HasValue || filter.StartIndex.HasValue)
         {
@@ -314,7 +314,7 @@ public sealed class BaseItemRepository
         dbQuery = TranslateQuery(dbQuery, context, filter);
         dbQuery = ApplyOrder(dbQuery, filter);
         dbQuery = ApplyGroupingFilter(dbQuery, filter);
-        dbQuery = ApplyQueryPageing(dbQuery, filter);
+        dbQuery = ApplyQueryPaging(dbQuery, filter);
         return dbQuery;
     }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -357,7 +357,7 @@ public sealed class BaseItemRepository
     {
         ArgumentException.ThrowIfNullOrEmpty(typeName);
 
-        // TODO: this isn't great. Refactor later to be both globally handled by a dedicated service not just an static variable and be loaded eagar.
+        // TODO: this isn't great. Refactor later to be both globally handled by a dedicated service not just an static variable and be loaded eagerly.
         // currently this is done so that plugins may introduce their own type of baseitems as we dont know when we are first called, before or after plugins are loaded
         return _typeMap.GetOrAdd(typeName, k => AppDomain.CurrentDomain.GetAssemblies()
             .Select(a => a.GetType(k))

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2197,7 +2197,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var videoFrameRate = videoStream.ReferenceFrameRate;
 
                 // Add a little tolerance to the framerate check because some videos might record a framerate
-                // that is slightly higher than the intended framerate, but the device can still play it correctly.
+                // that is slightly greater than the intended framerate, but the device can still play it correctly.
                 // 0.05 fps tolerance should be safe enough.
                 if (!videoFrameRate.HasValue || videoFrameRate.Value > requestedFramerate.Value + 0.05f)
                 {

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -324,7 +324,7 @@ namespace MediaBrowser.Controller.Session
         Task<SessionInfo> GetSessionByAuthenticationToken(Device info, string deviceId, string remoteEndpoint, string appVersion);
 
         /// <summary>
-        /// Logouts the specified access token.
+        /// Logs out the specified access token.
         /// </summary>
         /// <param name="accessToken">The access token.</param>
         /// <returns>A <see cref="Task"/> representing the log out process.</returns>

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -286,7 +286,7 @@ namespace MediaBrowser.Controller.Session
         /// <summary>
         /// Gets or sets the playlist item id.
         /// </summary>
-        /// <value>The splaylist item id.</value>
+        /// <value>The playlist item id.</value>
         public string PlaylistItemId { get; set; }
 
         /// <summary>

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -96,7 +96,7 @@ namespace MediaBrowser.LocalMetadata.Savers
             var directory = Path.GetDirectoryName(path) ?? throw new InvalidDataException($"Provided path ({path}) is not valid.");
             Directory.CreateDirectory(directory);
 
-            // On Windows, savint the file will fail if the file is hidden or readonly
+            // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
 
             var fileStreamOptions = new FileStreamOptions()

--- a/MediaBrowser.Model/Dto/SessionInfoDto.cs
+++ b/MediaBrowser.Model/Dto/SessionInfoDto.cs
@@ -163,7 +163,7 @@ public class SessionInfoDto
     /// <summary>
     /// Gets or sets the playlist item id.
     /// </summary>
-    /// <value>The splaylist item id.</value>
+    /// <value>The playlist item id.</value>
     public string? PlaylistItemId { get; set; }
 
     /// <summary>

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -634,7 +634,7 @@ namespace MediaBrowser.Providers.MediaInfo
         {
             var runtime = video.RunTimeTicks.GetValueOrDefault();
 
-            // Only process files with a runtime higher than 0 and lower than 12h. The latter are likely corrupted.
+            // Only process files with a runtime greater than 0 and less than 12h. The latter are likely corrupted.
             if (runtime < 0 || runtime > TimeSpan.FromHours(12).Ticks)
             {
                 throw new ArgumentException(

--- a/src/Jellyfin.Drawing.Skia/SplashscreenBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/SplashscreenBuilder.cs
@@ -12,7 +12,7 @@ public class SplashscreenBuilder
 {
     private const int FinalWidth = 1920;
     private const int FinalHeight = 1080;
-    // generated collage resolution should be higher than the final resolution
+    // generated collage resolution should be greater than the final resolution
     private const int WallWidth = FinalWidth * 3;
     private const int WallHeight = FinalHeight * 2;
     private const int Rows = 6;

--- a/src/Jellyfin.LiveTv/Listings/SchedulesDirectDtos/LineupDto.cs
+++ b/src/Jellyfin.LiveTv/Listings/SchedulesDirectDtos/LineupDto.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.LiveTv.Listings.SchedulesDirectDtos
     public class LineupDto
     {
         /// <summary>
-        /// Gets or sets the linup.
+        /// Gets or sets the lineup.
         /// </summary>
         [JsonPropertyName("lineup")]
         public string? Lineup { get; set; }

--- a/src/Jellyfin.LiveTv/Listings/SchedulesDirectDtos/MetadataDto.cs
+++ b/src/Jellyfin.LiveTv/Listings/SchedulesDirectDtos/MetadataDto.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.LiveTv.Listings.SchedulesDirectDtos
     public class MetadataDto
     {
         /// <summary>
-        /// Gets or sets the linup.
+        /// Gets or sets the lineup.
         /// </summary>
         [JsonPropertyName("lineup")]
         public string? Lineup { get; set; }

--- a/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
@@ -93,7 +93,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                 }
                 else if (!string.IsNullOrWhiteSpace(extInf) && !trimmedLine.StartsWith('#'))
                 {
-                    var channel = GetChannelnfo(extInf, tunerHostId, trimmedLine);
+                    var channel = GetChannelInfo(extInf, tunerHostId, trimmedLine);
                     channel.Id = channelIdPrefix + trimmedLine.GetMD5().ToString("N", CultureInfo.InvariantCulture);
 
                     channel.Path = trimmedLine;
@@ -106,7 +106,7 @@ namespace Jellyfin.LiveTv.TunerHosts
             return channels;
         }
 
-        private ChannelInfo GetChannelnfo(string extInf, string tunerHostId, string mediaUrl)
+        private ChannelInfo GetChannelInfo(string extInf, string tunerHostId, string mediaUrl)
         {
             var channel = new ChannelInfo()
             {


### PR DESCRIPTION
**Changes**
Fixes misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/jellyfin/actions/runs/12979401882#summary-36195047679

The action will report that the changes in this PR would make it happy: https://github.com/jsoref/jellyfin/actions/runs/12979402012#summary-36195047936 -- Note that there are a number of tests that appear to be consistently failing. In order to get CI not not fail miserably, I included 0c236225278edacc5f9c93467d628ced8a960660 in my test PR (but they aren't included in this PR).

---

As before, if people are happy with the changes, I'll squash them.

There's one change that I omitted which was `BluRay` to `Bluray` (for everything except file names) because that upset the API checker. Ignoring files with `BluRay` in their names, there's an exactly equal number of `BluRay` and `Bluray`, I looked around and checked with people and do believe that the latter would be more correct (although it'd obviously require adding a new set of APIs and deprecating the old ones). If people are interested, I'm happy to make a PR for that separately.