### PR TITLE
Fix GetBaseItemDto to return related item counts via SQL count

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
@@ -98,6 +98,24 @@ namespace MediaBrowser.Controller.Entities.Audio
             return LibraryManager.GetItemList(query);
         }
 
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            query.ArtistIds = [Id];
+
+            var counts = new TaggedItemCounts();
+
+            query.IncludeItemTypes = [BaseItemKind.MusicAlbum];
+            counts.AlbumCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicVideo];
+            counts.MusicVideoCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Audio];
+            counts.SongCount = LibraryManager.GetCount(query);
+
+            return counts;
+        }
+
         public override int GetChildCount(User user)
         {
             return IsAccessedByName ? 0 : base.GetChildCount(user);

--- a/MediaBrowser.Controller/Entities/Audio/MusicGenre.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicGenre.cs
@@ -73,6 +73,27 @@ namespace MediaBrowser.Controller.Entities.Audio
             return LibraryManager.GetItemList(query);
         }
 
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            query.GenreIds = [Id];
+
+            var counts = new TaggedItemCounts();
+
+            query.IncludeItemTypes = [BaseItemKind.MusicAlbum];
+            counts.AlbumCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicArtist];
+            counts.ArtistCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicVideo];
+            counts.MusicVideoCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Audio];
+            counts.SongCount = LibraryManager.GetCount(query);
+
+            return counts;
+        }
+
         public static string GetPath(string name)
         {
             return GetPath(name, true);

--- a/MediaBrowser.Controller/Entities/Genre.cs
+++ b/MediaBrowser.Controller/Entities/Genre.cs
@@ -76,6 +76,37 @@ namespace MediaBrowser.Controller.Entities
             return LibraryManager.GetItemList(query);
         }
 
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            query.GenreIds = [Id];
+            query.ExcludeItemTypes =
+            [
+                BaseItemKind.MusicVideo,
+                BaseItemKind.Audio,
+                BaseItemKind.MusicAlbum,
+                BaseItemKind.MusicArtist
+            ];
+
+            var counts = new TaggedItemCounts();
+
+            query.IncludeItemTypes = [BaseItemKind.Episode];
+            counts.EpisodeCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Movie];
+            counts.MovieCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.LiveTvProgram];
+            counts.ProgramCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Series];
+            counts.SeriesCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Trailer];
+            counts.TrailerCount = LibraryManager.GetCount(query);
+
+            return counts;
+        }
+
         public static string GetPath(string name)
         {
             return GetPath(name, true);

--- a/MediaBrowser.Controller/Entities/IItemByName.cs
+++ b/MediaBrowser.Controller/Entities/IItemByName.cs
@@ -10,10 +10,35 @@ namespace MediaBrowser.Controller.Entities
     public interface IItemByName
     {
         IReadOnlyList<BaseItem> GetTaggedItems(InternalItemsQuery query);
+
+        TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query);
     }
 
     public interface IHasDualAccess : IItemByName
     {
         bool IsAccessedByName { get; }
+    }
+
+    public class TaggedItemCounts
+    {
+        public int? AlbumCount { get; set; }
+
+        public int? ArtistCount { get; set; }
+
+        public int? EpisodeCount { get; set; }
+
+        public int? MovieCount { get; set; }
+
+        public int? MusicVideoCount { get; set; }
+
+        public int? ProgramCount { get; set; }
+
+        public int? SeriesCount { get; set; }
+
+        public int? SongCount { get; set; }
+
+        public int? TrailerCount { get; set; }
+
+        public int ChildCount => (AlbumCount ?? 0) + (ArtistCount ?? 0) + (EpisodeCount ?? 0) + (MovieCount ?? 0) + (MusicVideoCount ?? 0) + (ProgramCount ?? 0) + (SeriesCount ?? 0) + (SongCount ?? 0) + (TrailerCount ?? 0);
     }
 }

--- a/MediaBrowser.Controller/Entities/IItemByName.cs
+++ b/MediaBrowser.Controller/Entities/IItemByName.cs
@@ -18,27 +18,4 @@ namespace MediaBrowser.Controller.Entities
     {
         bool IsAccessedByName { get; }
     }
-
-    public class TaggedItemCounts
-    {
-        public int? AlbumCount { get; set; }
-
-        public int? ArtistCount { get; set; }
-
-        public int? EpisodeCount { get; set; }
-
-        public int? MovieCount { get; set; }
-
-        public int? MusicVideoCount { get; set; }
-
-        public int? ProgramCount { get; set; }
-
-        public int? SeriesCount { get; set; }
-
-        public int? SongCount { get; set; }
-
-        public int? TrailerCount { get; set; }
-
-        public int ChildCount => (AlbumCount ?? 0) + (ArtistCount ?? 0) + (EpisodeCount ?? 0) + (MovieCount ?? 0) + (MusicVideoCount ?? 0) + (ProgramCount ?? 0) + (SeriesCount ?? 0) + (SongCount ?? 0) + (TrailerCount ?? 0);
-    }
 }

--- a/MediaBrowser.Controller/Entities/Person.cs
+++ b/MediaBrowser.Controller/Entities/Person.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Providers;
 using Microsoft.Extensions.Logging;
