### PR TITLE
Fix IMDb URL for People

### DIFF
--- a/MediaBrowser.Providers/Movies/ImdbExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Movies/ImdbExternalUrlProvider.cs
@@ -19,7 +19,14 @@ public class ImdbExternalUrlProvider : IExternalUrlProvider
         var baseUrl = "https://www.imdb.com/";
         if (item.TryGetProviderId(MetadataProvider.Imdb, out var externalId))
         {
-            yield return baseUrl + $"title/{externalId}";
+            if (item is Person)
+            {
+                yield return baseUrl + $"name/{externalId}";
+            }
+            else
+            {
+                yield return baseUrl + $"title/{externalId}";
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Updated the IMDb external URL provider to correctly handle both media (movies, series, etc.) and person URLs. The URL generation now uses :

baseURL + name/{externalId} for people 
 baseURL + title/{externalId} for all other types

**Issues**
Regression from #13175
