### PR TITLE
Fix root folder not being saved to Db if nessesary

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -799,6 +799,7 @@ namespace Emby.Server.Implementations.Library
             {
                 _logger.LogInformation("Resetting root folder path to {0}", rootFolderPath);
                 rootFolder.Path = rootFolderPath;
+                rootFolder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
             }
 
             // Add in the plug-in folders

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -799,7 +799,6 @@ namespace Emby.Server.Implementations.Library
             {
                 _logger.LogInformation("Resetting root folder path to {0}", rootFolderPath);
                 rootFolder.Path = rootFolderPath;
-                rootFolder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
             }
 
             // Add in the plug-in folders
@@ -827,6 +826,7 @@ namespace Emby.Server.Implementations.Library
 
             if (!folder.ParentId.Equals(rootFolder.Id))
             {
+                rootFolder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
                 folder.ParentId = rootFolder.Id;
                 folder.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, CancellationToken.None).GetAwaiter().GetResult();
             }


### PR DESCRIPTION
Fixes the issue of the root folder not been saved to the DB before adding libraries added though the setup process