### PR TITLE
Fix IsInMixedFolder not being set for Extras

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2721,9 +2721,11 @@ namespace Emby.Server.Implementations.Library
                 if (current.IsDirectory && _namingOptions.AllExtrasTypesFolderNames.ContainsKey(current.Name))
                 {
                     var filesInSubFolder = _fileSystem.GetFiles(current.FullName, null, false, false);
-                    bool subFolderIsMixedFolder = filesInSubFolder.Count() > 1;
+                    var filesInSubFolderList = filesInSubFolder.ToList();
 
-                    foreach (var file in filesInSubFolder)
+                    bool subFolderIsMixedFolder = filesInSubFolderList.Count > 1;
+
+                    foreach (var file in filesInSubFolderList)
                     {
                         if (!_extraResolver.TryGetExtraTypeForOwner(file.FullName, ownerVideoInfo, out var extraType))
                         {


### PR DESCRIPTION
**Changes**
Changed FindExtras() and GetExtra() to identify if there are more than one file in the directory. If this is the case, the files will receive "IsInMixedFolder=true" to avoid issues for subsequent steps like deleting a single Extra.

**Issues**
#13250 
