### PR TITLE
Add multi-file audiobook support

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -186,14 +186,8 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             foreach (var resolvedItem in resolverResult)
             {
-                if (resolvedItem.Files.Count > 1)
-                {
-                    // For now, until we sort out naming for multi-part books
-                    continue;
-                }
-
-                // Until multi-part books are handled letting files stack hides them from browsing in the client
-                if (resolvedItem.Files.Count == 0 || resolvedItem.Extras.Count > 0 || resolvedItem.AlternateVersions.Count > 0)
+                // Skip if there are no files
+                if (resolvedItem.Files.Count == 0)
                 {
                     continue;
                 }
@@ -208,8 +202,8 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
                     Name = parseName ?
                         resolvedItem.Name :
                         Path.GetFileNameWithoutExtension(firstMedia.Path),
-                    // AdditionalParts = resolvedItem.Files.Skip(1).Select(i => i.Path).ToArray(),
-                    // LocalAlternateVersions = resolvedItem.AlternateVersions.Select(i => i.Path).ToArray()
+                    AdditionalParts = resolvedItem.Files.Skip(1).Select(i => i.Path).ToArray(),
+                    LocalAlternateVersions = resolvedItem.AlternateVersions.Select(i => i.Path).ToArray()
                 };
 
                 result.Items.Add(libraryItem);

