### PR TITLE
Delay initialization of singleton services during migration CoreInitialisation stage

### DIFF
--- a/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
+++ b/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
@@ -34,7 +34,7 @@ internal class CodeMigration(Type migrationType, JellyfinMigrationAttribute meta
         {
             if (service.Lifetime == ServiceLifetime.Singleton && !service.ServiceType.IsGenericTypeDefinition)
             {
-                childServiceCollection.AddSingleton(service.ServiceType, (provider) => serviceProvider.GetService(service.ServiceType)!);
+                childServiceCollection.AddSingleton(service.ServiceType, _ => serviceProvider.GetService(service.ServiceType)!);
                 continue;
             }
 

--- a/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
+++ b/Jellyfin.Server/Migrations/Stages/CodeMigration.cs
@@ -34,12 +34,8 @@ internal class CodeMigration(Type migrationType, JellyfinMigrationAttribute meta
         {
             if (service.Lifetime == ServiceLifetime.Singleton && !service.ServiceType.IsGenericTypeDefinition)
             {
-                object? serviceInstance = serviceProvider.GetService(service.ServiceType);
-                if (serviceInstance != null)
-                {
-                    childServiceCollection.AddSingleton(service.ServiceType, serviceInstance);
-                    continue;
-                }
+                childServiceCollection.AddSingleton(service.ServiceType, (provider) => serviceProvider.GetService(service.ServiceType)!);
+                continue;
             }
 
             childServiceCollection.Add(service);


### PR DESCRIPTION
**Changes**
Delay initialization of singleton services during migration CoreInitialisation stage

**Issues**
Jellyfin code migrations that run during EF Core migrations generate:
```
[07:35:34] [ERR] [7] InternalCodeMigration: Migration 20250814000002_RemoveDuplicatePeopleStage2 failed System.NullReferenceException: Object reference not set to an instance of an object.
   at MediaBrowser.Providers.Plugins.Tmdb.TmdbClientManager..ctor(IMemoryCache memoryCache) in /src/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs:line 40
```
due to TmdbClientManager being initialized too early.

Credit: JPVenson