### PR TITLE
Add schema to 503 headers

### DIFF
--- a/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
+++ b/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -10,27 +8,44 @@ internal class RetryOnTemporarilyUnavailableFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        operation.Responses.Add("503", new OpenApiResponse()
-        {
-            Description = "The server is currently starting or is temporarily not available.",
-            Headers = new Dictionary<string, OpenApiHeader>()
+        operation.Responses.Add(
+            "503",
+            new OpenApiResponse
             {
+                Description = "The server is currently starting or is temporarily not available.",
+                Headers = new Dictionary<string, OpenApiHeader>
                 {
-                    "Retry-After",
-                    new() { AllowEmptyValue = true, Required = false, Description = "A hint for when to retry the operation in full seconds." }
+                    {
+                        "Retry-After", new OpenApiHeader
+                        {
+                            AllowEmptyValue = true,
+                            Required = false,
+                            Description = "A hint for when to retry the operation in full seconds.",
+                            Schema = new OpenApiSchema
+                            {
+                                Type = "integer",
+                                Format = "int32"
+                            }
+                        }
+                    },
+                    {
+                        "Message", new OpenApiHeader
+                        {
+                            AllowEmptyValue = true,
+                            Required = false,
+                            Description = "A short plain-text reason why the server is not available.",
+                            Schema = new OpenApiSchema
+                            {
+                                Type = "string",
+                                Format = "text"
+                            }
+                        }
+                    }
                 },
+                Content = new Dictionary<string, OpenApiMediaType>()
                 {
-                    "Message",
-                    new() { AllowEmptyValue = true, Required = false, Description = "A short plain-text reason why the server is not available." }
+                    { "text/html", new OpenApiMediaType() }
                 }
-            },
-            Content = new Dictionary<string, OpenApiMediaType>()
-            {
-                {
-                    "text/html",
-                    new OpenApiMediaType()
-                }
-            }
-        });
+            });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/14839

```json
{
  [...]
  "503": {
	"description": "The server is currently starting or is temporarily not available.",
	"headers": {
	  "Retry-After": {
	    "description": "A hint for when to retry the operation in full seconds.",
	    "allowEmptyValue": true,
	    "schema": {
	      "type": "integer",
	      "format": "int32"
	    }
	  },
	  "Message": {
	    "description": "A short plain-text reason why the server is not available.",
	    "allowEmptyValue": true,
	    "schema": {
	      "type": "string",
	      "format": "text"
	    }
	  }
	},
	"content": {
	  "text/html": { }
	}
  },
  [...]
}
```