### PR TITLE
Change Spanish variants order in iso6392.txt to make Castillian the "default" version

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -402,8 +402,8 @@ sog|||Sogdian|sogdien
 som||so|Somali|somali
 son|||Songhai languages|songhai, langues
 sot||st|Sotho, Southern|sotho du Sud
-spa||es-419|Spanish; Latin|espagnol; Latin
 spa||es|Spanish; Castilian|espagnol; castillan
+spa||es-419|Spanish; Latin|espagnol; Latin
 sqi|alb|sq|Albanian|albanais
 srd||sc|Sardinian|sarde
 srn|||Sranan Tongo|sranan tongo


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->


**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changed the order of the two Spanish culture variants present in the file to make Castillian be the first one.  This will make the language code used for Spanish to be "spa" instead of "es-419". This will fix the current behaviour of the "Smart" subtitle selection, that as of right now doesn't work with spanish. More info about it in the linked issue.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#14638 
