### PR TITLE
Restrict GetPublicUsers to local IPs only

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -114,16 +114,19 @@ public class UserController : BaseJellyfinApiController
             return Ok(Get(false, false, false, false));
         }
 
+        var networkConfiguration = _config.GetNetworkConfiguration();
         var ip = HttpContext.GetNormalizedRemoteIP();
         var isLocal = HttpContext.IsLocal() || _networkManager.IsInLocalNetwork(ip);
 
-        if (!isLocal)
+        if (networkConfiguration.PublicUserListing &&
+            (isLocal || !networkConfiguration.PublicUserListingLocalOnly))
         {
-            // Returning empty users list if request is not from a local IP
+            return Ok(Get(false, false, true, false));
+        }
+        else
+        {
             return Ok(Array.Empty<UserDto>().AsEnumerable());
         }
-
-        return Ok(Get(false, false, true, true));
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -114,6 +114,15 @@ public class UserController : BaseJellyfinApiController
             return Ok(Get(false, false, false, false));
         }
 
+        var ip = HttpContext.GetNormalizedRemoteIP();
+        var isLocal = HttpContext.IsLocal() || _networkManager.IsInLocalNetwork(ip);
+
+        if (!isLocal)
+        {
+            // Returning empty users list if request is not from a local IP
+            return Ok(Array.Empty<UserDto>().AsEnumerable());
+        }
+
         return Ok(Get(false, false, true, true));
     }
 

--- a/MediaBrowser.Common/Net/NetworkConfiguration.cs
+++ b/MediaBrowser.Common/Net/NetworkConfiguration.cs
@@ -173,4 +173,14 @@ public class NetworkConfiguration
     /// Gets or sets a value indicating whether <seealso cref="RemoteIPFilter"/> contains a blacklist or a whitelist. Default is a whitelist.
     /// </summary>
     public bool IsRemoteIPFilterBlacklist { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether public user listing is enabled.
+    /// </summary>
+    public bool PublicUserListing { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether public user listing is scoped to local network only.
+    /// </summary>
+    public bool PublicUserListingLocalOnly { get; set; } = true;
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This small PR blocks listing of Jellyfin users on public networks by returning an empty list of users. 
An alternative option would be to return 401 Unauthorized or 403 Forbidden.
This is done by adding a local IP check in GetPublicUsers which would change the behavior of Jellyfin and should be considered a breaking change. 
It is not wise to disclose any user information to the internet due to security concerns and similar features in other software such as Home Assistant got pulled due to the same exact reason.
Please let me know if this would be sufficient or if extra functionality needs to be added to provide a setting option to

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Addresses https://github.com/jellyfin/jellyfin-web/issues/2042