### PR TITLE
Enhance and fix live tv recording file names and retry logic

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -198,6 +198,7 @@
  - [revam](https://github.com/revam)
  - [allesmi](https://github.com/allesmi)
  - [ThunderClapLP](https://github.com/ThunderClapLP)
+ - [theshoeshiner](https://github.com/theshoeshiner)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/LiveTv/TimerInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/TimerInfo.cs
@@ -19,6 +19,7 @@ namespace MediaBrowser.Controller.LiveTv
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             SeriesProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             Tags = Array.Empty<string>();
+            RecordingPartPaths = Array.Empty<string>();
         }
 
         public Dictionary<string, string> ProviderIds { get; set; }
@@ -112,6 +113,8 @@ namespace MediaBrowser.Controller.LiveTv
 
         public int RetryCount { get; set; }
 
+        public int FailedRetryCount { get; set; }
+
         // Program properties
         public int? SeasonNumber { get; set; }
 
@@ -160,6 +163,10 @@ namespace MediaBrowser.Controller.LiveTv
         public string[] Genres { get; set; }
 
         public string RecordingPath { get; set; }
+
+        public string CurrentRecordingPath { get; set; }
+
+        public string[] RecordingPartPaths { get; set; }
 
         public KeepUntil KeepUntil { get; set; }
     }

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Dto;
@@ -281,5 +280,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="source">The <see cref="MediaSourceInfo"/>.</param>
         /// <param name="concatFilePath">The path the config should be written to.</param>
         void GenerateConcatConfig(MediaSourceInfo source, string concatFilePath);
+
+        /// <summary>
+        /// Runs a simple FFmpeg concatenation job on a list of files and writes them to the output file.
+        /// </summary>
+        /// <param name="filePaths">The file paths to concatenate.</param>
+        /// <param name="outputFile">The output file.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Task.</returns>
+        Task ConcatenateMedia(IReadOnlyCollection<string> filePaths, string outputFile, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -51,6 +51,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         internal const int DefaultHdrImageExtractionTimeout = 20000;
 
+        /// <summary>
+        /// The default media concatenation timeout in milliseconds.
+        /// </summary>
+        internal const int DefaultConcatTimeout = 60000;
+
         private readonly ILogger<MediaEncoder> _logger;
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IFileSystem _fileSystem;
@@ -1279,6 +1284,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 return;
             }
 
+            GenerateConcatConfig(concatFilePath, files, videoType);
+        }
+
+        internal void GenerateConcatConfig(string concatFilePath, IEnumerable<string> files, VideoType? videoType)
+        {
             // Generate concat configuration entries for each file and write to file
             Directory.CreateDirectory(Path.GetDirectoryName(concatFilePath));
             using var sw = new FormattingStreamWriter(concatFilePath, CultureInfo.InvariantCulture);
@@ -1304,6 +1314,69 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                 // Add duration stanza to concat configuration
                 sw.WriteLine("duration {0}", duration);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task ConcatenateMedia(IReadOnlyCollection<string> filePaths, string outputFile, CancellationToken cancellationToken)
+        {
+            if (filePaths.Count == 1)
+            {
+                string file = filePaths.First();
+                File.Move(file, outputFile, true);
+            }
+            else if (filePaths.Count > 1)
+            {
+                var tempDirectory = Path.Combine(_configurationManager.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(tempDirectory);
+                var concatConfigFile = Path.Combine(tempDirectory, Guid.NewGuid() + ".concat");
+                GenerateConcatConfig(concatConfigFile, filePaths, VideoType.VideoFile);
+                var tempOutputFile = Path.Combine(tempDirectory, Guid.NewGuid() + Path.GetExtension(outputFile));
+                var processStartInfo = new ProcessStartInfo
+                {
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    FileName = _ffmpegPath,
+                    Arguments = "-f concat -safe 0 -i \"" + concatConfigFile + "\" -v quiet -c copy \"" + tempOutputFile + "\"",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    ErrorDialog = false,
+                };
+
+                var process = new Process
+                {
+                    StartInfo = processStartInfo,
+                    EnableRaisingEvents = true,
+                };
+
+                using (var processWrapper = new ProcessWrapper(process, this))
+                {
+                    StartProcess(processWrapper);
+                    try
+                    {
+                        await process.WaitForExitAsync(TimeSpan.FromMilliseconds(DefaultConcatTimeout)).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        process.Kill(true);
+                        throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg concatenation cancelled for {0}", tempOutputFile), ex);
+                    }
+
+                    var outputFileInfo = _fileSystem.GetFileInfo(tempOutputFile);
+                    if (processWrapper.ExitCode > 0 || !outputFileInfo.Exists || outputFileInfo.Length == 0)
+                    {
+                        throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg concatenation failed for {0}", tempOutputFile));
+                    }
+
+                    // Remove concatenated files, must be done before moving temp file
+                    foreach (var file in filePaths)
+                    {
+                        _fileSystem.DeleteFile(file);
+                    }
+
+                    // Move concatenated file
+                    File.Move(tempOutputFile, outputFile, true);
+                    _logger.LogInformation("Concatenation successful for {0}", outputFile);
+                }
             }
         }
 

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -308,8 +308,8 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
 
         var timer = recordingInfo.Timer;
         var remoteMetadata = await FetchInternetMetadata(timer, CancellationToken.None).ConfigureAwait(false);
-        var recordingPath = GetRecordingPath(timer, remoteMetadata, out var seriesPath);
-
+        var baseRecordingPath = GetRecordingPath(timer, remoteMetadata, out var seriesPath);
+        string? currentRecordingPath = null;
         string? liveStreamId = null;
         RecordingStatus recordingStatus;
         try
@@ -336,51 +336,50 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
 
             using var recorder = GetRecorder(mediaStreamInfo);
 
-            recordingPath = recorder.GetOutputPath(mediaStreamInfo, recordingPath);
-            recordingPath = EnsureFileUnique(recordingPath, timer.Id);
+            if (timer.RecordingPath == null)
+            {
+                timer.RecordingPath = recorder.GetOutputPath(mediaStreamInfo, baseRecordingPath);
+            }
 
-            _libraryMonitor.ReportFileSystemChangeBeginning(recordingPath);
-
+            currentRecordingPath = EnsureFileUnique(timer.RecordingPath, timer.Id);
+            _libraryMonitor.ReportFileSystemChangeBeginning(currentRecordingPath);
             var duration = recordingEndDate - DateTime.UtcNow;
-
             _logger.LogInformation("Beginning recording. Will record for {Duration} minutes.", duration.TotalMinutes);
-            _logger.LogInformation("Writing file to: {Path}", recordingPath);
+            _logger.LogInformation("Writing file to: {0}", currentRecordingPath);
 
             async void OnStarted()
             {
-                recordingInfo.Path = recordingPath;
+                recordingInfo.Path = currentRecordingPath;
                 _activeRecordings.TryAdd(timer.Id, recordingInfo);
-
                 timer.Status = RecordingStatus.InProgress;
+                timer.CurrentRecordingPath = currentRecordingPath;
                 _timerManager.AddOrUpdate(timer, false);
-
-                await _recordingsMetadataManager.SaveRecordingMetadata(timer, recordingPath, seriesPath).ConfigureAwait(false);
+                await _recordingsMetadataManager.SaveRecordingMetadata(timer, timer.RecordingPath, seriesPath).ConfigureAwait(false);
                 await CreateRecordingFolders().ConfigureAwait(false);
-
-                TriggerRefresh(recordingPath);
+                TriggerRefresh(currentRecordingPath);
                 await EnforceKeepUpTo(timer, seriesPath).ConfigureAwait(false);
             }
 
             await recorder.Record(
                 directStreamProvider,
                 mediaStreamInfo,
-                recordingPath,
+                currentRecordingPath,
                 duration,
                 OnStarted,
                 recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
 
             recordingStatus = RecordingStatus.Completed;
-            _logger.LogInformation("Recording completed: {RecordPath}", recordingPath);
+            _logger.LogInformation("Recording completed: {CurrentRecordingPath}", currentRecordingPath);
         }
         catch (OperationCanceledException)
         {
-            _logger.LogInformation("Recording stopped: {RecordPath}", recordingPath);
-            recordingStatus = RecordingStatus.Completed;
+            _logger.LogInformation("Recording stopped currentRecordingPath: {CurrentRecordingPath}", currentRecordingPath);
+            recordingStatus = RecordingStatus.Cancelled;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error recording to {RecordPath}", recordingPath);
-            recordingStatus = RecordingStatus.Error;
+            _logger.LogError(ex, "Error recording to: currentRecordingPath: {CurrentRecordingPath}", currentRecordingPath);
+            recordingStatus = timer.Status == RecordingStatus.Cancelled ? RecordingStatus.Cancelled : RecordingStatus.Error;
         }
 
         if (!string.IsNullOrWhiteSpace(liveStreamId))
@@ -395,32 +394,53 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             }
         }
 
-        DeleteFileIfEmpty(recordingPath);
-        TriggerRefresh(recordingPath);
-        _libraryMonitor.ReportFileSystemChangeComplete(recordingPath, false);
         _activeRecordings.TryRemove(timer.Id, out _);
-
-        if (recordingStatus != RecordingStatus.Completed && DateTime.UtcNow < timer.EndDate && timer.RetryCount < 10)
+        DeleteFileIfEmpty(currentRecordingPath);
+        if (File.Exists(currentRecordingPath))
         {
-            const int RetryIntervalSeconds = 60;
-            _logger.LogInformation("Retrying recording in {0} seconds.", RetryIntervalSeconds);
+            _libraryMonitor.ReportFileSystemChangeComplete(currentRecordingPath, false);
+            timer.RecordingPartPaths = timer.RecordingPartPaths.Append(currentRecordingPath).ToArray();
+        }
+
+        if (recordingStatus == RecordingStatus.Error && DateTime.UtcNow < timer.EndDate && timer.FailedRetryCount < 20)
+        {
+            // For errors as long as we're getting data then we should try to keep on recording, so don't increment the retry count or timer
+            int retryIntervalSeconds = 0;
+            if (!File.Exists(currentRecordingPath))
+            {
+                retryIntervalSeconds = Math.Min(60, 1 << timer.FailedRetryCount);
+                timer.FailedRetryCount++;
+            }
+            else
+            {
+                timer.FailedRetryCount = 0;
+            }
+
+            _logger.LogInformation("Retrying recording in {0} seconds.", retryIntervalSeconds);
 
             timer.Status = RecordingStatus.New;
             timer.PrePaddingSeconds = 0;
-            timer.StartDate = DateTime.UtcNow.AddSeconds(RetryIntervalSeconds);
+            timer.StartDate = DateTime.UtcNow.AddSeconds(retryIntervalSeconds);
             timer.RetryCount++;
             _timerManager.AddOrUpdate(timer);
         }
-        else if (File.Exists(recordingPath))
-        {
-            timer.RecordingPath = recordingPath;
-            timer.Status = RecordingStatus.Completed;
-            _timerManager.AddOrUpdate(timer, false);
-            await PostProcessRecording(recordingPath).ConfigureAwait(false);
-        }
         else
         {
-            _timerManager.Delete(timer);
+            // For all other cases we want to update the timer and collect all files
+            timer.Status = recordingStatus;
+            if (timer.RecordingPartPaths.Length > 0)
+            {
+                await _mediaEncoder.ConcatenateMedia(timer.RecordingPartPaths, timer.RecordingPath, CancellationToken.None).ConfigureAwait(false);
+                timer.RecordingPartPaths = [timer.RecordingPath];
+                timer.CurrentRecordingPath = null;
+                TriggerRefresh(timer.RecordingPath);
+                _timerManager.AddOrUpdate(timer, false);
+                await PostProcessRecording(timer.RecordingPath).ConfigureAwait(false);
+            }
+            else
+            {
+                _timerManager.AddOrUpdate(timer, false);
+            }
         }
     }
 
