### PR TITLE
[feat] Additional http protocol support

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
@@ -17,6 +18,7 @@ using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Extensions;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -31,6 +33,7 @@ using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Authorization;
@@ -55,6 +58,7 @@ public class LibraryController : BaseJellyfinApiController
     private readonly ILibraryMonitor _libraryMonitor;
     private readonly ILogger<LibraryController> _logger;
     private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LibraryController"/> class.
@@ -68,6 +72,7 @@ public class LibraryController : BaseJellyfinApiController
     /// <param name="libraryMonitor">Instance of the <see cref="ILibraryMonitor"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{LibraryController}"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
     public LibraryController(
         IProviderManager providerManager,
         ILibraryManager libraryManager,
@@ -77,7 +82,8 @@ public class LibraryController : BaseJellyfinApiController
         ILocalizationManager localization,
         ILibraryMonitor libraryMonitor,
         ILogger<LibraryController> logger,
-        IServerConfigurationManager serverConfigurationManager)
+        IServerConfigurationManager serverConfigurationManager,
+        IHttpClientFactory httpClientFactory)
     {
         _providerManager = providerManager;
         _libraryManager = libraryManager;
@@ -88,6 +94,7 @@ public class LibraryController : BaseJellyfinApiController
         _libraryMonitor = libraryMonitor;
         _logger = logger;
         _serverConfigurationManager = serverConfigurationManager;
+        _httpClientFactory = httpClientFactory;
     }
 
     /// <summary>
@@ -384,7 +391,7 @@ public class LibraryController : BaseJellyfinApiController
 
         _libraryManager.DeleteItem(
             item,
-            new DeleteOptions { DeleteFileLocation = true },
+            new DeleteOptions { DeleteFileLocation = item.IsFileProtocol },
             true);
 
         return NoContent();
@@ -696,6 +703,12 @@ public class LibraryController : BaseJellyfinApiController
         if (user is not null)
         {
             await LogDownloadAsync(item, user).ConfigureAwait(false);
+        }
+
+        if ((item.ShortcutPathProtocol ?? item.PathProtocol) == MediaProtocol.Http)
+        {
+          var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
+          return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(item.ShortcutPath ?? item.Path, httpClient, HttpContext, true).ConfigureAwait(false);
         }
 
         // Quotes are valid in linux. They'll possibly cause issues here.

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -452,7 +452,7 @@ public class VideosController : BaseJellyfinApiController
         if (@static.HasValue && @static.Value && state.InputProtocol == MediaProtocol.Http)
         {
             var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-            return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, HttpContext).ConfigureAwait(false);
+            return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state.MediaPath, httpClient, HttpContext, false).ConfigureAwait(false);
         }
 
         if (@static.HasValue && @static.Value && state.InputProtocol != MediaProtocol.File)

--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -116,7 +116,7 @@ public class AudioHelper
         if (streamingRequest.Static && state.InputProtocol == MediaProtocol.Http)
         {
             var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-            return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state, httpClient, _httpContextAccessor.HttpContext).ConfigureAwait(false);
+            return await FileStreamResponseHelpers.GetStaticRemoteStreamResult(state.MediaPath, httpClient, _httpContextAccessor.HttpContext, false).ConfigureAwait(false);
         }
 
         if (streamingRequest.Static && state.InputProtocol != MediaProtocol.File)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -393,6 +393,22 @@ namespace MediaBrowser.Controller.Entities
 
         public string ShortcutPath { get; set; }
 
+        [JsonIgnore]
+        public MediaProtocol? ShortcutPathProtocol
+        {
+            get
+            {
+                var path = ShortcutPath;
+
+                if (string.IsNullOrEmpty(path))
+                {
+                    return null;
+                }
+
+                return MediaSourceManager.GetPathProtocol(path);
+            }
+        }
+
         public int Width { get; set; }
 
         public int Height { get; set; }
@@ -1173,7 +1189,7 @@ namespace MediaBrowser.Controller.Entities
 
                 if (video.IsShortcut && !string.IsNullOrEmpty(video.ShortcutPath))
                 {
-                    var shortcutProtocol = MediaSourceManager.GetPathProtocol(video.ShortcutPath);
+                    var shortcutProtocol = video.ShortcutPathProtocol ?? MediaSourceManager.GetPathProtocol(video.ShortcutPath);
 
                     // Only allow remote shortcut paths — local file paths in .strm files
                     // could be used to read arbitrary files from the server.

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -222,17 +222,23 @@ namespace MediaBrowser.Controller.Entities
         {
             get
             {
-                if (IsFileProtocol)
+                if (string.IsNullOrEmpty(Path))
                 {
-                    if (VideoType == VideoType.BluRay || VideoType == VideoType.Dvd)
-                    {
-                        return System.IO.Path.GetFileName(Path);
-                    }
-
-                    return System.IO.Path.GetFileNameWithoutExtension(Path);
+                    return null;
                 }
 
-                return null;
+                if (VideoType == VideoType.BluRay || VideoType == VideoType.Dvd)
+                {
+                    return System.IO.Path.GetFileName(Path);
+                }
+
+                var path = Path;
+                if (!IsFileProtocol && Uri.TryCreate(Path, UriKind.Absolute, out var uri))
+                {
+                    path = System.IO.Path.GetFileName(uri.LocalPath);
+                }
+
+                return System.IO.Path.GetFileNameWithoutExtension(path);
             }
         }
 
@@ -341,7 +347,7 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
-            return IsFileProtocol;
+            return PathProtocol == MediaProtocol.Http || PathProtocol == MediaProtocol.File;
         }
 
         protected override bool IsActiveRecording()
