### PR TITLE
Ensure subfolders are processed in folders containing one video file

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -456,8 +456,9 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
             {
                 var videoPath = result.Items[0].Path;
                 var hasPhotos = photos.Any(i => !PhotoResolver.IsOwnedByResolvedMedia(videoPath, i.Name));
+                var hasOtherSubfolders = multiDiscFolders.Count > 0;
 
-                if (!hasPhotos)
+                if (!hasPhotos && !hasOtherSubfolders)
                 {
                     var movie = (T)result.Items[0];
                     movie.IsInMixedFolder = false;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Previously, if a folder contained a single video file along with subfolders, the subfolders were ignored during media detection. This PR adds a check to ensure subfolders are properly processed and their contents detected.

**Issues**
Fixes #9221
