### PR TITLE
Fix: Allow collection thumbnails to be generated from content

### DIFF
--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -82,12 +82,9 @@ namespace Emby.Server.Implementations.Images
 
             if (image is not null)
             {
-                if (!image.IsLocalFile)
-                {
-                    return Task.FromResult(ItemUpdateType.None);
-                }
-
-                if (!FileSystem.ContainsSubPath(item.GetInternalMetadataPath(), image.Path))
+                // Only skip generation if there's already a local image in the metadata folder
+                // This allows dynamic images to be generated even when remote images exist
+                if (image.IsLocalFile && FileSystem.ContainsSubPath(item.GetInternalMetadataPath(), image.Path))
                 {
                     return Task.FromResult(ItemUpdateType.None);
                 }


### PR DESCRIPTION
Follow up on #14259 in an attempt to finally fix #12862

**Changes**
- Modified `CollectionImageProvider` to allow dynamic images for unlocked collections when no local Primary image exists
- Updated `BaseDynamicImageProvider` to only skip generation when a local image already exists in metadata folder (allows generation even with remote images)
- Fixes issue where auto-created collections weren't getting thumbnails generated from their content items

**Issues**
Fixes #12862 (maybe)

---

### Problem analysis

**Root cause:** Collections created automatically (e.g., via `CollectionPostScanTask`) are not getting dynamic thumbnails generated from their content because the `CollectionImageProvider.Supports()` method requires collections to be locked.

**Location:** `Emby.Server.Implementations/Collections/CollectionImageProvider.cs:41-44`:
```c#
if (!item.IsLocked)
{
    return false;
}
```

However, when collections are auto-created by `CollectionPostScanTask` (line 125), `IsLocked` is not set, defaulting to `false`. This prevents the dynamic image provider from running.