### PR TITLE
Fix incorrectly parsed positions in ELRC cues

### DIFF
--- a/MediaBrowser.Providers/Lyric/LrcLyricParser.cs
+++ b/MediaBrowser.Providers/Lyric/LrcLyricParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Jellyfin.Extensions;
 using LrcParser.Model;
@@ -68,39 +69,66 @@ public partial class LrcLyricParser : ILyricParser
         List<LyricLine> lyricList = [];
         for (var l = 0; l < sortedLyricData.Count; l++)
         {
+            string lyricLine;
             var cues = new List<LyricLineCue>();
             var lyric = sortedLyricData[l];
 
             if (lyric.TimeTags.Count != 0)
             {
+                var lineBuilder = new StringBuilder();
                 var keys = lyric.TimeTags.Keys.ToList();
-                int current = 0, next = 1;
+                int current = 0, next = 1, positionOffset = 0;
                 while (next < keys.Count)
                 {
                     var currentKey = keys[current];
+                    var nextKey = keys[next];
+                    var currentPos = Math.Max(currentKey.Index, 0);
+                    var nextPos = Math.Max(nextKey.Index, 0);
                     var currentMs = lyric.TimeTags[currentKey] ?? 0;
                     var nextMs = lyric.TimeTags[keys[next]] ?? 0;
+                    var currentSlice = lyric.Text[currentPos..nextPos];
+                    var currentSliceTrimmed = currentSlice.Trim();
 
-                    cues.Add(new LyricLineCue(
-                        position: Math.Max(currentKey.Index, 0),
-                        start: TimeSpan.FromMilliseconds(currentMs).Ticks,
-                        end: TimeSpan.FromMilliseconds(nextMs).Ticks));
+                    if (currentSliceTrimmed.Length > 0)
+                    {
+                        cues.Add(new LyricLineCue(
+                            position: currentPos - positionOffset,
+                            start: TimeSpan.FromMilliseconds(currentMs).Ticks,
+                            end: TimeSpan.FromMilliseconds(nextMs).Ticks));
 
+                        lineBuilder.Append(currentSliceTrimmed).Append(' ');
+                    }
+
+                    positionOffset += currentSlice.Length - (currentSliceTrimmed.Length + 1);
                     current++;
                     next++;
                 }
 
                 var lastKey = keys[current];
+                var lastPos = Math.Max(lastKey.Index, 0);
                 var lastMs = lyric.TimeTags[lastKey] ?? 0;
+                var lastSlice = lyric.Text[lastPos..];
+                var lastSliceTrimmed = lastSlice.Trim();
 
-                cues.Add(new LyricLineCue(
-                    position: Math.Max(lastKey.Index, 0),
-                    start: TimeSpan.FromMilliseconds(lastMs).Ticks,
-                    end: l + 1 < sortedLyricData.Count ? TimeSpan.FromMilliseconds(sortedLyricData[l + 1].StartTime).Ticks : null));
+                if (lastSliceTrimmed.Length > 0)
+                {
+                    cues.Add(new LyricLineCue(
+                        position: lastPos - positionOffset,
+                        start: TimeSpan.FromMilliseconds(lastMs).Ticks,
+                        end: l + 1 < sortedLyricData.Count ? TimeSpan.FromMilliseconds(sortedLyricData[l + 1].StartTime).Ticks : null));
+
+                    lineBuilder.Append(lastSliceTrimmed);
+                }
+
+                lyricLine = lineBuilder.ToString();
+            }
+            else
+            {
+                lyricLine = WhitespaceRegex().Replace(lyric.Text.Trim(), " ");
             }
 
             long lyricStartTicks = TimeSpan.FromMilliseconds(lyric.StartTime).Ticks;
-            lyricList.Add(new LyricLine(WhitespaceRegex().Replace(lyric.Text.Trim(), " "), lyricStartTicks, cues));
+            lyricList.Add(new LyricLine(lyricLine, lyricStartTicks, cues));
         }
 
         return new LyricDto { Lyrics = lyricList };

--- a/tests/Jellyfin.Providers.Tests/Lyrics/LrcLyricParserTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Lyrics/LrcLyricParserTests.cs
@@ -20,21 +20,24 @@ public static class LrcLyricParserTests
         var line1 = parsed.Lyrics[0];
         Assert.Equal("Every night that goes between", line1.Text);
         Assert.NotNull(line1.Cues);
-        Assert.Equal(9, line1.Cues.Count);
+        Assert.Equal(5, line1.Cues.Count);
         Assert.Equal(68400000, line1.Cues[0].Start);
         Assert.Equal(72000000, line1.Cues[0].End);
+        Assert.Equal(0, line1.Cues[0].Position);
+        Assert.Equal(7, line1.Cues[1].Position);
+        Assert.Equal(14, line1.Cues[2].Position);
 
         var line5 = parsed.Lyrics[4];
         Assert.Equal("Every night you do not come", line5.Text);
         Assert.NotNull(line5.Cues);
-        Assert.Equal(11, line5.Cues.Count);
-        Assert.Equal(377300000, line5.Cues[5].Start);
-        Assert.Equal(380000000, line5.Cues[5].End);
+        Assert.Equal(6, line5.Cues.Count);
+        Assert.Equal(375200000, line5.Cues[2].Start);
+        Assert.Equal(377300000, line5.Cues[2].End);
 
         var lastLine = parsed.Lyrics[^1];
         Assert.Equal("I have always been a storm", lastLine.Text);
         Assert.NotNull(lastLine.Cues);
-        Assert.Equal(11, lastLine.Cues.Count);
+        Assert.Equal(6, lastLine.Cues.Count);
         Assert.Equal(2358000000, lastLine.Cues[^1].Start);
         Assert.Null(lastLine.Cues[^1].End);
     }


### PR DESCRIPTION
As described in #14254, the positions returned with the ELRC cues are currently incorrect due to whitespace removal. This PR modifies the positions to correctly map to the lyric lines again.

**Changes**
If `TimeTags` are returned by the lrc parser, the lyric line is now assembled manually, by first extracting each substring from the original line, trimming it, and joining it with a single space. To ensure the positions are still correct, the new slice length is compared to the previous length, and added to an offset variable that impacts are consecutive slice positions. That way, all positions remain valid. Blank/empty slices (which only contain whitespace) are dropped silently, since they aren't relevant for clients.
I also updated the tests to match the newly returned data, and added checks for the positions (which weren't included before).

**Issues**
Fixes #14254.
