### PR TITLE
SQLite set database options and PRAGMAs via database.xml and apply on every database connection

### DIFF
--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -121,6 +121,7 @@ public static class ServiceCollectionExtensions
             }
         }
 
+        serviceCollection.AddSingleton(efCoreConfiguration);
         serviceCollection.AddSingleton<IJellyfinDatabaseProvider>(providerFactory!);
 
         switch (efCoreConfiguration.LockingBehavior)

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -97,7 +97,11 @@ public static class ServiceCollectionExtensions
                 efCoreConfiguration = new DatabaseConfigurationOptions()
                 {
                     DatabaseType = "Jellyfin-SQLite",
-                    LockingBehavior = DatabaseLockingBehaviorTypes.NoLock
+                    LockingBehavior = DatabaseLockingBehaviorTypes.NoLock,
+                    SqliteOptions = new SqliteOptions
+                    {
+                        DatabaseDirectory = configurationManager.ApplicationPaths.DataPath
+                    }
                 };
                 configurationManager.SaveConfiguration("database", efCoreConfiguration);
             }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -22,4 +22,14 @@ public class DatabaseConfigurationOptions
     /// Defaults to "NoLock".
     /// </summary>
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the database directory path. If not set, defaults to DataPath.
+    /// </summary>
+    public string? DatabaseDirectory { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the SQLite-specific options.
+    /// </summary>
+    public SqliteOptions? SqliteOptions { get; set; }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -24,11 +24,6 @@ public class DatabaseConfigurationOptions
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }
 
     /// <summary>
-    /// Gets or Sets the database directory path. If not set, defaults to DataPath.
-    /// </summary>
-    public string? DatabaseDirectory { get; set; }
-
-    /// <summary>
     /// Gets or Sets the SQLite-specific options.
     /// </summary>
     public SqliteOptions? SqliteOptions { get; set; }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Database.Implementations.DbConfiguration;
