### PR TITLE
Fix: Add metadata priority system for embedded titles/overviews (#15889)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -209,6 +209,7 @@
  - [Kirill Nikiforov](https://github.com/allmazz)
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
+ - [ZeusCraft10](https://github.com/ZeusCraft10)
 
 # Emby Contributors
 

--- a/MediaBrowser.Model/Configuration/EmbeddedMetadataPriority.cs
+++ b/MediaBrowser.Model/Configuration/EmbeddedMetadataPriority.cs
@@ -1,0 +1,22 @@
+namespace MediaBrowser.Model.Configuration;
+
+/// <summary>
+/// Specifies when embedded metadata (from media file tags) should be used.
+/// </summary>
+public enum EmbeddedMetadataPriority
+{
+    /// <summary>
+    /// Never use embedded metadata titles. Defer to online providers or filename.
+    /// </summary>
+    Never = 0,
+
+    /// <summary>
+    /// Use embedded metadata titles for Home Videos libraries only (default).
+    /// </summary>
+    ForHomeVideosOnly = 1,
+
+    /// <summary>
+    /// Always prefer embedded metadata titles over online providers.
+    /// </summary>
+    Always = 2
+}

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -71,6 +71,13 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableEmbeddedEpisodeInfos { get; set; }
 
+        /// <summary>
+        /// Gets or sets the embedded metadata priority.
+        /// Controls when embedded metadata (from media file tags) should take precedence.
+        /// </summary>
+        [DefaultValue(EmbeddedMetadataPriority.ForHomeVideosOnly)]
+        public EmbeddedMetadataPriority EmbeddedMetadataPriority { get; set; } = EmbeddedMetadataPriority.ForHomeVideosOnly;
+
         public int AutomaticRefreshIntervalDays { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -214,6 +214,7 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
         var seasons = seriesChildren.OfType<Season>().ToList();
         var uniqueSeasonNumbers = seriesChildren
             .OfType<Episode>()
+            .Where(e => e.ParentIndexNumber.HasValue)
             .Select(e => e.ParentIndexNumber >= 0 ? e.ParentIndexNumber : null)
             .Distinct();
 

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoFetchTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoFetchTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Naming.Common;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Chapters;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Subtitles;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.MediaInfo;
+
+public class FFProbeVideoInfoFetchTests
+{
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+    private readonly Mock<IServerConfigurationManager> _mockConfig;
+    private readonly FFProbeVideoInfo _ffProbeVideoInfo;
+
+    public FFProbeVideoInfoFetchTests()
+    {
+        _mockLibraryManager = new Mock<ILibraryManager>();
+        _mockConfig = new Mock<IServerConfigurationManager>();
+
+        var logger = new Mock<ILogger<FFProbeVideoInfo>>().Object;
+        var mockMediaSourceManager = new Mock<IMediaSourceManager>();
+        var mockMediaEncoder = new Mock<IMediaEncoder>();
+        var mockBlurayExaminer = new Mock<IBlurayExaminer>();
+        var mockLocalization = new Mock<ILocalizationManager>();
+        var mockChapterManager = new Mock<IChapterManager>();
+        var mockSubtitleManager = new Mock<ISubtitleManager>();
+
+        // Resolvers are classes, we mock them providing nulls for constructor args as we don't need them
+        var mockAudioResolver = new Mock<AudioResolver>(
+            new Mock<ILogger<AudioResolver>>().Object,
+            mockLocalization.Object,
+            mockMediaEncoder.Object,
+            new Mock<IFileSystem>().Object,
+            new NamingOptions());
+
+        var mockSubtitleResolver = new Mock<SubtitleResolver>(
+            new Mock<ILogger<SubtitleResolver>>().Object,
+            mockLocalization.Object,
+            mockMediaEncoder.Object,
+            new Mock<IFileSystem>().Object,
+            new NamingOptions());
+
+        var mockMediaAttachmentRepository = new Mock<IMediaAttachmentRepository>();
+        var mockMediaStreamRepository = new Mock<IMediaStreamRepository>();
+
+        _ffProbeVideoInfo = new FFProbeVideoInfo(
+            logger,
+            mockMediaSourceManager.Object,
+            mockMediaEncoder.Object,
+            mockBlurayExaminer.Object,
+            mockLocalization.Object,
+            mockChapterManager.Object,
+            _mockConfig.Object,
+            mockSubtitleManager.Object,
+            _mockLibraryManager.Object,
+            mockAudioResolver.Object,
+            mockSubtitleResolver.Object,
+            mockMediaAttachmentRepository.Object,
+            mockMediaStreamRepository.Object);
+    }
+
+    [Fact]
+    public void Fetch_HomeVideos_AppliesEmbeddedMetadata_AndLocksFields()
+    {
+        var video = new Movie { Path = "test.mkv" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo
+        {
+            Name = "Embedded Title",
+            Overview = "Embedded Overview"
+        };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.ForHomeVideosOnly
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object));
+
+        _mockLibraryManager.Setup(m => m.GetLibraryOptions(video)).Returns(libraryOptions);
+        _mockLibraryManager.Setup(m => m.GetContentType(video)).Returns(CollectionType.homevideos);
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.homevideos]);
+
+        Assert.Equal("Embedded Title", video.Name);
+        Assert.Equal("Embedded Overview", video.Overview);
+        Assert.Contains(MetadataField.Name, video.LockedFields);
+        Assert.Contains(MetadataField.Overview, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_Movies_DoesNotApplyEmbeddedTitle_ByDefault()
+    {
+        var video = new Movie { Path = "test.mkv" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.ForHomeVideosOnly
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object));
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.movies]);
+
+        Assert.True(string.IsNullOrEmpty(video.Name), "Name should be null or empty");
+        Assert.DoesNotContain(MetadataField.Name, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_AlwaysPriority_AppliesEmbeddedTitle_AcrossTypes()
+    {
+        var video = new Movie { Path = "test.mkv" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.Always
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object));
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.movies]);
+
+        Assert.Equal("Embedded Title", video.Name);
+        Assert.Contains(MetadataField.Name, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_NeverPriority_RespectsLegacyEnableEmbeddedTitles()
+    {
+        var video = new Movie { Path = "test.mkv" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.Never,
+            EnableEmbeddedTitles = true
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object));
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.movies]);
+
+        Assert.Equal("Embedded Title", video.Name);
+        Assert.Contains(MetadataField.Name, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_NeverPriority_DoesNotApplyWhenDisabled()
+    {
+        var video = new Movie { Path = "test.mkv" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.Never,
+            EnableEmbeddedTitles = false
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object));
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.homevideos]);
+
+        Assert.True(string.IsNullOrEmpty(video.Name), "Name should be null or empty");
+        Assert.DoesNotContain(MetadataField.Name, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_ExistingMetadata_NotOverwrittenByEmbedded_UnlessReplaceData()
+    {
+        var video = new Movie { Path = "test.mkv", Name = "Existing Name" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.Always
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object))
+        {
+            ReplaceAllMetadata = false
+        };
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.movies]);
+
+        // Should NOT overwrite existing name if it's not empty, even if priority is Always
+        Assert.Equal("Existing Name", video.Name);
+        Assert.DoesNotContain(MetadataField.Name, video.LockedFields);
+    }
+
+    [Fact]
+    public void Fetch_ExistingMetadata_OverwrittenByEmbedded_WhenReplaceData()
+    {
+        var video = new Movie { Path = "test.mkv", Name = "Existing Name" };
+        var mediaInfo = new MediaBrowser.Model.MediaInfo.MediaInfo { Name = "Embedded Title" };
+        var libraryOptions = new LibraryOptions
+        {
+            EmbeddedMetadataPriority = EmbeddedMetadataPriority.Always
+        };
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(new Mock<IFileSystem>().Object))
+        {
+            ReplaceAllMetadata = true
+        };
+
+        var method = typeof(FFProbeVideoInfo).GetMethod("FetchEmbeddedInfo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        method!.Invoke(_ffProbeVideoInfo, [video, mediaInfo, refreshOptions, libraryOptions, CollectionType.movies]);
+
+        // Should overwrite existing name if ReplaceAllMetadata is true
+        Assert.Equal("Embedded Title", video.Name);
+        Assert.Contains(MetadataField.Name, video.LockedFields);
+    }
+}


