### PR TITLE
Add async overloads to IPeopleRepository

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -209,6 +209,7 @@
  - [Kirill Nikiforov](https://github.com/allmazz)
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
+ - [Joshua Kearney](https://github.com/joshwkearney)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2974,7 +2974,8 @@ namespace Emby.Server.Implementations.Library
             if (people is not null)
             {
                 people = people.Where(e => e is not null).ToArray();
-                _peopleRepository.UpdatePeople(item.Id, people);
+
+                await _peopleRepository.UpdatePeopleAsync(item.Id, people, cancellationToken).ConfigureAwait(false);
                 await SavePeopleMetadataAsync(people, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
-using Jellyfin.Database.Implementations.Entities.Libraries;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Persistence;
@@ -30,7 +31,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider = dbProvider;
 
     /// <inheritdoc/>
-    public IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter)
+    public async Task<IReadOnlyList<PersonInfo>> GetPeopleAsync(InternalPeopleQuery filter, CancellationToken token = default)
     {
         using var context = _dbProvider.CreateDbContext();
         var dbQuery = TranslateQuery(context.Peoples.AsNoTracking(), context, filter);
@@ -53,11 +54,12 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
             dbQuery = dbQuery.Take(filter.Limit);
         }
 
-        return dbQuery.AsEnumerable().Select(Map).ToArray();
+        var results = await dbQuery.ToListAsync(token).ConfigureAwait(false);
+        return results.Select(Map).ToList();
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter)
+    public async Task<IReadOnlyList<string>> GetPeopleNamesAsync(InternalPeopleQuery filter, CancellationToken token = default)
     {
         using var context = _dbProvider.CreateDbContext();
         var dbQuery = TranslateQuery(context.Peoples.AsNoTracking(), context, filter).Select(e => e.Name).Distinct();
@@ -68,11 +70,11 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
             dbQuery = dbQuery.Take(filter.Limit);
         }
 
-        return dbQuery.ToArray();
+        return await dbQuery.ToListAsync(token).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people)
+    public async Task UpdatePeopleAsync(Guid itemId, IReadOnlyList<PersonInfo> people, CancellationToken token = default)
     {
         foreach (var item in people.Where(e => e.Role is null))
         {
@@ -84,28 +86,34 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         var personKeys = people.Select(e => e.Name + "-" + e.Type).ToArray();
 
         using var context = _dbProvider.CreateDbContext();
-        using var transaction = context.Database.BeginTransaction();
-        var existingPersons = context.Peoples.Select(e => new
+        using var transaction = await context.Database.BeginTransactionAsync(token).ConfigureAwait(false);
+
+        var existingPersons = await context.Peoples.Select(e => new
             {
                 item = e,
                 SelectionKey = e.Name + "-" + e.PersonType
             })
             .Where(p => personKeys.Contains(p.SelectionKey))
             .Select(f => f.item)
-            .ToArray();
+            .ToListAsync(token)
+            .ConfigureAwait(false);
 
         var toAdd = people
             .Where(e => e.Type is not PersonKind.Artist && e.Type is not PersonKind.AlbumArtist)
             .Where(e => !existingPersons.Any(f => f.Name == e.Name && f.PersonType == e.Type.ToString()))
             .Select(Map);
+
         context.Peoples.AddRange(toAdd);
-        context.SaveChanges();
+        await context.SaveChangesAsync(token).ConfigureAwait(false);
 
         var personsEntities = toAdd.Concat(existingPersons).ToArray();
-
-        var existingMaps = context.PeopleBaseItemMap.Include(e => e.People).Where(e => e.ItemId == itemId).ToList();
-
         var listOrder = 0;
+
+        var existingMaps = await context.PeopleBaseItemMap
+            .Include(e => e.People)
+            .Where(e => e.ItemId == itemId)
+            .ToListAsync(token)
+            .ConfigureAwait(false);
 
         foreach (var person in people)
         {
@@ -143,8 +151,8 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         context.PeopleBaseItemMap.RemoveRange(existingMaps);
 
-        context.SaveChanges();
-        transaction.Commit();
+        await context.SaveChangesAsync(token).ConfigureAwait(false);
+        await transaction.CommitAsync(token).ConfigureAwait(false);
     }
 
     private PersonInfo Map(People people)

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -31,6 +31,12 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider = dbProvider;
 
     /// <inheritdoc/>
+    public IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter)
+    {
+        return GetPeopleAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<PersonInfo>> GetPeopleAsync(InternalPeopleQuery filter, CancellationToken token = default)
     {
         using var context = _dbProvider.CreateDbContext();
@@ -59,6 +65,12 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
     }
 
     /// <inheritdoc/>
+    public IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter)
+    {
+        return GetPeopleNamesAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<string>> GetPeopleNamesAsync(InternalPeopleQuery filter, CancellationToken token = default)
     {
         using var context = _dbProvider.CreateDbContext();
@@ -71,6 +83,12 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         }
 
         return await dbQuery.ToListAsync(token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people)
+    {
+        UpdatePeopleAsync(itemId, people, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc />

--- a/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
@@ -17,7 +17,7 @@ public interface IPeopleRepository
     /// </summary>
     /// <param name="filter">The query.</param>
     /// <returns>The list of people matching the filter.</returns>
-    IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter) => this.GetPeopleAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+    IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter);
 
     /// <summary>
     /// Gets the people.
@@ -32,7 +32,7 @@ public interface IPeopleRepository
     /// </summary>
     /// <param name="itemId">The item identifier.</param>
     /// <param name="people">The people.</param>
-    void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people) => this.UpdatePeopleAsync(itemId, people, CancellationToken.None).GetAwaiter().GetResult();
+    void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people);
 
     /// <summary>
     /// Updates the people.
@@ -48,7 +48,7 @@ public interface IPeopleRepository
     /// </summary>
     /// <param name="filter">The query.</param>
     /// <returns>The list of people names matching the filter.</returns>
-    IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter) => this.GetPeopleNamesAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+    IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter);
 
     /// <summary>
     /// Gets the people names.

