### PR TITLE
Fix N+1 queries and add missing indexes for large database performance

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -210,6 +210,7 @@
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
  - [ZeusCraft10](https://github.com/ZeusCraft10)
+ - [mtrogman](https://github.com/mtrogman)
 
 # Emby Contributors
 

--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -136,13 +136,15 @@ public static class ServiceCollectionExtensions
                 break;
         }
 
-        serviceCollection.AddPooledDbContextFactory<JellyfinDbContext>((serviceProvider, opt) =>
-        {
-            var provider = serviceProvider.GetRequiredService<IJellyfinDatabaseProvider>();
-            provider.Initialise(opt, efCoreConfiguration);
-            var lockingBehavior = serviceProvider.GetRequiredService<IEntityFrameworkCoreLockingBehavior>();
-            lockingBehavior.Initialise(opt);
-        });
+        serviceCollection.AddPooledDbContextFactory<JellyfinDbContext>(
+            (serviceProvider, opt) =>
+            {
+                var provider = serviceProvider.GetRequiredService<IJellyfinDatabaseProvider>();
+                provider.Initialise(opt, efCoreConfiguration);
+                var lockingBehavior = serviceProvider.GetRequiredService<IEntityFrameworkCoreLockingBehavior>();
+                lockingBehavior.Initialise(opt);
+            },
+            efCoreConfiguration.ContextPoolSize);
 
         return serviceCollection;
     }

--- a/MediaBrowser.Controller/Entities/UserRootFolder.cs
+++ b/MediaBrowser.Controller/Entities/UserRootFolder.cs
@@ -44,6 +44,26 @@ namespace MediaBrowser.Controller.Entities
         [JsonIgnore]
         public override bool IsPreSorted => true;
 
+        /// <summary>
+        /// Gets or sets the children. Overridden to ensure the _childrenIds cache is cleared
+        /// when children are invalidated.
+        /// </summary>
+        [JsonIgnore]
+        public override IEnumerable<BaseItem> Children
+        {
+            get => base.Children;
+            set
+            {
+                // Clear the ID cache when children are being invalidated
+                if (value is null)
+                {
+                    ClearCache();
+                }
+
+                base.Children = value;
+            }
+        }
+
         private void ClearCache()
         {
             lock (_childIdsLock)

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -60,6 +60,7 @@ public class EncodingOptions
         SubtitleExtractionTimeoutMinutes = 30;
         AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = ["mkv"];
         HardwareDecodingCodecs = ["h264", "vc1"];
+        TranscodingLockPoolSize = 20;
     }
 
     /// <summary>
@@ -301,4 +302,11 @@ public class EncodingOptions
     /// Gets or sets the file extensions on-demand metadata based keyframe extraction is enabled for.
     /// </summary>
     public string[] AllowOnDemandMetadataBasedKeyframeExtractionForExtensions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pool size for transcoding locks.
