### PR TITLE
Use TryAdd instead of Add when registering custom OpenAPI responses

### DIFF
--- a/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
+++ b/Jellyfin.Server/Filters/RetryOnTemporarilyUnavailableFilter.cs
@@ -8,7 +8,7 @@ internal class RetryOnTemporarilyUnavailableFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        operation.Responses.Add(
+        operation.Responses.TryAdd(
             "503",
             new OpenApiResponse
             {

--- a/Jellyfin.Server/Filters/SecurityRequirementsOperationFilter.cs
+++ b/Jellyfin.Server/Filters/SecurityRequirementsOperationFilter.cs
@@ -66,15 +66,8 @@ public class SecurityRequirementsOperationFilter : IOperationFilter
             return;
         }
 
-        if (!operation.Responses.ContainsKey("401"))
-        {
-            operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
-        }
-
-        if (!operation.Responses.ContainsKey("403"))
-        {
-            operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
-        }
+        operation.Responses.TryAdd("401", new OpenApiResponse { Description = "Unauthorized" });
+        operation.Responses.TryAdd("403", new OpenApiResponse { Description = "Forbidden" });
 
         var scheme = new OpenApiSecurityScheme
         {


### PR DESCRIPTION
Turns out swagger doesn't currently load.. 