### PR TITLE
Add fast-path to getting just the SeriesPresentationUniqueKey for NextUp

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1329,7 +1329,7 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetCount(query);
         }
 
-        public IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, List<BaseItem> parents)
+        public IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents)
         {
             SetTopParentIdsOrAncestors(query, parents);
 
@@ -1342,6 +1342,21 @@ namespace Emby.Server.Implementations.Library
             }
 
             return _itemRepository.GetItemList(query);
+        }
+
+        public IReadOnlyList<string> GetSeriesPresentationUniqueKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents)
+        {
+            SetTopParentIdsOrAncestors(query, parents);
+
+            if (query.AncestorIds.Length == 0 && query.TopParentIds.Length == 0)
+            {
+                if (query.User is not null)
+                {
+                    AddUserToQuery(query, query.User);
+                }
+            }
+
+            return _itemRepository.GetSeriesPresentationUniqueKeys(query);
         }
 
         public QueryResult<BaseItem> QueryItems(InternalItemsQuery query)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -255,6 +255,23 @@ public sealed class BaseItemRepository
         return dbQuery.AsEnumerable().Where(e => e is not null).Select(w => DeserialiseBaseItem(w, filter.SkipDeserialization)).ToArray();
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetSeriesPresentationUniqueKeys(InternalItemsQuery filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        PrepareFilterQuery(filter);
+
+        using var context = _dbProvider.CreateDbContext();
+        IQueryable<BaseItemEntity> dbQuery = PrepareItemQuery(context, filter);
+
+        dbQuery = TranslateQuery(dbQuery, context, filter);
+
+        dbQuery = ApplyGroupingFilter(dbQuery, filter);
+        dbQuery = ApplyQueryPaging(dbQuery, filter);
+
+        return dbQuery.Where(q => q.SeriesPresentationUniqueKey != null).Select(q => q.SeriesPresentationUniqueKey!).AsEnumerable().Distinct().ToArray();
+    }
+
     private IQueryable<BaseItemEntity> ApplyGroupingFilter(IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
     {
         // This whole block is needed to filter duplicate entries on request

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -563,7 +563,15 @@ namespace MediaBrowser.Controller.Library
         /// <param name="query">The query to use.</param>
         /// <param name="parents">Items to use for query.</param>
         /// <returns>List of items.</returns>
-        IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, List<BaseItem> parents);
+        IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents);
+
+        /// <summary>
+        /// Gets the distinct list of series presentation keys.
+        /// </summary>
+        /// <param name="query">The query to use.</param>
+        /// <param name="parents">Items to use for query.</param>
+        /// <returns>The list of series presentation keys.</returns>
+        IReadOnlyList<string> GetSeriesPresentationUniqueKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents);
 
         /// <summary>
         /// Gets the items result.

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -60,6 +60,13 @@ public interface IItemRepository
     IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery filter);
 
     /// <summary>
+    /// Gets the list of series presentation keys.
+    /// </summary>
+    /// <param name="filter">The query.</param>
+    /// <returns>The list of keys.</returns>
+    IReadOnlyList<string> GetSeriesPresentationUniqueKeys(InternalItemsQuery filter);
+
+    /// <summary>
     /// Updates the inherited values.
     /// </summary>
     void UpdateInheritedValues();


### PR DESCRIPTION
Part of https://github.com/jellyfin/jellyfin/issues/13047

This doesn't actually fix the issue, but reduces the execution time with my prod database (~8-12s to ~3-5s) since we don't need to hydrate every single item