### PR TITLE
Fixed issue with ABI Compatability - Difference not completing

### DIFF
--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -106,7 +106,7 @@ jobs:
           {
             echo 'body<<EOF'
             for file in Jellyfin.Data.dll MediaBrowser.Common.dll MediaBrowser.Controller.dll MediaBrowser.Model.dll Emby.Naming.dll Jellyfin.Extensions.dll Jellyfin.MediaEncoding.Keyframes.dll Jellyfin.Database.Implementations.dll; do
-              COMPAT_OUTPUT="$( { apicompat --left ./abi-base/${file} --right ./abi-head/${file}; } 2>&1 )"
+              COMPAT_OUTPUT="$( { apicompat --left ./abi-base/${file} --right ./abi-head/${file}; } 2>&1 || true )"
               if [ "APICompat ran successfully without finding any breaking changes." != "${COMPAT_OUTPUT}" ]; then
                 printf "\n${file}\n${COMPAT_OUTPUT}\n"
               fi


### PR DESCRIPTION
**Changes**
When there are differences in the api file, we return exit code 1 and terminate the execution which results in an invalid file being generated and no EOF deliminater.

This simply adds a `|| true` to prevent it exiting early


Fixes issues found in other PR's e.g.:
 * https://github.com/jellyfin/jellyfin/pull/15921