### PR TITLE
Fix image extractor with more strict ffmpeg requirement

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -767,7 +767,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             // The mpegts demuxer cannot seek to keyframes, so we have to let the
             // decoder discard non-keyframes, which may contain corrupted images.
             var seekMpegTs = offset.HasValue && string.Equals("mpegts", container, StringComparison.OrdinalIgnoreCase);
-            if ((useIFrame && useTradeoff) || seekMpegTs)
+            if (useIFrame && (useTradeoff || seekMpegTs))
             {
                 args = "-skip_frame nokey " + args;
             }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -737,12 +737,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 {
                     var peak = videoStream.VideoRangeType == VideoRangeType.DOVI ? "400" : "100";
                     enableHdrExtraction = true;
-                    filters.Add($"tonemapx=tonemap=bt2390:desat=0:peak={peak}:t=bt709:m=bt709:p=bt709:format=yuv420p");
+                    filters.Add($"tonemapx=tonemap=bt2390:desat=0:peak={peak}:t=bt709:m=bt709:p=bt709:format=yuv420p:range=full");
                 }
                 else if (SupportsFilter("zscale") && videoStream.VideoRangeType != VideoRangeType.DOVI)
                 {
                     enableHdrExtraction = true;
-                    filters.Add("zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0:peak=100,zscale=t=bt709:m=bt709,format=yuv420p");
+                    filters.Add("zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0:peak=100,zscale=t=bt709:m=bt709:out_range=full,format=yuv420p");
                 }
             }
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -756,7 +756,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _threads,
                 vf,
                 isAudio ? string.Empty : GetImageResolutionParameter(),
-                EncodingHelper.GetVideoSyncOption("-1", EncoderVersion).Trim(), // auto decide fps mode
+                EncodingHelper.GetVideoSyncOption("-1", EncoderVersion), // auto decide fps mode
                 tempExtractPath);
 
             if (offset.HasValue)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

ffmpeg now does not accept limited range yuv as mjpeg encoder directly and will error out as that is not compliant with the standard, which will fail the image extractor silently when the tonemap is happening as our tonemap filter defaults to output in a range same as the input, and for most of the video files, the input would be in limited range yuv.

This PR now explicitly requires the tonemapx and zscale filters to output in full range to comply with the standard.

This PR also fixed spacing problems due to unnecessary trimming and a logic error to prevent the image extractor to be reran when I frame only mode failed. The new added mpegts workaround currently overwrites the `useIFrame` parameter which prevents the image extractor to be rerun in fallback mode to do the fallback extraction.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13960