### PR TITLE
Added Endpoint to Get the Items on a SyncPlay Queue

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -24,6 +24,7 @@ using MediaBrowser.Controller.Trickplay;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
+using MediaBrowser.Model.SyncPlay;
 using Microsoft.Extensions.Logging;
 using Book = MediaBrowser.Controller.Entities.Book;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
@@ -369,6 +370,14 @@ namespace Emby.Server.Implementations.Dto
             }
 
             return dto;
+        }
+
+        /// <inheritdoc />
+        public SyncPlayQueueItemDto GetSyncPlayQueueItemDto(SyncPlayQueueItem syncPlayQueueItem)
+        {
+            var baseItem = _libraryManager.GetItemById(syncPlayQueueItem.ItemId);
+            var baseItemDto = baseItem == null ? null : GetBaseItemDto(baseItem, new DtoOptions());
+            return new SyncPlayQueueItemDto(syncPlayQueueItem.ItemId, syncPlayQueueItem.PlaylistItemId, baseItemDto);
         }
 
         private void SetItemByNameInfo(BaseItemDto dto, User? user)

--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay;
@@ -69,16 +70,19 @@ namespace Emby.Server.Implementations.SyncPlay
         /// <param name="userManager">The user manager.</param>
         /// <param name="sessionManager">The session manager.</param>
         /// <param name="libraryManager">The library manager.</param>
+        /// <param name="dtoService">The dto service.</param>
         public Group(
             ILoggerFactory loggerFactory,
             IUserManager userManager,
             ISessionManager sessionManager,
-            ILibraryManager libraryManager)
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
         {
             _loggerFactory = loggerFactory;
             _userManager = userManager;
             _sessionManager = sessionManager;
             _libraryManager = libraryManager;
+            PlayQueue = new PlayQueueManager(dtoService);
             _logger = loggerFactory.CreateLogger<Group>();
 
             _state = new IdleGroupState(loggerFactory);
@@ -118,7 +122,7 @@ namespace Emby.Server.Implementations.SyncPlay
         /// Gets the group identifier.
         /// </summary>
         /// <value>The group identifier.</value>
-        public PlayQueueManager PlayQueue { get; } = new PlayQueueManager();
+        public PlayQueueManager PlayQueue { get; init; }
 
         /// <summary>
         /// Gets the runtime ticks of current playing item.
@@ -668,7 +672,7 @@ namespace Emby.Server.Implementations.SyncPlay
             return new PlayQueueUpdate(
                 reason,
                 PlayQueue.LastChange,
-                PlayQueue.GetPlaylist(),
+                PlayQueue.GetPlaylistDto(),
                 PlayQueue.PlayingItemIndex,
                 startPositionTicks,
                 isPlaying,

--- a/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
+++ b/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay;
@@ -44,6 +45,11 @@ namespace Emby.Server.Implementations.SyncPlay
         private readonly ILibraryManager _libraryManager;
 
         /// <summary>
+        /// The dto service.
+        /// </summary>
+        private readonly IDtoService _dtoService;
+
+        /// <summary>
         /// The map between users and counter of active sessions.
         /// </summary>
         private readonly ConcurrentDictionary<Guid, int> _activeUsers =
@@ -78,16 +84,19 @@ namespace Emby.Server.Implementations.SyncPlay
         /// <param name="userManager">The user manager.</param>
         /// <param name="sessionManager">The session manager.</param>
         /// <param name="libraryManager">The library manager.</param>
+        /// <param name="dtoService">The dto service.</param>
         public SyncPlayManager(
             ILoggerFactory loggerFactory,
             IUserManager userManager,
             ISessionManager sessionManager,
-            ILibraryManager libraryManager)
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
         {
             _loggerFactory = loggerFactory;
             _userManager = userManager;
             _sessionManager = sessionManager;
             _libraryManager = libraryManager;
+            _dtoService = dtoService;
             _logger = loggerFactory.CreateLogger<SyncPlayManager>();
             _sessionManager.SessionEnded += OnSessionEnded;
         }
@@ -122,7 +131,7 @@ namespace Emby.Server.Implementations.SyncPlay
                     LeaveGroup(session, leaveGroupRequest, cancellationToken);
                 }
 
-                var group = new Group(_loggerFactory, _userManager, _sessionManager, _libraryManager);
+                var group = new Group(_loggerFactory, _userManager, _sessionManager, _libraryManager, _dtoService);
                 _groups[group.GroupId] = group;
 
                 if (!_sessionToGroupMap.TryAdd(session.Id, group))

--- a/Jellyfin.Api/Controllers/SyncPlayController.cs
+++ b/Jellyfin.Api/Controllers/SyncPlayController.cs
@@ -222,6 +222,21 @@ public class SyncPlayController : BaseJellyfinApiController
     }
 
     /// <summary>
