### PR TITLE
Fix unittests

### DIFF
--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
@@ -54,7 +54,7 @@ public class XmlTvListingsProviderTests
             Path = path
         };
 
-        var startDate = new DateTime(2022, 11, 4);
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, 0, DateTimeKind.Utc);
         var programs = await _xmlTvListingsProvider.GetProgramsAsync(info, "3297", startDate, startDate.AddDays(1), CancellationToken.None);
         var programsList = programs.ToList();
         Assert.Single(programsList);
@@ -78,7 +78,7 @@ public class XmlTvListingsProviderTests
             Path = path
         };
 
-        var startDate = new DateTime(2022, 11, 4);
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
         var programs = await _xmlTvListingsProvider.GetProgramsAsync(info, "3297", startDate, startDate.AddDays(1), CancellationToken.None);
         var programsList = programs.ToList();
         Assert.Single(programsList);


### PR DESCRIPTION
Fix failing unit tests on machines where the local timezone offset is far enough away from the test data day to be off by a day.

**Changes**
Change the test startdate to specifically be utc instead of local machine timezone.
