### PR TITLE
Fix ArgumentNullException in TmdbExternalUrlProvider

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1478,7 +1478,7 @@ public sealed class BaseItemRepository
 
         if (maxWidth.HasValue)
         {
-            baseQuery = baseQuery.Where(e => e.Width >= maxWidth);
+            baseQuery = baseQuery.Where(e => e.Width <= maxWidth);
         }
 
         if (filter.MaxHeight.HasValue)
@@ -1696,7 +1696,7 @@ public sealed class BaseItemRepository
 
         if (filter.MinPremiereDate.HasValue)
         {
-            baseQuery = baseQuery.Where(e => e.PremiereDate <= filter.MinPremiereDate.Value);
+            baseQuery = baseQuery.Where(e => e.PremiereDate >= filter.MinPremiereDate.Value);
         }
 
         if (filter.MaxPremiereDate.HasValue)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
@@ -30,7 +30,7 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
 
                 break;
             case Season season:
-                if (season.Series != null && season.Series.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId))
+                if (season.Series?.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId) == true)
                 {
                     var orderString = season.Series.DisplayOrder;
                     var seasonNumber = season.IndexNumber;
@@ -51,7 +51,7 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
 
                 break;
             case Episode episode:
-                if (episode.Series != null && episode.Series.TryGetProviderId(MetadataProvider.Tmdb, out seriesExternalId))
+                if (episode.Series?.TryGetProviderId(MetadataProvider.Tmdb, out seriesExternalId) == true)
                 {
                     var orderString = episode.Series.DisplayOrder;
                     var seasonNumber = episode.Season?.IndexNumber;

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
@@ -30,7 +30,7 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
 
                 break;
             case Season season:
-                if (season.Series.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId))
+                if (season.Series != null && season.Series.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId))
                 {
                     var orderString = season.Series.DisplayOrder;
                     var seasonNumber = season.IndexNumber;
@@ -51,7 +51,7 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
 
                 break;
             case Episode episode:
-                if (episode.Series.TryGetProviderId(MetadataProvider.Imdb, out seriesExternalId))
+                if (episode.Series != null && episode.Series.TryGetProviderId(MetadataProvider.Tmdb, out seriesExternalId))
                 {
                     var orderString = episode.Series.DisplayOrder;
                     var seasonNumber = episode.Season?.IndexNumber;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Added null checks for `episode.Series` and `season.Series`
- Changed `Imdb `to `Tmdb`
- Fixed the comparison operator for `maxWidth `and `MinPremiereDate`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
<details>
  <summary>Log Error</summary>

```
 System.ArgumentNullException: Value cannot be null. (Parameter 'instance')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.TryGetProviderId(IHasProviderIds instance, String name, String& id) in C:\git\jellyfin\MediaBrowser.Model\Entities\ProviderIdsExtensions.cs:line 50
   at MediaBrowser.Model.Entities.ProviderIdsExtensions.TryGetProviderId(IHasProviderIds instance, MetadataProvider provider, String& id) in C:\git\jellyfin\MediaBrowser.Model\Entities\ProviderIdsExtensions.cs:line 78
   at MediaBrowser.Providers.Plugins.Tmdb.TmdbExternalUrlProvider.GetExternalUrls(BaseItem item)+MoveNext() in C:\git\jellyfin\MediaBrowser.Providers\Plugins\Tmdb\TmdbExternalUrlProvider.cs:line 54
   at System.Linq.Enumerable.IEnumerableSelectIterator`2.MoveNext()
   at System.Collections.Generic.SegmentedArrayBuilder`1.AddRange(IEnumerable`1 source)
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray()
   at Emby.Server.Implementations.Dto.DtoService.AttachBasicFields(BaseItemDto dto, BaseItem item, BaseItem owner, DtoOptions options) in C:\git\jellyfin\Emby.Server.Implementations\Dto\DtoService.cs:line 742
   at Emby.Server.Implementations.Dto.DtoService.GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User user, BaseItem owner) in C:\git\jellyfin\Emby.Server.Implementations\Dto\DtoService.cs:line 231
   at Emby.Server.Implementations.Dto.DtoService.GetBaseItemDto(BaseItem item, DtoOptions options, User user, BaseItem owner) in C:\git\jellyfin\Emby.Server.Implementations\Dto\DtoService.cs:line 140
   at Jellyfin.Api.Controllers.UserLibraryController.GetItem(Nullable`1 userId, Guid itemId) in C:\git\jellyfin\Jellyfin.Api\Controllers\UserLibraryController.cs:line 99
   at lambda_method6983(Closure, Object)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
```

</details>