### PR TITLE
Correct Album Artists merge logic

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1268,7 +1268,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                     targetHasAlbumArtist.AlbumArtists = sourceHasAlbumArtist.AlbumArtists;
                 }
-                else if (sourceHasAlbumArtist.AlbumArtists.Count > 0)
+                else
                 {
                     targetHasAlbumArtist.AlbumArtists = targetHasAlbumArtist.AlbumArtists.Concat(sourceHasAlbumArtist.AlbumArtists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 }

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1268,7 +1268,7 @@ namespace MediaBrowser.Providers.Manager
                 {
                     targetHasAlbumArtist.AlbumArtists = sourceHasAlbumArtist.AlbumArtists;
                 }
-                else
+                else if (sourceHasAlbumArtist.AlbumArtists.Count > 0)
                 {
                     targetHasAlbumArtist.AlbumArtists = targetHasAlbumArtist.AlbumArtists.Concat(sourceHasAlbumArtist.AlbumArtists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
                 }

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -116,7 +116,7 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
 
         updateType |= SetProviderIdFromSongs(item, songs, MetadataProvider.MusicBrainzAlbumArtist);
 
-        if (!item.AlbumArtists.SequenceEqual(albumArtists, StringComparer.OrdinalIgnoreCase))
+        if (!item.AlbumArtists.SequenceEqual(albumArtists))
         {
             item.AlbumArtists = albumArtists;
             updateType |= ItemUpdateType.MetadataEdit;
@@ -136,7 +136,7 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
             .Select(g => g.Key)
             .ToArray();
 
-        if (!item.Artists.SequenceEqual(artists, StringComparer.OrdinalIgnoreCase))
+        if (!item.Artists.SequenceEqual(artists))
         {
             item.Artists = artists;
             updateType |= ItemUpdateType.MetadataEdit;

--- a/MediaBrowser.Providers/Music/AlbumMetadataService.cs
+++ b/MediaBrowser.Providers/Music/AlbumMetadataService.cs
@@ -109,14 +109,14 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
 
         var albumArtists = songs
             .SelectMany(i => i.AlbumArtists)
-            .GroupBy(i => i)
+            .GroupBy(i => i, StringComparer.OrdinalIgnoreCase)
             .OrderByDescending(g => g.Count())
             .Select(g => g.Key)
             .ToArray();
 
         updateType |= SetProviderIdFromSongs(item, songs, MetadataProvider.MusicBrainzAlbumArtist);
 
-        if (!item.AlbumArtists.SequenceEqual(albumArtists))
+        if (!item.AlbumArtists.SequenceEqual(albumArtists, StringComparer.Ordinal))
         {
             item.AlbumArtists = albumArtists;
             updateType |= ItemUpdateType.MetadataEdit;
@@ -131,12 +131,12 @@ public class AlbumMetadataService : MetadataService<MusicAlbum, AlbumInfo>
 
         var artists = songs
             .SelectMany(i => i.Artists)
-            .GroupBy(i => i)
+            .GroupBy(i => i, StringComparer.OrdinalIgnoreCase)
             .OrderByDescending(g => g.Count())
             .Select(g => g.Key)
             .ToArray();
 
-        if (!item.Artists.SequenceEqual(artists))
+        if (!item.Artists.SequenceEqual(artists, StringComparer.Ordinal))
         {
             item.Artists = artists;
             updateType |= ItemUpdateType.MetadataEdit;


### PR DESCRIPTION
**Changes**
Correct Album Artists merge logic in MetadataService that causes empty
metadata sources to overwrite populated Album Artists arrays. This impacted
People-to-BaseItem relationships and caused orphaned records in Peoples.

Correct equality checks to be case-sensitive so Jelly metadata exactly
matches file metadata.

**Issues**
This impacted People-to-BaseItem relationships and caused orphaned records in Peoples.

File metadata changes that varied only in case were not updated in Jellyfin, causing Firstname Lastname and firstname lastname to be 2 separate records because the metadata update was case-insensitive but people record names are case-sensitive.