### PR TITLE
Fix Search results are case-sensitive for people

### DIFF
--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -155,7 +155,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!string.IsNullOrWhiteSpace(filter.NameContains))
         {
-            query = query.Where(e => EF.Functions.Like(e.Name, $"%{filter.NameContains}%"));
+            query = query.Where(e => e.Name.ToUpper().Contains(filter.NameContains.ToUpper()));
         }
 
         return query;

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -155,7 +155,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!string.IsNullOrWhiteSpace(filter.NameContains))
         {
-            query = query.Where(e => e.Name.Contains(filter.NameContains));
+            query = query.Where(e => EF.Functions.Like(e.Name, $"%{filter.NameContains}%"));
         }
 
         return query;

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -158,7 +158,8 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!string.IsNullOrWhiteSpace(filter.NameContains))
         {
-            query = query.Where(e => e.Name.ToUpper().Contains(filter.NameContains.ToUpper()));
+            var nameContainsUpper = filter.NameContains.ToUpper();
+            query = query.Where(e => e.Name.ToUpper().Contains(nameContainsUpper));
         }
 
         return query;

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -11,6 +11,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Jellyfin.Server.Implementations.Item;
 #pragma warning disable RS0030 // Do not use banned APIs
+#pragma warning disable CA1304 // Specify CultureInfo
+#pragma warning disable CA1311 // Specify a culture or use an invariant version
+#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 
 /// <summary>
 /// Manager for handling people.


### PR DESCRIPTION
The search for people is currently case-sensitive (#13510).

**Changes**
The SQL query has been modified to make the search case-insensitive.

**Issues**
Fixes #13510 
