### PR TITLE
Add MediaType support to playlist updates

### DIFF
--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -618,6 +618,11 @@ namespace Emby.Server.Implementations.Playlists
                 playlist.OpenAccess = request.Public.Value;
             }
 
+            if (request.MediaType is not null)
+            {
+                playlist.SetMediaType(request.MediaType);
+            }
+
             await UpdatePlaylistInternal(playlist).ConfigureAwait(false);
         }
 

--- a/Jellyfin.Api/Controllers/PlaylistsController.cs
+++ b/Jellyfin.Api/Controllers/PlaylistsController.cs
@@ -144,7 +144,8 @@ public class PlaylistsController : BaseJellyfinApiController
             Name = updatePlaylistRequest.Name,
             Ids = updatePlaylistRequest.Ids,
             Users = updatePlaylistRequest.Users,
-            Public = updatePlaylistRequest.IsPublic
+            Public = updatePlaylistRequest.IsPublic,
+            MediaType = updatePlaylistRequest.MediaType
         }).ConfigureAwait(false);
 
         return NoContent();

--- a/Jellyfin.Api/Models/PlaylistDtos/UpdatePlaylistDto.cs
+++ b/Jellyfin.Api/Models/PlaylistDtos/UpdatePlaylistDto.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Jellyfin.Data.Enums;
 using Jellyfin.Extensions.Json.Converters;
 using MediaBrowser.Model.Entities;
 
@@ -31,4 +32,9 @@ public class UpdatePlaylistDto
     /// Gets or sets a value indicating whether the playlist is public.
     /// </summary>
     public bool? IsPublic { get; set; }
+
+    /// <summary>
+    /// Gets or sets the media type of the playlist.
+    /// </summary>
+    public MediaType? MediaType { get; set; }
 }

--- a/MediaBrowser.Model/Playlists/PlaylistUpdateRequest.cs
+++ b/MediaBrowser.Model/Playlists/PlaylistUpdateRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Model.Playlists;
@@ -38,4 +39,9 @@ public class PlaylistUpdateRequest
     /// Gets or sets a value indicating whether the playlist is public.
     /// </summary>
     public bool? Public { get; set; }
+
+    /// <summary>
+    /// Gets or sets the media type of the playlist.
+    /// </summary>
+    public MediaType? MediaType { get; set; }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Add MediaType support to playlist updates through API. This fixes issues where plugins manage playlists, as the PlaylistMediaType for new playlists are "Audio" by default when empty. With this change, you can now set the PlaylistMediaType through the API. 

**Issues**
https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/29
