### PR TITLE
Fix video lacking SAR and DAR are marked as anamorphic

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -853,7 +853,12 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
 
                 // http://stackoverflow.com/questions/17353387/how-to-detect-anamorphic-video-with-ffprobe
-                if (string.Equals(streamInfo.SampleAspectRatio, "1:1", StringComparison.Ordinal))
+                if (string.IsNullOrEmpty(streamInfo.SampleAspectRatio)
+                    && string.IsNullOrEmpty(streamInfo.DisplayAspectRatio))
+                {
+                    stream.IsAnamorphic = false;
+                }
+                else if (string.Equals(streamInfo.SampleAspectRatio, "1:1", StringComparison.Ordinal))
                 {
                     stream.IsAnamorphic = false;
                 }


### PR DESCRIPTION
Some videos do not have SAR and DAR information written into them.

**Changes**
- Fix video lacking SAR and DAR are marked as anamorphic