### PR TITLE
Fix 4 compiler warnings in Emby.Server.Implementations by renaming th…

### DIFF
--- a/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
+++ b/Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs
@@ -64,10 +64,10 @@ namespace Emby.Server.Implementations.AppBase
         public event EventHandler<ConfigurationUpdateEventArgs>? NamedConfigurationUpdated;
 
         /// <summary>
-        /// Gets the type of the configuration.
+        /// Gets the type of the common configuration.
         /// </summary>
-        /// <value>The type of the configuration.</value>
-        protected abstract Type ConfigurationType { get; }
+        /// <value>The type of the common configuration.</value>
+        protected abstract Type CommonConfigurationType { get; }
 
         /// <summary>
         /// Gets the logger.
@@ -107,7 +107,7 @@ namespace Emby.Server.Implementations.AppBase
                         return _configuration;
                     }
 
-                    return _configuration = (BaseApplicationConfiguration)ConfigurationHelper.GetXmlConfiguration(ConfigurationType, CommonApplicationPaths.SystemConfigurationFilePath, XmlSerializer);
+                    return _configuration = (BaseApplicationConfiguration)ConfigurationHelper.GetXmlConfiguration(CommonConfigurationType, CommonApplicationPaths.SystemConfigurationFilePath, XmlSerializer);
                 }
             }
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -163,7 +163,7 @@ namespace Emby.Server.Implementations
             _pluginManager = new PluginManager(
                 LoggerFactory.CreateLogger<PluginManager>(),
                 this,
-                ConfigurationManager.Configuration,
+                ConfigurationManager.ServerConfig,
                 ApplicationPaths.PluginsPath,
                 ApplicationVersion);
 
@@ -267,9 +267,9 @@ namespace Emby.Server.Implementations
         public bool ListenWithHttps => Certificate is not null && ConfigurationManager.GetNetworkConfiguration().EnableHttps;
 
         public string FriendlyName =>
-            string.IsNullOrEmpty(ConfigurationManager.Configuration.ServerName)
+            string.IsNullOrEmpty(ConfigurationManager.ServerConfig.ServerName)
                 ? Environment.MachineName
-                : ConfigurationManager.Configuration.ServerName;
+                : ConfigurationManager.ServerConfig.ServerName;
 
         public string RestoreBackupPath { get; set; }
 
@@ -438,7 +438,7 @@ namespace Emby.Server.Implementations
             NetManager = new NetworkManager(ConfigurationManager, _startupConfig, LoggerFactory.CreateLogger<NetworkManager>());
 
             // Initialize runtime stat collection
-            if (ConfigurationManager.Configuration.EnableMetrics)
+            if (ConfigurationManager.ServerConfig.EnableMetrics)
             {
                 _disposableParts.Add(DotNetRuntimeStatsBuilder.Default().StartCollecting());
             }
