### PR TITLE
Fix Serbian ISO 639-2 codes

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -373,7 +373,7 @@ sam|||Samaritan Aramaic|samaritain
 san||sa|Sanskrit|sanskrit
 sas|||Sasak|sasak
 sat|||Santali|santal
-scc|srp|sr|Serbian|serbe
+srp||sr|Serbian|serbe
 scn|||Sicilian|sicilien
 sco|||Scots|écossais
 sel|||Selkup|selkoupe


### PR DESCRIPTION
The correct ISO 639-2/T for Serbia is srp, scc was deprecated in 2008: https://www.loc.gov/standards/iso639-2/php/code_changes.php

**Issues**
 Fixes #14473
