### PR TITLE
Initialize transcode marker during startup

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -184,6 +184,12 @@ namespace Jellyfin.Server
                         .AddSingleton<IServiceCollection>(e))
                     .Build();
 
+                /*
+                 * Initialize the transcode path marker so we avoid starting Jellyfin in a broken state.
+                 * This should really be a part of IApplicationPaths but this path is configured differently.
+                 */
+                _ = appHost.ConfigurationManager.GetTranscodePath();
+
                 // Re-use the host service provider in the app host since ASP.NET doesn't allow a custom service collection.
                 appHost.ServiceProvider = _jellyfinHost.Services;
                 PrepareDatabaseProvider(appHost.ServiceProvider);


### PR DESCRIPTION
Not a permanent fix but good enough until config rewrite.

Now instead of throwing the exception during first transcode it will be thrown during startup.

```
[19:17:02] [FTL] [8] Main: Error while starting server
System.InvalidOperationException: Exepected to find only .jellyfin-transcode but found marker for C:\Users\Cody\AppData\Local\jellyfin\cache\.jellyfin-cache.
   at Emby.Server.Implementations.AppBase.BaseApplicationPaths.CheckOrCreateMarker(String path, String markerName, Boolean recursive) in C:\Code\Jellyfin\jellyfin\Emby.Server.Implementations\AppBase\BaseApplicationPaths.cs:line 113
   at Emby.Server.Implementations.AppBase.BaseApplicationPaths.CreateAndCheckMarker(String path, String markerName, Boolean recursive) in C:\Users\Cody\Code\Jellyfin\jellyfin\Emby.Server.Implementations\AppBase\BaseApplicationPaths.cs:line 100
   at MediaBrowser.Common.Configuration.EncodingConfigurationExtensions.GetTranscodePath(IConfigurationManager configurationManager) in C:\Users\Cody\Code\Jellyfin\jellyfin\MediaBrowser.Common\Configuration\EncodingConfigurationExtensions.cs:line 38
   at Jellyfin.Server.Program.StartServer(IServerApplicationPaths appPaths, StartupOptions options, IConfiguration startupConfig) in C:\Users\Cody\Code\Jellyfin\jellyfin\Jellyfin.Server\Program.cs:line 192
```

Fixes https://github.com/jellyfin/jellyfin/issues/15058
Fixes https://github.com/jellyfin/jellyfin/discussions/15181