### PR TITLE
Remove all DB data on item removal, delete internal trickplay files

### DIFF
--- a/Emby.Server.Implementations/Data/CleanDatabaseScheduledTask.cs
+++ b/Emby.Server.Implementations/Data/CleanDatabaseScheduledTask.cs
@@ -5,80 +5,80 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Server.Implementations;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Trickplay;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Emby.Server.Implementations.Data
+namespace Emby.Server.Implementations.Data;
+
+public class CleanDatabaseScheduledTask : ILibraryPostScanTask
 {
-    public class CleanDatabaseScheduledTask : ILibraryPostScanTask
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<CleanDatabaseScheduledTask> _logger;
+    private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
+
+    public CleanDatabaseScheduledTask(
+        ILibraryManager libraryManager,
+        ILogger<CleanDatabaseScheduledTask> logger,
+        IDbContextFactory<JellyfinDbContext> dbProvider)
     {
-        private readonly ILibraryManager _libraryManager;
-        private readonly ILogger<CleanDatabaseScheduledTask> _logger;
-        private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
+        _libraryManager = libraryManager;
+        _logger = logger;
+        _dbProvider = dbProvider;
+    }
 
-        public CleanDatabaseScheduledTask(
-            ILibraryManager libraryManager,
-            ILogger<CleanDatabaseScheduledTask> logger,
-            IDbContextFactory<JellyfinDbContext> dbProvider)
-        {
-            _libraryManager = libraryManager;
-            _logger = logger;
-            _dbProvider = dbProvider;
-        }
+    public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        await CleanDeadItems(cancellationToken, progress).ConfigureAwait(false);
+    }
 
-        public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
+    private async Task CleanDeadItems(CancellationToken cancellationToken, IProgress<double> progress)
+    {
+        var itemIds = _libraryManager.GetItemIds(new InternalItemsQuery
         {
-            await CleanDeadItems(cancellationToken, progress).ConfigureAwait(false);
-        }
+            HasDeadParentId = true
+        });
 
-        private async Task CleanDeadItems(CancellationToken cancellationToken, IProgress<double> progress)
+        var numComplete = 0;
+        var numItems = itemIds.Count + 1;
+
+        _logger.LogDebug("Cleaning {Number} items with dead parent links", numItems);
+
+        foreach (var itemId in itemIds)
         {
-            var itemIds = _libraryManager.GetItemIds(new InternalItemsQuery
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var item = _libraryManager.GetItemById(itemId);
+            if (item is not null)
             {
-                HasDeadParentId = true
-            });
+                _logger.LogInformation("Cleaning item {Item} type: {Type} path: {Path}", item.Name, item.GetType().Name, item.Path ?? string.Empty);
 
-            var numComplete = 0;
-            var numItems = itemIds.Count + 1;
-
-            _logger.LogDebug("Cleaning {0} items with dead parent links", numItems);
-
-            foreach (var itemId in itemIds)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var item = _libraryManager.GetItemById(itemId);
-
-                if (item is not null)
+                _libraryManager.DeleteItem(item, new DeleteOptions
                 {
-                    _logger.LogInformation("Cleaning item {0} type: {1} path: {2}", item.Name, item.GetType().Name, item.Path ?? string.Empty);
-
-                    _libraryManager.DeleteItem(item, new DeleteOptions
-                    {
-                        DeleteFileLocation = false
-                    });
-                }
-
-                numComplete++;
-                double percent = numComplete;
-                percent /= numItems;
-                progress.Report(percent * 100);
+                    DeleteFileLocation = false
+                });
             }
 
