### PR TITLE
Fix duplicate paths in PhysicalLocationsList causing slow library loads

### DIFF
--- a/MediaBrowser.Controller/Entities/AggregateFolder.cs
+++ b/MediaBrowser.Controller/Entities/AggregateFolder.cs
@@ -93,11 +93,15 @@ namespace MediaBrowser.Controller.Entities
 
             if (!changed)
             {
-                var locations = PhysicalLocations;
+                var locations = PhysicalLocations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations;
+                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-                if (!locations.SequenceEqual(newLocations))
+                if (!locations.SequenceEqual(newLocations, StringComparer.OrdinalIgnoreCase))
                 {
                     changed = true;
                 }
@@ -141,10 +145,16 @@ namespace MediaBrowser.Controller.Entities
                 args.FileSystemChildren = files;
             }
 
-            _requiresRefresh = _requiresRefresh || !args.PhysicalLocations.SequenceEqual(PhysicalLocations);
+            var physicalLocations = args.PhysicalLocations
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var currentLocations = PhysicalLocations
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            _requiresRefresh = _requiresRefresh || !physicalLocations.SequenceEqual(currentLocations, StringComparer.OrdinalIgnoreCase);
             if (setPhysicalLocations)
             {
-                PhysicalLocationsList = args.PhysicalLocations;
+                PhysicalLocationsList = physicalLocations;
             }
 
             return args;

--- a/MediaBrowser.Controller/Entities/CollectionFolder.cs
+++ b/MediaBrowser.Controller/Entities/CollectionFolder.cs
@@ -189,11 +189,15 @@ namespace MediaBrowser.Controller.Entities
 
             if (!changed)
             {
-                var locations = PhysicalLocations;
+                var locations = PhysicalLocations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations;
+                var newLocations = CreateResolveArgs(new DirectoryService(FileSystem), false).PhysicalLocations
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-                if (!locations.SequenceEqual(newLocations))
+                if (!locations.SequenceEqual(newLocations, StringComparer.OrdinalIgnoreCase))
                 {
                     changed = true;
                 }
@@ -299,11 +303,17 @@ namespace MediaBrowser.Controller.Entities
                 args.FileSystemChildren = files;
             }
 
-            _requiresRefresh = _requiresRefresh || !args.PhysicalLocations.SequenceEqual(PhysicalLocations);
+            var physicalLocations = args.PhysicalLocations
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var currentLocations = PhysicalLocations
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            _requiresRefresh = _requiresRefresh || !physicalLocations.SequenceEqual(currentLocations, StringComparer.OrdinalIgnoreCase);
 
             if (setPhysicalLocations)
             {
-                PhysicalLocationsList = args.PhysicalLocations;
+                PhysicalLocationsList = physicalLocations;
             }
 
             return args;


### PR DESCRIPTION
**Changes**

Saw #15966 about Collections libraries taking ~5 seconds to load after upgrading to 10.11. I was able to reproduce the issue and found that duplicate paths were being stored in PhysicalLocationsList, causing the same folders to get scanned multiple times.

The fix deduplicates paths when storing and comparing PhysicalLocationsList in both CollectionFolder and AggregateFolder. Also made the comparison logic use case-insensitive matching throughout so paths like \/Media/Movies\ and \/media/movies\ are treated as the same on case-insensitive filesystems.

Existing databases should fix themselves on the next library refresh - no migration needed.

**Issues**
Fixes #15966