### PR TITLE
Add  Filter MatchAllTags

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -154,6 +154,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -244,6 +245,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -352,6 +354,7 @@ public class ItemsController : BaseJellyfinApiController
                 IsHD = isHd,
                 Is4K = is4K,
                 Tags = tags,
+                MatchAllTags = matchAllTags,
                 OfficialRatings = officialRatings,
                 Genres = genres,
                 ArtistIds = artistIds,
@@ -620,6 +623,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -711,6 +715,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
         => GetItems(
@@ -798,6 +803,7 @@ public class ItemsController : BaseJellyfinApiController
             nameLessThan,
             studioIds,
             genreIds,
+            matchAllTags,
             enableTotalRecordCount,
             enableImages);
 

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -121,6 +121,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="genres">Optional. If specified, results will be filtered based on genre. This allows multiple, pipe delimited.</param>
     /// <param name="officialRatings">Optional. If specified, results will be filtered based on OfficialRating. This allows multiple, pipe delimited.</param>
     /// <param name="tags">Optional. If specified, results will be filtered based on tag. This allows multiple, pipe delimited.</param>
+    /// <param name="allTags">Optional. If specified, results will be filtered based on all tags. This allows multiple, pipe delimited.</param>
     /// <param name="years">Optional. If specified, results will be filtered based on production year. This allows multiple, comma delimited.</param>
     /// <param name="enableUserData">Optional, include user data.</param>
     /// <param name="imageTypeLimit">Optional, the max number of images to return, per image type.</param>
@@ -154,7 +155,6 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
-    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -212,6 +212,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] genres,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] officialRatings,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] tags,
+        [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] allTags,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] int[] years,
         [FromQuery] bool? enableUserData,
         [FromQuery] int? imageTypeLimit,
@@ -245,7 +246,6 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
-        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -354,7 +354,7 @@ public class ItemsController : BaseJellyfinApiController
                 IsHD = isHd,
                 Is4K = is4K,
                 Tags = tags,
-                MatchAllTags = matchAllTags,
+                AllTags = allTags,
                 OfficialRatings = officialRatings,
                 Genres = genres,
                 ArtistIds = artistIds,
@@ -590,6 +590,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="genres">Optional. If specified, results will be filtered based on genre. This allows multiple, pipe delimited.</param>
     /// <param name="officialRatings">Optional. If specified, results will be filtered based on OfficialRating. This allows multiple, pipe delimited.</param>
     /// <param name="tags">Optional. If specified, results will be filtered based on tag. This allows multiple, pipe delimited.</param>
+    /// <param name="allTags">Optional. If specified, results will be filtered based on all tags. This allows multiple, pipe delimited.</param>
     /// <param name="years">Optional. If specified, results will be filtered based on production year. This allows multiple, comma delimited.</param>
     /// <param name="enableUserData">Optional, include user data.</param>
     /// <param name="imageTypeLimit">Optional, the max number of images to return, per image type.</param>
@@ -623,7 +624,6 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
-    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -682,6 +682,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] genres,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] officialRatings,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] tags,
+        [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] allTags,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] int[] years,
         [FromQuery] bool? enableUserData,
         [FromQuery] int? imageTypeLimit,
@@ -715,7 +716,6 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
-        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
         => GetItems(
@@ -770,6 +770,7 @@ public class ItemsController : BaseJellyfinApiController
             genres,
             officialRatings,
             tags,
+            allTags,
             years,
             enableUserData,
             imageTypeLimit,
@@ -803,7 +804,6 @@ public class ItemsController : BaseJellyfinApiController
             nameLessThan,
             studioIds,
             genreIds,
-            matchAllTags,
             enableTotalRecordCount,
             enableImages);
 

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -80,6 +80,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="genres">Optional. If specified, results will be filtered based on genre. This allows multiple, pipe delimited.</param>
     /// <param name="officialRatings">Optional. If specified, results will be filtered based on OfficialRating. This allows multiple, pipe delimited.</param>
     /// <param name="tags">Optional. If specified, results will be filtered based on tag. This allows multiple, pipe delimited.</param>
+    /// <param name="allTags">Optional. If specified, results will be filtered based on all tags. This allows multiple, pipe delimited.</param>
     /// <param name="years">Optional. If specified, results will be filtered based on production year. This allows multiple, comma delimited.</param>
     /// <param name="enableUserData">Optional, include user data.</param>
     /// <param name="imageTypeLimit">Optional, the max number of images to return, per image type.</param>
@@ -113,7 +114,6 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
-    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the trailers.</returns>
@@ -169,6 +169,7 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] genres,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] officialRatings,
         [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] tags,
+        [FromQuery, ModelBinder(typeof(PipeDelimitedCollectionModelBinder))] string[] allTags,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] int[] years,
         [FromQuery] bool? enableUserData,
         [FromQuery] int? imageTypeLimit,
