### PR TITLE
Fix transcoding if audio is unsupported

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1367,7 +1367,7 @@ namespace MediaBrowser.Model.Dlna
                         failureReasons |= audioCodecProfileReasons;
                     }
 
-                    var directStreamFailureReasons = failureReasons & (~DirectStreamReasons);
+                    var directStreamFailureReasons = failureReasons & ~DirectStreamReasons;
 
                     PlayMethod? playMethod = null;
                     if (failureReasons == 0 && isEligibleForDirectPlay && mediaSource.SupportsDirectPlay)

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1367,7 +1367,7 @@ namespace MediaBrowser.Model.Dlna
                         failureReasons |= audioCodecProfileReasons;
                     }
 
-                    var directStreamFailureReasons = failureReasons & ~DirectStreamReasons;
+                    var directStreamFailureReasons = failureReasons & DirectStreamReasons;
 
                     PlayMethod? playMethod = null;
                     if (failureReasons == 0 && isEligibleForDirectPlay && mediaSource.SupportsDirectPlay)


### PR DESCRIPTION
**Changes**
When using DLNA to play a video on another device that doesn't support the audio stream of that video, Jellyfin doesn't transcode it (typical log message: `PlayMethod=DirectStream, TranscodeReason=ContainerNotSupported, AudioCodecNotSupported`). The line responsible for filtering direct stream issues *excludes* these reasons rather than making them *exclusive*.

Changing the negated bitwise-anding to a regular one fixes this problem. I could verify that the correct audio stream was then provided to my DLNA renderer and that playback via Jellyfin web was still functioning as expected (without the need for transcoding).

**Issues**
https://github.com/jellyfin/jellyfin-plugin-dlna/issues/23

Please correct me if this change would have unwanted consequences.