### PR TITLE
Fix XmlOutputFormatter

### DIFF
--- a/Jellyfin.Api/Formatters/XmlOutputFormatter.cs
+++ b/Jellyfin.Api/Formatters/XmlOutputFormatter.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Jellyfin.Api.Formatters;
@@ -6,7 +10,7 @@ namespace Jellyfin.Api.Formatters;
 /// <summary>
 /// Xml output formatter.
 /// </summary>
-public sealed class XmlOutputFormatter : StringOutputFormatter
+public sealed class XmlOutputFormatter : TextOutputFormatter
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlOutputFormatter"/> class.
@@ -15,5 +19,24 @@ public sealed class XmlOutputFormatter : StringOutputFormatter
     {
         SupportedMediaTypes.Clear();
         SupportedMediaTypes.Add(MediaTypeNames.Text.Xml);
+
+        SupportedEncodings.Add(Encoding.UTF8);
+        SupportedEncodings.Add(Encoding.Unicode);
+    }
+
+    /// <inheritdoc />
+    public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(selectedEncoding);
+
+        var valueAsString = context.Object?.ToString();
+        if (string.IsNullOrEmpty(valueAsString))
+        {
+            return;
+        }
+
+        var response = context.HttpContext.Response;
+        await response.WriteAsync(valueAsString, selectedEncoding).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin-plugin-dlna/issues/168

Full credit to @reecewilliams7 for finding the issue

Partially reverts #12925
`StringOutputFormatter` only writes if the object is a string, where the XmlFormatter also needs to write other types.