### PR TITLE
Storage: return per-folder sizes and cache results

### DIFF
--- a/Emby.Server.Implementations/SystemManager.cs
+++ b/Emby.Server.Implementations/SystemManager.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Server.Implementations.StorageHelpers;
 using MediaBrowser.Common.Configuration;
@@ -13,7 +15,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Emby.Server.Implementations;
 
-/// <inheritdoc />
+/// <summary>
+/// Manages system-level information and storage reporting for the server.
+/// </summary>
 public class SystemManager : ISystemManager
 {
     private readonly IHostApplicationLifetime _applicationLifetime;
@@ -27,13 +31,13 @@ public class SystemManager : ISystemManager
     /// <summary>
     /// Initializes a new instance of the <see cref="SystemManager"/> class.
     /// </summary>
-    /// <param name="applicationLifetime">Instance of <see cref="IHostApplicationLifetime"/>.</param>
-    /// <param name="applicationHost">Instance of <see cref="IServerApplicationHost"/>.</param>
-    /// <param name="applicationPaths">Instance of <see cref="IServerApplicationPaths"/>.</param>
-    /// <param name="configurationManager">Instance of <see cref="IServerConfigurationManager"/>.</param>
-    /// <param name="startupOptions">Instance of <see cref="IStartupOptions"/>.</param>
-    /// <param name="installationManager">Instance of <see cref="IInstallationManager"/>.</param>
-    /// <param name="libraryManager">Instance of <see cref="ILibraryManager"/>.</param>
+    /// <param name="applicationLifetime">Application lifetime.</param>
+    /// <param name="applicationHost">Application host.</param>
+    /// <param name="applicationPaths">Application paths.</param>
+    /// <param name="configurationManager">Configuration manager.</param>
+    /// <param name="startupOptions">Startup options.</param>
+    /// <param name="installationManager">Installation manager.</param>
+    /// <param name="libraryManager">Library manager.</param>
     public SystemManager(
         IHostApplicationLifetime applicationLifetime,
         IServerApplicationHost applicationHost,
@@ -52,7 +56,11 @@ public class SystemManager : ISystemManager
         _libraryManager = libraryManager;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Gets overall system information.
+    /// </summary>
+    /// <param name="request">The current HTTP request (used to build local addresses).</param>
+    /// <returns>A <see cref="SystemInfo"/> object describing the system.</returns>
     public SystemInfo GetSystemInfo(HttpRequest request)
     {
         return new SystemInfo
@@ -64,7 +72,7 @@ public class SystemManager : ISystemManager
             WebSocketPortNumber = _applicationHost.HttpPort,
             CompletedInstallations = _installationManager.CompletedInstallations.ToArray(),
             Id = _applicationHost.SystemId,
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618
             ProgramDataPath = _applicationPaths.ProgramDataPath,
             WebPath = _applicationPaths.WebPath,
             LogPath = _applicationPaths.LogDirectoryPath,
@@ -72,7 +80,7 @@ public class SystemManager : ISystemManager
             InternalMetadataPath = _applicationPaths.InternalMetadataPath,
             CachePath = _applicationPaths.CachePath,
             TranscodingTempPath = _configurationManager.GetTranscodePath(),
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618
             ServerName = _applicationHost.FriendlyName,
             LocalAddress = _applicationHost.GetSmartApiUrl(request),
             StartupWizardCompleted = _configurationManager.CommonConfiguration.IsStartupWizardCompleted,
@@ -82,20 +90,25 @@ public class SystemManager : ISystemManager
         };
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets storage information for common Jellyfin folders and libraries.
+    /// This method will attempt to compute cached per-folder sizes (may block briefly while priming cache).
+    /// </summary>
+    /// <returns>A <see cref="SystemStorageInfo"/> object with folder and library storage details.</returns>
     public SystemStorageInfo GetSystemStorageInfo()
     {
         var virtualFolderInfos = _libraryManager
             .GetVirtualFolders()
-            .Where(e => !string.IsNullOrWhiteSpace(e.ItemId)) // this should not be null but for some users it is.
-            .Select(e => new LibraryStorageInfo()
-        {
-            Id = Guid.Parse(e.ItemId),
-            Name = e.Name,
-            Folders = e.Locations.Select(f => StorageHelper.GetFreeSpaceOf(f)).ToArray()
-        });
+            .Where(e => !string.IsNullOrWhiteSpace(e.ItemId))
+            .Select(e => new LibraryStorageInfo
+            {
+                Id = Guid.Parse(e.ItemId),
+                Name = e.Name,
+                Folders = e.Locations.Select(f => StorageHelper.GetFreeSpaceOf(f)).ToArray()
+            })
+            .ToArray();
 
-        return new SystemStorageInfo()
+        var systemStorage = new SystemStorageInfo
         {
             ProgramDataFolder = StorageHelper.GetFreeSpaceOf(_applicationPaths.ProgramDataPath),
             WebFolder = StorageHelper.GetFreeSpaceOf(_applicationPaths.WebPath),
@@ -104,11 +117,113 @@ public class SystemManager : ISystemManager
             InternalMetadataFolder = StorageHelper.GetFreeSpaceOf(_applicationPaths.InternalMetadataPath),
             CacheFolder = StorageHelper.GetFreeSpaceOf(_applicationPaths.CachePath),
             TranscodingTempFolder = StorageHelper.GetFreeSpaceOf(_configurationManager.GetTranscodePath()),
-            Libraries = virtualFolderInfos.ToArray()
+            Libraries = virtualFolderInfos
         };
+
+        var allPaths = new List<string?>
+        {
+            systemStorage.ProgramDataFolder?.Path,
+            systemStorage.WebFolder?.Path,
+            systemStorage.LogFolder?.Path,
+            systemStorage.ImageCacheFolder?.Path,
+            systemStorage.InternalMetadataFolder?.Path,
+            systemStorage.CacheFolder?.Path,
+            systemStorage.TranscodingTempFolder?.Path
+        };
+
+        foreach (var lib in systemStorage.Libraries ?? Array.Empty<LibraryStorageInfo>())
+        {
+            if (lib?.Folders != null)
+            {
+                foreach (var f in lib.Folders)
+                {
+                    allPaths.Add(f?.Path);
+                }
+            }
+        }
+
+        var distinctPaths = allPaths
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var computeTasks = distinctPaths
+            .Select(p => StorageHelper.ComputeAndCacheFolderSizeAsync(p!, CancellationToken.None))
+            .ToArray();
+
+        Task.WhenAll(computeTasks).GetAwaiter().GetResult();
+
+        void PopulateFolderInfo(FolderStorageInfo? fi)
+        {
+            if (fi == null || string.IsNullOrWhiteSpace(fi.Path))
+            {
+                return;
+            }
+
+            fi.FolderSizeBytes = StorageHelper.GetCachedFolderSize(fi.Path);
+            fi.DriveTotalBytes = StorageHelper.GetDriveTotalBytes(fi.Path);
+        }
+
+        if (systemStorage.ProgramDataFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.ProgramDataFolder);
+        }
+
+        if (systemStorage.WebFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.WebFolder);
+        }
+
+        if (systemStorage.LogFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.LogFolder);
+        }
+
+        if (systemStorage.ImageCacheFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.ImageCacheFolder);
+        }
+
+        if (systemStorage.InternalMetadataFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.InternalMetadataFolder);
+        }
+
+        if (systemStorage.CacheFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.CacheFolder);
+        }
+
+        if (systemStorage.TranscodingTempFolder != null)
+        {
+            PopulateFolderInfo(systemStorage.TranscodingTempFolder);
+        }
+
+        if (systemStorage.Libraries != null)
+        {
+            foreach (var lib in systemStorage.Libraries)
+            {
+                if (lib?.Folders == null)
+                {
+                    continue;
+                }
+
+                foreach (var f in lib.Folders)
+                {
+                    PopulateFolderInfo(f);
+                }
+            }
+        }
+
+        return systemStorage;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Gets public-facing system information.
+    /// </summary>
+    /// <param name="request">The current HTTP request (used to build local addresses).</param>
+    /// <returns>A <see cref="PublicSystemInfo"/> object.</returns>
     public PublicSystemInfo GetPublicSystemInfo(HttpRequest request)
     {
         return new PublicSystemInfo
@@ -122,19 +237,30 @@ public class SystemManager : ISystemManager
         };
     }
 
