### PR TITLE
Order MediaStream query by StreamIndex

### DIFF
--- a/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
@@ -88,7 +88,7 @@ public class MediaStreamRepository : IMediaStreamRepository
             query = query.Where(e => e.StreamType == typeValue);
         }
 
-        return query;
+        return query.OrderBy(e => e.StreamIndex);
     }
 
     private MediaStream Map(MediaStreamInfo entity)


### PR DESCRIPTION
Our stream index calculation logic implemented in #7529, assumes an in-order array. However, our current query may return out-of-order items, leading the server to pass an incorrect index to ffmpeg, causing the transcoding to crash.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13505
