### PR TITLE
Enable listening on IPv6 by default

### DIFF
--- a/Jellyfin.Server/Migrations/PreStartupRoutines/CreateNetworkConfiguration.cs
+++ b/Jellyfin.Server/Migrations/PreStartupRoutines/CreateNetworkConfiguration.cs
@@ -102,7 +102,7 @@ public class CreateNetworkConfiguration : IMigrationRoutine
 
         public int PublicPort { get; set; } = DefaultHttpPort;
 
-        public bool EnableIPV6 { get; set; }
+        public bool EnableIPV6 { get; set; } = true;
 
         public bool EnableIPV4 { get; set; } = true;
 

--- a/Jellyfin.Server/Migrations/PreStartupRoutines/MigrateNetworkConfiguration.cs
+++ b/Jellyfin.Server/Migrations/PreStartupRoutines/MigrateNetworkConfiguration.cs
@@ -157,7 +157,7 @@ public class MigrateNetworkConfiguration : IMigrationRoutine
 
         public string UDPPortRange { get; set; } = string.Empty;
 
-        public bool EnableIPV6 { get; set; }
+        public bool EnableIPV6 { get; set; } = true;
 
         public bool EnableIPV4 { get; set; } = true;
 

--- a/MediaBrowser.Common/Net/NetworkConfiguration.cs
+++ b/MediaBrowser.Common/Net/NetworkConfiguration.cs
@@ -121,7 +121,7 @@ public class NetworkConfiguration
     /// <summary>
     /// Gets or sets a value indicating whether IPv6 is enabled.
     /// </summary>
-    public bool EnableIPv6 { get; set; }
+    public bool EnableIPv6 { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether access from outside of the LAN is permitted.


### PR DESCRIPTION
**Changes**
This change enables listening on IPv6 addresses by default. Right now the server is only listening on IPv4 and can't be easily configured to change that which makes it hard to use in an IPv6-only environment.

**Issues**
Fixes #13930
