### PR TITLE
Log the message more clear when network manager is not ready

### DIFF
--- a/Jellyfin.Server/ServerSetupApp/SetupServer.cs
+++ b/Jellyfin.Server/ServerSetupApp/SetupServer.cs
@@ -250,6 +250,7 @@ public sealed class SetupServer : IDisposable
                                                 { "isInReportingMode", _isUnhealthy },
                                                 { "retryValue", retryAfterValue },
                                                 { "logs", startupLogEntries },
+                                                { "networkManagerReady", networkManager is not null },
                                                 { "localNetworkRequest", networkManager is not null && context.Connection.RemoteIpAddress is not null && networkManager.IsInLocalNetwork(context.Connection.RemoteIpAddress) }
                                             },
                                             new ByteCounterStream(context.Response.BodyWriter.AsStream(), IODefaults.FileStreamBufferSize, true, _startupUiRenderer.ParserOptions))

--- a/Jellyfin.Server/ServerSetupApp/index.mstemplate.html
+++ b/Jellyfin.Server/ServerSetupApp/index.mstemplate.html
@@ -213,7 +213,12 @@
             </ol>
         </div>
         {{#ELSE}}
+        {{#IF networkManagerReady}}
         <p>Please visit this page from your local network to view detailed startup logs.</p>
+        {{#ELSE}}
+        <p>Initializing network settings. Please wait.</p>
+        {{/ELSE}}
+        {{/IF}}
         {{/ELSE}}
         {{/IF}}
     </div>


### PR DESCRIPTION
During starup logging, we have to wait the for network manager is up to actually log anything. But current log is confusing as it directly tells the user to connect from LAN even when the user already does.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #15052 
