### PR TITLE
Improve season folder parsing

### DIFF
--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -10,11 +10,16 @@ namespace Emby.Naming.TV
     /// </summary>
     public static partial class SeasonPathParser
     {
+        private static readonly Regex CleanNameRegex = new(@"[ ._\-\[\]]", RegexOptions.Compiled);
+
         [GeneratedRegex(@"^\s*((?<seasonnumber>(?>\d+))(?:st|nd|rd|th|\.)*(?!\s*[Ee]\d+))\s*(?:[[시즌]*|[シーズン]*|[sS](?:eason|æson|aison|taffel|eries|tagione|äsong|eizoen|easong|ezon|ezona|ezóna|ezonul)*|[tT](?:emporada)*|[kK](?:ausi)*|[Сс](?:езон)*)\s*(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
         private static partial Regex ProcessPre();
 
-        [GeneratedRegex(@"^\s*(?:[[시즌]*|[シーズン]*|[sS](?:eason|æson|aison|taffel|eries|tagione|äsong|eizoen|easong|ezon|ezona|ezóna|ezonul)*|[tT](?:emporada)*|[kK](?:ausi)*|[Сс](?:езон)*)\s*(?<seasonnumber>(?>\d+)(?!\s*[Ee]\d+))(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"^\s*(?:[[시즌]*|[シーズン]*|[sS](?:eason|æson|aison|taffel|eries|tagione|äsong|eizoen|easong|ezon|ezona|ezóna|ezonul)*|[tT](?:emporada)*|[kK](?:ausi)*|[Сс](?:езон)*)\s*(?<seasonnumber>\d+?)(?=\d{3,4}p|[^\d]|$)(?!\s*[Ee]\d)(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
         private static partial Regex ProcessPost();
+
+        [GeneratedRegex(@"[sS](\d{1,4})(?!\d|[eE]\d)(?=\.|_|-|\[|\]|\s|$)", RegexOptions.None)]
+        private static partial Regex SeasonPrefix();
 
         /// <summary>
         /// Attempts to parse season number from path.
@@ -56,44 +61,34 @@ namespace Emby.Naming.TV
             bool supportSpecialAliases,
             bool supportNumericSeasonFolders)
         {
-            string filename = Path.GetFileName(path);
-            filename = Regex.Replace(filename, "[ ._-]", string.Empty);
+            var fileName = Path.GetFileName(path);
+
+            var seasonPrefixMatch = SeasonPrefix().Match(fileName);
+            if (seasonPrefixMatch.Success &&
+                int.TryParse(seasonPrefixMatch.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
+            {
+                return (val, true);
+            }
+
+            string filename = CleanNameRegex.Replace(fileName, string.Empty);
 
             if (parentFolderName is not null)
             {
-                parentFolderName = Regex.Replace(parentFolderName, "[ ._-]", string.Empty);
-                filename = filename.Replace(parentFolderName, string.Empty, StringComparison.OrdinalIgnoreCase);
+                var cleanParent = CleanNameRegex.Replace(parentFolderName, string.Empty);
+                filename = filename.Replace(cleanParent, string.Empty, StringComparison.OrdinalIgnoreCase);
             }
 
-            if (supportSpecialAliases)
+            if (supportSpecialAliases &&
+                (filename.Equals("specials", StringComparison.OrdinalIgnoreCase) ||
+                 filename.Equals("extras", StringComparison.OrdinalIgnoreCase)))
             {
-                if (string.Equals(filename, "specials", StringComparison.OrdinalIgnoreCase))
-                {
-                    return (0, true);
-                }
-
-                if (string.Equals(filename, "extras", StringComparison.OrdinalIgnoreCase))
-                {
-                    return (0, true);
-                }
+                return (0, true);
             }
 
-            if (supportNumericSeasonFolders)
+            if (supportNumericSeasonFolders &&
+                int.TryParse(filename, NumberStyles.Integer, CultureInfo.InvariantCulture, out val))
             {
-                if (int.TryParse(filename, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
-                {
-                    return (val, true);
-                }
-            }
-
-            if (filename.Length > 0 && (filename[0] == 'S' || filename[0] == 's'))
-            {
-                var testFilename = filename.AsSpan()[1..];
-
-                if (int.TryParse(testFilename, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
-                {
-                    return (val, true);
-                }
+                return (val, true);
             }
 
             var preMatch = ProcessPre().Match(filename);

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
@@ -69,6 +69,12 @@ public class SeasonPathParserTests
     [InlineData("/media/YouTube/Devyn Johnston/2024-01-24 4070 Ti SUPER in under 7 minutes", "/media/YouTube/Devyn Johnston", null, false)]
     [InlineData("/media/YouTube/Devyn Johnston/2025-01-28 5090 vs 2 SFF Cases", "/media/YouTube/Devyn Johnston", null, false)]
     [InlineData("/Drive/202401244070", "/Drive", null, false)]
+    [InlineData("/Drive/Drive.S01.2160p.WEB-DL.DDP5.1.H.265-XXXX", "/Drive", 1, true)]
+    [InlineData("The Wonder Years/The.Wonder.Years.S04.1080p.PDTV.x264-JCH", "/The Wonder Years", 4, true)]
+    [InlineData("The Wonder Years/[The.Wonder.Years.S04.1080p.PDTV.x264-JCH]", "/The Wonder Years", 4, true)]
+    [InlineData("The Wonder Years/The.Wonder.Years [S04][1080p.PDTV.x264-JCH]", "/The Wonder Years", 4, true)]
+    [InlineData("The Wonder Years/The Wonder Years Season 01 1080p", "/The Wonder Years", 1, true)]
+
     public void GetSeasonNumberFromPathTest(string path, string? parentPath, int? seasonNumber, bool isSeasonDirectory)
     {
         var result = SeasonPathParser.Parse(path, parentPath, true, true);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Fixed `SeasonPathParser` to extract season numbers from filenames and folder names with bracketed season tags and numeric prefixes, while preventing false matches from resolution numbers like 1080p or 2160p. Added a `SeasonPrefix` regex and a `CleanNameRegex` to handle various filename formats that previously failed. Included new test patterns from user examples, covering cases that failed in the previous `SeasonPathParser`.

**Issues**
 Fixes #15253
