### PR TITLE
Avoid creating duplicate folder in a library

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3085,7 +3085,7 @@ namespace Emby.Server.Implementations.Library
             var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
             var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
             var libraryOptions = CollectionFolder.GetLibraryOptions(virtualFolderPath);
-            if (Array.Find(libraryOptions.PathInfos, i => string.Equals(i.Path, path, StringComparison.Ordinal)) is not null)
+            if (Array.Find(libraryOptions.PathInfos, i => i.Path.StartsWith(path, StringComparison.Ordinal) || path.StartsWith(i.Path, StringComparison.Ordinal)) is not null)
             {
                 return;
             }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3084,6 +3084,11 @@ namespace Emby.Server.Implementations.Library
 
             var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
             var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
+            var libraryOptions = CollectionFolder.GetLibraryOptions(virtualFolderPath);
+            if (Array.Find(libraryOptions.PathInfos, i => string.Equals(i.Path, path, StringComparison.Ordinal)) is not null)
+            {
+                return;
+            }
 
             var shortcutFilename = Path.GetFileNameWithoutExtension(path);
 
@@ -3101,8 +3106,6 @@ namespace Emby.Server.Implementations.Library
 
             if (saveLibraryOptions)
             {
-                var libraryOptions = CollectionFolder.GetLibraryOptions(virtualFolderPath);
-
                 libraryOptions.PathInfos = [.. libraryOptions.PathInfos, pathInfo];
 
                 SyncLibraryOptionsToLocations(virtualFolderPath, libraryOptions);


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Currently it is possible that the same folder added multiple times to the same library, as there are no verification before adding a path. With this change when a path is already in the library, adding that new one is skipped.
   
**Issues**
A folder can be added multiple times to a library, which is highly confusing. 