### PR TITLE
Cleanup file related code

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
+++ b/Emby.Server.Implementations/AppBase/BaseApplicationPaths.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 
 namespace Emby.Server.Implementations.AppBase
@@ -91,10 +92,7 @@ namespace Emby.Server.Implementations.AppBase
         /// <inheritdoc />
         public void CreateAndCheckMarker(string path, string markerName, bool recursive = false)
         {
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
-            }
+            Directory.CreateDirectory(path);
 
             CheckOrCreateMarker(path, $".jellyfin-{markerName}", recursive);
         }
@@ -115,7 +113,7 @@ namespace Emby.Server.Implementations.AppBase
             var markerPath = Path.Combine(path, markerName);
             if (!File.Exists(markerPath))
             {
-                File.Create(markerPath).Dispose();
+                FileHelper.CreateEmpty(markerPath);
             }
         }
     }

--- a/Emby.Server.Implementations/IO/ManagedFileSystem.cs
+++ b/Emby.Server.Implementations/IO/ManagedFileSystem.cs
@@ -159,13 +159,13 @@ namespace Emby.Server.Implementations.IO
             catch (IOException)
             {
                 // Cross device move requires a copy
-                Directory.CreateDirectory(destination);
-                foreach (string file in Directory.GetFiles(source))
+                var directory = Directory.CreateDirectory(destination);
+                foreach (var file in directory.EnumerateFiles())
                 {
-                    File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), true);
+                    file.CopyTo(Path.Combine(destination, file.Name), true);
                 }
 
-                Directory.Delete(source, true);
+                directory.Delete(true);
             }
         }
 

--- a/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
@@ -20,7 +20,7 @@ public class DotIgnoreIgnoreRule : IResolverIgnoreRule
         }
 
         var parentDir = directory.Parent;
-        if (parentDir == null || parentDir.FullName == directory.FullName)
+        if (parentDir is null)
         {
             return null;
         }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2945,7 +2945,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     var path = Path.Combine(virtualFolderPath, collectionType.ToString()!.ToLowerInvariant() + ".collection"); // Can't be null with legal values?
 
