### PR TITLE
Fix videos with cropping metadata are probed as anamorphic

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -930,6 +930,15 @@ namespace MediaBrowser.MediaEncoding.Probing
                         {
                             stream.Rotation = data.Rotation;
                         }
+
+                        // Parse video frame cropping metadata from side_data
+                        // TODO: save them and make HW filters to apply them in HWA pipelines
+                        else if (string.Equals(data.SideDataType, "Frame Cropping", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Streams containing artificially added frame cropping
+                            // metadata should not be marked as anamorphic.
+                            stream.IsAnamorphic = false;
+                        }
                     }
                 }
 


### PR DESCRIPTION
**Changes**
- Fix videos with cropping metadata are probed as anamorphic
  (regression made in #14648)

**Issues**
- Fixes #15134
