### PR TITLE
Update Authorization Controller endpoints to be more explicit

### DIFF
--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -251,6 +251,7 @@ public class UserController : BaseJellyfinApiController
     /// <returns>A <see cref="Task"/> containing an <see cref="AuthenticationRequest"/> with information about the new session.</returns>
     [HttpPost("AuthenticateWithQuickConnect")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<AuthenticationResult> AuthenticateWithQuickConnect([FromBody, Required] QuickConnectDto request)
     {
         try


### PR DESCRIPTION
Change the AuthenticateUserByName endpoint to return a 401 with `Invalid Authorization Cookie` instead of a generic 400 Error

Add 404 onto the AuthenticateWithQuickConnect so the docs get [updated here
](https://api.jellyfin.org/#tag/User/operation/AuthenticateWithQuickConnect)