### PR TITLE
Refactor: Rename PostCapabilities methods in SessionController

### DIFF
--- a/Jellyfin.Api/Controllers/SessionController.cs
+++ b/Jellyfin.Api/Controllers/SessionController.cs
@@ -345,7 +345,7 @@ public class SessionController : BaseJellyfinApiController
     [HttpPost("Sessions/Capabilities")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> PostCapabilities(
+    public async Task<ActionResult> UpdateCapabilities(
         [FromQuery] string? id,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] MediaType[] playableMediaTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] GeneralCommandType[] supportedCommands,
@@ -377,7 +377,7 @@ public class SessionController : BaseJellyfinApiController
     [HttpPost("Sessions/Capabilities/Full")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> PostFullCapabilities(
+    public async Task<ActionResult> UpdateFullCapabilities(
         [FromQuery] string? id,
         [FromBody, Required] ClientCapabilitiesDto capabilities)
     {


### PR DESCRIPTION
Fixes #15815

### 🏗️ Pull Request

**What was broken?**
The `SessionController` contained methods named using the generic HTTP verb `Post` (`PostCapabilities`, `PostFullCapabilities`). This results in unclear internal code references and less descriptive OpenAPI OperationIds for client SDKs.

**What was fixed?**
* Renamed `PostCapabilities` -> `UpdateCapabilities`
* Renamed `PostFullCapabilities` -> `UpdateFullCapabilities`

**Why this approach?**
Aligns with the repository goal of removing generic controller method names to improve code readability and SDK generation. This refactor preserves all existing `[Route]` attributes, ensuring **no breaking changes** for API clients.

**Checklist**
- [x] Code follows repo standards
- [x] No breaking API changes
- [x] Tested locally (Build compiles)