### PR TITLE
Better exception message when folders or folder items are missing

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -204,7 +204,7 @@ namespace Emby.Server.Implementations.Collections
         {
             if (_libraryManager.GetItemById(collectionId) is not BoxSet collection)
             {
-                throw new ArgumentException("No collection exists with the supplied Id");
+                throw new ArgumentException("No collection exists with the supplied collectionId " + collectionId);
             }
 
             List<BaseItem>? itemList = null;
@@ -218,7 +218,7 @@ namespace Emby.Server.Implementations.Collections
 
                 if (item is null)
                 {
-                    throw new ArgumentException("No item exists with the supplied Id");
+                    throw new ArgumentException("No item exists with the supplied Id " + id);
                 }
 
                 if (!currentLinkedChildrenIds.Contains(id))


### PR DESCRIPTION
Emit the not-found Id in the exception for easier diagnosis

**Changes**
Add the ID guid to the thrown exception

**Issues**
N/A (useful when debugging something else)
