### PR TITLE
Avoid duplicate BaseItem & BaseItemProviders

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -600,8 +600,8 @@ public sealed class BaseItemRepository
             }
             else
             {
-                context.BaseItemProviders.Where(e => e.ItemId == entity.Id).ExecuteDelete();
                 context.BaseItems.Attach(entity).State = EntityState.Modified;
+                context.BaseItemProviders.Where(e => e.ItemId == entity.Id).ExecuteDelete();
             }
         }
 


### PR DESCRIPTION
**Changes**
Avoid duplicate BaseItems using UPSERT, similar to Peoples.

Avoid duplicate BaseItemProviders using by reordering operations to move provider deletion after Map() call to ensure delete and insert happen in same transaction.

Refactor BaseItem query that used string concatenation for indexability.
    
**Issues**
Addresses occasional duplicate BaseItem / BaseItemProviders.

Note: EF Core will log duplicate key errors (x3 for command error retry), however they are followed by a log showing that Jellyfin rematched the records.