### PR TITLE
Rename Islamic Republic of Pakistan to Pakistan

### DIFF
--- a/Emby.Server.Implementations/Localization/countries.json
+++ b/Emby.Server.Implementations/Localization/countries.json
@@ -336,7 +336,7 @@
         "TwoLetterISORegionName": "IE"
     },
     {
-        "DisplayName": "Islamic Republic of Pakistan",
+        "DisplayName": "Pakistan",
         "Name": "PK",
         "ThreeLetterISORegionName": "PAK",
         "TwoLetterISORegionName": "PK"


### PR DESCRIPTION
**Changes**

- Country rename for practical accessibility in a browser native select.

**Issues**

- We look for Pakistan under P.
