### PR TITLE
Fix TV Series Name Parsing for Shows with only Digits in its Title

### DIFF
--- a/Emby.Naming/TV/SeriesResolver.cs
+++ b/Emby.Naming/TV/SeriesResolver.cs
@@ -27,10 +27,17 @@ namespace Emby.Naming.TV
         {
             string seriesName = Path.GetFileName(path);
 
-            SeriesPathParserResult result = SeriesPathParser.Parse(options, path);
-            if (result.Success)
+            // First check if the name starts with 4 digits (potential series name)
+            var match = Regex.Match(seriesName, @"^-?([0-9]{4})\s*(?:\(.*\))?");
+            if (match.Success)
             {
-                if (!string.IsNullOrEmpty(result.SeriesName))
+                seriesName = match.Groups[1].Value; // Just take the numeric part as series name
+            }
+            else
+            {
+                // Fall back to original SeriesPathParser way
+                SeriesPathParserResult result = SeriesPathParser.Parse(options, path);
+                if (result.Success && !string.IsNullOrEmpty(result.SeriesName))
                 {
                     seriesName = result.SeriesName;
                 }

--- a/tests/Jellyfin.Naming.Tests/TV/SeriesResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeriesResolverTests.cs
@@ -19,6 +19,8 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("/some/path/The Show", "The Show")]
         [InlineData("/some/path/The Show s02e10 720p hdtv", "The Show")]
         [InlineData("/some/path/The Show s02e10 the episode 720p hdtv", "The Show")]
+        [InlineData("/some/path/1923 (2022)", "1923")]
+        [InlineData("/some/path/-1923 (2022)", "1923")]
         public void SeriesResolverResolveTest(string path, string name)
         {
             var res = SeriesResolver.Resolve(_namingOptions, path);


### PR DESCRIPTION

**Changes**
Within the Resolve function in the SeriesResolver class, I added the case where the title of the tv show is only numbers. Currently it only looks for tv show titles with 4 digits. It uses Regex for possible matches and takes the numeric part for the instance where the title is `1923 (2022)`, it rightfully recognizes that `1923` is the title of the show. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes #13875.
