### PR TITLE
Fix seasons random (#13224)

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -695,7 +695,7 @@ namespace MediaBrowser.Controller.Entities
                     items = GetRecursiveChildren(user, query);
                 }
 
-                return PostFilterAndSort(items, query, true);
+                return PostFilterAndSort(items, query);
             }
 
             if (this is not UserRootFolder
@@ -959,10 +959,10 @@ namespace MediaBrowser.Controller.Entities
                 items = GetChildren(user, true, childQuery).Where(filter);
             }
 
-            return PostFilterAndSort(items, query, true);
+            return PostFilterAndSort(items, query);
         }
 
-        protected QueryResult<BaseItem> PostFilterAndSort(IEnumerable<BaseItem> items, InternalItemsQuery query, bool enableSorting)
+        protected QueryResult<BaseItem> PostFilterAndSort(IEnumerable<BaseItem> items, InternalItemsQuery query)
         {
             var user = query.User;
 
@@ -995,7 +995,7 @@ namespace MediaBrowser.Controller.Entities
                 items = UserViewBuilder.FilterForAdjacency(items.ToList(), query.AdjacentTo.Value);
             }
 
-            return UserViewBuilder.SortAndPage(items, null, query, LibraryManager, enableSorting);
+            return UserViewBuilder.SortAndPage(items, null, query, LibraryManager);
         }
 
         private static IEnumerable<BaseItem> CollapseBoxSetItemsIfNeeded(

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -179,7 +179,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
             var items = GetEpisodes(user, query.DtoOptions, true).Where(filter);
 
-            return PostFilterAndSort(items, query, false);
+            return PostFilterAndSort(items, query);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Entities/UserRootFolder.cs
+++ b/MediaBrowser.Controller/Entities/UserRootFolder.cs
@@ -80,7 +80,7 @@ namespace MediaBrowser.Controller.Entities
                 PresetViews = query.PresetViews
             });
 
-            return UserViewBuilder.SortAndPage(result, null, query, LibraryManager, true);
+            return UserViewBuilder.SortAndPage(result, null, query, LibraryManager);
         }
 
         public override int GetChildCount(User user)

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -438,22 +438,18 @@ namespace MediaBrowser.Controller.Entities
                 items = FilterForAdjacency(items.ToList(), query.AdjacentTo.Value);
             }
 
-            return SortAndPage(items, totalRecordLimit, query, libraryManager, true);
+            return SortAndPage(items, totalRecordLimit, query, libraryManager);
         }
 
         public static QueryResult<BaseItem> SortAndPage(
             IEnumerable<BaseItem> items,
             int? totalRecordLimit,
             InternalItemsQuery query,
-            ILibraryManager libraryManager,
-            bool enableSorting)
+            ILibraryManager libraryManager)
         {
-            if (enableSorting)
+            if (query.OrderBy.Count > 0)
             {
-                if (query.OrderBy.Count > 0)
-                {
-                    items = libraryManager.Sort(items, query.User, query.OrderBy);
-                }
+                items = libraryManager.Sort(items, query.User, query.OrderBy);
             }
 
             var itemsArray = totalRecordLimit.HasValue ? items.Take(totalRecordLimit.Value).ToArray() : items.ToArray();


### PR DESCRIPTION
Sorting was always enabled so removed the `enableSorting` parameter in QueryResult method.

**Changes**
To correctly answer the query we need to enable sorting. As no other call is done without enabling sorting, I rework the thing to get rid of this parameter.

**Issues**
Fixes #13224 
