### PR TITLE
Recognize ".m4b", ".m4a", ".aac", ".flac", ".mp3", and ".opus" as an audio-book formats 

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
@@ -16,7 +16,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Books
 {
     public class BookResolver : ItemResolver<Book>
     {
-        private readonly string[] _validExtensions = { ".azw", ".azw3", ".cb7", ".cbr", ".cbt", ".cbz", ".epub", ".mobi", ".pdf", ".m4b", ".m4a", ".aac", ".flac", ".mp3" };
+        private readonly string[] _validExtensions = { ".azw", ".azw3", ".cb7", ".cbr", ".cbt", ".cbz", ".epub", ".mobi", ".pdf", ".m4b", ".m4a", ".aac", ".flac", ".mp3", ".opus" };
 
         protected override Book Resolve(ItemResolveArgs args)
         {


### PR DESCRIPTION
**Changes**
- Has the resolver recognize the ".m4b", ".m4a", ".aac", ".flac", ".mp3", and ".opus" audio extensions as type `Book`

**Issues**
- Patches audiobook discovery as Jellyfin reverts to seeing the file as a music file without this check
  - Without Jellyfin marking the audio file as a book, the book metadata fetchers like, Google Books, become unavailable.

Below is the directory structure that allows for this bug to be reproducible:

```
Books
├── Author
│   └── Book2
│       └── Book2.m4b
```