### PR TITLE
fix: Handle unknown item types gracefully in DeserializeBaseItem

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -1247,8 +1247,11 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
         }
 
         var baseItem = BaseItemRepository.DeserializeBaseItem(entity, _logger, null, false);
-        var dataKeys = baseItem.GetUserDataKeys();
-        userDataKeys.AddRange(dataKeys);
+        if (baseItem is not null)
+        {
+            var dataKeys = baseItem.GetUserDataKeys();
+            userDataKeys.AddRange(dataKeys);
+        }
 
         return (entity, userDataKeys.ToArray());
     }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public class BaseItemRepositoryTests
+{
+    [Fact]
+    public void DeserializeBaseItem_WithUnknownType_ReturnsNull()
+    {
+        // Arrange
+        var entity = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = "NonExistent.Plugin.CustomItemType"
+        };
+
+        // Act
+        var result = BaseItemRepository.DeserializeBaseItem(entity, NullLogger.Instance, null, false);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DeserializeBaseItem_WithUnknownType_LogsWarning()
+    {
+        // Arrange
+        var entity = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = "NonExistent.Plugin.CustomItemType"
+        };
+        var loggerMock = new Mock<ILogger>();
+
+        // Act
+        BaseItemRepository.DeserializeBaseItem(entity, loggerMock.Object, null, false);
+
+        // Assert
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("unknown type", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void DeserializeBaseItem_WithKnownType_ReturnsItem()
+    {
+        // Arrange
+        var entity = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = "MediaBrowser.Controller.Entities.Movies.Movie"
+        };
+
+        // Act
+        var result = BaseItemRepository.DeserializeBaseItem(entity, NullLogger.Instance, null, false);
+
+        // Assert
+        Assert.NotNull(result);
+    }
+}


### PR DESCRIPTION
## The Problem

I reproduced issue #15945 where querying \/Items\ with \
ecursive=true\ and \isLocked=false\ throws a 500 error. After digging into it, I found that the root cause is in \DeserializeBaseItem\ - when an item has a type that can't be resolved (like from a plugin that was removed), it throws an \InvalidOperationException\ instead of handling it gracefully.

## What I Changed

The fix is pretty straightforward - instead of throwing when we encounter an unknown type, we now:

1. Log a warning with the item ID and type name (so admins know what's happening)
2. Return \
ull\ instead of crashing
3. Filter out the null results in all the calling code

This follows the same pattern that's already used for JSON deserialization errors a few lines down - log and continue rather than blow up the whole request.

## Changes

- **\BaseItemRepository.cs\**: Updated \DeserializeBaseItem\ to return nullable and handle unknown types with a warning log. Updated all 8 call sites to filter out nulls.
- **\MigrateLibraryDb.cs\**: Added null check since this migration also uses \DeserializeBaseItem\
- **Added tests**: Created \BaseItemRepositoryTests.cs\ with tests to verify the new behavior

## Testing

- All new tests pass
- Verified the existing test suite still passes
- The fix ensures that items with unknown types are simply skipped instead of causing a server error

Fixes #15945