### PR TITLE
Add bitrate ladder support for automatic media source selection

### DIFF
--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -213,7 +213,11 @@ public class MediaInfoController : BaseJellyfinApiController
                     Request.HttpContext.GetNormalizedRemoteIP());
             }
 
-            _mediaInfoHelper.SortMediaSources(info, maxStreamingBitrate);
+            _mediaInfoHelper.SortMediaSources(
+                info,
+                maxStreamingBitrate,
+                playbackInfoDto?.MediaSourceSelectionMode ?? MediaBrowser.Model.Dlna.MediaSourceSelectionMode.PreferDirectPlay,
+                playbackInfoDto?.AvailableBandwidth);
         }
 
         if (autoOpenLiveStream.Value)

--- a/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
+++ b/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
@@ -87,4 +87,16 @@ public class PlaybackInfoDto
     /// Gets or sets a value indicating whether always burn in subtitles when transcoding.
     /// </summary>
     public bool? AlwaysBurnInSubtitleWhenTranscoding { get; set; }
+
+    /// <summary>
+    /// Gets or sets the media source selection mode.
+    /// Controls how the optimal media source is selected when multiple versions are available.
+    /// </summary>
+    public MediaSourceSelectionMode? MediaSourceSelectionMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the available network bandwidth in bits per second.
+    /// Used for network-aware media source selection.
+    /// </summary>
+    public long? AvailableBandwidth { get; set; }
 }

--- a/MediaBrowser.Model/Dlna/MediaOptions.cs
+++ b/MediaBrowser.Model/Dlna/MediaOptions.cs
@@ -113,6 +113,18 @@ namespace MediaBrowser.Model.Dlna
         public int? SubtitleStreamIndex { get; set; }
 
         /// <summary>
+        /// Gets or sets the media source selection mode.
+        /// Controls how the optimal media source is selected when multiple versions are available.
+        /// </summary>
+        public MediaSourceSelectionMode SelectionMode { get; set; } = MediaSourceSelectionMode.PreferDirectPlay;
+
+        /// <summary>
+        /// Gets or sets the available network bandwidth in bits per second.
+        /// Used for network-aware media source selection.
+        /// </summary>
+        public long? AvailableBandwidth { get; set; }
+
+        /// <summary>
         /// Gets the maximum bitrate.
         /// </summary>
         /// <param name="isAudio">Whether or not this is audio.</param>

--- a/MediaBrowser.Model/Dlna/MediaSourceSelectionMode.cs
+++ b/MediaBrowser.Model/Dlna/MediaSourceSelectionMode.cs
@@ -1,0 +1,27 @@
+namespace MediaBrowser.Model.Dlna
+{
+    /// <summary>
+    /// Defines how the server selects the optimal media source when multiple versions are available.
+    /// </summary>
+    public enum MediaSourceSelectionMode
+    {
+        /// <summary>
+        /// Default behavior - prefer highest quality, sorted by resolution descending.
+        /// This may result in transcoding if the highest quality source is not directly playable.
+        /// </summary>
+        HighestQuality = 0,
+
+        /// <summary>
+        /// Prefer direct-playable sources over higher quality sources that require transcoding.
+        /// Among direct-playable sources, prefer highest quality.
+        /// </summary>
+        PreferDirectPlay = 1,
+
+        /// <summary>
+        /// Network-aware selection. Considers available bandwidth when selecting between
+        /// direct-playable sources. Will use a lower quality direct-playable source rather
+        /// than transcoding a higher quality source when bandwidth is limited.
+        /// </summary>
+        NetworkAware = 2
+    }
+}

--- a/MediaBrowser.Model/MediaInfo/PlaybackInfoResponse.cs
+++ b/MediaBrowser.Model/MediaInfo/PlaybackInfoResponse.cs
@@ -35,5 +35,12 @@ namespace MediaBrowser.Model.MediaInfo
         /// </summary>
         /// <value>The error code.</value>
         public PlaybackErrorCode? ErrorCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optimal media source ID based on device capabilities and network conditions.
+        /// Clients should use this source for automatic playback when available.
+        /// </summary>
+        /// <value>The optimal media source identifier.</value>
+        public string? OptimalMediaSourceId { get; set; }
     }
 }


### PR DESCRIPTION
When multiple versions of media exist (4K HDR, 1080p SDR, 720p), Jellyfin selects the highest resolution first—even when it requires transcoding. This PR adds intelligent source selection that prioritizes direct-playable versions and enables true adaptive bitrate streaming between pre-encoded files.

**Changes**
- Add `MediaSourceSelectionMode` enum with `HighestQuality`, `PreferDirectPlay` (default), and `NetworkAware` modes
- Add `OptimalMediaSourceId` to `PlaybackInfoResponse` for client auto-selection
- Prioritize direct-playable sources over higher-quality sources that require transcoding
- Push unplayable sources (e.g., needs transcoding but user lacks permission) to end of selection
- Extend HLS master playlist to include variants for all pre-encoded alternate versions, enabling mid-stream quality switching without server transcoding

**Issues**
Addresses feature request for "bitrate ladder" support similar to Netflix, where clients automatically receive the most appropriate version based on device capabilities and network conditions. See https://features.jellyfin.org/posts/3680/bitrate-ladder-support