### PR TITLE
Trying to add a feature for a user to hide items

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -199,6 +199,7 @@
  - [allesmi](https://github.com/allesmi)
  - [ThunderClapLP](https://github.com/ThunderClapLP)
  - [Shoham Peller](https://github.com/spellr)
+ - [Eytam Levine](https://github.com/Eyt-Lev)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -120,6 +120,11 @@ namespace Emby.Server.Implementations.Library
                 userData.Likes = userDataDto.Likes.Value;
             }
 
+            if (userDataDto.IsHiddenByUser.HasValue)
+            {
+                userData.IsHiddenByUser = userDataDto.IsHiddenByUser.Value;
+            }
+
             if (userDataDto.Played.HasValue)
             {
                 userData.Played = userDataDto.Played.Value;
@@ -152,6 +157,7 @@ namespace Emby.Server.Implementations.Library
                 Likes = dto.Likes,
                 PlaybackPositionTicks = dto.PlaybackPositionTicks,
                 PlayCount = dto.PlayCount,
+                IsHiddenByUser = dto.IsHiddenByUser,
                 Played = dto.Played,
                 Rating = dto.Rating,
                 UserId = userId,
@@ -170,6 +176,7 @@ namespace Emby.Server.Implementations.Library
                 Likes = dto.Likes,
                 PlaybackPositionTicks = dto.PlaybackPositionTicks,
                 PlayCount = dto.PlayCount,
+                IsHiddenByUser = dto.IsHiddenByUser,
                 Played = dto.Played,
                 Rating = dto.Rating,
                 SubtitleStreamIndex = dto.SubtitleStreamIndex,
@@ -277,6 +284,7 @@ namespace Emby.Server.Implementations.Library
                 PlaybackPositionTicks = data.PlaybackPositionTicks,
                 PlayCount = data.PlayCount,
                 Rating = data.Rating,
+                IsHiddenByUser = data.IsHiddenByUser,
                 Played = data.Played,
                 LastPlayedDate = data.LastPlayedDate,
                 ItemId = itemId,

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -114,6 +114,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="includeItemTypes">Optional. If specified, results will be filtered based on the item type. This allows multiple, comma delimited.</param>
     /// <param name="filters">Optional. Specify additional filters to apply. This allows multiple, comma delimited. Options: IsFolder, IsNotFolder, IsUnplayed, IsPlayed, IsFavorite, IsResumable, Likes, Dislikes.</param>
     /// <param name="isFavorite">Optional filter by items that are marked as favorite, or not.</param>
+    /// <param name="isHiddenByUser">Optional filter by items that are marked as hidden by the user, or not.</param>
     /// <param name="mediaTypes">Optional filter by MediaType. Allows multiple, comma delimited.</param>
     /// <param name="imageTypes">Optional. If specified, results will be filtered based on those containing image types. This allows multiple, comma delimited.</param>
     /// <param name="sortBy">Optional. Specify one or more sort orders, comma delimited. Options: Album, AlbumArtist, Artist, Budget, CommunityRating, CriticRating, DateCreated, DatePlayed, PlayCount, PremiereDate, ProductionYear, SortName, Random, Revenue, Runtime.</param>
@@ -204,6 +205,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] BaseItemKind[] includeItemTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFilter[] filters,
         [FromQuery] bool? isFavorite,
+        [FromQuery] bool? isHiddenByUser,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] MediaType[] mediaTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] imageTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[] sortBy,
@@ -318,6 +320,7 @@ public class ItemsController : BaseJellyfinApiController
                 Recursive = recursive ?? false,
                 OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder),
                 IsFavorite = isFavorite,
+                IsHiddenByUser = isHiddenByUser,
                 Limit = limit,
                 StartIndex = startIndex,
                 IsMissing = isMissing,
@@ -399,6 +402,9 @@ public class ItemsController : BaseJellyfinApiController
                         break;
                     case ItemFilter.IsFavoriteOrLikes:
                         query.IsFavoriteOrLiked = true;
+                        break;
+                    case ItemFilter.IsHiddenByUser:
+                        query.IsHiddenByUser = true;
                         break;
                     case ItemFilter.IsFolder:
                         query.IsFolder = true;