@@ -663,9 +663,9 @@ namespace Emby.Server.Implementations
         /// </summary>
         private void FindParts()
         {
-            if (!ConfigurationManager.Configuration.IsPortAuthorized)
+            if (!ConfigurationManager.ServerConfig.IsPortAuthorized)
             {
-                ConfigurationManager.Configuration.IsPortAuthorized = true;
+                ConfigurationManager.ServerConfig.IsPortAuthorized = true;
                 ConfigurationManager.SaveConfiguration();
             }
 
@@ -748,9 +748,9 @@ namespace Emby.Server.Implementations
                 if (networkConfiguration.InternalHttpPort != HttpPort
                     || networkConfiguration.InternalHttpsPort != HttpsPort)
                 {
-                    if (ConfigurationManager.Configuration.IsPortAuthorized)
+                    if (ConfigurationManager.ServerConfig.IsPortAuthorized)
                     {
-                        ConfigurationManager.Configuration.IsPortAuthorized = false;
+                        ConfigurationManager.ServerConfig.IsPortAuthorized = false;
                         ConfigurationManager.SaveConfiguration();
 
                         requiresRestart = true;

--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -38,10 +38,10 @@ namespace Emby.Server.Implementations.Configuration
         public event EventHandler<GenericEventArgs<ServerConfiguration>>? ConfigurationUpdating;
 
         /// <summary>
-        /// Gets the type of the configuration.
+        /// Gets the type of the common configuration.
         /// </summary>
-        /// <value>The type of the configuration.</value>
-        protected override Type ConfigurationType => typeof(ServerConfiguration);
+        /// <value>The type of the common configuration.</value>
+        protected override Type CommonConfigurationType => typeof(ServerConfiguration);
 
         /// <summary>
         /// Gets the application paths.
@@ -53,7 +53,7 @@ namespace Emby.Server.Implementations.Configuration
         /// Gets the configuration.
         /// </summary>
         /// <value>The configuration.</value>
-        public ServerConfiguration Configuration => (ServerConfiguration)CommonConfiguration;
+        public ServerConfiguration ServerConfig => (ServerConfiguration)CommonConfiguration;
 
         /// <summary>
         /// Called when [configuration updated].
@@ -73,9 +73,9 @@ namespace Emby.Server.Implementations.Configuration
         /// <exception cref="IOException">If the directory does not exist, and it also could not be created.</exception>
         private void UpdateMetadataPath()
         {
-            ((ServerApplicationPaths)ApplicationPaths).InternalMetadataPath = string.IsNullOrWhiteSpace(Configuration.MetadataPath)
+            ((ServerApplicationPaths)ApplicationPaths).InternalMetadataPath = string.IsNullOrWhiteSpace(ServerConfig.MetadataPath)
                 ? ApplicationPaths.DefaultInternalMetadataPath
-                : Configuration.MetadataPath;
+                : ServerConfig.MetadataPath;
             Directory.CreateDirectory(ApplicationPaths.InternalMetadataPath);
         }
 
@@ -105,7 +105,7 @@ namespace Emby.Server.Implementations.Configuration
             var newPath = newConfig.MetadataPath;
 
             if (!string.IsNullOrWhiteSpace(newPath)
-                && !string.Equals(Configuration.MetadataPath, newPath, StringComparison.Ordinal))
+                && !string.Equals(ServerConfig.MetadataPath, newPath, StringComparison.Ordinal))
             {
                 if (!Directory.Exists(newPath))
                 {

--- a/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
+++ b/Emby.Server.Implementations/EntryPoints/LibraryChangedNotifier.cs
@@ -182,7 +182,7 @@ public sealed class LibraryChangedNotifier : IHostedService, IDisposable
 
         lock (_libraryChangedSyncLock)
         {
-            var updateDuration = TimeSpan.FromSeconds(_configurationManager.Configuration.LibraryUpdateDuration);
+            var updateDuration = TimeSpan.FromSeconds(_configurationManager.ServerConfig.LibraryUpdateDuration);
 
             if (_libraryUpdateTimer is null)
             {

--- a/Emby.Server.Implementations/IO/FileRefresher.cs
+++ b/Emby.Server.Implementations/IO/FileRefresher.cs
@@ -76,11 +76,11 @@ namespace Emby.Server.Implementations.IO
 
                 if (_timer is null)
                 {
-                    _timer = new Timer(OnTimerCallback, null, TimeSpan.FromSeconds(_configurationManager.Configuration.LibraryMonitorDelay), TimeSpan.FromMilliseconds(-1));
+                    _timer = new Timer(OnTimerCallback, null, TimeSpan.FromSeconds(_configurationManager.ServerConfig.LibraryMonitorDelay), TimeSpan.FromMilliseconds(-1));
                 }
                 else
                 {
-                    _timer.Change(TimeSpan.FromSeconds(_configurationManager.Configuration.LibraryMonitorDelay), TimeSpan.FromMilliseconds(-1));
+                    _timer.Change(TimeSpan.FromSeconds(_configurationManager.ServerConfig.LibraryMonitorDelay), TimeSpan.FromMilliseconds(-1));
                 }
             }
         }

--- a/Emby.Server.Implementations/IO/MbLinkShortcutHandler.cs
+++ b/Emby.Server.Implementations/IO/MbLinkShortcutHandler.cs
@@ -1,15 +1,18 @@
-#pragma warning disable CS1591
-
 using System;
 using System.IO;
 using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.IO
 {
+    /// <summary>
+    /// Handler for .mblink shortcut files.
+    /// </summary>
     public class MbLinkShortcutHandler : IShortcutHandler
     {
+        /// <inheritdoc />
         public string Extension => ".mblink";
 
+        /// <inheritdoc />
         public string? Resolve(string shortcutPath)
         {
             ArgumentException.ThrowIfNullOrEmpty(shortcutPath);
@@ -24,6 +27,7 @@ namespace Emby.Server.Implementations.IO
             return null;
         }
 
+        /// <inheritdoc />
         public void Create(string shortcutPath, string targetPath)
         {
             ArgumentException.ThrowIfNullOrEmpty(shortcutPath);

--- a/Emby.Server.Implementations/Images/ArtistImageProvider.cs
+++ b/Emby.Server.Implementations/Images/ArtistImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using MediaBrowser.Common.Configuration;
@@ -16,6 +14,13 @@ namespace Emby.Server.Implementations.Images
     /// </summary>
     public class ArtistImageProvider : BaseDynamicImageProvider<MusicArtist>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
         public ArtistImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor)
         {

--- a/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseFolderImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -15,17 +13,30 @@ using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Images
 {
+    /// <summary>
+    /// Base class for folder image providers.
+    /// </summary>
+    /// <typeparam name="T">The folder type.</typeparam>
     public abstract class BaseFolderImageProvider<T> : BaseDynamicImageProvider<T>
         where T : Folder, new()
     {
         private readonly ILibraryManager _libraryManager;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseFolderImageProvider{T}"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
+        /// <param name="libraryManager">The library manager.</param>
         protected BaseFolderImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor)
         {
             _libraryManager = libraryManager;
         }
 
+        /// <inheritdoc />
         protected override IReadOnlyList<BaseItem> GetItemsWithImages(BaseItem item)
         {
             return _libraryManager.GetItemList(new InternalItemsQuery
@@ -43,16 +54,19 @@ namespace Emby.Server.Implementations.Images
             });
         }
 
+        /// <inheritdoc />
         protected override string CreateImage(BaseItem item, IReadOnlyCollection<BaseItem> itemsWithImages, string outputPathWithoutExtension, ImageType imageType, int imageIndex)
         {
             return CreateSingleImage(itemsWithImages, outputPathWithoutExtension, ImageType.Primary);
         }
 
+        /// <inheritdoc />
         protected override bool Supports(BaseItem item)
         {
             return item is T;
         }
 
+        /// <inheritdoc />
         protected override bool HasChangedByDate(BaseItem item, ItemImageInfo image)
         {
             if (item is MusicAlbum)

--- a/Emby.Server.Implementations/Images/FolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/FolderImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
@@ -10,13 +8,25 @@ using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Images
 {
+    /// <summary>
+    /// Provides folder images.
+    /// </summary>
     public class FolderImageProvider : BaseFolderImageProvider<Folder>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FolderImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
+        /// <param name="libraryManager">The library manager.</param>
         public FolderImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor, libraryManager)
         {
         }
 
+        /// <inheritdoc />
         protected override bool Supports(BaseItem item)
         {
             if (item is PhotoAlbum || item is MusicAlbum)

--- a/Emby.Server.Implementations/Images/GenreImageProvider.cs
+++ b/Emby.Server.Implementations/Images/GenreImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -25,6 +23,14 @@ namespace Emby.Server.Implementations.Images
         /// </summary>
         private readonly ILibraryManager _libraryManager;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenreImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
+        /// <param name="libraryManager">The library manager.</param>
         public GenreImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager) : base(fileSystem, providerManager, applicationPaths, imageProcessor)
         {
             _libraryManager = libraryManager;

--- a/Emby.Server.Implementations/Images/MusicAlbumImageProvider.cs
+++ b/Emby.Server.Implementations/Images/MusicAlbumImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Common.Configuration;
@@ -12,13 +10,25 @@ using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Images
 {
+    /// <summary>
+    /// Provides images for music albums.
+    /// </summary>
     public class MusicAlbumImageProvider : BaseFolderImageProvider<MusicAlbum>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MusicAlbumImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
+        /// <param name="libraryManager">The library manager.</param>
         public MusicAlbumImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor, libraryManager)
         {
         }
 
+        /// <inheritdoc />
         protected override IReadOnlyList<BaseItem> GetItemsWithImages(BaseItem item)
         {
             var items = base.GetItemsWithImages(item);

--- a/Emby.Server.Implementations/Images/PhotoAlbumImageProvider.cs
+++ b/Emby.Server.Implementations/Images/PhotoAlbumImageProvider.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
@@ -9,8 +7,19 @@ using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Images
 {
+    /// <summary>
+    /// Provides images for photo albums.
+    /// </summary>
     public class PhotoAlbumImageProvider : BaseFolderImageProvider<PhotoAlbum>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PhotoAlbumImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="providerManager">The provider manager.</param>
+        /// <param name="applicationPaths">The application paths.</param>
+        /// <param name="imageProcessor">The image processor.</param>
+        /// <param name="libraryManager">The library manager.</param>
         public PhotoAlbumImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
             : base(fileSystem, providerManager, applicationPaths, imageProcessor, libraryManager)
         {

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -153,7 +153,7 @@ namespace Emby.Server.Implementations.Library
             _itemRepository = itemRepository;
             _imageProcessor = imageProcessor;
 
-            _cache = new FastConcurrentLru<Guid, BaseItem>(_configurationManager.Configuration.CacheSize);
+            _cache = new FastConcurrentLru<Guid, BaseItem>(_configurationManager.ServerConfig.CacheSize);
 
             _namingOptions = namingOptions;
             _peopleRepository = peopleRepository;
@@ -162,7 +162,7 @@ namespace Emby.Server.Implementations.Library
 
             _configurationManager.ConfigurationUpdated += ConfigurationUpdated;
 
-            RecordConfigurationValues(_configurationManager.Configuration);
+            RecordConfigurationValues(_configurationManager.ServerConfig);
         }
 
         /// <summary>
@@ -279,7 +279,7 @@ namespace Emby.Server.Implementations.Library
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         private void ConfigurationUpdated(object? sender, EventArgs e)
         {
-            var config = _configurationManager.Configuration;
+            var config = _configurationManager.ServerConfig;
 
             var wizardChanged = config.IsStartupWizardCompleted != _wizardCompleted;
 
@@ -641,7 +641,7 @@ namespace Emby.Server.Implementations.Library
                     .Replace('/', '\\');
             }
 
-            if (forceCaseInsensitive || !_configurationManager.Configuration.EnableCaseSensitiveItemIds)
+            if (forceCaseInsensitive || !_configurationManager.ServerConfig.EnableCaseSensitiveItemIds)
             {
                 key = key.ToLowerInvariant();
             }
@@ -1088,7 +1088,7 @@ namespace Emby.Server.Implementations.Library
         private Guid GetItemByNameId<T>(string path)
               where T : BaseItem, new()
         {
-            var forceCaseInsensitiveId = _configurationManager.Configuration.EnableNormalizedItemByNameIds;
+            var forceCaseInsensitiveId = _configurationManager.ServerConfig.EnableNormalizedItemByNameIds;
             return GetNewItemIdInternal(path, typeof(T), forceCaseInsensitiveId);
         }
 
@@ -2344,7 +2344,7 @@ namespace Emby.Server.Implementations.Library
 
         private CollectionType? GetContentTypeOverride(string path, bool inherit)
         {
-            var nameValuePair = _configurationManager.Configuration.ContentTypes
+            var nameValuePair = _configurationManager.ServerConfig.ContentTypes
                                     .FirstOrDefault(i => _fileSystem.AreEqual(i.Name, path)
                                                          || (inherit && !string.IsNullOrEmpty(i.Name)
                                                                      && _fileSystem.ContainsSubPath(i.Name, path)));
@@ -2880,7 +2880,7 @@ namespace Emby.Server.Implementations.Library
 
         public string GetPathAfterNetworkSubstitution(string path, BaseItem? ownerItem)
         {
-            foreach (var map in _configurationManager.Configuration.PathSubstitutions)
+            foreach (var map in _configurationManager.ServerConfig.PathSubstitutions)
             {
                 if (path.TryReplaceSubPath(map.From, map.To, out var newPath))
                 {
@@ -3287,7 +3287,7 @@ namespace Emby.Server.Implementations.Library
 
             List<NameValuePair>? removeList = null;
 
-            foreach (var contentType in _configurationManager.Configuration.ContentTypes)
+            foreach (var contentType in _configurationManager.ServerConfig.ContentTypes)
             {
                 if (string.IsNullOrWhiteSpace(contentType.Name)
                     || _fileSystem.AreEqual(path, contentType.Name)
@@ -3299,7 +3299,7 @@ namespace Emby.Server.Implementations.Library
 
             if (removeList is not null)
             {
-                _configurationManager.Configuration.ContentTypes = _configurationManager.Configuration.ContentTypes
+                _configurationManager.ServerConfig.ContentTypes = _configurationManager.ServerConfig.ContentTypes
                     .Except(removeList)
                     .ToArray();
 

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations.Library
         {
             _config = config;
             _repository = repository;
-            _cache = new FastConcurrentLru<string, UserItemData>(Environment.ProcessorCount, _config.Configuration.CacheSize, StringComparer.OrdinalIgnoreCase);
+            _cache = new FastConcurrentLru<string, UserItemData>(Environment.ProcessorCount, _config.ServerConfig.CacheSize, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />
@@ -303,12 +303,12 @@ namespace Emby.Server.Implementations.Library
             {
                 var pctIn = decimal.Divide(positionTicks, runtimeTicks) * 100;
 
-                if (pctIn < _config.Configuration.MinResumePct)
+                if (pctIn < _config.ServerConfig.MinResumePct)
                 {
                     // ignore progress during the beginning
                     positionTicks = 0;
                 }
-                else if (pctIn > _config.Configuration.MaxResumePct || positionTicks >= (runtimeTicks - TimeSpan.TicksPerSecond))
+                else if (pctIn > _config.ServerConfig.MaxResumePct || positionTicks >= (runtimeTicks - TimeSpan.TicksPerSecond))
                 {
                     // mark as completed close to the end
                     positionTicks = 0;
@@ -318,7 +318,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     // Enforce MinResumeDuration
                     var durationSeconds = TimeSpan.FromTicks(runtimeTicks).TotalSeconds;
-                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
+                    if (durationSeconds < _config.ServerConfig.MinResumeDurationSeconds)
                     {
                         positionTicks = 0;
                         data.Played = playedToCompletion = true;
@@ -330,12 +330,12 @@ namespace Emby.Server.Implementations.Library
                 var playbackPositionInMinutes = TimeSpan.FromTicks(positionTicks).TotalMinutes;
                 var remainingTimeInMinutes = TimeSpan.FromTicks(runtimeTicks - positionTicks).TotalMinutes;
 
-                if (playbackPositionInMinutes < _config.Configuration.MinAudiobookResume)
+                if (playbackPositionInMinutes < _config.ServerConfig.MinAudiobookResume)
                 {
                     // ignore progress during the beginning
                     positionTicks = 0;
                 }
-                else if (remainingTimeInMinutes < _config.Configuration.MaxAudiobookResume || positionTicks >= runtimeTicks)
+                else if (remainingTimeInMinutes < _config.ServerConfig.MaxAudiobookResume || positionTicks >= runtimeTicks)
                 {
                     // mark as completed close to the end
                     positionTicks = 0;

--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -110,7 +110,7 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            if (_config.Configuration.EnableFolderView)
+            if (_config.ServerConfig.EnableFolderView)
             {
                 var name = _localizationManager.GetLocalizedString("Folders");
                 list.Add(_libraryManager.GetNamedView(name, CollectionType.folders, string.Empty));

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -264,7 +264,7 @@ namespace Emby.Server.Implementations.Localization
             // Fallback to server default if no country code is specified.
             if (string.IsNullOrEmpty(countryCode))
             {
-                countryCode = _configurationManager.Configuration.MetadataCountryCode;
+                countryCode = _configurationManager.ServerConfig.MetadataCountryCode;
             }
 
             if (_allParentalRatings.TryGetValue(countryCode, out var countryValue))
@@ -360,7 +360,7 @@ namespace Emby.Server.Implementations.Localization
         /// <inheritdoc />
         public string GetLocalizedString(string phrase)
         {
-            return GetLocalizedString(phrase, _configurationManager.Configuration.UICulture);
+            return GetLocalizedString(phrase, _configurationManager.ServerConfig.UICulture);
         }
 
         /// <inheritdoc />
@@ -368,7 +368,7 @@ namespace Emby.Server.Implementations.Localization
         {
             if (string.IsNullOrEmpty(culture))
             {
-                culture = _configurationManager.Configuration.UICulture;
+                culture = _configurationManager.ServerConfig.UICulture;
             }
 
             if (string.IsNullOrEmpty(culture))

--- a/Emby.Server.Implementations/Playlists/PlaylistsFolder.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistsFolder.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -12,6 +10,9 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Playlists
 {
+    /// <summary>
+    /// Represents a folder containing playlists.
+    /// </summary>
     [RequiresSourceSerialisation]
     public class PlaylistsFolder : BasePluginFolder
     {

--- a/Emby.Server.Implementations/QuickConnect/QuickConnectManager.cs
+++ b/Emby.Server.Implementations/QuickConnect/QuickConnectManager.cs
@@ -55,7 +55,7 @@ namespace Emby.Server.Implementations.QuickConnect
         }
 
         /// <inheritdoc />
-        public bool IsEnabled => _config.Configuration.QuickConnectAvailable;
+        public bool IsEnabled => _config.ServerConfig.QuickConnectAvailable;
 
         /// <summary>
         /// Assert that quick connect is currently active and throws an exception if it is not.

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanActivityLogTask.cs
@@ -58,7 +58,7 @@ public class CleanActivityLogTask : IScheduledTask, IConfigurableScheduledTask
     /// <inheritdoc />
     public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var retentionDays = _serverConfigurationManager.Configuration.ActivityLogRetentionDays;
+        var retentionDays = _serverConfigurationManager.ServerConfig.ActivityLogRetentionDays;
         if (!retentionDays.HasValue || retentionDays < 0)
         {
             throw new InvalidOperationException($"Activity Log Retention days must be at least 0. Currently: {retentionDays}");

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -155,7 +155,9 @@ namespace Emby.Server.Implementations.Session
         /// Gets all connections.
         /// </summary>
         /// <value>All connections.</value>
+#pragma warning disable CA1721 // Property name conflicts with method name but this is part of ISessionManager public interface
         public IEnumerable<SessionInfo> Sessions => _activeConnections.Values.OrderByDescending(c => c.LastActivityDate);
+#pragma warning restore CA1721
 
         private void OnDeviceManagerDeviceOptionsUpdated(object sender, GenericEventArgs<Tuple<string, DeviceOptions>> e)
         {
@@ -613,7 +615,7 @@ namespace Emby.Server.Implementations.Session
         {
             _idleTimer ??= new Timer(CheckForIdlePlayback, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
 
-            if (_config.Configuration.InactiveSessionThreshold > 0)
+            if (_config.ServerConfig.InactiveSessionThreshold > 0)
             {
                 _inactiveTimer ??= new Timer(CheckForInactiveSteams, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             }
@@ -684,11 +686,11 @@ namespace Emby.Server.Implementations.Session
             var inactiveSessions = Sessions.Where(i =>
                     i.NowPlayingItem is not null
                     && i.PlayState.IsPaused
-                    && (DateTime.UtcNow - i.LastPausedDate).Value.TotalMinutes > _config.Configuration.InactiveSessionThreshold);
+                    && (DateTime.UtcNow - i.LastPausedDate).Value.TotalMinutes > _config.ServerConfig.InactiveSessionThreshold);
 
             foreach (var session in inactiveSessions)
             {
-                _logger.LogDebug("Session {Session} has been inactive for {InactiveTime} minutes. Stopping it.", session.Id, _config.Configuration.InactiveSessionThreshold);
+                _logger.LogDebug("Session {Session} has been inactive for {InactiveTime} minutes. Stopping it.", session.Id, _config.ServerConfig.InactiveSessionThreshold);
 
                 try
                 {
@@ -1935,7 +1937,7 @@ namespace Emby.Server.Implementations.Session
         }
 
         /// <inheritdoc/>
-        public IReadOnlyList<SessionInfoDto> GetSessions(
+        public IReadOnlyList<SessionInfoDto> GetAllSessions(
             Guid userId,
             string deviceId,
             int? activeWithinSeconds,

--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
@@ -9,6 +7,9 @@ using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Sorting
 {
+    /// <summary>
+    /// Compares episodes by their aired order.
+    /// </summary>
     public class AiredEpisodeOrderComparer : IBaseItemComparer
     {
         /// <summary>

--- a/Emby.Server.Implementations/SystemManager.cs
+++ b/Emby.Server.Implementations/SystemManager.cs
@@ -78,7 +78,7 @@ public class SystemManager : ISystemManager
             StartupWizardCompleted = _configurationManager.CommonConfiguration.IsStartupWizardCompleted,
             SupportsLibraryMonitor = true,
             PackageName = _startupOptions.PackageName,
-            CastReceiverApplications = _configurationManager.Configuration.CastReceiverApplications
+            CastReceiverApplications = _configurationManager.ServerConfig.CastReceiverApplications
         };
     }
 

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +17,9 @@ using Series = MediaBrowser.Controller.Entities.TV.Series;
 
 namespace Emby.Server.Implementations.TV
 {
+    /// <summary>
+    /// Manages TV series data and operations.
+    /// </summary>
     public class TVSeriesManager : ITVSeriesManager
     {
         private readonly IUserDataManager _userDataManager;
@@ -182,7 +183,7 @@ namespace Emby.Server.Implementations.TV
 
                 var nextEpisode = _libraryManager.GetItemList(nextQuery).Cast<Episode>().FirstOrDefault();
 
-                if (_configurationManager.Configuration.DisplaySpecialsWithinSeasons)
+                if (_configurationManager.ServerConfig.DisplaySpecialsWithinSeasons)
                 {
                     var consideredEpisodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
                     {

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -167,7 +167,7 @@ namespace Emby.Server.Implementations.Updates
         public async Task<IReadOnlyList<PackageInfo>> GetAvailablePackages(CancellationToken cancellationToken = default)
         {
             var result = new List<PackageInfo>();
-            foreach (RepositoryInfo repository in _config.Configuration.PluginRepositories)
+            foreach (RepositoryInfo repository in _config.ServerConfig.PluginRepositories)
             {
                 if (repository.Enabled && repository.Url is not null)
                 {
@@ -548,11 +548,9 @@ namespace Emby.Server.Implementations.Updates
                 {
                     Directory.Delete(targetDir, true);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
-                catch
-#pragma warning restore CA1031 // Do not catch general exception types
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
                 {
-                    // Ignore any exceptions.
+                    // Ignore any exceptions related to file system operations.
                 }
             }
 

--- a/Jellyfin.Api/Controllers/ClientLogController.cs
+++ b/Jellyfin.Api/Controllers/ClientLogController.cs
@@ -49,7 +49,7 @@ public class ClientLogController : BaseJellyfinApiController
     [RequestSizeLimit(MaxDocumentSize)]
     public async Task<ActionResult<ClientLogDocumentResponseDto>> LogFile()
     {
-        if (!_serverConfigurationManager.Configuration.AllowClientLogUpload)
+        if (!_serverConfigurationManager.ServerConfig.AllowClientLogUpload)
         {
             return Forbid();
         }

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -51,7 +51,7 @@ public class ConfigurationController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<ServerConfiguration> GetConfiguration()
     {
-        return _configurationManager.Configuration;
+        return _configurationManager.ServerConfig;
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -214,7 +214,7 @@ public class ItemUpdateController : BaseJellyfinApiController
 
         var path = item.ContainingFolderPath;
 
-        var types = _serverConfigurationManager.Configuration.ContentTypes
+        var types = _serverConfigurationManager.ServerConfig.ContentTypes
             .Where(i => !string.IsNullOrWhiteSpace(i.Name))
             .Where(i => !string.Equals(i.Name, path, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -228,7 +228,7 @@ public class ItemUpdateController : BaseJellyfinApiController
             });
         }
 
-        _serverConfigurationManager.Configuration.ContentTypes = types.ToArray();
+        _serverConfigurationManager.ServerConfig.ContentTypes = types.ToArray();
         _serverConfigurationManager.SaveConfiguration();
         return NoContent();
     }

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -758,7 +758,7 @@ public class LibraryController : BaseJellyfinApiController
         if (isMovie.Value)
         {
             includeItemTypes.Add(BaseItemKind.Movie);
-            if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+            if (_serverConfigurationManager.ServerConfig.EnableExternalContentInSuggestions)
             {
                 includeItemTypes.Add(BaseItemKind.Trailer);
                 includeItemTypes.Add(BaseItemKind.LiveTvProgram);
@@ -995,7 +995,7 @@ public class LibraryController : BaseJellyfinApiController
             return false;
         }
 
-        var metadataOptions = _serverConfigurationManager.Configuration.MetadataOptions
+        var metadataOptions = _serverConfigurationManager.ServerConfig.MetadataOptions
             .Where(i => itemTypes.Contains(i.ItemType ?? string.Empty, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 

--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -101,7 +101,7 @@ public class MoviesController : BaseJellyfinApiController
         var recentlyPlayedMovies = _libraryManager.GetItemList(query);
 
         var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+        if (_serverConfigurationManager.ServerConfig.EnableExternalContentInSuggestions)
         {
             itemTypes.Add(BaseItemKind.Trailer);
             itemTypes.Add(BaseItemKind.LiveTvProgram);
@@ -184,7 +184,7 @@ public class MoviesController : BaseJellyfinApiController
         RecommendationType type)
     {
         var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+        if (_serverConfigurationManager.ServerConfig.EnableExternalContentInSuggestions)
         {
             itemTypes.Add(BaseItemKind.Trailer);
             itemTypes.Add(BaseItemKind.LiveTvProgram);
@@ -225,7 +225,7 @@ public class MoviesController : BaseJellyfinApiController
     private IEnumerable<RecommendationDto> GetWithActor(User? user, IEnumerable<string> names, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
     {
         var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+        if (_serverConfigurationManager.ServerConfig.EnableExternalContentInSuggestions)
         {
             itemTypes.Add(BaseItemKind.Trailer);
             itemTypes.Add(BaseItemKind.LiveTvProgram);
@@ -264,7 +264,7 @@ public class MoviesController : BaseJellyfinApiController
     private IEnumerable<RecommendationDto> GetSimilarTo(User? user, IEnumerable<BaseItem> baselineItems, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
     {
         var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+        if (_serverConfigurationManager.ServerConfig.EnableExternalContentInSuggestions)
         {
             itemTypes.Add(BaseItemKind.Trailer);
             itemTypes.Add(BaseItemKind.LiveTvProgram);

--- a/Jellyfin.Api/Controllers/PackageController.cs
+++ b/Jellyfin.Api/Controllers/PackageController.cs
@@ -144,7 +144,7 @@ public class PackageController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<IEnumerable<RepositoryInfo>> GetRepositories()
     {
-        return Ok(_serverConfigurationManager.Configuration.PluginRepositories.AsEnumerable());
+        return Ok(_serverConfigurationManager.ServerConfig.PluginRepositories.AsEnumerable());
     }
 
     /// <summary>
@@ -157,7 +157,7 @@ public class PackageController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult SetRepositories([FromBody, Required] RepositoryInfo[] repositoryInfos)
     {
-        _serverConfigurationManager.Configuration.PluginRepositories = repositoryInfos;
+        _serverConfigurationManager.ServerConfig.PluginRepositories = repositoryInfos;
         _serverConfigurationManager.SaveConfiguration();
         return NoContent();
     }

--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -58,7 +58,7 @@ public class SessionController : BaseJellyfinApiController
         [FromQuery] int? activeWithinSeconds)
     {
         Guid? controllableUserToCheck = controllableByUserId is null ? null : RequestHelpers.GetUserId(User, controllableByUserId);
-        var result = _sessionManager.GetSessions(
+        var result = _sessionManager.GetAllSessions(
             User.GetUserId(),
             deviceId,
             activeWithinSeconds,

--- a/Jellyfin.Api/Controllers/StartupController.cs
+++ b/Jellyfin.Api/Controllers/StartupController.cs
@@ -42,7 +42,7 @@ public class StartupController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult CompleteWizard()
     {
-        _config.Configuration.IsStartupWizardCompleted = true;
+        _config.ServerConfig.IsStartupWizardCompleted = true;
         _config.SaveConfiguration();
         return NoContent();
     }
@@ -58,10 +58,10 @@ public class StartupController : BaseJellyfinApiController
     {
         return new StartupConfigurationDto
         {
-            ServerName = _config.Configuration.ServerName,
-            UICulture = _config.Configuration.UICulture,
-            MetadataCountryCode = _config.Configuration.MetadataCountryCode,
-            PreferredMetadataLanguage = _config.Configuration.PreferredMetadataLanguage
+            ServerName = _config.ServerConfig.ServerName,
+            UICulture = _config.ServerConfig.UICulture,
+            MetadataCountryCode = _config.ServerConfig.MetadataCountryCode,
+            PreferredMetadataLanguage = _config.ServerConfig.PreferredMetadataLanguage
         };
     }
 
@@ -75,10 +75,10 @@ public class StartupController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateInitialConfiguration([FromBody, Required] StartupConfigurationDto startupConfiguration)
     {
-        _config.Configuration.ServerName = startupConfiguration.ServerName ?? string.Empty;
-        _config.Configuration.UICulture = startupConfiguration.UICulture ?? string.Empty;
-        _config.Configuration.MetadataCountryCode = startupConfiguration.MetadataCountryCode ?? string.Empty;
-        _config.Configuration.PreferredMetadataLanguage = startupConfiguration.PreferredMetadataLanguage ?? string.Empty;
+        _config.ServerConfig.ServerName = startupConfiguration.ServerName ?? string.Empty;
+        _config.ServerConfig.UICulture = startupConfiguration.UICulture ?? string.Empty;
+        _config.ServerConfig.MetadataCountryCode = startupConfiguration.MetadataCountryCode ?? string.Empty;
+        _config.ServerConfig.PreferredMetadataLanguage = startupConfiguration.PreferredMetadataLanguage ?? string.Empty;
         _config.SaveConfiguration();
         return NoContent();
     }

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -109,7 +109,7 @@ public class UserController : BaseJellyfinApiController
     public ActionResult<IEnumerable<UserDto>> GetPublicUsers()
     {
         // If the startup wizard hasn't been completed then just return all users
-        if (!_config.Configuration.IsStartupWizardCompleted)
+        if (!_config.ServerConfig.IsStartupWizardCompleted)
         {
             return Ok(Get(false, false, false, false));
         }

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -499,7 +499,7 @@ public class MediaInfoHelper
 
         if (remoteClientMaxBitrate <= 0)
         {
-            remoteClientMaxBitrate = _serverConfigurationManager.Configuration.RemoteClientBitrateLimit;
+            remoteClientMaxBitrate = _serverConfigurationManager.ServerConfig.RemoteClientBitrateLimit;
         }
 
         if (remoteClientMaxBitrate > 0)

--- a/Jellyfin.Api/Middleware/ResponseTimeMiddleware.cs
+++ b/Jellyfin.Api/Middleware/ResponseTimeMiddleware.cs
@@ -42,8 +42,8 @@ public class ResponseTimeMiddleware
     {
         var startTimestamp = Stopwatch.GetTimestamp();
 
-        var enableWarning = serverConfigurationManager.Configuration.EnableSlowResponseWarning;
-        var warningThreshold = serverConfigurationManager.Configuration.SlowResponseThresholdMs;
+        var enableWarning = serverConfigurationManager.ServerConfig.EnableSlowResponseWarning;
+        var warningThreshold = serverConfigurationManager.ServerConfig.SlowResponseThresholdMs;
         context.Response.OnStarting(() =>
         {
             var responseTime = Stopwatch.GetElapsedTime(startTimestamp);

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1131,7 +1131,7 @@ public sealed class BaseItemRepository
     private BaseItemDto DeserializeBaseItem(BaseItemEntity baseItemEntity, bool skipDeserialization = false)
     {
         ArgumentNullException.ThrowIfNull(baseItemEntity, nameof(baseItemEntity));
-        if (_serverConfigurationManager?.Configuration is null)
+        if (_serverConfigurationManager?.ServerConfig is null)
         {
             throw new InvalidOperationException("Server Configuration manager or configuration is null");
         }
@@ -1141,7 +1141,7 @@ public sealed class BaseItemRepository
             baseItemEntity,
             _logger,
             _appHost,
-            skipDeserialization || (_serverConfigurationManager.Configuration.SkipDeserializationForBasicTypes && (typeToSerialise == typeof(Channel) || typeToSerialise == typeof(UserRootFolder))));
+            skipDeserialization || (_serverConfigurationManager.ServerConfig.SkipDeserializationForBasicTypes && (typeToSerialise == typeof(Channel) || typeToSerialise == typeof(UserRootFolder))));
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
@@ -90,12 +90,12 @@ namespace Jellyfin.Server.Implementations.Security
                 auth.TryGetValue("Token", out token);
             }
 
-            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
+            if (_configurationManager.ServerConfig.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = headers["X-Emby-Token"];
             }
 
-            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
+            if (_configurationManager.ServerConfig.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = headers["X-MediaBrowser-Token"];
             }
@@ -105,7 +105,7 @@ namespace Jellyfin.Server.Implementations.Security
                 token = queryString["ApiKey"];
             }
 
-            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
+            if (_configurationManager.ServerConfig.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
             {
                 token = queryString["api_key"];
             }
@@ -230,7 +230,7 @@ namespace Jellyfin.Server.Implementations.Security
         {
             var auth = httpReq.Headers[HeaderNames.Authorization];
 
-            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(auth))
+            if (_configurationManager.ServerConfig.EnableLegacyAuthorization && string.IsNullOrEmpty(auth))
             {
                 auth = httpReq.Headers["X-Emby-Authorization"];
             }
@@ -256,7 +256,7 @@ namespace Jellyfin.Server.Implementations.Security
             var name = authorizationHeader[..firstSpace];
 
             var validName = name.Equals("MediaBrowser", StringComparison.OrdinalIgnoreCase);
-            validName = validName || (_configurationManager.Configuration.EnableLegacyAuthorization && name.Equals("Emby", StringComparison.OrdinalIgnoreCase));
+            validName = validName || (_configurationManager.ServerConfig.EnableLegacyAuthorization && name.Equals("Emby", StringComparison.OrdinalIgnoreCase));
 
             if (!validName)
             {

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -80,7 +80,7 @@ public class TrickplayManager : ITrickplayManager
     /// <inheritdoc />
     public async Task MoveGeneratedTrickplayDataAsync(Video video, LibraryOptions libraryOptions, CancellationToken cancellationToken)
     {
-        var options = _config.Configuration.TrickplayOptions;
+        var options = _config.ServerConfig.TrickplayOptions;
         if (libraryOptions is null || !libraryOptions.EnableTrickplayImageExtraction || !CanGenerateTrickplay(video, options.Interval))
         {
             return;
@@ -138,7 +138,7 @@ public class TrickplayManager : ITrickplayManager
     /// <inheritdoc />
     public async Task RefreshTrickplayDataAsync(Video video, bool replace, LibraryOptions libraryOptions, CancellationToken cancellationToken)
     {
-        var options = _config.Configuration.TrickplayOptions;
+        var options = _config.ServerConfig.TrickplayOptions;
         if (!CanGenerateTrickplay(video, options.Interval) || libraryOptions is null)
         {
             return;

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -307,7 +307,7 @@ namespace Jellyfin.Server.Implementations.Users
         public UserDto GetUserDto(User user, string? remoteEndPoint = null)
         {
             var hasPassword = GetAuthenticationProvider(user).HasPassword(user);
-            var castReceiverApplications = _serverConfigurationManager.Configuration.CastReceiverApplications;
+            var castReceiverApplications = _serverConfigurationManager.ServerConfig.CastReceiverApplications;
             return new UserDto
             {
                 Name = user.Username,
@@ -632,7 +632,7 @@ namespace Jellyfin.Server.Implementations.Users
 
                 // Only set cast receiver id if it is passed in and it exists in the server config.
                 if (!string.IsNullOrEmpty(config.CastReceiverId)
-                    && _serverConfigurationManager.Configuration.CastReceiverApplications.Any(c => string.Equals(c.Id, config.CastReceiverId, StringComparison.Ordinal)))
+                    && _serverConfigurationManager.ServerConfig.CastReceiverApplications.Any(c => string.Equals(c.Id, config.CastReceiverId, StringComparison.Ordinal)))
                 {
                     user.CastReceiverId = config.CastReceiverId;
                 }

--- a/Jellyfin.Server/Configuration/CorsPolicyProvider.cs
+++ b/Jellyfin.Server/Configuration/CorsPolicyProvider.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Server.Configuration
         /// <inheritdoc />
         public Task<CorsPolicy?> GetPolicyAsync(HttpContext context, string? policyName)
         {
-            var corsHosts = _serverConfigurationManager.Configuration.CorsHosts;
+            var corsHosts = _serverConfigurationManager.ServerConfig.CorsHosts;
             var builder = new CorsPolicyBuilder()
                 .AllowAnyMethod()
                 .AllowAnyHeader();

--- a/Jellyfin.Server/Migrations/Routines/AddDefaultCastReceivers.cs
+++ b/Jellyfin.Server/Migrations/Routines/AddDefaultCastReceivers.cs
@@ -26,7 +26,7 @@ public class AddDefaultCastReceivers : IMigrationRoutine
     /// <inheritdoc />
     public void Perform()
     {
-        _serverConfigurationManager.Configuration.CastReceiverApplications =
+        _serverConfigurationManager.ServerConfig.CastReceiverApplications =
         [
             new()
             {

--- a/Jellyfin.Server/Migrations/Routines/AddDefaultPluginRepository.cs
+++ b/Jellyfin.Server/Migrations/Routines/AddDefaultPluginRepository.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Server.Migrations.Routines
         /// <inheritdoc/>
         public void Perform()
         {
-            _serverConfigurationManager.Configuration.PluginRepositories = new[] { _defaultRepositoryInfo };
+            _serverConfigurationManager.ServerConfig.PluginRepositories = new[] { _defaultRepositoryInfo };
             _serverConfigurationManager.SaveConfiguration();
         }
     }

--- a/Jellyfin.Server/Migrations/Routines/ReaddDefaultPluginRepository.cs
+++ b/Jellyfin.Server/Migrations/Routines/ReaddDefaultPluginRepository.cs
@@ -33,9 +33,9 @@ public class ReaddDefaultPluginRepository : IMigrationRoutine
     public void Perform()
     {
         // Only add if repository list is empty
-        if (_serverConfigurationManager.Configuration.PluginRepositories.Length == 0)
+        if (_serverConfigurationManager.ServerConfig.PluginRepositories.Length == 0)
         {
-            _serverConfigurationManager.Configuration.PluginRepositories = new[] { _defaultRepositoryInfo };
+            _serverConfigurationManager.ServerConfig.PluginRepositories = new[] { _defaultRepositoryInfo };
             _serverConfigurationManager.SaveConfiguration();
         }
     }

--- a/Jellyfin.Server/Migrations/Routines/UpdateDefaultPluginRepository.cs
+++ b/Jellyfin.Server/Migrations/Routines/UpdateDefaultPluginRepository.cs
@@ -29,7 +29,7 @@ public class UpdateDefaultPluginRepository : IMigrationRoutine
     public void Perform()
     {
         var updated = false;
-        foreach (var repo in _serverConfigurationManager.Configuration.PluginRepositories)
+        foreach (var repo in _serverConfigurationManager.ServerConfig.PluginRepositories)
         {
             if (string.Equals(repo.Url, OldRepositoryUrl, StringComparison.OrdinalIgnoreCase))
             {

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -216,7 +216,7 @@ namespace Jellyfin.Server
                 mainApp.UseWebSocketHandler();
                 mainApp.UseServerStartupMessage();
 
-                if (_serverConfigurationManager.Configuration.EnableMetrics)
+                if (_serverConfigurationManager.ServerConfig.EnableMetrics)
                 {
                     // Must be registered after any middleware that could change HTTP response codes or the data will be bad
                     mainApp.UseHttpMetrics();
@@ -225,7 +225,7 @@ namespace Jellyfin.Server
                 mainApp.UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();
-                    if (_serverConfigurationManager.Configuration.EnableMetrics)
+                    if (_serverConfigurationManager.ServerConfig.EnableMetrics)
                     {
                         endpoints.MapMetrics();
                     }

--- a/MediaBrowser.Controller/Configuration/IServerConfigurationManager.cs
+++ b/MediaBrowser.Controller/Configuration/IServerConfigurationManager.cs
@@ -18,6 +18,6 @@ namespace MediaBrowser.Controller.Configuration
         /// Gets the configuration.
         /// </summary>
         /// <value>The configuration.</value>
-        ServerConfiguration Configuration { get; }
+        ServerConfiguration ServerConfig { get; }
     }
 }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -929,7 +929,7 @@ namespace MediaBrowser.Controller.Entities
 
             var sortable = Name.Trim().ToLowerInvariant();
 
-            foreach (var search in ConfigurationManager.Configuration.SortRemoveWords)
+            foreach (var search in ConfigurationManager.ServerConfig.SortRemoveWords)
             {
                 // Remove from beginning if a space follows
                 if (sortable.StartsWith(search + " ", StringComparison.Ordinal))
@@ -947,12 +947,12 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
-            foreach (var removeChar in ConfigurationManager.Configuration.SortRemoveCharacters)
+            foreach (var removeChar in ConfigurationManager.ServerConfig.SortRemoveCharacters)
             {
                 sortable = sortable.Replace(removeChar, string.Empty, StringComparison.Ordinal);
             }
 
-            foreach (var replaceChar in ConfigurationManager.Configuration.SortReplaceCharacters)
+            foreach (var replaceChar in ConfigurationManager.ServerConfig.SortReplaceCharacters)
             {
                 sortable = sortable.Replace(replaceChar, " ", StringComparison.Ordinal);
             }
@@ -1511,7 +1511,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (string.IsNullOrEmpty(lang))
             {
-                lang = ConfigurationManager.Configuration.PreferredMetadataLanguage;
+                lang = ConfigurationManager.ServerConfig.PreferredMetadataLanguage;
             }
 
             return lang;
@@ -1546,7 +1546,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (string.IsNullOrEmpty(lang))
             {
-                lang = ConfigurationManager.Configuration.MetadataCountryCode;
+                lang = ConfigurationManager.ServerConfig.MetadataCountryCode;
             }
 
             return lang;

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1092,8 +1092,8 @@ namespace MediaBrowser.Controller.Entities
             if (!param.HasValue)
             {
                 if (user is not null && query.IncludeItemTypes.Any(type =>
-                    (type == BaseItemKind.Movie && !configurationManager.Configuration.EnableGroupingMoviesIntoCollections) ||
-                    (type == BaseItemKind.Series && !configurationManager.Configuration.EnableGroupingShowsIntoCollections)))
+                    (type == BaseItemKind.Movie && !configurationManager.ServerConfig.EnableGroupingMoviesIntoCollections) ||
+                    (type == BaseItemKind.Series && !configurationManager.ServerConfig.EnableGroupingShowsIntoCollections)))
                 {
                     return false;
                 }

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -363,7 +363,7 @@ namespace MediaBrowser.Controller.Entities.TV
 
         public List<BaseItem> GetSeasonEpisodes(Season parentSeason, User user, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
-            var queryFromSeries = ConfigurationManager.Configuration.DisplaySpecialsWithinSeasons;
+            var queryFromSeries = ConfigurationManager.ServerConfig.DisplaySpecialsWithinSeasons;
 
             // add optimization when this setting is not enabled
             var seriesKey = queryFromSeries ?
@@ -414,7 +414,7 @@ namespace MediaBrowser.Controller.Entities.TV
                 return GetSeasonEpisodes(parentSeason, user, options, shouldIncludeMissingEpisodes);
             }
 
-            var episodes = FilterEpisodesBySeason(allSeriesEpisodes, parentSeason, ConfigurationManager.Configuration.DisplaySpecialsWithinSeasons);
+            var episodes = FilterEpisodesBySeason(allSeriesEpisodes, parentSeason, ConfigurationManager.ServerConfig.DisplaySpecialsWithinSeasons);
 
             var sortBy = (parentSeason.IndexNumber ?? -1) == 0 ? ItemSortBy.SortName : ItemSortBy.AiredEpisodeOrder;
 

--- a/MediaBrowser.Controller/Library/MetadataConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Library/MetadataConfigurationExtensions.cs
@@ -19,6 +19,6 @@ namespace MediaBrowser.Controller.Library
         /// <param name="type">The type to get the <see cref="MetadataOptions" /> for.</param>
         /// <returns>The <see cref="MetadataOptions" /> for the specified type or <c>null</c>.</returns>
         public static MetadataOptions? GetMetadataOptionsForType(this IServerConfigurationManager config, string type)
-            => Array.Find(config.Configuration.MetadataOptions, i => string.Equals(i.ItemType, type, StringComparison.OrdinalIgnoreCase));
+            => Array.Find(config.ServerConfig.MetadataOptions, i => string.Equals(i.ItemType, type, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/MediaBrowser.Controller/LibraryTaskScheduler/LimitedConcurrencyLibraryScheduler.cs
+++ b/MediaBrowser.Controller/LibraryTaskScheduler/LimitedConcurrencyLibraryScheduler.cs
@@ -99,14 +99,14 @@ public sealed class LimitedConcurrencyLibraryScheduler : ILimitedConcurrencyLibr
     private bool ShouldForceSequentialOperation()
     {
         // if the user either set the setting to 1 or it's unset and we have fewer than 4 cores it's better to run sequentially.
-        var fanoutSetting = _serverConfigurationManager.Configuration.LibraryScanFanoutConcurrency;
+        var fanoutSetting = _serverConfigurationManager.ServerConfig.LibraryScanFanoutConcurrency;
         return fanoutSetting == 1 || (fanoutSetting <= 0 && Environment.ProcessorCount <= 3);
     }
 
     private int CalculateScanConcurrencyLimit()
     {
         // when this is invoked, we already checked ShouldForceSequentialOperation for the sequential check.
-        var fanoutConcurrency = _serverConfigurationManager.Configuration.LibraryScanFanoutConcurrency;
+        var fanoutConcurrency = _serverConfigurationManager.ServerConfig.LibraryScanFanoutConcurrency;
         if (fanoutConcurrency <= 0)
         {
             // in case the user did not set a limit manually, we can assume he has 3 or more cores as already checked by ShouldForceSequentialOperation.

--- a/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
@@ -92,7 +92,7 @@ namespace MediaBrowser.Controller.LiveTv
         {
             var list = base.GetUserDataKeys();
 
-            if (!ConfigurationManager.Configuration.DisableLiveTvChannelUserDataName)
+            if (!ConfigurationManager.ServerConfig.DisableLiveTvChannelUserDataName)
             {
                 list.Insert(0, GetClientTypeName() + "-" + Name);
             }

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -303,7 +303,7 @@ namespace MediaBrowser.Controller.Session
         /// <param name="controllableUserToCheck">Filter for sessions remote controllable for this user.</param>
         /// <param name="isApiKey">Is the request authenticated with API key.</param>
         /// <returns>IReadOnlyList{SessionInfoDto}.</returns>
-        IReadOnlyList<SessionInfoDto> GetSessions(Guid userId, string deviceId, int? activeWithinSeconds, Guid? controllableUserToCheck, bool isApiKey);
+        IReadOnlyList<SessionInfoDto> GetAllSessions(Guid userId, string deviceId, int? activeWithinSeconds, Guid? controllableUserToCheck, bool isApiKey);
 
         /// <summary>
         /// Gets the session by authentication token.

--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -140,7 +140,7 @@ namespace MediaBrowser.LocalMetadata.Savers
                 }
             }
 
-            if (ConfigurationManager.Configuration.SaveMetadataHidden)
+            if (ConfigurationManager.ServerConfig.SaveMetadataHidden)
             {
                 SetHidden(path, true);
             }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -127,7 +127,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             _jsonSerializerOptions.Converters.Add(new JsonBoolStringConverter());
 
             // Although the type is not nullable, this might still be null during unit tests
-            var semaphoreCount = serverConfig.Configuration?.ParallelImageEncodingLimit ?? 0;
+            var semaphoreCount = serverConfig.ServerConfig?.ParallelImageEncodingLimit ?? 0;
             if (semaphoreCount < 1)
             {
                 semaphoreCount = Environment.ProcessorCount;
@@ -646,7 +646,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private string GetImageResolutionParameter()
         {
-            var imageResolutionParameter = _serverConfig.Configuration.ChapterImageResolution switch
+            var imageResolutionParameter = _serverConfig.ServerConfig.ChapterImageResolution switch
             {
                 ImageResolution.P144 => "256x144",
                 ImageResolution.P240 => "426x240",
@@ -798,7 +798,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 {
                     StartProcess(processWrapper);
 
-                    var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
+                    var timeoutMs = _configurationManager.ServerConfig.ImageExtractionTimeoutMs;
                     if (timeoutMs <= 0)
                     {
                         timeoutMs = enableHdrExtraction ? DefaultHdrImageExtractionTimeout : DefaultSdrImageExtractionTimeout;
@@ -1052,7 +1052,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                     bool isResponsive = true;
                     int lastCount = 0;
-                    var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
+                    var timeoutMs = _configurationManager.ServerConfig.ImageExtractionTimeoutMs;
                     timeoutMs = timeoutMs <= 0 ? DefaultHdrImageExtractionTimeout : timeoutMs;
 
                     while (isResponsive && !cancellationToken.IsCancellationRequested)

--- a/MediaBrowser.Model/Channels/ChannelFeatures.cs
+++ b/MediaBrowser.Model/Channels/ChannelFeatures.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Channels
 {
@@ -38,13 +39,13 @@ namespace MediaBrowser.Model.Channels
         /// Gets or sets the media types.
         /// </summary>
         /// <value>The media types.</value>
-        public ChannelMediaType[] MediaTypes { get; set; }
+        public IReadOnlyList<ChannelMediaType> MediaTypes { get; set; }
 
         /// <summary>
         /// Gets or sets the content types.
         /// </summary>
         /// <value>The content types.</value>
-        public ChannelMediaContentType[] ContentTypes { get; set; }
+        public IReadOnlyList<ChannelMediaContentType> ContentTypes { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of records the channel allows retrieving at a time.
@@ -61,7 +62,7 @@ namespace MediaBrowser.Model.Channels
         /// Gets or sets the default sort orders.
         /// </summary>
         /// <value>The default sort orders.</value>
-        public ChannelItemSortField[] DefaultSortFields { get; set; }
+        public IReadOnlyList<ChannelItemSortField> DefaultSortFields { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether a sort ascending/descending toggle is supported.

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -303,7 +303,7 @@ namespace MediaBrowser.Providers.Manager
                     await source.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
                 }
 
-                if (_config.Configuration.SaveMetadataHidden)
+                if (_config.ServerConfig.SaveMetadataHidden)
                 {
                     SetHidden(path, true);
                 }
@@ -338,7 +338,7 @@ namespace MediaBrowser.Providers.Manager
         /// <returns>IEnumerable{System.String}.</returns>
         private string[] GetSavePaths(BaseItem item, ImageType type, int? imageIndex, string mimeType, bool saveLocally)
         {
-            if (!saveLocally || (_config.Configuration.ImageSavingConvention == ImageSavingConvention.Legacy))
+            if (!saveLocally || (_config.ServerConfig.ImageSavingConvention == ImageSavingConvention.Legacy))
             {
                 return new[] { GetStandardSavePath(item, type, imageIndex, mimeType, saveLocally) };
             }
@@ -504,7 +504,7 @@ namespace MediaBrowser.Providers.Manager
                 item is MusicArtist ||
                 item is PhotoAlbum ||
                 item is Person ||
-                (saveLocally && _config.Configuration.ImageSavingConvention == ImageSavingConvention.Legacy) ?
+                (saveLocally && _config.ServerConfig.ImageSavingConvention == ImageSavingConvention.Legacy) ?
                 "folder" :
                 "poster";
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -837,12 +837,12 @@ namespace MediaBrowser.Providers.Manager
 
             if (string.IsNullOrWhiteSpace(searchInfo.SearchInfo.MetadataLanguage))
             {
-                searchInfo.SearchInfo.MetadataLanguage = _configurationManager.Configuration.PreferredMetadataLanguage;
+                searchInfo.SearchInfo.MetadataLanguage = _configurationManager.ServerConfig.PreferredMetadataLanguage;
             }
 
             if (string.IsNullOrWhiteSpace(searchInfo.SearchInfo.MetadataCountryCode))
             {
-                searchInfo.SearchInfo.MetadataCountryCode = _configurationManager.Configuration.MetadataCountryCode;
+                searchInfo.SearchInfo.MetadataCountryCode = _configurationManager.ServerConfig.MetadataCountryCode;
             }
 
             var resultList = new List<RemoteSearchResult>();

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -281,7 +281,7 @@ namespace MediaBrowser.Providers.MediaInfo
             if (options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh
                 || options.MetadataRefreshMode == MetadataRefreshMode.Default)
             {
-                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
+                if (_config.ServerConfig.DummyChapterDuration > 0 && chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
                 {
                     chapters = CreateDummyChapters(video);
                 }
@@ -648,7 +648,7 @@ namespace MediaBrowser.Providers.MediaInfo
                         TimeSpan.FromTicks(runtime).TotalMinutes));
             }
 
-            long dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
+            long dummyChapterDuration = TimeSpan.FromSeconds(_config.ServerConfig.DummyChapterDuration).Ticks;
             if (runtime <= dummyChapterDuration)
             {
                 return [];

--- a/MediaBrowser.Providers/Trickplay/TrickplayProvider.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayProvider.cs
@@ -106,7 +106,7 @@ public class TrickplayProvider : ICustomMetadataProvider<Episode>,
             return ItemUpdateType.None;
         }
 
-        if (_config.Configuration.TrickplayOptions.ScanBehavior == TrickplayScanBehavior.Blocking)
+        if (_config.ServerConfig.TrickplayOptions.ScanBehavior == TrickplayScanBehavior.Blocking)
         {
             await _trickplayManager.RefreshTrickplayDataAsync(video, replace, libraryOptions, cancellationToken).ConfigureAwait(false);
         }

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -224,7 +224,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 await stream.CopyToAsync(filestream).ConfigureAwait(false);
             }
 
-            if (ConfigurationManager.Configuration.SaveMetadataHidden)
+            if (ConfigurationManager.ServerConfig.SaveMetadataHidden)
             {
                 SetHidden(path, true);
             }

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -65,7 +65,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
         _imageEncoder = imageEncoder;
         _appPaths = appPaths;
 
-        var semaphoreCount = config.Configuration.ParallelImageEncodingLimit;
+        var semaphoreCount = config.ServerConfig.ParallelImageEncodingLimit;
         if (semaphoreCount < 1)
         {
             semaphoreCount = Environment.ProcessorCount;

--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -54,7 +54,7 @@ namespace Jellyfin.LiveTv.Listings
                 return info.PreferredLanguage;
             }
 
-            return _config.Configuration.PreferredMetadataLanguage;
+            return _config.ServerConfig.PreferredMetadataLanguage;
         }
 
         private async Task<string> GetXml(ListingsProviderInfo info, CancellationToken cancellationToken)

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -463,8 +463,8 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             {
                 ProviderIds = timer.SeriesProviderIds,
                 Name = timer.Name,
-                MetadataCountryCode = _config.Configuration.MetadataCountryCode,
-                MetadataLanguage = _config.Configuration.PreferredMetadataLanguage
+                MetadataCountryCode = _config.ServerConfig.MetadataCountryCode,
+                MetadataLanguage = _config.ServerConfig.PreferredMetadataLanguage
             }
         };
 

--- a/tests/Jellyfin.Controller.Tests/BaseItemManagerTests.cs
+++ b/tests/Jellyfin.Controller.Tests/BaseItemManagerTests.cs
@@ -35,7 +35,7 @@ namespace Jellyfin.Controller.Tests
             }
 
             var serverConfigurationManager = new Mock<IServerConfigurationManager>();
-            serverConfigurationManager.Setup(scm => scm.Configuration)
+            serverConfigurationManager.Setup(scm => scm.ServerConfig)
                 .Returns(serverConfiguration);
 
             var baseItemManager = new BaseItemManager(serverConfigurationManager.Object);
@@ -68,7 +68,7 @@ namespace Jellyfin.Controller.Tests
             }
 
             var serverConfigurationManager = new Mock<IServerConfigurationManager>();
-            serverConfigurationManager.Setup(scm => scm.Configuration)
+            serverConfigurationManager.Setup(scm => scm.ServerConfig)
                 .Returns(serverConfiguration);
 
             var baseItemManager = new BaseItemManager(serverConfigurationManager.Object);

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -557,7 +557,7 @@ namespace Jellyfin.Providers.Tests.Manager
             IBaseItemManager? baseItemManager = null)
         {
             var serverConfigurationManager = new Mock<IServerConfigurationManager>(MockBehavior.Strict);
-            serverConfigurationManager.Setup(i => i.Configuration)
+            serverConfigurationManager.Setup(i => i.ServerConfig)
                 .Returns(serverConfiguration ?? new ServerConfiguration());
 
             var libraryManager = new Mock<ILibraryManager>(MockBehavior.Strict);

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
@@ -21,7 +21,7 @@ public class FFProbeVideoInfoTests
             DummyChapterDuration = (int)TimeSpan.FromMinutes(5).TotalSeconds
         };
         var serverConfig = new Mock<IServerConfigurationManager>();
-        serverConfig.Setup(c => c.Configuration)
+        serverConfig.Setup(c => c.ServerConfig)
             .Returns(serverConfiguration);
 
         IFixture fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -236,7 +236,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         private LocalizationManager Setup(ServerConfiguration config)
         {
             var mockConfiguration = new Mock<IServerConfigurationManager>();
-            mockConfiguration.SetupGet(x => x.Configuration).Returns(config);
+            mockConfiguration.SetupGet(x => x.ServerConfig).Returns(config);
 
             return new LocalizationManager(mockConfiguration.Object, new NullLogger<LocalizationManager>());
         }

--- a/tests/Jellyfin.Server.Implementations.Tests/QuickConnect/QuickConnectManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/QuickConnect/QuickConnectManagerTests.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Server.Implementations.Tests.QuickConnect
         {
             _config = new ServerConfiguration();
             var configManager = new Mock<IServerConfigurationManager>();
-            configManager.Setup(x => x.Configuration).Returns(_config);
+            configManager.Setup(x => x.ServerConfig).Returns(_config);
 
             _fixture = new Fixture();
             _fixture.Customize(new AutoMoqCustomization


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
We resolved 4 different compiler warnings as described below:
- In `Emby.Server.Implementations/Session/SessionManager.cs`: Changed the name of GetSessions to GetAllSessions to remove warning CA1721; also removed the comment suppressing the warning as it was no longer needed
- In `Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs`: Renamed Configuration to ServerConfig to remove warning CA1721 and reduce ambiguity
- In `Emby.Server.Implementations/Images/ArtistImageProvider.cs: Removed #pragma warning that disables CS1591 directives and added proper XML documentation comments to improve code documentation coverage
- In `Emby.Server.Implementations/AppBase/BaseConfigurationManager.cs‎: Renamed ConfigurationType to CommonConfigurationType to better reflect its purpose and resolved warning CA1721 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Contributes to #2149 - Eliminate All Compiler Warnings In Solution