### PR TITLE
Add fast-path to getting just the SeriesPresentationUniqueKey for NextUp

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1344,7 +1344,7 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetItemList(query);
         }
 
-        public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents)
+        public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents, DateTime dateCutoff)
         {
             SetTopParentIdsOrAncestors(query, parents);
 
@@ -1356,7 +1356,7 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            return _itemRepository.GetNextUpSeriesKeys(query);
+            return _itemRepository.GetNextUpSeriesKeys(query, dateCutoff);
         }
 
         public QueryResult<BaseItem> QueryItems(InternalItemsQuery query)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1344,6 +1344,21 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetItemList(query);
         }
 
+        public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents)
+        {
+            SetTopParentIdsOrAncestors(query, parents);
+
+            if (query.AncestorIds.Length == 0 && query.TopParentIds.Length == 0)
+            {
+                if (query.User is not null)
+                {
+                    AddUserToQuery(query, query.User);
+                }
+            }
+
+            return _itemRepository.GetNextUpSeriesKeys(query);
+        }
+
         public QueryResult<BaseItem> QueryItems(InternalItemsQuery query)
         {
             if (query.User is not null)

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -99,25 +99,9 @@ namespace Emby.Server.Implementations.TV
                 limit = limit.Value + 10;
             }
 
-            var items = _libraryManager
-                .GetItemList(
-                    new InternalItemsQuery(user)
-                    {
-                        IncludeItemTypes = new[] { BaseItemKind.Episode },
-                        OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending) },
-                        SeriesPresentationUniqueKey = presentationUniqueKey,
-                        Limit = limit,
-                        DtoOptions = new DtoOptions { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = false },
-                        GroupBySeriesPresentationUniqueKey = true
-                    },
-                    parentsFolders.ToList())
-                .Cast<Episode>()
-                .Where(episode => !string.IsNullOrEmpty(episode.SeriesPresentationUniqueKey))
-                .Select(GetUniqueSeriesKey)
-                .ToList();
+            var nextUpSeriesKeys = _libraryManager.GetNextUpSeriesKeys(new InternalItemsQuery(user) { Limit = limit }, parentsFolders);
 
-            // Avoid implicitly captured closure
-            var episodes = GetNextUpEpisodes(request, user, items.Distinct().ToArray(), options);
+            var episodes = GetNextUpEpisodes(request, user, nextUpSeriesKeys, options);
 
             return GetResult(episodes, request);
         }

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
@@ -86,7 +87,7 @@ public class TvShowsController : BaseJellyfinApiController
         [FromQuery] bool? enableUserData,
         [FromQuery] DateTime? nextUpDateCutoff,
         [FromQuery] bool enableTotalRecordCount = true,
-        [FromQuery] bool disableFirstEpisode = false,
+        [FromQuery][ParameterObsolete] bool disableFirstEpisode = false,
         [FromQuery] bool enableResumable = true,
         [FromQuery] bool enableRewatching = false)
     {
@@ -109,7 +110,6 @@ public class TvShowsController : BaseJellyfinApiController
                 StartIndex = startIndex,
                 User = user,
                 EnableTotalRecordCount = enableTotalRecordCount,
-                DisableFirstEpisode = disableFirstEpisode,
                 NextUpDateCutoff = nextUpDateCutoff ?? DateTime.MinValue,
                 EnableResumable = enableResumable,
                 EnableRewatching = enableRewatching

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -256,7 +256,7 @@ public sealed class BaseItemRepository
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter)
+    public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter, DateTime dateCutoff)
     {
         ArgumentNullException.ThrowIfNull(filter);
         ArgumentNullException.ThrowIfNull(filter.User);
@@ -274,7 +274,7 @@ public sealed class BaseItemRepository
                 (entity, data) => new { Item = entity, UserData = data })
             .GroupBy(g => g.Item.SeriesPresentationUniqueKey)
             .Select(g => new { g.Key, LastPlayedDate = g.Max(u => u.UserData.LastPlayedDate) })
-            .Where(g => g.Key != null && g.LastPlayedDate != null)
+            .Where(g => g.Key != null && g.LastPlayedDate != null && g.LastPlayedDate >= dateCutoff)
             .OrderByDescending(g => g.LastPlayedDate)
             .Select(g => g.Key!);
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -255,6 +255,37 @@ public sealed class BaseItemRepository
         return dbQuery.AsEnumerable().Where(e => e is not null).Select(w => DeserialiseBaseItem(w, filter.SkipDeserialization)).ToArray();
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(filter.User);
+
+        using var context = _dbProvider.CreateDbContext();
+
+        var query = context.BaseItems
+            .AsNoTracking()
+            .Where(i => filter.TopParentIds.Contains(i.TopParentId!.Value))
+            .Where(i => i.Type == _itemTypeLookup.BaseItemKindNames[BaseItemKind.Episode])
+            .Join(
+                context.UserData.AsNoTracking(),
+                i => new { UserId = filter.User.Id, ItemId = i.Id },
+                u => new { UserId = u.UserId, ItemId = u.ItemId },
+                (entity, data) => new { Item = entity, UserData = data })
+            .GroupBy(g => g.Item.SeriesPresentationUniqueKey)
+            .Select(g => new { g.Key, LastPlayedDate = g.Max(u => u.UserData.LastPlayedDate) })
+            .Where(g => g.Key != null && g.LastPlayedDate != null)
+            .OrderByDescending(g => g.LastPlayedDate)
+            .Select(g => g.Key!);
+
+        if (filter.Limit.HasValue)
+        {
+            query = query.Take(filter.Limit.Value);
+        }
+
+        return query.ToArray();
+    }
+
     private IQueryable<BaseItemEntity> ApplyGroupingFilter(IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
     {
         // This whole block is needed to filter duplicate entries on request

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -570,8 +570,9 @@ namespace MediaBrowser.Controller.Library
         /// </summary>
         /// <param name="query">The query to use.</param>
         /// <param name="parents">Items to use for query.</param>
+        /// <param name="dateCutoff">The minimum date for a series to have been most recently watched.</param>
         /// <returns>List of series presentation keys.</returns>
-        IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents);
+        IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents, DateTime dateCutoff);
 
         /// <summary>
         /// Gets the items result.

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -566,6 +566,14 @@ namespace MediaBrowser.Controller.Library
         IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, List<BaseItem> parents);
 
         /// <summary>
