### PR TITLE
feat: add option to require file size change for media refreshes

### DIFF
--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -75,6 +75,11 @@ namespace MediaBrowser.Controller.Extensions
         public const string DetectNetworkChangeKey = "DetectNetworkChange";
 
         /// <summary>
+        /// The key for the file change require size change option.
+        /// </summary>
+        public const string FileChangeRequireSizeChangeKey = "FileChangeRequireSizeChange";
+
+        /// <summary>
         /// Gets a value indicating whether the application should host static web content from the <see cref="IConfiguration"/>.
         /// </summary>
         /// <param name="configuration">The configuration to retrieve the value from.</param>

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -288,4 +288,9 @@ public class ServerConfiguration : BaseApplicationConfiguration
     /// Gets or sets a value indicating whether old authorization methods are allowed.
     /// </summary>
     public bool EnableLegacyAuthorization { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to require file size change in addition to modification time when detecting media file changes.
+    /// </summary>
+    public bool FileChangeRequireSizeChange { get; set; } = false;
 }

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -48,6 +48,7 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly LyricResolver _lyricResolver;
         private readonly FFProbeVideoInfo _videoProber;
         private readonly AudioFileProber _audioProber;
+        private readonly IServerConfigurationManager _config;
         private readonly Task<ItemUpdateType> _cachedTask = Task.FromResult(ItemUpdateType.None);
 
         /// <summary>
@@ -87,6 +88,7 @@ namespace MediaBrowser.Providers.MediaInfo
             _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _subtitleResolver = new SubtitleResolver(loggerFactory.CreateLogger<SubtitleResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _lyricResolver = new LyricResolver(loggerFactory.CreateLogger<LyricResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
+            _config = config;
 
             _videoProber = new FFProbeVideoInfo(
                 loggerFactory.CreateLogger<FFProbeVideoInfo>(),
@@ -130,10 +132,17 @@ namespace MediaBrowser.Providers.MediaInfo
                 if (!string.IsNullOrWhiteSpace(path) && item.IsFileProtocol)
                 {
                     var file = directoryService.GetFile(path);
-                    if (file is not null && item.HasChanged(file.LastWriteTimeUtc))
+                    if (file is not null)
                     {
-                        _logger.LogDebug("Refreshing {ItemPath} due to file system modification.", path);
-                        return true;
+                        bool fileChanged = _config.Configuration.FileChangeRequireSizeChange
+                            ? item.HasChanged(file.LastWriteTimeUtc) && item.Size == file.Length
+                            : item.HasChanged(file.LastWriteTimeUtc);
+
+                        if (fileChanged)
+                        {
+                            _logger.LogDebug("Refreshing {ItemPath} due to file system modification.", path);
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This adds new system setting `FileChangeRequireSizeChange` that allows users to control how Jellyfin detects changes in media files. When enabled, the server will require both the modification time and the file size to have changed before triggering a metadata refresh.

This is based on the discussions in #13839 and #14674 and makes the behavior reintroduced in #14674 configurable.

With #14674, Jellyfin only checks the modification time of a file to determine if it has changed, which can lead to unnecessary metadata refreshes when a file's timestamp is updated without any actual change to its content. This is problematic for users with remote filesystems that may not provide stable timestamps, aswell as just copying files around without changing anything. 

I do recognize that this feels a bit hacky and would be fixed properly by hashing the files instead of relying on their timestsamps and size, but it's worth it in my opinion as this workaroud will prevent a lot of unnecessary rescans and especially uninented trickplay regeneration for a lot of users.

