### PR TITLE
Make ReadInputAtNativeFramerate configurable for M3U tuner

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6980,7 +6980,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             state.RemoteHttpHeaders = mediaSource.RequiredHttpHeaders;
             state.ReadInputAtNativeFramerate = mediaSource.ReadAtNativeFramerate;
 
-            if (state.ReadInputAtNativeFramerate
+            if ((state.ReadInputAtNativeFramerate && !state.IsSegmentedLiveStream)
                 || (mediaSource.Protocol == MediaProtocol.File
                 && string.Equals(mediaSource.Container, "wtv", StringComparison.OrdinalIgnoreCase)))
             {

--- a/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
+++ b/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
@@ -9,6 +9,7 @@ namespace MediaBrowser.Model.LiveTv
         {
             AllowHWTranscoding = true;
             IgnoreDts = true;
+            ReadAtNativeFramerate = false;
             AllowStreamSharing = true;
             AllowFmp4TranscodingContainer = false;
             FallbackMaxStreamingBitrate = 30000000;
@@ -43,5 +44,7 @@ namespace MediaBrowser.Model.LiveTv
         public string UserAgent { get; set; }
 
         public bool IgnoreDts { get; set; }
+
+        public bool ReadAtNativeFramerate { get; set; }
     }
 }

--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -190,7 +190,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                 RequiresClosing = true,
                 RequiresLooping = info.EnableStreamLooping,
 
-                ReadAtNativeFramerate = false,
+                ReadAtNativeFramerate = info.ReadAtNativeFramerate,
 
                 Id = channel.Path.GetMD5().ToString("N", CultureInfo.InvariantCulture),
                 IsInfiniteStream = true,


### PR DESCRIPTION
This PR makes ReadInputAtNativeFramerate configurable for the M3U Tuner and works very similar to PR #7903 that added IgnoreDts as a configurable option.

Changes

Added ReadInputAtNativeFramerate to TunerHostInfo
Added ReadInputAtNativeFramerate checkbox to M3U tuner configuration page: https://github.com/jellyfin/jellyfin-web/pull/6659

Fixes #13772
