### PR TITLE
Fix LUFS detection deadlock per issue #13697

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -277,7 +277,6 @@ public partial class AudioNormalizationTask : IScheduledTask
 
                 lufs = float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
                 foundLufs = true;
-                // Don't break - keep draining stderr to prevent buffer deadlock
             }
 
             if (lufs is null)


### PR DESCRIPTION
The current implementation of the Audio Normalization task has a deadlock issue when scanning albums containing tracks with non-uniform sample rates (e.g., an album where most tracks are 48kHz but one is 96kHz). The task hangs during album LUFS calculation because ffmpeg generates verbose output about sample rate conversions, but the code stops reading stderr after finding the LUFS value.

**Root Cause**
When processing albums with mismatched sample rates, ffmpeg outputs additional warnings/messages to stderr while resampling. The original code used break to exit the loop immediately after finding the LUFS value, which stopped reading from stderr. This causes ffmpeg's stderr buffer to fill up, and ffmpeg blocks waiting for the buffer to drain, resulting in a deadlock.

**Changes**
Replaced the break statement in CalculateLUFSAsync with a foundLufs flag that allows the loop to continue reading and draining ffmpeg's stderr stream after the LUFS value is found. This prevents the deadlock by ensuring the stderr buffer never fills up,regardless of how verbose ffmpeg's output is.

**Issues**
Fixes #13697 

**Remarks**
In my testing of this issue I never got the "Failed to find LUFS value in output" error; it simply hung. This *should* fix that issue based on the original description of the issue, though. 
