### PR TITLE
Fix startup logger, startup health check

### DIFF
--- a/Jellyfin.Server/ServerSetupApp/SetupServer.cs
+++ b/Jellyfin.Server/ServerSetupApp/SetupServer.cs
@@ -19,7 +19,6 @@ using MediaBrowser.Model.System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -29,6 +28,8 @@ using Microsoft.Extensions.Primitives;
 using Morestachio;
 using Morestachio.Framework.IO.SingleStream;
 using Morestachio.Rendering;
+using Serilog;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Jellyfin.Server.ServerSetupApp;
 
@@ -143,8 +144,10 @@ public sealed class SetupServer : IDisposable
         var config = _configurationManager.GetNetworkConfiguration()!;
         _startupServer = Host.CreateDefaultBuilder(["hostBuilder:reloadConfigOnChange=false"])
             .UseConsoleLifetime()
+            .UseSerilog()
             .ConfigureServices(serv =>
             {
+                serv.AddSingleton(this);
                 serv.AddHealthChecks()
                     .AddCheck<SetupHealthcheck>("StartupCheck");
                 serv.Configure<ForwardedHeadersOptions>(options =>


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/14318

Also fixes the startup logger

Before:
```
[18:31:26] [INF] [11] Main: Kestrel is listening on 0.0.0.0
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://localhost:8096/health - - -
warn: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
      Health check StartupCheck with status Degraded completed after 2.383ms with message 'Server is still starting up.'
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 GET http://localhost:8096/health - 200 - text/plain 39.1417ms
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://localhost:8096/health - - -
warn: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
      Health check StartupCheck with status Degraded completed after 0.0263ms with message 'Server is still starting up.'
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 GET http://localhost:8096/health - 200 - text/plain 5.4347ms
```

After
```
[18:32:00] [INF] [11] Main: Kestrel is listening on 0.0.0.0
[18:32:02] [WRN] [11] Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService: Health check StartupCheck with status Degraded completed after 1.5943ms with message 'Server is still starting up.'
[18:32:02] [WRN] [11] Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService: Health check StartupCheck with status Degraded completed after 0.0232ms with message 'Server is still starting up.'
[18:32:03] [WRN] [20] Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService: Health check StartupCheck with status Degraded completed after 0.0023ms with message 'Server is still starting up.'
[18:32:03] [WRN] [11] Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService: Health check StartupCheck with status Degraded completed after 0.0032ms with message 'Server is still starting up.'
```