### PR TITLE
Adding CudaDevice encoding option to allow users to select Cuda deviceIndex

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1126,7 +1126,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     return string.Empty;
                 }
 
-                args.Append(GetCudaDeviceArgs(0, CudaAlias))
+                args.Append(GetCudaDeviceArgs(options.CudaDevice, CudaAlias))
                      .Append(GetFilterHwDeviceArgs(CudaAlias));
             }
             else if (optHwaccelType == HardwareAccelerationType.amf)

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -29,6 +29,7 @@ public class EncodingOptions
         // plus it's the default one in ffmpeg if you don't specify anything
         VaapiDevice = "/dev/dri/renderD128";
         QsvDevice = string.Empty;
+        CudaDevice = 0;
         EnableTonemapping = false;
         EnableVppTonemapping = false;
         EnableVideoToolboxTonemapping = false;
@@ -145,6 +146,11 @@ public class EncodingOptions
     /// Gets or sets the QSV device.
     /// </summary>
     public string QsvDevice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Cuda device.
+    /// </summary>
+    public int CudaDevice { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether tonemapping is enabled.


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
My Jellyfin instance on my Unraid server is unable to properly use the second GPU on my machine. If I pass `NVIDIA_VISIBLE_DEVICES=<GPU_ID>` the container picks up my GPU but when running ffmpeg I get a CUDA_ERROR_NO_DEVICE error since it shows as GPU 0 in the container but is GPU 1 on my machine. If I expose `NVIDIA_VISIBLE_DEVICES=all` then it will always select my first GPU. Adding the encoding option to set which index to use will solve my issue. I have tried to separate the GPU's with IOMMU but without any luck. With testing I found that setting `NVIDIA_VISIBLE_DEVICES=all` and using `-init_hw_device cuda=cu:1` manually it uses the correct GPU without issues.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Add `CudaDevice` to `EncodingOptions.cs`
- Pass `options.CudaDevice` into `GetCudaDeviceArgs` instead of hardcoded `0`
- Default `options.CudaDevice` to `0` to remain existing functionality

**Links**
jellyfin-web PR: https://github.com/jellyfin/jellyfin-web/pull/7184

I followed the pattern from a previously added encoding option: https://github.com/jellyfin/jellyfin/pull/12384
Reference to initial hardcode in 2021 and unchanged since then: https://github.com/jellyfin/jellyfin/pull/6934#discussion_r771781193
