### PR TITLE
Clone fallback audio tags instead of use ATL.Track.set

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -170,11 +170,15 @@ namespace MediaBrowser.Providers.MediaInfo
                 _logger.LogWarning("File {File} only has ID3v1 tags, some fields may be truncated", audio.Path);
             }
 
-            track.Title = string.IsNullOrEmpty(track.Title) ? mediaInfo.Name : track.Title;
-            track.Album = string.IsNullOrEmpty(track.Album) ? mediaInfo.Album : track.Album;
-            track.Year = track.Year is null or 0 ? mediaInfo.ProductionYear : track.Year;
-            track.TrackNumber = track.TrackNumber is null or 0 ? mediaInfo.IndexNumber : track.TrackNumber;
-            track.DiscNumber = track.DiscNumber is null or 0 ? mediaInfo.ParentIndexNumber : track.DiscNumber;
+            // We should never use the property setter of the ATL.Track class.
+            // That setter is meant for its own tag parser and external editor usage and will have unwanted side effects
+            // For example, setting the Year property will also set the Date property, which is not what we want here.
+            // To properly handle fallback values, we make a clone of those fields when valid.
+            var trackTitle = string.IsNullOrEmpty(track.Title) ? mediaInfo.Name : track.Title;
+            var trackAlbum = string.IsNullOrEmpty(track.Album) ? mediaInfo.Album : track.Album;
+            var trackYear = track.Year is null or 0 ? mediaInfo.ProductionYear : track.Year;
+            var trackTrackNumber = track.TrackNumber is null or 0 ? mediaInfo.IndexNumber : track.TrackNumber;
+            var trackDiscNumber = track.DiscNumber is null or 0 ? mediaInfo.ParentIndexNumber : track.DiscNumber;
 
             if (audio.SupportsPeople && !audio.LockedFields.Contains(MetadataField.Cast))
             {
@@ -271,22 +275,22 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            if (!audio.LockedFields.Contains(MetadataField.Name) && !string.IsNullOrEmpty(track.Title))
+            if (!audio.LockedFields.Contains(MetadataField.Name) && !string.IsNullOrEmpty(trackTitle))
             {
-                audio.Name = track.Title;
+                audio.Name = trackTitle;
             }
 
             if (options.ReplaceAllMetadata)
             {
-                audio.Album = track.Album;
-                audio.IndexNumber = track.TrackNumber;
-                audio.ParentIndexNumber = track.DiscNumber;
+                audio.Album = trackAlbum;
+                audio.IndexNumber = trackTrackNumber;
+                audio.ParentIndexNumber = trackDiscNumber;
             }
             else
             {
-                audio.Album ??= track.Album;
-                audio.IndexNumber ??= track.TrackNumber;
-                audio.ParentIndexNumber ??= track.DiscNumber;
+                audio.Album ??= trackAlbum;
+                audio.IndexNumber ??= trackTrackNumber;
+                audio.ParentIndexNumber ??= trackDiscNumber;
             }
 
             if (track.Date.HasValue)
@@ -294,11 +298,12 @@ namespace MediaBrowser.Providers.MediaInfo
                 audio.PremiereDate = track.Date;
             }
 
-            if (track.Year.HasValue)
+            if (trackYear.HasValue)
             {
-                var year = track.Year.Value;
+                var year = trackYear.Value;
                 audio.ProductionYear = year;
 
+                // ATL library handles such fallback this with its own internal logic, but we also need to handle it here for the ffprobe fallbacks.
                 if (!audio.PremiereDate.HasValue)
                 {
                     try
@@ -307,7 +312,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
                     catch (ArgumentOutOfRangeException ex)
                     {
-                        _logger.LogError(ex, "Error parsing YEAR tag in {File}. '{TagValue}' is an invalid year", audio.Path, track.Year);
+                        _logger.LogError(ex, "Error parsing YEAR tag in {File}. '{TagValue}' is an invalid year", audio.Path, trackYear);
                     }
                 }
             }


### PR DESCRIPTION
The setter of the `Track` class is not intended for such use cases and will have unwanted side effects to change valid values. We should never use it and use all fields from `ATL.Track` class read-only.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13692
