### PR TITLE
Add media source version prioritization

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,6 +87,7 @@
  - [Maxr1998](https://github.com/Maxr1998)
  - [mcarlton00](https://github.com/mcarlton00)
  - [mitchfizz05](https://github.com/mitchfizz05)
+ - [mlaustin44](https://github.com/mlaustin44)
  - [mohd-akram](https://github.com/mohd-akram)
  - [MrTimscampi](https://github.com/MrTimscampi)
  - [n8225](https://github.com/n8225)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1103,7 +1103,8 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
-            return result.OrderBy(i =>
+            var mediaSourceOptions = ConfigurationManager.Configuration.MediaSourceOptions;
+            var sorted = result.OrderBy(i =>
             {
                 if (i.VideoType == VideoType.VideoFile)
                 {
@@ -1111,9 +1112,33 @@ namespace MediaBrowser.Controller.Entities
                 }
 
                 return 1;
-            }).ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
-            .ThenByDescending(i => i, new MediaSourceWidthComparator())
-            .ToArray();
+            }).ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0);
+
+            // Apply preferred resolution if configured
+            if (mediaSourceOptions.PreferredVideoHeight.HasValue)
+            {
+                var preferredHeight = mediaSourceOptions.PreferredVideoHeight.Value;
+                sorted = sorted.ThenBy(i =>
+                {
+                    var height = i.VideoStream?.Height ?? 0;
+                    // Preferred resolution goes first (0), everything else goes after (1)
+                    return Math.Abs(height - preferredHeight) < 10 ? 0 : 1;
+                });
+            }
+
+            // Apply sort direction for remaining items
+            // Note: We sort by width since alternate versions have different paths
+            // and MediaSourceWidthComparator only compares items with the same path
+            if (mediaSourceOptions.SortOrder == Model.Configuration.MediaSourceSortOrder.Ascending)
+            {
+                sorted = sorted.ThenBy(i => i.VideoStream?.Width ?? 0);
+            }
+            else
+            {
+                sorted = sorted.ThenByDescending(i => i.VideoStream?.Width ?? 0);
+            }
+
+            return sorted.ToArray();
         }
 
         protected virtual IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()

--- a/MediaBrowser.Model/Configuration/MediaSourceOptions.cs
+++ b/MediaBrowser.Model/Configuration/MediaSourceOptions.cs
@@ -1,0 +1,35 @@
+namespace MediaBrowser.Model.Configuration;
+
+/// <summary>
+/// Sort direction for media sources.
+/// </summary>
+public enum MediaSourceSortOrder
+{
+    /// <summary>
+    /// Sort by descending resolution (highest first).
+    /// </summary>
+    Descending = 0,
+
+    /// <summary>
+    /// Sort by ascending resolution (lowest first).
+    /// </summary>
+    Ascending = 1
+}
+
+/// <summary>
+/// Configuration options for media source selection and ordering.
+/// </summary>
+public class MediaSourceOptions
+{
+    /// <summary>
+    /// Gets or sets the sort order for media sources when multiple versions are available.
+    /// </summary>
+    public MediaSourceSortOrder SortOrder { get; set; } = MediaSourceSortOrder.Descending;
+
+    /// <summary>
+    /// Gets or sets the preferred video resolution height (e.g., 1080, 720, 2160).
+    /// If set, this resolution will be prioritized as the first option, followed by others sorted by SortOrder.
+    /// Null means no preference.
+    /// </summary>
+    public int? PreferredVideoHeight { get; set; }
+}

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -285,6 +285,12 @@ public class ServerConfiguration : BaseApplicationConfiguration
     public TrickplayOptions TrickplayOptions { get; set; } = new TrickplayOptions();
 
     /// <summary>
+    /// Gets or sets the media source options.
+    /// </summary>
+    /// <value>The media source options.</value>
+    public MediaSourceOptions MediaSourceOptions { get; set; } = new MediaSourceOptions();
+
+    /// <summary>
     /// Gets or sets a value indicating whether old authorization methods are allowed.
     /// </summary>
     public bool EnableLegacyAuthorization { get; set; } = true;

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -1,5 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
 using Moq;
 using Xunit;
@@ -42,5 +51,168 @@ public class BaseItemTests
 
         Assert.Equal(name, video.GetMediaSourceName(video));
         Assert.Equal(altName, video.GetMediaSourceName(videoAlt));
+    }
+
+    [Fact]
+    public void GetMediaSources_DefaultDescending_OrdersHighToLow()
+    {
+        var (video, _) = SetupVideoTest(null, null);
+
+        var sources = video.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(2160, sources[0].VideoStream?.Height);
+        Assert.Equal(1080, sources[1].VideoStream?.Height);
+        Assert.Equal(720, sources[2].VideoStream?.Height);
+    }
+
+    [Fact]
+    public void GetMediaSources_AscendingSortOrder_OrdersLowToHigh()
+    {
+        var (video, _) = SetupVideoTest(MediaSourceSortOrder.Ascending, null);
+
+        var sources = video.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(720, sources[0].VideoStream?.Height);
+        Assert.Equal(1080, sources[1].VideoStream?.Height);
+        Assert.Equal(2160, sources[2].VideoStream?.Height);
+    }
+
+    [Fact]
+    public void GetMediaSources_PreferredHeight1080_Places1080First()
+    {
+        var (video, _) = SetupVideoTest(MediaSourceSortOrder.Descending, 1080);
+
+        var sources = video.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(1080, sources[0].VideoStream?.Height);
+        Assert.Equal(2160, sources[1].VideoStream?.Height);
+        Assert.Equal(720, sources[2].VideoStream?.Height);
+    }
+
+    [Fact]
+    public void GetMediaSources_PreferredHeight720WithAscending_Places720FirstThenAscending()
+    {
+        var (video, _) = SetupVideoTest(MediaSourceSortOrder.Ascending, 720);
+
+        var sources = video.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(720, sources[0].VideoStream?.Height);
+        Assert.Equal(1080, sources[1].VideoStream?.Height);
+        Assert.Equal(2160, sources[2].VideoStream?.Height);
+    }
+
+    [Fact]
+    public void GetMediaSources_PreferredHeight2160WithAscending_Places2160FirstThenAscending()
+    {
+        var (video, _) = SetupVideoTest(MediaSourceSortOrder.Ascending, 2160);
+
+        var sources = video.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(2160, sources[0].VideoStream?.Height);
+        Assert.Equal(720, sources[1].VideoStream?.Height);
+        Assert.Equal(1080, sources[2].VideoStream?.Height);
+    }
+
+    private static (TestableVideo Video, Mock<IMediaSourceManager> MediaSourceManager) SetupVideoTest(MediaSourceSortOrder? sortOrder, int? preferredHeight)
+    {
+        var serverConfiguration = new ServerConfiguration
+        {
+            MediaSourceOptions = new MediaSourceOptions
+            {
+                SortOrder = sortOrder ?? MediaSourceSortOrder.Descending,
+                PreferredVideoHeight = preferredHeight
+            }
+        };
+
+        var configurationManager = new Mock<IServerConfigurationManager>();
+        configurationManager.Setup(x => x.Configuration).Returns(serverConfiguration);
+
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>()))
+            .Returns(MediaProtocol.File);
+        mediaSourceManager.Setup(x => x.GetMediaStreams(It.IsAny<Guid>()))
+            .Returns((Guid id) =>
+            {
+                // Return appropriate video stream based on the video ID
+                var streams = new List<MediaStream>();
+                var idString = id.ToString();
+                if (idString.EndsWith("0720", StringComparison.Ordinal))
+                {
+                    streams.Add(new MediaStream { Type = MediaStreamType.Video, Height = 720, Width = 1280 });
+                }
+                else if (idString.EndsWith("1080", StringComparison.Ordinal))
+                {
+                    streams.Add(new MediaStream { Type = MediaStreamType.Video, Height = 1080, Width = 1920 });
+                }
+                else if (idString.EndsWith("2160", StringComparison.Ordinal))
+                {
+                    streams.Add(new MediaStream { Type = MediaStreamType.Video, Height = 2160, Width = 3840 });
+                }
+
+                return streams;
+            });
+        mediaSourceManager.Setup(x => x.GetMediaAttachments(It.IsAny<Guid>()))
+            .Returns(Array.Empty<MediaAttachment>());
+
+        var recordingsManager = new Mock<IRecordingsManager>();
+        recordingsManager.Setup(x => x.GetActiveRecordingInfo(It.IsAny<string>()))
+            .Returns((ActiveRecordingInfo?)null);
+
+        var mediaSegmentManager = new Mock<IMediaSegmentManager>();
+        mediaSegmentManager.Setup(x => x.IsTypeSupported(It.IsAny<BaseItem>()))
+            .Returns(false);
+        mediaSegmentManager.Setup(x => x.HasSegments(It.IsAny<Guid>()))
+            .Returns(false);
+
+        BaseItem.ConfigurationManager = configurationManager.Object;
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        BaseItem.MediaSegmentManager = mediaSegmentManager.Object;
+        Video.RecordingsManager = recordingsManager.Object;
+
+        var video = new TestableVideo();
+
+        return (video, mediaSourceManager);
+    }
+
+    private class TestableVideo : Video
+    {
+        public TestableVideo()
+        {
+            // Create three versions with different resolutions
+            Id = Guid.Parse("00000000-0000-0000-0000-000000002160");
+            Path = "/media/movie-4k.mkv";
+
+            LocalAlternateVersions =
+            [
+                "/media/movie-1080p.mkv",
+                "/media/movie-720p.mkv"
+            ];
+        }
+
+        protected override IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()
+        {
+            // Return the main item (4K)
+            yield return (this, MediaSourceType.Default);
+
+            // Return alternate versions
+            var video1080 = new Video
+            {
+                Id = Guid.Parse("00000000-0000-0000-0000-000000001080"),
+                Path = "/media/movie-1080p.mkv"
+            };
+            yield return (video1080, MediaSourceType.Default);
+
+            var video720 = new Video
+            {
+                Id = Guid.Parse("00000000-0000-0000-0000-000000000720"),
+                Path = "/media/movie-720p.mkv"
+            };
+            yield return (video720, MediaSourceType.Default);
+        }
     }
 }

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -179,7 +179,7 @@ public class BaseItemTests
         return (video, mediaSourceManager);
     }
 
-    private class TestableVideo : Video
+    private sealed class TestableVideo : Video
     {
         public TestableVideo()
         {


### PR DESCRIPTION
**Changes**
Adds server configuration options to control the ordering of media sources when multiple video versions are available (e.g., 4K, 1080p, 720p). Administrators can set a preferred resolution (e.g., 1080p) to be selected first, and configure whether remaining versions sort by ascending or descending quality. This allows control of which version is used by default during playback, which is highly useful for libraries that have a 4k and a 720p/1080p version of content - as right now the default behavior would be to transcode the 4k version!

This PR only covers the server, but I intend to work on a matching PR to the web app once this is merged.

**Issues**

