### PR TITLE
Fix Live TV audio by updating HLS allowlist and improving filtering logic

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -209,6 +209,7 @@
  - [Kirill Nikiforov](https://github.com/allmazz)
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
+ - [ZeusCraft10](https://github.com/ZeusCraft10)
 
 # Emby Contributors
 


### PR DESCRIPTION
**Changes**
Fixed the issue where Live TV channels (Plex/Pluto) had no audio on HLS-based clients (e.g., Linux Player) by updating the HLS audio allowlist and improving filtering logic.

**Issues**
Fixes #15887