@@ -202,7 +203,6 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
-        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -261,6 +261,7 @@ public class TrailersController : BaseJellyfinApiController
                 genres,
                 officialRatings,
                 tags,
+                allTags,
                 years,
                 enableUserData,
                 imageTypeLimit,
@@ -294,7 +295,6 @@ public class TrailersController : BaseJellyfinApiController
                 nameLessThan,
                 studioIds,
                 genreIds,
-                matchAllTags,
                 enableTotalRecordCount,
                 enableImages);
     }

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -113,6 +113,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="matchAllTags">Optional. If specified, results will be filtered based on matchAllTags. This allows multiple, pipe delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the trailers.</returns>
@@ -201,6 +202,7 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery] bool matchAllTags = false,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -292,6 +294,7 @@ public class TrailersController : BaseJellyfinApiController
                 nameLessThan,
                 studioIds,
                 genreIds,
+                matchAllTags,
                 enableTotalRecordCount,
                 enableImages);
     }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1778,8 +1778,16 @@ public sealed class BaseItemRepository
         if (tags.Count > 0)
         {
             var cleanValues = tags.Select(e => GetCleanValue(e)).ToArray();
-            baseQuery = baseQuery
-                    .Where(e => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && cleanValues.Contains(f.ItemValue.CleanValue)));
+            if (filter.MatchAllTags)
+            {
+                baseQuery = baseQuery
+                .Where(e => cleanValues.All(tag => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && f.ItemValue.CleanValue == tag)));
+            }
+            else
+            {
+                baseQuery = baseQuery
+                .Where(e => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && cleanValues.Contains(f.ItemValue.CleanValue)));
+            }
         }
 
         if (excludeTags.Count > 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1365,6 +1365,7 @@ public sealed class BaseItemRepository
         }
 
         var tags = filter.Tags.ToList();
+        var allTags = filter.AllTags.ToList();
         var excludeTags = filter.ExcludeTags.ToList();
 
         if (filter.IsMovie == true)
@@ -1778,16 +1779,15 @@ public sealed class BaseItemRepository
         if (tags.Count > 0)
         {
             var cleanValues = tags.Select(e => GetCleanValue(e)).ToArray();
-            if (filter.MatchAllTags)
-            {
-                baseQuery = baseQuery
-                .Where(e => cleanValues.All(tag => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && f.ItemValue.CleanValue == tag)));
-            }
-            else
-            {
-                baseQuery = baseQuery
-                .Where(e => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && cleanValues.Contains(f.ItemValue.CleanValue)));
-            }
+            baseQuery = baseQuery
+                    .Where(e => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && cleanValues.Contains(f.ItemValue.CleanValue)));
+        }
+
+        if (allTags.Count > 0)
+        {
+            var cleanValues = allTags.Select(e => GetCleanValue(e)).ToArray();
+            baseQuery = baseQuery
+                    .Where(e => cleanValues.All(tag => e.ItemValues!.Any(f => f.ItemValue.Type == ItemValueType.Tags && f.ItemValue.CleanValue == tag)));
         }
 
         if (excludeTags.Count > 0)

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -48,6 +48,7 @@ namespace MediaBrowser.Controller.Entities
             SourceTypes = Array.Empty<SourceType>();
             StudioIds = Array.Empty<Guid>();
             Tags = Array.Empty<string>();
+            MatchAllTags = false;
             TopParentIds = Array.Empty<Guid>();
             TrailerTypes = Array.Empty<TrailerType>();
             VideoTypes = Array.Empty<VideoType>();
@@ -179,6 +180,8 @@ namespace MediaBrowser.Controller.Entities
         public int[] Years { get; set; }
 
         public string[] Tags { get; set; }
+
+        public bool MatchAllTags { get; set; }
 
         public string[] OfficialRatings { get; set; }
 

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -48,7 +48,7 @@ namespace MediaBrowser.Controller.Entities
             SourceTypes = Array.Empty<SourceType>();
             StudioIds = Array.Empty<Guid>();
             Tags = Array.Empty<string>();
-            MatchAllTags = false;
+            AllTags = Array.Empty<string>();
             TopParentIds = Array.Empty<Guid>();
             TrailerTypes = Array.Empty<TrailerType>();
             VideoTypes = Array.Empty<VideoType>();
@@ -181,7 +181,7 @@ namespace MediaBrowser.Controller.Entities
 
         public string[] Tags { get; set; }
 
-        public bool MatchAllTags { get; set; }
+        public string[] AllTags { get; set; }
 
         public string[] OfficialRatings { get; set; }
 


### PR DESCRIPTION
Currently, filtering by tags only returns results that match any of the selected tags (i.e., OR logic).

**Changes**
- This change adds an optional parameter to enable filtering by all selected tags (i.e., AND logic), allowing for more precise results.

A follow-up pull request will be submitted to update the UI accordingly to support this new filtering option.