### PR TITLE
Add support for downloading playlists

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -387,6 +387,13 @@ namespace Emby.Server.Implementations.Dto
                     : item.CanDownload(user);
             }
 
+            if (options.ContainsField(ItemFields.CanExport))
+            {
+                dto.CanExport = user is null
+                    ? item.CanExport()
+                    : item.CanExport(user);
+            }
+
             if (options.ContainsField(ItemFields.Etag))
             {
                 dto.Etag = item.GetEtag(user);

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -705,6 +705,67 @@ public class LibraryController : BaseJellyfinApiController
             await LogDownloadAsync(item, user).ConfigureAwait(false);
         }
 
+        // Quotes are valid in linux. They'll possibly cause issues here.
+        var filename = Path.GetFileName(item.Path)?.Replace("\"", string.Empty, StringComparison.Ordinal);
+        var filePath = item.Path;
+        if (item.IsFileProtocol)
+        {
+            // PhysicalFile does not work well with symlinks at the moment.
+            var resolved = FileSystemHelper.ResolveLinkTarget(filePath, returnFinalTarget: true);
+            if (resolved is not null && resolved.Exists)
+            {
+                filePath = resolved.FullName;
+            }
+        }
+
+        return PhysicalFile(filePath, MimeTypes.GetMimeType(filePath), filename, true);
+    }
+
+    /// <summary>
+    /// Exports item media.
+    /// </summary>
+    /// <param name="itemId">The item id.</param>
+    /// <response code="200">Media downloaded.</response>
+    /// <response code="404">Item not found.</response>
+    /// <returns>A <see cref="FileResult"/> containing the media stream.</returns>
+    /// <exception cref="ArgumentException">User can't download or item can't be downloaded.</exception>
+    [HttpGet("Items/{itemId}/Export")]
+    [Authorize(Policy = Policies.Download)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesFile("video/*", "audio/*")]
+    public async Task<ActionResult> GetExport([FromRoute, Required] Guid itemId)
+    {
+        var userId = User.GetUserId();
+        var user = userId.IsEmpty()
+            ? null
+            : _userManager.GetUserById(userId);
+        var item = _libraryManager.GetItemById<BaseItem>(itemId, user);
+        if (item is null)
+        {
+            return NotFound();
+        }
+
+        if (user is not null)
+        {
+            if (!item.CanExport(user))
+            {
+                throw new ArgumentException("Item does not support exporting");
+            }
+        }
+        else
+        {
+            if (!item.CanExport())
+            {
+                throw new ArgumentException("Item does not support exporting");
+            }
+        }
+
+        if (user is not null)
+        {
+            await LogDownloadAsync(item, user).ConfigureAwait(false);
+        }
+
         if (item.GetType() == typeof(Playlist))
         {
             Response.Headers.Append("Content-Disposition", "attachment; filename=\"Playlist.zip\"");
@@ -736,20 +797,7 @@ public class LibraryController : BaseJellyfinApiController
         }
         else
         {
-            // Quotes are valid in linux. They'll possibly cause issues here.
-            var filename = Path.GetFileName(item.Path)?.Replace("\"", string.Empty, StringComparison.Ordinal);
-            var filePath = item.Path;
-            if (item.IsFileProtocol)
-            {
-                // PhysicalFile does not work well with symlinks at the moment.
-                var resolved = FileSystemHelper.ResolveLinkTarget(filePath, returnFinalTarget: true);
-                if (resolved is not null && resolved.Exists)
-                {
-                    filePath = resolved.FullName;
-                }
-            }
-
-            return PhysicalFile(filePath, MimeTypes.GetMimeType(filePath), filename, true);
+            throw new ArgumentException("Item does not support exporting");
         }
     }
 

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -713,11 +713,9 @@ public class LibraryController : BaseJellyfinApiController
             var playlistFile = playlist.GetPlaylistAsFileBytes(user);
 
             List<(string, byte[])> filesVirtual = [("Playlist.m3u8", playlistFile)];
