### PR TITLE
Fix NullReferenceException in GetPathProtocol when path is null

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -226,6 +226,11 @@ namespace Emby.Server.Implementations.Library
         /// <inheritdoc />>
         public MediaProtocol GetPathProtocol(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                return MediaProtocol.File;
+            }
+
             if (path.StartsWith("Rtsp", StringComparison.OrdinalIgnoreCase))
             {
                 return MediaProtocol.Rtsp;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
`MediaSourceManager.GetPathProtocol()` throws a `NullReferenceException`  when called with a null/empty path. This occurs with empty .strm files.

**Changes**

Added null/empty check in the `GetPathProtocol()` method, which returns `MediaProtocol.File`. 

**Issues**
<details>
  <summary>Log Error</summary>

```
[02:06:35] [ERR] [20] Jellyfin.Api.Middleware.ExceptionMiddleware: Error processing request. URL GET /Users/94037aa3e2974012ae8376003523c62d/Items/4d7839e0367fe95a8f4702a9aa748f44.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Emby.Server.Implementations.Library.MediaSourceManager.GetPathProtocol(String path) in C:\Gits\jellyfin\Emby.Server.Implementations\Library\MediaSourceManager.cs:line 234
   at MediaBrowser.Controller.Entities.BaseItem.GetVersionInfo(Boolean enablePathSubstitution, BaseItem item, MediaSourceType type) in C:\Gits\jellyfin\MediaBrowser.Controller\Entities\BaseItem.cs:line 1169
   at MediaBrowser.Controller.Entities.BaseItem.<>c__DisplayClass389_0.<GetMediaSources>b__0(ValueTuple`2 i) in C:\Gits\jellyfin\MediaBrowser.Controller\Entities\BaseItem.cs:line 1096
   at System.Linq.Enumerable.ListSelectIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.ListSelectIterator`2.ToList()
   at MediaBrowser.Controller.Entities.BaseItem.GetMediaSources(Boolean enablePathSubstitution) in C:\Gits\jellyfin\MediaBrowser.Controller\Entities\BaseItem.cs:line 1096
   at Emby.Server.Implementations.Library.MediaSourceManager.GetStaticMediaSources(BaseItem item, Boolean enablePathSubstitution, User user) in C:\Gits\jellyfin\Emby.Server.Implementations\Library\MediaSourceManager.cs:line 354
   at Emby.Server.Implementations.Dto.DtoService.GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User user, BaseItem owner) in C:\Gits\jellyfin\Emby.Server.Implementations\Dto\DtoService.cs:line 261
   at Emby.Server.Implementations.Dto.DtoService.GetBaseItemDto(BaseItem item, DtoOptions options, User user, BaseItem owner) in C:\Gits\jellyfin\Emby.Server.Implementations\Dto\DtoService.cs:line 200
   at Jellyfin.Api.Controllers.UserLibraryController.GetItem(Nullable`1 userId, Guid itemId) in C:\Gits\jellyfin\Jellyfin.Api\Controllers\UserLibraryController.cs:line 100
   at lambda_method2983(Closure, Object)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Jellyfin.Api.Middleware.ServerStartupMessageMiddleware.Invoke(HttpContext httpContext, IServerApplicationHost serverApplicationHost, ILocalizationManager localizationManager) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\ServerStartupMessageMiddleware.cs:line 41
   at Jellyfin.Api.Middleware.WebSocketHandlerMiddleware.Invoke(HttpContext httpContext, IWebSocketManager webSocketManager) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\WebSocketHandlerMiddleware.cs:line 33
   at Jellyfin.Api.Middleware.IPBasedAccessValidationMiddleware.Invoke(HttpContext httpContext, INetworkManager networkManager) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\IpBasedAccessValidationMiddleware.cs:line 41
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.QueryStringDecodingMiddleware.Invoke(HttpContext httpContext) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\QueryStringDecodingMiddleware.cs:line 36
   at Swashbuckle.AspNetCore.ReDoc.ReDocMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Jellyfin.Api.Middleware.RobotsRedirectionMiddleware.Invoke(HttpContext httpContext) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\RobotsRedirectionMiddleware.cs:line 43
   at Jellyfin.Api.Middleware.LegacyEmbyRouteRewriteMiddleware.Invoke(HttpContext httpContext) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\LegacyEmbyRouteRewriteMiddleware.cs:line 51
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Jellyfin.Api.Middleware.ResponseTimeMiddleware.Invoke(HttpContext context, IServerConfigurationManager serverConfigurationManager) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\ResponseTimeMiddleware.cs:line 66
   at Jellyfin.Api.Middleware.ExceptionMiddleware.Invoke(HttpContext context) in C:\Gits\jellyfin\Jellyfin.Api\Middleware\ExceptionMiddleware.cs:line 55
```

</details>
