### PR TITLE
Only save images when changed

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2036,7 +2036,7 @@ namespace Emby.Server.Implementations.Library
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Cannot compute blurhash for {ImagePath}", image.Path);
-                    anyChange = anyChange || !string.Empty.Equals(image.BlurHash, StringComparison.Ordinal);
+                    anyChange = anyChange || !string.IsNullOrEmpty(image.BlurHash);
                     image.BlurHash = string.Empty;
                 }
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1981,6 +1981,8 @@ namespace Emby.Server.Implementations.Library
                 return;
             }
 
+            var anyChange = false;
+
             foreach (var img in outdated)
             {
                 var image = img;
@@ -2012,6 +2014,7 @@ namespace Emby.Server.Implementations.Library
                 try
                 {
                     size = _imageProcessor.GetImageDimensions(item, image);
+                    anyChange = image.Width != size.Width || image.Height != size.Height;
                     image.Width = size.Width;
                     image.Height = size.Height;
                 }
@@ -2019,23 +2022,29 @@ namespace Emby.Server.Implementations.Library
                 {
                     _logger.LogError(ex, "Cannot get image dimensions for {ImagePath}", image.Path);
                     size = default;
+                    anyChange = image.Width != size.Width || image.Height != size.Height;
                     image.Width = 0;
                     image.Height = 0;
                 }
 
                 try
                 {
-                    image.BlurHash = _imageProcessor.GetImageBlurHash(image.Path, size);
+                    var blurhash = _imageProcessor.GetImageBlurHash(image.Path, size);
+                    anyChange = anyChange || !blurhash.Equals(image.BlurHash, StringComparison.Ordinal);
+                    image.BlurHash = blurhash;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Cannot compute blurhash for {ImagePath}", image.Path);
+                    anyChange = anyChange || !string.Empty.Equals(image.BlurHash, StringComparison.Ordinal);
                     image.BlurHash = string.Empty;
                 }
 
                 try
                 {
-                    image.DateModified = _fileSystem.GetLastWriteTimeUtc(image.Path);
+                    var modifiedDate = _fileSystem.GetLastWriteTimeUtc(image.Path);
+                    anyChange = anyChange || modifiedDate != image.DateModified;
+                    image.DateModified = modifiedDate;
                 }
                 catch (Exception ex)
                 {
@@ -2043,7 +2052,11 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            _itemRepository.SaveImages(item);
+            if (anyChange)
+            {
+                _itemRepository.SaveImages(item);
+            }
+
             RegisterItem(item);
         }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -567,7 +567,7 @@ public sealed class BaseItemRepository
 
         var itemValuesStore = existingValues.Concat(missingItemValues).ToArray();
         var valueMap = itemValueMaps
-            .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore.First(g => g.Value == e.Value && g.Type == e.MagicNumber)).ToArray()))
+            .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore.First(g => g.Value == e.Value && g.Type == e.MagicNumber)).DistinctBy(e => e.ItemValueId).ToArray()))
             .ToArray();
 
         var mappedValues = context.ItemValuesMap.Where(e => ids.Contains(e.ItemId)).ToList();


### PR DESCRIPTION
fixes https://github.com/jellyfin/jellyfin/issues/14412
fixes https://github.com/jellyfin/jellyfin/issues/14384
fixes https://github.com/jellyfin/jellyfin/issues/14331

Introduces new bug, manually saved images might not bust the internal cache and need to be refreshed during a scan. This is however better then just failing to scan overall.