### PR TITLE
Fix AncestorIds not migrating 

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -383,8 +383,6 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
                     });
                 }
 
-                baseItemIds.Clear();
-
                 foreach (var item in peopleCache)
                 {
                     operation.JellyfinDbContext.Peoples.Add(item.Value.Person);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Clearing baseItemIds in the move people migration causes the [AncestorId](https://github.com/jellyfin/jellyfin/blob/0598c6eaf6c7bdafaaf6c6f6518a50f3444dbc69/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs#L447) and Chapter migrations to come back with 0 items. 

**Changes**
Don't clear baseItemIds

**Issues**
Fixes  #14900
Fixes #15028
And chapter migration

Before:
```
[2025-11-09 03:04:49.345 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Moving Chapters"
[2025-11-09 03:04:49.346 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Loading Chapters"
[2025-11-09 03:04:49.516 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Loading Chapters" took '00:00:00.1697364'
[2025-11-09 03:04:49.518 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Saving 0 Chapters entries"
[2025-11-09 03:04:49.520 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Saving 0 Chapters entries" took '00:00:00.0019643'
[2025-11-09 03:04:49.522 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Moving Chapters" took '00:00:00.1769655'
[2025-11-09 03:04:49.524 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Moving AncestorIds"
[2025-11-09 03:04:49.526 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Loading AncestorIds"
[2025-11-09 03:04:49.740 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Loading AncestorIds" took '00:00:00.2144310'
[2025-11-09 03:04:49.742 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Saving 0 AncestorId entries"
[2025-11-09 03:04:49.743 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Saving 0 AncestorId entries" took '00:00:00.0011256'
[2025-11-09 03:04:49.745 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Moving AncestorIds" took '00:00:00.2204243'
[2025-11-09 03:04:49.746 -05:00] [INF] [9] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Migration of the Library.db done.
```

After:
```
[2025-11-09 02:37:16.169 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Moving Chapters"
[2025-11-09 02:37:16.169 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Loading Chapters"
[2025-11-09 02:37:16.680 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Loading Chapters" took '00:00:00.5116349'
[2025-11-09 02:37:16.690 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Saving 68262 Chapters entries"
[2025-11-09 02:37:18.646 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Saving 68262 Chapters entries" took '00:00:01.9555500'
[2025-11-09 02:37:18.646 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Moving Chapters" took '00:00:02.4771938'
[2025-11-09 02:37:18.646 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Moving AncestorIds"
[2025-11-09 02:37:18.646 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Loading AncestorIds"
[2025-11-09 02:37:19.274 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Loading AncestorIds" took '00:00:00.6277471'
[2025-11-09 02:37:19.277 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Start "Saving 97321 AncestorId entries"
[2025-11-09 02:37:22.389 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Saving 97321 AncestorId entries" took '00:00:03.1121741'
[2025-11-09 02:37:22.389 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: "Moving AncestorIds" took '00:00:03.7434218'
[2025-11-09 02:37:22.389 -05:00] [INF] [7] Jellyfin.Server.Migrations.Routines.MigrateLibraryDb: Migration of the Library.db done.
```