### PR TITLE
Add 2nd level cache for DB queries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="5.3.1" />
-    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" Version="5.3.1" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.0" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Diacritics" Version="3.3.29" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
+    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" Version="5.3.1" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.0" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="BlurHashSharp" Version="1.4.0-pre.1" />
     <PackageVersion Include="CacheManager.Core" Version="2.0.0" />
     <PackageVersion Include="CacheManager.Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
-    <PackageVersion Include="CacheManager.Serialization.Json" Version="2.0.0" />
+    <PackageVersion Include="CacheManager.Serialization.Bond" Version="2.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Diacritics" Version="3.3.29" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,15 +12,13 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.4" />
     <PackageVersion Include="BlurHashSharp.SkiaSharp" Version="1.4.0-pre.1" />
     <PackageVersion Include="BlurHashSharp" Version="1.4.0-pre.1" />
-    <PackageVersion Include="CacheManager.Core" Version="2.0.0" />
-    <PackageVersion Include="CacheManager.Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
-    <PackageVersion Include="CacheManager.Serialization.Bond" Version="2.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Diacritics" Version="3.3.29" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" Version="5.3.1" />
+    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor" Version="5.3.1" />
+    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" Version="5.3.1" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.0" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />
@@ -73,7 +71,7 @@
     <PackageVersion Include="Serilog.Sinks.Graylog" Version="3.1.1" />
     <PackageVersion Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
-     <!-- Pinned to 3.116.1 because https://github.com/jellyfin/jellyfin/pull/14255 -->
+    <!-- Pinned to 3.116.1 because https://github.com/jellyfin/jellyfin/pull/14255 -->
     <PackageVersion Include="SkiaSharp" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,12 +12,15 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.4" />
     <PackageVersion Include="BlurHashSharp.SkiaSharp" Version="1.4.0-pre.1" />
     <PackageVersion Include="BlurHashSharp" Version="1.4.0-pre.1" />
+    <PackageVersion Include="CacheManager.Core" Version="2.0.0" />
+    <PackageVersion Include="CacheManager.Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
+    <PackageVersion Include="CacheManager.Serialization.Json" Version="2.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Diacritics" Version="3.3.29" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" Version="5.3.1" />
+    <PackageVersion Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" Version="5.3.1" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.0" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageVersion Include="ICU4N.Transliterator" Version="60.1.0-alpha.356" />

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -88,7 +88,7 @@ public static class ServiceCollectionExtensions
 
         serviceCollection.AddSingleton(typeof(ICacheManager<>), typeof(BaseCacheManager<>));
         serviceCollection.AddSingleton(new CacheConfigurationBuilder()
-                                        .WithJsonSerializer()
+                                        .WithBondCompactBinarySerializer()
                                         .WithMicrosoftMemoryCacheHandle(instanceName: "MemoryCache")
                                         .Build());
 

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using CacheManager.Core;
 using EFCoreSecondLevelCacheInterceptor;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.DbConfiguration;
@@ -80,10 +81,16 @@ public static class ServiceCollectionExtensions
         IConfiguration configuration)
     {
         serviceCollection.AddEFSecondLevelCache(options =>
-            options.UseMemoryCacheProvider()
+            options.UseCacheManagerCoreProvider()
                 .ConfigureLogging(true)
                 .UseCacheKeyPrefix("EF_")
                 .UseDbCallsIfCachingProviderIsDown(TimeSpan.FromMinutes(1)));
+
+        serviceCollection.AddSingleton(typeof(ICacheManager<>), typeof(BaseCacheManager<>));
+        serviceCollection.AddSingleton(new CacheConfigurationBuilder()
+                                        .WithJsonSerializer()
+                                        .WithMicrosoftMemoryCacheHandle(instanceName: "MemoryCache")
+                                        .Build());
 
         var efCoreConfiguration = configurationManager.GetConfiguration<DatabaseConfigurationOptions>("database");
         JellyfinDbProviderFactory? providerFactory = null;

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -159,7 +159,6 @@ public static class ServiceCollectionExtensions
             opt.AddInterceptors(serviceProvider.GetRequiredService<JellyfinSecondLevelCacheInterceptor>());
             var lockingBehavior = serviceProvider.GetRequiredService<IEntityFrameworkCoreLockingBehavior>();
             lockingBehavior.Initialise(opt);
-            opt.AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>());
         });
 
         return serviceCollection;

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -29,7 +29,13 @@
     <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
