### PR TITLE
Fix issue with syncplay group incorrectly playing content on creation

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -474,6 +474,7 @@ namespace Emby.Server.Implementations.Session
         private void RemoveNowPlayingItem(SessionInfo session)
         {
             session.NowPlayingItem = null;
+            session.FullNowPlayingItem = null;
             session.PlayState = new PlayerStateInfo();
 
             if (!string.IsNullOrEmpty(session.DeviceId))


### PR DESCRIPTION
When a sync play group is created it is checking the sessions `FullNowPlayingItem` property to determine if it should start playback. This property wasn't being set when playback stopped for the session. Newly created groups would then automatically start playback on items that were no longer being played on the session.

**Changes**

Set `FullNowPlayingItem` to null in `RemoveNowPlayingItem` method to ensure `FullNowPlayingItem` and `NowPlayingItem` are kept in sync on item removal and groups don't see a stale value