### PR TITLE
Change Spanish; Latin language code according to BCP 47 specification

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -402,7 +402,7 @@ sog|||Sogdian|sogdien
 som||so|Somali|somali
 son|||Songhai languages|songhai, langues
 sot||st|Sotho, Southern|sotho du Sud
-spa||es-mx|Spanish; Latin|espagnol; Latin
+spa||es-419|Spanish; Latin|espagnol; Latin
 spa||es|Spanish; Castilian|espagnol; castillan
 sqi|alb|sq|Albanian|albanais
 srd||sc|Sardinian|sarde


### PR DESCRIPTION
Changed the language code of the Spanish; Latin to better accommodate the BCP 47 standard (`es-419` – Spanish appropriate for the Latin America and Caribbean region, using the [UN M.49 region code](https://en.wikipedia.org/wiki/UN_M.49)). `es-mx` only refers to the region of Mexico, while `es-419` refers to the Latin America regions as a whole.

**Changes**
Changed the language code in `Emby.Server.Implementations/Localization/iso6392.txt`
