### PR TITLE
Add year parameter to TMDB series cache key

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -374,7 +374,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <returns>The TMDb tv show information.</returns>
         public async Task<IReadOnlyList<SearchTv>> SearchSeriesAsync(string name, string language, int year = 0, CancellationToken cancellationToken = default)
         {
-            var key = $"searchseries-{name}-{language}";
+            var key = $"searchseries-{name}-{year.ToString(CultureInfo.InvariantCulture)}-{language}";
             if (_memoryCache.TryGetValue(key, out SearchContainer<SearchTv>? series) && series is not null)
             {
                 return series.Results;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Problem**
When performing metadata searches for series with the same title but different release years, the caching system was using a key that did not include the year. As a result, the first fetched result was cached and reused for all other searches with the same title, regardless of the specified year.

For example, after fetching metadata for Doctor Who (1963), a request for Doctor Who (2005) or Doctor Who (2024) would incorrectly return data for the 1963 version.

**Changes**
Updated the cache key for series metadata lookups to include the release year .

This aligns with how movie cache keys are handled and ensures series with the same title but different years are cached and retrieved separately.

Before:
![1](https://github.com/user-attachments/assets/66574b74-634a-4eef-8c93-0f1ce2283e05)
After: 

![4](https://github.com/user-attachments/assets/3239a60a-237d-4464-b000-20b53f4f62f1)

