### PR TITLE
Fix broken chapter image placeholders when no image is present

### DIFF
--- a/Jellyfin.Server.Implementations/Item/ChapterRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/ChapterRepository.cs
@@ -112,7 +112,12 @@ public class ChapterRepository : IChapterRepository
             ImagePath = chapterInfo.ImagePath,
             Name = chapterInfo.Name,
         };
-        chapterEntity.ImageTag = _imageProcessor.GetImageCacheTag(baseItemPath, chapterEntity.ImageDateModified);
+
+        if (!string.IsNullOrEmpty(chapterInfo.ImagePath))
+        {
+            chapterEntity.ImageTag = _imageProcessor.GetImageCacheTag(baseItemPath, chapterEntity.ImageDateModified);
+        }
+
         return chapterEntity;
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Only generate ImageTag for chapters that have an actual ImagePath. Previously, ImageTag was always set regardless of whether an image existed, causing broken image placeholders in the UI for chapters without extracted images.

**Issues**
Fixes: #13578