### PR TITLE
Disallow incremental updates to JellyfinDbModelSnapshot

### DIFF
--- a/Jellyfin.Server.Implementations/Migrations/.gitattributes
+++ b/Jellyfin.Server.Implementations/Migrations/.gitattributes
@@ -1,0 +1,1 @@
+JellyfinDbModelSnapshot.cs binary


### PR DESCRIPTION
From https://jkdev.me/handling-ef-core-migrations/

This disallows incremental updates in git, so developers will be forced to fully regenerate the migration if upstream has changed