### PR TITLE
Improve performance on people query

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1875,10 +1875,17 @@ public sealed class BaseItemRepository
 
         if (filter.PersonIds.Length > 0)
         {
+            var peopleEntityIds = context.BaseItems
+                .Where(b => filter.PersonIds.Contains(b.Id))
+                .Join(
+                    context.Peoples,
+                    b => b.Name,
+                    p => p.Name,
+                    (b, p) => p.Id);
+
             baseQuery = baseQuery
-                .Where(e =>
-                    context.PeopleBaseItemMap.Where(w => context.BaseItems.Where(r => filter.PersonIds.Contains(r.Id)).Any(f => f.Name == w.People.Name))
-                        .Any(f => f.ItemId == e.Id));
+                .Where(e => context.PeopleBaseItemMap
+                    .Any(m => m.ItemId == e.Id && peopleEntityIds.Contains(m.PeopleId)));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.Person))

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1876,7 +1876,7 @@ public sealed class BaseItemRepository
         if (filter.PersonIds.Length > 0)
         {
             var peopleEntityIds = context.BaseItems
-                .Where(b => filter.PersonIds.Contains(b.Id))
+                .WhereOneOrMany(filter.PersonIds, b => b.Id)
                 .Join(
                     context.Peoples,
                     b => b.Name,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Replaced nested subqueries with a direct join between `BaseItems` and` Peoples` on `Name`, then filtered `PeopleBaseItemMap` using the resulting `People.Id`.

Individual cast and crew queries now take less than half a second compared to 2-5 seconds. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