-            List<(string, string)> filesDisk = new List<(string, string)>();
-            foreach (var playlistItem in playlist.GetChildPaths(user))
-            {
-                filesDisk.Add((playlistItem.TrimStart('/'), playlistItem));
-            }
+            List<(string, string)> filesDisk = playlist.GetChildPaths(user)
+                .Select(path => (path.TrimStart('/'), path))
+                .ToList();
 
             await WriteZipAsStream(Response.Body, filesVirtual, filesDisk).ConfigureAwait(false);
             return new EmptyResult();
@@ -729,11 +727,9 @@ public class LibraryController : BaseJellyfinApiController
             Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{fileName}.zip\"");
 
             List<(string, byte[])> filesVirtual = [];
-            List<(string, string)> filesDisk = new List<(string, string)>();
-            foreach (var track in album.Tracks)
-            {
-                filesDisk.Add((Path.GetFileName(track.Path), track.Path));
-            }
+            List<(string, string)> filesDisk = album.Tracks
+                .Select(track => (Path.GetFileName(track.Path), track.Path))
+                .ToList();
 
             await WriteZipAsStream(Response.Body, filesVirtual, filesDisk).ConfigureAwait(false);
             return new EmptyResult();
@@ -764,19 +760,21 @@ public class LibraryController : BaseJellyfinApiController
             foreach (var file in filesVirtual)
             {
                 var entry = archive.CreateEntry(file.FileName);
-                using (var entryStream = entry.Open())
+                var rawEntryStream = await entry.OpenAsync().ConfigureAwait(false);
+                await using (var entryStream = rawEntryStream.ConfigureAwait(false))
                 {
-                    await entryStream.WriteAsync(file.FileBytes).ConfigureAwait(false);
+                    await rawEntryStream.WriteAsync(file.FileBytes).ConfigureAwait(false);
                 }
             }
 
             foreach (var file in filesDisk)
             {
                 var entry = archive.CreateEntry(file.FileName, CompressionLevel.NoCompression);
-                using (var entryStream = entry.Open())
+                var rawEntryStream = await entry.OpenAsync().ConfigureAwait(false);
+                await using (var entryStream = rawEntryStream.ConfigureAwait(false))
                 using (var fileStream = System.IO.File.OpenRead(file.FilePath))
                 {
-                    await fileStream.CopyToAsync(entryStream).ConfigureAwait(false);
+                    await fileStream.CopyToAsync(rawEntryStream).ConfigureAwait(false);
                 }
             }
         }

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,6 +27,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Configuration;
@@ -703,21 +705,81 @@ public class LibraryController : BaseJellyfinApiController
             await LogDownloadAsync(item, user).ConfigureAwait(false);
         }
 
