### PR TITLE
Include SortName in LibraryDb migration query

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -89,7 +89,7 @@ public class MigrateLibraryDb : IMigrationRoutine
          Audio, ExternalServiceId, IsInMixedFolder, DateLastSaved, LockedFields, Studios, Tags, TrailerTypes, OriginalTitle, PrimaryVersionId,
          DateLastMediaAdded, Album, LUFS, NormalizationGain, CriticRating, IsVirtualItem, SeriesName, UserDataKey, SeasonName, SeasonId, SeriesId,
          PresentationUniqueKey, InheritedParentalRatingValue, ExternalSeriesId, Tagline, ProviderIds, Images, ProductionLocations, ExtraIds, TotalBitrate,
-         ExtraType, Artists, AlbumArtists, ExternalId, SeriesPresentationUniqueKey, ShowId, OwnerId, MediaType FROM TypedBaseItems
+         ExtraType, Artists, AlbumArtists, ExternalId, SeriesPresentationUniqueKey, ShowId, OwnerId, MediaType, SortName FROM TypedBaseItems
          """;
         dbContext.BaseItems.ExecuteDelete();
 
@@ -1032,6 +1032,11 @@ public class MigrateLibraryDb : IMigrationRoutine
         if (reader.TryGetString(index++, out var mediaType))
         {
             entity.MediaType = mediaType;
+        }
+
+        if (reader.TryGetString(index++, out var sortName))
+        {
+            entity.SortName = sortName;
         }
 
         var baseItem = BaseItemRepository.DeserialiseBaseItem(entity, _logger, null, false);


### PR DESCRIPTION
**Changes**
Include `SortName` in LibraryDb migration so sort title is respected after migration.

**Issues**
Fixes #13642  