### PR TITLE
Add authentication for 'Get subtitles in a specified format' endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -206,6 +206,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}")]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesFile("text/*")]
     public async Task<ActionResult> GetSubtitle(
@@ -293,6 +294,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Stream.{routeFormat}")]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesFile("text/*")]
     public Task<ActionResult> GetSubtitleWithTicks(


### PR DESCRIPTION
Tested locally, if not provided any token, the endpoints return `401` HTTP code. 

The `?ApiKey` query parameter is already being provided by the web client.

**Changes**
- Add `Authorize` attribute for the Get subtitles in a specified format endpoints.

**Issues**
Fixes #13985 
