### PR TITLE
Fix ItemAdded event triggering when updating metadata

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -721,8 +721,6 @@ namespace MediaBrowser.Providers.Manager
                     }
                 }
             }
-
-            _libraryManager.CreateItem(item, null);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Remove `CreateItem` call in `ProviderManager.SaveMetadataAsync` which was causing `ItemAdded` events to trigger when updating existing items. The item is already saved to the database by `UpdateItemsAsync` after metadata files are written.

**Issues**
Fixes #15245
Fixes https://github.com/jellyfin/jellyfin-plugin-webhook/issues/356
Fixes https://github.com/jellyfin/jellyfin-plugin-webhook/issues/358