### PR TITLE
fix: artist metadata not saving properly

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1031,26 +1031,6 @@ namespace Emby.Server.Implementations.Dto
             {
                 dto.Artists = hasArtist.Artists;
 
-                // var artistItems = _libraryManager.GetArtists(new InternalItemsQuery
-                // {
-                //    EnableTotalRecordCount = false,
-                //    ItemIds = new[] { item.Id.ToString("N", CultureInfo.InvariantCulture) }
-                // });
-
-                // dto.ArtistItems = artistItems.Items
-                //    .Select(i =>
-                //    {
-                //        var artist = i.Item1;
-                //        return new NameIdPair
-                //        {
-                //            Name = artist.Name,
-                //            Id = artist.Id.ToString("N", CultureInfo.InvariantCulture)
-                //        };
-                //    })
-                //    .ToList();
-
-                // Include artists that are not in the database yet, e.g., just added via metadata editor
-                // var foundArtists = artistItems.Items.Select(i => i.Item1.Name).ToList();
                 var artistsLookup = _libraryManager.GetArtists([.. hasArtist.Artists.Where(e => !string.IsNullOrWhiteSpace(e))]);
 
                 dto.ArtistItems = hasArtist.Artists
@@ -1066,24 +1046,6 @@ namespace Emby.Server.Implementations.Dto
             if (item is IHasAlbumArtist hasAlbumArtist)
             {
                 dto.AlbumArtist = hasAlbumArtist.AlbumArtists.FirstOrDefault();
-
-                // var artistItems = _libraryManager.GetAlbumArtists(new InternalItemsQuery
-                // {
-                //    EnableTotalRecordCount = false,
-                //    ItemIds = new[] { item.Id.ToString("N", CultureInfo.InvariantCulture) }
-                // });
-
-                // dto.AlbumArtists = artistItems.Items
-                //    .Select(i =>
-                //    {
-                //        var artist = i.Item1;
-                //        return new NameIdPair
-                //        {
-                //            Name = artist.Name,
-                //            Id = artist.Id.ToString("N", CultureInfo.InvariantCulture)
-                //        };
-                //    })
-                //    .ToList();
 
                 var albumArtistsLookup = _libraryManager.GetArtists([.. hasAlbumArtist.AlbumArtists.Where(e => !string.IsNullOrWhiteSpace(e))]);
 

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -459,17 +459,9 @@ public class ItemsController : BaseJellyfinApiController
             // Artists
             if (artists.Length != 0)
             {
-                query.ArtistIds = artists.Select(i =>
-                {
-                    try
-                    {
-                        return _libraryManager.GetArtist(i, new DtoOptions(false));
-                    }
-                    catch
-                    {
-                        return null;
-                    }
-                }).Where(i => i is not null).Select(i => i!.Id).ToArray();
+                query.ArtistIds = _libraryManager.GetArtists(artists)
+                    .SelectMany(criteria => criteria.Value.Where(artist => artist is not null).Select(artist => artist.Id))
+                    .ToArray();
             }
 
             // ExcludeArtistIds

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1494,7 +1494,7 @@ public sealed class BaseItemRepository
 
         if (item is IHasArtist hasArtist)
         {
-            list.AddRange(hasArtist.Artists.Select(i => ((ItemValueType)0, i)));
+            list.AddRange(hasArtist.Artists.Select(i => (ItemValueType.Artist, i)));
         }
 
         if (item is IHasAlbumArtist hasAlbumArtist)

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -533,6 +533,12 @@ namespace MediaBrowser.Controller.Library
         Task UpdatePeopleAsync(BaseItem item, IReadOnlyList<PersonInfo> people, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Updates the artists.
+        /// </summary>
+        /// <param name="artists">The artists.</param>
+        void UpdateArtists(IEnumerable<string> artists);
+
+        /// <summary>
         /// Gets the item ids.
         /// </summary>
         /// <param name="query">The query.</param>


### PR DESCRIPTION
**Changes**
Partially reverted commit 5a6d9180fed81a30cb91ef3fed30176cd4402116 which introduced a regression in artist creation. 

**Issues**
Fixes metadata edition from #15283

**Some questions regarding this metadata**
The way artist creation is handled is really confusing. As it is right now, artists are added to the BaseItems table when an Item containing unknown Artists is returned by the API. This was done for both Album Artists and Artists, but on 5a6d9180fed81a30cb91ef3fed30176cd4402116 the code that was handling that was changed to prevent duplication. Judging by the changes made in that commit, this change wasn't actually necessary and should come back, although in the future I feel like the artist should be added to the database on creation instead of when it's returned by any API endpoint? Maybe I can work on that next if no one is working on it?

During the investigation of this issue I also came across three ways of saving Artist and Album Artists, which sounds a bit backwards to me. One is in the BaseItems table, another in each BaseItems record (there's an Artist and AlbumArtist field that contains a list of them separated by ```|```) and another table ItemValues (joined to ItemValuesMap) that has the artist info again, maybe we should look into consolidating this into just one?
