### PR TITLE
Fix unnecessary database JOINs in ApplyNavigations

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -410,10 +410,25 @@ public sealed class BaseItemRepository
 
     private static IQueryable<BaseItemEntity> ApplyNavigations(IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
     {
-        dbQuery = dbQuery.Include(e => e.TrailerTypes)
-           .Include(e => e.Provider)
-           .Include(e => e.LockedFields)
-           .Include(e => e.UserData);
+        if (filter.TrailerTypes.Length > 0 || filter.IncludeItemTypes.Contains(BaseItemKind.Trailer))
+        {
+            dbQuery = dbQuery.Include(e => e.TrailerTypes);
+        }
+
+        if (filter.DtoOptions.ContainsField(ItemFields.ProviderIds))
+        {
+            dbQuery = dbQuery.Include(e => e.Provider);
+        }
+
+        if (filter.DtoOptions.ContainsField(ItemFields.Settings))
+        {
+            dbQuery = dbQuery.Include(e => e.LockedFields);
+        }
+
+        if (filter.DtoOptions.EnableUserData)
+        {
+            dbQuery = dbQuery.Include(e => e.UserData);
+        }
 
         if (filter.DtoOptions.EnableImages)
         {


### PR DESCRIPTION
Slight performance opitmization. For example, when navigating to a Movie library via jellyfin-web:

`https://localhost/Users/<UserId>/Items?SortBy=DateCreated%2CSortName%2CProductionYear&SortOrder=Descending&IncludeItemTypes=Movie&Recursive=true&Fields=PrimaryImageAspectRatio%2CMediaSourceCount&ImageTypeLimit=1&EnableImageTypes=Primary%2CBackdrop%2CBanner%2CThumb&StartIndex=0&ParentId=<ParentId>&Limit=100`

I compared the performance of retrieving that URL using curl and two identical servers. This change resulted in a decrease from ~83ms to ~52ms in request duration.

```
$ hyperfine -r 200 ./before.sh ./after.sh
Benchmark 1: ./before.sh
  Time (mean ± σ):      83.8 ms ±   3.8 ms    [User: 8.8 ms, System: 4.2 ms]
  Range (min … max):    78.2 ms … 102.1 ms    200 runs
 
Benchmark 2: ./after.sh
  Time (mean ± σ):      52.1 ms ±   2.7 ms    [User: 8.9 ms, System: 4.0 ms]
  Range (min … max):    47.6 ms …  64.0 ms    200 runs
 
Summary
  ./after.sh ran
    1.61 ± 0.11 times faster than ./before.sh
```