### PR TITLE
Add authentication for VideoAttachmentsController

### DIFF
--- a/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
+++ b/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
@@ -6,10 +6,12 @@ using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,6 +21,7 @@ namespace Jellyfin.Api.Controllers;
 /// Attachments controller.
 /// </summary>
 [Route("Videos")]
+[Authorize(Policy = Policies.FirstTimeSetupOrElevated)]
 public class VideoAttachmentsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;


### PR DESCRIPTION
Require authentication when trying to access attachments for video.

Without Token:
```curl
> GET /videos/bba5d913a29c7c09c2cd53264b06e063/bba5d913a29c7c09c2cd53264b06e063/Attachments/3 HTTP/1.1
> Host: localhost:8096
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 401 Unauthorized
< Content-Length: 0
< Date: Mon, 19 May 2025 15:27:58 GMT
< Server: Kestrel
< X-Response-Time-ms: 0.1888
<
```

With token:
```curl
> GET /videos/bba5d913a29c7c09c2cd53264b06e063/bba5d913a29c7c09c2cd53264b06e063/Attachments/3 HTTP/1.1
> Host: localhost:8096
> User-Agent: curl/8.5.0
> Accept: */*
> Authorization: MediaBrowser Token="xxxx"
>
< HTTP/1.1 200 OK
< Content-Length: 313572
< Content-Type: application/x-truetype-font
< Date: Mon, 19 May 2025 15:26:52 GMT
< Server: Kestrel
< X-Response-Time-ms: 9.5682
<
```

**Changes**
- Add `Authorize` attribute in `VideoAttachmentsController`

**Issues**
Fixes #13983 


> This is my first time trying to contribute, trying to familiarize myself with the codebase. Feedback is much appreciated.