### PR TITLE
Added PlaybackSpeed option to SyncPlay

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -688,7 +688,7 @@ namespace Emby.Server.Implementations.SyncPlay
         /// <inheritdoc />
         public void SetPlaybackSpeed(double playbackSpeed)
         {
-            PlaybackSpeed = Math.Clamp(playbackSpeed, 0.25, 3.0);
+            PlaybackSpeed = Math.Clamp(playbackSpeed, 0.25, 5.0);
         }
     }
 }

--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -139,6 +139,12 @@ namespace Emby.Server.Implementations.SyncPlay
         public DateTime LastActivity { get; set; }
 
         /// <summary>
+        /// Gets or sets the playback speed.
+        /// </summary>
+        /// <value>The playback speed.</value>
+        public double PlaybackSpeed { get; set; } = 1.0;
+
+        /// <summary>
         /// Adds the session to the group.
         /// </summary>
         /// <param name="session">The session.</param>
@@ -422,7 +428,8 @@ namespace Emby.Server.Implementations.SyncPlay
                 LastActivity,
                 type,
                 PositionTicks,
-                DateTime.UtcNow);
+                DateTime.UtcNow,
+                PlaybackSpeed);
         }
 
         /// <inheritdoc />
@@ -662,7 +669,9 @@ namespace Emby.Server.Implementations.SyncPlay
                 // In other words, LastActivity is in the future,
                 // when playback unpause is supposed to happen.
                 // Adjust ticks only if playback actually started.
-                startPositionTicks += Math.Max(elapsedTime.Ticks, 0);
+                // Apply playback speed to elapsed time calculation.
+                var elapsedTicks = Math.Max(elapsedTime.Ticks, 0);
+                startPositionTicks += (long)(elapsedTicks * PlaybackSpeed);
             }
 
             return new PlayQueueUpdate(
@@ -674,6 +683,12 @@ namespace Emby.Server.Implementations.SyncPlay
                 isPlaying,
                 PlayQueue.ShuffleMode,
                 PlayQueue.RepeatMode);
+        }
+
+        /// <inheritdoc />
+        public void SetPlaybackSpeed(double playbackSpeed)
+        {
+            PlaybackSpeed = Math.Clamp(playbackSpeed, 0.25, 3.0);
         }
     }
 }

--- a/Jellyfin.Api/Controllers/SyncPlayController.cs
+++ b/Jellyfin.Api/Controllers/SyncPlayController.cs
@@ -422,6 +422,23 @@ public class SyncPlayController : BaseJellyfinApiController
     }
 
     /// <summary>
