### PR TITLE
Don't allow library name with leading or trailing space

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -81,6 +82,12 @@ public class LibraryStructureController : BaseJellyfinApiController
         [FromBody] AddVirtualFolderDto? libraryOptionsDto,
         [FromQuery] bool refreshLibrary = false)
     {
+        // Windows does not allow files or folders with names that has leading or trailing spaces
+        if (name.Length != name.Trim().Length)
+        {
+            return BadRequest();
+        }
+
         var libraryOptions = libraryOptionsDto?.LibraryOptions ?? new LibraryOptions();
 
         if (paths is not null && paths.Length > 0)

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -75,18 +75,14 @@ public class LibraryStructureController : BaseJellyfinApiController
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> AddVirtualFolder(
-        [FromQuery] string name,
+        [FromQuery]
+        [RegularExpression(@"^(?:\S(?:.*\S)?)$", ErrorMessage = "Library name cannot be empty or have leading/trailing spaces.")]
+        string name,
         [FromQuery] CollectionTypeOptions? collectionType,
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] paths,
         [FromBody] AddVirtualFolderDto? libraryOptionsDto,
         [FromQuery] bool refreshLibrary = false)
     {
-        // Windows does not allow files or folders with names that has leading or trailing spaces
-        if (name.Length != name.Trim().Length)
-        {
-            return BadRequest();
-        }
-
         var libraryOptions = libraryOptionsDto?.LibraryOptions ?? new LibraryOptions();
 
         if (paths is not null && paths.Length > 0)


### PR DESCRIPTION
Windows has a specific requirement on filenames that cannot have leading or trailing spaces and the folder creation would fail. Reject such request in the api controller.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13429
