### PR TITLE
Fix ParentIndexNumber when no Season folders are present

### DIFF
--- a/MediaBrowser.Providers/TV/EpisodeMetadataService.cs
+++ b/MediaBrowser.Providers/TV/EpisodeMetadataService.cs
@@ -104,7 +104,8 @@ namespace MediaBrowser.Providers.TV
                 targetItem.IndexNumberEnd = sourceItem.IndexNumberEnd;
             }
 
-            if (replaceData || !targetItem.ParentIndexNumber.HasValue)
+            // Handles ParentIndexNumber = 1, which is the default in LibraryManager when no Season is present in filename
+            if (replaceData || !targetItem.ParentIndexNumber.HasValue || targetItem.ParentIndexNumber == 1)
             {
                 targetItem.ParentIndexNumber = sourceItem.ParentIndexNumber;
             }

--- a/MediaBrowser.Providers/TV/EpisodeMetadataService.cs
+++ b/MediaBrowser.Providers/TV/EpisodeMetadataService.cs
@@ -105,7 +105,7 @@ namespace MediaBrowser.Providers.TV
             }
 
             // Handles ParentIndexNumber = 1, which is the default in LibraryManager when no Season is present in filename
-            if (replaceData || !targetItem.ParentIndexNumber.HasValue || targetItem.ParentIndexNumber == 1)
+            if (replaceData || !targetItem.ParentIndexNumber.HasValue || (targetItem.ParentIndexNumber == 1 && sourceItem.ParentIndexNumber.HasValue))
             {
                 targetItem.ParentIndexNumber = sourceItem.ParentIndexNumber;
             }


### PR DESCRIPTION
**Changes**
`EpisodeService`s `MergeData` method now merges `ParentIndexNumber` returned from remote providers if it is equal to 1 (which is a fallback value specified by the `LibraryManager` [to make TMDB plugin work](https://github.com/jellyfin/jellyfin/blob/317d7a9f4f76dbd964e2649ed4b7d03d3e68ca9d/Emby.Server.Implementations/Library/LibraryManager.cs#L2631-L2636)). 

**Issues**
Fixes #13358 
