### PR TITLE
Seal Emby.Naming.Video.StackResolver.StackMetadata to silence a compiler warning

### DIFF
--- a/Emby.Naming/Video/StackResolver.cs
+++ b/Emby.Naming/Video/StackResolver.cs
@@ -132,7 +132,7 @@ namespace Emby.Naming.Video
             }
         }
 
-        private class StackMetadata
+        private sealed class StackMetadata
         {
             public StackMetadata(bool isDirectory, bool isNumerical, string partType)
             {


### PR DESCRIPTION
…
Make private Emby.Naming.Video.StackResolver.StackMetadata sealed to silence a compiler warning

**Changes**
Make private Emby.Naming.Video.StackResolver.StackMetadata sealed to silence a compiler warning

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/2149 (though not entirely)

**Note**
I am a jellyfin self-hoster (great project btw!) looking to start contributing and started by running the tests while noticing a few compiler warnings. I thought I could start there. Since this is a private class and only internal to Emby.Naming.Video.StackResolver, preventing inheritance shouldn't break anything downstream. It doesn't seem that this class was explicitly designed with the idea that one might inherit from it [See here](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/why-are-so-many-of-the-framework-classes-sealed). Apparently this [_might_ be more jit-friendly](https://github.com/dotnet/runtime/issues/49944) by avoiding "virtual-table" traversal/method-resolution. But mainly it silences one compiler warning.