### PR TITLE
Write only for query columns to EFCore db

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -689,6 +689,7 @@ public sealed class BaseItemRepository
         entity.IndexNumber = dto.IndexNumber;
         entity.IsLocked = dto.IsLocked;
         entity.Name = dto.Name;
+        entity.CleanName = GetCleanValue(dto.Name);
         entity.OfficialRating = dto.OfficialRating;
         entity.Overview = dto.Overview;
         entity.ParentIndexNumber = dto.ParentIndexNumber;
@@ -820,6 +821,8 @@ public sealed class BaseItemRepository
         {
             entity.StartDate = hasStartDate.StartDate;
         }
+
+        entity.UnratedType = dto.GetBlockUnratedType().ToString();
 
         // Fields that are present in the DB but are never actually used
         // dto.UnratedType = entity.UnratedType;

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -825,9 +825,6 @@ public sealed class BaseItemRepository
         entity.UnratedType = dto.GetBlockUnratedType().ToString();
 
         // Fields that are present in the DB but are never actually used
-        // dto.UnratedType = entity.UnratedType;
-        // dto.TopParentId = entity.TopParentId;
-        // dto.CleanName = entity.CleanName;
         // dto.UserDataKey = entity.UserDataKey;
 
         if (dto is Folder folder)


### PR DESCRIPTION
We currently don't write the columns that do not exist on the BaseItem class definition in db. However, columns like `CleanName` is still useful and being used by internal queries and current behavior would cause such query to return nothing.

The only exception is the UserDataKey which is not even being used for internal query that can be omitted.

Alternatively we can dynamically compute those columns use the correcponsfing method every time during query so that we don't need those columns to be written. I'm not sure which approach is better, but for this PR I choose to match the old behavior.
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13541
