### PR TITLE
Change image language priority to prefer English over images with no language

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -272,3 +272,4 @@
  - [Martin Reuter](https://github.com/reuterma24)
  - [Michael McElroy](https://github.com/mcmcelro)
  - [Soumyadip Auddy](https://github.com/SoumyadipAuddy)
+ - [rasko](https://github.com/rasko-dev)

--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -28,9 +28,9 @@ namespace MediaBrowser.Model.Extensions
                 {
                     // Image priority ordering:
                     //  - Images that match the requested language
+                    //  - Images in English
                     //  - Images with no language
                     //  - TODO: Images that match the original language
-                    //  - Images in English
                     //  - Images that don't match the requested language
 
                     if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
@@ -38,12 +38,12 @@ namespace MediaBrowser.Model.Extensions
                         return 4;
                     }
 
-                    if (string.IsNullOrEmpty(i.Language))
+                    if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
                     {
                         return 3;
                     }
 
-                    if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+                    if (string.IsNullOrEmpty(i.Language))
                     {
                         return 2;
                     }


### PR DESCRIPTION
**Changes**
Changes the ordering of remote images to prioritize English over images with no language. This was the intended behaviour prior to #8946, which changed this in order to prevent English from being equally ranked with No language when English was the requested language. However to me it looks like the change of ordering priority was due to an oversight, as the fix could easily have kept the intended priority order.

Image ordering is now:

1. Requested language
2. English 
3. No language
4. Any language

Which means that when English is the requested language, it is still prioritized higher than No language.