### PR TITLE
Make priority class setting more robust

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1122,7 +1122,15 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private void StartProcess(ProcessWrapper process)
         {
             process.Process.Start();
-            process.Process.PriorityClass = ProcessPriorityClass.BelowNormal;
+
+            try
+            {
+                process.Process.PriorityClass = ProcessPriorityClass.BelowNormal;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Unable to set process priority to BelowNormal for {ProcessFileName}", process.Process.StartInfo.FileName);
+            }
 
             lock (_runningProcessesLock)
             {

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -42,7 +42,15 @@ public static class FfProbeKeyframeExtractor
         try
         {
             process.Start();
-            process.PriorityClass = ProcessPriorityClass.BelowNormal;
+            try
+            {
+                process.PriorityClass = ProcessPriorityClass.BelowNormal;
+            }
+            catch
+            {
+                // We do not care if process priority setting fails
+                // Ideally log a warning but this does not have a logger available
+            }
 
             return ParseStream(process.StandardOutput);
         }


### PR DESCRIPTION
Currently the tasks simply crashes because the user running jellyfin server does not have the permission to change priority of a process. The below normal is a best-effort optimization and should not crash the task entirely. Add a try catch to make the task to move on even when priority cannot be set.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #14901
