### PR TITLE
fix: watched status resetting on re-watch

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -822,7 +822,7 @@ namespace Emby.Server.Implementations.Session
             {
                 data.Played = true;
             }
-            else
+            else if (!data.Played)
             {
                 data.Played = false;
             }


### PR DESCRIPTION
Preservation of Watched Status on Re-watch


**Changes**
 This change modifies the playback start logic to preserve the "Watched" status of media items when they are re-watched. Previously, starting playback on any item that supports resume would immediately mark the item as "Unwatched". This update ensures that Played status is only set to false if the item was not previously marked as played, allowing completed items to remain marked as completed during a re-watch session


