### PR TITLE
Fix wrong audio track selected when using instant play

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -669,11 +669,17 @@ namespace MediaBrowser.Model.Dlna
             {
                 if (audioStream?.IsDefault == true)
                 {
-                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.IsDefault).ToArray();
+                    candidateAudioStreams = item.MediaStreams
+                        .Where(stream => stream.Type == MediaStreamType.Audio && stream.IsDefault)
+                        .OrderByDescending(stream => stream.Index == audioStream?.Index)
+                        .ToArray();
                 }
                 else
                 {
-                    candidateAudioStreams = item.MediaStreams.Where(stream => stream.Type == MediaStreamType.Audio && stream.Language == audioStream?.Language).ToArray();
+                    candidateAudioStreams = item.MediaStreams
+                        .Where(stream => stream.Type == MediaStreamType.Audio && stream.Language == audioStream?.Language)
+                        .OrderByDescending(stream => stream.Index == audioStream?.Index)
+                        .ToArray();
                 }
             }
 


### PR DESCRIPTION
When using "instant play" described in #13774 Jellyfin Web/JMP do not specify an audioindex in their request. This causes Jellyfin to decide on an audiotrack by the candidateaudiostreams logic in StreamBuilder.cs, which is not taking any user or last played preferences into account. The issue is also more widespread than described in Issue #13774. It also selects the wrong track when you have for example 2 english tracks. If you played it the last time for example with track 2 it will switch to track 1 when using instant play. This is not specific to the default track flag.

**Changes**
The candidateAudioStreams logic is no longer applied when the playlistitem has already an AudioStreamIndex.

Fixes #13774
