### PR TITLE
Fix latest items grouping by collection type

### DIFF
--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -381,7 +381,7 @@ namespace Emby.Server.Implementations.Library
                         UserView userView => userView.CollectionType,
                         _ => null
                     })
-                    .FirstOrDefault(type => type != null);
+                    .FirstOrDefault(type => type is not null);
 
                 if (collectionType == CollectionType.tvshows)
                 {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Update `UserViewManager` to correctly detect collection types by checking both ICollectionFolder and UserView objects. This replaces the previous `All()`-based checks, which caused grouped movies to be misclassified as a tvshows collection type.


**Issues**
Fixes #14735
