### PR TITLE
Fix SQLite Error 5: 'database is locked' and other db errors.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Diacritics" Version="3.3.29" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
+    <PackageVersion Include="DotNext.Threading" Version="5.22.0" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.0" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />
@@ -69,7 +70,7 @@
     <PackageVersion Include="Serilog.Sinks.Graylog" Version="3.1.1" />
     <PackageVersion Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
-     <!-- Pinned to 3.116.1 because https://github.com/jellyfin/jellyfin/pull/14255 -->
+    <!-- Pinned to 3.116.1 because https://github.com/jellyfin/jellyfin/pull/14255 -->
     <PackageVersion Include="SkiaSharp" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabaseTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/OptimizeDatabaseTask.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,7 @@ public class OptimizeDatabaseTask : IScheduledTask, IConfigurableScheduledTask
     private readonly ILogger<OptimizeDatabaseTask> _logger;
     private readonly ILocalizationManager _localization;
     private readonly IJellyfinDatabaseProvider _jellyfinDatabaseProvider;
+    private readonly ILibraryManager _libraryManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OptimizeDatabaseTask" /> class.
@@ -24,14 +26,17 @@ public class OptimizeDatabaseTask : IScheduledTask, IConfigurableScheduledTask
     /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
     /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="jellyfinDatabaseProvider">Instance of the JellyfinDatabaseProvider that can be used for provider specific operations.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     public OptimizeDatabaseTask(
         ILogger<OptimizeDatabaseTask> logger,
         ILocalizationManager localization,
-        IJellyfinDatabaseProvider jellyfinDatabaseProvider)
+        IJellyfinDatabaseProvider jellyfinDatabaseProvider,
+        ILibraryManager libraryManager)
     {
         _logger = logger;
         _localization = localization;
         _jellyfinDatabaseProvider = jellyfinDatabaseProvider;
+        _libraryManager = libraryManager;
     }
 
     /// <inheritdoc />
@@ -68,6 +73,11 @@ public class OptimizeDatabaseTask : IScheduledTask, IConfigurableScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
+        if (_libraryManager.IsScanRunning)
+        {
+            return;
+        }
+
         _logger.LogInformation("Optimizing and vacuuming jellyfin.db...");
 
         try

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -216,7 +216,7 @@ namespace Emby.Server.Implementations.Session
                 },
                 _logger);
 
-            _eventManager.Publish(new SessionEndedEventArgs(info));
+            await _eventManager.PublishAsync(new SessionEndedEventArgs(info));
 
             await info.DisposeAsync().ConfigureAwait(false);
         }

--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Dto;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Api.Controllers;
@@ -58,6 +59,8 @@ public class DisplayPreferencesController : BaseJellyfinApiController
         {
             itemId = displayPreferencesId.GetMD5();
         }
+
+        using var dbLock = _displayPreferencesManager.AcquireWriterLock();
 
         var displayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId.Value, itemId, client);
         var itemPreferences = _displayPreferencesManager.GetItemDisplayPreferences(displayPreferences.UserId, itemId, displayPreferences.Client);
@@ -138,6 +141,8 @@ public class DisplayPreferencesController : BaseJellyfinApiController
         {
             itemId = displayPreferencesId.GetMD5();
         }
+
+        using var dbLock = _displayPreferencesManager.AcquireWriterLock();
 
         var existingDisplayPreferences = _displayPreferencesManager.GetDisplayPreferences(userId.Value, itemId, client);
         existingDisplayPreferences.IndexBy = Enum.TryParse<IndexingKind>(displayPreferences.IndexBy, true, out var indexBy) ? indexBy : null;

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -97,7 +97,8 @@ public static class ServiceCollectionExtensions
                 efCoreConfiguration = new DatabaseConfigurationOptions()
                 {
                     DatabaseType = "Jellyfin-SQLite",
-                    LockingBehavior = DatabaseLockingBehaviorTypes.NoLock
+                    LockingBehavior = DatabaseLockingBehaviorTypes.NoLock,
+                    WriteBehavior = DatabaseWriteBehaviorTypes.SerializedWrites
                 };
                 configurationManager.SaveConfiguration("database", efCoreConfiguration);
             }
