### PR TITLE
Skip extracted files in migration if bad timestamp or no access

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MoveExtractedFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/MoveExtractedFiles.cs
@@ -224,6 +224,12 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
 
                 return null;
             }
+            catch (UnauthorizedAccessException e)
+            {
+                _logger.LogDebug("Skipping subtitle at index {Index} for {Path}: {Exception}", attachmentStreamIndex, mediaPath, e.Message);
+
+                return null;
+            }
             catch (ArgumentOutOfRangeException e)
             {
                 _logger.LogDebug("Skipping attachment at index {Index} for {Path}: {Exception}", attachmentStreamIndex, mediaPath, e.Message);
@@ -270,6 +276,12 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
             date = File.GetLastWriteTimeUtc(path);
         }
         catch (ArgumentOutOfRangeException e)
+        {
+            _logger.LogDebug("Skipping subtitle at index {Index} for {Path}: {Exception}", streamIndex, path, e.Message);
+
+            return null;
+        }
+        catch (UnauthorizedAccessException e)
         {
             _logger.LogDebug("Skipping subtitle at index {Index} for {Path}: {Exception}", streamIndex, path, e.Message);
 


### PR DESCRIPTION
For some  reason in certain cases the filesystem reports invalid dates for creation dates. Not much we can do about this but now the migration at least does not crash.

**Changes**
* Skip files with invalid timestamps
* Skip files if access denied

**Issues**
Fixes #15024
Fixes #15030