### PR TITLE
Remove the hashed password from startup users response

### DIFF
--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -114,8 +114,7 @@ public class StartupController : BaseJellyfinApiController
         var user = _userManager.Users.First();
         return new StartupUserDto
         {
-            Name = user.Username,
-            Password = user.Password
+            Name = user.Username
         };
     }
 

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/StartupControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/StartupControllerTests.cs
@@ -90,9 +90,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
             var newUser = await getResponse.Content.ReadFromJsonAsync<StartupUserDto>(_jsonOptions);
             Assert.NotNull(newUser);
             Assert.Equal(user.Name, newUser.Name);
-            Assert.NotNull(newUser.Password);
-            Assert.NotEmpty(newUser.Password);
-            Assert.NotEqual(user.Password, newUser.Password);
+            Assert.Null(newUser.Password);
         }
 
         [Fact]


### PR DESCRIPTION
**Changes**
* Don't include the (hashed) password in the response of the `/Startup/User` API

![Screenshot_20250412_024641](https://github.com/user-attachments/assets/76639d3b-4fa1-48dc-af6c-6d02f93709ad)

**Issues**
N/A
