### PR TITLE
fix: add back missing behavior for HasAnyProviderId

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2278,6 +2278,7 @@ public sealed class BaseItemRepository
 
         if (filter.HasAnyProviderId is not null && filter.HasAnyProviderId.Count > 0)
         {
+            // Allow setting a null or empty value to get all items that have the specified provider set.
             var includeAny = filter.HasAnyProviderId.Where(e => string.IsNullOrEmpty(e.Value)).Select(e => e.Key).ToArray();
             if (includeAny.Length > 0)
             {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2281,7 +2281,7 @@ public sealed class BaseItemRepository
             var includeAny = filter.HasAnyProviderId.Where(e => string.IsNullOrEmpty(e.Value)).Select(e => e.Key).ToArray();
             if (includeAny.Length > 0)
             {
-                baseQuery = baseQuery.Where(e => e.Provider!.Select(f => f.ProviderId)!.Any(f => includeAny.Contains(f)));
+                baseQuery = baseQuery.Where(e => e.Provider!.Any(f => includeAny.Contains(f.ProviderId)));
             }
 
             var includeSelected = filter.HasAnyProviderId.Where(e => !string.IsNullOrEmpty(e.Value)).Select(e => $"{e.Key}:{e.Value}").ToArray();

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2278,8 +2278,17 @@ public sealed class BaseItemRepository
 
         if (filter.HasAnyProviderId is not null && filter.HasAnyProviderId.Count > 0)
         {
-            var include = filter.HasAnyProviderId.Select(e => $"{e.Key}:{e.Value}").ToArray();
-            baseQuery = baseQuery.Where(e => e.Provider!.Select(f => f.ProviderId + ":" + f.ProviderValue)!.Any(f => include.Contains(f)));
+            var includeAny = filter.HasAnyProviderId.Where(e => string.IsNullOrEmpty(e.Value)).Select(e => e.Key).ToArray();
+            if (includeAny.Length > 0)
+            {
+                baseQuery = baseQuery.Where(e => e.Provider!.Select(f => f.ProviderId)!.Any(f => includeAny.Contains(f)));
+            }
+
+            var includeSelected = filter.HasAnyProviderId.Where(e => !string.IsNullOrEmpty(e.Value)).Select(e => $"{e.Key}:{e.Value}").ToArray();
+            if (includeSelected.Length > 0)
+            {
+                baseQuery = baseQuery.Where(e => e.Provider!.Select(f => f.ProviderId + ":" + f.ProviderValue)!.Any(f => includeSelected.Contains(f)));
+            }
         }
 
         if (filter.HasImdbId.HasValue)


### PR DESCRIPTION
**Changes**

Follow up for #14249, adding back the missing behavior to query items with any value for a provider id set.

I noticed while testing the 10.11 RC 5 that the `HasAnyProviderId` usage with an empty value was broken compared to 10.10, where it previously allowed you to query for all base items with the the given providers set regardless of the actual ID. Tested that it works locally.

**Issues / PRs**
https://github.com/jellyfin/jellyfin/issues/14108
https://github.com/jellyfin/jellyfin/pull/14249