### PR TITLE
Remove textless poster

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -388,16 +388,14 @@ namespace MediaBrowser.Providers.Manager
         private bool IsValidImage(RemoteImageInfo image, string preferredLanguage, string fallbackLanguage = "en")
         {
             // TODO: should exception case of "en" (English) eventually be removed?
+            bool matchesLanguage = MatchesLanguage(preferredLanguage, image.Language) || MatchesLanguage(image.Language, fallbackLanguage);
+
             if (RequiresLanguage(image.Type))
             {
-                return image.Language is not null &&
-                       (MatchesLanguage(preferredLanguage, image.Language) ||
-                        MatchesLanguage(image.Language, fallbackLanguage));
+                return image.Language is not null && matchesLanguage;
             }
 
-            return string.IsNullOrEmpty(image.Language) ||
-                   MatchesLanguage(preferredLanguage, image.Language) ||
-                   MatchesLanguage(image.Language, fallbackLanguage);
+            return string.IsNullOrEmpty(image.Language) || matchesLanguage;
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -354,9 +354,9 @@ namespace MediaBrowser.Providers.Manager
                     // Filter out languages that do not match the preferred languages.
                     //
                     // TODO: should exception case of "en" (English) eventually be removed?
-                    result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
-                                               string.Equals(preferredLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
-                                               string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
+                    result = result.Where(i => i.Language is not null &&
+                                               (string.Equals(preferredLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
+                                               string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase)));
                 }
 
                 return result.OrderByLanguageDescending(preferredLanguage);

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -388,7 +388,7 @@ namespace MediaBrowser.Providers.Manager
         private bool IsValidImage(RemoteImageInfo image, string preferredLanguage, string fallbackLanguage = "en")
         {
             // TODO: should exception case of "en" (English) eventually be removed?
-            bool matchesLanguage = MatchesLanguage(preferredLanguage, image.Language) || MatchesLanguage(image.Language, fallbackLanguage);
+            bool matchesLanguage = MatchesLanguage(image.Language, preferredLanguage) || MatchesLanguage(image.Language, fallbackLanguage);
 
             if (RequiresLanguage(image.Type))
             {


### PR DESCRIPTION
**Changes**
Removed textless posters by enhancing image language filtering. For images like posters, logos, and thumbnails, this PR enforces language requirements to filter out images without text. Images are now retrieved with a default language preference, eliminating textless versions while maintaining the same behavior when the "All languages" option is selected.

I am not a C# developer, so any feedback or suggestions for improvement would be greatly appreciated. Please feel free to point out any issues or better approaches in the code - I'm looking to learn and improve.

**Issues**
Fixes #9878 
[forum post](https://forum.jellyfin.org/t-textless-posters)
