### PR TITLE
Limit decoder thread count on AMD AMF to save VRAM

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6552,7 +6552,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (isD3d11Supported && isCodecAvailable)
                 {
                     return " -hwaccel d3d11va" + (outputHwSurface ? " -hwaccel_output_format d3d11 -noautorotate" + stripRotationDataArgs : string.Empty)
-                        + (profileMismatch ? " -hwaccel_flags +allow_profile_mismatch" : string.Empty) + (isAv1 ? " -c:v av1" : string.Empty);
+                        + (profileMismatch ? " -hwaccel_flags +allow_profile_mismatch" : string.Empty) + " -threads 2" + (isAv1 ? " -c:v av1" : string.Empty);
                 }
             }
 


### PR DESCRIPTION
Just like we did before for QSV and NVDEC. More threads can not improve performance.

**Changes**
- Limit decoder thread count on AMD AMF to save VRAM