### PR TITLE
Fix libraries not loading after startup wizard, Change AddVirtualFolder to validate folders

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3051,10 +3051,10 @@ namespace Emby.Server.Implementations.Library
             }
             finally
             {
+                await ValidateTopLibraryFolders(CancellationToken.None).ConfigureAwait(false);
+
                 if (refreshLibrary)
                 {
-                    await ValidateTopLibraryFolders(CancellationToken.None).ConfigureAwait(false);
-
                     StartScanInBackground();
                 }
                 else


### PR DESCRIPTION
**Changes**
Changed the AddVirtualFolder method so that ValidateTopLibraryFolders is always called, regardless of whether the refreshLibrary argument was passed into AddVirtualFolder. This ensures that the new libraries are loaded after completing the startup wizard without triggering a full re-scan. 

**Issues**
Fixes #14868 
