### PR TITLE
Reject invalid replaygain tag value

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -343,7 +343,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     trackGainTag = trackGainTag[..^2].Trim();
                 }
 
-                if (float.TryParse(trackGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+                if (float.TryParse(trackGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) && float.IsFinite(value))
                 {
                     audio.NormalizationGain = value;
                 }


### PR DESCRIPTION
In .NET, `float.TryParse("NaN", NumberStyles.Float, CultureInfo.InvariantCulture, out var value)` returns `true` and value will be `float.NaN`.

Only accept finite values for replaygain tag.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #13290
