### PR TITLE
Fix refreshing the library cannot delete old attachments

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -276,10 +276,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             _mediaStreamRepository.SaveMediaStreams(video.Id, mediaStreams, cancellationToken);
 
-            if (mediaAttachments.Any())
-            {
-                _mediaAttachmentRepository.SaveMediaAttachments(video.Id, mediaAttachments, cancellationToken);
-            }
+            _mediaAttachmentRepository.SaveMediaAttachments(video.Id, mediaAttachments, cancellationToken);
 
             if (options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh
                 || options.MetadataRefreshMode == MetadataRefreshMode.Default)


### PR DESCRIPTION
**Changes**
- Fix refreshing the library cannot delete old attachments

**Issues**
- A user replaced an MKV video from one that included embedded fonts to one that did not, causing SSA/ASS subtitle rendering on the web to fail because the old attachment information was not deleted from the database.

<img width="1151" height="436" alt="image" src="https://github.com/user-attachments/assets/46290c9d-8449-4f5b-bb82-95ea268f3627" />
