### PR TITLE
Comment code that intentionally generates MultipleCollectionIncludeWarning

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -610,6 +610,7 @@ namespace Jellyfin.Server.Implementations.Users
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
+                // Code intentionally generates MultipleCollectionIncludeWarning
                 var user = dbContext.Users
                                .Include(u => u.Permissions)
                                .Include(u => u.Preferences)
@@ -654,6 +655,7 @@ namespace Jellyfin.Server.Implementations.Users
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
+                // Code intentionally generates MultipleCollectionIncludeWarning
                 var user = dbContext.Users
                                .Include(u => u.Permissions)
                                .Include(u => u.Preferences)


### PR DESCRIPTION
This code generates MultipleCollectionIncludeWarning.  Verified with JPVenson that it is intended to be a single query.

Warnings can only be disabled globally so adding a comment for future developers.