### PR TITLE
Fix MoveTrickplayFiles migration

### DIFF
--- a/Jellyfin.Server/Migrations/MigrationRunner.cs
+++ b/Jellyfin.Server/Migrations/MigrationRunner.cs
@@ -53,9 +53,9 @@ namespace Jellyfin.Server.Migrations
             typeof(Routines.AddDefaultCastReceivers),
             typeof(Routines.UpdateDefaultPluginRepository),
             typeof(Routines.FixAudioData),
-            typeof(Routines.MoveTrickplayFiles),
             typeof(Routines.RemoveDuplicatePlaylistChildren),
             typeof(Routines.MigrateLibraryDb),
+            typeof(Routines.MoveTrickplayFiles),
         };
 
         /// <summary>

--- a/Jellyfin.Server/Migrations/Routines/MoveTrickplayFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/MoveTrickplayFiles.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Jellyfin.Data.Enums;
-using MediaBrowser.Common;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Trickplay;
@@ -16,7 +15,7 @@ namespace Jellyfin.Server.Migrations.Routines;
 /// <summary>
 /// Migration to move trickplay files to the new directory.
 /// </summary>
-public class MoveTrickplayFiles : IMigrationRoutine
+public class MoveTrickplayFiles : IDatabaseMigrationRoutine
 {
     private readonly ITrickplayManager _trickplayManager;
     private readonly IFileSystem _fileSystem;

--- a/Jellyfin.Server/Migrations/Routines/RemoveDuplicatePlaylistChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/RemoveDuplicatePlaylistChildren.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Linq;
 using System.Threading;
-
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
-using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Server.Migrations.Routines;
 
@@ -15,16 +13,13 @@ namespace Jellyfin.Server.Migrations.Routines;
 /// </summary>
 internal class RemoveDuplicatePlaylistChildren : IMigrationRoutine
 {
-    private readonly ILogger<RemoveDuplicatePlaylistChildren> _logger;
     private readonly ILibraryManager _libraryManager;
     private readonly IPlaylistManager _playlistManager;
 
     public RemoveDuplicatePlaylistChildren(
-        ILogger<RemoveDuplicatePlaylistChildren> logger,
         ILibraryManager libraryManager,
         IPlaylistManager playlistManager)
     {
-        _logger = logger;
         _libraryManager = libraryManager;
         _playlistManager = playlistManager;
     }


### PR DESCRIPTION
**Changes**
Run `MoveTrickplayFiles` after the EFcore migration, otherwise no data is fetched.

Fixes #13801