### PR TITLE
Fix stack overflow during scan (#15000)

### DIFF
--- a/MediaBrowser.Controller/LibraryTaskScheduler/LimitedConcurrencyLibraryScheduler.cs
+++ b/MediaBrowser.Controller/LibraryTaskScheduler/LimitedConcurrencyLibraryScheduler.cs
@@ -242,7 +242,7 @@ public sealed class LimitedConcurrencyLibraryScheduler : ILimitedConcurrencyLibr
             };
         }).ToArray();
 
-        if (ShouldForceSequentialOperation())
+        if (ShouldForceSequentialOperation() || _deadlockDetector.Value is not null)
         {
             _logger.LogDebug("Process sequentially.");
             try
@@ -267,32 +267,11 @@ public sealed class LimitedConcurrencyLibraryScheduler : ILimitedConcurrencyLibr
             _tasks.Add(item, CancellationToken.None);
         }
 
-        if (_deadlockDetector.Value is not null)
-        {
-            _logger.LogDebug("Nested invocation detected, process in-place.");
-            try
-            {
-                // we are in a nested loop. There is no reason to spawn a task here as that would just lead to deadlocks and no additional concurrency is achieved
-                while (workItems.Any(e => !e.Done.Task.IsCompleted) && _tasks.TryTake(out var item, 200, _deadlockDetector.Value.Token))
-                {
-                    await ProcessItem(item).ConfigureAwait(false);
-                }
-            }
-            catch (OperationCanceledException) when (_deadlockDetector.Value.IsCancellationRequested)
-            {
-                // operation is cancelled. Do nothing.
-            }
-
-            _logger.LogDebug("process in-place done.");
-        }
-        else
-        {
-            Worker();
-            _logger.LogDebug("Wait for {NoWorkers} to complete.", workItems.Length);
-            await Task.WhenAll([.. workItems.Select(f => f.Done.Task)]).ConfigureAwait(false);
-            _logger.LogDebug("{NoWorkers} completed.", workItems.Length);
-            ScheduleTaskCleanup();
-        }
+        Worker();
+        _logger.LogDebug("Wait for {NoWorkers} to complete.", workItems.Length);
+        await Task.WhenAll([.. workItems.Select(f => f.Done.Task)]).ConfigureAwait(false);
+        _logger.LogDebug("{NoWorkers} completed.", workItems.Length);
+        ScheduleTaskCleanup();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
In function MediaBrowser.Controller.LibraryTaskScheduler.Enqueue, if we enter the "we are in a nested loop" block, the logic try get a item from _tasks, making function Enqueue not process the file in subfolder, but start from a new folder which increase Call Stack. This make the length of Call Stack is not depends on the depth of filesystem, but the count of subfolders. Therefore, if there are lots of subfolders, the Call Stack will exceed a certain limit and cause Stack Overflow.

**Changes**
When _deadlockDetector.Value is not null, using existed ForceSequentialOperation.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/15000
