### PR TITLE
Delete children from cache on parent delete

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -454,6 +454,7 @@ namespace Emby.Server.Implementations.Library
             foreach (var child in children)
             {
                 _itemRepository.DeleteItem(child.Id);
+                _cache.TryRemove(child.Id, out _);
             }
 
             _cache.TryRemove(item.Id, out _);


### PR DESCRIPTION
This seems like a simple and safe (small) win.
Automatically invalidating cache entries after a while would be even better (or not having a cache at all) but such changes are too big for a point release IMO.
