### PR TITLE
Stop choosing stream with "Latin" in its title as preferred language stream

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -44,8 +44,8 @@ namespace Emby.Server.Implementations.Library
                 .Where(i => i.Type == MediaStreamType.Subtitle)
                 .OrderByDescending(x => x.IsExternal)
                 .ThenByDescending(x => x.IsDefault)
-                .ThenByDescending(x => !x.IsForced && MatchesPreferredLanguage(x.Language, preferredLanguages))
-                .ThenByDescending(x => x.IsForced && MatchesPreferredLanguage(x.Language, preferredLanguages))
+                .ThenByDescending(x => !x.IsForced && MatchesPreferredLanguage(x.Language, preferredLanguages) && !x.Title.Contains("latin", StringComparison.OrdinalIgnoreCase))
+                .ThenByDescending(x => x.IsForced && MatchesPreferredLanguage(x.Language, preferredLanguages) && !x.Title.Contains("latin", StringComparison.OrdinalIgnoreCase))
                 .ThenByDescending(x => x.IsForced && IsLanguageUndefined(x.Language))
                 .ThenByDescending(x => x.IsForced)
                 .ToList();


### PR DESCRIPTION
<!--
Change the stream sorting order to prioritize spanish streams that don't contain the word "latin", ensuring that if there are two spanish streams, one in castillian and the other in Latin, always chooses the castillian one. This is a hack suited for my needs.
-->

**Changes**
<!-- When checking if the language matches the preferred language, also check if the title of the stream contains "latin" -->
