### PR TITLE
Use square root scaling for high framerate videos' bitrate requirements

### DIFF
--- a/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
@@ -43,6 +43,7 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
+            // Our reference bitrate is based on SDR h264 at 30fps
             var referenceFps = targetFps ?? 30.0f;
             var referenceScale = referenceFps <= 30.0f
                 ? 30.0f / referenceFps

--- a/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionNormalizer.cs
@@ -43,7 +43,11 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
-            var referenceBitrate = h264EquivalentOutputBitrate * (30.0f / (targetFps ?? 30.0f));
+            var referenceFps = targetFps ?? 30.0f;
+            var referenceScale = referenceFps <= 30.0f
+                ? 30.0f / referenceFps
+                : 1.0f / MathF.Sqrt(referenceFps / 30.0f);
+            var referenceBitrate = h264EquivalentOutputBitrate * referenceScale;
 
             if (isHdr)
             {


### PR DESCRIPTION
The previous linear scaling model is inefficient for modern codecs for high frame rate(>30fps) videos. It may force an extremely low resolution like 540p, under poor network conditions(<5Mbps). High frame rates benefit from H264’s temporal inter-frame compression, and human perception of quality diminishes with increasing frame rates. Square root scaling for high framerate videos fits the use case better.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #14238
