### PR TITLE
Fix negated IP addresses without subnet mask not being parsed correctly

### DIFF
--- a/MediaBrowser.Common/Net/NetworkUtils.cs
+++ b/MediaBrowser.Common/Net/NetworkUtils.cs
@@ -198,14 +198,25 @@ public static partial class NetworkUtils
     /// <returns><c>True</c> if parsing was successful.</returns>
     public static bool TryParseToSubnet(ReadOnlySpan<char> value, [NotNullWhen(true)] out IPNetwork? result, bool negated = false)
     {
+        // If multiple IP addresses are in a comma-separated string, the individual addresses may contain leading and/or trailing whitespace
         value = value.Trim();
+
+        bool isAddressNegated = false;
+        if (value.StartsWith('!'))
+        {
+            isAddressNegated = true;
+            value = value[1..]; // Remove leading '!' character
+        }
+
+        if (isAddressNegated != negated)
+        {
+            result = null;
+            return false;
+        }
+
         if (value.Contains('/'))
         {
-            if (negated && value.StartsWith("!") && IPNetwork.TryParse(value[1..], out result))
-            {
-                return true;
-            }
-            else if (!negated && IPNetwork.TryParse(value, out result))
+            if (IPNetwork.TryParse(value, out result))
             {
                 return true;
             }

--- a/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
@@ -79,7 +79,10 @@ namespace Jellyfin.Networking.Tests
         [InlineData("[fe80::7add:12ff:febb:c67b%16]")]
         [InlineData("fd23:184f:2029:0:3139:7386:67d7:d517/56")]
         public static void TryParseValidIPStringsTrue(string address)
-            => Assert.True(NetworkUtils.TryParseToSubnet(address, out _));
+        {
+            Assert.True(NetworkUtils.TryParseToSubnet(address, out _));
+            Assert.True(NetworkUtils.TryParseToSubnet('!' + address, out _, true));
+        }
 
         /// <summary>
         /// Checks invalid IP address formats.


### PR DESCRIPTION
This PR fixes that IP addresses without subnet mask were not being parsed correctly with the `bool negated` argument of the `NetworkUtils.TryParseToSubnet` function set to `true`, which leads to IP addresses from the "LAN networks" setting being classified as excluded in the `NetworkManager._excludedSubnets` variable, which in turn leads to these IP addresses not being considered local.

**Changes**
* Change `NetworkUtils.TryParseToSubnet` function to also respect the ! character for IP address without subnet
* Update `NetworkParseTests.TryParseValidIPStringsTrue` to test with both `true` and `false` for the `negated` parameter of the `TryParseToSubnet` function

**Issue details**
This PR fixes an issue which I encountered with the following setup:
* Jellyfin installed from the debian jellyfin repository
* Nginx as reverse proxy on the same machine which serves as entrypoint for remote connections
* Public static IPv4 address and domain name "jellyfin.example.com"
* Internet streaming bitrate limit set to a relatively small value
* Known proxies set to "127.0.0.1"
* LAN networks set to "10.0.0.0/24, 1.2.3.4" (10.0.0.0/24 is my LAN, instead of 1.2.3.4 I use my real public IPv4 address)

The goal of this setup is that when using the hostname "jellyfin.example.com" from within the LAN, I dont want the bitrate limit to apply since my router supports NAT-loopback and the connection speed is not limited by my internet upload speed. But this does not work, since IP addresses without subnets are not parsed correctly.
A workaround is to use "1.2.3.4/32" instead, which is technically equivalent, but it took me some time to figure out why the setup was not working with just "1.2.3.4", since the info text below the "LAN networks" field suggests that IP addresses with and without subnet mask are supported.