### PR TITLE
Save item to database before providers run to prevent FK errors

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -151,9 +151,9 @@ namespace MediaBrowser.Providers.Manager
                 .ConfigureAwait(false);
             updateType |= beforeSaveResult;
 
-            if (!isFirstRefresh)
+            if (isFirstRefresh)
             {
-                updateType = await SaveInternal(item, refreshOptions, updateType, isFirstRefresh, requiresRefresh, metadataResult, cancellationToken).ConfigureAwait(false);
+                await SaveItemAsync(metadataResult, ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
             }
 
             // Next run metadata providers


### PR DESCRIPTION
In #15529, `isFirstRefresh` check was added to prevent folder names from overwriting NFO titles, but this caused FK constraint errors when providers tried to save data before the parent item existed in the database. 

**Changes**
On first refresh, save a minimal item record before running providers, then save the final metadata after. This prevents FK errors while preserving NFO handling.


**Issues**
<details>
  <summary>Log Error</summary>

```
[10:02:23] [ERR] [18] Microsoft.EntityFrameworkCore.Database.Command: Failed executing DbCommand (1ms) [Parameters=[@p0='?' (DbType = Guid), @p1='?' (DbType = Int32), @p2='?' (Size = 4), @p3='?' (DbType = Single), @p4='?' (DbType = Int32), @p5='?' (DbType = Int32), @p6='?' (DbType = Int32), @p7='?', @p8='?' (DbType = Int32), @p9='?' (Size = 4), @p10='?', @p11='?', @p12='?' (Size = 6), @p13='?' (Size = 8), @p14='?' (Size = 9), @p15='?', @p16='?' (DbType = Int32), @p17='?' (DbType = Int32), @p18='?' (DbType = Int32), @p19='?' (DbType = Int32), @p20='?' (DbType = Int32), @p21='?' (DbType = Int32), @p22='?' (DbType = Boolean), @p23='?' (DbType = Int32), @p24='?' (DbType = Boolean), @p25='?' (DbType = Boolean), @p26='?' (DbType = Boolean), @p27='?' (DbType = Boolean), @p28='?' (DbType = Boolean), @p29='?' (DbType = Boolean), @p30='?' (DbType = Boolean), @p31='?', @p32='?' (Size = 3), @p33='?' (DbType = Single), @p34='?', @p35='?', @p36='?' (Size = 11), @p37='?' (Size = 7), @p38='?' (DbType = Single), @p39='?' (DbType = Int32), @p40='?' (DbType = Int32), @p41='?' (DbType = Int32), @p42='?' (DbType = Int32), @p43='?' (DbType = Int32), @p44='?' (Size = 6), @p45='?', @p46='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
INSERT INTO "MediaStreamInfos" ("ItemId", "StreamIndex", "AspectRatio", "AverageFrameRate", "BitDepth", "BitRate", "BlPresentFlag", "ChannelLayout", "Channels", "Codec", "CodecTag", "CodecTimeBase", "ColorPrimaries", "ColorSpace", "ColorTransfer", "Comment", "DvBlSignalCompatibilityId", "DvLevel", "DvProfile", "DvVersionMajor", "DvVersionMinor", "ElPresentFlag", "Hdr10PlusPresentFlag", "Height", "IsAnamorphic", "IsAvc", "IsDefault", "IsExternal", "IsForced", "IsHearingImpaired", "IsInterlaced", "KeyFrames", "Language", "Level", "NalLengthSize", "Path", "PixelFormat", "Profile", "RealFrameRate", "RefFrames", "Rotation", "RpuPresentFlag", "SampleRate", "StreamType", "TimeBase", "Title", "Width")
VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19, @p20, @p21, @p22, @p23, @p24, @p25, @p26, @p27, @p28, @p29, @p30, @p31, @p32, @p33, @p34, @p35, @p36, @p37, @p38, @p39, @p40, @p41, @p42, @p43, @p44, @p45, @p46);
SELECT changes();
[10:02:23] [ERR] [18] Microsoft.EntityFrameworkCore.Update: An exception occurred in the database while saving changes for context type 'Jellyfin.Database.Implementations.JellyfinDbContext'.
Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
   at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReader(RelationalCommandParameterObject parameterObject)
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   --- End of inner exception stack trace ---
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(StateManager stateManager, Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
   at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReader(RelationalCommandParameterObject parameterObject)
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   --- End of inner exception stack trace ---
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(StateManager stateManager, Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
Exception thrown: 'Microsoft.EntityFrameworkCore.DbUpdateException' in Microsoft.EntityFrameworkCore.dll
[10:02:23] [ERR] [18] Jellyfin.Database.Implementations.JellyfinDbContext: Error trying to save changes.
Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
   at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReader(RelationalCommandParameterObject parameterObject)
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   --- End of inner exception stack trace ---
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(StateManager stateManager, Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Jellyfin.Database.Implementations.JellyfinDbContext.<>n__1(Boolean acceptAllChangesOnSuccess)
   at Jellyfin.Database.Implementations.JellyfinDbContext.<>c__DisplayClass63_1.<SaveChanges>b__0() in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\JellyfinDbContext.cs:line 288
   at Jellyfin.Database.Implementations.Locking.NoLockBehavior.OnSaveChanges(JellyfinDbContext context, Action saveChanges) in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\Locking\NoLockBehavior.cs:line 27
   at Jellyfin.Database.Implementations.JellyfinDbContext.SaveChanges(Boolean acceptAllChangesOnSuccess) in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\JellyfinDbContext.cs:line 286
Exception thrown: 'Microsoft.EntityFrameworkCore.DbUpdateException' in Jellyfin.Database.Implementations.dll
Exception thrown: 'Microsoft.EntityFrameworkCore.DbUpdateException' in System.Private.CoreLib.dll
Exception thrown: 'Microsoft.EntityFrameworkCore.DbUpdateException' in System.Private.CoreLib.dll
[10:02:23] [ERR] [18] MediaBrowser.Providers.Videos.VideoMetadataService: Error in Probe Provider
Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
   at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReader(RelationalCommandParameterObject parameterObject)
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   --- End of inner exception stack trace ---
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(StateManager stateManager, Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Jellyfin.Database.Implementations.JellyfinDbContext.<>n__1(Boolean acceptAllChangesOnSuccess)
   at Jellyfin.Database.Implementations.JellyfinDbContext.<>c__DisplayClass63_1.<SaveChanges>b__0() in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\JellyfinDbContext.cs:line 288
   at Jellyfin.Database.Implementations.Locking.NoLockBehavior.OnSaveChanges(JellyfinDbContext context, Action saveChanges) in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\Locking\NoLockBehavior.cs:line 27
   at Jellyfin.Database.Implementations.JellyfinDbContext.SaveChanges(Boolean acceptAllChangesOnSuccess) in C:\Gits\jellyfin\src\Jellyfin.Database\Jellyfin.Database.Implementations\JellyfinDbContext.cs:line 286
   at Jellyfin.Server.Implementations.Item.MediaStreamRepository.SaveMediaStreams(Guid id, IReadOnlyList`1 streams, CancellationToken cancellationToken) in C:\Gits\jellyfin\Jellyfin.Server.Implementations\Item\MediaStreamRepository.cs:line 46
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.Fetch(Video video, CancellationToken cancellationToken, MediaInfo mediaInfo, BlurayDiscInfo blurayInfo, MetadataRefreshOptions options) in C:\Gits\jellyfin\MediaBrowser.Providers\MediaInfo\FFProbeVideoInfo.cs:line 277
   at MediaBrowser.Providers.MediaInfo.FFProbeVideoInfo.ProbeVideo[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.Providers\MediaInfo\FFProbeVideoInfo.cs:line 153
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 875
```
</details>
