### PR TITLE
Preserve SplashscreenLocation when updating branding config

### DIFF
--- a/Jellyfin.Api/Controllers/BrandingController.cs
+++ b/Jellyfin.Api/Controllers/BrandingController.cs
@@ -29,18 +29,18 @@ public class BrandingController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the branding configuration.</returns>
     [HttpGet("Configuration")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<BrandOptionsDto> GetBrandingOptions()
+    public ActionResult<BrandingOptionsDto> GetBrandingOptions()
     {
         var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
 
-        var brandOptionsDto = new BrandOptionsDto
+        var brandingOptionsDto = new BrandingOptionsDto
         {
             LoginDisclaimer = brandingOptions.LoginDisclaimer,
             CustomCss = brandingOptions.CustomCss,
             SplashscreenEnabled = brandingOptions.SplashscreenEnabled
         };
 
-        return brandOptionsDto;
+        return brandingOptionsDto;
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/BrandingController.cs
+++ b/Jellyfin.Api/Controllers/BrandingController.cs
@@ -29,9 +29,18 @@ public class BrandingController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the branding configuration.</returns>
     [HttpGet("Configuration")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<BrandingOptions> GetBrandingOptions()
+    public ActionResult<BrandOptionsDto> GetBrandingOptions()
     {
-        return _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
+        var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
+
+        var brandOptionsDto = new BrandOptionsDto
+        {
+            LoginDisclaimer = brandingOptions.LoginDisclaimer,
+            CustomCss = brandingOptions.CustomCss,
+            SplashscreenEnabled = brandingOptions.SplashscreenEnabled
+        };
+
+        return brandOptionsDto;
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Extensions.Json;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Branding;
 using MediaBrowser.Model.Configuration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -117,6 +118,51 @@ public class ConfigurationController : BaseJellyfinApiController
     public ActionResult<MetadataOptions> GetDefaultMetadataOptions()
     {
         return new MetadataOptions();
+    }
+
+    /// <summary>
+    /// Gets branding configuration.
+    /// </summary>
+    /// <response code="200">Branding configuration returned.</response>
+    /// <returns>Branding configuration.</returns>
+    [HttpGet("Configuration/Branding")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<BrandOptionsDto> GetBrandingConfiguration()
+    {
+        var brandingOptions = (BrandingOptions)_configurationManager.GetConfiguration("branding");
+
+        var brandOptionsDto = new BrandOptionsDto
+        {
+            LoginDisclaimer = brandingOptions.LoginDisclaimer,
+            CustomCss = brandingOptions.CustomCss,
+            SplashscreenEnabled = brandingOptions.SplashscreenEnabled
+        };
+
+        return brandOptionsDto;
+    }
+
+    /// <summary>
+    /// Updates branding configuration.
+    /// </summary>
+    /// <param name="configuration">Branding configuration.</param>
+    /// <response code="204">Branding configuration updated.</response>
+    /// <returns>Update status.</returns>
+    [HttpPost("Configuration/Branding")]
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public ActionResult UpdateBrandingConfiguration([FromBody, Required] BrandOptionsDto configuration)
+    {
+        // Get the current branding configuration to preserve SplashscreenLocation
+        var currentBranding = (BrandingOptions)_configurationManager.GetConfiguration("branding");
+
+        // Update only the properties from BrandOptionsDto
+        currentBranding.LoginDisclaimer = configuration.LoginDisclaimer;
+        currentBranding.CustomCss = configuration.CustomCss;
+        currentBranding.SplashscreenEnabled = configuration.SplashscreenEnabled;
+
+        _configurationManager.SaveConfiguration("branding", currentBranding);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -121,27 +121,6 @@ public class ConfigurationController : BaseJellyfinApiController
     }
 
     /// <summary>
-    /// Gets branding configuration.
-    /// </summary>
-    /// <response code="200">Branding configuration returned.</response>
-    /// <returns>Branding configuration.</returns>
-    [HttpGet("Configuration/Branding")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<BrandOptionsDto> GetBrandingConfiguration()
-    {
-        var brandingOptions = (BrandingOptions)_configurationManager.GetConfiguration("branding");
-
-        var brandOptionsDto = new BrandOptionsDto
-        {
-            LoginDisclaimer = brandingOptions.LoginDisclaimer,
-            CustomCss = brandingOptions.CustomCss,
-            SplashscreenEnabled = brandingOptions.SplashscreenEnabled
-        };
-
-        return brandOptionsDto;
-    }
-
-    /// <summary>
     /// Updates branding configuration.
     /// </summary>
     /// <param name="configuration">Branding configuration.</param>

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -129,12 +129,12 @@ public class ConfigurationController : BaseJellyfinApiController
     [HttpPost("Configuration/Branding")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public ActionResult UpdateBrandingConfiguration([FromBody, Required] BrandOptionsDto configuration)
+    public ActionResult UpdateBrandingConfiguration([FromBody, Required] BrandingOptionsDto configuration)
     {
         // Get the current branding configuration to preserve SplashscreenLocation
         var currentBranding = (BrandingOptions)_configurationManager.GetConfiguration("branding");
 
-        // Update only the properties from BrandOptionsDto
+        // Update only the properties from BrandingOptionsDto
         currentBranding.LoginDisclaimer = configuration.LoginDisclaimer;
         currentBranding.CustomCss = configuration.CustomCss;
         currentBranding.SplashscreenEnabled = configuration.SplashscreenEnabled;

--- a/Jellyfin.Server/Filters/AdditionalModelFilter.cs
+++ b/Jellyfin.Server/Filters/AdditionalModelFilter.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Server.Filters
     public class AdditionalModelFilter : IDocumentFilter
     {
         // Array of options that should not be visible in the api spec.
-        private static readonly Type[] _ignoredConfigurations = { typeof(MigrationOptions) };
+        private static readonly Type[] _ignoredConfigurations = { typeof(MigrationOptions), typeof(MediaBrowser.Model.Branding.BrandingOptions) };
         private readonly IServerConfigurationManager _serverConfigurationManager;
 
         /// <summary>

--- a/MediaBrowser.Model/Branding/BrandOptionsDto.cs
+++ b/MediaBrowser.Model/Branding/BrandOptionsDto.cs
@@ -1,9 +1,10 @@
 namespace MediaBrowser.Model.Branding;
 
 /// <summary>
-/// The branding options.
+/// The branding options DTO for API use.
+/// This DTO excludes SplashscreenLocation to prevent it from being updated via API.
 /// </summary>
-public class BrandingOptions
+public class BrandOptionsDto
 {
     /// <summary>
     /// Gets or sets the login disclaimer.
@@ -21,9 +22,4 @@ public class BrandingOptions
     /// Gets or sets a value indicating whether to enable the splashscreen.
     /// </summary>
     public bool SplashscreenEnabled { get; set; } = false;
-
-    /// <summary>
-    /// Gets or sets the splashscreen location on disk.
-    /// </summary>
-    public string? SplashscreenLocation { get; set; }
 }

--- a/MediaBrowser.Model/Branding/BrandingOptionsDto.cs
+++ b/MediaBrowser.Model/Branding/BrandingOptionsDto.cs
@@ -4,7 +4,7 @@ namespace MediaBrowser.Model.Branding;
 /// The branding options DTO for API use.
 /// This DTO excludes SplashscreenLocation to prevent it from being updated via API.
 /// </summary>
-public class BrandOptionsDto
+public class BrandingOptionsDto
 {
     /// <summary>
     /// Gets or sets the login disclaimer.


### PR DESCRIPTION
Changes
This PR adds handling for BrandingOptions to preserve SplashscreenLocation when updating configuration.

_sorry accidentally closed the last_

Moved logic from to the ConfigurationController to BaseConfigurationManager.cs and now target master

Issues
Fixes: #13744 