### PR TITLE
Handle xx as TMDb no language for backdrops

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -595,10 +595,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 var language = TmdbUtils.AdjustImageLanguage(image.Iso_639_1, requestLanguage);
 
                 // Return Backdrops with a language specified (it has text) as Thumb.
-                // TMDb now returns "no language" as "xx".
-                if (imageType == ImageType.Backdrop
-                    && !string.IsNullOrEmpty(language)
-                    && !string.Equals(language, "xx", StringComparison.OrdinalIgnoreCase))
+                if (imageType == ImageType.Backdrop && !string.IsNullOrEmpty(language))
                 {
                     imageType = ImageType.Thumb;
                 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -595,7 +595,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 var language = TmdbUtils.AdjustImageLanguage(image.Iso_639_1, requestLanguage);
 
                 // Return Backdrops with a language specified (it has text) as Thumb.
-                if (imageType == ImageType.Backdrop && !string.IsNullOrEmpty(language))
+                // TMDb now returns "no language" as "xx".
+                if (imageType == ImageType.Backdrop
+                    && !string.IsNullOrEmpty(language)
+                    && !string.Equals(language, "xx", StringComparison.OrdinalIgnoreCase))
                 {
                     imageType = ImageType.Thumb;
                 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -185,7 +185,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 return requestLanguage;
             }
 
-            return imageLanguage;
+            // TMDb now returns xx for no language instead of an empty string.
+            return string.Equals(imageLanguage, "xx", StringComparison.OrdinalIgnoreCase)
+                ? string.Empty
+                : imageLanguage;
         }
 
         /// <summary>

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Providers.Tests.Tmdb
         [InlineData("fr-CA", "fr-BE", "fr-CA")]
         [InlineData("fr-CA", "fr", "fr-CA")]
         [InlineData("de", "en-US", "de")]
+        [InlineData("", "en-US", "")]
         public static void AdjustImageLanguage_Valid_Success(string imageLanguage, string requestLanguage, string? expected)
         {
             Assert.Equal(expected, TmdbUtils.AdjustImageLanguage(imageLanguage, requestLanguage));


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
TMDb now returns `xx` for images that don't have a language, so this change only sets the image type to Thumb if the language is something other than that.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/issues/14922