### PR TITLE
Only scale chapter images based on resolution height to preserve aspect ratio and don't upscale them

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -210,6 +210,7 @@
  - [bjorntp](https://github.com/bjorntp)
  - [martenumberto](https://github.com/martenumberto)
  - [ZeusCraft10](https://github.com/ZeusCraft10)
+ - [MarcoCoreDuo](https://github.com/MarcoCoreDuo)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -659,7 +659,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _ => string.Empty
             };
 
-            return string.IsNullOrEmpty(target) ? string.Empty : $",scale=-2:'min(ih,{target})'";
+            return string.IsNullOrEmpty(target) ? string.Empty : $",scale=-2:min(ih\\,{target})";
         }
 
         private async Task<string> ExtractImageInternal(

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -646,25 +646,20 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private string GetImageResolutionParameter()
         {
-            var imageResolutionParameter = _serverConfig.Configuration.ChapterImageResolution switch
+            var target = _serverConfig.Configuration.ChapterImageResolution switch
             {
-                ImageResolution.P144 => "256x144",
-                ImageResolution.P240 => "426x240",
-                ImageResolution.P360 => "640x360",
-                ImageResolution.P480 => "854x480",
-                ImageResolution.P720 => "1280x720",
-                ImageResolution.P1080 => "1920x1080",
-                ImageResolution.P1440 => "2560x1440",
-                ImageResolution.P2160 => "3840x2160",
+                ImageResolution.P144 => "144",
+                ImageResolution.P240 => "240",
+                ImageResolution.P360 => "360",
+                ImageResolution.P480 => "480",
+                ImageResolution.P720 => "720",
+                ImageResolution.P1080 => "1080",
+                ImageResolution.P1440 => "1440",
+                ImageResolution.P2160 => "2160",
                 _ => string.Empty
             };
 
-            if (!string.IsNullOrEmpty(imageResolutionParameter))
-            {
-                imageResolutionParameter = " -s " + imageResolutionParameter;
-            }
-
-            return imageResolutionParameter;
+            return string.IsNullOrEmpty(target) ? string.Empty : $",scale=-2:'min(ih,{target})'";
         }
 
         private async Task<string> ExtractImageInternal(


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

Currently, chapter image extraction uses a fixed 16:9 resolution when not set to "Match Source" . This causes images from videos with other aspect ratios to be stretched to 16:9 when a fixed resolution is applied. In addition, if a video’s resolution is lower than the configured chapter image resolution, ffmpeg will upscale the image, which seems unnecessary in this case.

**Changes**
- chapter images are now scaled only based on height
- chapter images are not upscaled if they are lower resolution than the configured resolution
