### PR TITLE
fix(Session): don't query DB if queue hasn't changed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -456,7 +456,7 @@ namespace Emby.Server.Implementations.Session
 
             var nowPlayingQueue = info.NowPlayingQueue;
 
-            if (nowPlayingQueue?.Length > 0)
+            if (nowPlayingQueue?.Length > 0 && !nowPlayingQueue.SequenceEqual(session.NowPlayingQueue) && updateLastCheckInTime)
             {
                 session.NowPlayingQueue = nowPlayingQueue;
 


### PR DESCRIPTION
Background and additional debugging details are given in the mentioned issue (jellyfin/jellyfin#13628), and jellyfin/jellyfin-mpv-shim#265

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Checks if the session's `nowPlayingQueue` has changed since the last `ProgressUpdate` event, and if so, then queries the database for data transfer objects.

**Issues**
fixes #13628

**Note**
The last time I used C# was 3 years ago, so I don't know how to exactly get around the following. `SequenceEqual` uses the equality operator to check each item in an `IEnumerable<T>`, which compares the references and not the actual values. In this case, the values are more important, not the memory location. Changing `MediaBrowser.Model/Session/QueueItem.cs` to the following would be ideal:
```c#
#nullable disable
#pragma warning disable CS1591

using System;

namespace MediaBrowser.Model.Session
{
    public class QueueItem : IEquatable<QueueItem>
    {
        public Guid Id { get; set; }

        public string PlaylistItemId { get; set; }

        public bool Equals(QueueItem? other) => Id == other.Id && PlaylistItemId == other.PlaylistItemId;
    }
}
```
But the project's settings do not allow this. If there is a better way to do this, then it would be ideal, because currently the queues remain unequal even when the value is the same, due to memory location changes probably.