### PR TITLE
Revert invalid Portuguese translations 

### DIFF
--- a/Emby.Server.Implementations/Localization/Core/pt.json
+++ b/Emby.Server.Implementations/Localization/Core/pt.json
@@ -135,7 +135,5 @@
     "TaskMoveTrickplayImagesDescription": "Move os ficheiros trickplay existentes de acordo com as definições da mediateca.",
     "TaskExtractMediaSegments": "Analisar segmentos de multimédia",
     "TaskExtractMediaSegmentsDescription": "Extrai ou obtém segmentos de multimédia a partir de plugins com suporte para MediaSegment.",
-    "TaskMoveTrickplayImages": "Migrar a localização da imagem do Trickplay",
-    "CleanupUserDataTaskDescription": "Limpa todos os dados do usuário (estado de exibição, status de favorito etc.) de mídias que não estão mais presentes por pelo menos 90 dias.",
-    "CleanupUserDataTask": "Tarefa de limpeza de dados do usuário"
+    "TaskMoveTrickplayImages": "Migrar a localização da imagem do Trickplay"
 }


### PR DESCRIPTION
**Changes**
Reverts invalid Portuguese translations

It looks like the comments on the commits have been deleted, but the translator indicated they inadvertently changed the generic Portuguese translations to Brazilian Portuguese.

**Issues**
N/A