### PR TITLE
Add milliseconds to default console output format

### DIFF
--- a/Jellyfin.Server/Resources/Configuration/logging.json
+++ b/Jellyfin.Server/Resources/Configuration/logging.json
@@ -11,7 +11,7 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                    "outputTemplate": "[{Timestamp:HH:mm:ss.fff}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
                 }
             },
             {


### PR DESCRIPTION
**Changes**

Change the default console output format to include milliseconds. Example output:

```
Oct 26 10:30:44 hostname jellyfin[2486470]: [10:30:44.133] [INF] [12] Emby.Server.Implementations.ApplicationHost: Core startup complete
```

**Issues**

Fixes #15226