@@ -584,8 +604,13 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         return Path.Combine(recordingPath, recordingFileName);
     }
 
-    private void DeleteFileIfEmpty(string path)
+    private void DeleteFileIfEmpty(string? path)
     {
+        if (path == null)
+        {
+            return;
+        }
+
         var file = _fileSystem.GetFileInfo(path);
 
         if (file.Exists && file.Length == 0)
@@ -773,18 +798,19 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         var parent = Path.GetDirectoryName(path)!;
         var name = Path.GetFileNameWithoutExtension(path);
         var extension = Path.GetExtension(path);
-
-        var index = 1;
-        while (File.Exists(path) || _activeRecordings.Any(i
-                   => string.Equals(i.Value.Path, path, StringComparison.OrdinalIgnoreCase)
-                      && !string.Equals(i.Value.Timer.Id, timerId, StringComparison.OrdinalIgnoreCase)))
+        string uniqueName;
+        var index = 0;
+        do
         {
-            name += " - " + index.ToString(CultureInfo.InvariantCulture);
-
-            path = Path.ChangeExtension(Path.Combine(parent, name), extension);
+            uniqueName = name + "_" + index.ToString(CultureInfo.InvariantCulture);
+            path = Path.ChangeExtension(Path.Combine(parent, uniqueName), extension);
             index++;
         }
-
+        while (File.Exists(path) || _activeRecordings.Any(i =>
+                string.Equals(i.Value.Path, path, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(i.Value.Timer.Id, timerId, StringComparison.OrdinalIgnoreCase)
+            )
+        );
         return path;
     }
 


### PR DESCRIPTION
### Changes

This PR fixes (and enhances) the livetv recording logic. The high level points are:

- Adjusts retry logic to lose less content while still preventing swamping the server
- Changes the file names to use a more sane pattern
- Adds a concatenation process at the end of the recording to ensure the result is a single file

For a more detailed summary and justification...
(Apologies for the length, first PR here, trying to be thorough, perhaps to a fault)

### Detailed summary of changes
1) Keeps track of all recording parts for given timer in `TimerInfo.RecordingPartPaths` and file currently being written in `TimerInfo.CurrentRecordingPath`.
1) Tracks the total retry count in `TimerInfo.RetryCount` for posterity, and the _true_ failed retries (retries that produced no data) in `TimerInfo.FailedRetryCount`.
1) Scales the retry delay up to 60s based on the number of _true_ failures so that a single short failure will only lose a minimal amount of stream content.
1) Fails the recording only when the `TimerInfo.FailedRetryCount` reaches 20 i.e. about ~15m of total retrying _with no data_.
1) Fixes issue with how recording retry files are named:
   - Current logic creates files like this:
      - [Prefix] - 1.ts
      - [Prefix] - 1 - 2.ts
      - [Prefix] - 1 - 2 - 3.ts
   - New logic will create:
      - [Prefix]_0.ts
      - [Prefix]_1.ts
      - [Prefix]_2.ts
   - Final file will be named: [Prefix].ts
