### PR TITLE
Fix contributing artist query

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2014,7 +2014,7 @@ public sealed class BaseItemRepository
 
         if (filter.ArtistIds.Length > 0)
         {
-            baseQuery = baseQuery.WhereReferencedItem(context, ItemValueType.Artist, filter.ArtistIds);
+            baseQuery = baseQuery.WhereReferencedItemMultipleTypes(context, [ItemValueType.Artist, ItemValueType.AlbumArtist], filter.ArtistIds);
         }
 
         if (filter.AlbumArtistIds.Length > 0)

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
@@ -54,6 +54,33 @@ public static class JellyfinQueryHelperExtensions
     }
 
     /// <summary>
+    /// Builds a query that checks referenced ItemValues for a cross BaseItem lookup.
+    /// </summary>
+    /// <param name="baseQuery">The source query.</param>
+    /// <param name="context">The database context.</param>
+    /// <param name="itemValueTypes">The type of item value to reference.</param>
+    /// <param name="referenceIds">The list of BaseItem ids to check matches.</param>
+    /// <param name="invert">If set an exclusion check is performed instead.</param>
+    /// <returns>A Query.</returns>
+    public static IQueryable<BaseItemEntity> WhereReferencedItemMultipleTypes(
+        this IQueryable<BaseItemEntity> baseQuery,
+        JellyfinDbContext context,
+        IList<ItemValueType> itemValueTypes,
+        IList<Guid> referenceIds,
+        bool invert = false)
+    {
+        var itemFilter = OneOrManyExpressionBuilder<BaseItemEntity, Guid>(referenceIds, f => f.Id);
+
+        return baseQuery.Where(item =>
+            context.ItemValues
+                .Join(context.ItemValuesMap, e => e.ItemValueId, e => e.ItemValueId, (itemVal, map) => new { itemVal, map })
+                .Any(val =>
+                    itemValueTypes.Contains(val.itemVal.Type)
+                    && context.BaseItems.Where(itemFilter).Any(e => e.CleanName == val.itemVal.CleanValue)
+                    && val.map.ItemId == item.Id) == EF.Constant(!invert));
+    }
+
+    /// <summary>
     /// Builds a query expression that checks referenced ItemValues for a cross BaseItem lookup.
     /// </summary>
     /// <param name="context">The database context.</param>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

The `ContributingArtistIds` query included items where the artist appeared as both a contributing and album artist, without properly excluding the latter.

**Changes**
- Filter items where the artist appears as a contributing artist
- Explicitly exclude items where the same artist also appears as an album artist
- Update `ArtistIds` filter to check both `ItemValueType.Artist` and `ItemValueType.AlbumArtist` 
- Added `WhereReferencedItemMultipleTypes` helper method

**Issues**
Fixes #14980
