### PR TITLE
include external IDs and URLs for book providers

### DIFF
--- a/MediaBrowser.Providers/Books/Isbn/ISBNExternalId.cs
+++ b/MediaBrowser.Providers/Books/Isbn/ISBNExternalId.cs
@@ -1,0 +1,23 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace MediaBrowser.Providers.Books.Isbn
+{
+    /// <inheritdoc />
+    public class IsbnExternalId : IExternalId
+    {
+        /// <inheritdoc />
+        public string ProviderName => "ISBN";
+
+        /// <inheritdoc />
+        public string Key => "ISBN";
+
+        /// <inheritdoc />
+        public ExternalIdMediaType? Type => null;
+
+        /// <inheritdoc />
+        public bool Supports(IHasProviderIds item) => item is Book;
+    }
+}

--- a/MediaBrowser.Providers/Books/Isbn/ISBNExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Books/Isbn/ISBNExternalUrlProvider.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+
+namespace MediaBrowser.Providers.Books.Isbn;
+
+/// <inheritdoc/>
+public class IsbnExternalUrlProvider : IExternalUrlProvider
+{
+    /// <inheritdoc/>
+    public string Name => "ISBN";
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetExternalUrls(BaseItem item)
+    {
+        if (item.TryGetProviderId("ISBN", out var externalId))
+        {
+            if (item is Book)
+            {
+                yield return $"https://search.worldcat.org/search?q=bn:{externalId}";
+            }
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ComicVine/ComicVineExternalId.cs
+++ b/MediaBrowser.Providers/Plugins/ComicVine/ComicVineExternalId.cs
@@ -1,0 +1,23 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace MediaBrowser.Providers.Plugins.ComicVine
+{
+    /// <inheritdoc />
+    public class ComicVineExternalId : IExternalId
+    {
+        /// <inheritdoc />
+        public string ProviderName => "Comic Vine";
+
+        /// <inheritdoc />
+        public string Key => "ComicVine";
+
+        /// <inheritdoc />
+        public ExternalIdMediaType? Type => null;
+
+        /// <inheritdoc />
+        public bool Supports(IHasProviderIds item) => item is Book;
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ComicVine/ComicVineExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Plugins/ComicVine/ComicVineExternalUrlProvider.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+
+namespace MediaBrowser.Providers.Plugins.ComicVine;
+
+/// <inheritdoc/>
+public class ComicVineExternalUrlProvider : IExternalUrlProvider
+{
+    /// <inheritdoc/>
+    public string Name => "Comic Vine";
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetExternalUrls(BaseItem item)
+    {
+        if (item.TryGetProviderId("ComicVine", out var externalId))
+        {
+            switch (item)
+            {
+                case Person:
+                case Book:
+                    yield return $"https://comicvine.gamespot.com/{externalId}";
+                    break;
+            }
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/ComicVine/ComicVinePersonExternalId.cs
+++ b/MediaBrowser.Providers/Plugins/ComicVine/ComicVinePersonExternalId.cs
@@ -1,0 +1,23 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace MediaBrowser.Providers.Plugins.ComicVine
+{
+    /// <inheritdoc />
+    public class ComicVinePersonExternalId : IExternalId
+    {
+        /// <inheritdoc />
+        public string ProviderName => "Comic Vine";
+
+        /// <inheritdoc />
+        public string Key => "ComicVine";
+
+        /// <inheritdoc />
+        public ExternalIdMediaType? Type => ExternalIdMediaType.Person;
+
+        /// <inheritdoc />
+        public bool Supports(IHasProviderIds item) => item is Person;
+    }
+}

--- a/MediaBrowser.Providers/Plugins/GoogleBooks/GoogleBooksExternalId.cs
+++ b/MediaBrowser.Providers/Plugins/GoogleBooks/GoogleBooksExternalId.cs
@@ -1,0 +1,23 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace MediaBrowser.Providers.Plugins.GoogleBooks
+{
+    /// <inheritdoc />
+    public class GoogleBooksExternalId : IExternalId
+    {
+        /// <inheritdoc />
+        public string ProviderName => "Google Books";
+
+        /// <inheritdoc />
+        public string Key => "GoogleBooks";
+
+        /// <inheritdoc />
+        public ExternalIdMediaType? Type => null;
+
+        /// <inheritdoc />
+        public bool Supports(IHasProviderIds item) => item is Book;
+    }
+}

--- a/MediaBrowser.Providers/Plugins/GoogleBooks/GoogleBooksExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Plugins/GoogleBooks/GoogleBooksExternalUrlProvider.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+
+namespace MediaBrowser.Providers.Plugins.GoogleBooks;
+
+/// <inheritdoc/>
+public class GoogleBooksExternalUrlProvider : IExternalUrlProvider
+{
+    /// <inheritdoc />
+    public string Name => "Google Books";
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetExternalUrls(BaseItem item)
+    {
+        if (item.TryGetProviderId("GoogleBooks", out var externalId))
+        {
+            if (item is Book)
+            {
+                yield return $"https://books.google.com/books?id={externalId}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

Part one of several that will extract the local metadata providers from the bookshelf plugin and include them in the server to improve book support out of the box.

**Issues**

None