### PR TITLE
Add albumart as recognized filename for music artwork

### DIFF
--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -33,7 +33,8 @@ namespace MediaBrowser.LocalMetadata.Images
             "poster",
             "cover",
             "jacket",
-            "default"
+            "default",
+            "albumart"
         };
 
         private static readonly string[] _personImageFileNames =


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Adds `albumart` to the list of recognized image filenames for music content

**Issues**
N/A