@@ -133,6 +134,16 @@ public static class ServiceCollectionExtensions
                 break;
             case DatabaseLockingBehaviorTypes.Optimistic:
                 serviceCollection.AddSingleton<IEntityFrameworkCoreLockingBehavior, OptimisticLockBehavior>();
+                break;
+        }
+
+        switch (efCoreConfiguration.WriteBehavior)
+        {
+            case DatabaseWriteBehaviorTypes.ConcurrentWrites:
+                serviceCollection.AddSingleton<IEntityFrameworkDatabaseLockingBehavior, ConcurrentDatabaseLockingBehavior>();
+                break;
+            case DatabaseWriteBehaviorTypes.SerializedWrites:
+                serviceCollection.AddSingleton<IEntityFrameworkDatabaseLockingBehavior, SerializedDatabaseLockingBehavior>();
                 break;
         }
 

--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -8,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Database.Implementations.Locking;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Entities;
@@ -29,6 +29,7 @@ public class MediaSegmentManager : IMediaSegmentManager
 {
     private readonly ILogger<MediaSegmentManager> _logger;
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
+    private readonly IEntityFrameworkDatabaseLockingBehavior _writeBehavior;
     private readonly IMediaSegmentProvider[] _segmentProviders;
 
     /// <summary>
@@ -36,14 +37,17 @@ public class MediaSegmentManager : IMediaSegmentManager
     /// </summary>
     /// <param name="logger">Logger.</param>
     /// <param name="dbProvider">EFCore Database factory.</param>
+    /// <param name="writeBehavior">Instance of the <see cref="IEntityFrameworkDatabaseLockingBehavior"/> interface.</param>
     /// <param name="segmentProviders">List of all media segment providers.</param>
     public MediaSegmentManager(
         ILogger<MediaSegmentManager> logger,
         IDbContextFactory<JellyfinDbContext> dbProvider,
+        IEntityFrameworkDatabaseLockingBehavior writeBehavior,
         IEnumerable<IMediaSegmentProvider> segmentProviders)
     {
         _logger = logger;
         _dbProvider = dbProvider;
+        _writeBehavior = writeBehavior;
 
         _segmentProviders = segmentProviders
             .OrderBy(i => i is IHasOrder hasOrder ? hasOrder.Order : 0)
@@ -68,86 +72,89 @@ public class MediaSegmentManager : IMediaSegmentManager
             return;
         }
 
-        using var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        _logger.LogDebug("Start media segment extraction for {MediaPath} with {CountProviders} providers enabled", baseItem.Path, providers.Count);
-
-        if (forceOverwrite)
+        var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
         {
-            // delete all existing media segments if forceOverwrite is set.
-            await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
-        }
+            using var dbLock = await _writeBehavior.AcquireWriterLockAsync(db, cancellationToken).ConfigureAwait(false);
+            _logger.LogDebug("Start media segment extraction for {MediaPath} with {CountProviders} providers enabled", baseItem.Path, providers.Count);
 
-        foreach (var provider in providers)
-        {
-            if (!await provider.Supports(baseItem).ConfigureAwait(false))
-            {
-                _logger.LogDebug("Media Segment provider {ProviderName} does not support item with path {MediaPath}", provider.Name, baseItem.Path);
-                continue;
-            }
-
-            IQueryable<MediaSegment> existingSegments;
             if (forceOverwrite)
             {
-                existingSegments = Array.Empty<MediaSegment>().AsQueryable();
-            }
-            else
-            {
-                existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));
+                // delete all existing media segments if forceOverwrite is set.
+                await db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            var requestItem = new MediaSegmentGenerationRequest()
+            foreach (var provider in providers)
             {
-                ItemId = baseItem.Id,
-                ExistingSegments = existingSegments.Select(e => Map(e)).ToArray()
-            };
-
-            try
-            {
-                var segments = await provider.GetMediaSegments(requestItem, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (!forceOverwrite)
+                if (!await provider.Supports(baseItem).ConfigureAwait(false))
                 {
-                    var existingSegmentsList = existingSegments.ToArray(); // Cannot use requestItem's list, as the provider might tamper with its items.
-                    if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegmentsList.Any(f =>
+                    _logger.LogDebug("Media Segment provider {ProviderName} does not support item with path {MediaPath}", provider.Name, baseItem.Path);
+                    continue;
+                }
+
+                IQueryable<MediaSegment> existingSegments;
+                if (forceOverwrite)
+                {
+                    existingSegments = Array.Empty<MediaSegment>().AsQueryable();
+                }
+                else
+                {
+                    existingSegments = db.MediaSegments.Where(e => e.ItemId.Equals(baseItem.Id) && e.SegmentProviderId == GetProviderId(provider.Name));
+                }
+
+                var requestItem = new MediaSegmentGenerationRequest()
+                {
+                    ItemId = baseItem.Id,
+                    ExistingSegments = existingSegments.Select(e => Map(e)).ToArray()
+                };
+
+                try
+                {
+                    var segments = await provider.GetMediaSegments(requestItem, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (!forceOverwrite)
                     {
-                        return
-                            e.StartTicks == f.StartTicks &&
-                            e.EndTicks == f.EndTicks &&
-                            e.Type == f.Type;
-                    })))
+                        var existingSegmentsList = existingSegments.ToArray(); // Cannot use requestItem's list, as the provider might tamper with its items.
+                        if (segments.Count == requestItem.ExistingSegments.Count && segments.All(e => existingSegmentsList.Any(f =>
+                        {
+                            return
+                                e.StartTicks == f.StartTicks &&
+                                e.EndTicks == f.EndTicks &&
+                                e.Type == f.Type;
+                        })))
+                        {
+                            _logger.LogDebug("Media Segment provider {ProviderName} did not modify any segments for {MediaPath}", provider.Name, baseItem.Path);
+                            continue;
+                        }
+
+                        // delete existing media segments that were re-generated.
+                        await existingSegments.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    if (segments.Count == 0 && !requestItem.ExistingSegments.Any())
                     {
-                        _logger.LogDebug("Media Segment provider {ProviderName} did not modify any segments for {MediaPath}", provider.Name, baseItem.Path);
+                        _logger.LogDebug("Media Segment provider {ProviderName} did not find any segments for {MediaPath}", provider.Name, baseItem.Path);
+                        continue;
+                    }
+                    else if (segments.Count == 0 && requestItem.ExistingSegments.Any())
+                    {
+                        _logger.LogDebug("Media Segment provider {ProviderName} deleted all segments for {MediaPath}", provider.Name, baseItem.Path);
                         continue;
                     }
 
-                    // delete existing media segments that were re-generated.
-                    await existingSegments.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogInformation("Media Segment provider {ProviderName} found {CountSegments} for {MediaPath}", provider.Name, segments.Count, baseItem.Path);
+                    var providerId = GetProviderId(provider.Name);
+                    foreach (var segment in segments)
+                    {
+                        segment.ItemId = baseItem.Id;
+                        await DoCreateSegmentAsync(db, segment, providerId).ConfigureAwait(false);
+                    }
                 }
-
-                if (segments.Count == 0 && !requestItem.ExistingSegments.Any())
+                catch (Exception ex)
                 {
-                    _logger.LogDebug("Media Segment provider {ProviderName} did not find any segments for {MediaPath}", provider.Name, baseItem.Path);
-                    continue;
+                    _logger.LogError(ex, "Provider {ProviderName} failed to extract segments from {MediaPath}", provider.Name, baseItem.Path);
                 }
-                else if (segments.Count == 0 && requestItem.ExistingSegments.Any())
-                {
-                    _logger.LogDebug("Media Segment provider {ProviderName} deleted all segments for {MediaPath}", provider.Name, baseItem.Path);
-                    continue;
-                }
-
-                _logger.LogInformation("Media Segment provider {ProviderName} found {CountSegments} for {MediaPath}", provider.Name, segments.Count, baseItem.Path);
-                var providerId = GetProviderId(provider.Name);
-                foreach (var segment in segments)
-                {
-                    segment.ItemId = baseItem.Id;
-                    await CreateSegmentAsync(segment, providerId).ConfigureAwait(false);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Provider {ProviderName} failed to extract segments from {MediaPath}", provider.Name, baseItem.Path);
             }
         }
     }
