### PR TITLE
Only save chapters that are within the runtime of the video file

### DIFF
--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -223,7 +223,7 @@ public class ChapterManager : IChapterManager
 
         if (saveChapters && changesMade)
         {
-            _chapterRepository.SaveChapters(video.Id, chapters);
+            SaveChapters(video, chapters);
         }
 
         DeleteDeadImages(currentImages, chapters);
@@ -234,7 +234,9 @@ public class ChapterManager : IChapterManager
     /// <inheritdoc />
     public void SaveChapters(Video video, IReadOnlyList<ChapterInfo> chapters)
     {
-        _chapterRepository.SaveChapters(video.Id, chapters);
+        // Remove any chapters that are outside of the runtime of the video
+        var validChapters = chapters.Where(c => c.StartPositionTicks < video.RunTimeTicks).ToList();
+        _chapterRepository.SaveChapters(video.Id, validChapters);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
**Changes**
Added a filter to remove any chapters that have their starting ticks outside the span of the video

**Issues**
Fixes #15059 
