### PR TITLE
Prioritize better matches on search

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1558,29 +1558,36 @@ public sealed class BaseItemRepository
 
         IOrderedQueryable<BaseItemEntity>? orderedQuery = null;
 
+        // When searching, prioritize by match quality: exact match > prefix match > contains
+        if (hasSearch)
+        {
+            orderedQuery = query.OrderBy(OrderMapper.MapSearchRelevanceOrder(filter.SearchTerm!));
+        }
+
         var firstOrdering = orderBy.FirstOrDefault();
         if (firstOrdering != default)
         {
             var expression = OrderMapper.MapOrderByField(firstOrdering.OrderBy, filter, context);
-            if (firstOrdering.SortOrder == SortOrder.Ascending)
+            if (orderedQuery is null)
             {
-                orderedQuery = query.OrderBy(expression);
+                // No search relevance ordering, start fresh
+                orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
+                    ? query.OrderBy(expression)
+                    : query.OrderByDescending(expression);
             }
             else
             {
-                orderedQuery = query.OrderByDescending(expression);
+                // Search relevance ordering already applied, chain with ThenBy
+                orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
+                    ? orderedQuery.ThenBy(expression)
+                    : orderedQuery.ThenByDescending(expression);
             }
 
             if (firstOrdering.OrderBy is ItemSortBy.Default or ItemSortBy.SortName)
             {
-                if (firstOrdering.SortOrder is SortOrder.Ascending)
-                {
-                    orderedQuery = orderedQuery.ThenBy(e => e.Name);
-                }
-                else
-                {
-                    orderedQuery = orderedQuery.ThenByDescending(e => e.Name);
-                }
+                orderedQuery = firstOrdering.SortOrder is SortOrder.Ascending
+                    ? orderedQuery.ThenBy(e => e.Name)
+                    : orderedQuery.ThenByDescending(e => e.Name);
             }
         }
 


### PR DESCRIPTION
This makes search results with full and prefix matches appear before contains matches to improve results.

**Changes**
Prioritize search results by `exact match > prefix match with word boundary > prefix match > contains`

**Issues**
If you search for the series `FROM`, you'll first get any episodes that includes `from` in their name right now because their `CleanName` is prefixed with numbers. If you have more than 100 of such episodes, you'll not see the series, even though the name is a full match. Same thing happens for movies like `From Dusk Till Dawn`.