### PR TITLE
Fix LiveTV images not saving to database

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -614,6 +614,13 @@ public sealed class BaseItemRepository
             else
             {
                 context.BaseItemProviders.Where(e => e.ItemId == entity.Id).ExecuteDelete();
+                context.BaseItemImageInfos.Where(e => e.ItemId == entity.Id).ExecuteDelete();
+
+                if (entity.Images is { Count: > 0 })
+                {
+                    context.BaseItemImageInfos.AddRange(entity.Images);
+                }
+
                 context.BaseItems.Attach(entity).State = EntityState.Modified;
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

LiveTV images were not being saved to the database because `UpdateOrInsertItems` only handled provider IDs during updates, but ignored images. When `GuideManager` set images on LiveTV channels and programs and called `UpdateOrInsertItems`, the images, although downloaded, were never written to the database.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added image handling to the update path in `UpdateOrInsertItems`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 

Reported on the [forum](https://forum.jellyfin.org/t-10-11-update-breaks-channel-logos-in-live-tv?pid=65530#pid65530)
