### PR TITLE
Prune trickplay data on regenerate and scan

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -152,13 +152,16 @@ public class TrickplayManager : ITrickplayManager
             if (!libraryOptions.EnableTrickplayImageExtraction || replace)
             {
                 // Prune existing data
-                try
+                if (Directory.Exists(trickplayDirectory))
                 {
-                    Directory.Delete(trickplayDirectory, true);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning("Unable to clear trickplay directory: {Directory}: {Exception}", trickplayDirectory, ex);
+                    try
+                    {
+                        Directory.Delete(trickplayDirectory, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning("Unable to clear trickplay directory: {Directory}: {Exception}", trickplayDirectory, ex);
+                    }
                 }
 
                 await dbContext.TrickplayInfos
@@ -205,6 +208,7 @@ public class TrickplayManager : ITrickplayManager
             {
                 try
                 {
+                    _logger.LogWarning("Pruning trickplay files for {Item}", video.Path);
                     Directory.Delete(folder, true);
                 }
                 catch (Exception ex)

--- a/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
@@ -59,14 +59,14 @@ public class TrickplayImagesTask : IScheduledTask
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        return new[]
-        {
+        return
+        [
             new TaskTriggerInfo
             {
                 Type = TaskTriggerInfoType.DailyTrigger,
                 TimeOfDayTicks = TimeSpan.FromHours(3).Ticks
             }
-        };
+        ];
     }
 
     /// <inheritdoc />
@@ -74,8 +74,8 @@ public class TrickplayImagesTask : IScheduledTask
     {
         var query = new InternalItemsQuery
         {
-            MediaTypes = new[] { MediaType.Video },
-            SourceTypes = new[] { SourceType.Library },
+            MediaTypes = [MediaType.Video],
+            SourceTypes = [SourceType.Library],
             IsVirtualItem = false,
             IsFolder = false,
             Recursive = true,


### PR DESCRIPTION
**Changes**
* If trickplay is disabled for library all trickplay data is pruned
* If we refresh, all trickplay data will be removed and then for the current widths recreated
* If we just run, all trickplay data which is not matching the current configuration is removed
* When running the scheduled task we also prune any data for libraries where trickplay was disabled

**Issues**
Fixes #13918