### PR TITLE
Fix false positive matching in specific regex expression.

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -380,7 +380,7 @@ namespace Emby.Naming.Common
                 // /server/anything_102.mp4
                 // /server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv
                 // /server/anything_1996.11.14.mp4
-                new EpisodeExpression(@"[\\/._ -](?<seriesname>(?![0-9]+[0-9][0-9])([^\\\/_])*)[\\\/._ -](?<seasonnumber>[0-9]+)(?<epnumber>[0-9][0-9](?:(?:[a-i]|\.[1-9])(?![0-9]))?)([._ -][^\\\/]*)$")
+                new EpisodeExpression(@"(?:^|[\\/])(?<seriesname>(?=[^\\/]*[A-Za-z])[^\\/_]+?(?:[._ -][^\\/_]+?)*)[._ -](?<!\d)(?<seasonnumber>\d{1,3})(?<epnumber>(?!00)\d{2})(?:(?:[a-i]|\.[1-9])(?!\d))?(?:[._ -][^\\/]*)*\.(?<ext>\w{3,4})$")
                 {
                     IsOptimistic = true,
                     IsNamed = true,


### PR DESCRIPTION
I considered removing the regex because it failed two cases it was originally meant to handle:

* `/server/anything_102.mp4` → Series: `anything`, Season: `1`, Episode: `02` (**intended match**)
* `/server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv` → Series: `james.corden`, Season: `20`, Episode: `17` (**should not match, but does**)
* `/server/anything_1996.11.14.mp4` → Series: `anything`, Season: `19`, Episode: `96` (**should not match, but does**)

Removing the expression caused other tests to fail due to side effects. To maintain backward compatibility, I replaced it with a stricter pattern. The new regex still matches all formats it was originally intended to support (e.g., `anything_102`) and rejects unintended patterns such as `YYMMDD anything`.
