### PR TITLE
Skip extracted files in migration if bad timestamp or no access

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateKeyframeData.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateKeyframeData.cs
@@ -122,6 +122,16 @@ public class MigrateKeyframeData : IDatabaseMigrationRoutine
         {
             lastWriteTimeUtc = File.GetLastWriteTimeUtc(filePath);
         }
+        catch (ArgumentOutOfRangeException e)
+        {
+            _logger.LogDebug("Skipping {Path}: {Exception}", filePath, e.Message);
+            return null;
+        }
+        catch (UnauthorizedAccessException e)
+        {
+            _logger.LogDebug("Skipping {Path}: {Exception}", filePath, e.Message);
+            return null;
+        }
         catch (IOException e)
         {
             _logger.LogDebug("Skipping {Path}: {Exception}", filePath, e.Message);


### PR DESCRIPTION
For some reason in certain cases the filesystem reports invalid dates for creation dates. Not much we can do about this but now the migration at least does not crash.

Previous Push-Request previous-error: #15112 
Fixes #15024  next-error

**Changes**
- Skip files with invalid timestamps
- Skip files if access denied

**Issues**
Fixes #15024 next-error (same error).
