### PR TITLE
Fix sort order for mixed content types in TV shows

### DIFF
--- a/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
+++ b/Emby.Server.Implementations/Sorting/IndexNumberComparer.cs
@@ -36,12 +36,12 @@ namespace Emby.Server.Implementations.Sorting
 
             if (!x.IndexNumber.HasValue)
             {
-                return -1;
+                return 1;
             }
 
             if (!y.IndexNumber.HasValue)
             {
-                return 1;
+                return -1;
             }
 
             return x.IndexNumber.Value.CompareTo(y.IndexNumber.Value);

--- a/tests/Jellyfin.Server.Implementations.Tests/Sorting/IndexNumberComparerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Sorting/IndexNumberComparerTests.cs
@@ -27,8 +27,8 @@ public class IndexNumberComparerTests
 
     [Theory]
     [InlineData(null, null, 0)]
-    [InlineData(0, null, 1)]
-    [InlineData(null, 0, -1)]
+    [InlineData(0, null, -1)]
+    [InlineData(null, 0, 1)]
     [InlineData(1, 1, 0)]
     [InlineData(0, 1, -1)]
     [InlineData(1, 0, 1)]


### PR DESCRIPTION
## Description

This PR fixes a regression in 10.11.x where Movies/Specials placed inside TV Series folders appeared at the **beginning** of the list regardless of their Index Number.

**Before this fix:** Movie (appears first) → Season 1 → Season 2 → Season 3
**After this fix:** Season 1 → Season 2 → Movie (with IndexNumber 3) → Season 3 → Season 4

## Changes

- Modified `IndexNumberComparer.cs` to sort items **without** `IndexNumber` to the **end** instead of the beginning
- Updated corresponding unit tests

## Root Cause

Commit e16ea7b236 changed the default sort from `SortName` to `IndexNumber`. The `IndexNumberComparer` previously placed items without an `IndexNumber` at the beginning (returning -1), which worked fine with `SortName` but caused issues when `IndexNumber` became the primary sort.

## Fixes

Fixes #15895
