### PR TITLE
Fix RemoteIPHeader handling in WebSocketManager

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketManager.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketManager.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations.HttpServer
         /// <inheritdoc />
         public async Task WebSocketRequestHandler(HttpContext context)
         {
-            var clientIpAddress = _networkManager.GetRemoteIp(context.Request);
+            var clientIpAddress = context.Request.GetRemoteIp(_networkManager);
             var authorizationInfo = await _authService.Authenticate(context.Request).ConfigureAwait(false);
             if (!authorizationInfo.IsAuthenticated)
             {


### PR DESCRIPTION
Fix RemoteIPHeader handling for WebSocket connections

**Changes**
This PR updates WebSocketManager to use NetworkManager.GetRemoteIp(context.Request) instead of context.Connection.RemoteIpAddress.

As a result:
- RemoteIPHeader and KnownProxies settings are now respected for WebSocket connections.
- Clients behind reverse proxies will show their real IP addresses in logs.
- Logging has been updated to include client IP for request, error, and closed events.

Motivation:
Previously, WebSocket connections ignored RemoteIPHeader and always logged the proxy IP.
This caused issues for deployments behind reverse proxies (Nginx, Traefik, Caddy).
With this fix, administrators can correctly trace client connections.

Testing:
Not yet tested behind reverse proxy. Needs validation by maintainers/community.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
