### PR TITLE
Added an option to Disable "noaccurate_seek"

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2922,7 +2922,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                         && !string.Equals(segmentFormat, "ts", StringComparison.OrdinalIgnoreCase)
                         && state.TranscodingType != TranscodingJobType.Progressive
                         && !state.EnableBreakOnNonKeyFrames(outputVideoCodec)
-                        && (state.BaseRequest.StartTimeTicks ?? 0) > 0)
+                        && (state.BaseRequest.StartTimeTicks ?? 0) > 0
+                        && options.EnableNoAccurateSeek)
                     {
                         seekParam += " -noaccurate_seek";
                     }

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -21,6 +21,7 @@ public class EncodingOptions
         DownMixStereoAlgorithm = DownMixStereoAlgorithms.None;
         MaxMuxingQueueSize = 2048;
         EnableThrottling = false;
+        EnableNoAccurateSeek = true;
         ThrottleDelaySeconds = 180;
         EnableSegmentDeletion = false;
         SegmentKeepSeconds = 720;
@@ -105,6 +106,11 @@ public class EncodingOptions
     /// Gets or sets a value indicating whether throttling is enabled.
     /// </summary>
     public bool EnableThrottling { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether ffmpeg noaccurate_seek is enabled.
+    /// </summary>
+    public bool EnableNoAccurateSeek { get; set; }
 
     /// <summary>
     /// Gets or sets the delay after which throttling happens.


### PR DESCRIPTION
**Changes**
Adds a configuration option to disable "noaccurate_seek" when transcoding ffmpeg

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/13965
