### PR TITLE
Fix typo in 503 response for API

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -253,7 +253,7 @@ namespace Jellyfin.Server.Extensions
                 c.AddSwaggerTypeMappings();
 
                 c.SchemaFilter<IgnoreEnumSchemaFilter>();
-                c.OperationFilter<RetryOnTemporarlyUnavailableFilter>();
+                c.OperationFilter<RetryOnTemporarilyUnavailableFilter>();
                 c.OperationFilter<SecurityRequirementsOperationFilter>();
                 c.OperationFilter<FileResponseFilter>();
                 c.OperationFilter<FileRequestFilter>();

--- a/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
+++ b/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
@@ -6,13 +6,13 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Jellyfin.Server.Filters;
 
-internal class RetryOnTemporarlyUnavailableFilter : IOperationFilter
+internal class RetryOnTemporarilyUnavailableFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
         operation.Responses.Add("503", new OpenApiResponse()
         {
-            Description = "The server is currently starting or is temporarly not available.",
+            Description = "The server is currently starting or is temporarily not available.",
             Headers = new Dictionary<string, OpenApiHeader>()
             {
                 {


### PR DESCRIPTION
Nothing too big of a change, but noticed a typo in the API 503 response while contributing to another project. `Temporarly` is now `Temporarily` in the 503 response. Didn't create an issue for this as it didn't seem to fit into any issue type, and the change is more of a 'might as well' instead of a breaking issue.

## Changes
- Fix typo in class name 
> `RetryOnTemporarlyUnavailableFilter` -> `RetryOnTemporarilyUnavailableFilter`
- Fix typo in API 503 response description
> `temporarly` -> `temporarily`
- Fix typo in file name 
> `.../Filters/RetryOnTemporarlyUnavailableFilter.cs` -> `.../Filters/RetryOnTemporarilyUnavailableFilter.cs`