### PR TITLE
feat: Add Live TV channel grouping and filtering capabilities.

### DIFF
--- a/Jellyfin.Api/Models/LiveTvDtos/GetProgramsDto.cs
+++ b/Jellyfin.Api/Models/LiveTvDtos/GetProgramsDto.cs
@@ -116,6 +116,12 @@ public class GetProgramsDto
     public IReadOnlyList<Guid>? GenreIds { get; set; }
 
     /// <summary>
+    /// Gets or sets the channel group ids to return guide information for.
+    /// </summary>
+    [JsonConverter(typeof(JsonCommaDelimitedCollectionConverterFactory))]
+    public IReadOnlyList<Guid>? ChannelGroupIds { get; set; }
+
+    /// <summary>
     /// Gets or sets include image information in output.
     /// </summary>
     public bool? EnableImages { get; set; }

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -24,6 +24,7 @@ namespace MediaBrowser.Controller.Entities
             BlockUnratedItems = Array.Empty<UnratedItem>();
             BoxSetLibraryFolders = Array.Empty<Guid>();
             ChannelIds = Array.Empty<Guid>();
+            ChannelGroupIds = Array.Empty<Guid>();
             ContributingArtistIds = Array.Empty<Guid>();
             DtoOptions = new DtoOptions();
             EnableTotalRecordCount = true;
@@ -226,6 +227,8 @@ namespace MediaBrowser.Controller.Entities
         public double? MinCommunityRating { get; set; }
 
         public IReadOnlyList<Guid> ChannelIds { get; set; }
+
+        public IReadOnlyList<Guid> ChannelGroupIds { get; set; }
 
         public int? ParentIndexNumber { get; set; }
 

--- a/MediaBrowser.Controller/LiveTv/ChannelInfo.cs
+++ b/MediaBrowser.Controller/LiveTv/ChannelInfo.cs
@@ -2,6 +2,9 @@
 
 #pragma warning disable CS1591
 
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
 using MediaBrowser.Model.LiveTv;
 
 namespace MediaBrowser.Controller.LiveTv
@@ -48,10 +51,31 @@ namespace MediaBrowser.Controller.LiveTv
         public ChannelType ChannelType { get; set; }
 
         /// <summary>
-        /// Gets or sets the group of the channel.
+        /// Gets or sets the groups the channel belongs to.
         /// </summary>
