### PR TITLE
Only remove image file if it exists

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2002,9 +2002,10 @@ namespace MediaBrowser.Controller.Entities
             }
 
             // Remove from file system
-            if (info.IsLocalFile)
+            var path = info.Path;
+            if (info.IsLocalFile && !string.IsNullOrWhiteSpace(path))
             {
-                FileSystem.DeleteFile(info.Path);
+                FileSystem.DeleteFile(path);
             }
 
             // Remove from item


### PR DESCRIPTION
If image files are manually removed, deleting the image entry fails if the file path is empty.

**Changes**
* Check if path is null empty or whitespace and only remove from file system if it is not

**Issues**
Fixes #14301