### PR TITLE
Lower required tmp dir size to 512MiB

### DIFF
--- a/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
+++ b/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
@@ -27,7 +27,7 @@ public static class StorageHelper
         TestDataDirectorySize(applicationPaths.LogDirectoryPath, logger, FiveHundredAndTwelveMegaByte);
         TestDataDirectorySize(applicationPaths.CachePath, logger, TwoGigabyte);
         TestDataDirectorySize(applicationPaths.ProgramDataPath, logger, TwoGigabyte);
-        TestDataDirectorySize(applicationPaths.TempDirectory, logger, TwoGigabyte);
+        TestDataDirectorySize(applicationPaths.TempDirectory, logger, FiveHundredAndTwelveMegaByte);
     }
 
     /// <summary>


### PR DESCRIPTION
We don't put anything big there anyway and I prefer to not put up an artificial limitation.

**Issues**
Fixes #15036
