### PR TITLE
Don't use ffprobe frame options on audio probe

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -511,7 +511,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 ? "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_chapters -show_format"
                 : "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_format";
 
-            if (_proberSupportsFirstVideoFrame)
+            if (!isAudio && _proberSupportsFirstVideoFrame)
             {
                 args += " -show_frames -only_first_vframe";
             }


### PR DESCRIPTION
Jellyfin OOMed on me when probing a mka file indefinitly. By trial and error, these two options were responsible.
