### PR TITLE
Improve search with partial term matching

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1423,7 +1423,8 @@ public sealed class BaseItemRepository
 
             var tokens = searchTerm.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-            // Construire une requête OR avec chaque token
+            // Construct the SQL FTS query
+            // This is a simple OR query for all tokens
             var orQuery = string.Join(" OR ", tokens.Select(t => t + "*"));
 
             var v = context.BaseItems.FromSqlRaw(
@@ -2215,22 +2216,5 @@ public sealed class BaseItemRepository
         }
 
         return baseQuery;
-    }
-
-    // Auxiliary function to generate n-grams
-    private List<string> GenerateNGrams(string text, int n)
-    {
-        if (string.IsNullOrEmpty(text) || text.Length < n)
-        {
-            return [text];
-        }
-
-        var ngrams = new List<string>();
-        for (var i = 0; i <= text.Length - n; i++)
-        {
-            ngrams.Add(text.Substring(i, n));
-        }
-
-        return ngrams;
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
@@ -62,4 +62,14 @@ public interface IJellyfinDatabaseProvider
     /// <param name="cancellationToken">A cancelation token.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task RestoreBackupFast(string key, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Configures the fuzzy search functions.
+    /// </summary>
+    /// <param name="connectionString">The connection string.</param>
+    /// <remarks>
+    /// This method is called when the database is created or migrated.
+    /// It should create the necessary functions for fuzzy search.
+    /// </remarks>
+    void ConfigureFuzzySearchFunctions(string connectionString);
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -134,6 +134,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             using var command = connection.CreateCommand();
 
             // Drop the existing FTS5 table if it exists
+            // In the long term, these lines will need to be removed
             command.CommandText = "DROP TABLE IF EXISTS item_search_fts;";
             _ = command.ExecuteNonQuery();
             command.CommandText = "DROP TRIGGER IF EXISTS baseitem_ai_fts;";
@@ -143,7 +144,6 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             command.CommandText = "DROP TRIGGER IF EXISTS baseitem_ad_fts;";
             _ = command.ExecuteNonQuery();
 
-            // Créer une table virtuelle FTS5 pour les titres et autres champs de recherche
             command.CommandText = @"
                 -- Create a virtual FTS5 table for searching
                 CREATE VIRTUAL TABLE IF NOT EXISTS item_search_fts USING FTS5(
@@ -158,6 +158,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                 );
 
                 -- Create triggers to keep the FTS5 table in sync with the BaseItems table
+
                 CREATE TRIGGER IF NOT EXISTS baseitem_ai_fts AFTER INSERT ON BaseItems BEGIN
                     INSERT INTO item_search_fts(id, clean_name, original_title, tags, genres)
                     VALUES (
@@ -171,7 +172,6 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                     );
                 END;
 
-                -- Create triggers to keep the FTS5 table in sync with the BaseItems table
                 CREATE TRIGGER IF NOT EXISTS baseitem_au_fts AFTER UPDATE ON BaseItems BEGIN
                     UPDATE item_search_fts
                     SET
@@ -191,7 +191,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
             _ = command.ExecuteNonQuery();
 
-            // Initialiser la table avec les données existantes
+            // Initialize the FTS5 table with existing data
             command.CommandText = @"
                 INSERT INTO item_search_fts(id, clean_name, original_title, episode_title, path, tags, genres)
                 SELECT

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
@@ -41,6 +42,8 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         options.UseSqlite(
             $"Filename={Path.Combine(_applicationPaths.DataPath, "jellyfin.db")};Pooling=false",
             sqLiteOptions => sqLiteOptions.MigrationsAssembly(GetType().Assembly));
+
+        ConfigureFuzzySearchFunctions($"Filename={Path.Combine(_applicationPaths.DataPath, "jellyfin.db")};Pooling=false");
     }
 
     /// <inheritdoc/>
