### PR TITLE
add m3u8 files support

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -44,6 +44,8 @@ namespace Emby.Naming.Common
                 ".m2t",
                 ".m2ts",
                 ".m2v",
+                ".m3u8",
+                ".m3u",
                 ".m4v",
                 ".mkv",
                 ".mk3d",

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -513,8 +513,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             CancellationToken cancellationToken)
         {
             var args = extractChapters
-                ? "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_chapters -show_format"
-                : "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_format";
+                ? "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_chapters -show_format -protocol_whitelist \"file,https,tls,crypto,http,tcp\""
+                : "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_format -protocol_whitelist \"file,https,tls,crypto,http,tcp\"";
 
             if (_proberSupportsFirstVideoFrame)
             {


### PR DESCRIPTION
Local m3u8 file are not detected and not loaded in library, there is workaround to use m3u8 container file .strm.
 
**Changes**
1. Adding m3u and m3u8 in array of supporting extension.
2. Local m3u, m3u8 file with http segments requires protocol whitelist.

**Issues**
#13830 