### PR TITLE
Fix GET MetadataEditor ContentTypeOptions for mixed content

### DIFF
--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -180,11 +180,14 @@ public class ItemUpdateController : BaseJellyfinApiController
                 info.ContentTypeOptions = GetContentTypeOptions(true).ToArray();
                 info.ContentType = configuredContentType;
 
-                if (inheritedContentType is null || inheritedContentType == CollectionType.tvshows)
+                if (inheritedContentType is null
+                    || inheritedContentType == CollectionType.tvshows
+                    || inheritedContentType == CollectionType.movies)
                 {
                     info.ContentTypeOptions = info.ContentTypeOptions
                         .Where(i => string.IsNullOrWhiteSpace(i.Value)
-                                    || string.Equals(i.Value, "TvShows", StringComparison.OrdinalIgnoreCase))
+                                    || string.Equals(i.Value, "TvShows", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(i.Value, "Movies", StringComparison.OrdinalIgnoreCase))
                         .ToArray();
                 }
             }


### PR DESCRIPTION
<!--
In the mixed content, a certain movie folder was detected as a TV show folder. However, when editing the metadata, it was impossible to force the folder to be a movie folder; only the TV show folder option was visible.
-->

**Changes**
Add "movies" option for content type in mixed content

**Issues**
https://github.com/jellyfin/jellyfin/issues/15676
