### PR TITLE
Swagger: load xml comments from plugins

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -194,8 +194,9 @@ namespace Jellyfin.Server.Extensions
         /// Adds Swagger to the service collection.
         /// </summary>
         /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="pluginAssemblies">An IEnumerable containing all plugin assemblies.</param>
         /// <returns>The updated service collection.</returns>
-        public static IServiceCollection AddJellyfinApiSwagger(this IServiceCollection serviceCollection)
+        public static IServiceCollection AddJellyfinApiSwagger(this IServiceCollection serviceCollection, IEnumerable<Assembly> pluginAssemblies)
         {
             return serviceCollection.AddSwaggerGen(c =>
             {
@@ -230,6 +231,26 @@ namespace Jellyfin.Server.Extensions
                 foreach (var xmlFile in xmlFiles)
                 {
                     c.IncludeXmlComments(xmlFile);
+                }
+
+                // Add xml doc files from plugins.
+                foreach (var pluginAssembly in pluginAssemblies)
+                {
+                    var pluginDir = Path.GetDirectoryName(pluginAssembly.Location);
+                    if (string.IsNullOrEmpty(pluginDir))
+                    {
+                        continue;
+                    }
+
+                    var pluginXmlFiles = Directory.EnumerateFiles(
+                        pluginDir,
+                        "*.xml",
+                        SearchOption.TopDirectoryOnly);
+
+                    foreach (var xmlFile in pluginXmlFiles)
+                    {
+                        c.IncludeXmlComments(xmlFile);
+                    }
                 }
 
                 // Order actions by route path, then by http method.

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -66,9 +66,10 @@ namespace Jellyfin.Server
                 options.HttpsPort = _serverApplicationHost.HttpsPort;
             });
 
-            services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
+            var pluginAssemblies = _serverApplicationHost.GetApiPluginAssemblies();
+            services.AddJellyfinApi(pluginAssemblies, _serverConfigurationManager.GetNetworkConfiguration());
             services.AddJellyfinDbContext(_serverApplicationHost.ConfigurationManager, _configuration);
-            services.AddJellyfinApiSwagger();
+            services.AddJellyfinApiSwagger(pluginAssemblies);
 
             // configure custom legacy authentication
             services.AddCustomAuthentication();


### PR DESCRIPTION
**Changes**

This PR allows plugins to include xml comments from custom rest endpoints in the swagger docs.
With the comments included, you can then test your plugin's endpoints on the swagger page and also generate openapi client implementations for the plugin.

For this to work, the plugin must enable docs generation in the `.csproj` file:
```xml
  <PropertyGroup>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
  </PropertyGroup>
```

The resulting `My.Plugin.Name.xml` file must also be included in the release zip of the plugin.