### PR TITLE
Optimize WhereReferencedItemMultipleTypes filtering

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2046,7 +2046,7 @@ public sealed class BaseItemRepository
 
         if (filter.ExcludeArtistIds.Length > 0)
         {
-            baseQuery = baseQuery.WhereReferencedItem(context, ItemValueType.Artist, filter.ExcludeArtistIds, true);
+            baseQuery = baseQuery.WhereReferencedItemMultipleTypes(context, [ItemValueType.Artist, ItemValueType.AlbumArtist], filter.ExcludeArtistIds, true);
         }
 
         if (filter.GenreIds.Count > 0)

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
@@ -70,13 +70,14 @@ public static class JellyfinQueryHelperExtensions
         bool invert = false)
     {
         var itemFilter = OneOrManyExpressionBuilder<BaseItemEntity, Guid>(referenceIds, f => f.Id);
+        var typeFilter = OneOrManyExpressionBuilder<ItemValue, ItemValueType>(itemValueTypes, iv => iv.Type);
 
         return baseQuery.Where(item =>
             context.ItemValues
+                .Where(typeFilter)
                 .Join(context.ItemValuesMap, e => e.ItemValueId, e => e.ItemValueId, (itemVal, map) => new { itemVal, map })
                 .Any(val =>
-                    itemValueTypes.Contains(val.itemVal.Type)
-                    && context.BaseItems.Where(itemFilter).Any(e => e.CleanName == val.itemVal.CleanValue)
+                    context.BaseItems.Where(itemFilter).Any(e => e.CleanName == val.itemVal.CleanValue)
                     && val.map.ItemId == item.Id) == EF.Constant(!invert));
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Use the `OneOrManyExpressionBuilder` for the type filter
- Applied the type filter .`Where(typeFilter)` before the join operation

Other changes:
- Update `ExcludeArtistIds` filter to check both `ItemValueType.Artist` and `ItemValueType.AlbumArtist`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #15111
Fixes issue reported in [15079](https://github.com/jellyfin/jellyfin/issues/15079)
