### PR TITLE
Update WebSocketManager.cs Fix RemoteIPHeader for WebSocket connections

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketManager.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketManager.cs
@@ -44,7 +44,9 @@ namespace Emby.Server.Implementations.HttpServer
 
             try
             {
-                _logger.LogInformation("WS {IP} request", context.Connection.RemoteIpAddress);
+                var clientIpAddress = _networkManager.GetRemoteIp(context.Request);
+
+                _logger.LogInformation("WS {ClientIpAddress} request", clientIpAddress);
 
                 WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
 
@@ -67,12 +69,12 @@ namespace Emby.Server.Implementations.HttpServer
                     await Task.WhenAll(tasks).ConfigureAwait(false);
 
                     await connection.ReceiveAsync().ConfigureAwait(false);
-                    _logger.LogInformation("WS {IP} closed", context.Connection.RemoteIpAddress);
+                    _logger.LogInformation("WS {ClientIpAddress} closed", clientIpAddress);
                 }
             }
             catch (Exception ex) // Otherwise ASP.Net will ignore the exception
             {
-                _logger.LogError(ex, "WS {IP} WebSocketRequestHandler error", context.Connection.RemoteIpAddress);
+                _logger.LogInformation("WS {ClientIpAddress} error", clientIpAddress);
                 if (!context.Response.HasStarted)
                 {
                     context.Response.StatusCode = 500;


### PR DESCRIPTION
Fix RemoteIPHeader for WebSocket connections

**Changes**
Replaced usage of context.Connection.RemoteIpAddress in WebSocketManager with NetworkManager.GetRemoteIp(context.Request).
This ensures that RemoteIPHeader and KnownProxies settings are respected for WebSocket connections.
As a result, clients behind reverse proxies will now show their real IP addresses instead of the proxy IP.

**Issues**
No related issue filed. Can be linked later if maintainers request.
