### PR TITLE
fix: in optimistic locking, key off table is locked

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
@@ -52,10 +52,14 @@ public class OptimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
 
         _logger = logger;
         _writePolicy = Policy
-            .HandleInner<Exception>(e => e.Message.Contains("database is locked", StringComparison.InvariantCultureIgnoreCase))
+            .HandleInner<Exception>(e =>
+                e.Message.Contains("database is locked", StringComparison.InvariantCultureIgnoreCase) ||
+                e.Message.Contains("database table is locked", StringComparison.InvariantCultureIgnoreCase))
             .WaitAndRetry(sleepDurations.Length, backoffProvider, RetryHandle);
         _writeAsyncPolicy = Policy
-            .HandleInner<Exception>(e => e.Message.Contains("database is locked", StringComparison.InvariantCultureIgnoreCase))
+            .HandleInner<Exception>(e =>
+                e.Message.Contains("database is locked", StringComparison.InvariantCultureIgnoreCase) ||
+                e.Message.Contains("database table is locked", StringComparison.InvariantCultureIgnoreCase))
             .WaitAndRetryAsync(sleepDurations.Length, backoffProvider, RetryHandle);
 
         void RetryHandle(Exception exception, TimeSpan timespan, int retryNo, Context context)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Optimistic locking logic only keys off of "database is locked". Another possible error is "table is locked". This adds a check for "table is locked" so retries are attempted.

**Notes**
I validated this on my local instance. Before I would just see "table is locked" stack traces, now I see (e.g.):

```
[14:04:06] [WRN] [12] Jellyfin.Database.Implementations.Locking.OptimisticLockBehavior: Operation failed retry 1
```