### PR TITLE
Fix race condition in SessionManager.GetSessionInfo

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -508,13 +508,11 @@ namespace Emby.Server.Implementations.Session
             ArgumentException.ThrowIfNullOrEmpty(deviceId);
 
             var key = GetSessionKey(appName, deviceId);
-
-            CheckDisposed();
-
-            if (!_activeConnections.TryGetValue(key, out var sessionInfo))
+            SessionInfo newSession = CreateSessionInfo(key, appName, appVersion, deviceId, deviceName, remoteEndPoint, user);
+            SessionInfo sessionInfo = _activeConnections.GetOrAdd(key, newSession);
+            if (ReferenceEquals(newSession, sessionInfo))
             {
-                sessionInfo = CreateSession(key, appName, appVersion, deviceId, deviceName, remoteEndPoint, user);
-                _activeConnections[key] = sessionInfo;
+                OnSessionStarted(newSession);
             }
 
             sessionInfo.UserId = user?.Id ?? Guid.Empty;
@@ -538,7 +536,7 @@ namespace Emby.Server.Implementations.Session
             return sessionInfo;
         }
 
-        private SessionInfo CreateSession(
+        private SessionInfo CreateSessionInfo(
             string key,
             string appName,
             string appVersion,
@@ -582,7 +580,6 @@ namespace Emby.Server.Implementations.Session
                 sessionInfo.HasCustomDeviceName = true;
             }
 
-            OnSessionStarted(sessionInfo);
             return sessionInfo;
         }
 


### PR DESCRIPTION
This PR addresses a thread safety issue in SessionManager.GetSessionInfo where concurrent access could lead to a race condition.

Fixes #14132