### PR TITLE
Fix CA1051 and CA1815 warnings, Change public fields to auto properties

### DIFF
--- a/Emby.Naming/AudioBook/AudioBookNameParserResult.cs
+++ b/Emby.Naming/AudioBook/AudioBookNameParserResult.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CA1815
+
 namespace Emby.Naming.AudioBook
 {
     /// <summary>

--- a/Emby.Naming/Video/CleanDateTimeResult.cs
+++ b/Emby.Naming/Video/CleanDateTimeResult.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CA1815
+
 namespace Emby.Naming.Video
 {
     /// <summary>

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -23,9 +23,6 @@ namespace MediaBrowser.Controller.MediaEncoding
     {
         private static readonly char[] _separators = ['|', ','];
 
-        public int? OutputAudioBitrate;
-        public int? OutputAudioChannels;
-
         private TranscodeReason? _transcodeReasons = null;
 
         public EncodingJobInfo(TranscodingJobType jobType)
@@ -36,6 +33,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             SupportedVideoCodecs = Array.Empty<string>();
             SupportedSubtitleCodecs = Array.Empty<string>();
         }
+
+        public int? OutputAudioBitrate { get; set; }
+
+        public int? OutputAudioChannels { get; set; }
 
         public TranscodeReason TranscodeReasons
         {

--- a/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
+++ b/MediaBrowser.Controller/Net/BasePeriodicWebSocketListener.cs
@@ -40,11 +40,6 @@ namespace MediaBrowser.Controller.Net
         /// </summary>
         private readonly List<(IWebSocketConnection Connection, CancellationTokenSource CancellationTokenSource, TStateType State)> _activeConnections = new();
 
-        /// <summary>
-        /// The logger.
-        /// </summary>
-        protected readonly ILogger<BasePeriodicWebSocketListener<TReturnDataType, TStateType>> Logger;
-
         private readonly Task _messageConsumerTask;
 
         protected BasePeriodicWebSocketListener(ILogger<BasePeriodicWebSocketListener<TReturnDataType, TStateType>> logger)
@@ -55,6 +50,11 @@ namespace MediaBrowser.Controller.Net
 
             _messageConsumerTask = HandleMessages();
         }
+
+        /// <summary>
+        /// Gets the Logger.
+        /// </summary>
+        protected ILogger<BasePeriodicWebSocketListener<TReturnDataType, TStateType>> Logger { get; }
 
         /// <summary>
         /// Gets the type used for the messages sent to the client.

--- a/MediaBrowser.Model/Drawing/ImageDimensions.cs
+++ b/MediaBrowser.Model/Drawing/ImageDimensions.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS1591
+#pragma warning disable CA1815
 
 using System.Globalization;
 


### PR DESCRIPTION
**Changes**
Disabled warnings on 3 different structs that had not implemented the Equals function. 
Changed 3 visible instance fields to auto properties. 
Moved the new auto properties below the constructor to follow styling rules. 

**Issues**
Fixes #2149 
