### PR TITLE
Add start index to /Programs/Recommended endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -698,6 +698,7 @@ public class LiveTvController : BaseJellyfinApiController
     /// Gets recommended live tv epgs.
     /// </summary>
     /// <param name="userId">Optional. filter by user id.</param>
+    /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
     /// <param name="limit">Optional. The maximum number of records to return.</param>
     /// <param name="isAiring">Optional. Filter by programs that are currently airing, or not.</param>
     /// <param name="hasAired">Optional. Filter by programs that have completed airing, or not.</param>
@@ -720,6 +721,7 @@ public class LiveTvController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<QueryResult<BaseItemDto>>> GetRecommendedPrograms(
         [FromQuery] Guid? userId,
+        [FromQuery] int? startIndex,
         [FromQuery] int? limit,
         [FromQuery] bool? isAiring,
         [FromQuery] bool? hasAired,
@@ -744,6 +746,7 @@ public class LiveTvController : BaseJellyfinApiController
         var query = new InternalItemsQuery(user)
         {
             IsAiring = isAiring,
+            StartIndex = startIndex,
             Limit = limit,
             HasAired = hasAired,
             IsSeries = isSeries,


### PR DESCRIPTION
Targeting master as this parameter also didn't exist in any earlier JF version AFAIK.

Fixes #13681

