### PR TITLE
Filter plugins by id instead of name

### DIFF
--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -223,14 +223,13 @@ namespace Emby.Server.Implementations.Updates
             Guid id = default,
             Version? specificVersion = null)
         {
-            if (name is not null)
-            {
-                availablePackages = availablePackages.Where(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            }
-
             if (!id.IsEmpty())
             {
                 availablePackages = availablePackages.Where(x => x.Id.Equals(id));
+            }
+            else if (name is not null)
+            {
+                availablePackages = availablePackages.Where(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             }
 
             if (specificVersion is not null)


### PR DESCRIPTION
Allows a plugin to be updated after being renamed in the manifest

Fixes https://github.com/jellyfin/jellyfin/issues/15161
Fixes https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/193

I thought there were some other issues but I can't find them anymore