@@ -157,24 +164,42 @@ public class MediaSegmentManager : IMediaSegmentManager
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(mediaSegment.EndTicks, mediaSegment.StartTicks);
 
-        using var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
+        var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            using var dbLock = await _writeBehavior.AcquireWriterLockAsync(db).ConfigureAwait(false);
+            await DoCreateSegmentAsync(db, mediaSegment, segmentProviderId).ConfigureAwait(false);
+            return mediaSegment;
+        }
+    }
+
+    private static async Task DoCreateSegmentAsync(JellyfinDbContext db, MediaSegmentDto mediaSegment, string segmentProviderId)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(mediaSegment.EndTicks, mediaSegment.StartTicks);
         db.MediaSegments.Add(Map(mediaSegment, segmentProviderId));
         await db.SaveChangesAsync().ConfigureAwait(false);
-        return mediaSegment;
     }
 
     /// <inheritdoc />
     public async Task DeleteSegmentAsync(Guid segmentId)
     {
-        using var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-        await db.MediaSegments.Where(e => e.Id.Equals(segmentId)).ExecuteDeleteAsync().ConfigureAwait(false);
+        var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            using var dbLock = await _writeBehavior.AcquireWriterLockAsync(db).ConfigureAwait(false);
+            await db.MediaSegments.Where(e => e.Id.Equals(segmentId)).ExecuteDeleteAsync().ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
     public async Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken)
     {
-        using var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await db.MediaSegments.Where(e => e.ItemId.Equals(itemId)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            using var dbLock = await _writeBehavior.AcquireWriterLockAsync(db, cancellationToken).ConfigureAwait(false);
+            await db.MediaSegments.Where(e => e.ItemId.Equals(itemId)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
@@ -186,36 +211,39 @@ public class MediaSegmentManager : IMediaSegmentManager
             return [];
         }
 
-        using var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
-
-        var query = db.MediaSegments
-            .Where(e => e.ItemId.Equals(item.Id));
-
-        if (typeFilter is not null)
+        var db = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
         {
-            query = query.Where(e => typeFilter.Contains(e.Type));
-        }
+            using var dbLock = await _writeBehavior.AcquireReaderLockAsync(db).ConfigureAwait(false);
+            var query = db.MediaSegments
+                .Where(e => e.ItemId.Equals(item.Id));
 
-        if (filterByProvider)
-        {
-            var providerIds = _segmentProviders
-                .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
-                .Select(f => GetProviderId(f.Name))
-                .ToArray();
-            if (providerIds.Length == 0)
+            if (typeFilter is not null)
             {
-                return [];
+                query = query.Where(e => typeFilter.Contains(e.Type));
             }
 
-            query = query.Where(e => providerIds.Contains(e.SegmentProviderId));
-        }
+            if (filterByProvider)
+            {
+                var providerIds = _segmentProviders
+                    .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
+                    .Select(f => GetProviderId(f.Name))
+                    .ToArray();
+                if (providerIds.Length == 0)
+                {
+                    return [];
+                }
 
-        return query
-            .OrderBy(e => e.StartTicks)
-            .AsNoTracking()
-            .AsEnumerable()
-            .Select(Map)
-            .ToArray();
+                query = query.Where(e => providerIds.Contains(e.SegmentProviderId));
+            }
+
+            return query
+                .OrderBy(e => e.StartTicks)
+                .AsNoTracking()
+                .AsEnumerable()
+                .Select(Map)
+                .ToArray();
+        }
     }
 
     private static MediaSegmentDto Map(MediaSegment segment)
