### PR TITLE
Add hidden file check in BdInfoDirectoryInfo.cs.

### DIFF
--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoDirectoryInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using BDInfo.IO;
@@ -58,6 +59,8 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
         }
     }
 
+    private static bool IsHidden(ReadOnlySpan<char> name) => name.StartsWith('.');
+
     /// <summary>
     /// Gets the directories.
     /// </summary>
@@ -65,6 +68,7 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
     public IDirectoryInfo[] GetDirectories()
     {
         return _fileSystem.GetDirectories(_impl.FullName)
+            .Where(d => !IsHidden(d.Name))
             .Select(x => new BdInfoDirectoryInfo(_fileSystem, x))
             .ToArray();
     }
@@ -76,6 +80,7 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
     public IFileInfo[] GetFiles()
     {
         return _fileSystem.GetFiles(_impl.FullName)
+            .Where(d => !IsHidden(d.Name))
             .Select(x => new BdInfoFileInfo(x))
             .ToArray();
     }
@@ -88,6 +93,7 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
     public IFileInfo[] GetFiles(string searchPattern)
     {
         return _fileSystem.GetFiles(_impl.FullName, new[] { searchPattern }, false, false)
+            .Where(d => !IsHidden(d.Name))
             .Select(x => new BdInfoFileInfo(x))
             .ToArray();
     }
@@ -105,6 +111,7 @@ public class BdInfoDirectoryInfo : IDirectoryInfo
                 new[] { searchPattern },
                 false,
                 searchOption == SearchOption.AllDirectories)
+            .Where(d => !IsHidden(d.Name))
             .Select(x => new BdInfoFileInfo(x))
             .ToArray();
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The hidden files start with "." generated by MacOS in external exFAT drives will causes error when scanning the Bluray directories. This issue occurs even running locally and natively without using docker on MacOS.
I added a check in BdInfoDirectoryInfo.cs to skip those files.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
I found this issue recently and didn't see any similar issues. The screenshot about the error I found is attached below.
<img width="4480" height="2520" alt="image" src="https://github.com/user-attachments/assets/4cdeddc6-6790-485b-a888-ccca632d5965" />

