### PR TITLE
Only selecting a forced subtitle in smart mode if it matches audio language

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -64,7 +64,7 @@ namespace Emby.Server.Implementations.Library
                 // If the audio language is one of the user's preferred subtitle languages behave like OnlyForced.
                 if (!preferredLanguages.Contains(audioTrackLanguage, StringComparison.OrdinalIgnoreCase))
                 {
-                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced));
+                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced || IsLanguageUndefined(audioTrackLanguage)));
                 }
                 else
                 {

--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -64,7 +64,7 @@ namespace Emby.Server.Implementations.Library
                 // If the audio language is one of the user's preferred subtitle languages behave like OnlyForced.
                 if (!preferredLanguages.Contains(audioTrackLanguage, StringComparison.OrdinalIgnoreCase))
                 {
-                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages));
+                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced));
                 }
                 else
                 {


### PR DESCRIPTION
**Changes**
This PR addresses an issue where, in "Smart" mode, if a subtitle track is marked as default and as forced and is in your preferred language, it will be selected independently of the audio language of the file. I adjusted the subtitle selection in "Smart" mode to only select your preferred language forced subtitle track if it's language it's the same as the audio track language, or if the language is undefined (for example: silent movies).

