### PR TITLE
Change BaseItemEntity ChannelId to nullable Guid

### DIFF
--- a/Jellyfin.Data/Entities/BaseItemEntity.cs
+++ b/Jellyfin.Data/Entities/BaseItemEntity.cs
@@ -22,7 +22,7 @@ public class BaseItemEntity
 
     public DateTime? EndDate { get; set; }
 
-    public string? ChannelId { get; set; }
+    public Guid? ChannelId { get; set; }
 
     public bool IsMovie { get; set; }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -553,7 +553,7 @@ public sealed class BaseItemRepository
         dto.Genres = entity.Genres?.Split('|') ?? [];
         dto.DateCreated = entity.DateCreated.GetValueOrDefault();
         dto.DateModified = entity.DateModified.GetValueOrDefault();
-        dto.ChannelId = string.IsNullOrWhiteSpace(entity.ChannelId) ? Guid.Empty : (Guid.TryParse(entity.ChannelId, out var channelId) ? channelId : Guid.Empty);
+        dto.ChannelId = entity.ChannelId ?? Guid.Empty;
         dto.DateLastRefreshed = entity.DateLastRefreshed.GetValueOrDefault();
         dto.DateLastSaved = entity.DateLastSaved.GetValueOrDefault();
         dto.OwnerId = string.IsNullOrWhiteSpace(entity.OwnerId) ? Guid.Empty : (Guid.TryParse(entity.OwnerId, out var ownerId) ? ownerId : Guid.Empty);
@@ -716,7 +716,7 @@ public sealed class BaseItemRepository
         entity.Genres = string.Join('|', dto.Genres);
         entity.DateCreated = dto.DateCreated;
         entity.DateModified = dto.DateModified;
-        entity.ChannelId = dto.ChannelId.ToString();
+        entity.ChannelId = dto.ChannelId;
         entity.DateLastRefreshed = dto.DateLastRefreshed;
         entity.DateLastSaved = dto.DateLastSaved;
         entity.OwnerId = dto.OwnerId.ToString();
@@ -1451,8 +1451,7 @@ public sealed class BaseItemRepository
 
         if (filter.ChannelIds.Count > 0)
         {
-            var channelIds = filter.ChannelIds.Select(e => e.ToString("N", CultureInfo.InvariantCulture)).ToArray();
-            baseQuery = baseQuery.Where(e => channelIds.Contains(e.ChannelId));
+            baseQuery = baseQuery.Where(e => e.ChannelId != null && filter.ChannelIds.Contains(e.ChannelId.Value));
         }
 
         if (!filter.ParentId.IsEmpty())

--- a/Jellyfin.Server.Implementations/Migrations/20250214031148_ChannelIdGuid.Designer.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20250214031148_ChannelIdGuid.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Server.Implementations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Server.Implementations.Migrations
 {
     [DbContext(typeof(JellyfinDbContext))]
-    partial class JellyfinDbModelSnapshot : ModelSnapshot
+    [Migration("20250214031148_ChannelIdGuid")]
+    partial class ChannelIdGuid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/Jellyfin.Server.Implementations/Migrations/20250214031148_ChannelIdGuid.cs
+++ b/Jellyfin.Server.Implementations/Migrations/20250214031148_ChannelIdGuid.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Server.Implementations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChannelIdGuid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // NOOP, Guids and strings are stored the same in SQLite.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // NOOP, Guids and strings are stored the same in SQLite.
+        }
+    }
+}

--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -678,7 +678,7 @@ public class MigrateLibraryDb : IMigrationRoutine
             entity.EndDate = endDate;
         }
 
-        if (reader.TryGetString(index++, out var guid))
+        if (reader.TryGetGuid(index++, out var guid))
         {
             entity.ChannelId = guid;
         }


### PR DESCRIPTION
Part of https://github.com/jellyfin/jellyfin/issues/13047
Fixes: https://github.com/jellyfin/jellyfin/issues/13164

BaseItem.ChannelId has been a Guid since Jellyfin's inception, should be safe to change the db model to reflect that.