### PR TITLE
Normalize paths in database queries

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1763,7 +1763,8 @@ public sealed class BaseItemRepository
 
         if (!string.IsNullOrWhiteSpace(filter.Path))
         {
-            baseQuery = baseQuery.Where(e => e.Path == filter.Path);
+            var pathToQuery = GetPathToSave(filter.Path);
+            baseQuery = baseQuery.Where(e => e.Path == pathToQuery);
         }
 
         if (!string.IsNullOrWhiteSpace(filter.PresentationUniqueKey))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Database queries using path filters were failing to find items when virtual path substitution was enabled because raw paths were being compared to normalized database entries.

**Changes**
Normalize the filter path using `GetPathToSave()` before database comparison

**Issues**
 Fixes #15037

