### PR TITLE
Simulate old GetItemValueNames behavior

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -854,7 +854,10 @@ public sealed class BaseItemRepository
         }
 
         // query = query.DistinctBy(e => e.CleanValue);
-        return query.Select(e => e.ItemValue.CleanValue).ToArray();
+        return query.Select(e => e.ItemValue)
+            .GroupBy(e => e.CleanValue)
+            .Select(e => e.First().Value)
+            .ToArray();
     }
 
     private static bool TypeRequiresDeserialization(Type type)


### PR DESCRIPTION
The GetItemValueNames function in the old implementation was intended to retrieve the original value rather than the cleaned value. The old implementation lacked a clear specification regarding which value to return for the non-cleaned value in a group and relied on an undefined behavior of SQLite, and this implementation assumes the first one is the desired one.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13538 