### PR TITLE
Enable segment deletion for livestreams that are transcoded or remuxed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -62,6 +62,9 @@ namespace Emby.Server.Implementations.Session
         private readonly ConcurrentDictionary<string, SessionInfo> _activeConnections
             = new(StringComparer.OrdinalIgnoreCase);
 
+        private static readonly ConcurrentDictionary<string, long> _liveStreamPlaybackPositions
+            = new(StringComparer.OrdinalIgnoreCase);
+
         private Timer _idleTimer;
         private Timer _inactiveTimer;
 
@@ -818,6 +821,12 @@ namespace Emby.Server.Implementations.Session
                 }
             }
 
+            if (!string.IsNullOrEmpty(info.LiveStreamId) && !string.IsNullOrEmpty(info.PlaySessionId) && info.PlayMethod == PlayMethod.Transcode)
+            {
+                var playbackPosition = info.PositionTicks.HasValue ? info.PositionTicks.Value / 10000000 : 0;
+                _liveStreamPlaybackPositions.AddOrUpdate(info.PlaySessionId, playbackPosition, (key, oldValue) => playbackPosition);
+            }
+
             var eventArgs = new PlaybackProgressEventArgs
             {
                 Item = libraryItem,
@@ -911,6 +920,12 @@ namespace Emby.Server.Implementations.Session
             }
 
             return changed;
+        }
+
+        /// <inheritdoc />
+        public Task<long> GetLiveStreamPlaybackPositionAsync(string playSessionId)
+        {
+            return Task.FromResult(_liveStreamPlaybackPositions.TryGetValue(playSessionId, out var position) ? position : 0L);
         }
 
         /// <summary>
@@ -1007,6 +1022,11 @@ namespace Emby.Server.Implementations.Session
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error closing live stream");
+                }
+
+                if (!string.IsNullOrEmpty(info.PlaySessionId))
+                {
+                _liveStreamPlaybackPositions.TryRemove(info.PlaySessionId, out _);
                 }
             }
 
@@ -2055,6 +2075,7 @@ namespace Emby.Server.Implementations.Session
             }
 
             _activeConnections.Clear();
+            _liveStreamPlaybackPositions.Clear();
         }
     }
 }

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -341,5 +341,12 @@ namespace MediaBrowser.Controller.Session
         Task RevokeUserTokens(Guid userId, string currentAccessToken);
 
         Task CloseIfNeededAsync(SessionInfo session);
+
+        /// <summary>
+        /// Retrieves the playback position for a given livestream session.
+        /// </summary>
+        /// <param name="playSessionId">The play session Id.</param>
+        /// <returns>Task containing the playback position in seconds.</returns>
+        Task<long> GetLiveStreamPlaybackPositionAsync(string playSessionId);
     }
 }

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -572,7 +572,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
     {
         if (EnableSegmentCleaning(state))
         {
-            transcodingJob.TranscodingSegmentCleaner = new TranscodingSegmentCleaner(transcodingJob, _loggerFactory.CreateLogger<TranscodingSegmentCleaner>(), _serverConfigurationManager, _fileSystem, _mediaEncoder, state.SegmentLength);
+            transcodingJob.TranscodingSegmentCleaner = new TranscodingSegmentCleaner(transcodingJob, _loggerFactory.CreateLogger<TranscodingSegmentCleaner>(), _serverConfigurationManager, _fileSystem, _mediaEncoder, _sessionManager, state.SegmentLength);
             transcodingJob.TranscodingSegmentCleaner.Start();
         }
     }
@@ -581,8 +581,8 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         => state.InputProtocol is MediaProtocol.File or MediaProtocol.Http
            && state.IsInputVideo
            && state.TranscodingType == TranscodingJobType.Hls
-           && state.RunTimeTicks.HasValue
-           && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks;
+           && ((state.RunTimeTicks.HasValue && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks)
+            || state.IsSegmentedLiveStream);
 
     private TranscodingJob OnTranscodeBeginning(
         string path,


### PR DESCRIPTION
This PR enables segment deletion for livestreams that are transcoded or remuxed.

The problem I ran into was that livestreams do not report the value downloadpositionticks to reflect the current watch position.
I came up with the idea to use the positionticks value reported in the OnPlaybackProgressinfo class. This worked perfectly and segments are now correctly deleted after the specified time by "Time to keep segments".

Fixes #13725