### PR TITLE
Fix issue 12734 Rm StartupTrigger for CleanupCollectionAndPlaylistpathsTask

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -131,9 +131,6 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        yield return new TaskTriggerInfo
-        {
-            Type = TaskTriggerInfoType.StartupTrigger,
-        };
+        yield break;
     }
 }


### PR DESCRIPTION


**Changes**
The "Clean up collection and playlist" task is not triggered on startup anymore because that can lead to data loss quickly if the data storage is not mounted.


**Issues**
issue [12734](https://github.com/jellyfin/jellyfin/issues/12734)
