### PR TITLE
Don't rewrite unchanged NFO files

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,6 +83,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageVersion Include="System.Globalization" Version="4.3.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.2" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.10" />
     <PackageVersion Include="System.Text.Json" Version="9.0.10" />

--- a/MediaBrowser.XbmcMetadata/MediaBrowser.XbmcMetadata.csproj
+++ b/MediaBrowser.XbmcMetadata/MediaBrowser.XbmcMetadata.csproj
@@ -20,6 +20,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" />
+  </ItemGroup>
+
   <!-- Code Analyzers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="IDisposableAnalyzers">
@@ -34,5 +38,4 @@
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" PrivateAssets="All" />
   </ItemGroup>
-
 </Project>

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -197,14 +198,31 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await SaveToFileAsync(memoryStream, path).ConfigureAwait(false);
+                await SaveToFileAsync(memoryStream, path, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task SaveToFileAsync(Stream stream, string path)
+        private async Task SaveToFileAsync(Stream stream, string path, CancellationToken cancellationToken)
         {
             var directory = Path.GetDirectoryName(path) ?? throw new ArgumentException($"Provided path ({path}) is not valid.", nameof(path));
             Directory.CreateDirectory(directory);
+
+            // Compare metadata hashes before proceeding
+            if (File.Exists(path))
+            {
+                byte[] existingFileHash;
+                using (var existingFileStream = File.OpenRead(path))
+                {
+                    existingFileHash = await ComputeHash(existingFileStream, cancellationToken).ConfigureAwait(false);
+                }
+
+                byte[] newContentHash = await ComputeHash(stream, cancellationToken).ConfigureAwait(false);
+
+                if (existingFileHash.SequenceEqual(newContentHash))
+                {
+                    return; // Don't save since .nfo is unchanged
+                }
+            }
 
             // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
@@ -221,13 +239,25 @@ namespace MediaBrowser.XbmcMetadata.Savers
             var filestream = new FileStream(path, fileStreamOptions);
             await using (filestream.ConfigureAwait(false))
             {
-                await stream.CopyToAsync(filestream).ConfigureAwait(false);
+                await stream.CopyToAsync(filestream, cancellationToken).ConfigureAwait(false);
             }
 
             if (ConfigurationManager.Configuration.SaveMetadataHidden)
             {
                 SetHidden(path, true);
             }
+        }
+
+        private static async Task<byte[]> ComputeHash(Stream stream, CancellationToken cancellationToken)
+        {
+            byte[] hash;
+            using (SHA256 hasher = SHA256.Create())
+            {
+                hash = await hasher.ComputeHashAsync(stream, cancellationToken).ConfigureAwait(false);
+                stream.Position = 0;    // reseek to the stream beginning for the upcoming save
+            }
+
+            return hash;
         }
 
         private void SetHidden(string path, bool hidden)

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Hashing;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -250,14 +251,12 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private static async Task<byte[]> ComputeHash(Stream stream, CancellationToken cancellationToken)
         {
-            byte[] hash;
-            using (SHA256 hasher = SHA256.Create())
-            {
-                hash = await hasher.ComputeHashAsync(stream, cancellationToken).ConfigureAwait(false);
-                stream.Position = 0;    // reseek to the stream beginning for the upcoming save
-            }
+            stream.Position = 0;
+            var hasher = new XxHash3();
+            await hasher.AppendAsync(stream, cancellationToken).ConfigureAwait(false);
+            stream.Position = 0;
 
-            return hash;
+            return hasher.GetCurrentHash();
         }
 
         private void SetHidden(string path, bool hidden)


### PR DESCRIPTION
When computing the NFO contents, we will rewrite the file even if everything is unchanged. This causes the file updated time to change and increases load on the filesystem (and underlying drives).

Add `ComputeHash` to compute the  _XxHash3_ hash of the file-on-disk and the stream we've just created and if the same just returns.

Also now passes the `cancellationToken` down to the stream copy so we abort faster if cancelled.

Fixes #12978
