### PR TITLE
Refactor query from EXISTS to JOIN to avoid API timeouts with large libraries

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1108,13 +1108,18 @@ public sealed class BaseItemRepository
             IsSeries = filter.IsSeries
         });
 
+        var itemValuesQuery = context.ItemValues
+            .Where(f => itemValueTypes.Contains(f.Type))
+            .SelectMany(f => f.BaseItemsMap!, (f, w) => new { f, w })
+            .Join(
+                innerQueryFilter,
+                fw => fw.w.ItemId,
+                g => g.Id,
+                (fw, g) => fw.f.CleanValue);
+
         var innerQuery = PrepareItemQuery(context, filter)
             .Where(e => e.Type == returnType)
-            .Where(e => context.ItemValues!
-                .Where(f => itemValueTypes.Contains(f.Type))
-                .Where(f => innerQueryFilter.Any(g => f.BaseItemsMap!.Any(w => w.ItemId == g.Id)))
-                .Select(f => f.CleanValue)
-                .Contains(e.CleanName));
+            .Where(e => itemValuesQuery.Contains(e.CleanName));
 
         var outerQueryFilter = new InternalItemsQuery(filter.User)
         {


### PR DESCRIPTION
**Changes**
This change refactors a critical query used by APIs like /Artists to replace nested EXISTS with explicit JOINs. This enables index usage and eliminates timeouts when querying large libraries.

A client like Manet requesting /Artists with limit = 200 could not complete library sync due to SQL command timeout because the query could not use indexes.  With this change, a SQL query simulating /Artists retrieving all artists ran on my system in 0.173 ms, and Manet is able to complete full library sync successfully. /Artists performs OK overall even with limit = 0 following this change, while other APIs remain slow due to DTO overhead but at least all API used by Manet complete execution now where they previously could not.

My library is approximately 3200 artists, 2500 albums, 41.5k tracks.  I am not sure at what point a library is large enough to cause API timeouts, but another user with a large library confirmed my experience with Manet in the developer chat.

I reviewed other nested EXISTS queries; some showed minor improvements, but none matched the significant benefit of this change. In some cases, performance even regressed.

Given the complexity of the original and improved queries, it is not obvious they produce identical results. I verified with Claude and ChatGPT, and have attached an explanation from ChatGPT.

Original version:

- Filters ItemValues (f) by itemValueTypes.
- Uses nested .Any() checks to verify existence of a related BaseItemsMap entry (w) whose ItemId matches any Id in innerQueryFilter (g).
- Selects CleanValue of those filtered f.
- Filters outer query on whether e.CleanName is in that selected set.
 
Improved version:

- Filters ItemValues (f) by itemValueTypes.
- Uses SelectMany to flatten BaseItemsMap entries (w). Performs an explicit Join between w.ItemId and g.Id in innerQueryFilter.
- Selects the same CleanValue from matching f.
- Filters outer query on whether e.CleanName is in this joined set.
 
Logical equivalence rationale:

- The old .Any() corresponds to existential quantification (“there exists some g and some w matching”).
- The new Join explicitly enumerates all such matching pairs.
- Both yield the same set of CleanValues, differing only in possible duplication due to join multiplicity, which does not affect .Contains() semantics.
- EF Core translates both forms into SQL queries with equivalent join and filter semantics, ensuring identical result sets.
- The new form allows the query planner to leverage efficient index-based joins, reducing execution time and avoiding correlated subquery timeouts.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Issues**
Fixes API timeouts for large libraries with Manet and similar apps, no issue #.