+        /// Gets the list of series presentation keys for next up.
+        /// </summary>
+        /// <param name="query">The query to use.</param>
+        /// <param name="parents">Items to use for query.</param>
+        /// <returns>List of series presentation keys.</returns>
+        IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents);
+
+        /// <summary>
         /// Gets the items result.
         /// </summary>
         /// <param name="query">The query.</param>

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -63,8 +63,9 @@ public interface IItemRepository
     /// Gets the list of series presentation keys for next up.
     /// </summary>
     /// <param name="filter">The query.</param>
+    /// <param name="dateCutoff">The minimum date for a series to have been most recently watched.</param>
     /// <returns>The list of keys.</returns>
-    IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter);
+    IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter, DateTime dateCutoff);
 
     /// <summary>
     /// Updates the inherited values.

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -60,6 +60,13 @@ public interface IItemRepository
     IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery filter);
 
     /// <summary>
+    /// Gets the list of series presentation keys for next up.
+    /// </summary>
+    /// <param name="filter">The query.</param>
+    /// <returns>The list of keys.</returns>
+    IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery filter);
+
+    /// <summary>
     /// Updates the inherited values.
     /// </summary>
     void UpdateInheritedValues();

--- a/MediaBrowser.Model/Querying/NextUpQuery.cs
+++ b/MediaBrowser.Model/Querying/NextUpQuery.cs
@@ -4,76 +4,69 @@ using System;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Model.Entities;
 
-namespace MediaBrowser.Model.Querying
+namespace MediaBrowser.Model.Querying;
+
+public class NextUpQuery
 {
-    public class NextUpQuery
+    public NextUpQuery()
     {
-        public NextUpQuery()
-        {
-            EnableImageTypes = Array.Empty<ImageType>();
-            EnableTotalRecordCount = true;
-            DisableFirstEpisode = false;
-            NextUpDateCutoff = DateTime.MinValue;
-            EnableResumable = false;
-            EnableRewatching = false;
-        }
-
-        /// <summary>
-        /// Gets or sets the user.
-        /// </summary>
-        /// <value>The user.</value>
-        public required User User { get; set; }
-
-        /// <summary>
-        /// Gets or sets the parent identifier.
-        /// </summary>
-        /// <value>The parent identifier.</value>
-        public Guid? ParentId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the series id.
-        /// </summary>
-        /// <value>The series id.</value>
-        public Guid? SeriesId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the start index. Use for paging.
-        /// </summary>
-        /// <value>The start index.</value>
-        public int? StartIndex { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum number of items to return.
-        /// </summary>
-        /// <value>The limit.</value>
-        public int? Limit { get; set; }
-
-        /// <summary>
-        /// Gets or sets the enable image types.
-        /// </summary>
-        /// <value>The enable image types.</value>
-        public ImageType[] EnableImageTypes { get; set; }
-
-        public bool EnableTotalRecordCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether do disable sending first episode as next up.
-        /// </summary>
-        public bool DisableFirstEpisode { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
-        /// </summary>
-        public DateTime NextUpDateCutoff { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to include resumable episodes as next up.
-        /// </summary>
-        public bool EnableResumable { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether getting rewatching next up list.
-        /// </summary>
-        public bool EnableRewatching { get; set; }
+        EnableImageTypes = Array.Empty<ImageType>();
+        EnableTotalRecordCount = true;
+        NextUpDateCutoff = DateTime.MinValue;
+        EnableResumable = false;
+        EnableRewatching = false;
     }
+
+    /// <summary>
+    /// Gets or sets the user.
+    /// </summary>
+    /// <value>The user.</value>
+    public required User User { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent identifier.
+    /// </summary>
+    /// <value>The parent identifier.</value>
+    public Guid? ParentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the series id.
+    /// </summary>
+    /// <value>The series id.</value>
+    public Guid? SeriesId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the start index. Use for paging.
+    /// </summary>
+    /// <value>The start index.</value>
+    public int? StartIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of items to return.
+    /// </summary>
+    /// <value>The limit.</value>
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the enable image types.
+    /// </summary>
+    /// <value>The enable image types.</value>
+    public ImageType[] EnableImageTypes { get; set; }
+
+    public bool EnableTotalRecordCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the oldest date for a show to appear in Next Up.
+    /// </summary>
+    public DateTime NextUpDateCutoff { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include resumable episodes as next up.
+    /// </summary>
+    public bool EnableResumable { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether getting rewatching next up list.
+    /// </summary>
+    public bool EnableRewatching { get; set; }
 }


### PR DESCRIPTION
Part of https://github.com/jellyfin/jellyfin/issues/13047

Alternate to https://github.com/jellyfin/jellyfin/pull/13679

This change makes the next up call take ~1.5s (0.1s in get series keys)

It's possible that this query is missing some of the functionality but it returns the correct set of next up series for the account I tested with