### PR TITLE
replace command line parser with system one

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,6 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.4" />
     <PackageVersion Include="BlurHashSharp.SkiaSharp" Version="1.4.0-pre.1" />
     <PackageVersion Include="BlurHashSharp" Version="1.4.0-pre.1" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Diacritics" Version="4.0.17" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
@@ -82,6 +81,7 @@
     <PackageVersion Include="Svg.Skia" Version="3.0.6" />
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.1.25451.107" />
     <PackageVersion Include="System.Globalization" Version="4.3.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.9" />

--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -40,10 +40,10 @@
     <PackageReference Include="SerilogAnalyzer" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" PrivateAssets="All" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />

--- a/Jellyfin.Server/Options.cs
+++ b/Jellyfin.Server/Options.cs
@@ -1,0 +1,44 @@
+using System;
+using System.CommandLine;
+using System.Reflection;
+
+namespace Jellyfin.Server
+{
+    /// <summary>
+    /// Base class used to parse command line arguments.
+    /// </summary>
+    public class Options
+    {
+#pragma warning disable CA1200
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Options"/> class.
+        /// </summary>
+        /// <description>
+        /// To be called with the result of calling <see cref="o:Command.Parse"/> on the <see cref="RootCommand"/> given to the <see cref="StartupOptions.Setup"/> method.
+        /// </description>
+        /// <param name="parseResult">Instance of the <see cref="ParseResult"/> interface.</param>
+#pragma warning restore CA1200
+        public Options(ParseResult parseResult)
+        {
+            ParseResult = parseResult;
+        }
+
+        /// <summary>
+        /// Gets or sets the parse result.
+        /// </summary>
+        protected ParseResult ParseResult { get; set; }
+
+        /// <summary>
+        /// Generic function to setup options from class fields.
+        /// </summary>
+        /// <param name="cmd">The <see cref="RootCommand"/> or <see cref="Command"/> to add the arguments to.</param>
+        /// <param name="type">The <see cref="Type"/> of the class to read the fields from.</param>
+        protected static void Setup(Command cmd, Type type)
+        {
+            foreach (FieldInfo prop in type.GetFields(BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                cmd.Options.Add((Option)prop.GetValue(null)!);
+            }
+        }
+    }
+}

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,83 +1,185 @@
 using System.Collections.Generic;
-using CommandLine;
+using System.CommandLine;
 using Emby.Server.Implementations;
 using static MediaBrowser.Controller.Extensions.ConfigurationExtensions;
 
 namespace Jellyfin.Server
 {
     /// <summary>
-    /// Class used by CommandLine package when parsing the command line arguments.
+    /// Class used by when parsing the command line arguments for startup.
     /// </summary>
-    public class StartupOptions : IStartupOptions
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "SA1201:A field should not follow a property", Justification = "It is much easier to read this way since they work by pair.")]
+    public class StartupOptions : Options, IStartupOptions
     {
         /// <summary>
-        /// Gets or sets the path to the data directory.
+        /// Setup the options needed for Jellyfin server mode.
+        /// </summary>
+        /// <param name="cmd">The <see cref="RootCommand"/> or <see cref="Command"/> to add the arguments to.</param>
+        public static void Setup(Command cmd)
+        {
+            Options.Setup(cmd, typeof(StartupOptions));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartupOptions"/> class.
+        /// </summary>
+        /// <param name="parseResult">Instance of the <see cref="ParseResult"/> interface.</param>
+        public StartupOptions(ParseResult parseResult) : base(parseResult)
+        {
+        }
+
+        /// <summary>
+        /// Gets the path to the data directory.
         /// </summary>
         /// <value>The path to the data directory.</value>
-        [Option('d', "datadir", Required = false, HelpText = "Path to use for the data folder (database files, etc.).")]
-        public string? DataDir { get; set; }
+        public string? DataDir
+        {
+            get { return ParseResult.GetValue(dataDirOption); }
+        }
+
+        private static Option<string> dataDirOption = new("--datadir", "-d")
+        {
+            Description = "Path to use for the data folder (database files, etc.)."
+        };
 
         /// <summary>
-        /// Gets or sets a value indicating whether the server should not host the web client.
+        /// Gets a value indicating whether the server should not host the web client.
         /// </summary>
-        [Option("nowebclient", Required = false, HelpText = "Indicates that the web server should not host the web client.")]
-        public bool NoWebClient { get; set; }
+        public bool NoWebClient
+        {
+            get { return ParseResult.GetValue(noWebClientOption); }
+        }
+
+        private static Option<bool> noWebClientOption = new("--nowebclient")
+        {
+            Description = "Indicates that the web server should not host the web client."
+        };
 
         /// <summary>
-        /// Gets or sets the path to the web directory.
+        /// Gets the path to the web directory.
         /// </summary>
         /// <value>The path to the web directory.</value>
-        [Option('w', "webdir", Required = false, HelpText = "Path to the Jellyfin web UI resources.")]
-        public string? WebDir { get; set; }
+        public string? WebDir
+        {
+            get { return ParseResult.GetValue(webDirOption); }
+        }
+
+        private static Option<string> webDirOption = new("--webdir", "-w")
+        {
+            Description = "Path to the Jellyfin web UI resources."
+        };
 
         /// <summary>
-        /// Gets or sets the path to the cache directory.
+        /// Gets the path to the cache directory.
         /// </summary>
         /// <value>The path to the cache directory.</value>
-        [Option('C', "cachedir", Required = false, HelpText = "Path to use for caching.")]
-        public string? CacheDir { get; set; }
+        public string? CacheDir
+        {
+            get { return ParseResult.GetValue(cacheDirOption); }
+        }
+
+        private static Option<string> cacheDirOption = new("--cachedir", "-C")
+        {
+            Description = "Path to use for caching."
+        };
 
         /// <summary>
-        /// Gets or sets the path to the config directory.
+        /// Gets the path to the config directory.
         /// </summary>
         /// <value>The path to the config directory.</value>
-        [Option('c', "configdir", Required = false, HelpText = "Path to use for configuration data (user settings and pictures).")]
-        public string? ConfigDir { get; set; }
+        public string? ConfigDir
+        {
+            get { return ParseResult.GetValue(configDirOption); }
+        }
+
+        private static Option<string> configDirOption = new("--configdir", "-c")
+        {
+            Description = "Path to use for configuration data (user settings and pictures)."
+        };
 
         /// <summary>
-        /// Gets or sets the path to the log directory.
+        /// Gets the path to the log directory.
         /// </summary>
         /// <value>The path to the log directory.</value>
-        [Option('l', "logdir", Required = false, HelpText = "Path to use for writing log files.")]
-        public string? LogDir { get; set; }
+        public string? LogDir
+        {
+            get { return ParseResult.GetValue(logDirOption); }
+        }
+
+        private static Option<string> logDirOption = new("--logdir", "-l")
+        {
+            Description = "Path to use for writing log files."
+        };
 
         /// <inheritdoc />
-        [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg executable to use in place of default found in PATH.")]
-        public string? FFmpegPath { get; set; }
+        public string? FFmpegPath
+        {
+            get { return ParseResult.GetValue(ffmpegOption); }
+        }
+
+        private static Option<string> ffmpegOption = new("--ffmpeg")
+        {
+            Description = "Path to external FFmpeg executable to use in place of default found in PATH."
+        };
 
         /// <inheritdoc />
-        [Option("service", Required = false, HelpText = "Run as headless service.")]
-        public bool IsService { get; set; }
+        public bool IsService
+        {
+            get { return ParseResult.GetValue(isServiceOption); }
+        }
+
+        private static Option<bool> isServiceOption = new("--service")
+        {
+            Description = "Run as headless service."
+        };
 
         /// <inheritdoc />
-        [Option("package-name", Required = false, HelpText = "Used when packaging Jellyfin (example, synology).")]
-        public string? PackageName { get; set; }
+        public string? PackageName
+        {
+            get { return ParseResult.GetValue(packageNameOption); }
+        }
+
+        private static Option<string> packageNameOption = new("--packageName")
+        {
+            Description = "Used when packaging Jellyfin (example, synology)."
+        };
 
         /// <inheritdoc />
-        [Option("published-server-url", Required = false, HelpText = "Jellyfin Server URL to publish via auto discover process")]
-        public string? PublishedServerUrl { get; set; }
+        public string? PublishedServerUrl
+        {
+            get { return ParseResult.GetValue(publishedServerUrlOption); }
+        }
+
+        private static Option<string> publishedServerUrlOption = new("--published-server-url")
+        {
+            Description = "Jellyfin Server URL to publish via auto discover process."
+        };
 
         /// <summary>
-        /// Gets or sets a value indicating whether the server should not detect network status change.
+        /// Gets a value indicating whether the server should not detect network status change.
         /// </summary>
-        [Option("nonetchange", Required = false, HelpText = "Indicates that the server should not detect network status change.")]
-        public bool NoDetectNetworkChange { get; set; }
+        public bool NoDetectNetworkChange
+        {
+            get { return ParseResult.GetValue(noNetChangeOption); }
+        }
+
+        private static Option<bool> noNetChangeOption = new("--nonetchange")
+        {
+            Description = "Indicates that the server should not detect network status change."
+        };
 
         /// <summary>
-        /// Gets or sets the path to an jellyfin backup archive to restore the application to.
+        /// Gets the path to an jellyfin backup archive to restore the application to.
         /// </summary>
-        [Option("restore-archive", Required = false, HelpText = "Path to a Jellyfin backup archive to restore from")]
-        public string? RestoreArchive { get; set; }
+        public string? RestoreArchive
+        {
+            get { return ParseResult.GetValue(restoreArchiveOption); }
+        }
+
+        private Option<string> restoreArchiveOption = new("--restore-archive")
+        {
+            Description = "Path to a Jellyfin backup archive to restore from."
+        };
 
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.

--- a/src/Jellyfin.Networking/Jellyfin.Networking.csproj
+++ b/src/Jellyfin.Networking/Jellyfin.Networking.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.CommandLine;
 using System.Globalization;
 using System.IO;
 using Emby.Server.Implementations;
@@ -54,7 +55,10 @@ namespace Jellyfin.Server.Integration.Tests
             // Skip ffmpeg check for testing
             Environment.SetEnvironmentVariable("JELLYFIN_FFMPEG__NOVALIDATION", "true");
             // Specify the startup command line options
-            var commandLineOpts = new StartupOptions();
+            RootCommand rootCommand = new("Jellyfin.Server");
+            StartupOptions.Setup(rootCommand);
+            ParseResult parseResult = rootCommand.Parse([]);
+            var commandLineOpts = new StartupOptions(parseResult);
 
             // Use a temporary directory for the application paths
             var webHostPathRoot = Path.Combine(_testPathRoot, "test-host-" + Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));


### PR DESCRIPTION
This PR breaks down the effort started in https://github.com/jellyfin/jellyfin/pull/14422

It is the first step as outlined [here](https://github.com/jellyfin/jellyfin/pull/14422#issuecomment-3120291849), namely:

> I also believe we should use [System.CommandLine](https://github.com/dotnet/command-line-api) which will become stable in .NET 10 (which Jellyfin 10.12 is pretty much guaranteed to use).

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

Ran `dotnet add package System.CommandLine --prerelease` to get the package.

What I like about this change, on top of the nicer help output, is we got rid of the setters which were superfluous in the first place.

Also, the reflection used allows us to add command line argument fields and properties without forgetting to actually add them to the `Command` instance.

I took the liberty to silence warnings about the placement of the fields and methods as I find it much more logical to group them by argument name. 

Help before:

```
$ jellyfin --help
Jellyfin.Server 10.10.7.0
Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License

  -d, --datadir             Path to use for the data folder (database files, etc.).

  --nowebclient             Indicates that the web server should not host the web client.

  -w, --webdir              Path to the Jellyfin web UI resources.

  -C, --cachedir            Path to use for caching.

  -c, --configdir           Path to use for configuration data (user settings and pictures).

  -l, --logdir              Path to use for writing log files.

  --ffmpeg                  Path to external FFmpeg executable to use in place of default found in PATH.

  --service                 Run as headless service.

  --package-name            Used when packaging Jellyfin (example, synology).

  --published-server-url    Jellyfin Server URL to publish via auto discover process

  --nonetchange             Indicates that the server should not detect network status change.

  --help                    Display this help screen.

  --version                 Display version information.
```

Help now:

```
$ jellyfin --help
Description:
  Jellyfin.Server

Usage:
  jellyfin [options]

Options:
  -d, --datadir <datadir>                        Path to use for the data folder (database files, etc.).
  --nowebclient                                  Indicates that the web server should not host the web
                                                 client.
  -w, --webdir <webdir>                          Path to the Jellyfin web UI resources.
  -C, --cachedir <cachedir>                      Path to use for caching.
  -c, --configdir <configdir>                    Path to use for configuration data (user settings and
                                                 pictures).
  -l, --logdir <logdir>                          Path to use for writing log files.
  --ffmpeg <ffmpeg>                              Path to external FFmpeg executable to use in place of
                                                 default found in PATH.
  --service                                      Run as headless service.
  --packageName <packageName>                    Used when packaging Jellyfin (example, synology).
  --published-server-url <published-server-url>  Jellyfin Server URL to publish via auto discover process.
  --nonetchange                                  Indicates that the server should not detect network status
                                                 change.
  -?, -h, --help                                 Show help and usage information
  --version                                      Show version information
```

Help with wrong argument before:

```
$ jellyfin --asd
Jellyfin.Server 10.10.7.0
Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License

ERROR(S):
  Option 'asd' is unknown.

  -d, --datadir             Path to use for the data folder (database files, etc.).

  --nowebclient             Indicates that the web server should not host the web client.

  -w, --webdir              Path to the Jellyfin web UI resources.

  -C, --cachedir            Path to use for caching.

  -c, --configdir           Path to use for configuration data (user settings and pictures).

  -l, --logdir              Path to use for writing log files.

  --ffmpeg                  Path to external FFmpeg executable to use in place of default found in PATH.

  --service                 Run as headless service.

  --package-name            Used when packaging Jellyfin (example, synology).

  --published-server-url    Jellyfin Server URL to publish via auto discover process

  --nonetchange             Indicates that the server should not detect network status change.

  --help                    Display this help screen.

  --version                 Display version information.
```

Help with wrong argument now:

```
$ jellyfin --asd
'--asd' was not matched. Did you mean one of the following?
-d

Unrecognized command or argument '--asd'.

Description:
  Jellyfin.Server

Usage:
  jellyfin [options]

Options:
  -d, --datadir <datadir>                        Path to use for the data folder (database files, etc.).
  --nowebclient                                  Indicates that the web server should not host the web
                                                 client.
  -w, --webdir <webdir>                          Path to the Jellyfin web UI resources.
  -C, --cachedir <cachedir>                      Path to use for caching.
  -c, --configdir <configdir>                    Path to use for configuration data (user settings and
                                                 pictures).
  -l, --logdir <logdir>                          Path to use for writing log files.
  --ffmpeg <ffmpeg>                              Path to external FFmpeg executable to use in place of
                                                 default found in PATH.
  --service                                      Run as headless service.
  --packageName <packageName>                    Used when packaging Jellyfin (example, synology).
  --published-server-url <published-server-url>  Jellyfin Server URL to publish via auto discover process.
  --nonetchange                                  Indicates that the server should not detect network status
                                                 change.
  -?, -h, --help                                 Show help and usage information
  --version                                      Show version information
```

Sanity check run:

```
$ jellyfin
[23:10:39] [INF] [1] Emby.Server.Implementations.AppBase.BaseConfigurationManager: Setting cache path: /home/timi/.cache/jellyfin
[23:10:39] [INF] [9] Jellyfin.Server.ServerSetupApp.SetupServer: Kestrel is listening on 0.0.0.0
[23:10:39] [WRN] [9] Microsoft.AspNetCore.Server.Kestrel: Overriding address(es) 'http://localhost:8096'. Binding to endpoints defined via IConfiguration and/or UseKestrel() instead.
[23:10:39] [INF] [9] Main: Jellyfin version: 10.11.0
[23:10:39] [INF] [9] Main: Environment Variables: ["[ASPNETCORE_URLS, http://localhost:8096]", "[DOTNET_LAUNCH_PROFILE, Jellyfin.Server]", "[ASPNETCORE_ENVIRONMENT, Development]", "[JELLYFIN_LOG_DIR, /home/timi/.local/share/jellyfin/log]", "[DOTNET_ROOT_X64, /nix/store/l50mslybz1g9p3ad5722pv97av52k3dk-dotnet-sdk-9.0.304/share/dotnet]"]
[23:10:39] [INF] [9] Main: Arguments: ["/home/timi/Projects/jellyfin/Jellyfin.Server/bin/Debug/net9.0/jellyfin.dll"]
[23:10:39] [INF] [9] Main: Operating system: NixOS 25.11 (Xantusia)
[23:10:39] [INF] [9] Main: Architecture: X64
[23:10:39] [INF] [9] Main: 64-Bit Process: True
[23:10:39] [INF] [9] Main: User Interactive: True
[23:10:39] [INF] [9] Main: Processor count: 16
[23:10:39] [INF] [9] Main: Program data path: /home/timi/.local/share/jellyfin
[23:10:39] [INF] [9] Main: Log directory path: /home/timi/.local/share/jellyfin/log
[23:10:39] [INF] [9] Main: Config directory path: /home/timi/.config/jellyfin
[23:10:39] [INF] [9] Main: Cache path: /home/timi/.cache/jellyfin
[23:10:39] [INF] [9] Main: Temp directory path: /tmp/jellyfin
[23:10:39] [INF] [9] Main: Web resources path: /home/timi/Projects/jellyfin/Jellyfin.Server/bin/Debug/net9.0/jellyfin-web
[23:10:39] [INF] [9] Main: Application directory: /home/timi/Projects/jellyfin/Jellyfin.Server/bin/Debug/net9.0/
[23:10:39] [ERR] [9] Main: The server is expected to host the web client, but the provided content directory is either invalid or empty: /home/timi/Projects/jellyfin/Jellyfin.Server/bin/Debug/net9.0/jellyfin-web. If you do not want to host the web client with the server, you may set the '--nowebclient' command line flag, or set'hostwebclient=false' in your config settings
```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
