### PR TITLE
Support custom resolvers. 

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -666,6 +666,8 @@ namespace Emby.Server.Implementations
 
             _pluginManager.CreatePlugins();
 
+            Resolve<ILibraryManager>().AddScanners(GetExports<IScanner>());
+
             Resolve<ILibraryManager>().AddParts(
                 GetExports<IResolverIgnoreRule>(),
                 GetExports<IItemResolver>(),

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -222,6 +222,8 @@ namespace Emby.Server.Implementations.Library
 
         private IMultiItemResolver[] MultiItemResolvers { get; set; } = Array.Empty<IMultiItemResolver>();
 
+        private IScanner[] Scanners { get; set; } = Array.Empty<IScanner>();
+
         /// <summary>
         /// Gets or sets the comparers.
         /// </summary>
@@ -251,6 +253,16 @@ namespace Emby.Server.Implementations.Library
             IntroProviders = introProviders.ToArray();
             Comparers = itemComparers.ToArray();
             PostscanTasks = postscanTasks.ToArray();
+        }
+
+        public void AddScanners(IEnumerable<IScanner> scanners)
+        {
+            Scanners = scanners.ToArray();
+        }
+
+        public bool SupportsScanner(IScanner scanner)
+        {
+            return Scanners.Select(s => s.Enabled && s == scanner).FirstOrDefault(e => false);
         }
 
         /// <summary>

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -825,6 +825,15 @@ public class LibraryController : BaseJellyfinApiController
             .OrderBy(i => typesList.IndexOf(i.ItemType))
             .ToList();
 
+        result.MetadataResolvers = plugins
+            .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.MetadataResolver))
+            .Select(i => new LibraryOptionInfoDto
+            {
+                Name = i.Name
+            })
+            .DistinctBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         result.MetadataSavers = plugins
             .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.MetadataSaver))
             .Select(i => new LibraryOptionInfoDto
@@ -884,6 +893,16 @@ public class LibraryController : BaseJellyfinApiController
             typeOptions.Add(new LibraryTypeOptionsDto
             {
                 Type = type,
+                MetadataResolvers = plugins
+                    .Where(i => string.Equals(i.ItemType, type, StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.MetadataResolver))
+                    .Select(i => new LibraryOptionInfoDto
+                    {
+                        Name = i.Name,
+                        DefaultEnabled = false // TODO(Malik): implement IsDefault check
+                    })
+                    .DistinctBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
 
                 MetadataFetchers = plugins
                     .Where(i => string.Equals(i.ItemType, type, StringComparison.OrdinalIgnoreCase))

--- a/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
@@ -9,6 +9,11 @@ namespace Jellyfin.Api.Models.LibraryDtos;
 public class LibraryOptionsResultDto
 {
     /// <summary>
+    /// Gets or sets the metadata readers.
+    /// </summary>
+    public IReadOnlyList<LibraryOptionInfoDto> MetadataResolvers { get; set; } = Array.Empty<LibraryOptionInfoDto>();
+
+    /// <summary>
     /// Gets or sets the metadata savers.
     /// </summary>
     public IReadOnlyList<LibraryOptionInfoDto> MetadataSavers { get; set; } = Array.Empty<LibraryOptionInfoDto>();

--- a/Jellyfin.Api/Models/LibraryDtos/LibraryTypeOptionsDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/LibraryTypeOptionsDto.cs
@@ -18,6 +18,11 @@ public class LibraryTypeOptionsDto
     /// <summary>
     /// Gets or sets the metadata fetchers.
     /// </summary>
+    public IReadOnlyList<LibraryOptionInfoDto> MetadataResolvers { get; set; } = Array.Empty<LibraryOptionInfoDto>();
+
+    /// <summary>
+    /// Gets or sets the metadata fetchers.
+    /// </summary>
     public IReadOnlyList<LibraryOptionInfoDto> MetadataFetchers { get; set; } = Array.Empty<LibraryOptionInfoDto>();
 
     /// <summary>

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -212,6 +212,8 @@ namespace MediaBrowser.Controller.Library
         /// <returns>IEnumerable{System.String}.</returns>
         Task<IEnumerable<Video>> GetIntros(BaseItem item, User user);
 
+        public bool SupportsScanner(IScanner scanner);
+
         /// <summary>
         /// Adds the parts.
         /// </summary>
@@ -226,6 +228,8 @@ namespace MediaBrowser.Controller.Library
             IEnumerable<IIntroProvider> introProviders,
             IEnumerable<IBaseItemComparer> itemComparers,
             IEnumerable<ILibraryPostScanTask> postscanTasks);
+
+        void AddScanners(IEnumerable<IScanner> scanners);
 
         /// <summary>
         /// Sorts the specified items.

--- a/MediaBrowser.Controller/Resolvers/IScanner.cs
+++ b/MediaBrowser.Controller/Resolvers/IScanner.cs
@@ -1,0 +1,22 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.LiveTv;
+
+namespace MediaBrowser.Controller.Resolvers
+{
+    public interface IScanner
+    {
+        bool Enabled { get; set; }
+
+        bool Default { get; set; }
+
+        public ICollection<BaseItem> ApplyMetadata(ICollection<BaseItem> ts);
+    }
+}

--- a/MediaBrowser.Controller/Resolvers/Scanner.cs
+++ b/MediaBrowser.Controller/Resolvers/Scanner.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Controller.Resolvers
 
         protected BaseItem ApplyMetadata(BaseItem t)
         {
-            throw new NotImplementedException();
+            protected abstract BaseItem ApplyMetadata(BaseItem t);
         }
 
         public ICollection<BaseItem> ApplyMetadata(ICollection<BaseItem> ts)

--- a/MediaBrowser.Controller/Resolvers/Scanner.cs
+++ b/MediaBrowser.Controller/Resolvers/Scanner.cs
@@ -1,0 +1,38 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+
+namespace MediaBrowser.Controller.Resolvers
+{
+    public abstract class Scanner : IScanner
+    {
+        public bool Enabled { get; set; } = false;
+
+        public bool Default { get; set; } = false;
+
+        public ResolverPriority Priority => ResolverPriority.Plugin;
+
+        protected BaseItem ApplyMetadata(BaseItem t)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICollection<BaseItem> ApplyMetadata(ICollection<BaseItem> ts)
+        {
+            foreach (var t in ts)
+            {
+                ApplyMetadata(t);
+            }
+
+            return ts;
+        }
+    }
+}

--- a/MediaBrowser.Model/Configuration/MetadataOptions.cs
+++ b/MediaBrowser.Model/Configuration/MetadataOptions.cs
@@ -18,6 +18,8 @@ namespace MediaBrowser.Model.Configuration
             MetadataFetcherOrder = Array.Empty<string>();
             DisabledImageFetchers = Array.Empty<string>();
             ImageFetcherOrder = Array.Empty<string>();
+            MetadataResolvers = Array.Empty<string>();
+            DisabledMetadataResolvers = Array.Empty<string>();
         }
 
         public string ItemType { get; set; }
@@ -33,5 +35,9 @@ namespace MediaBrowser.Model.Configuration
         public string[] DisabledImageFetchers { get; set; }
 
         public string[] ImageFetcherOrder { get; set; }
+
+        public string[] MetadataResolvers { get; set; }
+
+        public string[] DisabledMetadataResolvers { get; set; }
     }
 }

