### PR TITLE
fix(collection): Do not lock newly created collections

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@
  - [cryptobank](https://github.com/cryptobank)
  - [cvium](https://github.com/cvium)
  - [dannymichel](https://github.com/dannymichel)
+ - [darioackermann](https://github.com/darioackermann)
  - [DaveChild](https://github.com/DaveChild)
  - [DavidFair](https://github.com/DavidFair)
  - [Delgan](https://github.com/Delgan)

--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -125,7 +125,6 @@ public class CollectionPostScanTask : ILibraryPostScanTask
                         boxSet = await _collectionManager.CreateCollectionAsync(new CollectionCreationOptions
                         {
                             Name = collectionName,
-                            IsLocked = true
                         }).ConfigureAwait(false);
 
                         await _collectionManager.AddToCollectionAsync(boxSet.Id, movieIds).ConfigureAwait(false);


### PR DESCRIPTION
From discussion in  #14237 : 

Fixes #12862 by not locking newly created collections. Once collections are locked, the remote metadata providers are no longer run, which leads to collection information (metadata as well as thumbnails) not being collected since TmdB is a RemoteMetadataProvider.

Existing collections need to be deleted manually after this fix has been merged / shipped.
