### PR TITLE
Fix Season Unknown bug by filtering unresolved episodes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -209,6 +209,7 @@
  - [Kirill Nikiforov](https://github.com/allmazz)
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
+ - [ZeusCraft10](https://github.com/ZeusCraft10)
 
 # Emby Contributors
 

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -214,6 +214,7 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
         var seasons = seriesChildren.OfType<Season>().ToList();
         var uniqueSeasonNumbers = seriesChildren
             .OfType<Episode>()
+            .Where(e => e.ParentIndexNumber.HasValue)
             .Select(e => e.ParentIndexNumber >= 0 ? e.ParentIndexNumber : null)
             .Distinct();
 


### PR DESCRIPTION
## Description

Fixes #15909

Fixes the bug where newly added TV episodes are incorrectly assigned to 'Season Unknown' even when they belong to an existing season.

### Root Cause
In SeriesMetadataService.CreateSeasonsAsync, episodes with unresolved ParentIndexNumber (null) were being grouped and triggering 'Season Unknown' creation during library scans.

### Changes
Added a .Where(e => e.ParentIndexNumber.HasValue) filter to skip episodes without a resolved season number, preventing unnecessary 'Season Unknown' entries.

### Logs (Before Fix)
`
[INF] Creating Season 'Season Unknown' entry for 'Robin Hood (2025)'
[INF] Removing virtual season null in series 'Robin Hood (2025)'
[INF] Removing item, Type: 'Season', Name: 'Season Unknown'
`

### Testing
- Build: 0 errors, 0 warnings  
- Provider Tests: 235/235 passed