### PR TITLE
Fix missing music genre metadata

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -340,9 +340,10 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 genres = genres.Trimmed().Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
 
-                audio.Genres = options.ReplaceAllMetadata || audio.Genres is null || audio.Genres.Length == 0
-                    ? genres
-                    : audio.Genres;
+                if (options.ReplaceAllMetadata || audio.Genres is null || audio.Genres.Length == 0 || genres.Length > 0)
+                {
+                    audio.Genres = genres;
+                }
             }
 
             TryGetSanitizedAdditionalFields(track, "REPLAYGAIN_TRACK_GAIN", out var trackGainTag);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Genre tags from audio files are now applied during initial scanning. Previously, these tags were ignored unless a Replace all Metadata scan was performed or the genre field was empty.

**Issues**
Fixes #14041
Fixes #6036


