### PR TITLE
Add ability to provide search pattern to GetFiles

### DIFF
--- a/MediaBrowser.Model/IO/IFileSystem.cs
+++ b/MediaBrowser.Model/IO/IFileSystem.cs
@@ -157,7 +157,35 @@ namespace MediaBrowser.Model.IO
         /// <returns>All found files.</returns>
         IEnumerable<FileSystemMetadata> GetFiles(string path, bool recursive = false);
 
+        /// <summary>
+        /// Gets the files.
+        /// </summary>
+        /// <param name="path">The path in which to search.</param>
+        /// <param name="searchPattern">The search string to match against the names of files. This parameter can contain a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.</param>
+        /// <param name="recursive">If set to <c>true</c> also searches in subdirectories.</param>
+        /// <returns>All found files.</returns>
+        IEnumerable<FileSystemMetadata> GetFiles(string path, string searchPattern, bool recursive = false);
+
+        /// <summary>
+        /// Gets the files.
+        /// </summary>
+        /// <param name="path">The path in which to search.</param>
+        /// <param name="extensions">The file extensions to search for.</param>
+        /// <param name="enableCaseSensitiveExtensions">Enable case-sensitive check for extensions.</param>
+        /// <param name="recursive">If set to <c>true</c> also searches in subdirectories.</param>
+        /// <returns>All found files.</returns>
         IEnumerable<FileSystemMetadata> GetFiles(string path, IReadOnlyList<string>? extensions, bool enableCaseSensitiveExtensions, bool recursive);
+
+        /// <summary>
+        /// Gets the files.
+        /// </summary>
+        /// <param name="path">The path in which to search.</param>
+        /// <param name="searchPattern">The search string to match against the names of files. This parameter can contain a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.</param>
+        /// <param name="extensions">The file extensions to search for.</param>
+        /// <param name="enableCaseSensitiveExtensions">Enable case-sensitive check for extensions.</param>
+        /// <param name="recursive">If set to <c>true</c> also searches in subdirectories.</param>
+        /// <returns>All found files.</returns>
+        IEnumerable<FileSystemMetadata> GetFiles(string path, string searchPattern, IReadOnlyList<string>? extensions, bool enableCaseSensitiveExtensions, bool recursive);
 
         /// <summary>
         /// Gets the file system entries.


### PR DESCRIPTION
**Changes**
Add new override to provide `searchPattern` for GetFiles call. This will allow to perform more optimized searches using prefix matches