### PR TITLE
Fix PeopleHelper.AddPerson Exceptions due to bad meta-data extracts.

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -201,17 +201,14 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var albumArtist in albumArtists)
                 {
-                    var name = albumArtist.Trim();
-                    if (string.IsNullOrEmpty(name))
+                    if (!string.IsNullOrWhiteSpace(albumArtist))
                     {
-                        continue;
+                        PeopleHelper.AddPerson(people, new PersonInfo
+                        {
+                            Name = albumArtist,
+                            Type = PersonKind.AlbumArtist
+                        });
                     }
-
-                    PeopleHelper.AddPerson(people, new PersonInfo
-                    {
-                        Name = name,
-                        Type = PersonKind.AlbumArtist
-                    });
                 }
 
                 string[]? performers = null;
@@ -236,34 +233,28 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var performer in performers)
                 {
-                    var name = performer.Trim();
-                    if (string.IsNullOrEmpty(name))
+                    if (!string.IsNullOrWhiteSpace(performer))
                     {
-                        continue;
+                        PeopleHelper.AddPerson(people, new PersonInfo
+                        {
+                            Name = performer,
+                            Type = PersonKind.Artist
+                        });
                     }
-
-                    PeopleHelper.AddPerson(people, new PersonInfo
-                    {
-                        Name = name,
-                        Type = PersonKind.Artist
-                    });
                 }
 
                 if (!string.IsNullOrWhiteSpace(trackComposer))
                 {
                     foreach (var composer in trackComposer.Split(InternalValueSeparator))
                     {
-                        var name = composer.Trim();
-                        if (string.IsNullOrEmpty(name))
+                        if (!string.IsNullOrWhiteSpace(composer))
                         {
-                            continue;
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = composer,
+                                Type = PersonKind.Composer
+                            });
                         }
-
-                        PeopleHelper.AddPerson(people, new PersonInfo
-                        {
-                            Name = name,
-                            Type = PersonKind.Composer
-                        });
                     }
                 }
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -201,14 +201,17 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var albumArtist in albumArtists)
                 {
-                    if (!string.IsNullOrWhiteSpace(albumArtist))
+                    var name = albumArtist.Trim();
+                    if (string.IsNullOrEmpty(name))
                     {
-                        PeopleHelper.AddPerson(people, new PersonInfo
-                        {
-                            Name = albumArtist.Trim(),
-                            Type = PersonKind.AlbumArtist
-                        });
+                        continue;
                     }
+
+                    PeopleHelper.AddPerson(people, new PersonInfo
+                    {
+                        Name = name,
+                        Type = PersonKind.AlbumArtist
+                    });
                 }
 
                 string[]? performers = null;
@@ -233,28 +236,34 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var performer in performers)
                 {
-                    if (!string.IsNullOrWhiteSpace(performer))
+                    var name = performer.Trim();
+                    if (string.IsNullOrEmpty(name))
                     {
-                        PeopleHelper.AddPerson(people, new PersonInfo
-                        {
-                            Name = performer.Trim(),
-                            Type = PersonKind.Artist
-                        });
+                        continue;
                     }
+
+                    PeopleHelper.AddPerson(people, new PersonInfo
+                    {
+                        Name = name,
+                        Type = PersonKind.Artist
+                    });
                 }
 
                 if (!string.IsNullOrWhiteSpace(trackComposer))
                 {
                     foreach (var composer in trackComposer.Split(InternalValueSeparator))
                     {
-                        if (!string.IsNullOrWhiteSpace(composer))
+                        var name = composer.Trim();
+                        if (string.IsNullOrEmpty(name))
                         {
-                            PeopleHelper.AddPerson(people, new PersonInfo
-                            {
-                                Name = composer.Trim(),
-                                Type = PersonKind.Composer
-                            });
+                            continue;
                         }
+
+                        PeopleHelper.AddPerson(people, new PersonInfo
+                        {
+                            Name = name,
+                            Type = PersonKind.Composer
+                        });
                     }
                 }
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Chapters;
@@ -516,18 +517,15 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var person in data.People)
                 {
-                    var name = person.Name.Trim();
-                    if (string.IsNullOrEmpty(name))
+                    if (!string.IsNullOrWhiteSpace(person.Name))
                     {
-                        continue;
+                        PeopleHelper.AddPerson(people, new PersonInfo
+                        {
+                            Name = person.Name,
+                            Type = person.Type,
+                            Role = person.Role.Trim()
+                        });
                     }
-
-                    PeopleHelper.AddPerson(people, new PersonInfo
-                    {
-                        Name = name,
-                        Type = person.Type,
-                        Role = person.Role.Trim()
-                    });
                 }
 
                 _libraryManager.UpdatePeople(video, people);

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -516,9 +516,15 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 foreach (var person in data.People)
                 {
+                    var name = person.Name.Trim();
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        continue;
+                    }
+
                     PeopleHelper.AddPerson(people, new PersonInfo
                     {
-                        Name = person.Name.Trim(),
+                        Name = name,
                         Type = person.Type,
                         Role = person.Role.Trim()
                     });

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -197,18 +197,30 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
 
             foreach (var albumArtist in item.AlbumArtists)
             {
+                var name = albumArtist.Trim();
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
                 PeopleHelper.AddPerson(people, new PersonInfo
                 {
-                    Name = albumArtist.Trim(),
+                    Name = name,
                     Type = PersonKind.AlbumArtist
                 });
             }
 
             foreach (var artist in item.Artists)
             {
+                var name = artist.Trim();
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
                 PeopleHelper.AddPerson(people, new PersonInfo
                 {
-                    Name = artist.Trim(),
+                    Name = name,
                     Type = PersonKind.Artist
                 });
             }

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -197,32 +197,26 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
 
             foreach (var albumArtist in item.AlbumArtists)
             {
-                var name = albumArtist.Trim();
-                if (string.IsNullOrEmpty(name))
+                if (!string.IsNullOrWhiteSpace(albumArtist))
                 {
-                    continue;
+                    PeopleHelper.AddPerson(people, new PersonInfo
+                    {
+                        Name = albumArtist,
+                        Type = PersonKind.AlbumArtist
+                    });
                 }
-
-                PeopleHelper.AddPerson(people, new PersonInfo
-                {
-                    Name = name,
-                    Type = PersonKind.AlbumArtist
-                });
             }
 
             foreach (var artist in item.Artists)
             {
-                var name = artist.Trim();
-                if (string.IsNullOrEmpty(name))
+                if (!string.IsNullOrWhiteSpace(artist))
                 {
-                    continue;
+                    PeopleHelper.AddPerson(people, new PersonInfo
+                    {
+                        Name = artist,
+                        Type = PersonKind.Artist
+                    });
                 }
-
-                PeopleHelper.AddPerson(people, new PersonInfo
-                {
-                    Name = name,
-                    Type = PersonKind.Artist
-                });
             }
 
             LibraryManager.UpdatePeople(item, people);


### PR DESCRIPTION
Fix PeopleHelper.AddPerson ArgumentException.ThrowIfNullOrEmpty(person.Name) due to bad meta-data extracts.

Ignore metadata extracts with blank names.