+    /// Higher values allow more concurrent transcoding operations but use more memory.
+    /// Default is 20.
+    /// </summary>
+    public int TranscodingLockPoolSize { get; set; }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -22,4 +22,10 @@ public class DatabaseConfigurationOptions
     /// Defaults to "NoLock".
     /// </summary>
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }
+
+    /// <summary>
+    /// Gets or sets the DbContext pool size for concurrent database operations.
+    /// Higher values support more concurrent users. Default is 1024.
+    /// </summary>
+    public int ContextPoolSize { get; set; } = 1024;
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/AncestorIdConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/AncestorIdConfiguration.cs
@@ -13,6 +13,7 @@ public class AncestorIdConfiguration : IEntityTypeConfiguration<AncestorId>
     public void Configure(EntityTypeBuilder<AncestorId> builder)
     {
         builder.HasKey(e => new { e.ItemId, e.ParentItemId });
+        builder.HasIndex(e => e.ItemId); // Index for queries filtering by ItemId alone
         builder.HasIndex(e => e.ParentItemId);
         builder.HasOne(e => e.ParentItem).WithMany(e => e.Children).HasForeignKey(f => f.ParentItemId);
         builder.HasOne(e => e.Item).WithMany(e => e.Parents).HasForeignKey(f => f.ItemId);

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/BaseItemImageInfoConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/BaseItemImageInfoConfiguration.cs
@@ -1,0 +1,20 @@
+using Jellyfin.Database.Implementations.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Jellyfin.Database.Implementations.ModelConfiguration;
+
+/// <summary>
+/// BaseItemImageInfo Configuration.
+/// </summary>
+public class BaseItemImageInfoConfiguration : IEntityTypeConfiguration<BaseItemImageInfo>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<BaseItemImageInfo> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.HasIndex(e => e.ItemId); // Index for queries filtering by ItemId
+        builder.HasOne(e => e.Item).WithMany(e => e.Images).HasForeignKey(e => e.ItemId)
+            .OnDelete(DeleteBehavior.Cascade); // Delete image info when item is deleted
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/ItemValuesMapConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/ItemValuesMapConfiguration.cs
@@ -13,7 +13,7 @@ public class ItemValuesMapConfiguration : IEntityTypeConfiguration<ItemValueMap>
     public void Configure(EntityTypeBuilder<ItemValueMap> builder)
     {
         builder.HasKey(e => new { e.ItemValueId, e.ItemId });
-        builder.HasIndex(e => e.ItemId); // Index for queries filtering by ItemId
+        builder.HasIndex(e => new { e.ItemId, e.ItemValueId });
         builder.HasOne(e => e.Item);
         builder.HasOne(e => e.ItemValue);
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/ItemValuesMapConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/ItemValuesMapConfiguration.cs
@@ -13,6 +13,7 @@ public class ItemValuesMapConfiguration : IEntityTypeConfiguration<ItemValueMap>
     public void Configure(EntityTypeBuilder<ItemValueMap> builder)
     {
         builder.HasKey(e => new { e.ItemValueId, e.ItemId });
+        builder.HasIndex(e => e.ItemId); // Index for queries filtering by ItemId
         builder.HasOne(e => e.Item);
         builder.HasOne(e => e.ItemValue);
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/KeyframeDataConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/KeyframeDataConfiguration.cs
@@ -13,6 +13,7 @@ public class KeyframeDataConfiguration : IEntityTypeConfiguration<KeyframeData>
     public void Configure(EntityTypeBuilder<KeyframeData> builder)
     {
         builder.HasKey(e => e.ItemId);
-        builder.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId);
+        builder.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId)
+            .OnDelete(DeleteBehavior.Cascade); // Delete keyframe data when item is deleted
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/MediaStreamInfoConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/MediaStreamInfoConfiguration.cs
@@ -17,5 +17,7 @@ public class MediaStreamInfoConfiguration : IEntityTypeConfiguration<MediaStream
         builder.HasIndex(e => e.StreamType);
         builder.HasIndex(e => new { e.StreamIndex, e.StreamType });
         builder.HasIndex(e => new { e.StreamIndex, e.StreamType, e.Language });
+        builder.HasOne(e => e.Item).WithMany(e => e.MediaStreams).HasForeignKey(e => e.ItemId)
+            .OnDelete(DeleteBehavior.Cascade); // Delete media streams when item is deleted
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/PeopleBaseItemMapConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/PeopleBaseItemMapConfiguration.cs
@@ -13,6 +13,7 @@ public class PeopleBaseItemMapConfiguration : IEntityTypeConfiguration<PeopleBas
     public void Configure(EntityTypeBuilder<PeopleBaseItemMap> builder)
     {
         builder.HasKey(e => new { e.ItemId, e.PeopleId, e.Role });
+        builder.HasIndex(e => e.PeopleId); // Index for queries filtering by PeopleId
         builder.HasIndex(e => new { e.ItemId, e.SortOrder });
         builder.HasIndex(e => new { e.ItemId, e.ListOrder });
         builder.HasOne(e => e.Item);

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/PeopleBaseItemMapConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/PeopleBaseItemMapConfiguration.cs
@@ -13,7 +13,7 @@ public class PeopleBaseItemMapConfiguration : IEntityTypeConfiguration<PeopleBas
     public void Configure(EntityTypeBuilder<PeopleBaseItemMap> builder)
     {
         builder.HasKey(e => new { e.ItemId, e.PeopleId, e.Role });
-        builder.HasIndex(e => e.PeopleId); // Index for queries filtering by PeopleId
+        builder.HasIndex(e => new { e.PeopleId, e.ItemId });
         builder.HasIndex(e => new { e.ItemId, e.SortOrder });
         builder.HasIndex(e => new { e.ItemId, e.ListOrder });
         builder.HasOne(e => e.Item);

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/UserDataConfiguration.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ModelConfiguration/UserDataConfiguration.cs
@@ -13,6 +13,7 @@ public class UserDataConfiguration : IEntityTypeConfiguration<UserData>
     public void Configure(EntityTypeBuilder<UserData> builder)
     {
         builder.HasKey(d => new { d.ItemId, d.UserId, d.CustomDataKey });
+        builder.HasIndex(d => d.UserId); // Index for queries filtering by UserId alone
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.Played });
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.PlaybackPositionTicks });
         builder.HasIndex(d => new { d.ItemId, d.UserId, d.IsFavorite });

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,8 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Database.Providers.Sqlite;
 
 /// <summary>
-/// Injects a series of PRAGMA on each connection open.
-/// Supports optional extra PRAGMAs loaded from a well-known file and executes them per-connection (pool-safe).
+/// Injects a series of PRAGMA on each connection starts.
 /// </summary>
 public class PragmaConnectionInterceptor : DbConnectionInterceptor
 {
@@ -26,29 +22,17 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private readonly int _syncMode;
     private readonly IDictionary<string, string> _customPragma;
 
-    private readonly IReadOnlyList<string> _extraPragmaStatements;
-
-    // Log the effective pragma values once per process start (avoid noisy logs)
-    private static int _pragmaVerifyLogged;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PragmaConnectionInterceptor"/> class.
     /// </summary>
-    /// <param name="logger">Logger instance.</param>
-    /// <param name="cacheSize">The PRAGMA cache_size value to apply (if any).</param>
-    /// <param name="lockingMode">The PRAGMA locking_mode value to apply (if any).</param>
-    /// <param name="journalSizeLimit">The PRAGMA journal_size_limit value to apply (if any).</param>
-    /// <param name="tempStoreMode">The PRAGMA temp_store value to apply.</param>
-    /// <param name="syncMode">The PRAGMA synchronous value to apply.</param>
-    /// <param name="customPragma">Additional custom pragmas.</param>
-    public PragmaConnectionInterceptor(
-        ILogger logger,
-        int? cacheSize,
-        string lockingMode,
-        int? journalSizeLimit,
-        int tempStoreMode,
-        int syncMode,
-        IDictionary<string, string> customPragma)
+    /// <param name="logger">The logger.</param>
+    /// <param name="cacheSize">Cache size.</param>
+    /// <param name="lockingMode">Locking mode.</param>
+    /// <param name="journalSizeLimit">Journal Size.</param>
+    /// <param name="tempStoreMode">The https://sqlite.org/pragma.html#pragma_temp_store pragma.</param>
+    /// <param name="syncMode">The https://sqlite.org/pragma.html#pragma_synchronous pragma.</param>
+    /// <param name="customPragma">A list of custom provided Pragma in the list of CustomOptions starting with "#PRAGMA:".</param>
+    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, IDictionary<string, string> customPragma)
     {
         _logger = logger;
         _cacheSize = cacheSize;
@@ -59,65 +43,30 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         _customPragma = customPragma;
 
         InitialCommand = BuildCommandText();
-
-        // Load extra pragmas from env/file/auto-discovered default file. Executed per-connection (pool-safe).
-        _extraPragmaStatements = LoadExtraPragmas(_logger);
-
         _logger.LogInformation("SQLITE connection pragma command set to: \r\n{PragmaCommand}", InitialCommand);
-
-        if (_extraPragmaStatements.Count > 0)
-        {
-            _logger.LogInformation(
-                "SQLITE extra pragma statements enabled ({Count}). Will execute on each connection open: {Pragmas}",
-                _extraPragmaStatements.Count,
-                string.Join(" ", _extraPragmaStatements));
-        }
     }
 
     private string? InitialCommand { get; set; }
 
-    /// <summary>
-    /// Called when a database connection has been opened.
-    /// </summary>
-    /// <param name="connection">The opened connection.</param>
-    /// <param name="eventData">Event data.</param>
+    /// <inheritdoc/>
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
         base.ConnectionOpened(connection, eventData);
 
-        ExecuteInitialCommand(connection);
-        ExecuteExtraPragmas(connection);
+        using (var command = connection.CreateCommand())
+        {
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+            command.CommandText = InitialCommand;
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+            command.ExecuteNonQuery();
+        }
     }
 
