### PR TITLE
Localization/iso6392.txt: Correct the Portuguese entries

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -347,8 +347,8 @@ pli||pi|Pali|pali
 pol||pl|Polish|polonais
 pon|||Pohnpeian|pohnpei
 por||pt|Portuguese|portugais
-pop||pt-pt|Portuguese (Portugal)|portugais (pt-pt)
-pob||pt-br|Portuguese (Brazil)|portugais (pt-br)
+por||pt-pt|Portuguese (Portugal)|portugais (pt-pt)
+por||pt-br|Portuguese (Brazil)|portugais (pt-br)
 pra|||Prakrit languages|prâkrit, langues
 pro|||Provençal, Old (to 1500)|provençal ancien (jusqu'à 1500)
 pus||ps|Pushto; Pashto|pachto


### PR DESCRIPTION
``pob`` and ``pop`` are not valid iso 639 codes for Portuguese. Wikipedia says ``pop`` is Pwapwâ (https://en.wikipedia.org/w/index.php?title=ISO_639:pop) and ``pob`` is Poqomchiʼ (https://en.wikipedia.org/w/index.php?title=ISO_639:pob).

For testing, it was needed to rescan the specific files. Just renaming/adding subtitle files was not enough, but the movie had to be new.

**Changes**
Changed the values to ``por`` which is the valid ISO 639-2 code for Portuguese.
Before this PR subtitle files like ``movie.pt-br.srt`` would be scanned as ``pob``:
![image](https://github.com/user-attachments/assets/2af5b6ad-ae96-4bf1-b637-5de66b46ac74)
After this PR they are read as ``por``:
![image](https://github.com/user-attachments/assets/ab4c49e6-9745-44de-a1a0-1ff87ffa39f8)


**Issues**
Should fix the problem referenced by @webysther in #6302.