-        // Quotes are valid in linux. They'll possibly cause issues here.
-        var filename = Path.GetFileName(item.Path)?.Replace("\"", string.Empty, StringComparison.Ordinal);
-
-        var filePath = item.Path;
-        if (item.IsFileProtocol)
+        if (item.GetType() == typeof(Playlist))
         {
-            // PhysicalFile does not work well with symlinks at the moment.
-            var resolved = FileSystemHelper.ResolveLinkTarget(filePath, returnFinalTarget: true);
-            if (resolved is not null && resolved.Exists)
+            Response.Headers.Append("Content-Disposition", "attachment; filename=\"Playlist.zip\"");
+
+            var playlist = (Playlist)item;
+            var playlistFile = playlist.GetPlaylistAsFileBytes(user);
+
+            List<(string, byte[])> filesVirtual = [("Playlist.m3u8", playlistFile)];
+            List<(string, string)> filesDisk = new List<(string, string)>();
+            foreach (var playlistItem in playlist.GetChildPaths(user))
             {
-                filePath = resolved.FullName;
+                filesDisk.Add((playlistItem.TrimStart('/'), playlistItem));
+            }
+
+            await WriteZipAsStream(Response.Body, filesVirtual, filesDisk).ConfigureAwait(false);
+            return new EmptyResult();
+        }
+        else if (item.GetType() == typeof(MusicAlbum))
+        {
+            var album = (MusicAlbum)item;
+            var fileName = string.Join("_", album.Name.Split(Path.GetInvalidFileNameChars()));
+            Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{fileName}.zip\"");
+
+            List<(string, byte[])> filesVirtual = [];
+            List<(string, string)> filesDisk = new List<(string, string)>();
+            foreach (var track in album.Tracks)
+            {
+                filesDisk.Add((Path.GetFileName(track.Path), track.Path));
+            }
+
+            await WriteZipAsStream(Response.Body, filesVirtual, filesDisk).ConfigureAwait(false);
+            return new EmptyResult();
+        }
+        else
+        {
+            // Quotes are valid in linux. They'll possibly cause issues here.
+            var filename = Path.GetFileName(item.Path)?.Replace("\"", string.Empty, StringComparison.Ordinal);
+            var filePath = item.Path;
+            if (item.IsFileProtocol)
+            {
+                // PhysicalFile does not work well with symlinks at the moment.
+                var resolved = FileSystemHelper.ResolveLinkTarget(filePath, returnFinalTarget: true);
+                if (resolved is not null && resolved.Exists)
+                {
+                    filePath = resolved.FullName;
+                }
+            }
+
+            return PhysicalFile(filePath, MimeTypes.GetMimeType(filePath), filename, true);
+        }
+    }
+
+    private static async Task WriteZipAsStream(Stream stream, List<(string FileName, byte[] FileBytes)> filesVirtual, List<(string FileName, string FilePath)> filesDisk)
+    {
+        using (ZipArchive archive = new ZipArchive(new PositionWrapperStream(stream), ZipArchiveMode.Create))
+        {
+            foreach (var file in filesVirtual)
+            {
+                var entry = archive.CreateEntry(file.FileName);
+                using (var entryStream = entry.Open())
+                {
+                    await entryStream.WriteAsync(file.FileBytes).ConfigureAwait(false);
+                }
+            }
+
+            foreach (var file in filesDisk)
+            {
+                var entry = archive.CreateEntry(file.FileName, CompressionLevel.NoCompression);
+                using (var entryStream = entry.Open())
+                using (var fileStream = System.IO.File.OpenRead(file.FilePath))
+                {
+                    await fileStream.CopyToAsync(entryStream).ConfigureAwait(false);
+                }
             }
         }
-
-        return PhysicalFile(filePath, MimeTypes.GetMimeType(filePath), filename, true);
     }
 
     /// <summary>

--- a/Jellyfin.Api/Helpers/PositionWrapperStream.cs
+++ b/Jellyfin.Api/Helpers/PositionWrapperStream.cs
@@ -1,0 +1,70 @@
+#pragma warning disable CS1591
+#pragma warning disable IDISP023
+
+using System;
+using System.IO;
+
+// from https://stackoverflow.com/a/21513194/2919731
+public class PositionWrapperStream : Stream
+{
+    private readonly Stream wrapped;
+
+    private long pos = 0;
+
+    public PositionWrapperStream(Stream wrapped)
+    {
+        this.wrapped = wrapped;
+    }
+
+    public override bool CanSeek
+    {
+        get { return false; }
+    }
+
+    public override bool CanWrite
+    {
+        get { return true; }
+    }
+
+    public override bool CanRead => throw new NotImplementedException();
+
+    public override long Length => throw new NotImplementedException();
+
+    public override long Position
+    {
+        get { return pos; }
+        set { throw new NotSupportedException(); }
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        pos += count;
+        wrapped.WriteAsync(buffer, offset, count);
+    }
+
+    public override void Flush()
+    {
+        wrapped.FlushAsync();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        wrapped.Dispose();
+        base.Dispose(disposing);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Jellyfin.Api/Helpers/PositionWrapperStream.cs
+++ b/Jellyfin.Api/Helpers/PositionWrapperStream.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 
+namespace Jellyfin.Api.Helpers;
+
 // from https://stackoverflow.com/a/21513194/2919731
 public class PositionWrapperStream : Stream
 {

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -223,5 +223,10 @@ namespace MediaBrowser.Controller.Entities.Audio
                 await artist.RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
             }
         }
+
+        public override bool CanDownload()
+        {
+            return true;
+        }
     }
 }

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -224,7 +224,7 @@ namespace MediaBrowser.Controller.Entities.Audio
             }
         }
 