--- a/MediaBrowser.Controller/Entities/AudioBook.cs
+++ b/MediaBrowser.Controller/Entities/AudioBook.cs
@@ -3,15 +3,37 @@
 #pragma warning disable CA1724, CS1591
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Dto;
 
 namespace MediaBrowser.Controller.Entities
 {
     [Common.RequiresSourceSerialisation]
     public class AudioBook : Audio.Audio, IHasSeries, IHasLookupInfo<SongInfo>
     {
+        public AudioBook()
+        {
+            AdditionalParts = Array.Empty<string>();
+            LocalAlternateVersions = Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets or sets the additional parts for multi-file audiobooks.
+        /// </summary>
+        /// <value>The paths to additional audio files that are part of this audiobook.</value>
+        public string[] AdditionalParts { get; set; }
+
+        /// <summary>
+        /// Gets or sets the local alternate versions (e.g., different editions or formats).
+        /// </summary>
+        /// <value>The paths to alternate versions of this audiobook.</value>
+        public string[] LocalAlternateVersions { get; set; }
+
         [JsonIgnore]
         public override bool SupportsPositionTicksResume => true;
 
@@ -60,6 +82,76 @@ namespace MediaBrowser.Controller.Entities
         public override UnratedItem GetBlockUnratedType()
         {
             return UnratedItem.Book;
+        }
+
+        /// <summary>
+        /// Gets the additional part IDs for this audiobook.
+        /// </summary>
+        /// <returns>An enumerable of GUIDs representing the additional parts.</returns>
+        public IEnumerable<Guid> GetAdditionalPartIds()
+        {
+            return AdditionalParts.Select(i => LibraryManager.GetNewItemId(i, typeof(AudioBook)));
+        }
+
+        /// <summary>
+        /// Gets the additional parts as AudioBook items.
+        /// </summary>
+        /// <returns>An ordered enumerable of AudioBook items representing the additional parts.</returns>
+        public IOrderedEnumerable<AudioBook> GetAdditionalParts()
+        {
+            return GetAdditionalPartIds()
+                .Select(i => LibraryManager.GetItemById(i))
+                .Where(i => i is not null)
+                .OfType<AudioBook>()
+                .OrderBy(i => i.SortName);
+        }
+
+        /// <summary>
+        /// Gets the local alternate version IDs for this audiobook.
+        /// </summary>
+        /// <returns>An enumerable of GUIDs representing the local alternate versions.</returns>
+        public IEnumerable<Guid> GetLocalAlternateVersionIds()
+        {
+            return LocalAlternateVersions.Select(i => LibraryManager.GetNewItemId(i, typeof(AudioBook)));
+        }
+
+        protected override IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()
+        {
+            var list = new List<(BaseItem, MediaSourceType)>
+            {
+                (this, MediaSourceType.Default)
+            };
+
+            var localAlternates = GetLocalAlternateVersionIds()
+                .Select(LibraryManager.GetItemById)
+                .Where(i => i is not null)
+                .ToList();
+
+            list.AddRange(localAlternates.Select(i => (i, MediaSourceType.Default)));
+
+            return list;
+        }
+
+        internal override ItemUpdateType UpdateFromResolvedItem(BaseItem newItem)
+        {
+            var updateType = base.UpdateFromResolvedItem(newItem);
+
+            if (newItem is AudioBook newAudioBook)
+            {
+                if (!AdditionalParts.SequenceEqual(newAudioBook.AdditionalParts, StringComparer.Ordinal))
+                {
+                    AdditionalParts = newAudioBook.AdditionalParts;
+                    updateType |= ItemUpdateType.MetadataImport;
+                }
+
+                if (!LocalAlternateVersions.SequenceEqual(newAudioBook.LocalAlternateVersions, StringComparer.Ordinal))
+                {
+                    LocalAlternateVersions = newAudioBook.LocalAlternateVersions;
+                    updateType |= ItemUpdateType.MetadataImport;
+                }
+            }
+
+            return updateType;
         }
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/AudioBookDurationProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioBookDurationProvider.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Naming.AudioBook;
+using Emby.Naming.Common;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Providers.MediaInfo
+{
+    /// <summary>
+    /// Provider to calculate total duration for multi-file audiobooks.
+    /// This runs after ProbeProvider to sum durations of all parts.
+    /// </summary>
+    public class AudioBookDurationProvider :
+        ICustomMetadataProvider<AudioBook>,
+        IHasOrder
+    {
+        private readonly ILogger<AudioBookDurationProvider> _logger;
+        private readonly IMediaEncoder _mediaEncoder;
+        private readonly IFileSystem _fileSystem;
+        private readonly NamingOptions _namingOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioBookDurationProvider"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="mediaEncoder">The media encoder.</param>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="namingOptions">The naming options.</param>
+        public AudioBookDurationProvider(
+            ILogger<AudioBookDurationProvider> logger,
+            IMediaEncoder mediaEncoder,
+            IFileSystem fileSystem,
+            NamingOptions namingOptions)
+        {
+            _logger = logger;
+            _mediaEncoder = mediaEncoder;
+            _fileSystem = fileSystem;
+            _namingOptions = namingOptions;
+        }
+
+        /// <inheritdoc />
+        public string Name => "AudioBook Duration Calculator";
+
+        /// <summary>
+        /// Gets the order. Should run after ProbeProvider (which has Order 100).
+        /// </summary>
+        public int Order => 200;
+
+        /// <inheritdoc />
+        public Task<ItemUpdateType> FetchAsync(AudioBook item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        {
+            // Always process audiobooks - we need to calculate total duration
+            return CalculateTotalDurationAsync(item, cancellationToken);
+        }
+
+        private async Task<ItemUpdateType> CalculateTotalDurationAsync(AudioBook item, CancellationToken cancellationToken)
+        {
+            // Get the directory containing the audiobook
+            if (string.IsNullOrEmpty(item.Path))
+            {
+                return ItemUpdateType.None;
+            }
+
+            var directory = Path.GetDirectoryName(item.Path);
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                return ItemUpdateType.None;
+            }
+
+            // Get all audio files in the directory
+            var files = _fileSystem.GetFiles(directory, true)
+                .Where(f => _namingOptions.AudioFileExtensions.Contains(Path.GetExtension(f.FullName), StringComparer.OrdinalIgnoreCase))
+                .OrderBy(f => f.FullName)
+                .ToList();
+
+            _logger.LogInformation(
+                "Calculating total duration for audiobook: {Name} with {Count} audio files in directory",
+                item.Name,
+                files.Count);
+
+            if (files.Count <= 1)
+            {
+                // Single file audiobook, ProbeProvider already handled it
+                return ItemUpdateType.None;
+            }
+
+            // Probe each file and sum durations
+            long totalTicks = 0;
+            int successCount = 0;
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    var partResult = await _mediaEncoder.GetMediaInfo(
+                        new MediaInfoRequest
+                        {
+                            MediaType = DlnaProfileType.Audio,
+                            MediaSource = new MediaSourceInfo
+                            {
+                                Path = file.FullName,
+                                Protocol = MediaProtocol.File
+                            }
+                        },
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (partResult.RunTimeTicks.HasValue)
+                    {
+                        totalTicks += partResult.RunTimeTicks.Value;
+                        successCount++;
+                        _logger.LogDebug(
+                            "Added {Minutes:F2} minutes from file {Index}/{Total}: {Path}",
+                            TimeSpan.FromTicks(partResult.RunTimeTicks.Value).TotalMinutes,
+                            successCount,
+                            files.Count,
+                            file.Name);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to probe duration for file: {Path}",
+                        file.FullName);
+                }
+            }
+
+            if (successCount > 0)
+            {
+                // Update the item's runtime
+                item.RunTimeTicks = totalTicks;
+
+                var totalHours = TimeSpan.FromTicks(totalTicks).TotalHours;
+                _logger.LogInformation(
+                    "Total runtime calculated for {Name}: {Hours:F2} hours ({SuccessCount}/{TotalCount} files)",
+                    item.Name,
+                    totalHours,
+                    successCount,
+                    files.Count);
+
+                return ItemUpdateType.MetadataImport;
+            }
+
+            return ItemUpdateType.None;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
Adds support for audiobooks split across multiple audio files by implementing multi-file detection in AudioBookResolver using stack patterns, storing additional parts in the AudioBook entity, and calculating total duration across all files with a new AudioBookDurationProvider.

**Issues**
Addresses common user requests for proper multi-file audiobook support, bringing Jellyfin to feature parity with other audiobook applications.