### PR TITLE
Fix People Issues

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3007,7 +3007,7 @@ namespace Emby.Server.Implementations.Library
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning("Failed to create person {Name}: {Exception}", person.Name, ex);
+                        _logger.LogWarning(ex, "Failed to create person {Name}", person.Name);
                         continue;
                     }
                 }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2987,21 +2987,29 @@ namespace Emby.Server.Implementations.Library
 
                 if (personEntity is null)
                 {
-                    var path = Person.GetPath(person.Name);
-                    var info = Directory.CreateDirectory(path);
-                    var lastWriteTime = info.LastWriteTimeUtc;
-                    personEntity = new Person()
+                    try
                     {
-                        Name = person.Name,
-                        Id = GetItemByNameId<Person>(path),
-                        DateCreated = info.CreationTimeUtc,
-                        DateModified = lastWriteTime,
-                        Path = path
-                    };
+                        var path = Person.GetPath(person.Name);
+                        var info = Directory.CreateDirectory(path);
+                        var lastWriteTime = info.LastWriteTimeUtc;
+                        personEntity = new Person()
+                        {
+                            Name = person.Name,
+                            Id = GetItemByNameId<Person>(path),
+                            DateCreated = info.CreationTimeUtc,
+                            DateModified = lastWriteTime,
+                            Path = path
+                        };
 
-                    personEntity.PresentationUniqueKey = personEntity.CreatePresentationUniqueKey();
-                    saveEntity = true;
-                    createEntity = true;
+                        personEntity.PresentationUniqueKey = personEntity.CreatePresentationUniqueKey();
+                        saveEntity = true;
+                        createEntity = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning("Failed to create person {Name}: {Exception}", person.Name, ex);
+                        continue;
+                    }
                 }
 
                 foreach (var id in person.ProviderIds)

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -262,14 +262,13 @@ namespace MediaBrowser.Providers.Manager
 
         protected async Task SaveItemAsync(MetadataResult<TItemType> result, ItemUpdateType reason, CancellationToken cancellationToken)
         {
+            await result.Item.UpdateToRepositoryAsync(reason, cancellationToken).ConfigureAwait(false);
             if (result.Item.SupportsPeople && result.People is not null)
             {
                 var baseItem = result.Item;
 
                 await LibraryManager.UpdatePeopleAsync(baseItem, result.People, cancellationToken).ConfigureAwait(false);
             }
-
-            await result.Item.UpdateToRepositoryAsync(reason, cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual Task AfterMetadataRefresh(TItemType item, MetadataRefreshOptions refreshOptions, CancellationToken cancellationToken)


### PR DESCRIPTION
People need to be associated AFTER the item is created, otherwise foreign key issues happen.

**Changes**
* Extract `SetPeople` to be run after saving instead of when updating metadata from children
* Skip People creation if local metadata path creation fails

**Issues**
Fixes #14245
Fixes #14283