-    /// <inheritdoc />
-    public void Restart() => ShutdownInternal(true);
+    /// <summary>
+    /// Restarts the server.
+    /// </summary>
+    public void Restart()
+    {
+        ShutdownInternal(true);
+    }
 
-    /// <inheritdoc />
-    public void Shutdown() => ShutdownInternal(false);
+    /// <summary>
+    /// Shuts down the server.
+    /// </summary>
+    public void Shutdown()
+    {
+        ShutdownInternal(false);
+    }
 
     private void ShutdownInternal(bool restart)
     {
-        Task.Run(async () =>
-        {
-            await Task.Delay(100).ConfigureAwait(false);
-            _applicationHost.ShouldRestart = restart;
-            _applicationLifetime.StopApplication();
-        });
+        Task.Run(
+            async () =>
+            {
+                await Task.Delay(100).ConfigureAwait(false);
+                _applicationHost.ShouldRestart = restart;
+                _applicationLifetime.StopApplication();
+            });
     }
 }

--- a/Jellyfin.Api/Models/SystemInfoDtos/FolderStorageDto.cs
+++ b/Jellyfin.Api/Models/SystemInfoDtos/FolderStorageDto.cs
@@ -32,6 +32,16 @@ public record FolderStorageDto
     /// </summary>
     public string? DeviceId { get; init; }
 
