### PR TITLE
Normalizer cleanup

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -309,7 +309,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return string.Join(',', splitFormat.Where(s => !string.IsNullOrEmpty(s)));
         }
 
-        private int? GetEstimatedAudioBitrate(string codec, int? channels)
+        private static int? GetEstimatedAudioBitrate(string codec, int? channels)
         {
             if (!channels.HasValue)
             {
@@ -530,7 +530,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return pairs;
         }
 
-        private void ProcessPairs(string key, List<NameValuePair> pairs, MediaInfo info)
+        private static void ProcessPairs(string key, List<NameValuePair> pairs, MediaInfo info)
         {
             List<BaseItemPerson> peoples = new List<BaseItemPerson>();
             var distinctPairs = pairs.Select(p => p.Value)
@@ -579,7 +579,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             info.People = peoples.ToArray();
         }
 
-        private NameValuePair GetNameValuePair(XmlReader reader)
+        private static NameValuePair GetNameValuePair(XmlReader reader)
         {
             string name = null;
             string value = null;
@@ -624,7 +624,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             };
         }
 
-        private string NormalizeSubtitleCodec(string codec)
+        private static string NormalizeSubtitleCodec(string codec)
         {
             if (string.Equals(codec, "dvb_subtitle", StringComparison.OrdinalIgnoreCase))
             {
@@ -851,15 +851,15 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
 
                 // http://stackoverflow.com/questions/17353387/how-to-detect-anamorphic-video-with-ffprobe
-                if (string.Equals(streamInfo.SampleAspectRatio, "1:1", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(streamInfo.SampleAspectRatio, "1:1", StringComparison.Ordinal))
                 {
                     stream.IsAnamorphic = false;
                 }
-                else if (!string.Equals(streamInfo.SampleAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
+                else if (!string.Equals(streamInfo.SampleAspectRatio, "0:1", StringComparison.Ordinal))
                 {
                     stream.IsAnamorphic = true;
                 }
-                else if (string.Equals(streamInfo.DisplayAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(streamInfo.DisplayAspectRatio, "0:1", StringComparison.Ordinal))
                 {
                     stream.IsAnamorphic = false;
                 }
@@ -872,7 +872,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                                  Height = streamInfo.Height,
                                  DisplayAspectRatio = null
                              }),
-                             StringComparison.OrdinalIgnoreCase))
+                             StringComparison.Ordinal))
                 {
                     stream.IsAnamorphic = true;
                 }
@@ -1024,7 +1024,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return stream;
         }
 
-        private void NormalizeStreamTitle(MediaStream stream)
+        private static void NormalizeStreamTitle(MediaStream stream)
         {
             if (string.Equals(stream.Title, "cc", StringComparison.OrdinalIgnoreCase)
                 || stream.Type == MediaStreamType.EmbeddedImage)
@@ -1039,7 +1039,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         /// <param name="tags">The tags.</param>
         /// <param name="key">The key.</param>
         /// <returns>System.String.</returns>
-        private string GetDictionaryValue(IReadOnlyDictionary<string, string> tags, string key)
+        private static string GetDictionaryValue(IReadOnlyDictionary<string, string> tags, string key)
         {
             if (tags is null)
             {
@@ -1051,7 +1051,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return val;
         }
 
-        private string ParseChannelLayout(string input)
+        private static string ParseChannelLayout(string input)
         {
             if (string.IsNullOrEmpty(input))
             {
@@ -1061,7 +1061,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return input.AsSpan().LeftPart('(').ToString();
         }
 
-        private string GetAspectRatio(MediaStreamInfo info)
+        private static string GetAspectRatio(MediaStreamInfo info)
         {
             var original = info.DisplayAspectRatio;
 
@@ -1130,7 +1130,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return original;
         }
 
-        private bool IsClose(double d1, double d2, double variance = .005)
+        private static bool IsClose(double d1, double d2, double variance = .005)
         {
             return Math.Abs(d1 - d2) <= variance;
         }
@@ -1163,7 +1163,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return divisor == 0f ? null : dividend / divisor;
         }
 
-        private void SetAudioRuntimeTicks(InternalMediaInfoResult result, MediaInfo data)
+        private static void SetAudioRuntimeTicks(InternalMediaInfoResult result, MediaInfo data)
         {
             // Get the first info stream
             var stream = result.Streams?.FirstOrDefault(s => s.CodecType == CodecType.Audio);
@@ -1188,7 +1188,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
         }
 
-        private int? GetBPSFromTags(MediaStreamInfo streamInfo)
+        private static int? GetBPSFromTags(MediaStreamInfo streamInfo)
         {
             if (streamInfo?.Tags is null)
             {
@@ -1204,7 +1204,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return null;
         }
 
-        private double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)
+        private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)
         {
             if (streamInfo?.Tags is null)
             {
@@ -1220,7 +1220,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return null;
         }
 
-        private long? GetNumberOfBytesFromTags(MediaStreamInfo streamInfo)
+        private static long? GetNumberOfBytesFromTags(MediaStreamInfo streamInfo)
         {
             if (streamInfo?.Tags is null)
             {
@@ -1237,7 +1237,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             return null;
         }
 
-        private void SetSize(InternalMediaInfoResult data, MediaInfo info)
+        private static void SetSize(InternalMediaInfoResult data, MediaInfo info)
         {
             if (data.Format is null)
             {
@@ -1382,7 +1382,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             audio.TrySetProviderId(MetadataProvider.MusicBrainzTrack, mb);
         }
 
-        private string GetMultipleMusicBrainzId(string value)
+        private static string GetMultipleMusicBrainzId(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -1680,7 +1680,7 @@ namespace MediaBrowser.MediaEncoding.Probing
         }
 
         // REVIEW: find out why the byte array needs to be 197 bytes long and comment the reason
-        private TransportStreamTimestamp GetMpegTimestamp(string path)
+        private static TransportStreamTimestamp GetMpegTimestamp(string path)
         {
             var packetBuffer = new byte[197];
 


### PR DESCRIPTION
In PR #14648 new analysis for isAnamorphic was added. The string comparisons there were added as StringComparison.OrdinalIgnoreCase, but the actual strings are always digits:digits (e.g. 3:4) so there's no alphabetic values to ignore case of... since StringComparision.Ordinal is much faster, switch to that.
Also, morphed all the private methods that should be to static since that eliminates a null-ref check on the this (at call-sites) and also makes the JIT happy.
