### PR TITLE
Update DateLastSaved after running metadata savers

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3060,6 +3060,8 @@ namespace Emby.Server.Implementations.Library
                     }
 
                     await RunMetadataSavers(personEntity, itemUpdateType).ConfigureAwait(false);
+                    personEntity.DateLastSaved = DateTime.UtcNow;
+
                     CreateItems([personEntity], null, CancellationToken.None);
                 }
             }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -697,6 +697,7 @@ namespace MediaBrowser.Providers.Manager
                     {
                         _libraryMonitor.ReportFileSystemChangeBeginning(path);
                         await saver.SaveAsync(item, CancellationToken.None).ConfigureAwait(false);
+                        item.DateLastSaved = DateTime.UtcNow;
                     }
                     catch (Exception ex)
                     {
@@ -712,6 +713,7 @@ namespace MediaBrowser.Providers.Manager
                     try
                     {
                         await saver.SaveAsync(item, CancellationToken.None).ConfigureAwait(false);
+                        item.DateLastSaved = DateTime.UtcNow;
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
**Changes**
Update `DateLastSaved` whenever we run metadata savers to prevent refresh on scan

**Issues**
Fixes #14507