### PR TITLE
Fix: GetUsers endpoint now requires Admin privileges

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -89,7 +89,7 @@ public class UserController : BaseJellyfinApiController
     /// <response code="200">Users returned.</response>
     /// <returns>An <see cref="IEnumerable{UserDto}"/> containing the users.</returns>
     [HttpGet]
-    [Authorize]
+    [Authorize(Roles = UserRoles.Administrator)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<IEnumerable<UserDto>> GetUsers(
         [FromQuery] bool? isHidden,

--- a/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs
@@ -28,20 +28,24 @@ namespace Jellyfin.Server.Integration.Tests
             using var completeResponse = await client.PostAsync("/Startup/Complete", new ByteArrayContent(Array.Empty<byte>()));
             Assert.Equal(HttpStatusCode.NoContent, completeResponse.StatusCode);
 
+            return await AuthenticateUserByNameAsync(client, user!.Name!, user.Password!);
+        }
+
+        public static async Task<string> AuthenticateUserByNameAsync(HttpClient client, string username, string password)
+        {
             using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/Users/AuthenticateByName");
             httpRequest.Headers.TryAddWithoutValidation(AuthHeaderName, DummyAuthHeader);
             httpRequest.Content = JsonContent.Create(
                 new AuthenticateUserByName()
                 {
-                    Username = user!.Name,
-                    Pw = user.Password,
+                    Username = username,
+                    Pw = password,
                 },
-                options: jsonOptions);
+                options: JsonDefaults.Options);
 
             using var authResponse = await client.SendAsync(httpRequest);
             authResponse.EnsureSuccessStatusCode();
-
-            var auth = await authResponse.Content.ReadFromJsonAsync<AuthenticationResultDto>(jsonOptions);
+            var auth = await authResponse.Content.ReadFromJsonAsync<AuthenticationResultDto>(JsonDefaults.Options);
 
             return auth!.AccessToken;
         }

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
@@ -137,6 +137,20 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
         [Fact]
         [Priority(1)]
+        public async Task GetUsersFromNewUser_Invalid_Fail()
+        {
+            var client = _factory.CreateClient();
+
+            var userAccessToken = await AuthHelper.AuthenticateUserByNameAsync(client, TestUsername, string.Empty);
+
+            client.DefaultRequestHeaders.AddAuthHeader(userAccessToken);
+
+            using var response = await client.GetAsync("Users");
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        [Priority(1)]
         public async Task UpdateUserPassword_Valid_Success()
         {
             var client = _factory.CreateClient();


### PR DESCRIPTION
**Summary**
GetUsers endpoint was identified as a security vulnerability in #5415, which the breakoff issue #13990 suggests requiring Admin privileges to access. 

**Changes**
GetUsers endpoint now requires admin access. 

UserControllerTests now includes a test to validate the created user cannot access that endpoint. 
AuthHelper had a method split to allow getting the access token of a particular user without changing the signature or function of `CompleteStartupAsync`. The new method is `Task<string> AuthenticateUserByNameAsync(HttpClient client, string username, string password)`.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/13990 
