### PR TITLE
Backport 10.11 API enum changes

### DIFF
--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Drawing;
@@ -586,6 +587,7 @@ namespace MediaBrowser.Model.Dto
         /// Gets or sets the type of the media.
         /// </summary>
         /// <value>The type of the media.</value>
+        [DefaultValue(MediaType.Unknown)]
         public MediaType MediaType { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Dto/BaseItemPerson.cs
+++ b/MediaBrowser.Model/Dto/BaseItemPerson.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Entities;
@@ -34,6 +35,7 @@ namespace MediaBrowser.Model.Dto
         /// Gets or sets the type.
         /// </summary>
         /// <value>The type.</value>
+        [DefaultValue(PersonKind.Unknown)]
         public PersonKind Type { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -172,6 +172,7 @@ namespace MediaBrowser.Model.Entities
         /// Gets the video range type.
         /// </summary>
         /// <value>The video range type.</value>
+        [DefaultValue(VideoRangeType.Unknown)]
         public VideoRangeType VideoRangeType
         {
             get

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -157,6 +157,7 @@ namespace MediaBrowser.Model.Entities
         /// Gets the video range.
         /// </summary>
         /// <value>The video range.</value>
+        [DefaultValue(VideoRange.Unknown)]
         public VideoRange VideoRange
         {
             get

--- a/MediaBrowser.Model/MediaSegments/MediaSegmentDto.cs
+++ b/MediaBrowser.Model/MediaSegments/MediaSegmentDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Jellyfin.Data.Enums;
 
 namespace MediaBrowser.Model.MediaSegments;
@@ -21,6 +22,7 @@ public class MediaSegmentDto
     /// <summary>
     /// Gets or sets the type of content this segment defines.
     /// </summary>
+    [DefaultValue(MediaSegmentType.Unknown)]
     public MediaSegmentType Type { get; set; }
 
     /// <summary>

--- a/MediaBrowser.Model/Search/SearchHint.cs
+++ b/MediaBrowser.Model/Search/SearchHint.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Jellyfin.Data.Enums;
 
 namespace MediaBrowser.Model.Search
@@ -115,6 +116,7 @@ namespace MediaBrowser.Model.Search
         /// Gets or sets the type of the media.
         /// </summary>
         /// <value>The type of the media.</value>
+        [DefaultValue(MediaType.Unknown)]
         public MediaType MediaType { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

This PR backports #13821 and part of #13277 to use the "Unknown" enum member as default value for all non-nullable properties in the API using an enum that has an Unknown member.

This is specifically needed in a 10.10 backport so a client build with the 10.10.7 API can still read responses from a 10.11 server now with the breaking API changes from #13277.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
