### PR TITLE
Fix movie titles using folder name when NFO saver is enabled

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -151,7 +151,10 @@ namespace MediaBrowser.Providers.Manager
                 .ConfigureAwait(false);
             updateType |= beforeSaveResult;
 
-            updateType = await SaveInternal(item, refreshOptions, updateType, isFirstRefresh, requiresRefresh, metadataResult, cancellationToken).ConfigureAwait(false);
+            if (!isFirstRefresh)
+            {
+                updateType = await SaveInternal(item, refreshOptions, updateType, isFirstRefresh, requiresRefresh, metadataResult, cancellationToken).ConfigureAwait(false);
+            }
 
             // Next run metadata providers
             if (refreshOptions.MetadataRefreshMode != MetadataRefreshMode.None)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Regression from https://github.com/jellyfin/jellyfin/pull/12798/commits/5167333602ec339ba6d3b5453dce16d200fe79db: When scanning a movie library with SaveImagePathsInNfo enabled, movie titles were incorrectly set to the folder name. This happened because the item was saved to the database twice before local metadata providers could run, locking in the folder name before the NFO file was read.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Skip the initial database save on first refresh, allowing local metadata providers to read NFO files and set the correct metadata before the first save occurs.

**Issues**
Fixes #15195