@@ -580,6 +586,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="includeItemTypes">Optional. If specified, results will be filtered based on the item type. This allows multiple, comma delimited.</param>
     /// <param name="filters">Optional. Specify additional filters to apply. This allows multiple, comma delimited. Options: IsFolder, IsNotFolder, IsUnplayed, IsPlayed, IsFavorite, IsResumable, Likes, Dislikes.</param>
     /// <param name="isFavorite">Optional filter by items that are marked as favorite, or not.</param>
+    /// <param name="isHiddenByUser">Optional filter by items that are marked as hidden, or not.</param>
     /// <param name="mediaTypes">Optional filter by MediaType. Allows multiple, comma delimited.</param>
     /// <param name="imageTypes">Optional. If specified, results will be filtered based on those containing image types. This allows multiple, comma delimited.</param>
     /// <param name="sortBy">Optional. Specify one or more sort orders, comma delimited. Options: Album, AlbumArtist, Artist, Budget, CommunityRating, CriticRating, DateCreated, DatePlayed, PlayCount, PremiereDate, ProductionYear, SortName, Random, Revenue, Runtime.</param>
@@ -671,6 +678,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] BaseItemKind[] includeItemTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFilter[] filters,
         [FromQuery] bool? isFavorite,
+        [FromQuery] bool? isHiddenByUser,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] MediaType[] mediaTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] imageTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[] sortBy,
@@ -758,6 +766,7 @@ public class ItemsController : BaseJellyfinApiController
             includeItemTypes,
             filters,
             isFavorite,
+            isHiddenByUser,
             mediaTypes,
             imageTypes,
             sortBy,

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -73,6 +73,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="excludeItemTypes">Optional. If specified, results will be filtered based on item type. This allows multiple, comma delimited.</param>
     /// <param name="filters">Optional. Specify additional filters to apply. This allows multiple, comma delimited. Options: IsFolder, IsNotFolder, IsUnplayed, IsPlayed, IsFavorite, IsResumable, Likes, Dislikes.</param>
     /// <param name="isFavorite">Optional filter by items that are marked as favorite, or not.</param>
+    /// <param name="isHiddenByUser">Optional filter by items that are marked as hidden by the user, or not.</param>
     /// <param name="mediaTypes">Optional filter by MediaType. Allows multiple, comma delimited.</param>
     /// <param name="imageTypes">Optional. If specified, results will be filtered based on those containing image types. This allows multiple, comma delimited.</param>
     /// <param name="sortBy">Optional. Specify one or more sort orders, comma delimited. Options: Album, AlbumArtist, Artist, Budget, CommunityRating, CriticRating, DateCreated, DatePlayed, PlayCount, PremiereDate, ProductionYear, SortName, Random, Revenue, Runtime.</param>
@@ -161,6 +162,7 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] BaseItemKind[] excludeItemTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFilter[] filters,
         [FromQuery] bool? isFavorite,
+        [FromQuery] bool? isHiddenByUser,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] MediaType[] mediaTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] imageTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[] sortBy,
@@ -252,6 +254,7 @@ public class TrailersController : BaseJellyfinApiController
                 includeItemTypes,
                 filters,
                 isFavorite,
+                isHiddenByUser,
                 mediaTypes,
                 imageTypes,
                 sortBy,

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1106,6 +1106,7 @@ public sealed class BaseItemRepository
         {
             IsPlayed = filter.IsPlayed,
             IsFavorite = filter.IsFavorite,
+            IsHiddenByUser = filter.IsHiddenByUser,
             IsFavoriteOrLiked = filter.IsFavoriteOrLiked,
             IsLiked = filter.IsLiked,
             IsLocked = filter.IsLocked,
@@ -1835,6 +1836,12 @@ public sealed class BaseItemRepository
         {
             baseQuery = baseQuery
                 .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.IsFavorite == filter.IsFavorite);
+        }
+
+        if (filter.IsHiddenByUser.HasValue)
+        {
+            baseQuery = baseQuery
+                .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.IsHiddenByUser == filter.IsHiddenByUser);
         }
 
         if (filter.IsPlayed.HasValue)