--- a/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 
 namespace MediaBrowser.Controller.Persistence;
@@ -15,19 +17,44 @@ public interface IPeopleRepository
     /// </summary>
     /// <param name="filter">The query.</param>
     /// <returns>The list of people matching the filter.</returns>
-    IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter);
+    IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter) => this.GetPeopleAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Gets the people.
+    /// </summary>
+    /// <param name="filter">The query.</param>
+    /// <param name="token">The <see cref="CancellationToken"/>.</param>
+    /// <returns>The list of people matching the filter.</returns>
+    Task<IReadOnlyList<PersonInfo>> GetPeopleAsync(InternalPeopleQuery filter, CancellationToken token = default);
 
     /// <summary>
     /// Updates the people.
     /// </summary>
     /// <param name="itemId">The item identifier.</param>
     /// <param name="people">The people.</param>
-    void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people);
+    void UpdatePeople(Guid itemId, IReadOnlyList<PersonInfo> people) => this.UpdatePeopleAsync(itemId, people, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Updates the people.
+    /// </summary>
+    /// <param name="itemId">The item identifier.</param>
+    /// <param name="people">The people.</param>
+    /// <param name="token">The <see cref="CancellationToken"/>.</param>
+    /// <returns>The async Task.</returns>
+    Task UpdatePeopleAsync(Guid itemId, IReadOnlyList<PersonInfo> people, CancellationToken token = default);
 
     /// <summary>
     /// Gets the people names.
     /// </summary>
     /// <param name="filter">The query.</param>
     /// <returns>The list of people names matching the filter.</returns>
-    IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter);
+    IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter) => this.GetPeopleNamesAsync(filter, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Gets the people names.
+    /// </summary>
+    /// <param name="filter">The query.</param>
+    /// <param name="token">The <see cref="CancellationToken"/>.</param>
+    /// <returns>The list of people names matching the filter.</returns>
+    Task<IReadOnlyList<string>> GetPeopleNamesAsync(InternalPeopleQuery filter, CancellationToken token = default);
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

## Changes
<!-- Describe your changes here in 1-5 sentences. -->
- Add async overloads of `GetPeopleAsync`, `UpdatePeopleAsync`, and `GetPeopleNamesAsync` to `IPeopleRepository`. 
- Modify the existing implementation of `PeopleRepository` to use async EF Core calls.
- Modify the sync overloads to call the new async implementations with `.GetAwaiter().GetResult()`.

## Motivation

Long term I would like to see Jellyfin support and run well on Postgres, and a big part of that is not blocking on network database calls. Moving the blocking EF Core calls to their async versions is the first step in that direction.

## Notes

- I agree that in general, `.GetAwaiter().GetResult()` should not be used because it blocks the calling thread and can lead to deadlocks. However, in this case the existing sync implementation already blocks the calling thread, so this matches existing behavior. The use of `.ConfigureAwait(false)` will also help to mitigate deadlocks.
- Should I create an issue for this? I wasn't sure what the policy here was for architecture / tech debt improvements that didn't immediately relate to a user issue

<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

## AI Disclosure

No AI was used to make this PR.

## PS

This is my first PR here so feel free to close this / roast me / etc
