### PR TITLE
Fix exception when saving user data to NFO files

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -317,7 +317,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             {
                                 userData.Played = played;
 
-                                if (!item.Id.Equals(Guid.Empty))
+                                if (!item.Id.IsEmpty())
                                 {
                                     _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
                                 }
@@ -338,7 +338,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             {
                                 userData.PlayCount = count;
 
-                                if (!item.Id.Equals(Guid.Empty))
+                                if (!item.Id.IsEmpty())
                                 {
                                     _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
                                 }
@@ -359,7 +359,7 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             {
                                 userData.LastPlayedDate = lastPlayed;
 
-                                if (!item.Id.Equals(Guid.Empty))
+                                if (!item.Id.IsEmpty())
                                 {
                                     _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);
                                 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixed an exception caused during metadata import when save watch data to NFO was enabled. The NFO parser now checks if an item has been saved to the database before attempting to save user data.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 
Fixes #14534
Fixes #14507
