### PR TITLE
Fix playlist move from smaller to larger index

### DIFF
--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -314,9 +314,7 @@ namespace Emby.Server.Implementations.Playlists
                 return;
             }
 
-            // Subtract when (newIndex > oldIndexAccessible), as the existing item is removed from the list.
-            // Otherwise, the index is now one greater than expected
-            var newPriorItemIndex = newIndex - 1 < 0 ? 0 : newIndex - 1;
+            var newPriorItemIndex = Math.Max(newIndex - 1, 0);
             var newPriorItemId = accessibleChildren[newPriorItemIndex].Item1.ItemId;
             var newPriorItemIndexOnAllChildren = children.FindIndex(c => c.Item1.ItemId.Equals(newPriorItemId));
             var adjustedNewIndex = DetermineAdjustedIndex(newPriorItemIndexOnAllChildren, newIndex);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
When attempting to use the `/move` API to move from a smaller index to a larger one, the actual value is one greater.
The fix for this is to always remove one from the index (except where it is already zero).
Before: `insertBeforeIndex = newIndex + 1 (from DetermineAdjustedIndex) + 1 (the item is removed from the list) = newIndex + 2`
After: `insertBeforeIndex = newINdex + 1 (from DetermineAdjustedIndex) - 1 (from this PR) + 1 (item is removed from list, things are offset by 1) = newIndex + 1`

**Issues**
Fixes #14792
