### PR TITLE
Add fallback for keyframe-only trickplay extraction

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@
  - [ikomhoog](https://github.com/ikomhoog)
  - [iwalton3](https://github.com/iwalton3)
  - [jftuga](https://github.com/jftuga)
+ - [jkhsjdhjs](https://github.com/jkhsjdhjs)
  - [jmshrv](https://github.com/jmshrv)
  - [joern-h](https://github.com/joern-h)
  - [joshuaboniface](https://github.com/joshuaboniface)

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -827,7 +827,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         /// <inheritdoc />
-        public Task<string> ExtractVideoImagesOnIntervalAccelerated(
+        public async Task<string> ExtractVideoImagesOnIntervalAccelerated(
             string inputFile,
             string container,
             MediaSourceInfo mediaSource,
@@ -918,18 +918,34 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-hwaccel_flags +low_priority " + inputArg;
             }
 
-            if (enableKeyFrameOnlyExtraction)
-            {
-                inputArg = "-skip_frame nokey " + inputArg;
-            }
-
             var filterParam = encodingHelper.GetVideoProcessingFilterParam(jobState, options, vidEncoder).Trim();
             if (string.IsNullOrWhiteSpace(filterParam))
             {
                 throw new InvalidOperationException("EncodingHelper returned empty or invalid filter parameters.");
             }
 
-            return ExtractVideoImagesOnIntervalInternal(inputArg, filterParam, vidEncoder, threads, qualityScale, priority, cancellationToken);
+            try
+            {
+                return await ExtractVideoImagesOnIntervalInternal(
+                    (enableKeyFrameOnlyExtraction ? "-skip_frame nokey " : string.Empty) + inputArg,
+                    filterParam,
+                    vidEncoder,
+                    threads,
+                    qualityScale,
+                    priority,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (FfmpegException ex)
+            {
+                if (!enableKeyFrameOnlyExtraction)
+                {
+                    throw;
+                }
+
+                _logger.LogWarning(ex, "I-frame trickplay extraction failed, will attempt standard way. Input: {InputFile}", inputFile);
+            }
+
+            return await ExtractVideoImagesOnIntervalInternal(inputArg, filterParam, vidEncoder, threads, qualityScale, priority, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<string> ExtractVideoImagesOnIntervalInternal(


### PR DESCRIPTION
Keyframe-only trickplay image extraction can fail for some media files. The current behavior is to skip the media file and try again on the next run, which will fail again.

This adds a fallback to regular non-keyframe-only extraction for failed runs, so the extraction can complete.

I implemented it in `MediaEncoder.ExtractVideoImagesOnIntervalAccelerated` analogously to `MediaEncoder.ExtractImage`, which already has a similar fallback:

https://github.com/jellyfin/jellyfin/blob/982e0c9370da3d940799c9292423edeca71b7b71/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs#L630-L644

`MediaEncoder.ExtractVideoImagesOnIntervalAccelerated` is called by `TrickplayManager.RefreshTrickplayDataInternal`, so alternatively is could also be implemented there:

https://github.com/jellyfin/jellyfin/blob/982e0c9370da3d940799c9292423edeca71b7b71/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs#L323-L338

I don't have a strong opinion on this. On one hand, `ExtractVideoImagesOnIntervalAccelerated` is passed `enableKeyFrameOnlyExtraction` as a parameter, so it should adhere to this and not do any fallbacks by itself, which may be unexpected. On the other hand, it's nice to have this fallback here so it doesn't need to be implemented in several places, in case any other function in the future also decides to call this.