### PR TITLE
Improve extra rule resolution and file handling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -200,6 +200,7 @@
  - [ThunderClapLP](https://github.com/ThunderClapLP)
  - [Shoham Peller](https://github.com/spellr)
  - [theshoeshiner](https://github.com/theshoeshiner)
+ - [TokerX](https://github.com/TokerX)
 
 # Emby Contributors
 

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -573,6 +573,18 @@ namespace Emby.Naming.Common
                     MediaType.Video),
 
                 new ExtraRule(
+                    ExtraType.Sample,
+                    ExtraRuleType.Filename,
+                    "sample",
+                    MediaType.Video),
+
+                new ExtraRule(
+                    ExtraType.ThemeSong,
+                    ExtraRuleType.Filename,
+                    "theme",
+                    MediaType.Audio),
+
+                new ExtraRule(
                     ExtraType.Trailer,
                     ExtraRuleType.Suffix,
                     "-trailer",
@@ -593,13 +605,7 @@ namespace Emby.Naming.Common
                 new ExtraRule(
                     ExtraType.Trailer,
                     ExtraRuleType.Suffix,
-                    " trailer",
-                    MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.Sample,
-                    ExtraRuleType.Filename,
-                    "sample",
+                    "- trailer",
                     MediaType.Video),
 
                 new ExtraRule(
@@ -623,14 +629,8 @@ namespace Emby.Naming.Common
                 new ExtraRule(
                     ExtraType.Sample,
                     ExtraRuleType.Suffix,
-                    " sample",
+                    "- sample",
                     MediaType.Video),
-
-                new ExtraRule(
-                    ExtraType.ThemeSong,
-                    ExtraRuleType.Filename,
-                    "theme",
-                    MediaType.Audio),
 
                 new ExtraRule(
                     ExtraType.Scene,

--- a/tests/Jellyfin.Naming.Tests/Video/ExtraTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/ExtraTests.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Naming.Tests.Video
             Test("300-trailer.mp4", ExtraType.Trailer);
             Test("300.trailer.mp4", ExtraType.Trailer);
             Test("300_trailer.mp4", ExtraType.Trailer);
-            Test("300 trailer.mp4", ExtraType.Trailer);
+            Test("300 - trailer.mp4", ExtraType.Trailer);
 
             Test("theme.mp3", ExtraType.ThemeSong);
         }
@@ -132,7 +132,14 @@ namespace Jellyfin.Naming.Tests.Video
             Test("300-sample.mp4", ExtraType.Sample);
             Test("300.sample.mp4", ExtraType.Sample);
             Test("300_sample.mp4", ExtraType.Sample);
-            Test("300 sample.mp4", ExtraType.Sample);
+            Test("300 - sample.mp4", ExtraType.Sample);
+        }
+
+        [Fact]
+        public void TestSuffixPartOfTitle()
+        {
+            Test("I Live In A Trailer.mp4", null);
+            Test("The DNA Sample.mp4", null);
         }
 
         private void Test(string input, ExtraType? expectedType)

--- a/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/VideoListResolverTests.cs
@@ -87,7 +87,7 @@ namespace Jellyfin.Naming.Tests.Video
             var files = new[]
             {
                 "300.mkv",
-                "300 trailer.mkv"
+                "300 - trailer.mkv"
             };
 
             var result = VideoListResolver.Resolve(

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/CoreResolutionIgnoreRuleTest.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/CoreResolutionIgnoreRuleTest.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using Emby.Naming.Common;
+using Emby.Naming.Video;
+using Emby.Server.Implementations.Library;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class CoreResolutionIgnoreRuleTest
+{
+    private readonly CoreResolutionIgnoreRule _rule;
+    private readonly NamingOptions _namingOptions;
+    private readonly Mock<IServerApplicationPaths> _appPathsMock;
+
+    public CoreResolutionIgnoreRuleTest()
+    {
+        _namingOptions = new NamingOptions();
+
+        _namingOptions.AllExtrasTypesFolderNames.TryAdd("extras", ExtraType.Trailer);
+
+        _appPathsMock = new Mock<IServerApplicationPaths>();
+        _appPathsMock.SetupGet(x => x.RootFolderPath).Returns("/server/root");
+
+        _rule = new CoreResolutionIgnoreRule(_namingOptions, _appPathsMock.Object);
+    }
+
+    private FileSystemMetadata MakeFileSystemMetadata(string fullName, bool isDirectory = false)
+        => new FileSystemMetadata { FullName = fullName, Name = Path.GetFileName(fullName), IsDirectory = isDirectory };
+
+    private BaseItem MakeParent(string name = "Parent", bool isTopParent = false, Type? type = null)
+    {
+        return type switch
+        {
+            Type t when t == typeof(Folder) => CreateMock<Folder>(name, isTopParent).Object,
+            Type t when t == typeof(AggregateFolder) => CreateMock<AggregateFolder>(name, isTopParent).Object,
+            Type t when t == typeof(UserRootFolder) => CreateMock<UserRootFolder>(name, isTopParent).Object,
+            _ => CreateMock<BaseItem>(name, isTopParent).Object
+        };
+    }
+
+    private static Mock<T> CreateMock<T>(string name, bool isTopParent)
+    where T : BaseItem
+    {
+        var mock = new Mock<T>();
+        mock.SetupGet(p => p.Name).Returns(name);
+        mock.SetupGet(p => p.IsTopParent).Returns(isTopParent);
+        return mock;
+    }
+
+    [Fact]
+    public void TestApplicationFolder()
+    {
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/server/root/extras", isDirectory: true),
+            null));
+
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/server/root/small.jpg"),
+            null));
+    }
+
+    [Fact]
+    public void TestTopLevelDirectory()
+    {
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("Series/Extras", true),
+            MakeParent(type: typeof(AggregateFolder))));
+
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("Series/Extras/Extras", true),
+            MakeParent(isTopParent: true)));
+    }
+
+    [Fact]
+    public void TestIgnorePatterns()
+    {
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/Media/big.jpg"),
+            MakeParent()));
+
+        Assert.True(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/Media/small.jpg"),
+            MakeParent()));
+    }
+
+    [Fact]
+    public void TestExtrasTypesFolderNames()
+    {
+        FileSystemMetadata fileSystemMetadata = MakeFileSystemMetadata("/Movies/Up/extras", true);
+
+        Assert.False(_rule.ShouldIgnore(
+            fileSystemMetadata,
+            MakeParent(type: typeof(AggregateFolder))));
+
+        Assert.False(_rule.ShouldIgnore(
+            fileSystemMetadata,
+            MakeParent(type: typeof(UserRootFolder))));
+
+        Assert.False(_rule.ShouldIgnore(
+            fileSystemMetadata,
+            null));
+
+        Assert.True(_rule.ShouldIgnore(
+            fileSystemMetadata,
+            MakeParent()));
+
+        Assert.True(_rule.ShouldIgnore(
+            fileSystemMetadata,
+            MakeParent(type: typeof(Folder))));
+    }
+
+    [Fact]
+    public void TestThemeSong()
+    {
+        Assert.False(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/Movies/Up/intro.mp3"),
+            MakeParent()));
+
+        Assert.True(_rule.ShouldIgnore(
+            MakeFileSystemMetadata("/Movies/Up/theme.mp3"),
+            MakeParent()));
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Plugins/PluginManagerTests.cs
@@ -301,7 +301,7 @@ namespace Jellyfin.Server.Implementations.Tests.Plugins
 
             var versionInfo = fixture.Create<VersionInfo>();
             versionInfo.Version = new Version(1, 0).ToString();
-            versionInfo.Timestamp = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+            versionInfo.Timestamp = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
 
             var packageInfo = fixture.Create<PackageInfo>();
             packageInfo.Versions = new[] { versionInfo };


### PR DESCRIPTION
**NamingOptions.cs**

- Updated suffix-based extra rules to prevent false positives on
legitimate file names ending in trailer or sample.

**ExtraRuleResolver.cs**

- Refactored if/else if into a switch expression for clarity.
- Moved repeated result assignment outside conditional blocks to
reduce duplication.
- Lifted invariant calculations outside the loop to improve
efficiency.

**CoreResolutionIgnoreRule.cs**

- Added support for checking top parent.
- Reduced nesting for readability.
- Removed redundant  "&& parent is not AggregateFolder" check
already evaluated upstream.

**Tests**

**ExtraTests.cs** and **VideoListResolverTests.cs**: updated to reflect
new logic.

**CoreResolutionIgnoreRuleTest.cs**: new tests added

**PluginManagerTests.cs**: fixed test failure by formatting
versionInfo.Timestamp using the "o" format to ensure consistent
UTC parsing.