### PR TITLE
Ignore initial delay in audio-only containers

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1625,8 +1625,11 @@ public class DynamicHlsController : BaseJellyfinApiController
 
             var useLegacySegmentOption = _mediaEncoder.EncoderVersion < _minFFmpegHlsSegmentOptions;
 
-            // fMP4 needs this flag to write the audio packet DTS/PTS including the initial delay into MOOF::TRAF::TFDT
-            hlsArguments += $" {(useLegacySegmentOption ? "-hls_ts_options" : "-hls_segment_options")} movflags=+frag_discont";
+            if (state.VideoStream is not null && state.IsOutputVideo)
+            {
+                // fMP4 needs this flag to write the audio packet DTS/PTS including the initial delay into MOOF::TRAF::TFDT
+                hlsArguments += $" {(useLegacySegmentOption ? "-hls_ts_options" : "-hls_segment_options")} movflags=+frag_discont";
+            }
 
             segmentFormat = "fmp4" + outputFmp4HeaderArg;
         }


### PR DESCRIPTION
For music transcoding we ignore the initial delay because we don't need to worry about A/V sync issues. This avoids a quirk in Firefox-based browsers.

**Changes**
- Ignore initial delay in audio-only containers

**Issues**
- Fixes #15241
