### PR TITLE
fix: prevent premature disposal of HTTP subtitle streams

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -963,15 +963,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             switch (protocol)
             {
                 case MediaProtocol.Http:
-                    {
-                        using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
-                            .GetAsync(new Uri(path), cancellationToken)
-                            .ConfigureAwait(false);
-                        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-                    }
+                {
+                    var client = _httpClientFactory.CreateClient(NamedClient.Default);
+                    var bytes = await client.GetByteArrayAsync(new Uri(path), cancellationToken).ConfigureAwait(false);
+                    return new MemoryStream(bytes, writable: false);
+                }
 
                 case MediaProtocol.File:
                     return AsyncFile.OpenRead(path);
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(protocol));
             }


### PR DESCRIPTION
### Summary
Fetching remote subtitles used `using var response` in `GetStream`, which disposed the HttpResponseMessage before the content stream was consumed. This caused `ObjectDisposedException` inside `UtfUnknown.CharsetDetector.DetectFromStreamAsync`.

### Changes
- Replace returning the response’s live stream with reading the subtitle bytes via `GetByteArrayAsync`.
- Wrap the bytes in a new `MemoryStream` (read-only) so the caller owns the stream lifetime.
- Leaves file protocol behavior unchanged.

### Testing
- Reproduced the crash by selecting remote WebVTT subtitles.
- Verified playback works after change.
- Checked local subtitles (file protocol) unaffected.