### PR TITLE
Add endpoint to fetch a random movie

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,33 @@ If the Server is configured to host the Web Client, and the Server is running, t
 
 API documentation can be viewed at `http://localhost:8096/api-docs/swagger/index.html`
 
+### Random Movies Endpoint
+
+Retrieve a random movie using `GET /Movies/Random`. The request accepts an optional
+`userId` query parameter to filter movies accessible to a specific user and include
+their user data. When no movie is found the server responds with **404 Not Found**.
+
+Example request:
+
+```http
+GET http://localhost:8096/Movies/Random?userId=<user-guid>
+```
+
+Example response:
+
+```json
+{
+  "Items": [
+    {
+      "Name": "Random Movie",
+      "Id": "01234567-89ab-cdef-0123-456789abcdef"
+    }
+  ],
+  "TotalRecordCount": 1,
+  "StartIndex": 0
+}
+```
+
 
 ### Running from GitHub Codespaces
 

--- a/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class MoviesControllerTests
+{
+    [Fact]
+    public void GetRandomMovies_WithMovies_ReturnsOk()
+    {
+        var movie = new Movie { Id = Guid.NewGuid(), Name = "Movie" };
+        var queryResult = new QueryResult<BaseItem>(new List<BaseItem> { movie });
+        var mockLibraryManager = new Mock<ILibraryManager>();
+        mockLibraryManager
+            .Setup(m => m.GetItemsResult(It.IsAny<InternalItemsQuery>()))
+            .Returns(queryResult);
+
+        var mockDtoService = new Mock<IDtoService>();
+        mockDtoService
+            .Setup(d => d.GetBaseItemDtos(It.IsAny<IReadOnlyList<BaseItem>>(), It.IsAny<DtoOptions>(), null))
+            .Returns(new List<BaseItemDto> { new() { Id = movie.Id } });
+
+        var controller = CreateController(mockLibraryManager.Object, mockDtoService.Object);
+
+        var result = controller.GetRandomMovies(null, null, null, false);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public void GetRandomMovies_NoMovies_ReturnsNotFound()
+    {
+        var mockLibraryManager = new Mock<ILibraryManager>();
+        mockLibraryManager
+            .Setup(m => m.GetItemsResult(It.IsAny<InternalItemsQuery>()))
+            .Returns(new QueryResult<BaseItem>());
+
+        var mockDtoService = new Mock<IDtoService>();
+        mockDtoService
+            .Setup(d => d.GetBaseItemDtos(It.IsAny<IReadOnlyList<BaseItem>>(), It.IsAny<DtoOptions>(), null))
+            .Returns(Array.Empty<BaseItemDto>());
+
+        var controller = CreateController(mockLibraryManager.Object, mockDtoService.Object);
+
+        var result = controller.GetRandomMovies(null, null, null, false);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    private static MoviesController CreateController(ILibraryManager libraryManager, IDtoService dtoService)
+    {
+        var mockUserManager = Mock.Of<IUserManager>();
+        var mockConfigManager = new Mock<IServerConfigurationManager>();
+        mockConfigManager.SetupGet(m => m.Configuration).Returns(new ServerConfiguration());
+        var controller = new MoviesController(mockUserManager, libraryManager, dtoService, mockConfigManager.Object);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(InternalClaimTypes.UserId, Guid.NewGuid().ToString("N"))
+                }))
+            }
+        };
+        return controller;
+    }
+}
+


### PR DESCRIPTION
**Changes**

* Introduced a new `GET /Random` endpoint in the Movies controller.
* Accepts optional `userId` query parameter to filter results and attach user-specific data.
* Utilizes internal query to fetch a random movie with proper `DtoOptions`.
* Returns `200 OK` with the movie DTO if found; otherwise, returns `404 Not Found`.

**Issues**

* Improves API support for personalized or randomized movie suggestions.
