### PR TITLE
Fix metadata not refreshing in negative UTC timezones

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -86,7 +86,7 @@ namespace MediaBrowser.Providers.Manager
             var itemOfType = (TItemType)item;
             var updateType = ItemUpdateType.None;
             var libraryOptions = LibraryManager.GetLibraryOptions(item);
-            var isFirstRefresh = item.DateLastRefreshed == default;
+            var isFirstRefresh = item.DateLastRefreshed.Date == DateTime.MinValue.Date;
             var hasRefreshedMetadata = true;
             var hasRefreshedImages = true;
 
@@ -650,7 +650,7 @@ namespace MediaBrowser.Providers.Manager
             var dateLastImageRefresh = item.DateLastRefreshed;
 
             // Run all if either of these flags are true
-            var runAllProviders = options.ImageRefreshMode == MetadataRefreshMode.FullRefresh || dateLastImageRefresh == default(DateTime);
+            var runAllProviders = options.ImageRefreshMode == MetadataRefreshMode.FullRefresh || dateLastImageRefresh.Date == DateTime.MinValue.Date;
 
             if (!runAllProviders)
             {


### PR DESCRIPTION
Jellyfin fails to fetch metadata for new items during regular library scans when running in negative UTC timezones on initial scan. The timezone offset is incorrectly applied to `DateTime.MinValue,` causing `== default(DateTime) `comparisons to fail.

**Changes**
Replace timezone-sensitive default DateTime comparisons with date-only comparisons

**Issues**
Fixes #13114
