### PR TITLE
Reject stream copy of HDR10+ video if the client does not support HDR10

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2390,8 +2390,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                             || (requestHasSDR && videoStream.VideoRangeType == VideoRangeType.DOVIWithSDR)
                             || (requestHasHDR10 && videoStream.VideoRangeType == VideoRangeType.HDR10Plus)))
                 {
-                    // If the video stream is in a static HDR format, don't allow copy if the client does not support HDR10 or HLG.
-                    if (videoStream.VideoRangeType is VideoRangeType.HDR10 or VideoRangeType.HLG)
+                    // If the video stream is in HDR10+ or a static HDR format, don't allow copy if the client does not support HDR10 or HLG.
+                    if (videoStream.VideoRangeType is VideoRangeType.HDR10Plus or VideoRangeType.HDR10 or VideoRangeType.HLG)
                     {
                         return false;
                     }


### PR DESCRIPTION
**Changes**
- Reject stream copy of HDR10+ video if the client does not support HDR10

**Issues**
- Fixes an issue with no server-side tone mapping when playing HDR10+ videos on Firefox