### PR TITLE
Add Configuration/UpdateTrustedNetwork api to change trusted network at runtime

### DIFF
--- a/Jellyfin.Api/Models/ConfigurationDtos/TrustedNetworkDto.cs
+++ b/Jellyfin.Api/Models/ConfigurationDtos/TrustedNetworkDto.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.ConfigurationDtos;
+
+/// <summary>
+/// Represents the configuration for trusted networks, including local network subnets and remote IP filtering options.
+/// </summary>
+public class TrustedNetworkDto
+{
+    /// <summary>
+    /// Gets or sets the subnets that are deemed to make up the LAN.
+    /// </summary>
+    public IReadOnlyList<string>? LocalNetworkSubnets { get; set; }
+
+    /// <summary>
+    /// Gets or sets the filter for remote IP connectivity. Used in conjunction with <seealso cref="IsRemoteIPFilterBlacklist"/>.
+    /// </summary>
+    public IReadOnlyList<string>? RemoteIPFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <seealso cref="RemoteIPFilter"/> contains a blacklist or a whitelist. Default is a whitelist.
+    /// </summary>
+    public bool? IsRemoteIPFilterBlacklist { get; set; }
+}

--- a/MediaBrowser.Common/Net/INetworkManager.cs
+++ b/MediaBrowser.Common/Net/INetworkManager.cs
@@ -129,5 +129,11 @@ namespace MediaBrowser.Common.Net
         /// <param name="remoteIP">IP address of the client.</param>
         /// <returns><b>True</b> if it has access, otherwise <b>false</b>.</returns>
         bool HasRemoteAccess(IPAddress remoteIP);
+
+        /// <summary>
+        /// Reloads all settings and re-Initializes the instance.
+        /// </summary>
+        /// <param name="configuration">The <see cref="NetworkConfiguration"/> to use.</param>
+        public void UpdateSettings(object configuration);
     }
 }

--- a/MediaBrowser.Common/Net/INetworkManager.cs
+++ b/MediaBrowser.Common/Net/INetworkManager.cs
@@ -134,6 +134,6 @@ namespace MediaBrowser.Common.Net
         /// Reloads all settings and re-Initializes the instance.
         /// </summary>
         /// <param name="configuration">The <see cref="NetworkConfiguration"/> to use.</param>
-        public void UpdateSettings(object configuration);
+        void UpdateSettings(object configuration);
     }
 }


### PR DESCRIPTION
Previously, updating trusted IPs (LocalNetworkSubnets, RemoteIPFilter, IsRemoteIPFilterBlacklist) required a server restart. This change introduces a new API endpoint that allows these network configuration fields to be updated at runtime, as their values are only read when needed. This improves flexibility for some special network environments.

Example:

```
curl 'http://localhost:8096/System/Configuration/UpdateTrustedNetwork' \
-X 'POST' \
-H 'Content-Type: application/json' \
-H 'Accept: */*' \
-H 'Authorization: MediaBrowser Client="Jellyfin Test", Device="Test", DeviceId="abcdefg", Version="10.11.0", Token="mytoken"' \
--data-raw '{"LocalNetworkSubnets":[],"RemoteIPFilter":[],"IsRemoteIPFilterBlacklist":false}'
```

Any of the LocalNetworkSubnets, RemoteIPFilter, IsRemoteIPFilterBlacklist can be null in the request, which means "no change".

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #14189 

An alternative approach to #14190
