### PR TITLE
Fix: Add 'Kairon; IRSE!' to artist whitelist

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -81,6 +81,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             "Smith/Kotzen",
             "We;Na",
             "LSR/CITY",
+            "Kairon; IRSE!",
         };
 
         /// <summary>


### PR DESCRIPTION
## Problem
Jellyfin incorrectly splits the artist **"Kairon; IRSE!"** into two separate artists:
- "Kairon"
- "IRSE!"

This happens because the semicolon is treated as a delimiter.

## Solution
Added `"Kairon; IRSE!"` to the whitelist in `ProbeResultNormalizer.cs`, so it is preserved as a single artist name.