### PR TITLE
Fix collections folder duplication

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -104,6 +104,8 @@ namespace Emby.Server.Implementations.Collections
 
             await _libraryManager.AddVirtualFolder(name, CollectionTypeOptions.boxsets, libraryOptions, true).ConfigureAwait(false);
 
+            _libraryManager.RootFolder.Children = null;
+
             return FindFolders(path).First();
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
-  Invalidate `RootFolder.Children` cache after creating collections virtual folder

**Issues**
Fixes a bug where creating the collections folder during library scans would fail with an error and/or create duplicate "Collections" libraries in the UI.

<details>
  <summary>Log Error</summary>

```
[23:29:17] [ERR] [82] Emby.Server.Implementations.Library.Validators.CollectionPostScanTask: Error refreshing Caminandes Collection with ["174d3cdb-1345-dc0b-bc8a-799068c5dcc7", "165c9d15-9367-45a2-8b0c-741fd0409d90", "ba8518a9-9969-f900-6808-8ef81424657b"]
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Emby.Server.Implementations.Collections.CollectionManager.EnsureLibraryFolder(String path, Boolean createIfNeeded) in C:\git\jellyfin\Emby.Server.Implementations\Collections\CollectionManager.cs:line 107
   at Emby.Server.Implementations.Collections.CollectionManager.CreateCollectionAsync(CollectionCreationOptions options) in C:\git\jellyfin\Emby.Server.Implementations\Collections\CollectionManager.cs:line 140
   at Emby.Server.Implementations.Library.Validators.CollectionPostScanTask.Run(IProgress`1 progress, CancellationToken cancellationToken) in C:\git\jellyfin\Emby.Server.Implementations\Library\Validators\CollectionPostScanTask.cs:line 125
[23:29:17] [ERR] [82] Microsoft.EntityFrameworkCore.Database.Connection: An error occurred using the connection to database 'main' on server 'C:\Users\Max\AppData\Local\jellyfin\data\jellyfin.db'.
```

</details>
