### PR TITLE
fix exception selecting the Content Type "Mixed Films and Programmes"

### DIFF
--- a/Jellyfin.Data/Enums/CollectionType.cs
+++ b/Jellyfin.Data/Enums/CollectionType.cs
@@ -161,5 +161,11 @@ public enum CollectionType
     /// Movie genre collection.
     /// </summary>
     [OpenApiIgnoreEnum]
-    moviegenre = 115
+    moviegenre = 115,
+
+    /// <summary>
+    /// Mixed collection.
+    /// </summary>
+    [OpenApiIgnoreEnum]
+    mixed = 116
 }


### PR DESCRIPTION
fix exception selecting the Content Type "Mixed Films and Programmes" in the "Add Media Library" web client dialog.

CollectionType is minning the "mixed" type witct is what the web client sends to the server when you select the "Mixed Films and Programmes" type.