--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -176,7 +176,7 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
         {
             var queryResult = connection.Query(
             """
-            SELECT key, userId, rating, played, playCount, isFavorite, playbackPositionTicks, lastPlayedDate, AudioStreamIndex, SubtitleStreamIndex FROM UserDatas
+            SELECT key, userId, rating, played, playCount, isFavorite, isHiddenByUser, playbackPositionTicks, lastPlayedDate, AudioStreamIndex, SubtitleStreamIndex FROM UserDatas
 
             WHERE EXISTS(SELECT 1 FROM TypedBaseItems WHERE TypedBaseItems.UserDataKey = UserDatas.key)
             """);
@@ -431,6 +431,7 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
             Played = dto.GetBoolean(3),
             PlayCount = dto.GetInt32(4),
             IsFavorite = dto.GetBoolean(5),
+            IsHiddenByUser = false, // Todo: The old library did not have a hidden flag. or whatever
             PlaybackPositionTicks = dto.GetInt64(6),
             LastPlayedDate = dto.IsDBNull(7) ? null : dto.GetDateTime(7),
             AudioStreamIndex = dto.IsDBNull(8) ? null : dto.GetInt32(8),

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2323,6 +2323,13 @@ namespace MediaBrowser.Controller.Entities
             return userdata is not null && userdata.Played;
         }
 
