### PR TITLE
Fix anamorphic video detection (#14640)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -202,6 +202,7 @@
  - [Shoham Peller](https://github.com/spellr)
  - [theshoeshiner](https://github.com/theshoeshiner)
  - [TokerX](https://github.com/TokerX)
+ - [GeneMarks](https://github.com/GeneMarks)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -850,12 +850,36 @@ namespace MediaBrowser.MediaEncoding.Probing
                     }
                 }
 
-                // stream.IsAnamorphic = string.Equals(streamInfo.sample_aspect_ratio, "0:1", StringComparison.OrdinalIgnoreCase) ||
-                //    string.Equals(stream.AspectRatio, "2.35:1", StringComparison.OrdinalIgnoreCase) ||
-                //    string.Equals(stream.AspectRatio, "2.40:1", StringComparison.OrdinalIgnoreCase);
-
                 // http://stackoverflow.com/questions/17353387/how-to-detect-anamorphic-video-with-ffprobe
-                stream.IsAnamorphic = string.Equals(streamInfo.SampleAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase);
+                if (string.Equals(streamInfo.SampleAspectRatio, "1:1", StringComparison.OrdinalIgnoreCase))
+                {
+                    stream.IsAnamorphic = false;
+                }
+                else if (!string.Equals(streamInfo.SampleAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
+                {
+                    stream.IsAnamorphic = true;
+                }
+                else if (string.Equals(streamInfo.DisplayAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
+                {
+                    stream.IsAnamorphic = false;
+                }
+                else if (!string.Equals(
+                             streamInfo.DisplayAspectRatio,
+                             // Force GetAspectRatio() to derive ratio from Width/Height directly by using null DAR
+                             GetAspectRatio(new MediaStreamInfo
+                             {
+                                 Width = streamInfo.Width,
+                                 Height = streamInfo.Height,
+                                 DisplayAspectRatio = null
+                             }),
+                             StringComparison.OrdinalIgnoreCase))
+                {
+                    stream.IsAnamorphic = true;
+                }
+                else
+                {
+                    stream.IsAnamorphic = false;
+                }
 
                 if (streamInfo.Refs > 0)
                 {


### PR DESCRIPTION
**Changes**
Previously, `IsAnamorphic` was set to `true` only when Sample Aspect Ratio (SAR) was `"0:1"`, causing incorrect detection for valid anamorphic videos. Updated the detection logic to handle common SAR/DAR edge cases, following the approach described https://stackoverflow.com/questions/17353387/how-to-detect-anamorphic-video-with-ffprobe.

**Issues**
Fixes #14640
