### PR TITLE
Fix trickplay directory path construction

### DIFF
--- a/Emby.Server.Implementations/Library/PathManager.cs
+++ b/Emby.Server.Implementations/Library/PathManager.cs
@@ -67,7 +67,7 @@ public class PathManager : IPathManager
         var id = item.Id.ToString("D", CultureInfo.InvariantCulture).AsSpan();
 
         return saveWithMedia
-            ? Path.Join(item.ContainingFolderPath, Path.ChangeExtension(item.Path, ".trickplay"))
+            ? Path.Join(item.ContainingFolderPath, Path.ChangeExtension(Path.GetFileName(item.Path), ".trickplay"))
             : Path.Join(_config.ApplicationPaths.TrickplayPath, id[..2], id);
     }
 

--- a/Emby.Server.Implementations/Library/PathManager.cs
+++ b/Emby.Server.Implementations/Library/PathManager.cs
@@ -29,14 +29,14 @@ public class PathManager : IPathManager
         _appPaths = appPaths;
     }
 
-    private string SubtitleCachePath => Path.Join(_appPaths.DataPath, "subtitles");
+    private string SubtitleCachePath => Path.Combine(_appPaths.DataPath, "subtitles");
 
-    private string AttachmentCachePath => Path.Join(_appPaths.DataPath, "attachments");
+    private string AttachmentCachePath => Path.Combine(_appPaths.DataPath, "attachments");
 
     /// <inheritdoc />
     public string GetAttachmentPath(string mediaSourceId, string fileName)
     {
-        return Path.Join(GetAttachmentFolderPath(mediaSourceId), fileName);
+        return Path.Combine(GetAttachmentFolderPath(mediaSourceId), fileName);
     }
 
     /// <inheritdoc />
@@ -58,7 +58,7 @@ public class PathManager : IPathManager
     /// <inheritdoc />
     public string GetSubtitlePath(string mediaSourceId, int streamIndex, string extension)
     {
-        return Path.Join(GetSubtitleFolderPath(mediaSourceId), streamIndex.ToString(CultureInfo.InvariantCulture) + extension);
+        return Path.Combine(GetSubtitleFolderPath(mediaSourceId), streamIndex.ToString(CultureInfo.InvariantCulture) + extension);
     }
 
     /// <inheritdoc />
@@ -67,14 +67,14 @@ public class PathManager : IPathManager
         var id = item.Id.ToString("D", CultureInfo.InvariantCulture).AsSpan();
 
         return saveWithMedia
-            ? Path.Join(item.ContainingFolderPath, Path.ChangeExtension(Path.GetFileName(item.Path), ".trickplay"))
+            ? Path.Combine(item.ContainingFolderPath, Path.ChangeExtension(Path.GetFileName(item.Path), ".trickplay"))
             : Path.Join(_config.ApplicationPaths.TrickplayPath, id[..2], id);
     }
 
     /// <inheritdoc/>
     public string GetChapterImageFolderPath(BaseItem item)
     {
-        return Path.Join(item.GetInternalMetadataPath(), "chapters");
+        return Path.Combine(item.GetInternalMetadataPath(), "chapters");
     }
 
     /// <inheritdoc/>
@@ -82,6 +82,6 @@ public class PathManager : IPathManager
     {
         var filename = item.DateModified.Ticks.ToString(CultureInfo.InvariantCulture) + "_" + chapterPositionTicks.ToString(CultureInfo.InvariantCulture) + ".jpg";
 
-        return Path.Join(GetChapterImageFolderPath(item), filename);
+        return Path.Combine(GetChapterImageFolderPath(item), filename);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Get filename using `Path.GetFileName()` before changing extension. 
Reverted to using `Path.Combine()` instead of` Path.Join()`

**Issues**
 Fixes: #14035