+        public virtual bool IsHiddenByUser(User user)
+        {
+            var userdata = UserDataManager.GetUserData(user, this);
+
+            return userdata is not null && userdata.IsHiddenByUser;
+        }
+
         public bool IsFavoriteOrLiked(User user)
         {
             var userdata = UserDataManager.GetUserData(user, this);

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -76,6 +76,8 @@ namespace MediaBrowser.Controller.Entities
 
         public bool? IsFavorite { get; set; }
 
+        public bool? IsHiddenByUser { get; set; }
+
         public bool? IsFavoriteOrLiked { get; set; }
 
         public bool? IsLiked { get; set; }

--- a/MediaBrowser.Controller/Entities/UserItemData.cs
+++ b/MediaBrowser.Controller/Entities/UserItemData.cs
@@ -64,6 +64,12 @@ namespace MediaBrowser.Controller.Entities
         public bool IsFavorite { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this instance is hidden ny the user.
+        /// </summary>
+        /// <value><c>true</c> if this instance is hidden by the user; otherwise, <c>false</c>.</value>
+        public bool IsHiddenByUser { get; set; }
+
+        /// <summary>
         /// Gets or sets the last played date.
         /// </summary>
         /// <value>The last played date.</value>

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -89,7 +89,7 @@ namespace MediaBrowser.Controller.Entities
 
                 case CollectionType.moviefavorites:
                     return GetFavoriteMovies(queryParent, user, query);
-
+                // HiddenByUser
                 case CollectionType.movielatest:
                     return GetMovieLatest(queryParent, user, query);
 
@@ -110,10 +110,10 @@ namespace MediaBrowser.Controller.Entities
 
                 case CollectionType.tvfavoriteepisodes:
                     return GetFavoriteEpisodes(queryParent, user, query);
-
+                // HiddenByUser
                 case CollectionType.tvfavoriteseries:
                     return GetFavoriteSeries(queryParent, user, query);
-
+                // HiddenByUser
                 default:
                     {
                         if (queryParent is UserView)
@@ -170,12 +170,34 @@ namespace MediaBrowser.Controller.Entities
             return _libraryManager.GetItemsResult(query);
         }
 
+        private QueryResult<BaseItem> GetHiddenByUserMovies(Folder parent, User user, InternalItemsQuery query)
+        {
+            query.Recursive = true;
+            query.Parent = parent;
+            query.SetUser(user);
+            query.IsHiddenByUser = true;
+            query.IncludeItemTypes = new[] { BaseItemKind.Movie };
+
+            return _libraryManager.GetItemsResult(query);
+        }
+
         private QueryResult<BaseItem> GetFavoriteSeries(Folder parent, User user, InternalItemsQuery query)
         {
             query.Recursive = true;
             query.Parent = parent;
             query.SetUser(user);
             query.IsFavorite = true;
+            query.IncludeItemTypes = new[] { BaseItemKind.Series };
+
+            return _libraryManager.GetItemsResult(query);
+        }
+
+        private QueryResult<BaseItem> GetHiddenByUserSeries(Folder parent, User user, InternalItemsQuery query)
+        {
+            query.Recursive = true;
+            query.Parent = parent;
+            query.SetUser(user);
+            query.IsHiddenByUser = true;
             query.IncludeItemTypes = new[] { BaseItemKind.Series };
 
             return _libraryManager.GetItemsResult(query);
@@ -529,6 +551,16 @@ namespace MediaBrowser.Controller.Entities
                 userData = userData ?? userDataManager.GetUserData(user, item);
 
                 if (userData.IsFavorite != query.IsFavorite.Value)
+                {
+                    return false;
+                }
+            }
+
+            if (query.IsHiddenByUser.HasValue)
+            {
+                userData = userData ?? userDataManager.GetUserData(user, item);
+
+                if (userData.IsHiddenByUser != query.IsHiddenByUser.Value)
                 {
                     return false;
                 }

--- a/MediaBrowser.Model/Dto/UpdateUserItemDataDto.cs
+++ b/MediaBrowser.Model/Dto/UpdateUserItemDataDto.cs
@@ -44,6 +44,12 @@ namespace MediaBrowser.Model.Dto
         public bool? IsFavorite { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this instance is hidden by the user.
+        /// </summary>
+        /// <value><c>true</c> if this instance is hidden by the user; otherwise, <c>false</c>.</value>
+        public bool? IsHiddenByUser { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="UpdateUserItemDataDto" /> is likes.
         /// </summary>
         /// <value><c>null</c> if [likes] contains no value, <c>true</c> if [likes]; otherwise, <c>false</c>.</value>

--- a/MediaBrowser.Model/Dto/UserItemDataDto.cs
+++ b/MediaBrowser.Model/Dto/UserItemDataDto.cs
@@ -44,6 +44,12 @@ namespace MediaBrowser.Model.Dto
         public bool IsFavorite { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this instance is hidden by the user.
+        /// </summary>
+        /// <value><c>true</c> if this instance is hidden by the user; otherwise, <c>false</c>.</value>
+        public bool IsHiddenByUser { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="UserItemDataDto" /> is likes.
         /// </summary>
         /// <value><c>null</c> if [likes] contains no value, <c>true</c> if [likes]; otherwise, <c>false</c>.</value>

--- a/MediaBrowser.Model/Querying/ItemFilter.cs
+++ b/MediaBrowser.Model/Querying/ItemFilter.cs
@@ -31,6 +31,11 @@ namespace MediaBrowser.Model.Querying
         IsFavorite = 5,
 
         /// <summary>
+        /// The item is a hidden.
+        /// </summary>
+        IsHiddenByUser = 6,
+
+        /// <summary>
         /// The item is resumable.
         /// </summary>
         IsResumable = 7,

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/UserData.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/UserData.cs
@@ -38,6 +38,12 @@ public class UserData
     public bool IsFavorite { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this instance is hidden by the user.
+    /// </summary>
+    /// <value><c>true</c> if this instance is hidden by the user; otherwise, <c>false</c>.</value>
+    public bool IsHiddenByUser { get; set; }
+
+    /// <summary>
     /// Gets or sets the last played date.
     /// </summary>
     /// <value>The last played date.</value>

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/UserDataConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/UserDataConfiguration.cs
@@ -16,6 +16,7 @@ public class UserDataConfiguration : IEntityTypeConfiguration<UserData>
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.Played });
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.PlaybackPositionTicks });
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.IsFavorite });
+        builder.HasIndex(d => new { d.ItemId, d.UserId, d.IsHiddenByUser });
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.LastPlayedDate });
         builder.HasOne(e => e.Item).WithMany(e => e.UserData);
     }


### PR DESCRIPTION
Based on [this request](https://features.jellyfin.org/posts/1072/let-the-user-hide-a-movie-or-tv-show):
An ability for the user to hide a movie or a show. I implemented it similarly to the 'favorite' feature (see also [this](https://features.jellyfin.org/posts/116/add-hide-ignore-for-series-seasons-episodes-as-an-alternative-to-favorite))
That's my first contribution, hope it's good, but I got problems when trying to iniate db migration hope someone can help:
`Unable to create a 'DbContext' of type 'RuntimeType'. The exception 'Unable to resolve service for type 'Microsoft.EntityFrameworkCore.DbContextOptions`1[Jellyfin.Database.Implementations.JellyfinDbContext]' while attempting to activate 'Jellyfin.Database.Implementations.JellyfinDbContext'.' was thrown while attempting to create an instance. For the different patterns supported at design time, see https://go.microsoft.com/fwlink/?linkid=851728`