### PR TITLE
Fix #15891: Allow music albums starting with a dot to be scanned on Linux

### DIFF
--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -81,12 +81,20 @@ namespace Emby.Server.Implementations.Library
             "**/.grab/**",
             "**/.grab",
 
-            // Unix hidden files
-            "**/.*",
-
-            // Mac - if you ever remove the above.
-            // "**/._*",
-            // "**/.DS_Store",
+            // Unix/Mac system and junk files (specific blocklist instead of blanket **/.*)
+            // See: https://github.com/jellyfin/jellyfin/issues/15891
+            "**/.DS_Store",
+            "**/._*",
+            "**/.Spotlight-V100",
+            "**/.Spotlight-V100/**",
+            "**/.Trashes",
+            "**/.Trashes/**",
+            "**/.fseventsd",
+            "**/.fseventsd/**",
+            "**/.AppleDouble",
+            "**/.AppleDouble/**",
+            "**/.TemporaryItems",
+            "**/.TemporaryItems/**",
 
             // thumbs.db
             "**/thumbs.db",

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
@@ -20,8 +20,8 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("thumbs.db", true)]
         [InlineData(@"C:\media\movies\movie.avi", false)]
         [InlineData("/media/.hiddendir/file.mp4", false)]
-        [InlineData("/media/dir/.hiddenfile.mp4", true)]
-        [InlineData("/media/dir/._macjunk.mp4", true)]
+        [InlineData("/media/dir/.hiddenfile.mp4", false)] // Generic dot-files now allowed (Issue #15891)
+        [InlineData("/media/dir/._macjunk.mp4", true)] // Mac resource forks still ignored
         [InlineData("/volume1/video/Series/@eaDir", true)]
         [InlineData("/volume1/video/Series/@eaDir/file.txt", true)]
         [InlineData("/directory/@Recycle", true)]
@@ -32,6 +32,20 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("/media/music/Foo B.A.R", false)]
         [InlineData("/media/music/Foo B.A.R.", false)]
         [InlineData("/movies/.zfs/snapshot/AutoM-2023-09", true)]
+        // New test cases for Issue #15891 - dot-prefixed user content allowed
+        [InlineData("/media/music/.AlbumName/song.mp3", false)]
+        [InlineData("/media/.MyHiddenAlbum", false)]
+        [InlineData("/media/.AlbumWithDot", false)]
+        // macOS system files still ignored
+        [InlineData("/media/.DS_Store", true)]
+        [InlineData("/media/album/.DS_Store", true)]
+        [InlineData("/media/.Spotlight-V100", true)]
+        [InlineData("/media/.Spotlight-V100/store.db", true)]
+        [InlineData("/media/.Trashes", true)]
+        [InlineData("/media/.Trashes/file.txt", true)]
+        [InlineData("/media/.fseventsd", true)]
+        [InlineData("/media/.AppleDouble", true)]
+        [InlineData("/media/.TemporaryItems", true)]
         public void PathIgnored(string path, bool expected)
         {
             Assert.Equal(expected, IgnorePatterns.ShouldIgnore(path));


### PR DESCRIPTION
**Changes**\nReplaced the blanket ignore pattern **/.* with a specific blocklist of known system and junk files (macOS/Unix), ensuring user media content in dot-prefixed folders (e.g. .AlbumName) IS correctly scanned.\n\n**Issues**\nFixes #15891