+
+/// <summary>
+/// SQLite-specific database configuration options.
+/// </summary>
+public class SqliteOptions
+{
+    /// <summary>
+    /// Gets or Sets the SQLite journal mode. If null, defaults to "WAL".
+    /// </summary>
+    public string? JournalMode { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the SQLite journal size limit in bytes. If null, defaults to 134217728 (128MB).
+    /// </summary>
+    public long? JournalSizeLimit { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the SQLite cache size. No default - not set if not specified.
+    /// </summary>
+    public int? CacheSize { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the SQLite memory-mapped I/O size. No default - not set if not specified.
+    /// </summary>
+    public long? MmapSize { get; set; }
+
+    /// <summary>
+    /// Gets or Sets whether to enable SQLite connection pooling. If null, defaults to false.
+    /// </summary>
+    public bool? Pooling { get; set; }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
@@ -8,6 +8,31 @@ namespace Jellyfin.Database.Implementations.DbConfiguration;
  public class SqliteOptions
 {
     /// <summary>
+    /// SQLite default journal size limit (unlimited).
+    /// </summary>
+    public const long DefaultJournalSizeLimit = -1;
+
+    /// <summary>
+    /// SQLite default cache size.
+    /// </summary>
+    public const int DefaultCacheSize = -2000;
+
+    /// <summary>
+    /// SQLite default memory-mapped I/O size.
+    /// </summary>
+    public const long DefaultMmapSize = 0;
+
+    /// <summary>
+    /// SQLite default page size.
+    /// </summary>
+    public const int DefaultPageSize = 4096;
+
+    /// <summary>
+    /// SQLite default synchronous setting for WAL mode.
+    /// </summary>
+    public const string DefaultSynchronous = "NORMAL"; // default for journal_mode = WAL
+
+    /// <summary>
     /// Gets or Sets the database directory path. Defaults to DataPath.
     /// </summary>
     public string DatabaseDirectory { get; set; } = string.Empty;

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/SqliteOptions.cs
@@ -5,30 +5,45 @@ namespace Jellyfin.Database.Implementations.DbConfiguration;
 /// <summary>
 /// SQLite-specific database configuration options.
 /// </summary>
-public class SqliteOptions
+ public class SqliteOptions
 {
     /// <summary>
-    /// Gets or Sets the SQLite journal mode. If null, defaults to "WAL".
+    /// Gets or Sets the database directory path. Defaults to DataPath.
     /// </summary>
-    public string? JournalMode { get; set; }
+    public string DatabaseDirectory { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or Sets the SQLite journal size limit in bytes. If null, defaults to 134217728 (128MB).
+    /// Gets or Sets a value indicating whether to enable SQLite connection pooling. Defaults to false.
     /// </summary>
-    public long? JournalSizeLimit { get; set; }
+    public bool Pooling { get; set; } = false;
 
     /// <summary>
-    /// Gets or Sets the SQLite cache size. No default - not set if not specified.
+    /// Gets or Sets the SQLite journal mode (PRAGMA journal_mode). Defaults to "WAL".
     /// </summary>
-    public int? CacheSize { get; set; }
+    public string JournalMode { get; set; } = "WAL";
 
     /// <summary>
-    /// Gets or Sets the SQLite memory-mapped I/O size. No default - not set if not specified.
+    /// Gets or Sets the SQLite journal size limit (PRAGMA journal_size_limit) in bytes. Defaults to 134217728 (128MB).
     /// </summary>
-    public long? MmapSize { get; set; }
+    public long JournalSizeLimit { get; set; } = 128 * 1024 * 1024;
 
     /// <summary>
-    /// Gets or Sets whether to enable SQLite connection pooling. If null, defaults to false.
+    /// Gets or Sets the SQLite cache size (PRAGMA cache_size). Negative values are expressed in kibibytes (1024 bytes), and positive numbers are expressed in SQLite pages.  Defaults to -2000 (2MB).
     /// </summary>
-    public bool? Pooling { get; set; }
+    public int CacheSize { get; set; } = -2000;
+
+    /// <summary>
+    /// Gets or Sets the SQLite memory-mapped I/O size (PRAGMA mmap_size) in bytes. Defaults to 0.
+    /// </summary>
+    public long MmapSize { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or Sets the SQLite page size (PRAGMA page_size) in bytes for new databases only. Defaults to 4096.
+    /// </summary>
+    public int PageSize { get; set; } = 4096;
+
+    /// <summary>
+    /// Gets or Sets the SQLite synchronous write behaviour (PRAGMA synchronous). Values are OFF, NORMAL, FULL, EXTRA. Defaults to NORMAL.
+    /// </summary>
+    public string Synchronous { get; set; } = "NORMAL";
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/SqliteDesignTimeJellyfinDbFactory.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/SqliteDesignTimeJellyfinDbFactory.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.DbConfiguration;
 using Jellyfin.Database.Implementations.Locking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
@@ -17,10 +18,16 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
             var optionsBuilder = new DbContextOptionsBuilder<JellyfinDbContext>();
             optionsBuilder.UseSqlite("Data Source=jellyfin.db", f => f.MigrationsAssembly(GetType().Assembly));
 
+            var databaseConfig = new DatabaseConfigurationOptions
+            {
+                DatabaseType = "Jellyfin-SQLite",
+                LockingBehavior = DatabaseLockingBehaviorTypes.NoLock
+            };
+
             return new JellyfinDbContext(
                 optionsBuilder.Options,
                 NullLogger<JellyfinDbContext>.Instance,
-                new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+                new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance, databaseConfig),
                 new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
         }
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -82,10 +82,27 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         // Log per-connection SQLite PRAGMAs set through SqlitePragmaInterceptor once at startup
         _logger.LogInformation("Set SQLite PRAGMA journal_mode = {JournalMode}", _databaseConfig.SqliteOptions.JournalMode);
-        _logger.LogInformation("Set SQLite PRAGMA journal_size_limit = {JournalSizeLimit}", _databaseConfig.SqliteOptions.JournalSizeLimit);
-        _logger.LogInformation("Set SQLite PRAGMA synchronous = {Synchronous}", _databaseConfig.SqliteOptions.Synchronous);
-        _logger.LogInformation("Set SQLite PRAGMA cache_size = {CacheSize}", _databaseConfig.SqliteOptions.CacheSize);
-        _logger.LogInformation("Set SQLite PRAGMA mmap_size = {MmapSize}", _databaseConfig.SqliteOptions.MmapSize);
+
+        if (_databaseConfig.SqliteOptions.JournalSizeLimit != SqliteOptions.DefaultJournalSizeLimit)
+        {
+            _logger.LogInformation("Set SQLite PRAGMA journal_size_limit = {JournalSizeLimit}", _databaseConfig.SqliteOptions.JournalSizeLimit);
+        }
+
+        if (_databaseConfig.SqliteOptions.Synchronous != SqliteOptions.DefaultSynchronous)
+        {
+            _logger.LogInformation("Set SQLite PRAGMA synchronous = {Synchronous}", _databaseConfig.SqliteOptions.Synchronous);
+        }
+
+        if (_databaseConfig.SqliteOptions.CacheSize != SqliteOptions.DefaultCacheSize)
+        {
+            _logger.LogInformation("Set SQLite PRAGMA cache_size = {CacheSize}", _databaseConfig.SqliteOptions.CacheSize);
+        }
+
+        if (_databaseConfig.SqliteOptions.MmapSize != SqliteOptions.DefaultMmapSize)
+        {
+            _logger.LogInformation("Set SQLite PRAGMA mmap_size = {MmapSize}", _databaseConfig.SqliteOptions.MmapSize);
+        }
+
         _logger.LogInformation("Set SQLite PRAGMA temp_store = MEMORY");
 
         options

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -52,25 +52,25 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         var connectionString = $"Filename={databasePath};Pooling={pooling}";
 
         _logger.LogInformation("Opening database {DatabasePath} with pooling={Pooling}", databasePath, pooling);
-        
+
         // Log SQLite configuration once at startup
         var sqliteOptions = _databaseConfig.SqliteOptions;
         var journalMode = sqliteOptions?.JournalMode ?? "WAL";
         var journalSizeLimit = sqliteOptions?.JournalSizeLimit ?? (128 * 1024 * 1024);
-        
+
         _logger.LogInformation("Set SQLite PRAGMA journal_mode = {JournalMode}", journalMode);
         _logger.LogInformation("Set SQLite PRAGMA journal_size_limit = {JournalSizeLimit}", journalSizeLimit);
-        
+
         if (sqliteOptions?.CacheSize.HasValue == true)
         {
             _logger.LogInformation("Set SQLite PRAGMA cache_size = {CacheSize}", sqliteOptions.CacheSize.Value);
         }
-        
+
         if (sqliteOptions?.MmapSize.HasValue == true)
         {
             _logger.LogInformation("Set SQLite PRAGMA mmap_size = {MmapSize}", sqliteOptions.MmapSize.Value);
         }
-        
+
         _logger.LogInformation("Set SQLite PRAGMA temp_store = 2 (MEMORY)");
 
         options

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -62,8 +62,8 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         _logger.LogInformation("Opening database {DatabasePath} with pooling={Pooling}", databasePath, _databaseConfig.SqliteOptions.Pooling);
 
-        // Only set page_size for new databases
-        if (!File.Exists(databasePath))
+        // Only set page_size for new databases if different from SQLite default
+        if (!File.Exists(databasePath) && _databaseConfig.SqliteOptions.PageSize != SqliteOptions.DefaultPageSize)
         {
             _logger.LogInformation("Set SQLite PRAGMA page_size = {PageSize} (new database)", _databaseConfig.SqliteOptions.PageSize);
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -259,21 +259,33 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             command.CommandText = $"PRAGMA journal_mode = {sqliteOptions.JournalMode}";
             command.ExecuteNonQuery();
 
-            // Set journal size limit
-            command.CommandText = $"PRAGMA journal_size_limit = {sqliteOptions.JournalSizeLimit}";
-            command.ExecuteNonQuery();
+            // Set journal size limit only if different from SQLite default
+            if (sqliteOptions.JournalSizeLimit != SqliteOptions.DefaultJournalSizeLimit)
+            {
+                command.CommandText = $"PRAGMA journal_size_limit = {sqliteOptions.JournalSizeLimit}";
+                command.ExecuteNonQuery();
+            }
 
-            // Set synchronous
-            command.CommandText = $"PRAGMA synchronous = {sqliteOptions.Synchronous}";
-            command.ExecuteNonQuery();
+            // Set synchronous only if different from SQLite default for WAL mode
+            if (sqliteOptions.Synchronous != SqliteOptions.DefaultSynchronous)
+            {
+                command.CommandText = $"PRAGMA synchronous = {sqliteOptions.Synchronous}";
+                command.ExecuteNonQuery();
+            }
 
-            // Set cache size
-            command.CommandText = $"PRAGMA cache_size = {sqliteOptions.CacheSize}";
-            command.ExecuteNonQuery();
+            // Set cache size only if different from SQLite default
+            if (sqliteOptions.CacheSize != SqliteOptions.DefaultCacheSize)
+            {
+                command.CommandText = $"PRAGMA cache_size = {sqliteOptions.CacheSize}";
+                command.ExecuteNonQuery();
+            }
 
-            // Set mmap size
-            command.CommandText = $"PRAGMA mmap_size = {sqliteOptions.MmapSize}";
-            command.ExecuteNonQuery();
+            // Set mmap size only if different from SQLite default
+            if (sqliteOptions.MmapSize != SqliteOptions.DefaultMmapSize)
+            {
+                command.CommandText = $"PRAGMA mmap_size = {sqliteOptions.MmapSize}";
+                command.ExecuteNonQuery();
+            }
 
             // Set temp_store to MEMORY
             command.CommandText = "PRAGMA temp_store = MEMORY";
@@ -295,21 +307,33 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             command.CommandText = $"PRAGMA journal_mode = {sqliteOptions.JournalMode}";
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-            // Set journal size limit
-            command.CommandText = $"PRAGMA journal_size_limit = {sqliteOptions.JournalSizeLimit}";
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            // Set journal size limit only if different from SQLite default
+            if (sqliteOptions.JournalSizeLimit != SqliteOptions.DefaultJournalSizeLimit)
+            {
+                command.CommandText = $"PRAGMA journal_size_limit = {sqliteOptions.JournalSizeLimit}";
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
 
-            // Set synchronous
-            command.CommandText = $"PRAGMA synchronous = {sqliteOptions.Synchronous}";
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            // Set synchronous only if different from SQLite default for WAL mode
+            if (sqliteOptions.Synchronous != SqliteOptions.DefaultSynchronous)
+            {
+                command.CommandText = $"PRAGMA synchronous = {sqliteOptions.Synchronous}";
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
 
-            // Set cache size
-            command.CommandText = $"PRAGMA cache_size = {sqliteOptions.CacheSize}";
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            // Set cache size only if different from SQLite default
+            if (sqliteOptions.CacheSize != SqliteOptions.DefaultCacheSize)
+            {
+                command.CommandText = $"PRAGMA cache_size = {sqliteOptions.CacheSize}";
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
 
-            // Set mmap size
-            command.CommandText = $"PRAGMA mmap_size = {sqliteOptions.MmapSize}";
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            // Set mmap size only if different from SQLite default
+            if (sqliteOptions.MmapSize != SqliteOptions.DefaultMmapSize)
+            {
+                command.CommandText = $"PRAGMA mmap_size = {sqliteOptions.MmapSize}";
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             // Set temp_store to MEMORY
             command.CommandText = "PRAGMA temp_store = MEMORY";


### PR DESCRIPTION
**Changes**
Enable SQLite database options and PRAGMAs to be configured via database.xml, and apply on every connection.  Most SQLite pragmas are per-connection.

Will enable Jellyfin team and advanced users to tune performance further without recompiling Jellyfin.

New configurable database options:
- Database Directory: defaults to DataPath, enables SQLite databases to be on separate storage including SSD or zfs datasets with database-tuned settings

New configurable SQLite options:
- Connection pooling: defaults to false (from 10.11)
- Journal mode: defaults to WAL (from 10.10, and what was expected of 10.11 but in practice does not work)
- Journal size limit: 128MB (from 10.10) -- NOTE: this is not the WAL maximum size, it is the size at which SQLite will allow an inactive WAL to remain in preparation for further writes
- Cache size: SQLite default (2MB, from 10.10), uses SQLite semantics that a positive number is expressed in pages, negative number in kB (-65536 = 64MB).
- MMAP size: SQLite default (0, not previously available)

Also sets PRAGMA temp_store = 2 (MEMORY).  Temporary tables are used for operations like ORDER BY, GROUP BY, DISTINCT not satisfied by an index.

Settings to be applied are logged once at start at information level, and on every connection at debug level.

Example complete database.xml (note: these are not good settings!  do not use these! read the SQLite documentation, and understand what the settings are likely to do in your environment!):
```
<?xml version="1.0" encoding="utf-8"?>
<DatabaseConfigurationOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XM LSchema">
  <DatabaseType>Jellyfin-SQLite</DatabaseType>
  <LockingBehavior>NoLock</LockingBehavior>
  <DatabaseDirectory>/sqlite_data</DatabaseDirectory>
  <SqliteOptions>
    <Pooling>false</Pooling>
    <JournalMode>WAL</JournalMode>
    <JournalSizeLimit>1073741824</JournalSizeLimit>
    <CacheSize>-65536</CacheSize>
    <MmapSize>2147483648</MmapSize>
  </SqliteOptions>
</DatabaseConfigurationOptions>
```
Testing completed:
Test 1: 10.11-master new library without this change: poor performance during and after as per #14366

Test 2: 10.11-master new library with this change: scan completed in ~7 hours, excellent performance during and after

Test 3: 10.10 upgrade to 10.11 with change: upgrade completed in ~1 minute, library scan ~5 min, excellent performance during and after

Library consists of over 40,000 tracks, almost 2500 albums, and a few hundred videos.  Server is: Dell T330, 4CPU/8 thread, 64GB RAM, media and database on 2x spinning disk in ZFS mirror.

Notes:
- AI assisted change. I designed the change and reveiewed every line but I am not an expert in Jellyfin or EFCore. I appreciate the time reviewers will take to review the change and welcome feedback.
- On first start after replacing the 10.10 container with 10.11-master+changes the database was marked read-only. I found it had journal_mode = DELETE, when 10.10 was set to WAL.  After resetting to WAL Jellyfin restarted and the migration proceeded as expected.
- If you make an error in database.xml, rather than fail EFCore will replace it with a clean default. Keep a copy of your database.xml if making changes!

**Issues**
Addresses performance/usability issues post-upgrade to 10.11-RC raised in #14366 and #14434, and feature #3372.
