### PR TITLE
Fix trickplay extraction ffmpeg error-handling

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1071,9 +1071,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     }
                 }
 
-                var exitCode = ranToCompletion ? processWrapper.ExitCode ?? 0 : -1;
-
-                if (exitCode == -1)
+                if (!ranToCompletion || processWrapper.ExitCode != 0)
                 {
                     _logger.LogError("ffmpeg image extraction failed for {ProcessDescription}", processDescription);
                     // Cleanup temp folder here, because the targetDirectory is not returned and the cleanup for failed ffmpeg process is not possible for caller.

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1073,7 +1073,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                 if (!ranToCompletion || processWrapper.ExitCode != 0)
                 {
-                    _logger.LogError("ffmpeg image extraction failed for {ProcessDescription}", processDescription);
                     // Cleanup temp folder here, because the targetDirectory is not returned and the cleanup for failed ffmpeg process is not possible for caller.
                     // Ideally the ffmpeg should not write any files if it fails, but it seems like it is not guaranteed.
                     try


### PR DESCRIPTION
If ffmpeg runs to completion, i.e. isn't killed due to being unresponsive, its exit code is >0 in case of an error. However, the current logic only throws an exception in case the exit code is -1, which is the virtual exit code assigned in case ffmpeg has been killed prematurely.

This commit simplifies the logic to throw an exception if ffmpeg didn't run to completion (as before) or exited with a non-zero exit code (new).

This change is especially important for #14467, as the fallback will not be triggered if ffmpeg errors are not recognized properly.