### PR TITLE
Never replace BoxSet LinkedChildren on update

### DIFF
--- a/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
+++ b/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
@@ -69,14 +69,8 @@ public class BoxSetMetadataService : MetadataService<BoxSet, BoxSetInfo>
 
         if (mergeMetadataSettings)
         {
-            if (replaceData || targetItem.LinkedChildren.Length == 0)
-            {
-                targetItem.LinkedChildren = sourceItem.LinkedChildren;
-            }
-            else
-            {
-                targetItem.LinkedChildren = sourceItem.LinkedChildren.Concat(targetItem.LinkedChildren).Distinct().ToArray();
-            }
+            // TODO: Change to only replace when currently empty or requested. This is currently not done because the metadata service is not handling attaching collection items based on the provider responses
+            targetItem.LinkedChildren = sourceItem.LinkedChildren.Concat(targetItem.LinkedChildren).Distinct().ToArray();
         }
     }
 


### PR DESCRIPTION
We should never updated LinkedChildren of Collections because right now the metadata service is not handling attaching collection items based on the provider responses, so we'll always reset but never attach.

**Issues**
Fixes #12724