### PR TITLE
Fix existing media segments not being handled on scan

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -196,6 +196,7 @@
  - [benedikt257](https://github.com/benedikt257)
  - [revam](https://github.com/revam)
  - [allesmi](https://github.com/allesmi)
+ - [ThunderClapLP](https://github.com/ThunderClapLP)
 
 # Emby Contributors
 

--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -51,7 +51,7 @@ public class MediaSegmentManager : IMediaSegmentManager
     }
 
     /// <inheritdoc/>
-    public async Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool overwrite, CancellationToken cancellationToken)
+    public async Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken)
     {
         var providers = _segmentProviders
             .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
@@ -70,18 +70,7 @@ public class MediaSegmentManager : IMediaSegmentManager
 
         using var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!overwrite && (await db.MediaSegments.AnyAsync(e => e.ItemId.Equals(baseItem.Id), cancellationToken).ConfigureAwait(false)))
-        {
-            _logger.LogDebug("Skip {MediaPath} as it already contains media segments", baseItem.Path);
-            return;
-        }
-
         _logger.LogDebug("Start media segment extraction for {MediaPath} with {CountProviders} providers enabled", baseItem.Path, providers.Count);
-
-        await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
-
-        // no need to recreate the request object every time.
-        var requestItem = new MediaSegmentGenerationRequest() { ItemId = baseItem.Id };
 
         foreach (var provider in providers)
         {
@@ -91,13 +80,50 @@ public class MediaSegmentManager : IMediaSegmentManager
                 continue;
             }
 
+            if (forceOverwrite)
+            {
+                // delete all existing media segments if forceOverwrite is set.
+                await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));
+            var requestItem = new MediaSegmentGenerationRequest()
+            {
+                ItemId = baseItem.Id,
+                ExistingSegments = existingSegments.Select(e => Map(e)).ToList()
+            };
+
             try
             {
                 var segments = await provider.GetMediaSegments(requestItem, cancellationToken)
                     .ConfigureAwait(false);
-                if (segments.Count == 0)
+
+                if (!forceOverwrite)
+                {
+                    if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegments.ToList().Any(f =>
+                    {
+                        return
+                            e.StartTicks == f.StartTicks &&
+                            e.EndTicks == f.EndTicks &&
+                            e.Type == f.Type;
+                    })))
+                    {
+                        _logger.LogDebug("Media Segment provider {ProviderName} did not modify any segments for {MediaPath}", provider.Name, baseItem.Path);
+                        continue;
+                    }
+
+                    // delete existing media segments that were re-generated.
+                    await existingSegments.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (segments.Count == 0 && !requestItem.ExistingSegments.Any())
                 {
                     _logger.LogDebug("Media Segment provider {ProviderName} did not find any segments for {MediaPath}", provider.Name, baseItem.Path);
+                    continue;
+                }
+                else if (segments.Count == 0 && requestItem.ExistingSegments.Any())
+                {
+                    _logger.LogDebug("Media Segment provider {ProviderName} deleted all segments for {MediaPath}", provider.Name, baseItem.Path);
                     continue;
                 }
 

--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -100,7 +100,8 @@ public class MediaSegmentManager : IMediaSegmentManager
 
                 if (!forceOverwrite)
                 {
-                    if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegments.ToList().Any(f =>
+                    var existingSegmentsList = existingSegments.ToList(); // Cannot use requestItem's list, as the provider might tamper with its items.
+                    if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegmentsList.Any(f =>
                     {
                         return
                             e.StartTicks == f.StartTicks &&

--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -86,11 +86,20 @@ public class MediaSegmentManager : IMediaSegmentManager
                 continue;
             }
 
-            var existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));
+            IQueryable<MediaSegment> existingSegments;
+            if (forceOverwrite)
+            {
+                existingSegments = Array.Empty<MediaSegment>().AsQueryable();
+            }
+            else
+            {
+                existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));
+            }
+
             var requestItem = new MediaSegmentGenerationRequest()
             {
                 ItemId = baseItem.Id,
-                ExistingSegments = existingSegments.Select(e => Map(e)).ToList()
+                ExistingSegments = existingSegments.Select(e => Map(e)).ToArray()
             };
 
             try
@@ -100,7 +109,7 @@ public class MediaSegmentManager : IMediaSegmentManager
 
                 if (!forceOverwrite)
                 {
-                    var existingSegmentsList = existingSegments.ToList(); // Cannot use requestItem's list, as the provider might tamper with its items.
+                    var existingSegmentsList = existingSegments.ToArray(); // Cannot use requestItem's list, as the provider might tamper with its items.
                     if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegmentsList.Any(f =>
                     {
                         return

--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -72,18 +72,18 @@ public class MediaSegmentManager : IMediaSegmentManager
 
         _logger.LogDebug("Start media segment extraction for {MediaPath} with {CountProviders} providers enabled", baseItem.Path, providers.Count);
 
+        if (forceOverwrite)
+        {
+            // delete all existing media segments if forceOverwrite is set.
+            await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         foreach (var provider in providers)
         {
             if (!await provider.Supports(baseItem).ConfigureAwait(false))
             {
                 _logger.LogDebug("Media Segment provider {ProviderName} does not support item with path {MediaPath}", provider.Name, baseItem.Path);
                 continue;
-            }
-
-            if (forceOverwrite)
-            {
-                // delete all existing media segments if forceOverwrite is set.
-                await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
             }
 
             var existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));

--- a/MediaBrowser.Controller/MediaSegments/IMediaSegmentManager.cs
+++ b/MediaBrowser.Controller/MediaSegments/IMediaSegmentManager.cs
@@ -20,10 +20,10 @@ public interface IMediaSegmentManager
     /// </summary>
     /// <param name="baseItem">The Item to evaluate.</param>
     /// <param name="libraryOptions">The library options.</param>
-    /// <param name="overwrite">If set, will remove existing segments and replace it with new ones otherwise will check for existing segments and if found any, stops.</param>
+    /// <param name="forceOverwrite">If set, will force to remove existing segments and replace it with new ones otherwise will check for existing segments and if found any that should not be deleted, stops.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that indicates the Operation is finished.</returns>
-    Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool overwrite, CancellationToken cancellationToken);
+    Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns if this item supports media segments.

--- a/MediaBrowser.Model/MediaSegments/MediaSegmentGenerationRequest.cs
+++ b/MediaBrowser.Model/MediaSegments/MediaSegmentGenerationRequest.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Model.MediaSegments;
 
 namespace MediaBrowser.Model;
 
@@ -11,4 +14,9 @@ public record MediaSegmentGenerationRequest
     /// Gets the Id to the BaseItem the segments should be extracted from.
     /// </summary>
     public Guid ItemId { get; init; }
+
+    /// <summary>
+    /// Gets existing media segments generated on an earlier scan by this provider.
+    /// </summary>
+    public required IReadOnlyList<MediaSegmentDto> ExistingSegments { get; init; }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Changes**
With this PR, media segment providers now can decide for each existing segment if they want to keep it or generate new ones.


--- 
**Original Description**

**Changes**
With this PR, media segment providers can now determine whether segments generated by them should be deleted and re-generated on each scan.

**Why not just re-generate the segments of all providers on scan?**
That was my first idea, but I do think it was intentional that the original implementation did not do that. E.g., if a provider grabs data over the network, refreshing them every 24h would not be optimal.

**Remaining issue**
While this resolves the original issue #14117 for all providers that set `DeleteOnScan = true`, segments generated by other providers still have no way of being deleted.
Maybe it would be a good idea to delete those on library scan if the user selects "replace all metadata"?

---
**Issues**
 Fixes #14117
