### PR TITLE
Remove database Endpoint to restore pre 10.11 functionality

### DIFF
--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -80,6 +80,11 @@ public class ConfigurationController : BaseJellyfinApiController
     [ProducesFile(MediaTypeNames.Application.Json)]
     public ActionResult<object> GetNamedConfiguration([FromRoute, Required] string key)
     {
+        if (string.Equals(key, "database", StringComparison.OrdinalIgnoreCase))
+        {
+            return NotFound();
+        }
+
         return _configurationManager.GetConfiguration(key);
     }
 
@@ -95,6 +100,11 @@ public class ConfigurationController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateNamedConfiguration([FromRoute, Required] string key, [FromBody, Required] JsonDocument configuration)
     {
+        if (string.Equals(key, "database", StringComparison.OrdinalIgnoreCase))
+        {
+            return NotFound();
+        }
+
         var configurationType = _configurationManager.GetConfigurationType(key);
         var deserializedConfiguration = configuration.Deserialize(configurationType, _serializerOptions);
 


### PR DESCRIPTION
this restores pre 10.11 handling of this endpoint.
as per chat with @JPVenson it seems like this was unintentionally added anyway in [aa811eb](https://github.com/jellyfin/jellyfin/commit/aa811eb1e3c78bdf8f4a751311c1bb6d639e851e).

Also im not so sure if its a good idea to let every authenticated user see the database connection details. with a provider like JPVenson/Jellyfin.Pgsql, this would leak the connection string.

**Changes**
- Removes the `POST/GET /System/Configuration/database` endpoint

this is kind of a hack, in the medium term i think the generic endpoint should be removed anyway. 