### PR TITLE
chore(library): Allow arbitrary minimum collection size

### DIFF
--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Library.Validators;
@@ -46,11 +47,12 @@ public class CollectionPostScanTask : ILibraryPostScanTask
     /// <returns>Task.</returns>
     public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var collectionNameMoviesMap = new Dictionary<string, HashSet<Guid>>();
+        var collectionNameMoviesMap = new Dictionary<string, (HashSet<Guid> MovieIds, HashSet<Guid> LibraryIds)>();
 
         foreach (var library in _libraryManager.RootFolder.Children)
         {
-            if (!_libraryManager.GetLibraryOptions(library).AutomaticallyAddToCollection)
+            var libraryOptions = _libraryManager.GetLibraryOptions(library);
+            if (!libraryOptions.AutomaticallyAddToCollection)
             {
                 continue;
             }
@@ -76,13 +78,17 @@ public class CollectionPostScanTask : ILibraryPostScanTask
                 {
                     if (m is Movie movie && !string.IsNullOrEmpty(movie.CollectionName))
                     {
-                        if (collectionNameMoviesMap.TryGetValue(movie.CollectionName, out var movieList))
+                        if (collectionNameMoviesMap.TryGetValue(movie.CollectionName, out var collectionInfo))
                         {
-                            movieList.Add(movie.Id);
+                            collectionInfo.MovieIds.Add(movie.Id);
+                            collectionInfo.LibraryIds.Add(library.Id);
                         }
                         else
                         {
-                            collectionNameMoviesMap[movie.CollectionName] = new HashSet<Guid> { movie.Id };
+                            collectionNameMoviesMap[movie.CollectionName] = (
+                                new HashSet<Guid> { movie.Id },
+                                new HashSet<Guid> { library.Id }
+                            );
                         }
                     }
                 }
@@ -112,28 +118,35 @@ public class CollectionPostScanTask : ILibraryPostScanTask
             Recursive = true
         });
 
-        foreach (var (collectionName, movieIds) in collectionNameMoviesMap)
+        foreach (var (collectionName, collectionInfo) in collectionNameMoviesMap)
         {
             try
             {
                 var boxSet = boxSets.FirstOrDefault(b => b?.Name == collectionName) as BoxSet;
                 if (boxSet is null)
                 {
-                    // won't automatically create collection if only one movie in it
-                    if (movieIds.Count >= 2)
+                    // Find the smallest MinCollectionSize among all libraries containing movies in this collection
+                    var minCollectionSize = collectionInfo.LibraryIds
+                        .Select(libraryId => _libraryManager.RootFolder.Children.FirstOrDefault(l => Guid.Equals(l.Id, libraryId)))
+                        .Where(library => library != null)
+                        .Select(library => _libraryManager.GetLibraryOptions(library!).MinCollectionSize)
+                        .DefaultIfEmpty(new LibraryOptions().MinCollectionSize)
+                        .Min();
+
+                    // Only create collection if we have enough movies
+                    if (collectionInfo.MovieIds.Count >= minCollectionSize)
                     {
                         boxSet = await _collectionManager.CreateCollectionAsync(new CollectionCreationOptions
                         {
                             Name = collectionName,
-                            IsLocked = true
                         }).ConfigureAwait(false);
 
-                        await _collectionManager.AddToCollectionAsync(boxSet.Id, movieIds).ConfigureAwait(false);
+                        await _collectionManager.AddToCollectionAsync(boxSet.Id, collectionInfo.MovieIds).ConfigureAwait(false);
                     }
                 }
                 else
                 {
-                    await _collectionManager.AddToCollectionAsync(boxSet.Id, movieIds).ConfigureAwait(false);
+                    await _collectionManager.AddToCollectionAsync(boxSet.Id, collectionInfo.MovieIds).ConfigureAwait(false);
                 }
 
                 numComplete++;
@@ -145,7 +158,7 @@ public class CollectionPostScanTask : ILibraryPostScanTask
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error refreshing {CollectionName} with {@MovieIds}", collectionName, movieIds);
+                _logger.LogError(ex, "Error refreshing {CollectionName} with {@MovieIds}", collectionName, collectionInfo.MovieIds);
             }
         }
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -26,6 +26,7 @@ namespace MediaBrowser.Model.Configuration
             AllowEmbeddedSubtitles = EmbeddedSubtitleOptions.AllowAll;
 
             AutomaticallyAddToCollection = false;
+            MinCollectionSize = 2;
             EnablePhotos = true;
             SaveSubtitlesWithMedia = true;
             SaveLyricsWithMedia = false;
@@ -132,6 +133,8 @@ namespace MediaBrowser.Model.Configuration
         public string[] DelimiterWhitelist { get; set; }
 
         public bool AutomaticallyAddToCollection { get; set; }
+
+        public int MinCollectionSize { get; set; }
 
         public EmbeddedSubtitleOptions AllowEmbeddedSubtitles { get; set; }
 


### PR DESCRIPTION
**Changes**
Jellyfin Backend changes to allow an arbitrary amount of movies required for a collection to be formed.

The adjusted code will keep track of the corresponding library the movie is in and will apply the corresponding value for the decision whether the collection shall be created. If movies from a collection stem from different libraries, the lower value will be applied.


