### PR TITLE
Fix AV1 decoding hang regression on RK3588

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7039,8 +7039,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 if (string.Equals(videoStream.Codec, "av1", StringComparison.OrdinalIgnoreCase))
                 {
-                    var accelType = GetHwaccelType(state, options, "av1", bitDepth, hwSurface);
-                    return accelType + ((!string.IsNullOrEmpty(accelType) && isAfbcSupported) ? " -afbc rga" : string.Empty);
+                    // there's an issue about AV1 AFBC on RK3588, disable it for now until it's fixed upstream
+                    return GetHwaccelType(state, options, "av1", bitDepth, hwSurface);
                 }
             }
 


### PR DESCRIPTION
**Changes**
- Fix AV1 decoding hang regression on RK3588

**Issues**
- The AFBC image output by AV1 decoder is invalid if the video width is not a multiple of 64 and this will reset the RGA3 hardware. Awaiting feedback from upstream. Disable it for now. https://forum.jellyfin.org/t-rk3588-do-not-hw-transcode-anymore