### PR TITLE
Add "part" as possible album prefix for stacking

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -187,7 +187,8 @@ namespace Emby.Naming.Common
                 "disc",
                 "disk",
                 "vol",
-                "volume"
+                "volume",
+                "part"
             };
 
             ArtistSubfolders = new[]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Sometimes different parts of an album are split up into folders labelled "part". Allow these to stack in albums instead of splitting into separate ones. Simply add the string "part" to the list of allowed album prefixes.

**Issues**
I was having issues with my albums showing as multiple different ones, despite the tags being correct. It was because of folder naming.