-        public override bool CanDownload()
+        public override bool CanExport()
         {
             return true;
         }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -883,6 +883,11 @@ namespace MediaBrowser.Controller.Entities
             return false;
         }
 
+        public virtual bool CanExport()
+        {
+            return false;
+        }
+
         public virtual bool IsAuthorizedToDownload(User user)
         {
             return user.HasPermission(PermissionKind.EnableContentDownloading);
@@ -891,6 +896,11 @@ namespace MediaBrowser.Controller.Entities
         public bool CanDownload(User user)
         {
             return CanDownload() && IsAuthorizedToDownload(user);
+        }
+
+        public bool CanExport(User user)
+        {
+            return CanExport() && IsAuthorizedToDownload(user);
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -231,6 +231,42 @@ namespace MediaBrowser.Controller.Playlists
             return [item];
         }
 
+        public byte[] GetPlaylistAsFileBytes(User user)
+        {
+            var query = new InternalItemsQuery(user);
+            var playlistItems = GetChildren(user, true, query);
+
+            using (var ms = new MemoryStream())
+            {
+                using (var playlistWriter = new StreamWriter(ms))
+                {
+                    playlistWriter.WriteLine("#EXTM3U");
+                    foreach (var playlistItem in playlistItems)
+                    {
+                        var relativeFilePath = playlistItem.Path.TrimStart('/');
+                        playlistWriter.WriteLine(relativeFilePath);
+                    }
+
+                    playlistWriter.Flush();
+                    return ms.ToArray();
+                }
+            }
+        }
+
+        public List<string> GetChildPaths(User user)
+        {
+            var query = new InternalItemsQuery(user);
+            var playlistItems = GetChildren(user, true, query);
+            List<string> paths = new List<string>();
+
+            foreach (var playlistItem in playlistItems)
+            {
+                paths.Add(playlistItem.Path);
+            }
+
+            return paths;
+        }
+
         public override bool IsVisible(User user, bool skipAllowedTagsCheck = false)
         {
             if (!IsSharedItem)
@@ -261,6 +297,11 @@ namespace MediaBrowser.Controller.Playlists
         public override bool CanDelete(User user)
         {
             return user.HasPermission(PermissionKind.IsAdministrator) || user.Id.Equals(OwnerUserId);
+        }
+
+        public override bool CanDownload()
+        {
+            return true;
         }
 
         public override bool IsVisibleStandalone(User user)

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -299,7 +299,7 @@ namespace MediaBrowser.Controller.Playlists
             return user.HasPermission(PermissionKind.IsAdministrator) || user.Id.Equals(OwnerUserId);
         }
 
-        public override bool CanDownload()
+        public override bool CanExport()
         {
             return true;
         }

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -78,6 +78,8 @@ namespace MediaBrowser.Model.Dto
 
         public bool? CanDownload { get; set; }
 
+        public bool? CanExport { get; set; }
+
         public bool? HasLyrics { get; set; }
 
         public bool? HasSubtitles { get; set; }

--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -21,6 +21,11 @@ namespace MediaBrowser.Model.Querying
         CanDownload,
 
         /// <summary>
+        /// The can export.
+        /// </summary>
+        CanExport,
+
+        /// <summary>
         /// The channel information.
         /// </summary>
         ChannelInfo,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR adds support for downloading playlists. When downloading a playlist items are put into a .zip file and the structure is preserved (i.e if I have a track from /media/music/artist/album/track_1 in a playlist it will generate a structure inside the playlist.zip of media/music/artist/album/track_1). It will also generate a .m3u8 from the playlist with the correct relative paths for these files to be played in the order they are defined in the playlist and this is put in the .zip file as well.

I suspect this could be fairly easily extended to also work for albums but havent tried that yet and it might make more sense for that to be in a seperate PR.

P.S - Please dont be too harsh, I havent written any C# in years :P

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes: 
- https://github.com/jellyfin/jellyfin-media-player/issues/604
- https://github.com/jellyfin/jellyfin-android/issues/498
- https://forum.jellyfin.org/t-playlist-download-all
- https://github.com/jellyfin/jellyfin-android/issues/162
- https://features.jellyfin.org/posts/655/download-a-batch-not-only-single-media-file
