### PR TITLE
Fix overwrite of PremierDate with a year-only value

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1010,7 +1010,7 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            if (replaceData || !target.PremiereDate.HasValue)
+            if (replaceData || !target.PremiereDate.HasValue || (IsYearOnlyDate(target.PremiereDate.Value) && source.PremiereDate.HasValue))
             {
                 target.PremiereDate = source.PremiereDate;
             }
@@ -1140,6 +1140,15 @@ namespace MediaBrowser.Providers.Manager
                     target.PreferredMetadataLanguage = source.PreferredMetadataLanguage;
                 }
             }
+        }
+
+        private static bool IsYearOnlyDate(DateTime date)
+        {
+            return date > DateTime.MinValue && date < DateTime.MaxValue
+                && date.Year > 0
+                && date.Month == 1
+                && date.Day == 1
+                && date.TimeOfDay == TimeSpan.Zero;
         }
 
         private static void MergePeople(List<PersonInfo> source, List<PersonInfo> target)

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1142,14 +1142,7 @@ namespace MediaBrowser.Providers.Manager
             }
         }
 
-        private static bool IsYearOnlyDate(DateTime date)
-        {
-            return date > DateTime.MinValue && date < DateTime.MaxValue
-                && date.Year > 0
-                && date.Month == 1
-                && date.Day == 1
-                && date.TimeOfDay == TimeSpan.Zero;
-        }
+        private static bool IsYearOnlyDate(DateTime date) => date.Month == 1 && date.Day == 1;
 
         private static void MergePeople(List<PersonInfo> source, List<PersonInfo> target)
         {

--- a/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
@@ -141,8 +141,10 @@ namespace Jellyfin.Providers.Tests.Manager
                 { "ProductionYear", 1, 2 },
                 { "CommunityRating", 1.0f, 2.0f },
                 { "CriticRating", 1.0f, 2.0f },
-                { "EndDate", DateTime.UnixEpoch, DateTime.Now },
-                { "PremiereDate", DateTime.UnixEpoch, DateTime.Now },
+                { "EndDate", DateTime.UnixEpoch, DateTime.UtcNow },
+                { "PremiereDate", DateTime.UnixEpoch, DateTime.UtcNow },
+                { "PremiereDate", new DateTime(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc), DateTime.UtcNow },
+                { "PremiereDate", new DateTime(2025, 2, 21, 0, 0, 0, DateTimeKind.Utc), DateTime.UtcNow },
                 { "Video3DFormat", Video3DFormat.HalfSideBySide, Video3DFormat.FullSideBySide }
             };
 
@@ -151,7 +153,15 @@ namespace Jellyfin.Providers.Tests.Manager
         public void MergeBaseItemData_SimpleField_ReplacesAppropriately(string propName, object oldValue, object newValue)
         {
             // Use type Movie to allow testing of Video3DFormat
-            Assert.False(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, newValue, null, false, out _));
+            if (propName.Equals("PremiereDate", StringComparison.Ordinal) && oldValue is DateTime oldDateTime)
+            {
+                bool expectReplaced = oldDateTime.Month == 1 && oldDateTime.Day == 1;
+                Assert.Equal(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, newValue, null, false, out _), expectReplaced);
+            }
+            else
+            {
+                Assert.False(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, newValue, null, false, out _));
+            }
 
             Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, newValue, null, true, out _));
             Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, null, newValue, null, false, out _));


### PR DESCRIPTION
When a update-metadata is processed and the information from one provider gives a full date (e.g. 2025-02-20) and another provider gives only the year (e.g. 2025-01-01), don't overwrite the date unless it's currently a year-only.

This comes up when (for example) The Audio DB has only the year, but MusicBrainz has a full date for the release date. With this change prefer the full date.

**Changes**
Add a test for IsYearOnlyDate, and use that in MetadataService.MergeBaseItemData to ensure we don't replace more-specific dates with less-specific ones.

**Issues**
Fixes #13596
