### PR TITLE
Always save images

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1981,8 +1981,6 @@ namespace Emby.Server.Implementations.Library
                 return;
             }
 
-            var anyChange = false;
-
             foreach (var img in outdated)
             {
                 var image = img;
@@ -2014,7 +2012,6 @@ namespace Emby.Server.Implementations.Library
                 try
                 {
                     size = _imageProcessor.GetImageDimensions(item, image);
-                    anyChange = image.Width != size.Width || image.Height != size.Height;
                     image.Width = size.Width;
                     image.Height = size.Height;
                 }
@@ -2022,7 +2019,6 @@ namespace Emby.Server.Implementations.Library
                 {
                     _logger.LogError(ex, "Cannot get image dimensions for {ImagePath}", image.Path);
                     size = default;
-                    anyChange = image.Width != size.Width || image.Height != size.Height;
                     image.Width = 0;
                     image.Height = 0;
                 }
@@ -2030,20 +2026,17 @@ namespace Emby.Server.Implementations.Library
                 try
                 {
                     var blurhash = _imageProcessor.GetImageBlurHash(image.Path, size);
-                    anyChange = anyChange || !blurhash.Equals(image.BlurHash, StringComparison.Ordinal);
                     image.BlurHash = blurhash;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Cannot compute blurhash for {ImagePath}", image.Path);
-                    anyChange = anyChange || !string.IsNullOrEmpty(image.BlurHash);
                     image.BlurHash = string.Empty;
                 }
 
                 try
                 {
                     var modifiedDate = _fileSystem.GetLastWriteTimeUtc(image.Path);
-                    anyChange = anyChange || modifiedDate != image.DateModified;
                     image.DateModified = modifiedDate;
                 }
                 catch (Exception ex)
@@ -2052,10 +2045,7 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            if (anyChange)
-            {
-                _itemRepository.SaveImages(item);
-            }
+            _itemRepository.SaveImages(item);
 
             RegisterItem(item);
         }


### PR DESCRIPTION
Because this operate son the updated base item which already has non-existing images removed, without saving those non-existing get never removed from the database and we re-run scans because of it on every scan.

**Changes**
* always save image infos of base item

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