--- a/MediaBrowser.Model/Configuration/MetadataPluginType.cs
+++ b/MediaBrowser.Model/Configuration/MetadataPluginType.cs
@@ -15,6 +15,7 @@ namespace MediaBrowser.Model.Configuration
         MetadataSaver,
         SubtitleFetcher,
         LyricFetcher,
-        MediaSegmentProvider
+        MediaSegmentProvider,
+        MetadataResolver
     }
 }

--- a/MediaBrowser.Model/Configuration/TypeOptions.cs
+++ b/MediaBrowser.Model/Configuration/TypeOptions.cs
@@ -309,6 +309,8 @@ namespace MediaBrowser.Model.Configuration
             ImageFetchers = Array.Empty<string>();
             ImageFetcherOrder = Array.Empty<string>();
             ImageOptions = Array.Empty<ImageOption>();
+            MetadataResolvers = Array.Empty<string>();
+            MetadataResolverOrder = Array.Empty<string>();
         }
 
         public string Type { get; set; }
@@ -320,6 +322,10 @@ namespace MediaBrowser.Model.Configuration
         public string[] ImageFetchers { get; set; }
 
         public string[] ImageFetcherOrder { get; set; }
+
+        public string[] MetadataResolvers { get; set; }
+
+        public string[] MetadataResolverOrder { get; set; }
 
         public ImageOption[] ImageOptions { get; set; }
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -591,6 +591,14 @@ namespace MediaBrowser.Providers.Manager
                 Type = MetadataPluginType.MediaSegmentProvider
             }));
 
+            // Filesystem to metadata resolvers
+            var metadataResolverProviders = summary.Plugins.Select(p => p.Type == MetadataPluginType.MetadataResolver && p.Name != null ? p : null);
+            pluginList.AddRange(metadataResolverProviders.Select(i => new MetadataPlugin
+            {
+                Name = i?.Name,
+                Type = MetadataPluginType.MetadataResolver
+            }));
+
             summary.Plugins = pluginList.ToArray();
 
             var supportedImageTypes = imageProviders.OfType<IRemoteImageProvider>()
@@ -611,10 +619,10 @@ namespace MediaBrowser.Providers.Manager
             var providers = GetMetadataProvidersInternal<T>(item, libraryOptions, options, true, true).ToList();
 
             // Locals
-            list.AddRange(providers.Where(i => i is ILocalMetadataProvider).Select(i => new MetadataPlugin
+            list.AddRange(providers.Where(i => i is IMetadataProvider && i is not IRemoteMetadataProvider && i is not ILocalMetadataProvider && i is not ICustomMetadataProvider).Select(i => new MetadataPlugin
             {
                 Name = i.Name,
-                Type = MetadataPluginType.LocalMetadataProvider
+                Type = MetadataPluginType.MetadataResolver
             }));
 
             // Fetchers


### PR DESCRIPTION
**Changes**
Allow additional scanners to read metadata from the file system structure of folders during a library scan. This should help support [custom resolvers](https://github.com/jellyfin/jellyfin/discussions/5732) as plugins. 

**Issues**
[5732](https://github.com/jellyfin/jellyfin/discussions/5732)
