### PR TITLE
chore(ci): Let CI fail independently on each platform

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+      fail-fast: false
 
     runs-on: "${{ matrix.os }}"
     steps:


### PR DESCRIPTION
**Changes**
Let each platform's CI run to completion (or failure) independently.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- This makes it easier to see that multiple platforms are unhappy in #13445 