@@ -356,7 +362,7 @@ namespace MediaBrowser.Controller.Entities
                 return false;
             }
 
-            return base.CanDelete();
+            return true;
         }
 
         public IEnumerable<Guid> GetAdditionalPartIds()

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -89,11 +89,6 @@ namespace MediaBrowser.Providers.MediaInfo
             bool clearCache,
             CancellationToken cancellationToken)
         {
-            if (!video.IsFileProtocol)
-            {
-                return Array.Empty<MediaStream>();
-            }
-
             var pathInfos = GetExternalFiles(video, directoryService, clearCache);
 
             if (!pathInfos.Any())
@@ -166,11 +161,6 @@ namespace MediaBrowser.Providers.MediaInfo
             IDirectoryService directoryService,
             bool clearCache)
         {
-            if (!audio.IsFileProtocol)
-            {
-                return Array.Empty<MediaStream>();
-            }
-
             var pathInfos = GetExternalFiles(audio, directoryService, clearCache);
 
             if (pathInfos.Count == 0)
@@ -206,20 +196,16 @@ namespace MediaBrowser.Providers.MediaInfo
             IDirectoryService directoryService,
             bool clearCache)
         {
-            if (!video.IsFileProtocol)
-            {
-                return Array.Empty<ExternalPathParserResult>();
-            }
-
             // Check if video folder exists
             string folder = video.ContainingFolderPath;
-            if (!_fileSystem.DirectoryExists(folder))
+            List<string> files = new List<string>();
+
+            if (_fileSystem.DirectoryExists(folder))
             {
-                return Array.Empty<ExternalPathParserResult>();
+                files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
+                files.Remove(video.Path);
             }
 
-            var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
-            files.Remove(video.Path);
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))
             {
@@ -264,11 +250,6 @@ namespace MediaBrowser.Providers.MediaInfo
             IDirectoryService directoryService,
             bool clearCache)
         {
-            if (!audio.IsFileProtocol)
-            {
-                return Array.Empty<ExternalPathParserResult>();
-            }
-
             string folder = audio.ContainingFolderPath;
             var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
             files.Remove(audio.Path);

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -262,7 +262,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
         private void FetchShortcutInfo(BaseItem item)
         {
-            var shortcutPath = File.ReadAllLines(item.Path)
+            var shortcutPath = item.ShortcutPath ?? File.ReadAllLines(item.Path)
                 .Select(NormalizeStrmLine)
                 .FirstOrDefault(i => !string.IsNullOrWhiteSpace(i) && !i.StartsWith('#'));
 

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -192,7 +192,7 @@ namespace MediaBrowser.Providers.Subtitles
             LibraryOptions libraryOptions,
             SubtitleResponse response)
         {
-            var saveInMediaFolder = libraryOptions.SaveSubtitlesWithMedia;
+            var saveInMediaFolder = video.IsFileProtocol ? libraryOptions.SaveSubtitlesWithMedia : false;
 
             var memoryStream = new MemoryStream();
             await using (memoryStream.ConfigureAwait(false))

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -74,23 +74,6 @@ public class MediaInfoResolverTests
         _subtitleResolver = new SubtitleResolver(Mock.Of<ILogger<SubtitleResolver>>(), _localizationManager, mediaEncoder.Object, fileSystem.Object, new NamingOptions());
     }
 
-    [Fact]
-    public void GetExternalFiles_BadProtocol_ReturnsNoSubtitles()
-    {
-        // need a media source manager capable of returning something other than file protocol
-        var mediaSourceManager = new Mock<IMediaSourceManager>();
-        mediaSourceManager.Setup(m => m.GetPathProtocol(It.IsRegex("http.*")))
-            .Returns(MediaProtocol.Http);
-        BaseItem.MediaSourceManager = mediaSourceManager.Object;
-
-        var video = new Movie
-        {
-            Path = "https://url.com/My.Video.mkv"
-        };
-
-        Assert.Empty(_subtitleResolver.GetExternalFiles(video, Mock.Of<IDirectoryService>(), false));
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
Improved HTTP protocol handling for video items

- Added download support for HTTP sources, including .strm files
- Items can now be deleted regardless of their protocol
- Allow video probing to retrieve remote streams (subtitles and audio) for non-file protocols