### PR TITLE
Preserve 3D format on metadata refresh

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -1279,7 +1279,7 @@ namespace MediaBrowser.Providers.Manager
         {
             if (source is Video sourceCast && target is Video targetCast)
             {
-                if (replaceData || !targetCast.Video3DFormat.HasValue)
+                if (sourceCast.Video3DFormat.HasValue && (replaceData || !targetCast.Video3DFormat.HasValue))
                 {
                     targetCast.Video3DFormat = sourceCast.Video3DFormat;
                 }

--- a/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
@@ -158,7 +158,7 @@ namespace Jellyfin.Providers.Tests.Manager
             Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, null, newValue, null, false, out _));
 
             // Video3DFormat - null values do NOT replace existing data
-            if (propName == "Video3DFormat")
+            if (string.Equals(propName, "Video3DFormat", StringComparison.Ordinal))
             {
                 Assert.False(
                     TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, null, null, true, out _));

--- a/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceTests.cs
@@ -157,7 +157,17 @@ namespace Jellyfin.Providers.Tests.Manager
             Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, newValue, null, true, out _));
             Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, null, newValue, null, false, out _));
 
-            Assert.True(TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, null, null, true, out _));
+            // Video3DFormat - null values do NOT replace existing data
+            if (propName == "Video3DFormat")
+            {
+                Assert.False(
+                    TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, null, null, true, out _));
+            }
+            else
+            {
+                Assert.True(
+                    TestMergeBaseItemData<Movie, MovieInfo>(propName, oldValue, null, null, true, out _));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Changes**
3D format is filename-based and not included in metadata providers. This change prevents it from being cleared during a full metadata refresh unless a new value is available.

**Issues**
 Fixes #13864