-                    await File.WriteAllBytesAsync(path, []).ConfigureAwait(false);
+                    FileHelper.CreateEmpty(path);
                 }
 
                 CollectionFolder.SaveLibraryOptions(virtualFolderPath, options);

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -681,17 +681,17 @@ namespace Emby.Server.Implementations.Library
 
                 mediaInfo = await _mediaEncoder.GetMediaInfo(
                     new MediaInfoRequest
-                {
-                    MediaSource = mediaSource,
-                    MediaType = isAudio ? DlnaProfileType.Audio : DlnaProfileType.Video,
-                    ExtractChapters = false
-                },
+                    {
+                        MediaSource = mediaSource,
+                        MediaType = isAudio ? DlnaProfileType.Audio : DlnaProfileType.Video,
+                        ExtractChapters = false
+                    },
                     cancellationToken).ConfigureAwait(false);
 
                 if (cacheFilePath is not null)
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(cacheFilePath));
-                    FileStream createStream = File.Create(cacheFilePath);
+                    FileStream createStream = AsyncFile.Create(cacheFilePath);
                     await using (createStream.ConfigureAwait(false))
                     {
                         await JsonSerializer.SerializeAsync(createStream, mediaInfo, _jsonOptions, cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -520,7 +520,7 @@ namespace Emby.Server.Implementations.Localization
         public bool TryGetISO6392TFromB(string isoB, [NotNullWhen(true)] out string? isoT)
         {
             // Unlikely case the dictionary is not (yet) initialized properly
-            if (_iso6392BtoT == null)
+            if (_iso6392BtoT is null)
             {
                 isoT = null;
                 return false;

--- a/Jellyfin.Api/Controllers/SyncPlayController.cs
+++ b/Jellyfin.Api/Controllers/SyncPlayController.cs
@@ -125,7 +125,7 @@ public class SyncPlayController : BaseJellyfinApiController
     {
         var currentSession = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
         var group = _syncPlayManager.GetGroup(currentSession, id);
-        return group == null ? NotFound() : Ok(group);
+        return group is null ? NotFound() : Ok(group);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
+++ b/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
@@ -72,10 +72,7 @@ public static class StorageHelper
     private static void TestDataDirectorySize(string path, ILogger logger, long threshold = -1)
     {
         logger.LogDebug("Check path {TestPath} for storage capacity", path);
-        if (!Directory.Exists(path))
-        {
-            Directory.CreateDirectory(path);
-        }
+        Directory.CreateDirectory(path);
 
         var drive = new DriveInfo(path);
         if (threshold != -1 && drive.AvailableFreeSpace < threshold)

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -215,7 +215,7 @@ namespace Jellyfin.Server.Extensions
                 });
 
                 // Add all xml doc files to swagger generator.
-                var xmlFiles = Directory.GetFiles(
+                var xmlFiles = Directory.EnumerateFiles(
                     AppContext.BaseDirectory,
                     "*.xml",
                     SearchOption.TopDirectoryOnly);

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -133,9 +133,9 @@ namespace MediaBrowser.MediaEncoding.Attachments
             var outputFolder = _pathManager.GetAttachmentFolderPath(mediaSource.Id);
             using (await _semaphoreLocks.LockAsync(outputFolder, cancellationToken).ConfigureAwait(false))
             {
-                Directory.CreateDirectory(outputFolder);
-                var fileNames = Directory.GetFiles(outputFolder, "*", SearchOption.TopDirectoryOnly).Select(f => Path.GetFileName(f));
-                var missingFiles = mediaSource.MediaAttachments.Where(a => !fileNames.Contains(a.FileName) && !string.Equals(a.Codec, "mjpeg", StringComparison.OrdinalIgnoreCase));
+                var directory = Directory.CreateDirectory(outputFolder);
+                var fileNames = directory.GetFiles("*", SearchOption.TopDirectoryOnly).Select(f => f.Name).ToHashSet();
+                var missingFiles = mediaSource.MediaAttachments.Where(a => a.FileName is not null && !fileNames.Contains(a.FileName) && !string.Equals(a.Codec, "mjpeg", StringComparison.OrdinalIgnoreCase));
                 if (!missingFiles.Any())
                 {
                     // Skip extraction if all files already exist

--- a/MediaBrowser.Model/IO/AsyncFile.cs
+++ b/MediaBrowser.Model/IO/AsyncFile.cs
@@ -27,6 +27,14 @@ namespace MediaBrowser.Model.IO
         };
 
         /// <summary>
+        /// Creates, or truncates and overwrites, a file in the specified path.
+        /// </summary>
+        /// <param name="path">The path and name of the file to create.</param>
+        /// <returns>A <see cref="FileStream" /> that provides read/write access to the file specified in path.</returns>
+        public static FileStream Create(string path)
+            => new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+
+        /// <summary>
         /// Opens an existing file for reading.
         /// </summary>
         /// <param name="path">The file to be opened for reading.</param>

--- a/src/Jellyfin.Extensions/FileHelper.cs
+++ b/src/Jellyfin.Extensions/FileHelper.cs
@@ -1,0 +1,20 @@
+using System.IO;
+
+namespace Jellyfin.Extensions;
+
+/// <summary>
+/// Provides helper functions for <see cref="File" />.
+/// </summary>
+public static class FileHelper
+{
+    /// <summary>
+    /// Creates, or truncates a file in the specified path.
+    /// </summary>
+    /// <param name="path">The path and name of the file to create.</param>
+    public static void CreateEmpty(string path)
+    {
+        using (File.OpenHandle(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+        {
+        }
+    }
+}

--- a/src/Jellyfin.LiveTv/Channels/ChannelManager.cs
+++ b/src/Jellyfin.LiveTv/Channels/ChannelManager.cs
@@ -363,7 +363,7 @@ namespace Jellyfin.LiveTv.Channels
 
             Directory.CreateDirectory(Path.GetDirectoryName(path));
 
-            FileStream createStream = File.Create(path);
+            FileStream createStream = AsyncFile.Create(path);
             await using (createStream.ConfigureAwait(false))
             {
                 await JsonSerializer.SerializeAsync(createStream, mediaSources, _jsonOptions).ConfigureAwait(false);
@@ -866,7 +866,7 @@ namespace Jellyfin.LiveTv.Channels
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
 
-                var createStream = File.Create(path);
+                var createStream = AsyncFile.Create(path);
                 await using (createStream.ConfigureAwait(false))
                 {
                     await JsonSerializer.SerializeAsync(createStream, result, _jsonOptions).ConfigureAwait(false);

--- a/tests/Jellyfin.Extensions.Tests/FileHelperTests.cs
+++ b/tests/Jellyfin.Extensions.Tests/FileHelperTests.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Xunit;
+
+namespace Jellyfin.Extensions.Tests;
+
+public static class FileHelperTests
+{
+    [Fact]
+    public static void CreateEmpty_Valid_Correct()
+    {
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        var fileInfo = new FileInfo(path);
+
+        Assert.False(fileInfo.Exists);
+
+        FileHelper.CreateEmpty(path);
+
+        fileInfo.Refresh();
+        Assert.True(fileInfo.Exists);
+
+        File.Delete(path);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using Emby.Server.Implementations.Library;
 using Emby.Server.Implementations.Plugins;
+using Jellyfin.Extensions;
 using Jellyfin.Extensions.Json;
 using Jellyfin.Extensions.Json.Converters;
 using MediaBrowser.Common.Plugins;
@@ -85,7 +86,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var dllPath = Path.GetDirectoryName(Path.Combine(_pluginPath, dllFile))!;
 
             Directory.CreateDirectory(dllPath);
-            File.Create(Path.Combine(dllPath, filename));
+            FileHelper.CreateEmpty(filename);
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
 
             File.WriteAllText(metafilePath, JsonSerializer.Serialize(manifest, _options));
@@ -141,7 +142,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
 
             foreach (var file in files)
             {
-                File.Create(Path.Combine(_pluginPath, file));
+                FileHelper.CreateEmpty(Path.Combine(_pluginPath, file));
             }
 
             var metafilePath = Path.Combine(_pluginPath, "meta.json");

--- a/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
@@ -86,7 +86,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
             var dllPath = Path.GetDirectoryName(Path.Combine(_pluginPath, dllFile))!;
 
             Directory.CreateDirectory(dllPath);
-            FileHelper.CreateEmpty(filename);
+            FileHelper.CreateEmpty(Path.Combine(dllPath, filename));
             var metafilePath = Path.Combine(_pluginPath, "meta.json");
 
             File.WriteAllText(metafilePath, JsonSerializer.Serialize(manifest, _options));

--- a/tests/Jellyfin.Server.Integration.Tests/OpenApiSpecTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/OpenApiSpecTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using MediaBrowser.Model.IO;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -33,7 +34,7 @@ namespace Jellyfin.Server.Integration.Tests
             // Write out for publishing
             string outputPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".", "openapi.json"));
             _outputHelper.WriteLine("Writing OpenAPI Spec JSON to '{0}'.", outputPath);
-            await using var fs = File.Create(outputPath);
+            await using var fs = AsyncFile.Create(outputPath);
             await response.Content.CopyToAsync(fs);
         }
     }


### PR DESCRIPTION
* Add a helper function to efficiently create empty files
* Use enumeration methods to gets files where possible
* Don't check for directory existence before calling Directory.Create
* Add AsyncFile.Create helper function

Benchmark results for the different file creation options:
```
| Method                | Mean     | Error     | StdDev    | Gen0   | Allocated |
|---------------------- |---------:|----------:|----------:|-------:|----------:|
| FileCreate            | 2.544 us | 0.0026 us | 0.0021 us | 0.0038 |     232 B |
| FileCreateEmptyBuffer | 2.511 us | 0.0050 us | 0.0046 us |      - |     160 B |
| FileWriteAllBytes     | 2.744 us | 0.0030 us | 0.0028 us |      - |      64 B |
| FileOpenHandle        | 2.448 us | 0.0071 us | 0.0066 us |      - |      64 B |
```
