### PR TITLE
FFProbe: Reduce probesize to 500M

### DIFF
--- a/Emby.Server.Implementations/ConfigurationOptions.cs
+++ b/Emby.Server.Implementations/ConfigurationOptions.cs
@@ -15,7 +15,7 @@ namespace Emby.Server.Implementations
         {
             { HostWebClientKey, bool.TrueString },
             { DefaultRedirectKey, "web/" },
-            { FfmpegProbeSizeKey, "1G" },
+            { FfmpegProbeSizeKey, "500M" },
             { FfmpegAnalyzeDurationKey, "200M" },
             { BindToUnixSocketKey, bool.FalseString },
             { SqliteCacheSizeKey, "20000" },


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Reduce the ffprobe probesize down from 1G -> 500M. With 500M i havent seen any warnings asking to increase the probsize or duration in the logs after doing a full scan on my movies. This brings down the average memory usage for my full movies scan down from 3.38 GB -> 2.75 GB. Should have a bigger impact for servers that are using a higher parallel scan count.

Memory usage before

<img width="2803" height="611" alt="probe_1g" src="https://github.com/user-attachments/assets/16306c98-7476-444a-89d3-79223c5ca15d" />






Memory usage after

<img width="2803" height="611" alt="probe_500m" src="https://github.com/user-attachments/assets/bae2059c-2b75-4194-bcb0-d82bc8bee5e4" />



**Issues**
Relates to #14095 