@@ -247,6 +275,7 @@ public class MediaSegmentManager : IMediaSegmentManager
     public bool HasSegments(Guid itemId)
     {
         using var db = _dbProvider.CreateDbContext();
+        using var dbLock = _writeBehavior.AcquireReaderLock(db);
         return db.MediaSegments.Any(e => e.ItemId.Equals(itemId));
     }
 

--- a/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
+++ b/Jellyfin.Server.Implementations/Users/DisplayPreferencesManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
 using MediaBrowser.Controller;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,15 +18,30 @@ namespace Jellyfin.Server.Implementations.Users
     /// </summary>
     public sealed class DisplayPreferencesManager : IDisplayPreferencesManager, IAsyncDisposable
     {
+        private readonly IEntityFrameworkDatabaseLockingBehavior _writeBehavior;
         private readonly JellyfinDbContext _dbContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DisplayPreferencesManager"/> class.
         /// </summary>
         /// <param name="dbContextFactory">The database context factory.</param>
-        public DisplayPreferencesManager(IDbContextFactory<JellyfinDbContext> dbContextFactory)
+        /// <param name="writeBehavior">Instance of the <see cref="IEntityFrameworkDatabaseLockingBehavior"/> interface.</param>
+        public DisplayPreferencesManager(IDbContextFactory<JellyfinDbContext> dbContextFactory, IEntityFrameworkDatabaseLockingBehavior writeBehavior)
         {
+            _writeBehavior = writeBehavior;
             _dbContext = dbContextFactory.CreateDbContext();
+        }
+
+        /// <inheritdoc />
+        public IDisposable AcquireWriterLock()
+        {
+            return _writeBehavior.AcquireWriterLock(_dbContext);
+        }
+
+        /// <inheritdoc />
+        public IDisposable AcquireReaderLock()
+        {
+            return _writeBehavior.AcquireReaderLock(_dbContext);
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -12,6 +12,7 @@ using Emby.Server.Implementations;
 using Emby.Server.Implementations.Configuration;
 using Emby.Server.Implementations.Serialization;
 using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Locking;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Helpers;
 using Jellyfin.Server.Implementations.DatabaseConfiguration;
@@ -345,7 +346,9 @@ namespace Jellyfin.Server
         {
             var factory = services.GetRequiredService<IDbContextFactory<JellyfinDbContext>>();
             var provider = services.GetRequiredService<IJellyfinDatabaseProvider>();
+            var writeBehavior = services.GetRequiredService<IEntityFrameworkDatabaseLockingBehavior>();
             provider.DbContextFactory = factory;
+            provider.WriteBehavior = writeBehavior;
         }
     }
 }

