### PR TITLE
Add リア;クオ or lia;quo to artist split whitelist

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -53,6 +53,8 @@ namespace MediaBrowser.MediaEncoding.Probing
             "DJ'TEKINA//SOMETHING",
             "IX/ON",
             "J-CORE SLi//CER",
+            "lia;quo",
+            "リア;クオ",
             "M(a/u)SH",
             "Kaoru/Brilliance",
             "signum/ii",


### PR DESCRIPTION
**Changes**
Adds another artist ([リア;クオ or lia;quo](https://www.youtube.com/watch?v=bfOOkjcKlw4)) to the artist split whitelist.

**Issues**
Related to #9636