### PR TITLE
Fix unreachable local API URLs in NAT/Docker by respecting Published Server URIs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -205,6 +205,7 @@
  - [theshoeshiner](https://github.com/theshoeshiner)
  - [TokerX](https://github.com/TokerX)
  - [GeneMarks](https://github.com/GeneMarks)
+ - [Marten Bosse](https://github.com/martenumberto)
 
 # Emby Contributors
 


### PR DESCRIPTION
### Description
This PR fixes an issue where Jellyfin returns unreachable internal IP addresses (e.g., Docker container IPs like `172.17.0.x`) to clients when `GetApiUrlForLocalAccess` is called. This behavior breaks functionality such as Live TV Direct Stream on Android TV clients running in a LAN environment different from the container's internal network.

**The Problem:**
Previously, `GetApiUrlForLocalAccess` checked for CLI startup overrides but ignored the "Published Server URIs" configured in the Web Dashboard (`NetworkConfiguration`). Consequently, even if a user configured a correct LAN URL (e.g., via `all=` or `internal=`), the server would still broadcast its internal container IP for local access requests.

**The Solution:**
The method has been updated to respect the `NetworkConfiguration`. The logic priority is now:
1. CLI/Startup Override (`--published-server-url`)
2. Dashboard Configuration `internal=` override (Best for LAN access in NAT)
3. Dashboard Configuration `all=` override
4. Fallback to detected Network Interface IP (Standard behavior)

### Related Issues
Fixes #15411

### How to test
1. Run Jellyfin in a Docker container (bridge mode).
2. Navigate to **Dashboard -> Networking**.
3. Set **Published Server URIs** to your actual LAN IP or Domain (e.g., `all=http://192.168.1.50:8096`).
4. Connect a client (e.g., Android TV) and attempt to play a Live TV stream that triggers the `GetApiUrlForLocalAccess` logic (often Direct Stream).
5. **Before fix:** Client receives `http://172.x.x.x:8096...` and fails/timeouts.
6. **After fix:** Client receives `http://192.168.1.50:8096...` or `https://mydomain.com...` and plays successfully.