### PR TITLE
Revert "Localization/iso6392.txt: change pob and pop"

### DIFF
--- a/Emby.Server.Implementations/Localization/iso6392.txt
+++ b/Emby.Server.Implementations/Localization/iso6392.txt
@@ -347,8 +347,8 @@ pli||pi|Pali|pali
 pol||pl|Polish|polonais
 pon|||Pohnpeian|pohnpei
 por||pt|Portuguese|portugais
-por||pt-pt|Portuguese (Portugal)|portugais (pt-pt)
-por||pt-br|Portuguese (Brazil)|portugais (pt-br)
+pop||pt-pt|Portuguese (Portugal)|portugais (pt-pt)
+pob||pt-br|Portuguese (Brazil)|portugais (pt-br)
 pra|||Prakrit languages|prâkrit, langues
 pro|||Provençal, Old (to 1500)|provençal ancien (jusqu'à 1500)
 pus||ps|Pushto; Pashto|pachto


### PR DESCRIPTION
**Changes**
This reverts #14030 by @baka0815 
Fixes (at least temporarily) portuguese lang being totally broken in 10.11.



**Issues**
Fixes #15106 
