### PR TITLE
Fix outdated xmltv cache

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -138,6 +138,7 @@
  - [ThibaultNocchi](https://github.com/ThibaultNocchi)
  - [thornbill](https://github.com/thornbill)
  - [ThreeFive-O](https://github.com/ThreeFive-O)
+ - [Timminator](https://github.com/timminator)
  - [TrisMcC](https://github.com/TrisMcC)
  - [trumblejoe](https://github.com/trumblejoe)
  - [TtheCreator](https://github.com/TtheCreator)

--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -66,11 +66,39 @@ namespace Jellyfin.LiveTv.Listings
 
             if (File.Exists(cacheFile) && File.GetLastWriteTimeUtc(cacheFile) >= DateTime.UtcNow.Subtract(_maxCacheAge))
             {
-                return cacheFile;
-            }
+                try
+                {
+                    if (info.Path.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                    {
+                        using var headRequest = new HttpRequestMessage(HttpMethod.Head, info.Path);
+                        using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
+                            .SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                            .ConfigureAwait(false);
 
-            // Must check if file exists as parent directory may not exist.
-            if (File.Exists(cacheFile))
+                        if (response.Content.Headers.LastModified.HasValue &&
+                            response.Content.Headers.LastModified.Value.UtcDateTime <= File.GetLastWriteTimeUtc(cacheFile))
+                        {
+                            return cacheFile;
+                        }
+
+                        File.Delete(cacheFile);
+                    }
+                    else if (File.Exists(info.Path))
+                    {
+                        if (File.GetLastWriteTimeUtc(info.Path) <= File.GetLastWriteTimeUtc(cacheFile))
+                        {
+                            return cacheFile;
+                        }
+
+                        File.Delete(cacheFile);
+                    }
+                }
+                catch (Exception)
+                {
+                    File.Delete(cacheFile);
+                }
+            }
+            else if (File.Exists(cacheFile))
             {
                 File.Delete(cacheFile);
             }

--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -93,8 +93,9 @@ namespace Jellyfin.LiveTv.Listings
                         File.Delete(cacheFile);
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    _logger.LogWarning(ex, "Unable to get last modified time for {Path}", info.Path);
                     File.Delete(cacheFile);
                 }
             }


### PR DESCRIPTION
If a xmltv program is added and updated afterwards changes are not showing up in Jellyfin. This is due to the parameter _maxCacheAge. Even if the guide data is manually refreshed the logic returns immediately with the old cache file instead of using the new one if the cache is not older than _maxCacheAge.
I updated this logic to compare thelastmodified time of the cache and the potentially new xml file, if the cache is not older than _maxCacheAge.
This ensures that changes are showing up in Jellyfin properly.

Changes:
Add Last-Modified check to XMLTV cache logic if cache is not older than 1 hour.

Fixes #6103
