### PR TITLE
Fix AlbumArtistIds filter to use correct ItemValueType

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1967,7 +1967,7 @@ public sealed class BaseItemRepository
 
         if (filter.AlbumArtistIds.Length > 0)
         {
-            baseQuery = baseQuery.WhereReferencedItem(context, ItemValueType.Artist, filter.AlbumArtistIds);
+            baseQuery = baseQuery.WhereReferencedItem(context, ItemValueType.AlbumArtist, filter.AlbumArtistIds);
         }
 
         if (filter.ContributingArtistIds.Length > 0)


### PR DESCRIPTION
**Changes**
Use ItemValueType.AlbumArtist instead of ItemValueType.Artist when filtering by AlbumArtistIds to ensure the correct items are returned.

**Issues**
No issue raised