### PR TITLE
Removing N+1 queries from the /items/Latest endpoint

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -160,10 +160,17 @@ namespace Emby.Server.Implementations.Dto
             List<(BaseItem, BaseItemDto)>? programTuples = null;
             List<(BaseItemDto, LiveTvChannel)>? channelTuples = null;
 
+            // Batch-fetch user data for all items to avoid N+1 queries
+            Dictionary<Guid, UserItemData>? userDataBatch = null;
+            if (user is not null && options.EnableUserData)
+            {
+                userDataBatch = _userDataRepository.GetUserDataBatch(accessibleItems, user);
+            }
+
             for (int index = 0; index < accessibleItems.Count; index++)
             {
                 var item = accessibleItems[index];
-                var dto = GetBaseItemDtoInternal(item, options, user, owner);
+                var dto = GetBaseItemDtoInternal(item, options, user, owner, userDataBatch);
 
                 if (item is LiveTvChannel tvChannel)
                 {
@@ -197,7 +204,7 @@ namespace Emby.Server.Implementations.Dto
 
         public BaseItemDto GetBaseItemDto(BaseItem item, DtoOptions options, User? user = null, BaseItem? owner = null)
         {
-            var dto = GetBaseItemDtoInternal(item, options, user, owner);
+            var dto = GetBaseItemDtoInternal(item, options, user, owner, null);
             if (item is LiveTvChannel tvChannel)
             {
                 LivetvManager.AddChannelInfo(new[] { (dto, tvChannel) }, options, user);
@@ -215,7 +222,7 @@ namespace Emby.Server.Implementations.Dto
             return dto;
         }
 
-        private BaseItemDto GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User? user = null, BaseItem? owner = null)
+        private BaseItemDto GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User? user = null, BaseItem? owner = null, Dictionary<Guid, UserItemData>? userDataBatch = null)
         {
             var dto = new BaseItemDto
             {
@@ -252,7 +259,7 @@ namespace Emby.Server.Implementations.Dto
 
             if (user is not null)
             {
-                AttachUserSpecificInfo(dto, item, user, options);
+                AttachUserSpecificInfo(dto, item, user, options, userDataBatch);
             }
 
             if (item is IHasMediaSources
@@ -458,7 +465,7 @@ namespace Emby.Server.Implementations.Dto
         /// <summary>
         /// Attaches the user specific info.
         /// </summary>
-        private void AttachUserSpecificInfo(BaseItemDto dto, BaseItem item, User user, DtoOptions options)
+        private void AttachUserSpecificInfo(BaseItemDto dto, BaseItem item, User user, DtoOptions options, Dictionary<Guid, UserItemData>? userDataBatch = null)
         {
             if (item.IsFolder)
             {
@@ -466,7 +473,17 @@ namespace Emby.Server.Implementations.Dto
 
                 if (options.EnableUserData)
                 {
-                    dto.UserData = _userDataRepository.GetUserDataDto(item, dto, user, options);
+                    if (userDataBatch is not null && userDataBatch.TryGetValue(item.Id, out var batchedUserData))
+                    {
+                        // Use pre-fetched user data
+                        dto.UserData = GetUserItemDataDto(batchedUserData, item.Id);
+                        item.FillUserDataDtoValues(dto.UserData, batchedUserData, dto, user, options);
+                    }
+                    else
+                    {
+                        // Fall back to individual fetch
+                        dto.UserData = _userDataRepository.GetUserDataDto(item, dto, user, options);
+                    }
                 }
 
                 if (!dto.ChildCount.HasValue && item.SourceType == SourceType.Library)
@@ -503,7 +520,17 @@ namespace Emby.Server.Implementations.Dto
             {
                 if (options.EnableUserData)
                 {
-                    dto.UserData = _userDataRepository.GetUserDataDto(item, user);
+                    if (userDataBatch is not null && userDataBatch.TryGetValue(item.Id, out var batchedUserData))
+                    {
+                        // Use pre-fetched user data
+                        dto.UserData = GetUserItemDataDto(batchedUserData, item.Id);
+                        item.FillUserDataDtoValues(dto.UserData, batchedUserData, dto, user, options);
+                    }
+                    else
+                    {
+                        // Fall back to individual fetch
+                        dto.UserData = _userDataRepository.GetUserDataDto(item, user);
+                    }
                 }
             }
 
@@ -511,6 +538,30 @@ namespace Emby.Server.Implementations.Dto
             {
                 dto.PlayAccess = item.GetPlayAccess(user);
             }
+        }
+
+        /// <summary>
+        /// Converts a UserItemData to a DTOUserItemData.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        /// <param name="itemId">The reference key to an Item.</param>
+        /// <returns>DtoUserItemData.</returns>
+        private static UserItemDataDto GetUserItemDataDto(UserItemData data, Guid itemId)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            return new UserItemDataDto
+            {
+                IsFavorite = data.IsFavorite,
+                Likes = data.Likes,
+                PlaybackPositionTicks = data.PlaybackPositionTicks,
+                PlayCount = data.PlayCount,
+                Rating = data.Rating,
+                Played = data.Played,
+                LastPlayedDate = data.LastPlayedDate,
+                ItemId = itemId,
+                Key = data.Key
+            };
         }
 
         private static int GetChildCount(Folder folder, User user)

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -170,7 +170,7 @@ namespace Emby.Server.Implementations.Dto
             for (int index = 0; index < accessibleItems.Count; index++)
             {
                 var item = accessibleItems[index];
-                var dto = GetBaseItemDtoInternal(item, options, user, owner, userDataBatch);
+                var dto = GetBaseItemDtoInternal(item, options, user, owner, userDataBatch?.GetValueOrDefault(item.Id));
 
                 if (item is LiveTvChannel tvChannel)
                 {
@@ -222,7 +222,7 @@ namespace Emby.Server.Implementations.Dto
             return dto;
         }
 
-        private BaseItemDto GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User? user = null, BaseItem? owner = null, Dictionary<Guid, UserItemData>? userDataBatch = null)
+        private BaseItemDto GetBaseItemDtoInternal(BaseItem item, DtoOptions options, User? user = null, BaseItem? owner = null, UserItemData? userData = null)
         {
             var dto = new BaseItemDto
             {
@@ -259,7 +259,7 @@ namespace Emby.Server.Implementations.Dto
 
             if (user is not null)
             {
-                AttachUserSpecificInfo(dto, item, user, options, userDataBatch);
+                AttachUserSpecificInfo(dto, item, user, options, userData);
             }
 
             if (item is IHasMediaSources
@@ -465,7 +465,7 @@ namespace Emby.Server.Implementations.Dto
         /// <summary>
         /// Attaches the user specific info.
         /// </summary>
-        private void AttachUserSpecificInfo(BaseItemDto dto, BaseItem item, User user, DtoOptions options, Dictionary<Guid, UserItemData>? userDataBatch = null)
+        private void AttachUserSpecificInfo(BaseItemDto dto, BaseItem item, User user, DtoOptions options, UserItemData? userData = null)
         {
             if (item.IsFolder)
             {
@@ -473,11 +473,11 @@ namespace Emby.Server.Implementations.Dto
 
                 if (options.EnableUserData)
                 {
-                    if (userDataBatch is not null && userDataBatch.TryGetValue(item.Id, out var batchedUserData))
+                    if (userData is not null)
                     {
                         // Use pre-fetched user data
-                        dto.UserData = GetUserItemDataDto(batchedUserData, item.Id);
-                        item.FillUserDataDtoValues(dto.UserData, batchedUserData, dto, user, options);
+                        dto.UserData = GetUserItemDataDto(userData, item.Id);
+                        item.FillUserDataDtoValues(dto.UserData, userData, dto, user, options);
                     }
                     else
                     {
@@ -520,11 +520,11 @@ namespace Emby.Server.Implementations.Dto
             {
                 if (options.EnableUserData)
                 {
-                    if (userDataBatch is not null && userDataBatch.TryGetValue(item.Id, out var batchedUserData))
+                    if (userData is not null)
                     {
                         // Use pre-fetched user data
-                        dto.UserData = GetUserItemDataDto(batchedUserData, item.Id);
-                        item.FillUserDataDtoValues(dto.UserData, batchedUserData, dto, user, options);
+                        dto.UserData = GetUserItemDataDto(userData, item.Id);
+                        item.FillUserDataDtoValues(dto.UserData, userData, dto, user, options);
                     }
                     else
                     {

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -467,24 +467,24 @@ namespace Emby.Server.Implementations.Dto
         /// </summary>
         private void AttachUserSpecificInfo(BaseItemDto dto, BaseItem item, User user, DtoOptions options, UserItemData? userData = null)
         {
+            if (options.EnableUserData)
+            {
+                if (userData is not null)
+                {
+                    // Use pre-fetched user data
+                    dto.UserData = GetUserItemDataDto(userData, item.Id);
+                    item.FillUserDataDtoValues(dto.UserData, userData, dto, user, options);
+                }
+                else
+                {
+                    // Fall back to individual fetch
+                    dto.UserData = _userDataRepository.GetUserDataDto(item, dto, user, options);
+                }
+            }
+
             if (item.IsFolder)
             {
                 var folder = (Folder)item;
-
-                if (options.EnableUserData)
-                {
-                    if (userData is not null)
-                    {
-                        // Use pre-fetched user data
-                        dto.UserData = GetUserItemDataDto(userData, item.Id);
-                        item.FillUserDataDtoValues(dto.UserData, userData, dto, user, options);
-                    }
-                    else
-                    {
-                        // Fall back to individual fetch
-                        dto.UserData = _userDataRepository.GetUserDataDto(item, dto, user, options);
-                    }
-                }
 
                 if (!dto.ChildCount.HasValue && item.SourceType == SourceType.Library)
                 {
@@ -514,23 +514,6 @@ namespace Emby.Server.Implementations.Dto
                 if (options.ContainsField(ItemFields.DateLastMediaAdded))
                 {
                     dto.DateLastMediaAdded = folder.DateLastMediaAdded;
-                }
-            }
-            else
-            {
-                if (options.EnableUserData)
-                {
-                    if (userData is not null)
-                    {
-                        // Use pre-fetched user data
-                        dto.UserData = GetUserItemDataDto(userData, item.Id);
-                        item.FillUserDataDtoValues(dto.UserData, userData, dto, user, options);
-                    }
-                    else
-                    {
-                        // Fall back to individual fetch
-                        dto.UserData = _userDataRepository.GetUserDataDto(item, user);
-                    }
                 }
             }
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1504,6 +1504,24 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetLatestItemList(query, collectionType);
         }
 
+        public IReadOnlyList<(BaseItem Container, IReadOnlyList<BaseItem> Items)> GetLatestItemsGrouped(InternalItemsQuery query, IReadOnlyList<BaseItem> parents, CollectionType? collectionType)
+        {
+            SetTopParentIdsOrAncestors(query, parents);
+
+            if (query.AncestorIds.Length == 0 && query.TopParentIds.Length == 0)
+            {
+                if (query.User is not null)
+                {
+                    AddUserToQuery(query, query.User);
+                }
+            }
+
+            // IItemRepository has #nullable disable, so we need to assert non-null here
+            return _itemRepository.GetLatestItemsGrouped(query, collectionType)
+                .Select(g => (g.Container!, g.Items))
+                .ToArray();
+        }
+
         public IReadOnlyList<string> GetNextUpSeriesKeys(InternalItemsQuery query, IReadOnlyCollection<BaseItem> parents, DateTime dateCutoff)
         {
             SetTopParentIdsOrAncestors(query, parents);

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -584,6 +584,16 @@ namespace MediaBrowser.Controller.Library
         IReadOnlyList<BaseItem> GetLatestItemList(InternalItemsQuery query, IReadOnlyList<BaseItem> parents, CollectionType collectionType);
 
         /// <summary>
+        /// Gets the latest items grouped by their container (Album for music, Series for TV).
+        /// Movies use themselves as both container and item.
+        /// </summary>
+        /// <param name="query">The query to use.</param>
+        /// <param name="parents">Items to use for query.</param>
+        /// <param name="collectionType">Collection Type.</param>
+        /// <returns>List of container-items tuples.</returns>
+        IReadOnlyList<(BaseItem Container, IReadOnlyList<BaseItem> Items)> GetLatestItemsGrouped(InternalItemsQuery query, IReadOnlyList<BaseItem> parents, CollectionType? collectionType);
+
+        /// <summary>
         /// Gets the list of series presentation keys for next up.
         /// </summary>
         /// <param name="query">The query to use.</param>

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -65,6 +65,28 @@ namespace MediaBrowser.Controller.Library
         UserItemDataDto? GetUserDataDto(BaseItem item, BaseItemDto? itemDto, User user, DtoOptions options);
 
         /// <summary>
+        /// Gets user data for multiple items in a batch.
+        /// </summary>
+        /// <param name="items">Items to get user data for.</param>
+        /// <param name="user">User to use.</param>
+        /// <returns>Dictionary mapping item ID to user data.</returns>
+        Dictionary<Guid, UserItemData> GetUserDataBatch(IReadOnlyList<BaseItem> items, User user)
+        {
+            // Default implementation falls back to individual queries for ABI compatibility
+            var result = new Dictionary<Guid, UserItemData>(items.Count);
+            foreach (var item in items)
+            {
+                var userData = GetUserData(user, item);
+                if (userData is not null)
+                {
+                    result[item.Id] = userData;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Updates playstate for an item and returns true or false indicating if it was played to completion.
         /// </summary>
         /// <param name="item">Item to update.</param>

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -72,6 +72,15 @@ public interface IItemRepository
     IReadOnlyList<BaseItem> GetLatestItemList(InternalItemsQuery filter, CollectionType collectionType);
 
     /// <summary>
+    /// Gets the latest items grouped by their container (Album for music, Series for TV).
+    /// Movies use themselves as both container and item.
+    /// </summary>
+    /// <param name="filter">The query parameters.</param>
+    /// <param name="collectionType">Collection Type.</param>
+    /// <returns>List of container-items tuples.</returns>
+    IReadOnlyList<(BaseItem Container, IReadOnlyList<BaseItem> Items)> GetLatestItemsGrouped(InternalItemsQuery filter, CollectionType? collectionType);
+
+    /// <summary>
     /// Gets the list of series presentation keys for next up.
     /// </summary>
     /// <param name="filter">The query.</param>


### PR DESCRIPTION
This PR address the N+1 queries on the /Latest endpoint that loads libraries into the home screen.

Prior to this change a sizable library (thousands of movies, hundreds of thousands of audio tracks) would not load faster than 30s on even very fast hardware.
After this change the endpoint returns even very large collections within 10 seconds.

This may address https://github.com/jellyfin/jellyfin/issues/15742 