### PR TITLE
Fix BdInfoDirectoryInfo.cs by skipping hidden files.

### DIFF
--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using BDInfo.IO;


### PR DESCRIPTION
**Changes**
The hidden files start with "." generated by MacOS in external exFAT drives will causes error when scanning the Bluray directories. This issue occurs even running locally and natively without using docker on MacOS.
I added a check in BdInfoDirectoryInfo.cs to skip those files.

**Issues**
I found this issue recently and didn't see any similar issues. The screenshot about the error I found is attached below.
<img width="2240" height="1260" alt="截屏2025-11-17 21 11 07" src="https://github.com/user-attachments/assets/85d7b5a4-d58e-456c-9faf-6dc999fe9e09" />

