### PR TITLE
Add SVG to transparent image types

### DIFF
--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -34,7 +34,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
     private const char Version = '3';
 
     private static readonly HashSet<string> _transparentImageTypes
-        = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".png", ".webp", ".gif" };
+        = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".png", ".webp", ".gif", ".svg" };
 
     private readonly ILogger<ImageProcessor> _logger;
     private readonly IFileSystem _fileSystem;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
SVG files were not included in the` _transparentImageTypes` list, which caused them to be rendered with an opaque background. This change adds `.svg `to that list to preserve transparency when processed.

Before:
![1](https://github.com/user-attachments/assets/18a1406f-2ffa-4fcc-b090-737ba8e41382)

With Fix:
![3](https://github.com/user-attachments/assets/feacfc21-380b-4167-8463-01f4efa76b7c)

**Issues**
Fixes: #13956
Fixes: [#3941](https://github.com/jellyfin/jellyfin-androidtv/issues/3941)
Other clients have already implemented workarounds for this issue, ex: [#301](https://github.com/jellyfin/jellyfin-roku/issues/301)
