### PR TITLE
Avoid constant arrays as arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -294,6 +294,9 @@ dotnet_diagnostic.CA1854.severity = error
 # error on CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = error
 
+# error on CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = error
+
 # error on CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 dotnet_diagnostic.CA1862.severity = error
 

--- a/MediaBrowser.Controller/Extensions/XmlReaderExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/XmlReaderExtensions.cs
@@ -167,12 +167,12 @@ public static class XmlReaderExtensions
 
         // Only split by comma if there is no pipe in the string
         // We have to be careful to not split names like Matthew, Jr.
-        var separator = !value.Contains('|', StringComparison.Ordinal)
+        ReadOnlySpan<char> separator = !value.Contains('|', StringComparison.Ordinal)
             && !value.Contains(';', StringComparison.Ordinal)
-                ? new[] { ',' }
-                : new[] { '|', ';' };
+                ? stackalloc[] { ',' }
+                : stackalloc[] { '|', ';' };
 
-        foreach (var part in value.Trim().Trim(separator).Split(separator))
+        foreach (var part in value.AsSpan().Trim().Trim(separator).ToString().Split(separator))
         {
             if (!string.IsNullOrWhiteSpace(part))
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using Jellyfin.Data.Enums;
@@ -22,6 +21,8 @@ namespace MediaBrowser.Controller.MediaEncoding
     // For now, a common base class until the API and MediaEncoding classes are unified
     public class EncodingJobInfo
     {
+        private static readonly char[] _separators = ['|', ','];
+
         public int? OutputAudioBitrate;
         public int? OutputAudioChannels;
 
@@ -586,7 +587,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (!string.IsNullOrEmpty(BaseRequest.Profile))
             {
-                return BaseRequest.Profile.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                return BaseRequest.Profile.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
             }
 
             if (!string.IsNullOrEmpty(codec))
@@ -595,7 +596,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (!string.IsNullOrEmpty(profile))
                 {
-                    return profile.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    return profile.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
                 }
             }
 
@@ -606,7 +607,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (!string.IsNullOrEmpty(BaseRequest.VideoRangeType))
             {
-                return BaseRequest.VideoRangeType.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                return BaseRequest.VideoRangeType.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
             }
 
             if (!string.IsNullOrEmpty(codec))
@@ -615,7 +616,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (!string.IsNullOrEmpty(rangetype))
                 {
-                    return rangetype.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    return rangetype.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
                 }
             }
 
@@ -626,7 +627,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (!string.IsNullOrEmpty(BaseRequest.CodecTag))
             {
-                return BaseRequest.CodecTag.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                return BaseRequest.CodecTag.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
             }
 
             if (!string.IsNullOrEmpty(codec))
@@ -635,7 +636,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (!string.IsNullOrEmpty(codectag))
                 {
-                    return codectag.Split(new[] { '|', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    return codectag.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
                 }
             }
 

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -30,9 +30,11 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private const string ArtistReplaceValue = " | ";
 
-        private readonly char[] _nameDelimiters = { '/', '|', ';', '\\' };
-        private readonly string[] _webmVideoCodecs = { "av1", "vp8", "vp9" };
-        private readonly string[] _webmAudioCodecs = { "opus", "vorbis" };
+        private static readonly char[] _basicDelimiters = ['/', ';'];
+        private static readonly char[] _nameDelimiters = [.. _basicDelimiters, '|', '\\'];
+        private static readonly char[] _genreDelimiters = [.. _basicDelimiters, ','];
+        private static readonly string[] _webmVideoCodecs = ["av1", "vp8", "vp9"];
+        private static readonly string[] _webmAudioCodecs = ["opus", "vorbis"];
 
         private readonly ILogger _logger;
         private readonly ILocalizationManager _localization;
@@ -174,7 +176,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             if (tags.TryGetValue("artists", out var artists) && !string.IsNullOrWhiteSpace(artists))
             {
-                info.Artists = SplitDistinctArtists(artists, new[] { '/', ';' }, false).ToArray();
+                info.Artists = SplitDistinctArtists(artists, _basicDelimiters, false).ToArray();
             }
             else
             {
@@ -1554,7 +1556,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             if (tags.TryGetValue("WM/Genre", out var genres) && !string.IsNullOrWhiteSpace(genres))
             {
-                var genreList = genres.Split(new[] { ';', '/', ',' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var genreList = genres.Split(_genreDelimiters, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
                 // If this is empty then don't overwrite genres that might have been fetched earlier
                 if (genreList.Length > 0)
@@ -1571,7 +1573,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             if (tags.TryGetValue("WM/MediaCredits", out var people) && !string.IsNullOrEmpty(people))
             {
                 video.People = Array.ConvertAll(
-                    people.Split(new[] { ';', '/' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                    people.Split(_basicDelimiters, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
                     i => new BaseItemPerson { Name = i, Type = PersonKind.Actor });
             }
 

--- a/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
@@ -200,8 +200,7 @@ namespace Jellyfin.LiveTv.TunerHosts
                         var numberIndex = nameInExtInf.IndexOf(' ');
                         if (numberIndex > 0)
                         {
-                            var numberPart = nameInExtInf.Slice(0, numberIndex).Trim(new[] { ' ', '.' });
-
+                            var numberPart = nameInExtInf[..numberIndex].Trim(stackalloc[] { ' ', '.' });
                             if (double.TryParse(numberPart, CultureInfo.InvariantCulture, out _))
                             {
                                 numberString = numberPart.ToString();
@@ -273,12 +272,12 @@ namespace Jellyfin.LiveTv.TunerHosts
                 var numberIndex = nameInExtInf.IndexOf(' ', StringComparison.Ordinal);
                 if (numberIndex > 0)
                 {
-                    var numberPart = nameInExtInf.AsSpan(0, numberIndex).Trim(new[] { ' ', '.' });
+                    var numberPart = nameInExtInf.AsSpan(0, numberIndex).Trim(stackalloc[] { ' ', '.' });
 
                     if (double.TryParse(numberPart, CultureInfo.InvariantCulture, out _))
                     {
                         // channel.Number = number.ToString();
-                        nameInExtInf = nameInExtInf.AsSpan(numberIndex + 1).Trim(new[] { ' ', '-' }).ToString();
+                        nameInExtInf = nameInExtInf.AsSpan(numberIndex + 1).Trim(stackalloc[] { ' ', '-' }).ToString();
                     }
                 }
             }


### PR DESCRIPTION
Should reduce the amount of char[] allocations.
