### PR TITLE
allow admin users to get Splashscreen even when it's disabled

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1727,7 +1727,8 @@ public class ImageController : BaseJellyfinApiController
         [FromQuery, Range(0, 100)] int quality = 90)
     {
         var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
-        if (!brandingOptions.SplashscreenEnabled)
+        var isAdmin = User.IsInRole(Constants.UserRoles.Administrator);
+        if (!brandingOptions.SplashscreenEnabled && !isAdmin)
         {
             return NotFound();
         }


### PR DESCRIPTION
**Changes**
allows admins to see Splashscreen even when disabled

background:
https://github.com/jellyfin/jellyfin-web/pull/6616#issuecomment-2768521400
i dont think it makes much sense to prevent an admin from viewing the Splashscreen when they are not prevented from deleting or updating it even when disabled.


**Issues**
none