+    /// <summary>
+    /// Gets or sets the measured folder size in bytes (nullable if unknown).
+    /// </summary>
+    public long? FolderSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total size of the drive containing this folder (nullable if unknown).
+    /// </summary>
+    public long? DriveTotalBytes { get; set; }
+
     internal static FolderStorageDto FromFolderStorageInfo(FolderStorageInfo model)
     {
         return new()
@@ -40,7 +50,9 @@ public record FolderStorageDto
             FreeSpace = model.FreeSpace,
             UsedSpace = model.UsedSpace,
             StorageType = model.StorageType,
-            DeviceId = model.DeviceId
+            DeviceId = model.DeviceId,
+            FolderSizeBytes = model.FolderSizeBytes,
+            DriveTotalBytes = model.DriveTotalBytes
         };
     }
 }

--- a/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
+++ b/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.System;
 using Microsoft.Extensions.Logging;
@@ -16,12 +20,19 @@ public static class StorageHelper
     private const long FiveHundredAndTwelveMegaByte = 536_870_911L;
     private static readonly string[] _byteHumanizedSuffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 
+    private static readonly ConcurrentDictionary<string, (long Size, DateTime Expires)> _sizeCache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly TimeSpan _cacheTtl = TimeSpan.FromMinutes(5);
+
     /// <summary>
     /// Tests the available storage capacity on the jellyfin paths with estimated minimum values.
     /// </summary>
     /// <param name="applicationPaths">The application paths.</param>
     /// <param name="logger">Logger.</param>
-    public static void TestCommonPathsForStorageCapacity(IApplicationPaths applicationPaths, ILogger logger)
+    public static void TestCommonPathsForStorageCapacity(
+        IApplicationPaths applicationPaths,
+        ILogger logger)
     {
         TestDataDirectorySize(applicationPaths.DataPath, logger, TwoGigabyte);
         TestDataDirectorySize(applicationPaths.LogDirectoryPath, logger, FiveHundredAndTwelveMegaByte);
@@ -34,32 +45,163 @@ public static class StorageHelper
     /// Gets the free space of a specific directory.
     /// </summary>
     /// <param name="path">Path to a folder.</param>
-    /// <returns>The number of bytes available space.</returns>
+    /// <returns>The folder storage info with free space, used space, and drive info.</returns>
     public static FolderStorageInfo GetFreeSpaceOf(string path)
     {
         try
         {
             var driveInfo = new DriveInfo(path);
-            return new FolderStorageInfo()
+            return new FolderStorageInfo
             {
                 Path = path,
                 FreeSpace = driveInfo.AvailableFreeSpace,
                 UsedSpace = driveInfo.TotalSize - driveInfo.AvailableFreeSpace,
                 StorageType = driveInfo.DriveType.ToString(),
                 DeviceId = driveInfo.Name,
+                DriveTotalBytes = driveInfo.IsReady ? driveInfo.TotalSize : (long?)null
             };
         }
         catch
         {
-            return new FolderStorageInfo()
+            return new FolderStorageInfo
             {
                 Path = path,
                 FreeSpace = -1,
                 UsedSpace = -1,
                 StorageType = null,
-                DeviceId = null
+                DeviceId = null,
+                DriveTotalBytes = null
             };
         }
+    }
+
+    /// <summary>
+    /// Asynchronously computes and caches the folder size.
+    /// </summary>
+    /// <param name="path">The folder path.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The folder size in bytes, or null if failed.</returns>
+    public static async Task<long?> ComputeAndCacheFolderSizeAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var size = await GetDirectorySizeAsync(path, cancellationToken).ConfigureAwait(false);
+            _sizeCache[path] = (size, DateTime.UtcNow.Add(_cacheTtl));
+            return size;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the cached folder size, if available.
+    /// </summary>
+    /// <param name="path">The folder path.</param>
+    /// <returns>The cached folder size in bytes, or null if unavailable.</returns>
+    public static long? GetCachedFolderSize(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return null;
+        }
+
+        if (_sizeCache.TryGetValue(path, out var entry) && entry.Expires > DateTime.UtcNow)
+        {
+            return entry.Size;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the total drive size for a given path.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns>The drive total bytes or null if unavailable.</returns>
+    public static long? GetDriveTotalBytes(string path)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            var root = Path.GetPathRoot(path);
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                return null;
+            }
+
+            var drive = new DriveInfo(root);
+            return drive.IsReady ? drive.TotalSize : (long?)null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Recursively calculates the total folder size asynchronously.
+    /// </summary>
+    /// <param name="path">Folder path.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Total size in bytes.</returns>
+    private static Task<long> GetDirectorySizeAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () =>
+            {
+                long size = 0;
+                var stack = new Stack<string>();
+                stack.Push(path);
+
+                while (stack.Count > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var current = stack.Pop();
+
+                    try
+                    {
+                        foreach (var file in Directory.EnumerateFiles(current))
+                        {
+                            try
+                            {
+                                var fi = new FileInfo(file);
+                                size += fi.Length;
+                            }
+                            catch
+                            {
+                                // Skip unreadable file.
+                            }
+                        }
+
+                        foreach (var dir in Directory.EnumerateDirectories(current))
+                        {
+                            stack.Push(dir);
+                        }
+                    }
+                    catch
+                    {
+                        // Skip unreadable directory.
+                    }
+                }
+
+                return size;
+            },
+            cancellationToken);
     }
 
     /// <summary>
