### PR TITLE
Allow resolvers to set creation/modified dates

### DIFF
--- a/Emby.Server.Implementations/Library/ResolverHelper.cs
+++ b/Emby.Server.Implementations/Library/ResolverHelper.cs
@@ -132,25 +132,28 @@ namespace Emby.Server.Implementations.Library
 
         private static void SetDateCreated(BaseItem item, FileSystemMetadata? info)
         {
-            var config = BaseItem.ConfigurationManager.GetMetadataConfiguration();
-
-            if (config.UseFileCreationTimeForDateAdded)
+            if (item.DateCreated == DateTime.MinValue)
             {
-                var fileCreationDate = info?.CreationTimeUtc;
-                if (fileCreationDate is not null)
+                var config = BaseItem.ConfigurationManager.GetMetadataConfiguration();
+
+                if (config.UseFileCreationTimeForDateAdded)
                 {
-                    var dateCreated = fileCreationDate;
-                    if (dateCreated == DateTime.MinValue)
+                    var fileCreationDate = info?.CreationTimeUtc;
+                    if (fileCreationDate is not null)
                     {
-                        dateCreated = DateTime.UtcNow;
-                    }
+                        var dateCreated = fileCreationDate;
+                        if (dateCreated == DateTime.MinValue)
+                        {
+                            dateCreated = DateTime.UtcNow;
+                        }
 
-                    item.DateCreated = dateCreated.Value;
+                        item.DateCreated = dateCreated.Value;
+                    }
                 }
-            }
-            else
-            {
-                item.DateCreated = DateTime.UtcNow;
+                else
+                {
+                    item.DateCreated = DateTime.UtcNow;
+                }
             }
 
             if (info is not null && !info.IsDirectory)
@@ -158,10 +161,13 @@ namespace Emby.Server.Implementations.Library
                 item.Size = info.Length;
             }
 
-            var fileModificationDate = info?.LastWriteTimeUtc;
-            if (fileModificationDate.HasValue)
+            if (item.DateModified == DateTime.MinValue)
             {
-                item.DateModified = fileModificationDate.Value;
+                var fileModificationDate = info?.LastWriteTimeUtc;
+                if (fileModificationDate.HasValue)
+                {
+                    item.DateModified = fileModificationDate.Value;
+                }
             }
         }
     }


### PR DESCRIPTION
**Changes**
Allow resolvers to set the creation and modified dates for items. Before https://github.com/jellyfin/jellyfin/pull/15209 I could use the symbolic links to alter the creation dates of items at a file system level — because it was reading the created/modified at dates of the symbolic link and not the source file — but after this PR landed it was no longer possible. This change will allow the resolver(s) to set the created/modified dates of items, which will allow my plugin to resolve the items with the dates even with the symbolic link fix applied.

I've tested that the `DateCreated` and `DateModified` are both set to `DateTime.MinValue` upon initialization if not altered/set by the resolver.

**Issues**
Related to https://github.com/jellyfin/jellyfin/pull/15209
