### PR TITLE
Don't pass through timestamp for image extractor

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -756,7 +756,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _threads,
                 vf,
                 isAudio ? string.Empty : GetImageResolutionParameter(),
-                EncodingHelper.GetVideoSyncOption("0", EncoderVersion).Trim(), // passthrough timestamp
+                EncodingHelper.GetVideoSyncOption("-1", EncoderVersion).Trim(), // auto decide fps mode
                 tempExtractPath);
 
             if (offset.HasValue)


### PR DESCRIPTION
Always passthrough timestamp may result in nothing be extracted when the timing is bad enough. Let ffmpeg decide whether to duplicate or drop a frame so that we always get one image.

If this is required by the mpegts workaround, then this should only be used with mpegts streams.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