-    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CacheManager.Core" />
+    <PackageReference Include="CacheManager.Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="CacheManager.Serialization.Json" />
+    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="CacheManager.Core" />
     <PackageReference Include="CacheManager.Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="CacheManager.Serialization.Json" />
+    <PackageReference Include="CacheManager.Serialization.Bond" />
     <PackageReference Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" />
   </ItemGroup>
 

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="CacheManager.Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="CacheManager.Serialization.Bond" />
     <PackageReference Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -32,14 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CacheManager.Core" />
-    <PackageReference Include="CacheManager.Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="CacheManager.Serialization.Bond" />
-    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.CacheManager.Core" />
-    <PackageReference Include="Newtonsoft.Json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Jellyfin.Data\Jellyfin.Data.csproj" />
     <ProjectReference Include="..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
     <ProjectReference Include="..\MediaBrowser.Model\MediaBrowser.Model.csproj" />

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Cache/EFCacheProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Cache/EFCacheProvider.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using BitFaster.Caching;
+using BitFaster.Caching.Lru;
+using EFCoreSecondLevelCacheInterceptor;
+
+namespace Jellyfin.Database.Implementations.Cache;
+
+/// <summary>
+/// Custom cache provider.
+/// </summary>
+public sealed class EFCacheProvider : IEFCacheServiceProvider, IDisposable
+{
+    private readonly IEFDebugLogger _efDebugLogger;
+    private readonly ICache<string, EFCachedData> _cache;
+    private readonly ConcurrentDictionary<string, ISet<string>> _dependantCache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EFCacheProvider"/> class.
+    /// </summary>
+    /// <param name="efDebugLogger">The EF debug logger.</param>
+    /// <param name="cacheSize">The cache size.</param>
+    public EFCacheProvider(
+        IEFDebugLogger efDebugLogger,
+        int cacheSize)
+    {
+        _efDebugLogger = efDebugLogger;
+        _cache = new ConcurrentLruBuilder<string, EFCachedData>()
+            .WithCapacity(cacheSize)
+            .WithExpireAfterAccess(TimeSpan.FromMinutes(5))
+            .WithMetrics()
+            .Build();
+
+        _cache.Events.Value!.ItemRemoved += CleanupDependencies;
+
+        _dependantCache = new ConcurrentDictionary<string, ISet<string>>(StringComparer.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public void ClearAllCachedEntries()
+    {
+        _cache.Clear();
+        _efDebugLogger.NotifyCacheInvalidation(clearAllCachedEntries: true, new HashSet<string>(StringComparer.Ordinal));
+    }
+
+    /// <inheritdoc />
+    public EFCachedData? GetValue(EFCacheKey cacheKey, EFCachePolicy cachePolicy)
+    {
+        _cache.TryGet(cacheKey.KeyHash, out var value);
+        return value;
+    }
+
+    /// <inheritdoc />
+    public void InsertValue(EFCacheKey cacheKey, EFCachedData? value, EFCachePolicy cachePolicy)
+    {
+        ArgumentNullException.ThrowIfNull(cacheKey);
+        value ??= new EFCachedData { IsNull = true };
+
+        _dependantCache[cacheKey.KeyHash] = cacheKey.CacheDependencies;
+        _cache.AddOrUpdate(cacheKey.KeyHash, value);
+    }
+
+    /// <inheritdoc />
+    public void InvalidateCacheDependencies(EFCacheKey cacheKey)
+    {
+        ArgumentNullException.ThrowIfNull(cacheKey);
+
+        _dependantCache.TryRemove(cacheKey.KeyHash, out _);
+        foreach (var rootCacheKey in cacheKey.CacheDependencies)
+        {
+            _cache.TryRemove(rootCacheKey, out _);
+        }
+    }
+
+    private void CleanupDependencies(object? sender, ItemRemovedEventArgs<string, EFCachedData> e)
+    {
+        if (_dependantCache.TryGetValue(e.Key, out var dependantKeys))
+        {
+            foreach (var key in dependantKeys)
+            {
+                _cache.TryRemove(key, out _);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cache.Events.Value!.ItemRemoved -= CleanupDependencies;
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Cache/JellyfinSecondLevelCacheInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Cache/JellyfinSecondLevelCacheInterceptor.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using EFCoreSecondLevelCacheInterceptor;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Cache;
+
+/// <summary>
+/// Adapted from <see href="https://github.com/VahidN/EFCoreSecondLevelCacheInterceptor/blob/master/src/EFCoreSecondLevelCacheInterceptor/SecondLevelCacheInterceptor.cs"/>
+/// with read/write lock.
+/// </summary>
+public class JellyfinSecondLevelCacheInterceptor : DbCommandInterceptor
+{
+    private static readonly ReaderWriterLockSlim _databaseLock = new(LockRecursionPolicy.SupportsRecursion);
+    private readonly IDbCommandInterceptorProcessor _processor;
+    private readonly ILogger<JellyfinSecondLevelCacheInterceptor> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JellyfinSecondLevelCacheInterceptor"/> class.
+    /// </summary>
+    /// <param name="processor">The processor.</param>
+    /// <param name="logger">The logger.</param>
+    public JellyfinSecondLevelCacheInterceptor(
+        IDbCommandInterceptorProcessor processor,
+        ILogger<JellyfinSecondLevelCacheInterceptor> logger)
+    {
+        _processor = processor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+    {
+        using (DbLock.EnterWrite(_logger))
+        {
+            return _processor.ProcessExecutedCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<int> NonQueryExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterWrite(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutedCommands(command, eventData?.Context, result));
+        }
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<int> NonQueryExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result)
+    {
+        using (DbLock.EnterWrite(_logger))
+        {
+            return _processor.ProcessExecutingCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterWrite(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutingCommands(command, eventData?.Context, result));
+        }
+    }
+
+    /// <inheritdoc />
+    public override DbDataReader ReaderExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return _processor.ProcessExecutedCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutedCommands(command, eventData?.Context, result));
+        }
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return _processor.ProcessExecutingCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutingCommands(command, eventData?.Context, result));
+        }
+    }
+
+    /// <inheritdoc />
+    public override object? ScalarExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return _processor.ProcessExecutedCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<object?> ScalarExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutedCommands(command, eventData?.Context, result));
+        }
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<object> ScalarExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<object> result)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return _processor.ProcessExecutingCommands(command, eventData?.Context, result);
+        }
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<object> result,
+        CancellationToken cancellationToken = default)
+    {
+        using (DbLock.EnterRead(_logger))
+        {
+            return ValueTask.FromResult(_processor.ProcessExecutingCommands(command, eventData?.Context, result));
+        }
+    }
+
+#pragma warning disable MT1013 // Releasing lock without guarantee of execution
+#pragma warning disable MT1012 // Acquiring lock without guarantee of releasing
+    private sealed class DbLock : IDisposable
+    {
+        private readonly Action? _action;
+        private bool _disposed;
+
+        private static readonly IDisposable _noLock = new DbLock(null) { _disposed = true };
+        private static (string Command, Guid Id, DateTimeOffset QueryDate, bool Printed) _blockQuery;
+
+        private DbLock(Action? action = null)
+        {
+            _action = action;
+        }
+
+#pragma warning disable IDISP015 // Member should not return created and cached instance
+        public static IDisposable EnterWrite(ILogger logger, IDbCommand? command = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+#pragma warning restore IDISP015 // Member should not return created and cached instance
+        {
+            logger.LogTrace("Enter Write for {Caller}:{Line}", callerMemberName, callerNo);
+            if (_databaseLock.IsWriteLockHeld)
+            {
+                logger.LogTrace("Write Held {Caller}:{Line}", callerMemberName, callerNo);
+                return _noLock;
+            }
+
+            BeginWriteLock(logger, command, callerMemberName, callerNo);
+            return new DbLock(() =>
+            {
+                EndWriteLock(logger, callerMemberName, callerNo);
+            });
+        }
+
+#pragma warning disable IDISP015 // Member should not return created and cached instance
+        public static IDisposable EnterRead(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+#pragma warning restore IDISP015 // Member should not return created and cached instance
+        {
+            logger.LogTrace("Enter Read {Caller}:{Line}", callerMemberName, callerNo);
+            if (_databaseLock.IsWriteLockHeld)
+            {
+                logger.LogTrace("Write Held {Caller}:{Line}", callerMemberName, callerNo);
+                return _noLock;
+            }
+
+            BeginReadLock(logger, callerMemberName, callerNo);
+            return new DbLock(() =>
+            {
+                ExitReadLock(logger, callerMemberName, callerNo);
+            });
+        }
+
+        private static void BeginWriteLock(ILogger logger, IDbCommand? command = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Acquire Write {Caller}:{Line}", callerMemberName, callerNo);
+            if (!_databaseLock.TryEnterWriteLock(TimeSpan.FromMilliseconds(1000)))
+            {
+                var blockingQuery = _blockQuery;
+                if (!blockingQuery.Printed)
+                {
+                    _blockQuery = (blockingQuery.Command, blockingQuery.Id, blockingQuery.QueryDate, true);
+                    logger.LogInformation("QueryLock: {Id} --- {Query}", blockingQuery.Id, blockingQuery.Command);
+                }
+
+                logger.LogInformation("Query congestion detected: '{Id}' since '{Date}'", blockingQuery.Id, blockingQuery.QueryDate);
+
+                _databaseLock.EnterWriteLock();
+
+                logger.LogInformation("Query congestion cleared: '{Id}' for '{Date}'", blockingQuery.Id, DateTimeOffset.Now - blockingQuery.QueryDate);
+            }
+
+            _blockQuery = (command?.CommandText ?? "Transaction", Guid.NewGuid(), DateTimeOffset.Now, false);
+
+            logger.LogTrace("Write Aquired {Caller}:{Line}", callerMemberName, callerNo);
+        }
+
+        private static void BeginReadLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Aquire Write {Caller}:{Line}", callerMemberName, callerNo);
+            _databaseLock.EnterReadLock();
+            logger.LogTrace("Read Aquired {Caller}:{Line}", callerMemberName, callerNo);
+        }
+
+        private static void EndWriteLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Release Write {Caller}:{Line}", callerMemberName, callerNo);
+            _databaseLock.ExitWriteLock();
+        }
+
+        private static void ExitReadLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Release Read {Caller}:{Line}", callerMemberName, callerNo);
+            _databaseLock.ExitReadLock();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _action?.Invoke();
+        }
+    }
+#pragma warning restore MT1013 // Releasing lock without guarantee of execution
+#pragma warning restore MT1012 // Acquiring lock without guarantee of releasing
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Jellyfin.Database.Implementations.DbConfiguration;
 
 /// <summary>

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" />
     <PackageReference Include="EFCoreSecondLevelCacheInterceptor" />
-    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj
@@ -24,6 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EFCoreSecondLevelCacheInterceptor" />
+    <PackageReference Include="EFCoreSecondLevelCacheInterceptor.MemoryCache" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">


### PR DESCRIPTION
Since we're now fully on EFcore, let's try this again

**Changes**
* Add 2nd level cache
* Use CacheManager Bond Serializer ([Benchmark](https://github.com/MichaCo/CacheManager/blob/dev/benchmarks/CacheManager.Benchmarks/SerializationBenchmark.cs))

**Comments**
* This increased UI responsiveness immensly for me
* So far I haven't encountered any issues