### PR TITLE
Fix trickplay images using wrong item on alternate versions

### DIFF
--- a/Jellyfin.Api/Controllers/TrickplayController.cs
+++ b/Jellyfin.Api/Controllers/TrickplayController.cs
@@ -86,7 +86,7 @@ public class TrickplayController : BaseJellyfinApiController
         [FromRoute, Required] int index,
         [FromQuery] Guid? mediaSourceId)
     {
-        var item = _libraryManager.GetItemById<BaseItem>(itemId, User.GetUserId());
+        var item = _libraryManager.GetItemById<BaseItem>(mediaSourceId ?? itemId, User.GetUserId());
         if (item is null)
         {
             return NotFound();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
The `GetTrickplayTileImage` endpoint was accepting a `mediaSourceId `query parameter but not using it. This caused trickplay images to always be fetched from the parent item rather than the specified media source version.

**Changes**
Updated `GetTrickplayTileImage` to use `mediaSourceId ?? itemId` when resolving the library item.

**Issues**
https://github.com/jellyfin/jellyfin/issues/15297#issuecomment-3560137897
Closes: [#7400](https://github.com/jellyfin/jellyfin-web/pull/7400)