### PR TITLE
Fix: Add FFmpeg reconnect flags for HTTP VOD streams to improve stability

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -205,6 +205,7 @@
  - [theshoeshiner](https://github.com/theshoeshiner)
  - [TokerX](https://github.com/TokerX)
  - [GeneMarks](https://github.com/GeneMarks)
+ - [martenumberto](https://github.com/martenumberto)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7153,6 +7153,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                 inputModifier += " -rtsp_transport tcp+udp -rtsp_flags prefer_tcp";
             }
 
+            if (state.InputProtocol == MediaProtocol.Http)
+            {
+                inputModifier += " -reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
+            }
+
             if (!string.IsNullOrEmpty(state.InputAudioSync))
             {
                 inputModifier += " -async " + state.InputAudioSync;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7153,9 +7153,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                 inputModifier += " -rtsp_transport tcp+udp -rtsp_flags prefer_tcp";
             }
 
-            if (state.InputProtocol == MediaProtocol.Http)
+            if (state.InputProtocol == MediaProtocol.Http && !state.MediaSource.IsInfiniteStream)
             {
-                inputModifier += " -reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
+                inputModifier += " -reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 30";
             }
 
             if (!string.IsNullOrEmpty(state.InputAudioSync))


### PR DESCRIPTION
### Describe the bug
Currently, Jellyfin playback stops immediately if an HTTP stream connection drops, times out, or is closed by the server/proxy prematurely (TCP FIN/RST). 

This behavior is particularly problematic for:
1.  **Proxies & Gateways:** Some IPTV/M3U proxies explicitly close client connections to trigger failovers or refresh tokens.
2.  **CDNs:** Connections may be dropped due to load balancing or timeouts, which `ffmpeg` interprets as a valid `EOF` (End of File), causing the movie to stop halfway.
3.  **Unstable Networks:** Temporary packet loss causes the transcoder/remuxer to exit instead of retrying.

Logs typically show `Stream ends prematurely` followed by a clean exit of ffmpeg, leaving the user with a stopped video.

### The Solution
This PR adds standard `ffmpeg` reconnect flags to the input arguments in `EncodingHelper.cs`.

**Logic Changes:**
* Applies flags **ONLY** if the input protocol is `Http` (which in Jellyfin handles both `http://` and `https://`).
* Applies flags **ONLY** if `IsInfiniteStream` is `false`. This ensures that **Live TV** logic (Tuners/M3U Live) remains untouched to prevent interference with existing live buffer mechanisms.

**Added Flags:**
* `-reconnect 1`: Retry connection on failure.
* `-reconnect_at_eof 1`: **Critical fix:** Retry if the stream ends before the expected duration/header length (fixes "premature EOF" issues).
* `-reconnect_streamed 1`: Allow reconnection for streamed data.
* `-reconnect_delay_max 30`: Sets a generous max delay (30s) to allow upstream proxies or gateways enough time to recover or switch routes.

### Testing Done
* **Environment:** Jellyfin connecting to a custom upstream HTTP proxy for VOD content (.mkv via .strm).
* **Scenario:** The proxy was forced to close the connection mid-stream (simulating a timeout or failover).
* **Before:** Jellyfin playback stopped immediately. FFmpeg log showed `Stream ends prematurely`.
* **After:** FFmpeg logged `Will reconnect at ...`, successfully re-established the connection, and playback continued to the end of the file without user intervention.

### Checklist
- [x] I have read the contributing guidelines.
- [x] I have verified that my change is targeting the correct branch.
- [x] I have verified that my changes do not break existing functionality (Live TV is excluded).