### PR TITLE
Improve RecordFromMediaSource resilience.

### DIFF
--- a/MediaBrowser.Model/IO/IODefaults.cs
+++ b/MediaBrowser.Model/IO/IODefaults.cs
@@ -21,5 +21,10 @@ namespace MediaBrowser.Model.IO
         /// The default <see cref="StreamWriter" /> buffer size.
         /// </summary>
         public const int StreamWriterBufferSize = 1024;
+
+        /// <summary>
+        /// The default buffer stream buffer size.
+        /// </summary>
+        public const int BufferStreamBufferSize = 131072;
     }
 }

--- a/src/Jellyfin.LiveTv/IO/StreamHelper.cs
+++ b/src/Jellyfin.LiveTv/IO/StreamHelper.cs
@@ -12,12 +12,12 @@ namespace Jellyfin.LiveTv.IO
 {
     public class StreamHelper : IStreamHelper
     {
-
         private readonly ILogger<StreamHelper> _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamHelper"/> class.
         /// </summary>
-        /// <param name="logger"></param>
+        /// <param name="logger">logger.</param>
         public StreamHelper(ILogger<StreamHelper> logger)
         {
             _logger = logger;

--- a/src/Jellyfin.LiveTv/IO/StreamHelper.cs
+++ b/src/Jellyfin.LiveTv/IO/StreamHelper.cs
@@ -6,11 +6,23 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.LiveTv.IO
 {
     public class StreamHelper : IStreamHelper
     {
+
+        private readonly ILogger<StreamHelper> _logger;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamHelper"/> class.
+        /// </summary>
+        /// <param name="logger"></param>
+        public StreamHelper(ILogger<StreamHelper> logger)
+        {
+            _logger = logger;
+        }
+
         public async Task CopyToAsync(Stream source, Stream destination, int bufferSize, Action? onStarted, CancellationToken cancellationToken)
         {
             byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
@@ -88,11 +100,24 @@ namespace Jellyfin.LiveTv.IO
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var bytesRead = await CopyToAsyncInternal(source, target, buffer, cancellationToken).ConfigureAwait(false);
-
-                    if (bytesRead == 0)
+                    try
                     {
-                        await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                        var bytesRead = await CopyToAsyncInternal(source, target, buffer, cancellationToken).ConfigureAwait(false);
+
+                        if (bytesRead == 0)
+                        {
+                            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.LogWarning("CopyToAsyncInternal canceled by CancellationToken");
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "CopyToAsyncInternal failed with error");
+                        throw;
                     }
                 }
             }
@@ -106,8 +131,9 @@ namespace Jellyfin.LiveTv.IO
         {
             int bytesRead;
             int totalBytesRead = 0;
+            using var bufferedStream = new BufferedStream(source, IODefaults.BufferStreamBufferSize);
 
-            while ((bytesRead = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) != 0)
+            while ((bytesRead = await bufferedStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) != 0)
             {
                 await destination.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Hi,

I recently added LiveTV functionality to my Jellyfin installation. When recording programs, I noticed that my recordings were much shorter then then they should be. For example, if I the recording should be 1,5 hours, it only recorded 1 to 30 minutes, but I couldn't find any errors. Probably because the streams I watch aren't as stable as you want to be. Although you don't notice this when watching live (buffering in the Android TV client).

I noticed that the current code doesn't have any error handling if the stream for whatever reasons stops before the durationToken cancellation is requested. So, I updated the code to handle this. For me this works perfectly now.

I think the recording should always try to reconnect as long as the linkedCancellationToken cancellation hasn't been requested.

Please let me know if you have feedback on my implementation. 

**Changes**
- Added retry logic for restarting the stream for method `RecordFromMediaSource` in `EncodedRecorder.cs`.
- Added a bufferstream to smooth out minor hiccups (shows less drops then the retry logic) for `CopyToAsyncInternal` in `StreamHelper.cs`.
