### PR TITLE
Update file size when refreshing metadata

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -229,6 +229,11 @@ namespace MediaBrowser.Providers.Manager
                         if (file is not null)
                         {
                             item.DateModified = file.LastWriteTimeUtc;
+
+                            if (!file.IsDirectory)
+                            {
+                                item.Size = file.Length;
+                            }
                         }
                     }
 


### PR DESCRIPTION
**Changes**
Currently, whenever Jellyfin server refreshes metadata of files in a library, it does correctly refresh information like codecs, etc. But if the filename stays the same, it never refreshes file size. A use case may be: replacing a file with another file having the same name but e.g. different codec.
This change fixes this behavior.

**How did I test**
Compiled and installed on a local server verifying the behavior is fixed.