-            var context = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-            await using (context.ConfigureAwait(false))
-            {
-                var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-                await using (transaction.ConfigureAwait(false))
-                {
-                    await context.ItemValues.Where(e => e.BaseItemsMap!.Count == 0).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
-                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            progress.Report(100);
+            numComplete++;
+            double percent = numComplete;
+            percent /= numItems;
+            progress.Report(percent * 100);
         }
+
+        var context = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (context.ConfigureAwait(false))
+        {
+            var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using (transaction.ConfigureAwait(false))
+            {
+                await context.ItemValues.Where(e => e.BaseItemsMap!.Count == 0).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        progress.Report(100);
     }
 }

--- a/Emby.Server.Implementations/Library/PathManager.cs
+++ b/Emby.Server.Implementations/Library/PathManager.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using System.IO;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.IO;
+
+namespace Emby.Server.Implementations.Library;
+
+/// <summary>
+/// IPathManager implementation.
+/// </summary>
+public class PathManager : IPathManager
+{
+    private readonly IServerConfigurationManager _config;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PathManager"/> class.
+    /// </summary>
+    /// <param name="config">The server configuration manager.</param>
+    public PathManager(
+        IServerConfigurationManager config)
+    {
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public string GetTrickplayDirectory(BaseItem item, bool saveWithMedia = false)
+    {
+        var basePath = _config.ApplicationPaths.TrickplayPath;
+        var idString = item.Id.ToString("N", CultureInfo.InvariantCulture);
+
+        return saveWithMedia
+            ? Path.Combine(item.ContainingFolderPath, Path.ChangeExtension(item.Path, ".trickplay"))
+            : Path.Combine(basePath, idString);
+    }
+}

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -101,16 +101,23 @@ public sealed class BaseItemRepository
 
         using var context = _dbProvider.CreateDbContext();
         using var transaction = context.Database.BeginTransaction();
+        context.AncestorIds.Where(e => e.ItemId == id || e.ParentItemId == id).ExecuteDelete();
+        context.AttachmentStreamInfos.Where(e => e.ItemId == id).ExecuteDelete();
+        context.BaseItemImageInfos.Where(e => e.ItemId == id).ExecuteDelete();
+        context.BaseItemMetadataFields.Where(e => e.ItemId == id).ExecuteDelete();
+        context.BaseItemProviders.Where(e => e.ItemId == id).ExecuteDelete();
+        context.BaseItemTrailerTypes.Where(e => e.ItemId == id).ExecuteDelete();
+        context.BaseItems.Where(e => e.Id == id).ExecuteDelete();
+        context.Chapters.Where(e => e.ItemId == id).ExecuteDelete();
+        context.CustomItemDisplayPreferences.Where(e => e.ItemId == id).ExecuteDelete();
+        context.ItemDisplayPreferences.Where(e => e.ItemId == id).ExecuteDelete();
+        context.ItemValues.Where(e => e.BaseItemsMap!.Count == 0).ExecuteDelete();
+        context.ItemValuesMap.Where(e => e.ItemId == id).ExecuteDelete();
+        context.MediaSegments.Where(e => e.ItemId == id).ExecuteDelete();
+        context.MediaStreamInfos.Where(e => e.ItemId == id).ExecuteDelete();
         context.PeopleBaseItemMap.Where(e => e.ItemId == id).ExecuteDelete();
         context.Peoples.Where(e => e.BaseItems!.Count == 0).ExecuteDelete();
-        context.Chapters.Where(e => e.ItemId == id).ExecuteDelete();
-        context.MediaStreamInfos.Where(e => e.ItemId == id).ExecuteDelete();
-        context.AncestorIds.Where(e => e.ItemId == id || e.ParentItemId == id).ExecuteDelete();
-        context.ItemValuesMap.Where(e => e.ItemId == id).ExecuteDelete();
-        context.ItemValues.Where(e => e.BaseItemsMap!.Count == 0).ExecuteDelete();
-        context.BaseItemImageInfos.Where(e => e.ItemId == id).ExecuteDelete();
-        context.BaseItemProviders.Where(e => e.ItemId == id).ExecuteDelete();
-        context.BaseItems.Where(e => e.Id == id).ExecuteDelete();
+        context.TrickplayInfos.Where(e => e.ItemId == id).ExecuteDelete();
         context.SaveChanges();
         transaction.Commit();
     }

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Trickplay;
@@ -37,9 +38,10 @@ public class TrickplayManager : ITrickplayManager
     private readonly IImageEncoder _imageEncoder;
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
     private readonly IApplicationPaths _appPaths;
+    private readonly IPathManager _pathManager;
 
     private static readonly AsyncNonKeyedLocker _resourcePool = new(1);
-    private static readonly string[] _trickplayImgExtensions = { ".jpg" };
+    private static readonly string[] _trickplayImgExtensions = [".jpg"];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrickplayManager"/> class.
@@ -53,6 +55,7 @@ public class TrickplayManager : ITrickplayManager
     /// <param name="imageEncoder">The image encoder.</param>
     /// <param name="dbProvider">The database provider.</param>
     /// <param name="appPaths">The application paths.</param>
+    /// <param name="pathManager">The path manager.</param>
     public TrickplayManager(
         ILogger<TrickplayManager> logger,
         IMediaEncoder mediaEncoder,
@@ -62,7 +65,8 @@ public class TrickplayManager : ITrickplayManager
         IServerConfigurationManager config,
         IImageEncoder imageEncoder,
         IDbContextFactory<JellyfinDbContext> dbProvider,
-        IApplicationPaths appPaths)
+        IApplicationPaths appPaths,
+        IPathManager pathManager)
     {
         _logger = logger;
         _mediaEncoder = mediaEncoder;
@@ -73,6 +77,7 @@ public class TrickplayManager : ITrickplayManager
         _imageEncoder = imageEncoder;
         _dbProvider = dbProvider;
         _appPaths = appPaths;
+        _pathManager = pathManager;
     }
 
     /// <inheritdoc />
@@ -610,12 +615,7 @@ public class TrickplayManager : ITrickplayManager
     /// <inheritdoc />
     public string GetTrickplayDirectory(BaseItem item, int tileWidth, int tileHeight, int width, bool saveWithMedia = false)
     {
-        var basePath = _config.ApplicationPaths.TrickplayPath;
-        var idString = item.Id.ToString("N", CultureInfo.InvariantCulture);
-        var path = saveWithMedia
-            ? Path.Combine(item.ContainingFolderPath, Path.ChangeExtension(item.Path, ".trickplay"))
-            : Path.Combine(basePath, idString);
-
+        var path = _pathManager.GetTrickplayDirectory(item, saveWithMedia);
         var subdirectory = string.Format(
             CultureInfo.InvariantCulture,
             "{0} - {1}x{2}",

--- a/MediaBrowser.Controller/IO/IPathManager.cs
+++ b/MediaBrowser.Controller/IO/IPathManager.cs
@@ -1,0 +1,17 @@
+using MediaBrowser.Controller.Entities;
+
+namespace MediaBrowser.Controller.IO;
+
+/// <summary>
+/// Interface ITrickplayManager.
+/// </summary>
+public interface IPathManager
+{
+    /// <summary>
+    /// Gets the path to the trickplay image base folder.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <param name="saveWithMedia">Whether or not the tile should be saved next to the media file.</param>
+    /// <returns>The absolute path.</returns>
+    public string GetTrickplayDirectory(BaseItem item, bool saveWithMedia = false);
+}


### PR DESCRIPTION
**Changes**
* Cleanup additional DB tables on item removal

**Issues**
* Images and subtitles can't reliably be cleaned up because their save folder depends on the media files's modifcaition date

**Still not cleaned up**
- keyframe JSONs
- subtitles (we are not able to clean them up because the path depends on the modification date of the already not existing media file...)
- attachments