+    /// Request to set playback speed in SyncPlay group.
+    /// </summary>
+    /// <param name="requestData">The new playback speed.</param>
+    /// <response code="204">Playback speed update sent to all group members.</response>
+    /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
+    [HttpPost("SetPlaybackSpeed")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [Authorize(Policy = Policies.SyncPlayIsInGroup)]
+    public async Task<ActionResult> SyncPlaySetPlaybackSpeed([FromBody, Required] SetPlaybackSpeedRequestDto requestData)
+    {
+        var currentSession = await RequestHelpers.GetSession(_sessionManager, _userManager, HttpContext).ConfigureAwait(false);
+        var syncPlayRequest = new SetPlaybackSpeedGroupRequest(requestData.PlaybackSpeed);
+        _syncPlayManager.HandleRequest(currentSession, syncPlayRequest, CancellationToken.None);
+        return NoContent();
+    }
+
+    /// <summary>
     /// Update session ping.
     /// </summary>
     /// <param name="requestData">The new ping.</param>

--- a/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
+++ b/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
@@ -6,7 +6,7 @@ namespace Jellyfin.Api.Models.SyncPlayDtos;
 public class SetPlaybackSpeedRequestDto
 {
     /// <summary>
-    /// Gets or sets the playback speed.
+    /// Gets or sets the playback speed, should be between 0.25 and 5.
     /// </summary>
     /// <value>The playback speed.</value>
     public double PlaybackSpeed { get; set; } = 1.0;

--- a/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
+++ b/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Jellyfin.Api.Models.SyncPlayDtos;
 
 /// <summary>
@@ -6,8 +8,9 @@ namespace Jellyfin.Api.Models.SyncPlayDtos;
 public class SetPlaybackSpeedRequestDto
 {
     /// <summary>
-    /// Gets or sets the playback speed, should be between 0.25 and 5.
+    /// Gets or sets the playback speed.
     /// </summary>
     /// <value>The playback speed.</value>
+    [Range(0.25, 5)]
     public double PlaybackSpeed { get; set; } = 1.0;
 }

--- a/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
+++ b/Jellyfin.Api/Models/SyncPlayDtos/SetPlaybackSpeedRequestDto.cs
@@ -1,0 +1,13 @@
+namespace Jellyfin.Api.Models.SyncPlayDtos;
+
+/// <summary>
+/// Class SetPlaybackSpeedRequestDto.
+/// </summary>
+public class SetPlaybackSpeedRequestDto
+{
+    /// <summary>
+    /// Gets or sets the playback speed.
+    /// </summary>
+    /// <value>The playback speed.</value>
+    public double PlaybackSpeed { get; set; } = 1.0;
+}

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/AbstractGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/AbstractGroupState.cs
@@ -198,6 +198,15 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
         }
 
         /// <inheritdoc />
+        public virtual void HandleRequest(SetPlaybackSpeedGroupRequest request, IGroupStateContext context, GroupStateType prevState, SessionInfo session, CancellationToken cancellationToken)
+        {
+            context.SetPlaybackSpeed(request.PlaybackSpeed);
+
+            var command = context.NewSyncPlayCommand(SendCommandType.SetPlaybackSpeed);
+            context.SendCommand(session, SyncPlayBroadcastType.AllGroup, command, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public virtual void HandleRequest(PingGroupRequest request, IGroupStateContext context, GroupStateType prevState, SessionInfo session, CancellationToken cancellationToken)
         {
             // Collected pings are used to account for network latency when unpausing playback.

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/AbstractGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/AbstractGroupState.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Threading;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay.PlaybackRequests;
@@ -200,6 +201,11 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
         /// <inheritdoc />
         public virtual void HandleRequest(SetPlaybackSpeedGroupRequest request, IGroupStateContext context, GroupStateType prevState, SessionInfo session, CancellationToken cancellationToken)
         {
+            if (Math.Abs(context.PlaybackSpeed - request.PlaybackSpeed) < 0.001)
+            {
+                return;
+            }
+
             context.SetPlaybackSpeed(request.PlaybackSpeed);
 
             var command = context.NewSyncPlayCommand(SendCommandType.SetPlaybackSpeed);

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/PausedGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/PausedGroupState.cs
@@ -77,7 +77,8 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 // In other words, LastActivity is in the future,
                 // when playback unpause is supposed to happen.
                 // Seek only if playback actually started.
-                context.PositionTicks += Math.Max(elapsedTime.Ticks, 0);
+                var elapsedTicks = Math.Max(elapsedTime.Ticks, 0);
+                context.PositionTicks += (long)(elapsedTicks * context.PlaybackSpeed);
 
                 var command = context.NewSyncPlayCommand(SendCommandType.Pause);
                 context.SendCommand(session, SyncPlayBroadcastType.AllGroup, command, cancellationToken);

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
@@ -73,7 +73,8 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 // In other words, LastActivity is in the future,
                 // when playback unpause is supposed to happen.
                 // Seek only if playback actually started.
-                context.PositionTicks += Math.Max(elapsedTime.Ticks, 0);
+                var elapsedTicks = Math.Max(elapsedTime.Ticks, 0);
+                context.PositionTicks += (long)(elapsedTicks * context.PlaybackSpeed);
             }
 
             // Prepare new session.
@@ -360,7 +361,8 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 // In other words, LastActivity is in the future,
                 // when playback unpause is supposed to happen.
                 // Seek only if playback actually started.
-                context.PositionTicks += Math.Max(elapsedTime.Ticks, 0);
+                var elapsedTicks = Math.Max(elapsedTime.Ticks, 0);
+                context.PositionTicks += (long)(elapsedTicks * context.PlaybackSpeed);
 
                 // Send pause command to all non-buffering sessions.
                 var command = context.NewSyncPlayCommand(SendCommandType.Pause);

--- a/MediaBrowser.Controller/SyncPlay/IGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/IGroupState.cs
@@ -137,6 +137,16 @@ namespace MediaBrowser.Controller.SyncPlay
         void HandleRequest(SeekGroupRequest request, IGroupStateContext context, GroupStateType prevState, SessionInfo session, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Handles a set-playback-speed request from a session. Context's state should not change.
+        /// </summary>
+        /// <param name="request">The playback-speed request.</param>
+        /// <param name="context">The context of the state.</param>
+        /// <param name="prevState">The previous state.</param>
+        /// <param name="session">The session.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        void HandleRequest(SetPlaybackSpeedGroupRequest request, IGroupStateContext context, GroupStateType prevState, SessionInfo session, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Handles a buffer request from a session. Context's state can change.
         /// </summary>
         /// <param name="request">The buffer request.</param>

--- a/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
+++ b/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
@@ -52,6 +52,12 @@ namespace MediaBrowser.Controller.SyncPlay
         DateTime LastActivity { get; set; }
 
         /// <summary>
+        /// Gets the playback speed.
+        /// </summary>
+        /// <value>The playback speed.</value>
+        double PlaybackSpeed { get; }
+
+        /// <summary>
         /// Gets the play queue.
         /// </summary>
         /// <value>The play queue.</value>
@@ -217,5 +223,11 @@ namespace MediaBrowser.Controller.SyncPlay
         /// <param name="reason">The reason for the update.</param>
         /// <returns>The play queue update.</returns>
         PlayQueueUpdate GetPlayQueueUpdate(PlayQueueUpdateReason reason);
+
+        /// <summary>
+        /// Sets the playback speed.
+        /// </summary>
+        /// <param name="playbackSpeed">The new playback speed.</param>
+        void SetPlaybackSpeed(double playbackSpeed);
     }
 }

--- a/MediaBrowser.Controller/SyncPlay/PlaybackRequests/SetPlaybackSpeedGroupRequest.cs
+++ b/MediaBrowser.Controller/SyncPlay/PlaybackRequests/SetPlaybackSpeedGroupRequest.cs
@@ -1,0 +1,37 @@
+#nullable disable
+
+using System.Threading;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.SyncPlay;
+
+namespace MediaBrowser.Controller.SyncPlay.PlaybackRequests;
+
+/// <summary>
+/// Class SetPlaybackSpeedGroupRequest.
+/// </summary>
+public class SetPlaybackSpeedGroupRequest : AbstractPlaybackRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetPlaybackSpeedGroupRequest"/> class.
+    /// </summary>
+    /// <param name="playbackSpeed">The playback speed.</param>
+    public SetPlaybackSpeedGroupRequest(double playbackSpeed)
+    {
+        PlaybackSpeed = playbackSpeed;
+    }
+
+    /// <summary>
+    /// Gets the playback speed.
+    /// </summary>
+    /// <value>The playback speed.</value>
+    public double PlaybackSpeed { get; }
+
+    /// <inheritdoc />
+    public override PlaybackRequestType Action { get; } = PlaybackRequestType.SetPlaybackSpeed;
+
+    /// <inheritdoc />
+    public override void Apply(IGroupStateContext context, IGroupState state, SessionInfo session, CancellationToken cancellationToken)
+    {
+        state.HandleRequest(this, context, state.Type, session, cancellationToken);
+    }
+}

--- a/MediaBrowser.Model/SyncPlay/PlaybackRequestType.cs
+++ b/MediaBrowser.Model/SyncPlay/PlaybackRequestType.cs
@@ -88,6 +88,11 @@ namespace MediaBrowser.Model.SyncPlay
         /// <summary>
         /// A user is requesting to be ignored on group wait.
         /// </summary>
-        IgnoreWait = 16
+        IgnoreWait = 16,
+
+        /// <summary>
+        /// A user is setting the playback speed.
+        /// </summary>
+        SetPlaybackSpeed = 17
     }
 }

