### PR TITLE
Removed unneccessary array creation

### DIFF
--- a/MediaBrowser.Api/Library/LibraryService.cs
+++ b/MediaBrowser.Api/Library/LibraryService.cs
@@ -425,16 +425,17 @@ namespace MediaBrowser.Api.Library
                        || string.Equals(name, "Image Extractor", StringComparison.OrdinalIgnoreCase);
             }
 
-            var metadataOptions = ServerConfigurationManager.Configuration.MetadataOptions
-                .Where(i => string.Equals(i.ItemType, type, StringComparison.OrdinalIgnoreCase))
-                .ToArray();
+            foreach (var metadataOption in ServerConfigurationManager.Configuration.MetadataOptions) {
+                if(!string.Equals(metadataOption.ItemType, type, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
 
-            if (metadataOptions.Length == 0)
-            {
-                return true;
+                if(!i.DisabledImageFetchers.Contains(name, StringComparer.OrdinalIgnoreCase)) {
+                    return true;
+                }
             }
 
-            return metadataOptions.Any(i => !i.DisabledImageFetchers.Contains(name, StringComparer.OrdinalIgnoreCase));
+            return false;
         }
 
         public object Get(GetLibraryOptionsInfo request)


### PR DESCRIPTION
**Changes**
1. Removed unnecessary array creation after `Where()`.
2. Replaced LINQ usage with a `foreach` loop as to avoid allocating a new `IEnumerable` instance.

**Issues**
Related to #1269
