### PR TITLE
Create dummy chapter for vides only has 1 chapter.

### DIFF
--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -179,7 +179,7 @@ public class ChapterManager : IChapterManager
                 var dummyChapters = CreateDummyChapters(video);
                 if (dummyChapters.Length > 1)
                 {
-                    _logger.LogInformation("Created {Count} dummy chapters for {Video}", chapters.Count, video.Name);
+                    _logger.LogInformation("Created {Count} dummy chapters for {Video}", dummyChapters.Length, video.Name);
                     chapters = dummyChapters;
                     changesMade = true;
                 }

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Chapters;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
@@ -33,6 +34,7 @@ public class ChapterManager : IChapterManager
     private readonly IChapterRepository _chapterRepository;
     private readonly ILibraryManager _libraryManager;
     private readonly IPathManager _pathManager;
+    private readonly IServerConfigurationManager _config;
 
     /// <summary>
     /// The first chapter ticks.
@@ -48,13 +50,15 @@ public class ChapterManager : IChapterManager
     /// <param name="chapterRepository">The <see cref="IChapterRepository"/>.</param>
     /// <param name="libraryManager">The <see cref="ILibraryManager"/>.</param>
     /// <param name="pathManager">The <see cref="IPathManager"/>.</param>
+    /// <param name="config">The server configuration manager.</param>
     public ChapterManager(
         ILogger<ChapterManager> logger,
         IFileSystem fileSystem,
         IMediaEncoder encoder,
         IChapterRepository chapterRepository,
         ILibraryManager libraryManager,
-        IPathManager pathManager)
+        IPathManager pathManager,
+        IServerConfigurationManager config)
     {
         _logger = logger;
         _fileSystem = fileSystem;
@@ -62,6 +66,7 @@ public class ChapterManager : IChapterManager
         _chapterRepository = chapterRepository;
         _libraryManager = libraryManager;
         _pathManager = pathManager;
+        _config = config;
     }
 
     /// <summary>
@@ -112,12 +117,81 @@ public class ChapterManager : IChapterManager
         return sum / chapters.Count;
     }
 
+    /// <summary>
+    /// Creates dummy chapters.
+    /// </summary>
+    /// <param name="video">The video.</param>
+    /// <returns>An array of dummy chapters.</returns>
+    private ChapterInfo[] CreateDummyChapters(Video video)
+    {
+        var runtime = video.RunTimeTicks.GetValueOrDefault();
+
+        // Only process files with a runtime
+        if (runtime <= 0)
+        {
+            return [];
+        }
+
+        // Get chapter duration from configuration
+        var dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
+        if (dummyChapterDuration <= 0)
+        {
+            return [];
+        }
+
+        int chapterCount = (int)(runtime / dummyChapterDuration);
+
+        if (chapterCount <= 1)
+        {
+            return [];
+        }
+
+        var chapters = new ChapterInfo[chapterCount];
+        long currentChapterTicks = 0;
+
+        for (int i = 0; i < chapterCount; i++)
+        {
+            chapters[i] = new ChapterInfo
+            {
+                StartPositionTicks = currentChapterTicks,
+                Name = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Chapter {0}",
+                    (i + 1).ToString(CultureInfo.InvariantCulture))
+            };
+
+            currentChapterTicks += dummyChapterDuration;
+        }
+
+        return chapters;
+    }
+
     /// <inheritdoc />
     public async Task<bool> RefreshChapterImages(Video video, IDirectoryService directoryService, IReadOnlyList<ChapterInfo> chapters, bool extractImages, bool saveChapters, CancellationToken cancellationToken)
     {
-        if (chapters.Count == 0)
+        var changesMade = false;
+
+        // Create dummy chapters when there are no or only one chapter
+        if (chapters.Count <= 1)
         {
-            return true;
+            if (_config.Configuration.DummyChapterDuration > 0)
+            {
+                var dummyChapters = CreateDummyChapters(video);
+                if (dummyChapters.Length > 1)
+                {
+                    _logger.LogInformation("Created {Count} dummy chapters for {Video}", chapters.Count, video.Name);
+                    chapters = dummyChapters;
+                    changesMade = true;
+                }
+                else if (chapters.Count == 0)
+                {
+                    return true;
+                }
+            }
+            else if (chapters.Count == 0)
+            {
+                return true;
+            }
         }
 
         var libraryOptions = _libraryManager.GetLibraryOptions(video);
@@ -136,7 +210,6 @@ public class ChapterManager : IChapterManager
         }
 
         var success = true;
-        var changesMade = false;
 
         var runtimeTicks = video.RunTimeTicks ?? 0;
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -281,7 +281,7 @@ namespace MediaBrowser.Providers.MediaInfo
             if (options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh
                 || options.MetadataRefreshMode == MetadataRefreshMode.Default)
             {
-                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
+                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length <= 1 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
                 {
                     chapters = CreateDummyChapters(video);
                 }


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Create dummy chapter for vides only has 1 chapter when refresh metadata and chapter image extraction.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/14478