1) Runs a simple FFmpeg concatenation process on the list of files in `TimerInfo.RecordingPartPaths` when the recording is either complete or failed and has multiple files listed in `TimerInfo.RecordingPartPaths`.
   - Makes use of some existing logic in `MediaEncoder.GenerateConcatConfig()` to generate the .concat config file, and adds `MediaEncoder.ConcatenateMedia()` to handle execution.
   - Removes the intermediate recording files *only* if concatenation is successful.

### Justification

1) Regarding concatenation - Given that retry logic already exists, it's clear the aim is to record the entire time slot, regardless of failures. With this in mind, it seems reasonable to have the recording produce a single file. Discontinuities will be present, but they exist regardless, and the separate files will remain if for some reason it cannot concatenate. Currently, the only way to do this would be to write a somewhat complex, implementation dependent, post-processing script (which means for the average user it is essentially impossible). I think that *maybe* this is a candidate for being configurable, but I have struggled to come up with a good reason for preferring multiple files (are users actually going to replace the gaps with the real content in the future??). If it were to be configurable then I would think concatenation should at least default to true, given that retrying is also the default. Note: While it is theoretically possible to setup an FFmpeg process that appends to a current file, it involves (per my understanding) stdout redirection, and overall seems more brittle than post-stream concatenation, which is the more standard method (Unless the custom jellyfin FFmpeg can handle appending in ways that core cannot).
1) Regarding the retry count and timer - I have personally encountered IPTV streams that generate intermittent FFmpeg failures every 5-10 minutes, but are otherwise high quality and stable. With the current logic, the recording would lose 1m each failure, max out at ~60m total recording time, and produce 10 different files. Obviously less than ideal. It's a much better experience to continue trying to record as long as the stream is returning data, and attempt to retain as much data as possible, while also avoiding swamping the server with useless retries, by starting with a short delay and scaling it up.
1) Regarding the file naming - I consider that to be a likely bug. I cannot fathom a reason that one would want files named like they are currently.

