### PR TITLE
Use RequestHelpers.GetSession in SessionWebSocketListener

### DIFF
--- a/Jellyfin.Api/Helpers/RequestHelpers.cs
+++ b/Jellyfin.Api/Helpers/RequestHelpers.cs
@@ -111,7 +111,16 @@ public static class RequestHelpers
         return user.EnableUserPreferenceAccess;
     }
 
-    internal static async Task<SessionInfo> GetSession(ISessionManager sessionManager, IUserManager userManager, HttpContext httpContext, Guid? userId = null)
+    /// <summary>
+    /// Get the session based on http request.
+    /// </summary>
+    /// <param name="sessionManager">The session manager.</param>
+    /// <param name="userManager">The user manager.</param>
+    /// <param name="httpContext">The http context.</param>
+    /// <param name="userId">The optional userid.</param>
+    /// <returns>The session.</returns>
+    /// <exception cref="ResourceNotFoundException">Session not found.</exception>
+    public static async Task<SessionInfo> GetSession(ISessionManager sessionManager, IUserManager userManager, HttpContext httpContext, Guid? userId = null)
     {
         userId ??= httpContext.User.GetUserId();
         User? user = null;


### PR DESCRIPTION
The SessionWebSocketListener is what registers a WebSocket connection to a Jellyfin session. Before this change it would the GetSessionByAuthenticationToken method in the SessionManager but this has one big quirk; it does not work reliably when there are multiple sessions with the same device id and just pick the first device it finds.
We already have a good helper method to convert an HTTP request into a session. This change simply updates the WebSocket code to use that helper.

This completes my multi-hour multi-project search into why I could no control my shield.

**Changes**

- Use RequestHelpers.GetSession in SessionWebSocketListener

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
