### PR TITLE
Use VBR and MBBRC in QSV encoders for better quality

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1572,6 +1572,26 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return FormattableString.Invariant($" -maxrate {bitrate} -bufsize {bufsize}");
             }
 
+            if (string.Equals(videoCodec, "h264_qsv", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(videoCodec, "hevc_qsv", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(videoCodec, "av1_qsv", StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO: probe QSV encoders' capabilities and enable more tuning options
+                // See also https://github.com/intel/media-delivery/blob/master/doc/quality.rst
+
+                // Enable MacroBlock level bitrate control for better subjective visual quality
+                var mbbrcOpt = string.Empty;
+                if (string.Equals(videoCodec, "h264_qsv", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(videoCodec, "hevc_qsv", StringComparison.OrdinalIgnoreCase))
+                {
+                    mbbrcOpt = " -mbbrc 1";
+                }
+
+                // Set (maxrate == bitrate + 1) to trigger VBR for better bitrate allocation
+                // Set (rc_init_occupancy == 2 * bitrate) and (bufsize == 4 * bitrate) to deal with drastic scene changes
+                return FormattableString.Invariant($"{mbbrcOpt} -b:v {bitrate} -maxrate {bitrate + 1} -rc_init_occupancy {bitrate * 2} -bufsize {bitrate * 4}");
+            }
+
             if (string.Equals(videoCodec, "h264_amf", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(videoCodec, "hevc_amf", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(videoCodec, "av1_amf", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
**Changes**
- Use VBR and MBBRC in QSV encoders for better quality

Use VBR for better bitrate allocation. Enable MacroBlock level bitrate control for better subjective visual quality.