### PR TITLE
Prevent Duplicate Persons when Searching

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2780,6 +2780,7 @@ namespace Emby.Server.Implementations.Library
             })
             .Where(i => i is not null)
             .Where(i => query.User is null || i!.IsVisible(query.User))
+            .DistinctBy(i => i!.Id)
             .ToList()!; // null values are filtered out
         }
 


### PR DESCRIPTION
**Changes**
Use DistinctBy with IDs when displaying persons after searching.

**Issues**
#13508
