### PR TITLE
Add season number fallback for OMDB and TMDB plugins

### DIFF
--- a/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
@@ -138,6 +138,8 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             var item = itemResult.Item;
+            item.IndexNumber = episodeNumber;
+            item.ParentIndexNumber = seasonNumber;
 
             var seasonResult = await GetSeasonRootObject(seriesImdbId, seasonNumber, cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -177,8 +177,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             var item = new Episode
             {
-                IndexNumber = info.IndexNumber,
-                ParentIndexNumber = info.ParentIndexNumber,
+                IndexNumber = episodeNumber,
+                ParentIndexNumber = seasonNumber,
                 IndexNumberEnd = info.IndexNumberEnd,
                 Name = episodeResult.Name,
                 PremiereDate = episodeResult.AirDate,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Add fallback value of 1 for season number when it is null.

Newer version of jellyfin does not seem to assign season number in case it is not indicated in the folder/file name and will group the episodes into "Season Unknown". This PR forces season 1 in case that happens.

**Issues**
Fixes #13997