@@ -68,6 +69,43 @@ namespace MediaBrowser.Controller.Entities
             query.PersonIds = new[] { Id };
 
             return LibraryManager.GetItemList(query);
+        }
+
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            query.PersonIds = [Id];
+
+            var counts = new TaggedItemCounts();
+
+            // TODO: Remove MusicAlbum and MusicArtist when the relationship between Persons and Music is removed
+            query.IncludeItemTypes = [BaseItemKind.MusicAlbum];
+            counts.AlbumCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicArtist];
+            counts.ArtistCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Episode];
+            counts.EpisodeCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Movie];
+            counts.MovieCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicVideo];
+            counts.MusicVideoCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.LiveTvProgram];
+            counts.ProgramCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Series];
+            counts.SeriesCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Audio];
+            counts.SongCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Trailer];
+            counts.TrailerCount = LibraryManager.GetCount(query);
+
+            return counts;
         }
 
         public override bool CanDelete()

--- a/MediaBrowser.Controller/Entities/Studio.cs
+++ b/MediaBrowser.Controller/Entities/Studio.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -69,6 +70,42 @@ namespace MediaBrowser.Controller.Entities
             query.StudioIds = new[] { Id };
 
             return LibraryManager.GetItemList(query);
+        }
+
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            query.StudioIds = [Id];
+
+            var counts = new TaggedItemCounts();
+
+            query.IncludeItemTypes = [BaseItemKind.MusicAlbum];
+            counts.AlbumCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicArtist];
+            counts.ArtistCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Episode];
+            counts.EpisodeCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Movie];
+            counts.MovieCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicVideo];
+            counts.MusicVideoCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.LiveTvProgram];
+            counts.ProgramCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Series];
+            counts.SeriesCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Audio];
+            counts.SongCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Trailer];
+            counts.TrailerCount = LibraryManager.GetCount(query);
+
+            return counts;
         }
 
         public static string GetPath(string name)

--- a/MediaBrowser.Controller/Entities/TaggedItemCounts.cs
+++ b/MediaBrowser.Controller/Entities/TaggedItemCounts.cs
@@ -1,0 +1,27 @@
+#pragma warning disable CS1591
+
+namespace MediaBrowser.Controller.Entities
+{
+    public class TaggedItemCounts
+    {
+        public int? AlbumCount { get; set; }
+
+        public int? ArtistCount { get; set; }
+
+        public int? EpisodeCount { get; set; }
+
+        public int? MovieCount { get; set; }
+
+        public int? MusicVideoCount { get; set; }
+
+        public int? ProgramCount { get; set; }
+
+        public int? SeriesCount { get; set; }
+
+        public int? SongCount { get; set; }
+
+        public int? TrailerCount { get; set; }
+
+        public int ChildCount => (AlbumCount ?? 0) + (ArtistCount ?? 0) + (EpisodeCount ?? 0) + (MovieCount ?? 0) + (MusicVideoCount ?? 0) + (ProgramCount ?? 0) + (SeriesCount ?? 0) + (SongCount ?? 0) + (TrailerCount ?? 0);
+    }
+}

--- a/MediaBrowser.Controller/Entities/Year.cs
+++ b/MediaBrowser.Controller/Entities/Year.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json.Serialization;
+using Jellyfin.Data.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Controller.Entities
@@ -66,6 +67,47 @@ namespace MediaBrowser.Controller.Entities
             query.Years = new[] { year };
 
             return LibraryManager.GetItemList(query);
+        }
+
+        public TaggedItemCounts GetTaggedItemCounts(InternalItemsQuery query)
+        {
+            if (!int.TryParse(Name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year))
+            {
+                return new TaggedItemCounts();
+            }
+
+            query.Years = [year];
+
+            var counts = new TaggedItemCounts();
+
+            query.IncludeItemTypes = [BaseItemKind.MusicAlbum];
+            counts.AlbumCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicArtist];
+            counts.ArtistCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Episode];
+            counts.EpisodeCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Movie];
+            counts.MovieCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.MusicVideo];
+            counts.MusicVideoCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.LiveTvProgram];
+            counts.ProgramCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Series];
+            counts.SeriesCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Audio];
+            counts.SongCount = LibraryManager.GetCount(query);
+
+            query.IncludeItemTypes = [BaseItemKind.Trailer];
+            counts.TrailerCount = LibraryManager.GetCount(query);
+
+            return counts;
         }
 
         public int? GetYearValue()


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
For API call /Items/{item id} GetBaseItemDto will return the counts of related items e.g. artists, albums, songs.  GetBaseItemDto currently does this by calling GetTaggedItems which retrieves the objects into memory to count them.  Replace with SQL count.

**Issues**
No known open bugs.

This should be an improvement for any large libraries, but especially large music libraries.  Example:

Request Library -> Genres -> any very popular genre in your large library, e.g. Classical Number of albums = 1552, songs = 23515, ...

- Before change: Try to retrieve 1552 albums, 23515 songs, ... in memory, API never returns, database on fire
- After change: API returns in 367ms and Genre view opens with 200 albums in 2 seconds

I verified the numbers returned are correct but note that there is a feature that sets TopParentId to NULL for a large portion of my MusicArtists and some other types, which causes them to not be counted by the existing GetCount() once the user's library restrictions are applied.  This is not related to this change, also happens with the existing code, and does not seem to affect the Web UI.