### PR TITLE
Remove choices from version selector

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue report.yml
+++ b/.github/ISSUE_TEMPLATE/issue report.yml
@@ -85,12 +85,9 @@ body:
     id: version
     attributes:
       label: Jellyfin Server version
-      description: What version of Jellyfin are you using?
-      options:
-        - 10.10.0+
-        - Master
-        - Unstable
-        - Older*
+      description: What version of Jellyfin are you using? ("Build version" on your server dashboard, or specify if self-built.)
+      placeholder: |
+        X.Y.Z (stable) | YYYYMMDDHHMM (unstable)
     validations:
       required: true
   - type: input

--- a/bump_version
+++ b/bump_version
@@ -28,7 +28,6 @@ jellyfin_subprojects=(
   Emby.Naming/Emby.Naming.csproj
   src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
 )
-issue_template_file="./.github/ISSUE_TEMPLATE/issue report.yml"
 
 new_version="$1"
 new_version_sed="$( cut -f1 -d'-' <<<"${new_version}" )"
@@ -56,9 +55,6 @@ for subproject in ${jellyfin_subprojects[@]}; do
     # Set the nuget version to the specified new_version
     sed -i "s|${old_version}|${new_version_sed}|g" ${subproject}
 done
-
-# Set the version in the GitHub issue template file
-sed -i "s|${old_version}|${new_version_sed}|g" "${issue_template_file}"
 
 # Stage the changed files for commit
 git add .


### PR DESCRIPTION
**Changes**
Keeping this up-to-date and providing all the potential options is not
viable. Switch to a text entry field instead and let the reporter type
in the actual value from their dashboard.

**Issues**
N/A
