### PR TITLE
Add 1 minute tolerance for NFO change detection

### DIFF
--- a/MediaBrowser.XbmcMetadata/Providers/BaseNfoProvider.cs
+++ b/MediaBrowser.XbmcMetadata/Providers/BaseNfoProvider.cs
@@ -75,8 +75,8 @@ namespace MediaBrowser.XbmcMetadata.Providers
 
             var fileTime = _fileSystem.GetLastWriteTimeUtc(file);
 
-            // 5s tolerance to avoid detecting our own file writes
-            return (fileTime - item.DateLastSaved).TotalSeconds > 5;
+            // 1 minute tolerance to avoid detecting our own file writes
+            return (fileTime - item.DateLastSaved) > TimeSpan.FromMinutes(1);
         }
 
         protected abstract void Fetch(MetadataResult<T> result, string path, CancellationToken cancellationToken);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
The NFO saver was writing the files 1-2 seconds after the `DateLastSaved` time.  On the next library scan, `HasChanged` detected the NFO file as newer and triggered a metadata refresh, which caused the file to be rewritten again.

**Changes**
Added a 1-minute tolerance to `BaseNfoProvider.HasChanged()`

**Issues**
 Fixes #14841
