### PR TITLE
Fix .ignore handling for directories

### DIFF
--- a/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
+++ b/Emby.Server.Implementations/Library/DotIgnoreIgnoreRule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Resolvers;
@@ -13,28 +12,24 @@ namespace Emby.Server.Implementations.Library;
 /// </summary>
 public class DotIgnoreIgnoreRule : IResolverIgnoreRule
 {
+    private static readonly bool IsWindows = OperatingSystem.IsWindows();
+
     private static FileInfo? FindIgnoreFile(DirectoryInfo directory)
     {
-        var ignoreFile = new FileInfo(Path.Join(directory.FullName, ".ignore"));
-        if (ignoreFile.Exists)
+        for (var current = directory; current is not null; current = current.Parent)
         {
-            return ignoreFile;
+            var ignorePath = Path.Join(current.FullName, ".ignore");
+            if (File.Exists(ignorePath))
+            {
+                return new FileInfo(ignorePath);
+            }
         }
 
-        var parentDir = directory.Parent;
-        if (parentDir is null)
-        {
-            return null;
-        }
-
-        return FindIgnoreFile(parentDir);
+        return null;
     }
 
     /// <inheritdoc />
-    public bool ShouldIgnore(FileSystemMetadata fileInfo, BaseItem? parent)
-    {
-        return IsIgnored(fileInfo, parent);
-    }
+    public bool ShouldIgnore(FileSystemMetadata fileInfo, BaseItem? parent) => IsIgnored(fileInfo, parent);
 
     /// <summary>
     /// Checks whether or not the file is ignored.
@@ -44,72 +39,58 @@ public class DotIgnoreIgnoreRule : IResolverIgnoreRule
     /// <returns>True if the file should be ignored.</returns>
     public static bool IsIgnored(FileSystemMetadata fileInfo, BaseItem? parent)
     {
-        if (fileInfo.IsDirectory)
-        {
-            var dirIgnoreFile = FindIgnoreFile(new DirectoryInfo(fileInfo.FullName));
-            if (dirIgnoreFile is null)
-            {
-                return false;
-            }
+        var searchDirectory = fileInfo.IsDirectory
+            ? new DirectoryInfo(fileInfo.FullName)
+            : new DirectoryInfo(Path.GetDirectoryName(fileInfo.FullName) ?? string.Empty);
 
-            // Fast path in case the ignore files isn't a symlink and is empty
-            if (dirIgnoreFile.LinkTarget is null && dirIgnoreFile.Length == 0)
-            {
-                return true;
-            }
-
-            // ignore the directory only if the .ignore file is empty
-            // evaluate individual files otherwise
-            return string.IsNullOrWhiteSpace(GetFileContent(dirIgnoreFile));
-        }
-
-        var parentDirPath = Path.GetDirectoryName(fileInfo.FullName);
-        if (string.IsNullOrEmpty(parentDirPath))
+        if (string.IsNullOrEmpty(searchDirectory.FullName))
         {
             return false;
         }
 
-        var folder = new DirectoryInfo(parentDirPath);
-        var ignoreFile = FindIgnoreFile(folder);
+        var ignoreFile = FindIgnoreFile(searchDirectory);
         if (ignoreFile is null)
         {
             return false;
         }
 
-        string ignoreFileString = GetFileContent(ignoreFile);
-
-        if (string.IsNullOrWhiteSpace(ignoreFileString))
+        // Fast path in case the ignore files isn't a symlink and is empty
+        if (ignoreFile.LinkTarget is null && ignoreFile.Length == 0)
         {
             // Ignore directory if we just have the file
             return true;
         }
 
-        // If file has content, base ignoring off the content .gitignore-style rules
-        var ignoreRules = ignoreFileString.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        var ignore = new Ignore.Ignore();
-        ignore.Add(ignoreRules);
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            // Mitigate the problem of the Ignore library not handling Windows paths correctly.
-            // See https://github.com/jellyfin/jellyfin/issues/15484
-            return ignore.IsIgnored(fileInfo.FullName.NormalizePath('/'));
-        }
-
-        return ignore.IsIgnored(fileInfo.FullName);
+        var content = GetFileContent(ignoreFile);
+        return string.IsNullOrWhiteSpace(content)
+            || CheckIgnoreRules(fileInfo.FullName, content, fileInfo.IsDirectory);
     }
 
-    private static string GetFileContent(FileInfo dirIgnoreFile)
+    private static bool CheckIgnoreRules(string path, string ignoreFileContent, bool isDirectory)
     {
-        dirIgnoreFile = FileSystemHelper.ResolveLinkTarget(dirIgnoreFile, returnFinalTarget: true) ?? dirIgnoreFile;
-        if (!dirIgnoreFile.Exists)
+        // If file has content, base ignoring off the content .gitignore-style rules
+        var rules = ignoreFileContent.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var ignore = new Ignore.Ignore();
+        ignore.Add(rules);
+
+         // Mitigate the problem of the Ignore library not handling Windows paths correctly.
+         // See https://github.com/jellyfin/jellyfin/issues/15484
+        var pathToCheck = IsWindows ? path.NormalizePath('/') : path;
+
+        // Add trailing slash for directories to match "folder/"
+        if (isDirectory)
         {
-            return string.Empty;
+            pathToCheck = string.Concat(pathToCheck.AsSpan().TrimEnd('/'), "/");
         }
 
-        using (var reader = dirIgnoreFile.OpenText())
-        {
-            return reader.ReadToEnd();
-        }
+        return ignore.IsIgnored(pathToCheck);
+    }
+
+    private static string GetFileContent(FileInfo ignoreFile)
+    {
+        ignoreFile = FileSystemHelper.ResolveLinkTarget(ignoreFile, returnFinalTarget: true) ?? ignoreFile;
+        return ignoreFile.Exists
+            ? File.ReadAllText(ignoreFile.FullName)
+            : string.Empty;
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Directories listed in .ignore (e.g., specials/) hid their contents but not the folder itself, contrary to the [documentation](https://github.com/jellyfin/jellyfin.org/pull/1650).

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Fix handling for directories (e.g., specials/) listed in the .ignore file
- Simplify `FindIgnoreFile` to use a loop
- Use a single `IsWindows` flag for OS detection
- Move ignore rule logic to `CheckIgnoreRules`
- Clean up reading of .ignore file content