-        /// <value>The group of the channel.</value>
-        public string ChannelGroup { get; set; }
+        /// <value>The groups of the channel.</value>
+        public string[] ChannelGroups { get; set; } = Array.Empty<string>();
+
+        [JsonIgnore]
+        [Obsolete("Use ChannelGroups")]
+        public string ChannelGroup
+        {
+            get => ChannelGroups.FirstOrDefault();
+            set => ChannelGroups = string.IsNullOrWhiteSpace(value) ? Array.Empty<string>() : new[] { value };
+        }
+
+        [JsonPropertyName("ChannelGroup")]
+        public string LegacyChannelGroup
+        {
+            get => null;
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(value) && (ChannelGroups is null || ChannelGroups.Length == 0))
+                {
+                    ChannelGroups = new[] { value };
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the image path if it can be accessed directly from the file system.

--- a/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
+++ b/MediaBrowser.Controller/LiveTv/ILiveTvManager.cs
@@ -210,6 +210,14 @@ namespace MediaBrowser.Controller.LiveTv
         QueryResult<BaseItem> GetInternalChannels(LiveTvChannelQuery query, DtoOptions dtoOptions, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Gets the channel groups.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Channel groups.</returns>
+        QueryResult<LiveTvChannelGroupDto> GetChannelGroups(InternalItemsQuery query, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Adds the information to program dto.
         /// </summary>
         /// <param name="programs">The programs.</param>

--- a/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveTvChannel.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
@@ -87,6 +86,8 @@ namespace MediaBrowser.Controller.LiveTv
         /// <value>The episode title.</value>
         [JsonIgnore]
         public string EpisodeTitle { get; set; }
+
+        public string[] ChannelGroups { get; set; } = Array.Empty<string>();
 
         public override List<string> GetUserDataKeys()
         {

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -701,6 +701,12 @@ namespace MediaBrowser.Model.Dto
         public string ChannelPrimaryImageTag { get; set; }
 
         /// <summary>
+        /// Gets or sets the channel groups.
+        /// </summary>
+        /// <value>The channel groups.</value>
+        public NameGuidPair[] ChannelGroups { get; set; }
+
+        /// <summary>
         /// Gets or sets the start date of the recording, in UTC.
         /// </summary>
         public DateTime? StartDate { get; set; }

--- a/MediaBrowser.Model/LiveTv/LiveTvChannelGroupDto.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvChannelGroupDto.cs
@@ -1,0 +1,42 @@
+#nullable disable
+
+using System;
+
+namespace MediaBrowser.Model.LiveTv
+{
+    /// <summary>
+    /// Represents a logical group of live tv channels.
+    /// </summary>
+    public class LiveTvChannelGroupDto
+    {
+        /// <summary>
+        /// Gets or sets the unique id of the channel group.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name of the group.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the group was created by a user.
+        /// </summary>
+        public bool? IsUserCreated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the group is hidden.
+        /// </summary>
+        public bool? IsHidden { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether membership is computed dynamically.
+        /// </summary>
+        public bool? IsDynamic { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of channels in this group.
+        /// </summary>
+        public int? ChannelCount { get; set; }
+    }
+}

--- a/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvChannelQuery.cs
@@ -107,5 +107,11 @@ namespace MediaBrowser.Model.LiveTv
         /// </summary>
         /// <value>The sort order.</value>
         public SortOrder? SortOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the channel group identifiers.
+        /// </summary>
+        /// <value>The channel group identifiers.</value>
+        public Guid[] ChannelGroupIds { get; set; }
     }
 }

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -444,6 +444,13 @@ public class GuideManager : IGuideManager
 
         item.Name = channelInfo.Name;
 
+        var normalizedGroups = NormalizeGroups(channelInfo.ChannelGroups);
+        if (!ChannelGroupsEqual(item.ChannelGroups, normalizedGroups))
+        {
+            forceUpdate = true;
+            item.ChannelGroups = normalizedGroups;
+        }
+
         if (!item.HasImage(ImageType.Primary))
         {
             if (!string.IsNullOrWhiteSpace(channelInfo.ImagePath))
@@ -468,6 +475,50 @@ public class GuideManager : IGuideManager
         }
 
         return item;
+    }
+
+    private static string[] NormalizeGroups(IReadOnlyCollection<string> groups)
+    {
+        if (groups is null || groups.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var normalized = new List<string>(groups.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var group in groups)
+        {
+            if (string.IsNullOrWhiteSpace(group) || !seen.Add(group))
+            {
+                continue;
+            }
+
+            normalized.Add(group);
+        }
+
+        return normalized.Count == 0 ? Array.Empty<string>() : normalized.ToArray();
+    }
+
+    private static bool ChannelGroupsEqual(IReadOnlyList<string> left, IReadOnlyList<string> right)
+    {
+        left ??= Array.Empty<string>();
+        right ??= Array.Empty<string>();
+
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!string.Equals(left[i], right[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private (LiveTvProgram Item, bool IsNew, bool IsUpdated) GetProgram(


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Add a `/LiveTv/ChannelGroups` endpoint so clients can discover available channel groups and their IDs.
- Extend the existing channel/program/guide endpoints to filter by `channelGroupIds` and surface each item’s group membership in the return.
- Update the M3U ingestion pipeline to track multiple group names per channel, normalize/merge them, and expose them consistently. As of #10323 the parser always replaces `tvg-id` on `channel.Id` with the stream URL hash, so only the first duplicate survives. This change should preserve that behavior while merging the extra group metadata into that single entry.
- Introduce the `LiveTvChannelGroupDto` type and supporting `NameGuidPair` mapping so clients receive deterministic IDs alongside display names.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
No issues, but this is the API implementation and first step towards implementing [this highly requested feature](https://features.jellyfin.org/posts/186/iptv-channel-groupings).
