### PR TITLE
Skip removed images when updating images

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2032,6 +2032,12 @@ namespace Emby.Server.Implementations.Library
                     }
                 }
 
+                if (!File.Exists(image.Path))
+                {
+                    _logger.LogWarning("Image not found at {ImagePath}", image.Path);
+                    continue;
+                }
+
                 ImageDimensions size;
                 try
                 {


### PR DESCRIPTION
It can happen that `item.ValidateImage()` which removes inaccessible images was not run before this method is run, so non-existing images could be probed here, leading to a lot of unneccessary log spam about not found images.

**Changes**
* check for file existence and skip if unavailable

**Remarks**
It might make sense to additionally call `item.ValidateImage()` at the end of the method just to be sure that images are in a clean state when returning.