### PR TITLE
Fix parental rating filtering with sub-scores

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1620,12 +1620,17 @@ namespace MediaBrowser.Controller.Entities
                 return isAllowed;
             }
 
-            if (maxAllowedSubRating is not null)
+            if (!maxAllowedRating.HasValue)
             {
-                return (ratingScore.SubScore ?? 0) <= maxAllowedSubRating && ratingScore.Score <= maxAllowedRating.Value;
+                return true;
             }
 
-            return !maxAllowedRating.HasValue || ratingScore.Score <= maxAllowedRating.Value;
+            if (ratingScore.Score != maxAllowedRating.Value)
+            {
+                return ratingScore.Score < maxAllowedRating.Value;
+            }
+
+            return !maxAllowedSubRating.HasValue || (ratingScore.SubScore ?? 0) <= maxAllowedSubRating.Value;
         }
 
         public ParentalRatingScore GetParentalRatingScore()


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Content was being incorrectly blocked because Jellyfin was evaluating the main rating and sub-ratings separately, instead of only using sub-ratings when the main rating was the same.


**Changes**
Compare the main rating first, and only consider the sub-score when the main scores are equal.


**Issues**
Fixes #15775

