### PR TITLE
Avoid concurrent dictionary snapshot

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -281,3 +281,4 @@
  - [Martin Reuter](https://github.com/reuterma24)
  - [Michael McElroy](https://github.com/mcmcelro)
  - [Soumyadip Auddy](https://github.com/SoumyadipAuddy)
+ - [Filip Grzonkowski](https://github.com/grzonu)

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -491,15 +491,6 @@ namespace Emby.Server.Implementations.Library
             .Where(i => i.Type != MediaSourceType.Placeholder);
         }
 
-        private IEnumerable<ILiveStream> GetCurrentLiveStreams()
-        {
-            using var streams = _openStreams.GetEnumerator();
-            while (streams.MoveNext())
-            {
-                yield return streams.Current.Value;
-            }
-        }
-
         public async Task<Tuple<LiveStreamResponse, IDirectStreamProvider>> OpenLiveStreamInternal(LiveStreamRequest request, CancellationToken cancellationToken)
         {
             MediaSourceInfo mediaSource;
@@ -509,7 +500,7 @@ namespace Emby.Server.Implementations.Library
             {
                 var (provider, keyId) = GetProvider(request.OpenToken);
 
-                var currentLiveStreams = GetCurrentLiveStreams().ToList();
+                var currentLiveStreams = _openStreams.Select(x => x.Value).ToList();
 
                 liveStream = await provider.OpenMediaSource(keyId, currentLiveStreams, cancellationToken).ConfigureAwait(false);
 

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -491,6 +491,15 @@ namespace Emby.Server.Implementations.Library
             .Where(i => i.Type != MediaSourceType.Placeholder);
         }
 
+        private IEnumerable<ILiveStream> GetCurrentLiveStreams()
+        {
+            using var streams = _openStreams.GetEnumerator();
+            while (streams.MoveNext())
+            {
+                yield return streams.Current.Value;
+            }
+        }
+
         public async Task<Tuple<LiveStreamResponse, IDirectStreamProvider>> OpenLiveStreamInternal(LiveStreamRequest request, CancellationToken cancellationToken)
         {
             MediaSourceInfo mediaSource;
@@ -500,7 +509,7 @@ namespace Emby.Server.Implementations.Library
             {
                 var (provider, keyId) = GetProvider(request.OpenToken);
 
-                var currentLiveStreams = _openStreams.Values.ToList();
+                var currentLiveStreams = GetCurrentLiveStreams().ToList();
 
                 liveStream = await provider.OpenMediaSource(keyId, currentLiveStreams, cancellationToken).ConfigureAwait(false);
 

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -155,7 +155,19 @@ namespace Emby.Server.Implementations.Session
         /// Gets all connections.
         /// </summary>
         /// <value>All connections.</value>
-        public IEnumerable<SessionInfo> Sessions => _activeConnections.Values.OrderByDescending(c => c.LastActivityDate);
+        public IEnumerable<SessionInfo> Sessions
+        {
+            get
+            {
+                using var enumerator = _activeConnections
+                    .OrderByDescending(c => c.Value.LastActivityDate)
+                    .GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    yield return enumerator.Current.Value;
+                }
+            }
+        }
 
         private void OnDeviceManagerDeviceOptionsUpdated(object sender, GenericEventArgs<Tuple<string, DeviceOptions>> e)
         {

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -159,13 +159,10 @@ namespace Emby.Server.Implementations.Session
         {
             get
             {
-                using var enumerator = _activeConnections
+                return _activeConnections
                     .OrderByDescending(c => c.Value.LastActivityDate)
-                    .GetEnumerator();
-                while (enumerator.MoveNext())
-                {
-                    yield return enumerator.Current.Value;
-                }
+                    .Select(x => x.Value)
+                    .ToList();
             }
         }
 

--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -135,17 +135,12 @@ namespace Jellyfin.Server.Implementations.Devices
         /// <inheritdoc />
         public DeviceInfoDto? GetDevice(string id)
         {
-            using var enumerator = _devices
-                .GetEnumerator();
             Device? device = null;
-            DateTime? deviceLastActivity = null;
-            while (enumerator.MoveNext())
+            foreach (var d in _devices)
             {
-                if (enumerator.Current.Value.DeviceId == id && (deviceLastActivity == null || deviceLastActivity < enumerator.Current.Value.DateLastActivity))
+                if (d.Value.DeviceId == id && (device == null || device.DateLastActivity < d.Value.DateLastActivity))
                 {
-                    device = enumerator.Current.Value;
-                    deviceLastActivity = enumerator.Current.Value.DateLastActivity;
-                    break;
+                    device = d.Value;
                 }
             }
 


### PR DESCRIPTION
**Changes**
When you using ConcurrentDictionary .Values there is lock, memory snapshot then unlock which has negative performance impact and negative memory impact.
Better to use GetEnumerator which is thread-safe but not make dictionary snapshot

