### PR TITLE
AudioNormalizationTask db progress saving

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -33,6 +33,8 @@ public partial class AudioNormalizationTask : IScheduledTask
     private readonly ILocalizationManager _localization;
     private readonly ILogger<AudioNormalizationTask> _logger;
 
+    private static readonly TimeSpan _dbSaveInterval = TimeSpan.FromMinutes(5);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AudioNormalizationTask"/> class.
     /// </summary>
@@ -82,7 +84,9 @@ public partial class AudioNormalizationTask : IScheduledTask
 
         foreach (var library in libraries)
         {
+            var startDbSaveInterval = Stopwatch.GetTimestamp();
             var albums = _libraryManager.GetItemList(new InternalItemsQuery { IncludeItemTypes = [BaseItemKind.MusicAlbum], Parent = library, Recursive = true });
+            var toSaveDbItems = new List<BaseItem>();
 
             double nextPercent = numComplete + 1;
             nextPercent /= libraries.Length;
@@ -114,12 +118,24 @@ public partial class AudioNormalizationTask : IScheduledTask
                                 string.Format(CultureInfo.InvariantCulture, "-f concat -safe 0 -i \"{0}\"", tempFile),
                                 OperatingSystem.IsWindows(), // Wait for process to exit on Windows before we try deleting the concat file
                                 cancellationToken).ConfigureAwait(false);
+                            toSaveDbItems.Add(a);
                         }
                         finally
                         {
                             File.Delete(tempFile);
                         }
                     }
+                }
+
+                if (Stopwatch.GetElapsedTime(startDbSaveInterval) > _dbSaveInterval)
+                {
+                    if (toSaveDbItems.Count > 1)
+                    {
+                        _itemRepository.SaveItems(toSaveDbItems, cancellationToken);
+                        toSaveDbItems.Clear();
+                    }
+
+                    startDbSaveInterval = Stopwatch.GetTimestamp();
                 }
 
                 // Update sub-progress for album gain
@@ -133,7 +149,13 @@ public partial class AudioNormalizationTask : IScheduledTask
             // Update progress to start at the track gain percent calculation
             percent += nextPercent;
 
-            _itemRepository.SaveItems(albums, cancellationToken);
+            if (toSaveDbItems.Count > 1)
+            {
+                _itemRepository.SaveItems(toSaveDbItems, cancellationToken);
+                toSaveDbItems.Clear();
+            }
+
+            startDbSaveInterval = Stopwatch.GetTimestamp();
 
             // Track gain
             var tracks = _libraryManager.GetItemList(new InternalItemsQuery { MediaTypes = [MediaType.Audio], IncludeItemTypes = [BaseItemKind.Audio], Parent = library, Recursive = true });
@@ -147,6 +169,18 @@ public partial class AudioNormalizationTask : IScheduledTask
                         string.Format(CultureInfo.InvariantCulture, "-i \"{0}\"", t.Path.Replace("\"", "\\\"", StringComparison.Ordinal)),
                         false,
                         cancellationToken).ConfigureAwait(false);
+                    toSaveDbItems.Add(t);
+                }
+
+                if (Stopwatch.GetElapsedTime(startDbSaveInterval) > _dbSaveInterval)
+                {
+                    if (toSaveDbItems.Count > 1)
+                    {
+                        _itemRepository.SaveItems(toSaveDbItems, cancellationToken);
+                        toSaveDbItems.Clear();
+                    }
+
+                    startDbSaveInterval = Stopwatch.GetTimestamp();
                 }
 
                 // Update sub-progress for track gain
@@ -157,7 +191,10 @@ public partial class AudioNormalizationTask : IScheduledTask
                 progress.Report(100 * (percent + (trackPercent * nextPercent)));
             }
 
-            _itemRepository.SaveItems(tracks, cancellationToken);
+            if (toSaveDbItems.Count > 1)
+            {
+                _itemRepository.SaveItems(toSaveDbItems, cancellationToken);
+            }
 
             // Update progress
             numComplete++;


### PR DESCRIPTION
Change db updating in AudioNormalizationTask to save in 5 min intervals of work to make sure progress is saved regularly so if the task is cancelled progress is not lost.

As requested by https://github.com/jellyfin/jellyfin/pull/14306.

**Changes**
Break up the SaveItems into roughly 5 min intervals of work.

**Issues**
https://github.com/jellyfin/jellyfin/pull/14306