### PR TITLE
Prevent copying HDR streams when only SDR is supported

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2378,6 +2378,13 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var requestHasSDR = requestedRangeTypes.Contains(VideoRangeType.SDR.ToString(), StringComparison.OrdinalIgnoreCase);
                 var requestHasDOVI = requestedRangeTypes.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase);
 
+                // If SDR is the only supported range, we should not copy any of the HDR streams.
+                // All the following copy check assumes at least one HDR format is supported.
+                if (requestedRangeTypes.Length == 1 && requestHasSDR && videoStream.VideoRangeType != VideoRangeType.SDR)
+                {
+                    return false;
+                }
+
                 // If the client does not support DOVI and the video stream is DOVI without fallback, we should not copy it.
                 if (!requestHasDOVI && videoStream.VideoRangeType == VideoRangeType.DOVI)
                 {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

If the SDR is the only supported range, disable all HDR copy tests. This is an obvious case but got unnoticed until recently we got stable firefox HEVC support. Previously, all major browsers supporting HEVC has client-side tone mapping capability which never triggered this case.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #15534
