### PR TITLE
Fix parental ratings

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2054,22 +2054,26 @@ public sealed class BaseItemRepository
         if (filter.MinParentalRating != null)
         {
             var min = filter.MinParentalRating;
-            minParentalRatingFilter = e => e.InheritedParentalRatingValue >= min.Score || e.InheritedParentalRatingValue == null;
-            if (min.SubScore != null)
-            {
-                minParentalRatingFilter = minParentalRatingFilter.And(e => e.InheritedParentalRatingValue >= min.SubScore || e.InheritedParentalRatingValue == null);
-            }
+            var minScore = min.Score;
+            var minSubScore = min.SubScore ?? 0;
+
+            minParentalRatingFilter = e =>
+                e.InheritedParentalRatingValue == null ||
+                e.InheritedParentalRatingValue > minScore ||
+                (e.InheritedParentalRatingValue == minScore && (e.InheritedParentalRatingSubValue ?? 0) >= minSubScore);
         }
 
         Expression<Func<BaseItemEntity, bool>>? maxParentalRatingFilter = null;
         if (filter.MaxParentalRating != null)
         {
             var max = filter.MaxParentalRating;
-            maxParentalRatingFilter = e => e.InheritedParentalRatingValue <= max.Score || e.InheritedParentalRatingValue == null;
-            if (max.SubScore != null)
-            {
-                maxParentalRatingFilter = maxParentalRatingFilter.And(e => e.InheritedParentalRatingValue <= max.SubScore || e.InheritedParentalRatingValue == null);
-            }
+            var maxScore = max.Score;
+            var maxSubScore = max.SubScore ?? 0;
+
+            maxParentalRatingFilter = e =>
+                e.InheritedParentalRatingValue == null ||
+                e.InheritedParentalRatingValue < maxScore ||
+                (e.InheritedParentalRatingValue == maxScore && (e.InheritedParentalRatingSubValue ?? 0) <= maxSubScore);
         }
 
         if (filter.HasParentalRating ?? false)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Changed min/max parental rating filters from `>=`/`<=` to `>`/`<` for score comparison
- Added subscore as a tie-breaker when main scores are equal
- Used `InheritedParentalRatingSubValue` field to properly compare subscores

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->Fixes filtering issues. For example, filtering by a parental rating of "R" only displayed "PG" items. Tested with various ratings and filtering now works correctly.