-    /// <summary>
-    /// Called when a database connection has been opened (async).
-    /// </summary>
-    /// <param name="connection">The opened connection.</param>
-    /// <param name="eventData">Event data.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A task representing the async operation.</returns>
-    public override async Task ConnectionOpenedAsync(
-        DbConnection connection,
-        ConnectionEndEventData eventData,
-        CancellationToken cancellationToken = default)
+    /// <inheritdoc/>
+    public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
     {
         await base.ConnectionOpenedAsync(connection, eventData, cancellationToken).ConfigureAwait(false);
 
-        await ExecuteInitialCommandAsync(connection, cancellationToken).ConfigureAwait(false);
-        await ExecuteExtraPragmasAsync(connection, cancellationToken).ConfigureAwait(false);
-    }
-
-    private void ExecuteInitialCommand(DbConnection connection)
-    {
-        using var command = connection.CreateCommand();
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-        command.CommandText = InitialCommand;
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
-        command.ExecuteNonQuery();
-    }
-
-    private async Task ExecuteInitialCommandAsync(DbConnection connection, CancellationToken cancellationToken)
-    {
         var command = connection.CreateCommand();
         await using (command.ConfigureAwait(false))
         {
@@ -125,124 +74,6 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
             command.CommandText = InitialCommand;
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private void ExecuteExtraPragmas(DbConnection connection)
-    {
-        if (_extraPragmaStatements.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var stmt in _extraPragmaStatements)
-        {
-            using var cmd = connection.CreateCommand();
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-            cmd.CommandText = stmt;
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
-            cmd.ExecuteNonQuery();
-        }
-
-        // Definitive proof: log effective values from the SAME connection after applying
-        LogEffectivePragmasOnce(connection);
-    }
-
-    private async Task ExecuteExtraPragmasAsync(DbConnection connection, CancellationToken cancellationToken)
-    {
-        if (_extraPragmaStatements.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var stmt in _extraPragmaStatements)
-        {
-            var cmd = connection.CreateCommand();
-            await using (cmd.ConfigureAwait(false))
-            {
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-                cmd.CommandText = stmt;
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
-                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        // Definitive proof: log effective values from the SAME connection after applying
-        await LogEffectivePragmasOnceAsync(connection, cancellationToken).ConfigureAwait(false);
-    }
-
-    private void LogEffectivePragmasOnce(DbConnection connection)
-    {
-        if (Interlocked.Exchange(ref _pragmaVerifyLogged, 1) != 0)
-        {
-            return;
-        }
-
-        try
-        {
-            string? Get(string pragma)
-            {
-                using var cmd = connection.CreateCommand();
-#pragma warning disable CA2100
-                cmd.CommandText = $"PRAGMA {pragma};";
-#pragma warning restore CA2100
-                var val = cmd.ExecuteScalar();
-                return val?.ToString();
-            }
-
-            _logger.LogInformation(
-                "SQLite PRAGMA verify (same Jellyfin connection, after apply): journal_mode={JournalMode}, synchronous={Synchronous}, temp_store={TempStore}, cache_size={CacheSize}, mmap_size={MmapSize}, cache_spill={CacheSpill}, threads={Threads}, wal_autocheckpoint={WalAutoCheckpoint}",
-                Get("journal_mode"),
-                Get("synchronous"),
-                Get("temp_store"),
-                Get("cache_size"),
-                Get("mmap_size"),
-                Get("cache_spill"),
-                Get("threads"),
-                Get("wal_autocheckpoint"));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "SQLite PRAGMA verify failed");
-        }
-    }
-
-    private async Task LogEffectivePragmasOnceAsync(DbConnection connection, CancellationToken cancellationToken)
-    {
-        if (Interlocked.Exchange(ref _pragmaVerifyLogged, 1) != 0)
-        {
-            return;
-        }
-
-        try
-        {
-            async Task<string?> GetAsync(string pragma)
-            {
-                var cmd = connection.CreateCommand();
-                await using (cmd.ConfigureAwait(false))
-                {
-#pragma warning disable CA2100
-                    cmd.CommandText = $"PRAGMA {pragma};";
-#pragma warning restore CA2100
-                    var val = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-                    return val?.ToString();
-                }
-            }
-
-            _logger.LogInformation(
-                "SQLite PRAGMA verify (same Jellyfin connection, after apply): journal_mode={JournalMode}, synchronous={Synchronous}, temp_store={TempStore}, cache_size={CacheSize}, mmap_size={MmapSize}, cache_spill={CacheSpill}, threads={Threads}, wal_autocheckpoint={WalAutoCheckpoint}",
-                await GetAsync("journal_mode").ConfigureAwait(false),
-                await GetAsync("synchronous").ConfigureAwait(false),
-                await GetAsync("temp_store").ConfigureAwait(false),
-                await GetAsync("cache_size").ConfigureAwait(false),
-                await GetAsync("mmap_size").ConfigureAwait(false),
-                await GetAsync("cache_spill").ConfigureAwait(false),
-                await GetAsync("threads").ConfigureAwait(false),
-                await GetAsync("wal_autocheckpoint").ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "SQLite PRAGMA verify failed");
         }
     }
 
@@ -273,207 +104,5 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         }
 
         return sb.ToString();
-    }
-
-    /// <summary>
-    /// Loads extra PRAGMA statements from:
-    /// - env var: JELLYFIN_SQLITE_PRAGMAS (semicolon separated)
-    /// - env var: JELLYFIN_SQLITE_PRAGMAS_FILE (path to a file)
-    /// - auto-discovered default files near the XML config directory and data directory.
-    /// </summary>
-    private static IReadOnlyList<string> LoadExtraPragmas(ILogger logger)
-    {
-        // 1) Direct env var (highest priority)
-        var raw = Environment.GetEnvironmentVariable("JELLYFIN_SQLITE_PRAGMAS");
-        if (!string.IsNullOrWhiteSpace(raw))
-        {
-            logger.LogInformation("Loading SQLite extra PRAGMAs from env var JELLYFIN_SQLITE_PRAGMAS.");
-            return ParsePragmaStatements(logger, raw);
-        }
-
-        // 2) Env var file path override
-        var filePath = Environment.GetEnvironmentVariable("JELLYFIN_SQLITE_PRAGMAS_FILE");
-        if (!string.IsNullOrWhiteSpace(filePath))
-        {
-            var fromFile = TryReadFile(logger, filePath, logWhenMissing: true);
-            if (!string.IsNullOrWhiteSpace(fromFile))
-            {
-                logger.LogInformation("Loading SQLite extra PRAGMAs from JELLYFIN_SQLITE_PRAGMAS_FILE: {Path}", filePath);
-                return ParsePragmaStatements(logger, fromFile);
-            }
-
-            return Array.Empty<string>();
-        }
-
-        // 3) Auto-discover: prioritize CONFIG dir (where XML lives), then DATA dir, then well-known fallbacks
-        foreach (var candidate in GetDefaultPragmaFileCandidates())
-        {
-            var fromFile = TryReadFile(logger, candidate, logWhenMissing: false);
-            if (!string.IsNullOrWhiteSpace(fromFile))
-            {
-                logger.LogInformation("Loading SQLite extra PRAGMAs from default file: {Path}", candidate);
-                return ParsePragmaStatements(logger, fromFile);
-            }
-        }
-
-        return Array.Empty<string>();
-    }
-
-    /// <summary>
-    /// Finds candidates in the most compatible order:
-    /// 1) JELLYFIN_CONFIG_DIR (official image: /config/config) where XML config lives
-    /// 2) JELLYFIN_DATA_DIR   (official image: /config)
-    /// 3) Common container paths (linuxserver/custom): /config/config, /conf/config, /config.
-    /// </summary>
-    private static IEnumerable<string> GetDefaultPragmaFileCandidates()
-    {
-        // Prefer config dir first (the "XML folder")
-        var configDir = Environment.GetEnvironmentVariable("JELLYFIN_CONFIG_DIR");
-        if (!string.IsNullOrWhiteSpace(configDir))
-        {
-            foreach (var p in CandidatesInDir(configDir))
-            {
-                yield return p;
-            }
-
-            // Also check parent of configDir (common: /config/config -> /config)
-            var parent = SafeGetParent(configDir);
-            if (!string.IsNullOrWhiteSpace(parent))
-            {
-                foreach (var p in CandidatesInDir(parent))
-                {
-                    yield return p;
-                }
-            }
-        }
-
-        // Then data dir
-        var dataDir = Environment.GetEnvironmentVariable("JELLYFIN_DATA_DIR");
-        if (!string.IsNullOrWhiteSpace(dataDir))
-        {
-            foreach (var p in CandidatesInDir(dataDir))
-            {
-                yield return p;
-            }
-        }
-
-        // Finally, known defaults for popular images / layouts
-        foreach (var p in CandidatesInDir("/config/config"))
-        {
-            yield return p;
-        }
-
-        foreach (var p in CandidatesInDir("/conf/config")) // in case you truly have /conf/config
-        {
-            yield return p;
-        }
-
-        foreach (var p in CandidatesInDir("/config"))
-        {
-            yield return p;
-        }
-    }
-
-    private static IEnumerable<string> CandidatesInDir(string dir)
-    {
-        // Keep it simple: allow either "pragmas.sql" or "sqlite-pragmas.sql"
-        yield return Path.Combine(dir, "pragmas.sql");
-        yield return Path.Combine(dir, "sqlite-pragmas.sql");
-    }
-
-    private static string? SafeGetParent(string path)
-    {
-        try
-        {
-            return Directory.GetParent(path)?.FullName;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? TryReadFile(ILogger logger, string path, bool logWhenMissing)
-    {
-        try
-        {
-            if (!File.Exists(path))
-            {
-                if (logWhenMissing)
-                {
-                    logger.LogWarning("SQLite PRAGMA file was set but does not exist: {Path}", path);
-                }
-
-                return null;
-            }
-
-            var info = new FileInfo(path);
-            const long maxBytes = 256 * 1024; // 256KB guardrail
-            if (info.Length > maxBytes)
-            {
-                logger.LogWarning(
-                    "SQLite PRAGMA file is too large ({Size} bytes). Max allowed is {Max} bytes. Ignoring: {Path}",
-                    info.Length,
-                    maxBytes,
-                    path);
-                return null;
-            }
-
-            return File.ReadAllText(path);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to read SQLite PRAGMA file: {Path}", path);
-            return null;
-        }
-    }
-
-    private static IReadOnlyList<string> ParsePragmaStatements(ILogger logger, string raw)
-    {
-        var lines = raw.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
-            .Select(l => l.Trim())
-            .Where(l => !string.IsNullOrWhiteSpace(l))
-            .Where(l => !IsFullLineComment(l))
-            .ToArray();
-
-        var normalized = string.Join("\n", lines);
-
-        var parts = normalized.Split(';')
-            .Select(p => p.Trim())
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .ToList();
-
-        var statements = new List<string>(parts.Count);
-        foreach (var p in parts)
-        {
-            var stmt = p.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase) ? p : $"PRAGMA {p}";
-
-            if (!stmt.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase))
-            {
-                logger.LogWarning("Ignoring non-PRAGMA SQLite statement from extra pragmas: {Statement}", p);
-                continue;
-            }
-
-            if (!stmt.EndsWith(';'))
-            {
-                stmt += ";";
-            }
-
-            statements.Add(stmt);
-        }
-
-        return statements
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    private static bool IsFullLineComment(string line)
-    {
-        if (line.StartsWith('#'))
-        {
-            return true;
-        }
-
-        return line.Length >= 2 && line[0] == '-' && line[1] == '-';
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +13,8 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Database.Providers.Sqlite;
 
 /// <summary>
-/// Injects a series of PRAGMA on each connection starts.
+/// Injects a series of PRAGMA on each connection open.
+/// Supports optional extra PRAGMAs loaded from a well-known file and executes them per-connection (pool-safe).
 /// </summary>
 public class PragmaConnectionInterceptor : DbConnectionInterceptor
 {
@@ -22,17 +26,29 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private readonly int _syncMode;
     private readonly IDictionary<string, string> _customPragma;
 
+    private readonly IReadOnlyList<string> _extraPragmaStatements;
+
+    // Log the effective pragma values once per process start (avoid noisy logs)
+    private static int _pragmaVerifyLogged;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PragmaConnectionInterceptor"/> class.
     /// </summary>
-    /// <param name="logger">The logger.</param>
-    /// <param name="cacheSize">Cache size.</param>
-    /// <param name="lockingMode">Locking mode.</param>
-    /// <param name="journalSizeLimit">Journal Size.</param>
-    /// <param name="tempStoreMode">The https://sqlite.org/pragma.html#pragma_temp_store pragma.</param>
-    /// <param name="syncMode">The https://sqlite.org/pragma.html#pragma_synchronous pragma.</param>
-    /// <param name="customPragma">A list of custom provided Pragma in the list of CustomOptions starting with "#PRAGMA:".</param>
-    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, IDictionary<string, string> customPragma)
+    /// <param name="logger">Logger instance.</param>
+    /// <param name="cacheSize">The PRAGMA cache_size value to apply (if any).</param>
+    /// <param name="lockingMode">The PRAGMA locking_mode value to apply (if any).</param>
+    /// <param name="journalSizeLimit">The PRAGMA journal_size_limit value to apply (if any).</param>
+    /// <param name="tempStoreMode">The PRAGMA temp_store value to apply.</param>
+    /// <param name="syncMode">The PRAGMA synchronous value to apply.</param>
+    /// <param name="customPragma">Additional custom pragmas.</param>
+    public PragmaConnectionInterceptor(
+        ILogger logger,
+        int? cacheSize,
+        string lockingMode,
+        int? journalSizeLimit,
+        int tempStoreMode,
+        int syncMode,
+        IDictionary<string, string> customPragma)
     {
         _logger = logger;
         _cacheSize = cacheSize;
@@ -43,30 +59,65 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         _customPragma = customPragma;
 
         InitialCommand = BuildCommandText();
+
+        // Load extra pragmas from env/file/auto-discovered default file. Executed per-connection (pool-safe).
+        _extraPragmaStatements = LoadExtraPragmas(_logger);
+
         _logger.LogInformation("SQLITE connection pragma command set to: \r\n{PragmaCommand}", InitialCommand);
+
+        if (_extraPragmaStatements.Count > 0)
+        {
+            _logger.LogInformation(
+                "SQLITE extra pragma statements enabled ({Count}). Will execute on each connection open: {Pragmas}",
+                _extraPragmaStatements.Count,
+                string.Join(" ", _extraPragmaStatements));
+        }
     }
 
     private string? InitialCommand { get; set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Called when a database connection has been opened.
+    /// </summary>
+    /// <param name="connection">The opened connection.</param>
+    /// <param name="eventData">Event data.</param>
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
         base.ConnectionOpened(connection, eventData);
 
-        using (var command = connection.CreateCommand())
-        {
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-            command.CommandText = InitialCommand;
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
-            command.ExecuteNonQuery();
-        }
+        ExecuteInitialCommand(connection);
+        ExecuteExtraPragmas(connection);
     }
 
-    /// <inheritdoc/>
-    public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Called when a database connection has been opened (async).
+    /// </summary>
+    /// <param name="connection">The opened connection.</param>
+    /// <param name="eventData">Event data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public override async Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
     {
         await base.ConnectionOpenedAsync(connection, eventData, cancellationToken).ConfigureAwait(false);
 
+        await ExecuteInitialCommandAsync(connection, cancellationToken).ConfigureAwait(false);
+        await ExecuteExtraPragmasAsync(connection, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ExecuteInitialCommand(DbConnection connection)
+    {
+        using var command = connection.CreateCommand();
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+        command.CommandText = InitialCommand;
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+        command.ExecuteNonQuery();
+    }
+
+    private async Task ExecuteInitialCommandAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
         var command = connection.CreateCommand();
         await using (command.ConfigureAwait(false))
         {
@@ -74,6 +125,124 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
             command.CommandText = InitialCommand;
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void ExecuteExtraPragmas(DbConnection connection)
+    {
+        if (_extraPragmaStatements.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var stmt in _extraPragmaStatements)
+        {
+            using var cmd = connection.CreateCommand();
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+            cmd.CommandText = stmt;
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+            cmd.ExecuteNonQuery();
+        }
+
+        // Definitive proof: log effective values from the SAME connection after applying
+        LogEffectivePragmasOnce(connection);
+    }
+
+    private async Task ExecuteExtraPragmasAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+        if (_extraPragmaStatements.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var stmt in _extraPragmaStatements)
+        {
+            var cmd = connection.CreateCommand();
+            await using (cmd.ConfigureAwait(false))
+            {
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+                cmd.CommandText = stmt;
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Definitive proof: log effective values from the SAME connection after applying
+        await LogEffectivePragmasOnceAsync(connection, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void LogEffectivePragmasOnce(DbConnection connection)
+    {
+        if (Interlocked.Exchange(ref _pragmaVerifyLogged, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            string? Get(string pragma)
+            {
+                using var cmd = connection.CreateCommand();
+#pragma warning disable CA2100
+                cmd.CommandText = $"PRAGMA {pragma};";
+#pragma warning restore CA2100
+                var val = cmd.ExecuteScalar();
+                return val?.ToString();
+            }
+
+            _logger.LogInformation(
+                "SQLite PRAGMA verify (same Jellyfin connection, after apply): journal_mode={JournalMode}, synchronous={Synchronous}, temp_store={TempStore}, cache_size={CacheSize}, mmap_size={MmapSize}, cache_spill={CacheSpill}, threads={Threads}, wal_autocheckpoint={WalAutoCheckpoint}",
+                Get("journal_mode"),
+                Get("synchronous"),
+                Get("temp_store"),
+                Get("cache_size"),
+                Get("mmap_size"),
+                Get("cache_spill"),
+                Get("threads"),
+                Get("wal_autocheckpoint"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SQLite PRAGMA verify failed");
+        }
+    }
+
+    private async Task LogEffectivePragmasOnceAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _pragmaVerifyLogged, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            async Task<string?> GetAsync(string pragma)
+            {
+                var cmd = connection.CreateCommand();
+                await using (cmd.ConfigureAwait(false))
+                {
+#pragma warning disable CA2100
+                    cmd.CommandText = $"PRAGMA {pragma};";
+#pragma warning restore CA2100
+                    var val = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                    return val?.ToString();
+                }
+            }
+
+            _logger.LogInformation(
+                "SQLite PRAGMA verify (same Jellyfin connection, after apply): journal_mode={JournalMode}, synchronous={Synchronous}, temp_store={TempStore}, cache_size={CacheSize}, mmap_size={MmapSize}, cache_spill={CacheSpill}, threads={Threads}, wal_autocheckpoint={WalAutoCheckpoint}",
+                await GetAsync("journal_mode").ConfigureAwait(false),
+                await GetAsync("synchronous").ConfigureAwait(false),
+                await GetAsync("temp_store").ConfigureAwait(false),
+                await GetAsync("cache_size").ConfigureAwait(false),
+                await GetAsync("mmap_size").ConfigureAwait(false),
+                await GetAsync("cache_spill").ConfigureAwait(false),
+                await GetAsync("threads").ConfigureAwait(false),
+                await GetAsync("wal_autocheckpoint").ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SQLite PRAGMA verify failed");
         }
     }
 
@@ -104,5 +273,207 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Loads extra PRAGMA statements from:
+    /// - env var: JELLYFIN_SQLITE_PRAGMAS (semicolon separated)
+    /// - env var: JELLYFIN_SQLITE_PRAGMAS_FILE (path to a file)
+    /// - auto-discovered default files near the XML config directory and data directory
+    /// </summary>
+    private static IReadOnlyList<string> LoadExtraPragmas(ILogger logger)
+    {
+        // 1) Direct env var (highest priority)
+        var raw = Environment.GetEnvironmentVariable("JELLYFIN_SQLITE_PRAGMAS");
+        if (!string.IsNullOrWhiteSpace(raw))
+        {
+            logger.LogInformation("Loading SQLite extra PRAGMAs from env var JELLYFIN_SQLITE_PRAGMAS.");
+            return ParsePragmaStatements(logger, raw);
+        }
+
+        // 2) Env var file path override
+        var filePath = Environment.GetEnvironmentVariable("JELLYFIN_SQLITE_PRAGMAS_FILE");
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            var fromFile = TryReadFile(logger, filePath, logWhenMissing: true);
+            if (!string.IsNullOrWhiteSpace(fromFile))
+            {
+                logger.LogInformation("Loading SQLite extra PRAGMAs from JELLYFIN_SQLITE_PRAGMAS_FILE: {Path}", filePath);
+                return ParsePragmaStatements(logger, fromFile);
+            }
+
+            return Array.Empty<string>();
+        }
+
+        // 3) Auto-discover: prioritize CONFIG dir (where XML lives), then DATA dir, then well-known fallbacks
+        foreach (var candidate in GetDefaultPragmaFileCandidates())
+        {
+            var fromFile = TryReadFile(logger, candidate, logWhenMissing: false);
+            if (!string.IsNullOrWhiteSpace(fromFile))
+            {
+                logger.LogInformation("Loading SQLite extra PRAGMAs from default file: {Path}", candidate);
+                return ParsePragmaStatements(logger, fromFile);
+            }
+        }
+
+        return Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Finds candidates in the most compatible order:
+    /// 1) JELLYFIN_CONFIG_DIR (official image: /config/config)  <-- where XML config is
+    /// 2) JELLYFIN_DATA_DIR   (official image: /config)
+    /// 3) Common container paths (linuxserver/custom): /config/config, /conf/config, /config
+    /// </summary>
+    private static IEnumerable<string> GetDefaultPragmaFileCandidates()
+    {
+        // Prefer config dir first (the "XML folder")
+        var configDir = Environment.GetEnvironmentVariable("JELLYFIN_CONFIG_DIR");
+        if (!string.IsNullOrWhiteSpace(configDir))
+        {
+            foreach (var p in CandidatesInDir(configDir))
+            {
+                yield return p;
+            }
+
+            // Also check parent of configDir (common: /config/config -> /config)
+            var parent = SafeGetParent(configDir);
+            if (!string.IsNullOrWhiteSpace(parent))
+            {
+                foreach (var p in CandidatesInDir(parent))
+                {
+                    yield return p;
+                }
+            }
+        }
+
+        // Then data dir
+        var dataDir = Environment.GetEnvironmentVariable("JELLYFIN_DATA_DIR");
+        if (!string.IsNullOrWhiteSpace(dataDir))
+        {
+            foreach (var p in CandidatesInDir(dataDir))
+            {
+                yield return p;
+            }
+        }
+
+        // Finally, known defaults for popular images / layouts
+        foreach (var p in CandidatesInDir("/config/config"))
+        {
+            yield return p;
+        }
+
+        foreach (var p in CandidatesInDir("/conf/config")) // in case you truly have /conf/config
+        {
+            yield return p;
+        }
+
+        foreach (var p in CandidatesInDir("/config"))
+        {
+            yield return p;
+        }
+    }
+
+    private static IEnumerable<string> CandidatesInDir(string dir)
+    {
+        // Keep it simple: allow either "pragmas.sql" or "sqlite-pragmas.sql"
+        yield return Path.Combine(dir, "pragmas.sql");
+        yield return Path.Combine(dir, "sqlite-pragmas.sql");
+    }
+
+    private static string? SafeGetParent(string path)
+    {
+        try
+        {
+            return Directory.GetParent(path)?.FullName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryReadFile(ILogger logger, string path, bool logWhenMissing)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                if (logWhenMissing)
+                {
+                    logger.LogWarning("SQLite PRAGMA file was set but does not exist: {Path}", path);
+                }
+
+                return null;
+            }
+
+            var info = new FileInfo(path);
+            const long maxBytes = 256 * 1024; // 256KB guardrail
+            if (info.Length > maxBytes)
+            {
+                logger.LogWarning(
+                    "SQLite PRAGMA file is too large ({Size} bytes). Max allowed is {Max} bytes. Ignoring: {Path}",
+                    info.Length,
+                    maxBytes,
+                    path);
+                return null;
+            }
+
+            return File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read SQLite PRAGMA file: {Path}", path);
+            return null;
+        }
+    }
+
+    private static IReadOnlyList<string> ParsePragmaStatements(ILogger logger, string raw)
+    {
+        var lines = raw.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+            .Select(l => l.Trim())
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .Where(l => !IsFullLineComment(l))
+            .ToArray();
+
+        var normalized = string.Join("\n", lines);
+
+        var parts = normalized.Split(';')
+            .Select(p => p.Trim())
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+
+        var statements = new List<string>(parts.Count);
+        foreach (var p in parts)
+        {
+            var stmt = p.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase) ? p : $"PRAGMA {p}";
+
+            if (!stmt.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogWarning("Ignoring non-PRAGMA SQLite statement from extra pragmas: {Statement}", p);
+                continue;
+            }
+
+            if (!stmt.EndsWith(';'))
+            {
+                stmt += ";";
+            }
+
+            statements.Add(stmt);
+        }
+
+        return statements
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool IsFullLineComment(string line)
+    {
+        if (line.StartsWith('#'))
+        {
+            return true;
+        }
+
+        return line.Length >= 2 && line[0] == '-' && line[1] == '-';
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -279,7 +279,7 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     /// Loads extra PRAGMA statements from:
     /// - env var: JELLYFIN_SQLITE_PRAGMAS (semicolon separated)
     /// - env var: JELLYFIN_SQLITE_PRAGMAS_FILE (path to a file)
-    /// - auto-discovered default files near the XML config directory and data directory
+    /// - auto-discovered default files near the XML config directory and data directory.
     /// </summary>
     private static IReadOnlyList<string> LoadExtraPragmas(ILogger logger)
     {

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -321,9 +321,9 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
 
     /// <summary>
     /// Finds candidates in the most compatible order:
-    /// 1) JELLYFIN_CONFIG_DIR (official image: /config/config)  <-- where XML config is
+    /// 1) JELLYFIN_CONFIG_DIR (official image: /config/config) where XML config lives
     /// 2) JELLYFIN_DATA_DIR   (official image: /config)
-    /// 3) Common container paths (linuxserver/custom): /config/config, /conf/config, /config
+    /// 3) Common container paths (linuxserver/custom): /config/config, /conf/config, /config.
     /// </summary>
     private static IEnumerable<string> GetDefaultPragmaFileCandidates()
     {


### PR DESCRIPTION
This PR addresses multiple performance issues affecting users with large libraries in 10.11.x.

**Changes**
- Add missing database indexes on ItemValuesMap, AncestorId, UserData, BaseItemImageInfo, and PeopleBaseItemMap
- Replace multiple COUNT() calls with single grouped query in GetItemCounts
- Batch load ancestor IDs in SaveItems instead of per-item queries
- Add sort-aware includes to prevent N+1 queries when sorting by DatePlayed, PlayCount, etc.
- Use JOIN instead of correlated subquery in PeopleRepository ordering
- Replace unbounded ConcurrentDictionary with LRU cache in DirectoryService
- Use EF.Functions.Like() for case-insensitive searches to utilize indexes
- Add cascade delete for KeyframeData, MediaStreamInfo, BaseItemImageInfo
- Add configurable ContextPoolSize and TranscodingLockPoolSize options
- Add support for custom SQLite pragmas via pragmas.sql file
- Fix DbUpdateConcurrencyException on simultaneous logins (adds retry logic)

**New Configuration Options**

`database.xml` - ContextPoolSize:
```xml
<ContextPoolSize>1024</ContextPoolSize>
```
Sets the DbContext pool size for concurrent database operations. Higher values support more concurrent users. Default is 1024.

`encoding.xml` - TranscodingLockPoolSize:
```xml
<TranscodingLockPoolSize>20</TranscodingLockPoolSize>
```
Sets the pool size for transcoding locks. Higher values allow more concurrent transcoding operations. Default is 20.

`pragmas.sql` - Custom SQLite pragmas:

Place a `pragmas.sql` file in your config directory to apply custom SQLite pragmas on each database connection. The file is auto-discovered from `JELLYFIN_CONFIG_DIR` or `JELLYFIN_DATA_DIR`.

Alternatively, set pragmas via environment variables:
- `JELLYFIN_SQLITE_PRAGMAS` - semicolon-separated pragma statements
- `JELLYFIN_SQLITE_PRAGMAS_FILE` - path to a custom pragma file

Example `pragmas.sql`:
```sql
# Performance tuning for large databases
PRAGMA cache_size=-128000;
PRAGMA mmap_size=3221225472;
PRAGMA temp_store=MEMORY;
PRAGMA wal_autocheckpoint=2000;
```

**Bug Fixes**

- Fix `DbUpdateConcurrencyException` when multiple logins occur simultaneously for the same user. The error caused users to need to enter credentials multiple times before successfully logging in. The fix adds retry logic with entity refresh on concurrency conflict.

A Docker image with these changes is available for testing: `mtrogman/jellyfin:10.11.5-v9`

**Issues**
Fixes #15063
Fixes #15090
Addresses #15070
Addresses #15742