### PR TITLE
Skip too large extracted season numbers

### DIFF
--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -113,8 +113,10 @@ namespace Emby.Naming.TV
             var numberString = match.Groups["seasonnumber"];
             if (numberString.Success)
             {
-                var seasonNumber = int.Parse(numberString.Value, CultureInfo.InvariantCulture);
-                return (seasonNumber, true);
+                if (int.TryParse(numberString.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seasonNumber))
+                {
+                    return (seasonNumber, true);
+                }
             }
 
             return (null, false);

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
@@ -66,6 +66,9 @@ public class SeasonPathParserTests
     [InlineData("/Drive/SPECIALS", "/Drive", 0, true)]
     [InlineData("/Drive/Episode 1 Season 2", "/Drive", null, false)]
     [InlineData("/Drive/Episode 1 SEASON 2", "/Drive", null, false)]
+    [InlineData("/media/YouTube/Devyn Johnston/2024-01-24 4070 Ti SUPER in under 7 minutes", "/media/YouTube/Devyn Johnston", null, false)]
+    [InlineData("/media/YouTube/Devyn Johnston/2025-01-28 5090 vs 2 SFF Cases", "/media/YouTube/Devyn Johnston", null, false)]
+    [InlineData("/Drive/202401244070", "/Drive", null, false)]
     public void GetSeasonNumberFromPathTest(string path, string? parentPath, int? seasonNumber, bool isSeasonDirectory)
     {
         var result = SeasonPathParser.Parse(path, parentPath, true, true);


### PR DESCRIPTION
**Changes**
* Use `TryParse` for found season numbers to skip any matches that don't fit in an int.

**Issues**
Fixes #15308