### PR TITLE
Skip directory entry when restoring from backup

### DIFF
--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -128,7 +128,8 @@ public class BackupService : IBackupService
                     var targetPath = Path.GetFullPath(Path.Combine(target, Path.GetRelativePath(source, item.FullName)));
 
                     if (!sourcePath.StartsWith(fullSourcePath, StringComparison.Ordinal)
-                        || !targetPath.StartsWith(fullTargetRoot, StringComparison.Ordinal))
+                        || !targetPath.StartsWith(fullTargetRoot, StringComparison.Ordinal)
+                        || Path.EndsInDirectorySeparator(item.FullName))
                     {
                         continue;
                     }


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/15162

Not completely sure how the backup archive was created with an unexpected subdir, but the fix is simple enough. Any files in that sub directory are extracted as expected