--- a/MediaBrowser.Model/SyncPlay/SendCommand.cs
+++ b/MediaBrowser.Model/SyncPlay/SendCommand.cs
@@ -16,7 +16,8 @@ namespace MediaBrowser.Model.SyncPlay
         /// <param name="command">The command.</param>
         /// <param name="positionTicks">The position ticks, for commands that require it.</param>
         /// <param name="emittedAt">The UTC time when this command has been emitted.</param>
-        public SendCommand(Guid groupId, Guid playlistItemId, DateTime when, SendCommandType command, long? positionTicks, DateTime emittedAt)
+        /// <param name="playbackSpeed">The playback speed, for commands that require it.</param>
+        public SendCommand(Guid groupId, Guid playlistItemId, DateTime when, SendCommandType command, long? positionTicks, DateTime emittedAt, double playbackSpeed)
         {
             GroupId = groupId;
             PlaylistItemId = playlistItemId;
@@ -24,6 +25,7 @@ namespace MediaBrowser.Model.SyncPlay
             Command = command;
             PositionTicks = positionTicks;
             EmittedAt = emittedAt;
+            PlaybackSpeed = playbackSpeed;
         }
 
         /// <summary>
@@ -61,5 +63,11 @@ namespace MediaBrowser.Model.SyncPlay
         /// </summary>
         /// <value>The UTC time when this command has been emitted.</value>
         public DateTime EmittedAt { get; }
+
+        /// <summary>
+        /// Gets the playback speed.
+        /// </summary>
+        /// <value>The playback speed.</value>
+        public double PlaybackSpeed { get; }
     }
 }

--- a/MediaBrowser.Model/SyncPlay/SendCommandType.cs
+++ b/MediaBrowser.Model/SyncPlay/SendCommandType.cs
@@ -23,6 +23,11 @@ namespace MediaBrowser.Model.SyncPlay
         /// <summary>
         /// The seek command. Instructs users to seek to a specified time.
         /// </summary>
-        Seek = 3
+        Seek = 3,
+
+        /// <summary>
+        /// The set playback speed command. Instructs users to change playback speed.
+        /// </summary>
+        SetPlaybackSpeed = 4
     }
 }


### PR DESCRIPTION
Adds the ability to set playback speed via syncplay, should be backwards compatable with clients that havent implemented this

**Changes**
Adds PlaybackSpeed field on SyncPlay websocket messages
Adds new POST Syncplay/SetPlaybackSpeed method

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7185
