### PR TITLE
Optimize `StringHelper.FirstToUpper()`

### DIFF
--- a/MediaBrowser.Model/Extensions/StringHelper.cs
+++ b/MediaBrowser.Model/Extensions/StringHelper.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediaBrowser.Model.Extensions
 {
     /// <summary>
@@ -25,14 +27,11 @@ namespace MediaBrowser.Model.Extensions
 
             return string.Create(
                 str.Length,
-                str,
+                str.AsSpan(),
                 (chars, buf) =>
                 {
                     chars[0] = char.ToUpperInvariant(buf[0]);
-                    for (int i = 1; i < chars.Length; i++)
-                    {
-                        chars[i] = buf[i];
-                    }
+                    buf.Slice(1).CopyTo(chars.Slice(1));
                 });
         }
     }


### PR DESCRIPTION
Optimize `StringHelper.FirstToUpper()`. This is primarily used at the moment to ensure the `CultureInfo.DisplayName`, when included in the MediaStream's `DisplayTitle`, will always have a leading capital.

**Changes**
Change an iterative char-by-char copy to a block copy. On my machine there is a small 1ns performance penalty for the single-character case but already at a 5-character string this optimized version runs in 80% of the time. A 25-character string is almost 2x as fast as the original implementation. I would expect any usages of this which pass in a language's `DisplayName` to usually be at least 5 or more characters long.

```
| Method    | Length | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0   | Code Size | Allocated | Alloc Ratio |
|---------- |------- |---------:|----------:|----------:|------:|--------:|-------:|----------:|----------:|------------:|
| Original  | 1      | 2.627 ns | 0.0424 ns | 0.0375 ns |  1.00 |    0.02 | 0.0038 |     559 B |      24 B |        1.00 |
| Optimized | 1      | 3.770 ns | 0.0450 ns | 0.0421 ns |  1.44 |    0.03 | 0.0038 |     919 B |      24 B |        1.00 |
|           |        |          |           |           |       |         |        |           |           |             |
| Original  | 5      | 4.842 ns | 0.0647 ns | 0.0540 ns |  1.00 |    0.02 | 0.0051 |     594 B |      32 B |        1.00 |
| Optimized | 5      | 3.777 ns | 0.0336 ns | 0.0314 ns |  0.78 |    0.01 | 0.0051 |     919 B |      32 B |        1.00 |
|           |        |          |           |           |       |         |        |           |           |             |
| Original  | 25     | 8.610 ns | 0.0413 ns | 0.0387 ns |  1.00 |    0.01 | 0.0115 |     612 B |      72 B |        1.00 |
| Optimized | 25     | 4.727 ns | 0.0400 ns | 0.0375 ns |  0.55 |    0.00 | 0.0115 |     908 B |      72 B |        1.00 |
```

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/15915
