### PR TITLE
Add additional language aliases for season folder paths

### DIFF
--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -21,7 +21,16 @@ namespace Emby.Naming.TV
             "staffel",
             "series",
             "сезон",
-            "stagione"
+            "stagione",
+            "kausi",
+            "säsong",
+            "seizoen",
+            "sesong",
+            "sezon",
+            "sezona",
+            "季",
+            "시즌",
+            "シーズン"
         };
 
         private static readonly char[] _splitChars = ['.', '_', ' ', '-'];


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
When looking for a season path, Jellyfin searches for the word "season" and several variations in different languages. If the word is not found in the list, duplicate season folders are created. This change adds the following variations of the word "season" to prevent the creation of duplicate folders:

    "kausi"    Finnish
    "säsong"   Swedish
    "seizoen"  Dutch
    "sesong"   Norwegian
    "sezon"    Turkish/Polish
    "sezona"   Croatian/Serbian/Slovenian
    "季"       Chinese (jì)
    "시즌"     Korean
    "シーズン" Japanese (shīzun)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 
Fixes: #12715, [Forum post](https://forum.jellyfin.org/t-duplicated-seasons)