@@ -117,5 +120,119 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         File.Copy(backupFile, path, true);
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void ConfigureFuzzySearchFunctions(string connectionString)
+    {
+        try
+        {
+            // Create a connection to register our custom functions
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            // Register the tokenization function
+            connection.CreateFunction("generate_tokens", (string text) =>
+            {
+                if (string.IsNullOrEmpty(text))
+                {
+                    return string.Empty;
+                }
+
+                // Convert to lowercase and remove non-alphanumeric characters
+                text = new string([.. text.ToLower(CultureInfo.CurrentCulture).Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c))]);
+
+                // Tokenize by space
+                return string.Join(" ", text.Split([' '], StringSplitOptions.RemoveEmptyEntries));
+            });
+
+            // Function to calculate a simple similarity score
+            connection.CreateFunction("simple_similarity", (string s1, string s2) =>
+            {
+                if (string.IsNullOrEmpty(s1) || string.IsNullOrEmpty(s2))
+                {
+                    return 0.0;
+                }
+
+                s1 = s1.ToLower(CultureInfo.CurrentCulture);
+                s2 = s2.ToLower(CultureInfo.CurrentCulture);
+
+                // Partial inclusion check
+                if (s1.Contains(s2, StringComparison.OrdinalIgnoreCase) || s2.Contains(s1, StringComparison.OrdinalIgnoreCase))
+                {
+                    return 0.8;
+                }
+
+                // Check first characters (errors often towards the end)
+                var prefixLen = Math.Min(Math.Min(s1.Length, s2.Length), 3);
+                if (prefixLen > 0 && s1[..prefixLen] == s2[..prefixLen])
+                {
+                    return 0.7;
+                }
+
+                // Simple similarity calculation based on common characters
+                var commonChars = 0;
+                foreach (var c in s1)
+                {
+                    if (s2.Contains(c, StringComparison.Ordinal))
+                    {
+                        commonChars++;
+                    }
+                }
+
+                return (double)commonChars / Math.Max(s1.Length, s2.Length);
+            });
+
+            // Function that checks if a string contains at least N tokens from the other
+            connection.CreateFunction("contains_tokens", (string text, string searchTerms, int minTokens) =>
+            {
+                if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(searchTerms))
+                {
+                    return 0;
+                }
+
+                var textTokens = text.ToLower(CultureInfo.CurrentCulture).Split([' '], StringSplitOptions.RemoveEmptyEntries);
+                var searchTokens = searchTerms.ToLower(CultureInfo.CurrentCulture).Split([' '], StringSplitOptions.RemoveEmptyEntries);
+
+                var matchCount = 0;
+                foreach (var token in searchTokens)
+                {
+                    if (token.Length < 3)
+                    {
+                        // For short tokens, check exact equality
+                        if (textTokens.Any(t => t.Equals(token, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            matchCount++;
+                        }
+                    }
+                    else
+                    {
+                        // For longer tokens, check if a text token contains the search token
+                        if (textTokens.Any(t => t.Contains(token, StringComparison.OrdinalIgnoreCase) || token.Contains(t, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            matchCount++;
+                        }
+                    }
+                }
+
+                return matchCount >= minTokens ? 1 : 0;
+            });
+
+            // Execute SQL queries to create indexes if necessary
+            using var command = connection.CreateCommand();
+
+            // Create an index on important columns for search
+            command.CommandText = @"
+                CREATE INDEX IF NOT EXISTS idx_baseitem_cleanname ON BaseItems(CleanName);
+                CREATE INDEX IF NOT EXISTS idx_baseitem_originaltitle ON BaseItems(OriginalTitle);
+            ";
+            _ = command.ExecuteNonQuery();
+
+            _logger.LogInformation("Configuration of fuzzy search functions completed successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error configuring fuzzy search functions");
+        }
     }
 }


### PR DESCRIPTION
**Changes**
This commit enhances the search functionality by implementing fuzzy matching for partial terms. It modifies how special characters are processed, adds support for shorter tokens in search queries, and improves the handling of numeric parts in search terms. These changes allow users to find content even with incomplete or partially typed search terms, making the search experience more forgiving and user-friendly. This is a test implementation to gather feedback from users and determine the best approach for fuzzy searching in the long term.

I've only been able to test this implementation on a small library with limited content, and the performance appears acceptable with no noticeable delays in search results. However, additional testing on larger libraries would be beneficial to fully understand the performance characteristics of these changes. Users with extensive collections may want to monitor search response times when testing this PR.

![image](https://github.com/user-attachments/assets/94ccd7bf-ef27-4c7a-84a8-cb9aa18ac016)


**Issues**
Fixes #1674 
