### PR TITLE
Use original name for MusicAritist matching

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1058,6 +1058,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     IncludeItemTypes = [BaseItemKind.MusicArtist],
                     Name = name,
+                    UseRawName = true,
                     DtoOptions = options
                 }).Cast<MusicArtist>()
                 .OrderBy(i => i.IsAccessedByName ? 1 : 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1930,8 +1930,15 @@ public sealed class BaseItemRepository
 
         if (!string.IsNullOrWhiteSpace(filter.Name))
         {
-            var cleanName = GetCleanValue(filter.Name);
-            baseQuery = baseQuery.Where(e => e.CleanName == cleanName);
+            if (filter.UseRawName == true)
+            {
+                baseQuery = baseQuery.Where(e => e.Name == filter.Name);
+            }
+            else
+            {
+                var cleanName = GetCleanValue(filter.Name);
+                baseQuery = baseQuery.Where(e => e.CleanName == cleanName);
+            }
         }
 
         // These are the same, for now

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -125,6 +125,8 @@ namespace MediaBrowser.Controller.Entities
 
         public string? Name { get; set; }
 
+        public bool? UseRawName { get; set; }
+
         public string? Person { get; set; }
 
         public Guid[] PersonIds { get; set; }


### PR DESCRIPTION
Our MusicArtist matching is now having inconsistencies after EFCore refactor:

- In LibraryManager.cs, `CreateItemByName` uses `GetItemList` to find existing artists and that query would transparently normalize the artist name into a clean name and return the artist matched with the clean name, even if the original artist name is different
- However, in BaseItemRepository.cs, the `FindArtists` match artists with the original name (not the normalized cleanName)

This inconsistency would cause the following case:

- One artist named Tim already exists
- Now another artist named TIM comes in
- This artist cannot be created because `CreateItemByName` thinks there is already an existing artist to be the same person
- But `FindArtists` will not be able to find that particular artist, and to user, there is just one "missing artist"

Given the fact that artists could having surprisingly similar name that just differ by cases or special characters, we should always use the original name to match existing artists.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #15283