### PR TITLE
Make keyframe extraction task cancellable

### DIFF
--- a/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
@@ -75,6 +75,8 @@ public class KeyframeExtractionScheduledTask : IScheduledTask
             var videos = _libraryManager.GetItemList(query);
             foreach (var video in videos)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // Only local files supported
                 var path = video.Path;
                 if (File.Exists(path))


### PR DESCRIPTION
**Changes**
* Check if processing is cancelled and interrupt, otherwise it always continues until the end