### Backwards Compatibility

I do not believe this will introduce any breaking changes to current features.
- No properties are removed from `TimerInfo`.
- No existing functionality is altered in `MediaEncoder`.
- During recording, files are kept separate so that users can still preview them as they can now.
- The only things that *might* break would be user post-processing scripts, if they are relying on the implementation details of the file naming. But honestly that functionality is already sort of broken since the script only gets a reference to the *latest* file. This enhancement would actually fix that issue since the script would now receive the path to the final merged file.

### Scenarios Tested

All of these scenarios worked as expected, producing a single file for the recording that contained all the content captured when the recording was in progress.
1) Streams with 0 up to ~30 failures / files to concatenate. The enhancement imposes no real limit (see concern # 1 below), but I only tested up to ~30)
1) Restarting the server mid-recording - Recording resumed automatically after startup and concatenated new chunk to existing chunk.
1) Manually stopping the recording and restarting - Recording resumed and concatenated new chunk to existing chunk.

I could maybe see an argument for not concatenating when the user manually stops/starts the recording, if we take that to be a sign that they *don't* want a single recording? My gut still tells me that a single time slot =  a single file, but could go either way.

### Concerns

1) I would be concerned about a theoretical stream (not sure if its even possible) that continuously produced a miniscule amount of data for FFmpeg to write to a file, and then failed. This would cause our logic to assume that the stream is "valid" and continue to quickly retry, until the timer expired. This shouldn't overload the server, as each prior process would be terminated, but could produce lots of files. If this is a valid possibility then I could introduce a cap on the number of files for a single recording. I would think something high like 1000 should reasonably cover most scenarios, and this could also be made configurable if necessary.
2) I have also considered that it may be nice to notify the user that "Hey, this recording was not perfect". Currently that is apparent by the presence of multiple (ridiculously named :-)) files. But if this change were implemented the user would not have much of an idea after the recording, aside from looking at the duration - which is not all that bad. Notifying would be a cooler UX, but live recording already has its imperfections, and there will always be tons of scenarios where the recordings are imperfect with no way whatsoever to notify the user. So I think any improvements to that would be reasonable to handle in follow up work.
