### PR TITLE
Fix playlist DateCreated and DateLastMediaAdded not being set

### DIFF
--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -244,6 +244,7 @@ namespace Emby.Server.Implementations.Playlists
 
             // Update the playlist in the repository
             playlist.LinkedChildren = [.. playlist.LinkedChildren, .. childrenToAdd];
+            playlist.DateLastMediaAdded = DateTime.UtcNow;
 
             await UpdatePlaylistInternal(playlist).ConfigureAwait(false);
 

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -344,7 +344,10 @@ namespace MediaBrowser.Providers.Manager
                     item.DateModified = info.LastWriteTimeUtc;
                     if (ServerConfigurationManager.GetMetadataConfiguration().UseFileCreationTimeForDateAdded)
                     {
-                        item.DateCreated = info.CreationTimeUtc;
+                        if (info.CreationTimeUtc > DateTime.MinValue)
+                        {
+                            item.DateCreated = info.CreationTimeUtc;
+                        }
                     }
 
                     if (item is Video video)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
`BeforeSaveInternal` in `MetadataService` was overwriting valid `DateCreated` values with `DateTime.MinValue` when the file system returned invalid creation times.

**Changes**
Added a check to only update `DateCreated` from file system info when it has a valid timestamp, and added code to set DateLastMediaAdded when items are added to playlists.

**Issues**
Fixes #15311
May fix: #14841
