### PR TITLE
add CultureDto cache

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -38,10 +38,10 @@ namespace Emby.Server.Implementations.Localization
 
         private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
+        private readonly ConcurrentDictionary<string, CultureDto?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
         private List<CultureDto> _cultures = [];
 
         private FrozenDictionary<string, string> _iso6392BtoT = null!;
-        private ConcurrentDictionary<string, CultureDto?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalizationManager" /> class.
@@ -162,6 +162,7 @@ namespace Emby.Server.Implementations.Localization
                     list.Add(new CultureDto(name, displayname, twoCharName, threeLetterNames));
                 }
 
+                _cultureCache.Clear();
                 _cultures = list;
                 _iso6392BtoT = iso6392BtoTdict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Some Ratings use the country code (e.g., DK-15) as prefix. In this scenario, the entire set of languages is searched, which becomes a costly operation due to its frequency.

This is technically not a regression fix, but given the amount of performance issues in 10.11, I think it's worth including this.

**Issues**
None reported
