### PR TITLE
Fix AddProperParentChildRelationBaseItemWithCascade migration deleting all items

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250913211637_AddProperParentChildRelationBaseItemWithCascade.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250913211637_AddProperParentChildRelationBaseItemWithCascade.cs
@@ -15,22 +15,22 @@ DELETE FROM BaseItems
         WHERE
         ParentId IS NOT NULL
         AND
-        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE ParentId = parent.Id);
+        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE parent.Id = BaseItems.ParentId);
 DELETE FROM BaseItems
         WHERE
         ParentId IS NOT NULL
         AND
-        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE ParentId = parent.Id);
+        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE parent.Id = BaseItems.ParentId);
 DELETE FROM BaseItems
         WHERE
         ParentId IS NOT NULL
         AND
-        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE ParentId = parent.Id);
+        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE parent.Id = BaseItems.ParentId);
 DELETE FROM BaseItems
         WHERE
         ParentId IS NOT NULL
         AND
-        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE ParentId = parent.Id);
+        NOT EXISTS(SELECT 1 FROM BaseItems parent WHERE parent.Id = BaseItems.ParentId);
 """);
             migrationBuilder.AddForeignKey(
                 name: "FK_BaseItems_BaseItems_ParentId",


### PR DESCRIPTION
**Changes**

The WHERE clause was selecting the ParentId from the parent item, not the actual item we wanted to check.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #14888
Fixes #14894
