### PR TITLE
Fix System.NullReferenceException when people's role is null (10.11.z)

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -520,7 +520,7 @@ namespace MediaBrowser.Providers.MediaInfo
                         {
                             Name = person.Name,
                             Type = person.Type,
-                            Role = person.Role = person.Role?.Trim()
+                            Role = person.Role?.Trim()
                         });
                     }
                 }


### PR DESCRIPTION
If "role" is `null` for a person in a movie record (TMDB Metadata), the movie will fail to import properly as it crashes here.
In this case the movie entry will be created and it will also load pictures, but it won't show any streams as the import process stops in the middle, therefore, the movie cannot be played.

Replaces #15415 as the branch there somehow broke during rebase onto 10.11.z branch.


**Changes**
Check whether role is null and only trim if it has a value.

**Issues**
I haven't seen someone else report this issue yet. It happened mostly with some German movies. This issue happend since the 10.11 release.

The log showed this:
```
[2025-11-04 11:43:15.293 +01:00] [ERR] [25] MediaBrowser.Providers.Movies.MovieMetadataService: Error in "Probe Provider"
System.NullReferenceException: Object reference not set to an instance of an object.
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.FetchPeople(Video video, MediaInfo data, MetadataRefreshOptions options)
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.Fetch(Video video, CancellationToken cancellationToken, MediaInfo mediaInfo, BlurayDiscInfo blurayInfo, MetadataRefreshOptions options)
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.ProbeVideo[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken)
```
