### PR TITLE
Support more rating formats

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -286,8 +286,10 @@ namespace Emby.Server.Implementations.Localization
             }
 
             // Fairly common for some users to have "Rated R" in their rating field
-            rating = rating.Replace("Rated :", string.Empty, StringComparison.OrdinalIgnoreCase);
-            rating = rating.Replace("Rated ", string.Empty, StringComparison.OrdinalIgnoreCase);
+            rating = rating.Replace("Rated :", string.Empty, StringComparison.OrdinalIgnoreCase)
+                            .Replace("Rated:", string.Empty, StringComparison.OrdinalIgnoreCase)
+                            .Replace("Rated ", string.Empty, StringComparison.OrdinalIgnoreCase)
+                            .Trim();
 
             // Use rating system matching the language
             if (!string.IsNullOrEmpty(countryCode))

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Emby.Server.Implementations.Localization;
 using MediaBrowser.Controller.Configuration;
@@ -116,6 +115,10 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         [InlineData("TV-MA", "US", 17)]
         [InlineData("XXX", "asdf", 1000)]
         [InlineData("Germany: FSK-18", "DE", 18)]
+        [InlineData("Rated : R", "US", 17)]
+        [InlineData("Rated: R", "US", 17)]
+        [InlineData("Rated R", "US", 17)]
+        [InlineData(" PG-13 ", "US", 13)]
         public async Task GetRatingLevel_GivenValidString_Success(string value, string countryCode, int expectedLevel)
         {
             var localizationManager = Setup(new ServerConfiguration()


### PR DESCRIPTION
Add support for `"Rated:"` and also trim blanks.
Updated unit tests.
