### PR TITLE
Parallelize library.db migration steps, minor fixes

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Emby.Server.Implementations.Data;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
@@ -81,10 +82,6 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
 
         connection.Open();
         using var dbContext = _provider.CreateDbContext();
-
-        migrationTotalTime += stopwatch.Elapsed;
-        _logger.LogInformation("Saving UserData entries took {0}.", stopwatch.Elapsed);
-        stopwatch.Restart();
 
         _logger.LogInformation("Start moving TypedBaseItem.");
         const string typedBaseItemsQuery = """
@@ -193,6 +190,9 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
         legacyBaseItemWithUserKeys.Clear();
         _logger.LogInformation("Try saving {0} UserData entries.", dbContext.UserData.Local.Count);
         dbContext.SaveChanges();
+        migrationTotalTime += stopwatch.Elapsed;
+        _logger.LogInformation("Saving UserData entries took {0}.", stopwatch.Elapsed);
+        stopwatch.Restart();
 
         _logger.LogInformation("Start moving MediaStreamInfos.");
         const string mediaStreamQuery = """

--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -81,7 +81,7 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
         var migrationTotalTime = TimeSpan.Zero;
 
         // Perform a cleanup first to remove stale data from previously failed migrations.
-        _logger.LogInformation("Cleaning leftovers to ensure no data from previous failed migrations exist...");
+        _logger.LogInformation("Ensure no data from previous attempts exist...");
         var dbContext = CreateDbContext();
         dbContext.BaseItems.ExecuteDelete();
         dbContext.ItemValues.ExecuteDelete();

--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -126,9 +126,10 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
         connection.Close();
         stopwatch.Stop();
         migrationTotalTime += stopwatch.Elapsed;
-        commitTasks.Add(() => CommitChanges(dbContext, "BaseItems"));
+        _logger.LogInformation("Saving BaseItems and processing related entities...");
 
         var taskTimes = Task.WhenAll(
+            Task.Run(() => CommitChanges(dbContext, "BaseItems")),
             Task.Run(() =>
             {
                 var dbContext = CreateDbContext();
@@ -374,7 +375,7 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
                 return stopwatch.Elapsed;
             })).GetAwaiter().GetResult();
 
-        _logger.LogInformation("Finished processing entities! Saving changes to database...");
+        _logger.LogInformation("Finished processing all entities! Saving remaining changes to database...");
         foreach (var task in commitTasks)
         {
             migrationTotalTime += task();


### PR DESCRIPTION
This PR further reduces the migration time from 04:26 (achieved through #13749) to **03:45** in my Raspberry Pi by parallelizing everything that can be executed in parallel.

The downside is that this increase a little the RAM usage because all the tasks are performed as early as possible and flushing changes to the DB is deferred to the end. The biggest one though (BaseItems) is flushed to the DB as soon as possible. I don't think this will ever be a problem though, since my bottleneck now is I/O bound, and  we can assume a correlation between the library size and better I/O speeds for flushing to the database (and, as soon as changes are flushed, space is freed). My 4 GB Pi 4 could handle it with a lot of headroom.

Also took the chance to fix the logger messages [(for people entries, ``MediaStreamInfos`` count was shown instead, for example)](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs#L275) and improve the wording (in my opinion) of the logged messages.

 