### PR TITLE
Fix playlist item de-duplication

### DIFF
--- a/MediaBrowser.Providers/Playlists/PlaylistMetadataService.cs
+++ b/MediaBrowser.Providers/Playlists/PlaylistMetadataService.cs
@@ -72,7 +72,7 @@ public class PlaylistMetadataService : MetadataService<Playlist, ItemLookupInfo>
             }
             else
             {
-                targetItem.LinkedChildren = sourceItem.LinkedChildren.Concat(targetItem.LinkedChildren).Distinct().ToArray();
+                targetItem.LinkedChildren = sourceItem.LinkedChildren.Concat(targetItem.LinkedChildren).DistinctBy(i => i.Path).ToArray();
             }
 
             if (replaceData || targetItem.Shares.Count == 0)


### PR DESCRIPTION
**Changes**
The PlaylistMetadataService.MergeData function was failing to de-duplicate the lists of child items. This was because the Distinct filter function checks for full equality while the items that were obtained from the playlist xml file didn't have the ItemId value populated. I changed the Distinct to Distinctby(i => i.Path) because this was the only unique field that was guaranteed to be populated. 

**Issues**
Fixes #15822