+    /// Gets the current SyncPlay queue.
+    /// </summary>
+    /// <response code="200">Queue returned.</response>
+    /// <returns>An <see cref="IEnumerable{SyncPlayQueueItem}"/> containing the current queue items.</returns>
+    [HttpGet("Queue")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [Authorize(Policy = Policies.SyncPlayIsInGroup)]
+    public async Task<ActionResult<IEnumerable<SyncPlayQueueItem>>> SyncPlayGetQueue()
+    {
+        var currentSession = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
+        var queue = _syncPlayManager.GetQueue(currentSession) ?? [];
+        return Ok(queue.AsEnumerable());
+    }
+
+    /// <summary>
     /// Request unpause in SyncPlay group.
     /// </summary>
     /// <response code="204">Unpause update sent to all group members.</response>

--- a/Jellyfin.Api/Controllers/SyncPlayController.cs
+++ b/Jellyfin.Api/Controllers/SyncPlayController.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay;
 using MediaBrowser.Controller.SyncPlay.PlaybackRequests;
 using MediaBrowser.Controller.SyncPlay.Requests;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.SyncPlay;
 using Microsoft.AspNetCore.Authorization;

--- a/Jellyfin.Api/Controllers/SyncPlayController.cs
+++ b/Jellyfin.Api/Controllers/SyncPlayController.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay;
 using MediaBrowser.Controller.SyncPlay.PlaybackRequests;
 using MediaBrowser.Controller.SyncPlay.Requests;
+using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.SyncPlay;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -225,15 +226,15 @@ public class SyncPlayController : BaseJellyfinApiController
     /// Gets the current SyncPlay queue.
     /// </summary>
     /// <response code="200">Queue returned.</response>
-    /// <returns>An <see cref="IEnumerable{SyncPlayQueueItem}"/> containing the current queue items.</returns>
+    /// <returns>A <see cref="QueryResult{SyncPlayQueueItem}"/> containing the current queue items.</returns>
     [HttpGet("Queue")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [Authorize(Policy = Policies.SyncPlayIsInGroup)]
-    public async Task<ActionResult<IEnumerable<SyncPlayQueueItem>>> SyncPlayGetQueue()
+    public async Task<ActionResult<QueryResult<SyncPlayQueueItem>>> SyncPlayGetQueue()
     {
         var currentSession = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
-        var queue = _syncPlayManager.GetQueue(currentSession) ?? [];
-        return Ok(queue.AsEnumerable());
+        var queue = _syncPlayManager.GetQueue(currentSession);
+        return Ok(new QueryResult<SyncPlayQueueItem>(queue));
     }
 
     /// <summary>

--- a/MediaBrowser.Controller/Dto/IDtoService.cs
+++ b/MediaBrowser.Controller/Dto/IDtoService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.SyncPlay;
 
 namespace MediaBrowser.Controller.Dto
 {
@@ -48,5 +49,12 @@ namespace MediaBrowser.Controller.Dto
         /// <param name="user">The user.</param>
         /// <returns>The item dto.</returns>
         BaseItemDto GetItemByNameDto(BaseItem item, DtoOptions options, List<BaseItem>? taggedItems, User? user = null);
+
+        /// <summary>
+        /// Gets the sync play queue item dto.
+        /// </summary>
+        /// <param name="syncPlayQueueItem">The item.</param>
+        /// <returns>SyncPlayQueueItemDto.</returns>
+        SyncPlayQueueItemDto GetSyncPlayQueueItemDto(SyncPlayQueueItem syncPlayQueueItem);
     }
 }

--- a/MediaBrowser.Controller/SyncPlay/ISyncPlayManager.cs
+++ b/MediaBrowser.Controller/SyncPlay/ISyncPlayManager.cs
@@ -56,6 +56,13 @@ namespace MediaBrowser.Controller.SyncPlay
         GroupInfoDto GetGroup(SessionInfo session, Guid groupId);
 
         /// <summary>
+        /// Gets the current queue for the session's group.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <returns>The current queue items.</returns>
+        IReadOnlyList<SyncPlayQueueItem> GetQueue(SessionInfo session);
+
+        /// <summary>
         /// Handle a request by a session in a group.
         /// </summary>
         /// <param name="session">The session.</param>

--- a/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
+++ b/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Dto;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.SyncPlay;
 
 namespace MediaBrowser.Controller.SyncPlay.Queue

--- a/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
+++ b/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Extensions;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Model.SyncPlay;
 
 namespace MediaBrowser.Controller.SyncPlay.Queue
@@ -20,6 +21,11 @@ namespace MediaBrowser.Controller.SyncPlay.Queue
         private const int NoPlayingItemIndex = -1;
 
         /// <summary>
+        /// The dto service.
+        /// </summary>
+        private readonly IDtoService _dtoService;
+
+        /// <summary>
         /// The sorted playlist.
         /// </summary>
         /// <value>The sorted playlist, or play queue of the group.</value>
@@ -34,8 +40,10 @@ namespace MediaBrowser.Controller.SyncPlay.Queue
         /// <summary>
         /// Initializes a new instance of the <see cref="PlayQueueManager" /> class.
         /// </summary>
-        public PlayQueueManager()
+        /// <param name="dtoService">The dto service.</param>
+        public PlayQueueManager(IDtoService dtoService)
         {
+            _dtoService = dtoService;
             Reset();
         }
 
@@ -79,6 +87,17 @@ namespace MediaBrowser.Controller.SyncPlay.Queue
         public IReadOnlyList<SyncPlayQueueItem> GetPlaylist()
         {
             return GetPlaylistInternal();
+        }
+
+        /// <summary>
+        /// Gets the current playlist considering the shuffle mode.
+        /// </summary>
+        /// <returns>The playlist.</returns>
+        public IReadOnlyList<SyncPlayQueueItemDto> GetPlaylistDto()
+        {
+            var playlist = GetPlaylist();
+
+            return playlist.Select(_dtoService.GetSyncPlayQueueItemDto).ToList();
         }
 
         /// <summary>

--- a/MediaBrowser.Model/Dto/SyncPlayQueueItemDto.cs
+++ b/MediaBrowser.Model/Dto/SyncPlayQueueItemDto.cs
@@ -1,7 +1,6 @@
 using System;
-using MediaBrowser.Model.Dto;
 
-namespace MediaBrowser.Model.SyncPlay;
+namespace MediaBrowser.Model.Dto;
 
 /// <summary>
 /// Enhanced SyncPlay queue item that includes full BaseItemDto details.

--- a/MediaBrowser.Model/SyncPlay/PlayQueueUpdate.cs
+++ b/MediaBrowser.Model/SyncPlay/PlayQueueUpdate.cs
@@ -1,82 +1,81 @@
 using System;
 using System.Collections.Generic;
 
-namespace MediaBrowser.Model.SyncPlay
+namespace MediaBrowser.Model.SyncPlay;
+
+/// <summary>
+/// Class PlayQueueUpdate.
+/// </summary>
+public class PlayQueueUpdate
 {
     /// <summary>
-    /// Class PlayQueueUpdate.
+    /// Initializes a new instance of the <see cref="PlayQueueUpdate"/> class.
     /// </summary>
-    public class PlayQueueUpdate
+    /// <param name="reason">The reason for the update.</param>
+    /// <param name="lastUpdate">The UTC time of the last change to the playing queue.</param>
+    /// <param name="playlist">The playlist.</param>
+    /// <param name="playingItemIndex">The playing item index in the playlist.</param>
+    /// <param name="startPositionTicks">The start position ticks.</param>
+    /// <param name="isPlaying">The playing item status.</param>
+    /// <param name="shuffleMode">The shuffle mode.</param>
+    /// <param name="repeatMode">The repeat mode.</param>
+    public PlayQueueUpdate(PlayQueueUpdateReason reason, DateTime lastUpdate, IReadOnlyList<SyncPlayQueueItemDto> playlist, int playingItemIndex, long startPositionTicks, bool isPlaying, GroupShuffleMode shuffleMode, GroupRepeatMode repeatMode)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PlayQueueUpdate"/> class.
-        /// </summary>
-        /// <param name="reason">The reason for the update.</param>
-        /// <param name="lastUpdate">The UTC time of the last change to the playing queue.</param>
-        /// <param name="playlist">The playlist.</param>
-        /// <param name="playingItemIndex">The playing item index in the playlist.</param>
-        /// <param name="startPositionTicks">The start position ticks.</param>
-        /// <param name="isPlaying">The playing item status.</param>
-        /// <param name="shuffleMode">The shuffle mode.</param>
-        /// <param name="repeatMode">The repeat mode.</param>
-        public PlayQueueUpdate(PlayQueueUpdateReason reason, DateTime lastUpdate, IReadOnlyList<SyncPlayQueueItem> playlist, int playingItemIndex, long startPositionTicks, bool isPlaying, GroupShuffleMode shuffleMode, GroupRepeatMode repeatMode)
-        {
-            Reason = reason;
-            LastUpdate = lastUpdate;
-            Playlist = playlist;
-            PlayingItemIndex = playingItemIndex;
-            StartPositionTicks = startPositionTicks;
-            IsPlaying = isPlaying;
-            ShuffleMode = shuffleMode;
-            RepeatMode = repeatMode;
-        }
-
-        /// <summary>
-        /// Gets the request type that originated this update.
-        /// </summary>
-        /// <value>The reason for the update.</value>
-        public PlayQueueUpdateReason Reason { get; }
-
-        /// <summary>
-        /// Gets the UTC time of the last change to the playing queue.
-        /// </summary>
-        /// <value>The UTC time of the last change to the playing queue.</value>
-        public DateTime LastUpdate { get; }
-
-        /// <summary>
-        /// Gets the playlist.
-        /// </summary>
-        /// <value>The playlist.</value>
-        public IReadOnlyList<SyncPlayQueueItem> Playlist { get; }
-
-        /// <summary>
-        /// Gets the playing item index in the playlist.
-        /// </summary>
-        /// <value>The playing item index in the playlist.</value>
-        public int PlayingItemIndex { get; }
-
-        /// <summary>
-        /// Gets the start position ticks.
-        /// </summary>
-        /// <value>The start position ticks.</value>
-        public long StartPositionTicks { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the current item is playing.
-        /// </summary>
-        /// <value>The playing item status.</value>
-        public bool IsPlaying { get; }
-
-        /// <summary>
-        /// Gets the shuffle mode.
-        /// </summary>
-        /// <value>The shuffle mode.</value>
-        public GroupShuffleMode ShuffleMode { get; }
-
-        /// <summary>
-        /// Gets the repeat mode.
-        /// </summary>
-        /// <value>The repeat mode.</value>
-        public GroupRepeatMode RepeatMode { get; }
+        Reason = reason;
+        LastUpdate = lastUpdate;
+        Playlist = playlist;
+        PlayingItemIndex = playingItemIndex;
+        StartPositionTicks = startPositionTicks;
+        IsPlaying = isPlaying;
+        ShuffleMode = shuffleMode;
+        RepeatMode = repeatMode;
     }
+
+    /// <summary>
+    /// Gets the request type that originated this update.
+    /// </summary>
+    /// <value>The reason for the update.</value>
+    public PlayQueueUpdateReason Reason { get; }
+
+    /// <summary>
+    /// Gets the UTC time of the last change to the playing queue.
+    /// </summary>
+    /// <value>The UTC time of the last change to the playing queue.</value>
+    public DateTime LastUpdate { get; }
+
+    /// <summary>
+    /// Gets the playlist.
+    /// </summary>
+    /// <value>The playlist.</value>
+    public IReadOnlyList<SyncPlayQueueItemDto> Playlist { get; }
+
+    /// <summary>
+    /// Gets the playing item index in the playlist.
+    /// </summary>
+    /// <value>The playing item index in the playlist.</value>
+    public int PlayingItemIndex { get; }
+
+    /// <summary>
+    /// Gets the start position ticks.
+    /// </summary>
+    /// <value>The start position ticks.</value>
+    public long StartPositionTicks { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the current item is playing.
+    /// </summary>
+    /// <value>The playing item status.</value>
+    public bool IsPlaying { get; }
+
+    /// <summary>
+    /// Gets the shuffle mode.
+    /// </summary>
+    /// <value>The shuffle mode.</value>
+    public GroupShuffleMode ShuffleMode { get; }
+
+    /// <summary>
+    /// Gets the repeat mode.
+    /// </summary>
+    /// <value>The repeat mode.</value>
+    public GroupRepeatMode RepeatMode { get; }
 }

--- a/MediaBrowser.Model/SyncPlay/PlayQueueUpdate.cs
+++ b/MediaBrowser.Model/SyncPlay/PlayQueueUpdate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using MediaBrowser.Model.Dto;
 
 namespace MediaBrowser.Model.SyncPlay;
 

--- a/MediaBrowser.Model/SyncPlay/SyncPlayQueueItemDto.cs
+++ b/MediaBrowser.Model/SyncPlay/SyncPlayQueueItemDto.cs
@@ -1,0 +1,41 @@
+using System;
+using MediaBrowser.Model.Dto;
+
+namespace MediaBrowser.Model.SyncPlay;
+
+/// <summary>
+/// Enhanced SyncPlay queue item that includes full BaseItemDto details.
+/// </summary>
+public class SyncPlayQueueItemDto
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SyncPlayQueueItemDto"/> class.
+    /// </summary>
+    /// <param name="itemId">The item identifier.</param>
+    /// <param name="playlistItemId">The playlist item identifier.</param>
+    /// <param name="item">The full item details.</param>
+    public SyncPlayQueueItemDto(Guid itemId, Guid playlistItemId, BaseItemDto? item)
+    {
+        ItemId = itemId;
+        PlaylistItemId = playlistItemId;
+        Item = item;
+    }
+
+    /// <summary>
+    /// Gets the item identifier.
+    /// </summary>
+    /// <value>The item identifier.</value>
+    public Guid ItemId { get; }
+
+    /// <summary>
+    /// Gets the playlist identifier of the item.
+    /// </summary>
+    /// <value>The playlist identifier of the item.</value>
+    public Guid PlaylistItemId { get; }
+
+    /// <summary>
+    /// Gets the full item details.
+    /// </summary>
+    /// <value>The full item details.</value>
+    public BaseItemDto? Item { get; }
+}


### PR DESCRIPTION
**Changes**
The current syncplay implementation has endpoints to Create a Queue and add/remove items from the queue, aswell as alerting other users through websockets when the queue is modified. However there is no way to get the current state of the queue through REST. (Especially useful if a new User just joined a group and wants to know what is on the queue)

This change simply adds in that GET SyncPlay/Queue endpoint

The method names here are fairly inconsistent between Queue and Playlist so im not sure which one is preferred, so went with Queue

It also Enhances the QueueItem model to include the BaseItemDto model so clients dont have to make extra api requests to see details of each item in the queue