### PR TITLE
Fix compiler warning for CodeMigration.cs

### DIFF
--- a/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
+++ b/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
@@ -82,7 +82,7 @@ internal class CodeMigration(Type migrationType, JellyfinMigrationAttribute meta
         }
     }
 
-    private class NestedStartupLogger<TCategory> : StartupLogger<TCategory>, IStartupLogger<TCategory>
+    private class NestedStartupLogger<TCategory> : StartupLogger<TCategory>
     {
         public NestedStartupLogger(ILogger logger, StartupLogTopic topic) : base(logger, topic)
         {


### PR DESCRIPTION
The StartupLogger<TCategory> already implements IStartupLogger<TCategory> and there is no explicit implementation of the interface in NestedStartupLogger. Remove the redundant type declaration to silence complier warning.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
