### PR TITLE
fix: check itemId in collection/playlist cleanup

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -118,12 +118,9 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
             var path = linkedChild.Path;
             var itemId = linkedChild.ItemId;
 
-            if (itemId is not null)
+            if (itemId is not null && _libraryManager.GetItemById(itemId.Value) is not null)
             {
-               if (_libraryManager.GetItemById(itemId.Value) is not null)
-               {
-                  continue;
-               }
+                continue;
             }
 
             if (!File.Exists(path) && !Directory.Exists(path))


### PR DESCRIPTION
Linking children can be done by either item id or path.

Currently, the cleanup function only takes path into account. This PR add support for item id.