### PR TITLE
Fix missing movie filter.

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1648,6 +1648,7 @@ public sealed class BaseItemRepository
         {
             if (filter.IncludeItemTypes.Length == 0
                 || filter.IncludeItemTypes.Contains(BaseItemKind.Movie)
+                || filter.IncludeItemTypes.Contains(BaseItemKind.LiveTvProgram)
                 || filter.IncludeItemTypes.Contains(BaseItemKind.Trailer))
             {
                 baseQuery = baseQuery.Where(e => e.IsMovie);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Add the BaseItemKind.LiveTvProgram  to the filters for database types that present movies.  PVR apps will identify  movies on TV based on genre Movies but there type is BaseItemKind.LiveTvProgram .

As as result rows in Movies category from NextPVR and probably other PVR  pass the first condition but not the filter so the result is random TV items from TV are return to PVR Programs unfiltered.



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
