### PR TITLE
Only reselect audio streams when user preference is respected

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -427,6 +427,7 @@ namespace Emby.Server.Implementations.Library
                 if (source.MediaStreams.Any(i => i.Type == MediaStreamType.Audio && i.Index == index))
                 {
                     source.DefaultAudioStreamIndex = index;
+                    source.DefaultAudioIndexSource = AudioIndexSource.User;
                     return;
                 }
             }
@@ -434,6 +435,15 @@ namespace Emby.Server.Implementations.Library
             var preferredAudio = NormalizeLanguage(user.AudioLanguagePreference);
 
             source.DefaultAudioStreamIndex = MediaStreamSelector.GetDefaultAudioStreamIndex(source.MediaStreams, preferredAudio, user.PlayDefaultAudioTrack);
+            if (user.PlayDefaultAudioTrack)
+            {
+                source.DefaultAudioIndexSource |= AudioIndexSource.Default;
+            }
+
+            if (preferredAudio.Count > 0)
+            {
+                source.DefaultAudioIndexSource |= AudioIndexSource.Language;
+            }
         }
 
         public void SetDefaultAudioAndSubtitleStreamIndices(BaseItem item, MediaSourceInfo source, User user)

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -129,6 +129,13 @@ public class MediaInfoHelper
             var mediaSourcesClone = JsonSerializer.Deserialize<MediaSourceInfo[]>(JsonSerializer.SerializeToUtf8Bytes(mediaSources));
             if (mediaSourcesClone is not null)
             {
+                // Carry over the default audio index source.
+                // This field is not intended to be exposed to API clients, but it is used internally by the server
+                for (int i = 0; i < mediaSourcesClone.Length && i < mediaSources.Length; i++)
+                {
+                    mediaSourcesClone[i].DefaultAudioIndexSource = mediaSources[i].DefaultAudioIndexSource;
+                }
+
                 result.MediaSources = mediaSourcesClone;
             }
 

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -24,6 +24,7 @@ namespace MediaBrowser.Model.Dto
             SupportsDirectPlay = true;
             SupportsProbing = true;
             UseMostCompatibleTranscodingProfile = false;
+            DefaultAudioIndexSource = AudioIndexSource.None;
         }
 
         public MediaProtocol Protocol { get; set; }
@@ -117,6 +118,9 @@ namespace MediaBrowser.Model.Dto
 
         [JsonIgnore]
         public TranscodeReason TranscodeReasons { get; set; }
+
+        [DefaultValue(AudioIndexSource.None)]
+        public AudioIndexSource DefaultAudioIndexSource { get; set; }
 
         public int? DefaultAudioStreamIndex { get; set; }
 

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -119,7 +119,7 @@ namespace MediaBrowser.Model.Dto
         [JsonIgnore]
         public TranscodeReason TranscodeReasons { get; set; }
 
-        [DefaultValue(AudioIndexSource.None)]
+        [JsonIgnore]
         public AudioIndexSource DefaultAudioIndexSource { get; set; }
 
         public int? DefaultAudioStreamIndex { get; set; }

--- a/MediaBrowser.Model/MediaInfo/AudioIndexSource.cs
+++ b/MediaBrowser.Model/MediaInfo/AudioIndexSource.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace MediaBrowser.Model.MediaInfo;
+
+/// <summary>
+/// How is the audio index determined.
+/// </summary>
+[Flags]
+public enum AudioIndexSource
+{
+    /// <summary>
+    /// The default index when no preference is specified.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The index is calculated whether the track is marked as default or not.
+    /// </summary>
+    Default = 1 << 0,
+
+    /// <summary>
+    /// The index is calculated whether the track is in preferred language or not.
+    /// </summary>
+    Language = 1 << 1,
+
+    /// <summary>
+    /// The index is specified by the user.
+    /// </summary>
+    User = 1 << 2
+}


### PR DESCRIPTION
The old logic will prefer the stream don't need transcoding with a very high priority. That behavior will mistakenly pick an audio stream in a language that is not preferred. We need to respect user preference in the StreamBuilder to limit the audio stream candidates.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

~~A new `DefaultAudioIndexSource` field is added to `MediaSourceInfo`. This is exposed to the API as the server-side clone is done by json serialization and deserialization which will reset all `JsonIgnore` fields. If there are any better way to survive a deep clone and keep this field server side only, please let me know.~~

This field is now copied explicitly and is marked with `JsonIgnore`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Closes #13813

Fixes #13774
