### PR TITLE
Add AlbumNormalizationGain field to BaseItemDto

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1019,6 +1019,15 @@ namespace Emby.Server.Implementations.Dto
                 {
                     dto.AlbumId = albumParent.Id;
                     dto.AlbumPrimaryImageTag = GetTagAndFillBlurhash(dto, albumParent, ImageType.Primary);
+                    if (albumParent.LUFS.HasValue)
+                    {
+                        // -18 LUFS reference, same as ReplayGain 2.0, compatible with ReplayGain 1.0
+                        dto.AlbumNormalizationGain = -18f - albumParent.LUFS;
+                    }
+                    else if (albumParent.NormalizationGain.HasValue)
+                    {
+                        dto.AlbumNormalizationGain = albumParent.NormalizationGain;
+                    }
                 }
 
                 // if (options.ContainsField(ItemFields.MediaSourceCount))

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -790,6 +790,12 @@ namespace MediaBrowser.Model.Dto
         public float? NormalizationGain { get; set; }
 
         /// <summary>
+        /// Gets or sets the gain required for audio normalization. This field is inherited from music album normalization gain.
+        /// </summary>
+        /// <value>The gain required for audio normalization.</value>
+        public float? AlbumNormalizationGain { get; set; }
+
+        /// <summary>
         /// Gets or sets the current program.
         /// </summary>
         /// <value>The current program.</value>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->


**Changes**

This PR adds the `AlbumNormalizationGain` field to BaseItemDto which is inherited from music albums and available only on tracks with album:

```json
{
  "Name":"...",
  ...
  "NormalizationGain":-1.5,
  "AlbumNormalizationGain":-0.70000076
}
```

No new tests are written since there's no tests for existing track NormalizationGain. The change follows existing example and is tiny enough to be expected not to break.

**Issues**

Sorry I did that as a way to avoid waiting on a feature request (and there's nothing in contributing guidelines on doing feature requests). This does not fix anything in jellyfin itself but:

- #14346 can be fixed using this PR (that's actually jellyfin-web issue)
- Generally, any client wanting to use album gain must fetch album separately like we did at https://github.com/jmshrv/finamp/pull/1302 (and jellyfin-web does that too - see previous item). This allows for less round trips here

<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

**Testing**

The tests were done manually with one caveat: I need to restart server before album normalization gain is returned to clients, both on rc5 and PR base with both this change applied and not (i.e. in total 4 test configurations). This means that `AlbumNormalizationGain` was not returned for tracks with this change applied as well as `NormalizationGain` was not returned for albums with or without this change applied before server restart. Note that I tested that on rootless docker and album count in library was 2, your mileage may wary.

To test, I simply looked at developer console (network tab) in browser while opening album or track.

Since there's no official packaging for jellyfin 10.11 provided, I used existing jellyfin-packaging repository and overridden dotnet version to 9.0:

<details>
<summary>Part of docker-compose.yml</summary>

```yaml
    build:
      context: ./jellyfin-packaging
      dockerfile: docker/Dockerfile
      args:
        DOTNET_ARCH: x64
        IMAGE_ARCH: amd64
        PACKAGE_ARCH: amd64
        QEMU_ARCH: x86_64
        TARGET_ARCH: amd64
        JELLYFIN_VERSION: "v10.11.0"
        CONFIG: Release
        DOTNET_VERSION: "9.0"
```

</details>