@@ -69,7 +211,10 @@ public static class StorageHelper
     /// <param name="logger">The logger.</param>
     /// <param name="threshold">The threshold to check for or -1 to just log the data.</param>
     /// <exception cref="InvalidOperationException">Thrown when the threshold is not available on the underlying storage.</exception>
-    private static void TestDataDirectorySize(string path, ILogger logger, long threshold = -1)
+    private static void TestDataDirectorySize(
+        string path,
+        ILogger logger,
+        long threshold = -1)
     {
         logger.LogDebug("Check path {TestPath} for storage capacity", path);
         Directory.CreateDirectory(path);
@@ -77,7 +222,10 @@ public static class StorageHelper
         var drive = new DriveInfo(path);
         if (threshold != -1 && drive.AvailableFreeSpace < threshold)
         {
-            throw new InvalidOperationException($"The path `{path}` has insufficient free space. Available: {HumanizeStorageSize(drive.AvailableFreeSpace)}, Required: {HumanizeStorageSize(threshold)}.");
+            throw new InvalidOperationException(
+                $"The path `{path}` has insufficient free space. " +
+                $"Available: {HumanizeStorageSize(drive.AvailableFreeSpace)}, " +
+                $"Required: {HumanizeStorageSize(threshold)}.");
         }
 
         logger.LogInformation(
@@ -89,13 +237,10 @@ public static class StorageHelper
     }
 
     /// <summary>
-    /// Formats a size in bytes into a common human readable form.
+    /// Formats a size in bytes into a human-readable form.
     /// </summary>
-    /// <remarks>
-    /// Taken and slightly modified from https://stackoverflow.com/a/4975942/1786007 .
-    /// </remarks>
     /// <param name="byteCount">The size in bytes.</param>
-    /// <returns>A human readable approximate representation of the argument.</returns>
+    /// <returns>A human-readable approximate representation of the argument.</returns>
     public static string HumanizeStorageSize(long byteCount)
     {
         if (byteCount == 0)

--- a/MediaBrowser.Model/System/FolderStorageInfo.cs
+++ b/MediaBrowser.Model/System/FolderStorageInfo.cs
@@ -29,4 +29,14 @@ public record FolderStorageInfo
     /// Gets the Device Identifier.
     /// </summary>
     public string? DeviceId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the measured folder size in bytes (nullable if unknown).
+    /// </summary>
+    public long? FolderSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total size of the drive containing this folder (nullable if unknown).
+    /// </summary>
+    public long? DriveTotalBytes { get; set; }
 }


### PR DESCRIPTION
### Summary

Add `FolderSizeBytes` and `DriveTotalBytes` to `FolderStorageInfo` and the API DTOs. Implement `StorageHelper` methods to compute and cache folder sizes (async). Populate the SystemStorage endpoint with per-folder sizes so frontend can display per-folder usage bars.

### Fixes
Fixes jellyfin-web issue: jellyfin/jellyfin-web#7323

### Notes
- Directory size scanning is cached for performance.
- Can be primed from server startup/background job.

<img width="885" height="923" alt="Screenshot 2025-11-11 222701" src="https://github.com/user-attachments/assets/6bf087b0-3ded-4702-bd37-209c274eaa79" />
