### PR TITLE
Fix disabled plugins incorrectly marked for deletion

### DIFF
--- a/Emby.Server.Implementations/Plugins/PluginManager.cs
+++ b/Emby.Server.Implementations/Plugins/PluginManager.cs
@@ -776,6 +776,14 @@ namespace Emby.Server.Implementations.Plugins
                         lastName = entry.Name;
                         continue;
                     }
+
+                    // Skip cleanup for intentionally disabled plugins - they should remain as-is
+                    // and not be treated as superseded versions or marked for deletion.
+                    // See: https://github.com/jellyfin/jellyfin/issues/15897
+                    if (entry.Manifest.Status == PluginStatus.Disabled)
+                    {
+                        continue;
+                    }
                 }
 
                 if (string.IsNullOrEmpty(lastName))


### PR DESCRIPTION
## Description

This PR fixes **Issue #15897**: DLNA plugin conflict issue.

### Problem

When a plugin is disabled (e.g., DLNA), it gets stuck in a "Deleted" state upon server restart. The logs show an `UnauthorizedAccessException` when `PluginManager` tries to delete the plugin folder.

### Root Cause

In `DiscoverPlugins()`, disabled plugins (`PluginStatus.Disabled`) fail the `IsEnabledAndSupported` check and incorrectly fall through to the cleanup logic intended for **superseded** plugin versions. This causes:

1. An attempt to delete the plugin folder (which fails on Windows if the DLL is locked)
2. The plugin status being changed to `PluginStatus.Deleted`

### Fix

Added an explicit check to skip cleanup logic for intentionally disabled plugins. A `Disabled` plugin is an explicit user choice and should not be treated as a superseded version or marked for deletion.

```csharp
// Skip cleanup for intentionally disabled plugins - they should remain as-is
// and not be treated as superseded versions or marked for deletion.
// See: https://github.com/jellyfin/jellyfin/issues/15897
if (entry.Manifest.Status == PluginStatus.Disabled)
{
    continue;
}
```

### Testing

- [ ] Disable DLNA plugin → Restart → Verify status shows "Disabled" (not "Deleted")
- [ ] Re-enable plugin → Restart → Verify status shows "Active"

Fixes #15897
