### PR TITLE
Fix LiveTV Guide Backdrop image not updating

### DIFF
--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -679,7 +679,9 @@ public class GuideManager : IGuideManager
         updated |= UpdateImage(ImageType.Logo, item, info);
 
         // Backdrop
-        return updated || UpdateImage(ImageType.Backdrop, item, info);
+        updated |= UpdateImage(ImageType.Backdrop, item, info);
+
+        return updated;
     }
 
     private static bool UpdateImage(ImageType imageType, BaseItem item, ProgramInfo info)


### PR DESCRIPTION
If the guide data changes any other image, the Backdrop image would not be updated.

This error was unintentionally introduced in PR https://github.com/jellyfin/jellyfin/pull/13227 [here](https://github.com/jellyfin/jellyfin/pull/13227/files#diff-68cbfbf495bc9462524e5e837822194c426c5008491dfccdbc8773ef784aea50R682)

## Changes
Replace the short-circuiting || operator with a normal | OR operator to ensure that the call for UpdateImage for the Backdrop image still happens even if other images were also updated.

```csharp
// Backdrop
return updated || UpdateImage(ImageType.Backdrop, item, info);
```
## Issues
Fixes https://github.com/jellyfin/jellyfin/issues/13496