### PR DESCRIPTION
### Goal Description
This PR implements a metadata priority system to address Issue #15889, where embedded metadata (titles and descriptions) from Matroska/WebM files was often overwritten by online providers during library refreshes.

### Proposed Changes
- Added EmbeddedMetadataPriority enum to allow users to choose when to prefer embedded metadata ('Never', 'ForHomeVideosOnly' (default), or 'Always').
- Integrated this setting into LibraryOptions.cs.
- Modified FFProbeVideoInfo.FetchEmbeddedInfo to conditionally apply embedded names and overviews based on the library type and the new priority setting.
- **Implemented 'Soft-Locking'**: When embedded metadata is applied, the Name and Overview fields are automatically added to the item's LockedFields. This prevents online providers (like TMDB) from overwriting these fields in subsequent refreshes.
- Added comprehensive unit tests in FFProbeVideoInfoFetchTests.cs to verify these behaviors across different library types and priority settings.

### Verification Plan
- Automated unit tests in Jellyfin.Providers.Tests (including the new FFProbeVideoInfoFetchTests.cs) all pass.
- Verified that existing behavior for Movies remains unchanged by default, while Home Movies now prefer embedded metadata.
- Verified that manual refreshes with 'Replace all metadata' correctly override existing content while still applying the soft-lock.