### PR TITLE
Fix 4K filtering when grouping movies into collections

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1200,6 +1200,11 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
+            if (request.Is4K.HasValue)
+            {
+                return false;
+            }
+
             if (request.IsHD.HasValue)
             {
                 return false;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. --> 
Filtering 4K does not work when Group Movies into Collections is enabled because the box set needs to be collapsed. This change adds a check for the `Is4K` property to ensure that 4K filtering functions correctly when collections are enabled in a library.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> Reported in comments: 
https://github.com/jellyfin/jellyfin/issues/13413#issuecomment-2611456177
