### PR TITLE
Fix case sensitivity edge case

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -149,7 +149,7 @@ namespace Jellyfin.Server.Implementations.Users
 
             ThrowIfInvalidUsername(newName);
 
-            if (user.Username.Equals(newName, StringComparison.OrdinalIgnoreCase))
+            if (user.Username.Equals(newName, StringComparison.Ordinal))
             {
                 throw new ArgumentException("The new and old names must be different.");
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
# Summary
Both UserController.UpdateUser and UserManager.RenameUser compare the new username with the old username. UpdateUser checked for case sensitive inequality while RenameUser was case insensitive. This led to an edge case where the username change would lead to an incomplete request if the only difference was the character case. e.g collin to Collin. This left the client unresponsive while it waited for a server request that would never come. 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changed equality in UserManager.RenameUser from case insensitive to case sensitive. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #15417
