### PR TITLE
Fix gitignore-style not working properly on windows.

### DIFF
--- a/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
@@ -93,7 +93,7 @@ public class DotIgnoreIgnoreRule : IResolverIgnoreRule
         {
             // Mitigate the problem of the Ignore library not handling Windows paths correctly.
             // See https://github.com/jellyfin/jellyfin/issues/15484
-            return ignore.IsIgnored(fileInfo.FullName.Replace('\\', '/'));
+            return ignore.IsIgnored(fileInfo.FullName.NormalizePath('/'));
         }
 
         return ignore.IsIgnored(fileInfo.FullName);


### PR DESCRIPTION
Added a check for Windows OS to handle path formatting correctly in the Ignore library.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
replace '\\' with '/' on windows to mitigate Ignore library issue.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #15484 