--- a/MediaBrowser.Controller/IDisplayPreferencesManager.cs
+++ b/MediaBrowser.Controller/IDisplayPreferencesManager.cs
@@ -63,5 +63,17 @@ namespace MediaBrowser.Controller
         /// Saves changes made to the database.
         /// </summary>
         void SaveChanges();
+
+        /// <summary>
+        /// Acquires the database writer lock.
+        /// </summary>
+        /// <returns>Lock scope.</returns>
+        IDisposable AcquireWriterLock();
+
+        /// <summary>
+        /// Acquires the database reader lock.
+        /// </summary>
+        /// <returns>Lock scope.</returns>
+        IDisposable AcquireReaderLock();
     }
 }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -695,7 +695,7 @@ namespace MediaBrowser.Providers.Manager
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Error in metadata saver");
+                        _logger.LogError(ex, "Error in metadata saver for {Path}", path);
                     }
                     finally
                     {

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -22,4 +22,10 @@ public class DatabaseConfigurationOptions
     /// Defaults to "NoLock".
     /// </summary>
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the kind of database write behavior jellyfin should perform. Possible options are "ConcurrentWrites", "SerialWrites".
+    /// Defaults to "NoLock".
+    /// </summary>
+    public DatabaseWriteBehaviorTypes WriteBehavior { get; set; }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseWriteBehaviorTypes.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseWriteBehaviorTypes.cs
@@ -1,0 +1,17 @@
+namespace Jellyfin.Database.Implementations.DbConfiguration;
+
+/// <summary>
+/// Defines all possible methods for database write access.
+/// </summary>
+public enum DatabaseWriteBehaviorTypes
+{
+    /// <summary>
+    /// Defines that provider concurrent database write access should be relied on.
+    /// </summary>
+    ConcurrentWrites = 0,
+
+    /// <summary>
+    /// Defines that provider serial database write access should be relied on.
+    /// </summary>
+    SerializedWrites = 1
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Locking;
 using Microsoft.EntityFrameworkCore;
 
 namespace Jellyfin.Database.Implementations;
@@ -12,9 +13,14 @@ namespace Jellyfin.Database.Implementations;
 public interface IJellyfinDatabaseProvider
 {
     /// <summary>
-    /// Gets or Sets the Database Factory when initialisaition is done.
+    /// Gets or Sets the Database Factory when initialization is done.
     /// </summary>
     IDbContextFactory<JellyfinDbContext>? DbContextFactory { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the WriteBehavior when initialization is done.
+    /// </summary>
+    public IEntityFrameworkDatabaseLockingBehavior? WriteBehavior { get; set; }
 
     /// <summary>
     /// Initialises jellyfins EFCore database access.

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNext.Threading" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/ConcurrentDatabaseLockingBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/ConcurrentDatabaseLockingBehavior.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+/// <summary>
+/// Concurrent database locking behavior.
+/// </summary>
+public class ConcurrentDatabaseLockingBehavior : IEntityFrameworkDatabaseLockingBehavior
+{
+    private static readonly Disposable _disposable = new();
+
+    /// <inheritdoc />
+    public IDisposable AcquireWriterLock(JellyfinDbContext context)
+    {
+        return _disposable;
+    }
+
+    /// <inheritdoc />
+    public Task<IDisposable> AcquireWriterLockAsync(JellyfinDbContext context, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IDisposable>(_disposable);
+    }
+
+    /// <inheritdoc />
+    public IDisposable AcquireReaderLock(JellyfinDbContext context)
+    {
+        return _disposable;
+    }
+
+    /// <inheritdoc />
+    public Task<IDisposable> AcquireReaderLockAsync(JellyfinDbContext context, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IDisposable>(_disposable);
+    }
+
+    private sealed class Disposable : IDisposable
+    {
+        public void Dispose()
+        {
+            // no-op
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/IEntityFrameworkDatabaseLockingBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/IEntityFrameworkDatabaseLockingBehavior.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+/// <summary>
+/// Defines a jellyfin database write locking behavior.
+/// </summary>
+public interface IEntityFrameworkDatabaseLockingBehavior
+{
+    /// <summary>
+    /// Acquires the database writer lock.
+    /// </summary>
+    /// <param name="context">JellyfinDbContext instance.</param>
+    /// <returns>Lock scope.</returns>
+    IDisposable AcquireWriterLock(JellyfinDbContext context);
+
+    /// <summary>
+    /// Acquires the database writer lock.
+    /// </summary>
+    /// <param name="context">JellyfinDbContext instance.</param>
+    /// <param name="cancellationToken">Instance of CancellationToken.</param>
+    /// <returns>Lock scope.</returns>
+    Task<IDisposable> AcquireWriterLockAsync(JellyfinDbContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acquires the database reader lock.
+    /// </summary>
+    /// <param name="context">JellyfinDbContext instance.</param>
+    /// <returns>Lock scope.</returns>
+    IDisposable AcquireReaderLock(JellyfinDbContext context);
+
+    /// <summary>
+    /// Acquires the database reader lock.
+    /// </summary>
+    /// <param name="context">JellyfinDbContext instance.</param>
+    /// <param name="cancellationToken">Instance of CancellationToken.</param>
+    /// <returns>Lock scope.</returns>
+    Task<IDisposable> AcquireReaderLockAsync(JellyfinDbContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedDatabaseLockingBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedDatabaseLockingBehavior.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Threading;
+using DotNext.Threading.Tasks;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+internal enum State
+{
+    None,
+    ReaderLock,
+    WriterLock
+}
+
+/// <summary>
+/// Serialized database write behavior.
+/// </summary>
+public sealed class SerializedDatabaseLockingBehavior : IEntityFrameworkDatabaseLockingBehavior, IAsyncDisposable
+{
+#pragma warning disable MT1016 // Replace ReaderWriterLock with ReaderWriterLockSlim
+    private readonly AsyncReaderWriterLock _lock = new();
+#pragma warning restore MT1016 // Replace ReaderWriterLock with ReaderWriterLockSlim
+
+    private static readonly AsyncLocal<State> _state = new();
+
+    /// <inheritdoc />
+    public IDisposable AcquireWriterLock(JellyfinDbContext context)
+    {
+        switch (_state.Value)
+        {
+            case State.None:
+                // Ensure that only one thread can write access the database at a time.
+                _lock.EnterWriteLockAsync().Wait();
+                _state.Value = State.WriterLock;
+                return new LockHolder(this);
+            case State.ReaderLock:
+                _lock.UpgradeToWriteLockAsync().Wait();
+                _state.Value = State.WriterLock;
+                return new UpgradeLockHolder(this);
+            case State.WriterLock:
+                // Already in a writer lock, no need to acquire again.
+                return new Empty();
+            default:
+                throw new NotSupportedException($"Bad SerializedDatabaseLockingBehavior State {_state.Value}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> AcquireWriterLockAsync(JellyfinDbContext context, CancellationToken cancellationToken)
+    {
+        switch (_state.Value)
+        {
+            case State.None:
+                // Ensure that only one thread can write access the database at a time.
+                await _lock.EnterWriteLockAsync(cancellationToken).ConfigureAwait(true);
+                _state.Value = State.WriterLock;
+                return new LockHolder(this);
+            case State.ReaderLock:
+                await _lock.UpgradeToWriteLockAsync(cancellationToken).ConfigureAwait(false);
+                _state.Value = State.WriterLock;
+                return new UpgradeLockHolder(this);
+            case State.WriterLock:
+                // Already in a writer lock, no need to acquire again.
+                return new Empty();
+            default:
+                throw new NotSupportedException($"Bad SerializedDatabaseLockingBehavior State {_state.Value}");
+        }
+    }
+
+    /// <inheritdoc />
+    public IDisposable AcquireReaderLock(JellyfinDbContext context)
+    {
+        switch (_state.Value)
+        {
+            case State.None:
+                // Ensure that only readers can read access the database at a time.
+                _lock.EnterReadLockAsync().Wait();
+                _state.Value = State.ReaderLock;
+                return new LockHolder(this);
+            case State.ReaderLock:
+            case State.WriterLock:
+                // Already in a reader or writer lock, no need to acquire again.
+                return new Empty();
+            default:
+                throw new NotSupportedException($"Bad SerializedDatabaseLockingBehavior State {_state.Value}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> AcquireReaderLockAsync(JellyfinDbContext context, CancellationToken cancellationToken = default)
+    {
+        switch (_state.Value)
+        {
+            case State.None:
+                // Ensure that only readers can read access the database at a time.
+                await _lock.EnterReadLockAsync(cancellationToken).ConfigureAwait(true);
+                return new LockHolder(this);
+            case State.ReaderLock:
+            case State.WriterLock:
+                // Already in a reader or writer lock, no need to acquire again.
+                return new Empty();
+            default:
+                throw new NotSupportedException($"Bad SerializedDatabaseLockingBehavior State {_state.Value}");
+        }
+    }
+
+    private void Release()
+    {
+        _state.Value = State.None;
+        _lock.Release();
+    }
+
+    private void DowngradeFromWriteLock()
+    {
+        _state.Value = State.ReaderLock;
+        _lock.DowngradeFromWriteLock();
+    }
+
+    /// <summary>
+    /// Disposes the lock when no longer needed.
+    /// </summary>
+    /// <returns>The task.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        await _lock.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed record LockHolder(SerializedDatabaseLockingBehavior LockData) : IDisposable
+    {
+        public void Dispose()
+        {
+            LockData.Release();
+        }
+    }
+
+    private sealed record UpgradeLockHolder(SerializedDatabaseLockingBehavior LockData) : IDisposable
+    {
+        public void Dispose()
+        {
+            LockData.DowngradeFromWriteLock();
+        }
+    }
+
+    private sealed record Empty : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
The main problem that is happening is that jelly fin is breaking the sqlite Multi-thread mode rules and EF is not helping in any way. https://www.sqlite.org/threadsafe.html
EF uses the Multi-thread mode of sqlite.

These basically break down to:
* Reads can be multi-threaded
* Only one write operation can happen at any one time (this includes overlapping reads, i.e. a read during a write operation/transaction can cause the 'database is locked')
* Only one transaction scope at one time (no overlapping writes or transactions)

In sqlite you can set a retry timeout but that doesn't help if you transactions.

My fix is to use i reader writer lock primitive (multiple readers but only one writer) at i coarse-grained lock level. This means it's not automatically added to JellyFin but has to be added to db usage areas manually and maintained. I have done this for the current db usage and tried to limit the db lock scope as much as makes sense.

The implementation also supports recursive locking, including upgrading/downgrading locks.

- Added `DotNext.Threading` package reference for AsyncReaderWriterLock.
- Introduced `Jellyfin.Database.Implementations.Locking` for database locking.
- Updated classes to include `IEntityFrameworkDatabaseLockingBehavior` for managing locks.
- Refactored methods in `CleanDatabaseScheduledTask`, `UserDataManager`, and others to use reader/writer locks.
- Implemented new locking strategies with `ConcurrentDatabaseLockingBehavior` and `SerializedDatabaseLockingBehavior`.
- Improved error handling and logging for better insights during database operations.

Also fixed
Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
...
   at Jellyfin.Database.Implementations.JellyfinDbContext.SaveChanges(Boolean acceptAllChangesOnSuccess) in D:\depot\github\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\JellyfinDbContext.cs:line 286
   at Jellyfin.Server.Implementations.Item.PeopleRepository.UpdatePeople(Guid itemId, IReadOnlyList`1 people) in D:\depot\github\jellyfin\Jellyfin.Server.Implementations\Item\PeopleRepository.cs:line 106
   at Emby.Server.Implementations.Library.LibraryManager.UpdatePeopleAsync(BaseItem item, IReadOnlyList`1 people, CancellationToken cancellationToken) in D:\depot\github\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 2864
   at Emby.Server.Implementations.Library.LibraryManager.UpdatePeople(BaseItem item, List`1 people) in D:\depot\github\jellyfin\Emby.Server.Implementations\Library\LibraryManager.cs:line 2850

With the multi-threaded nature of JellyFin, multiple overlapping calls to PeopleRepository.UpdatePeople can cause this problem. The write locking scope fixes this sort of problem, I also added a transaction boundary if JellyFin is gonig to support other db types where locking behavior can be turned off.
