### PR TITLE
Add TrueHD and DTS codes string for HLS

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -754,7 +754,9 @@ public class DynamicHlsHelper
     {
         if (string.Equals(state.ActualOutputAudioCodec, "aac", StringComparison.OrdinalIgnoreCase))
         {
-            string? profile = state.GetRequestedProfiles("aac").FirstOrDefault();
+            string? profile = EncodingHelper.IsCopyCodec(state.OutputAudioCodec)
+                ? state.AudioStream?.Profile : state.GetRequestedProfiles("aac").FirstOrDefault();
+
             return HlsCodecStringHelpers.GetAACString(profile);
         }
 
@@ -786,6 +788,19 @@ public class DynamicHlsHelper
         if (string.Equals(state.ActualOutputAudioCodec, "opus", StringComparison.OrdinalIgnoreCase))
         {
             return HlsCodecStringHelpers.GetOPUSString();
+        }
+
+        if (string.Equals(state.ActualOutputAudioCodec, "truehd", StringComparison.OrdinalIgnoreCase))
+        {
+            return HlsCodecStringHelpers.GetTRUEHDString();
+        }
+
+        if (string.Equals(state.ActualOutputAudioCodec, "dts", StringComparison.OrdinalIgnoreCase))
+        {
+            // lavc only support encoding DTS core profile
+            string? profile = EncodingHelper.IsCopyCodec(state.OutputAudioCodec) ? state.AudioStream?.Profile : "DTS";
+
+            return HlsCodecStringHelpers.GetDTSString(profile);
         }
 
         return string.Empty;

--- a/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
@@ -42,6 +42,11 @@ public static class HlsCodecStringHelpers
     public const string OPUS = "Opus";
 
     /// <summary>
+    /// Codec name for TRUEHD.
+    /// </summary>
+    public const string TRUEHD = "mlpa";
+
+    /// <summary>
     /// Gets a MP3 codec string.
     /// </summary>
     /// <returns>MP3 codec string.</returns>
@@ -59,7 +64,7 @@ public static class HlsCodecStringHelpers
     {
         StringBuilder result = new StringBuilder("mp4a", 9);
 
-        if (string.Equals(profile, "HE", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(profile, "HE-AAC", StringComparison.OrdinalIgnoreCase))
         {
             result.Append(".40.5");
         }
@@ -115,6 +120,46 @@ public static class HlsCodecStringHelpers
     public static string GetOPUSString()
     {
         return OPUS;
+    }
+
+    /// <summary>
+    /// Gets an TRUEHD codec string.
+    /// </summary>
+    /// <returns>TRUEHD codec string.</returns>
+    public static string GetTRUEHDString()
+    {
+        return TRUEHD;
+    }
+
+    /// <summary>
+    /// Gets an DTS codec string.
+    /// </summary>
+    /// <param name="profile">DTS profile.</param>
+    /// <returns>DTS codec string.</returns>
+    public static string GetDTSString(string? profile)
+    {
+        if (string.Equals(profile, "DTS", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(profile, "DTS-ES", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(profile, "DTS 96/24", StringComparison.OrdinalIgnoreCase))
+        {
+            return "dtsc";
+        }
+
+        if (string.Equals(profile, "DTS-HD HRA", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(profile, "DTS-HD MA", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(profile, "DTS-HD MA + DTS:X", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(profile, "DTS-HD MA + DTS:X IMAX", StringComparison.OrdinalIgnoreCase))
+        {
+            return "dtsh";
+        }
+
+        if (string.Equals(profile, "DTS Express", StringComparison.OrdinalIgnoreCase))
+        {
+            return "dtse";
+        }
+
+        // Default to DTS core if profile is invalid
+        return "dtsc";
     }
 
     /// <summary>


### PR DESCRIPTION
Since there are no Apple devices that support these two audio codecs in their HLS player, fourccs are taken and crosschecked from gpac/mp4box, androidx/media, libavcodec and [ts_103285v010401p.pdf](https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.04.01_60/ts_103285v010401p.pdf).

**Changes**
- Add TrueHD and DTS codes string for HLS
