### PR TITLE
Fix startup logger log file order

### DIFF
--- a/Jellyfin.Server/ServerSetupApp/SetupServer.cs
+++ b/Jellyfin.Server/ServerSetupApp/SetupServer.cs
@@ -113,7 +113,7 @@ public sealed class SetupServer : IDisposable
 
                                             var logFilePath = new DirectoryInfo(_applicationPaths.LogDirectoryPath)
                                                 .EnumerateFiles()
-                                                .OrderBy(f => f.CreationTimeUtc)
+                                                .OrderByDescending(f => f.CreationTimeUtc)
                                                 .FirstOrDefault()
                                                 ?.FullName;
                                             if (logFilePath is not null)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Changed the log file sorting from `OrderBy` to `OrderByDescending`

**Issues**
The startup logger was showing the oldest log file instead of the newest.
