### PR TITLE
Fix metadata manager infinite loading when Live TV access is revoked

### DIFF
--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -144,7 +144,6 @@ public class LiveTvController : BaseJellyfinApiController
     /// </returns>
     [HttpGet("Channels")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [Authorize(Policy = Policies.LiveTvAccess)]
     public ActionResult<QueryResult<BaseItemDto>> GetLiveTvChannels(
         [FromQuery] ChannelType? type,
         [FromQuery] Guid? userId,
@@ -168,6 +167,15 @@ public class LiveTvController : BaseJellyfinApiController
         [FromQuery] bool enableFavoriteSorting = false,
         [FromQuery] bool addCurrentProgram = true)
     {
+        // Check if authenticated user has Live TV access
+        var authenticatedUserId = User.GetUserId();
+        var authenticatedUser = _userManager.GetUserById(authenticatedUserId);
+        if (authenticatedUser == null || !authenticatedUser.HasPermission(PermissionKind.EnableLiveTvAccess))
+        {
+            // Return empty result instead of 403 to prevent metadata manager failures
+            return new QueryResult<BaseItemDto>();
+        }
+        
         userId = RequestHelpers.GetUserId(User, userId);
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddClientFields(User)
@@ -273,7 +281,6 @@ public class LiveTvController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the live tv recordings.</returns>
     [HttpGet("Recordings")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [Authorize(Policy = Policies.LiveTvAccess)]
     public async Task<ActionResult<QueryResult<BaseItemDto>>> GetRecordings(
         [FromQuery] string? channelId,
         [FromQuery] Guid? userId,
@@ -295,6 +302,15 @@ public class LiveTvController : BaseJellyfinApiController
         [FromQuery] bool? isLibraryItem,
         [FromQuery] bool enableTotalRecordCount = true)
     {
+        // Check if authenticated user has Live TV access
+        var authenticatedUserId = User.GetUserId();
+        var authenticatedUser = _userManager.GetUserById(authenticatedUserId);
+        if (authenticatedUser == null || !authenticatedUser.HasPermission(PermissionKind.EnableLiveTvAccess))
+        {
+            // Return empty result instead of 403 to prevent metadata manager failures
+            return new QueryResult<BaseItemDto>();
+        }
+        
         userId = RequestHelpers.GetUserId(User, userId);
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddClientFields(User)


### PR DESCRIPTION
Resolves issue where the metadata manager would show infinite loading screen when users don't have Live TV access permissions. The problem was caused by 403 Forbidden errors from LiveTv/Channels and LiveTv/Recordings endpoints.

**Changes**- Remove [Authorize(Policy = Policies.LiveTvAccess)] from GetLiveTvChannels() and GetRecordings()
- Add manual permission checks that return empty QueryResult instead of 403 errors
- Check authenticated user permissions rather than target user permissions
- Preserve security by validating PermissionKind.EnableLiveTvAccess

This allows the metadata manager to receive empty results gracefully instead of failing with 403 errors, preventing the infinite loading issue while maintaining proper authorization.

**Issues**
Fixes #9908

