### PR TITLE
Patch for WebOS issue 248 (Hanging on DV files)

### DIFF
--- a/MediaBrowser.Controller/Streaming/StreamState.cs
+++ b/MediaBrowser.Controller/Streaming/StreamState.cs
@@ -93,6 +93,12 @@ public class StreamState : EncodingJobInfo, IDisposable
                     return 6;
                 }
 
+                //Prevent freezes on WebOS when skipping ahead during Dolby Vision playback. Issue 248 jellyfin/jellyfin-webos.
+                if (userAgent.Contains("Web0S", StringComparison.OrdinalIgnoreCase))
+                {
+                      return 1;
+                }
+
                 if (IsSegmentedLiveStream)
                 {
                     return 3;


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The change aims to only impact the WebOS client by limiting segment length to 1 instead of 6. The author, fhelland,  described the issue it fixes as this:

“Using a shorter hls_time value of 1 second ensures that the playlist generated by FFmpeg matches the one created ahead of playback. When playback on Jellyfin WebOS reached a mismatched segment, playback would stop."

Multiple users have tested this change with success, most are now running their own custom build with it added in. Credit to @fhelland for the investigation and reasoning. This will help to prevent an extremely frustrating issue, at least until a better alternative is found.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
https://github.com/jellyfin/jellyfin-webos/issues/248