### PR TITLE
Add language priority list and original language support for images

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -28,6 +28,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
@@ -1605,10 +1606,10 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Gets the preferred image languages as an array (e.g., ["en", "de", "fr", "nolang"]).
+        /// Gets the preferred image languages.
         /// </summary>
         /// <returns>Array of preferred image languages.</returns>
-        public string[] GetPreferredImageLanguages()
+        public ImageLanguageOption[] GetPreferredImageLanguages()
         {
             var libraryOptions = LibraryManager.GetLibraryOptions(this);
             return libraryOptions.PreferredImageLanguages;

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1605,6 +1605,16 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
+        /// Gets the preferred image languages as an array (e.g., ["en", "de", "fr", "nolang"]).
+        /// </summary>
+        /// <returns>Array of preferred image languages.</returns>
+        public string[] GetPreferredImageLanguages()
+        {
+            var libraryOptions = LibraryManager.GetLibraryOptions(this);
+            return libraryOptions.PreferredImageLanguages;
+        }
+
+        /// <summary>
         /// Gets the original language of the item, inheriting from parent items if necessary.
         /// </summary>
         /// <returns>System.String.</returns>

--- a/MediaBrowser.Model/Configuration/ImageLanguageOption.cs
+++ b/MediaBrowser.Model/Configuration/ImageLanguageOption.cs
@@ -1,0 +1,39 @@
+namespace MediaBrowser.Model.Configuration;
+
+/// <summary>
+/// Type of the image language option.
+/// </summary>
+public enum ImageLanguageType
+{
+    /// <summary>
+    /// Specific language code.
+    /// </summary>
+    LanguageCode,
+
+    /// <summary>
+    /// No language.
+    /// </summary>
+    NoLanguage,
+
+    /// <summary>
+    /// Original language of the media.
+    /// </summary>
+    OriginalLanguage
+}
+
+/// <summary>
+/// Class ImageLanguageOption.
+/// </summary>
+public class ImageLanguageOption
+{
+    /// <summary>
+    /// Gets or sets the language code.
+    /// Only relevant if OptionType is LanguageCode.
+    /// </summary>
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of this option.
+    /// </summary>
+    public ImageLanguageType OptionType { get; set; }
+}

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -12,6 +12,7 @@ namespace MediaBrowser.Model.Configuration
 
         public LibraryOptions()
         {
+            PreferredImageLanguages = Array.Empty<string>();
             TypeOptions = Array.Empty<TypeOptions>();
             DisabledSubtitleFetchers = Array.Empty<string>();
             DisabledMediaSegmentProviders = Array.Empty<string>();
@@ -78,6 +79,13 @@ namespace MediaBrowser.Model.Configuration
         /// </summary>
         /// <value>The preferred metadata language.</value>
         public string? PreferredMetadataLanguage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the preferred image languages as an array (e.g., ["en", "de", "fr", "nolang"]).
+        /// If empty, PreferredMetadataLanguage will be used as fallback.
+        /// </summary>
+        /// <value>The preferred image languages.</value>
+        public string[] PreferredImageLanguages { get; set; }
 
         /// <summary>
         /// Gets or sets the metadata country code.

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Linq;
 
 namespace MediaBrowser.Model.Configuration
 {
@@ -12,7 +11,7 @@ namespace MediaBrowser.Model.Configuration
 
         public LibraryOptions()
         {
-            PreferredImageLanguages = Array.Empty<string>();
+            PreferredImageLanguages = Array.Empty<ImageLanguageOption>();
             TypeOptions = Array.Empty<TypeOptions>();
             DisabledSubtitleFetchers = Array.Empty<string>();
             DisabledMediaSegmentProviders = Array.Empty<string>();
@@ -81,11 +80,11 @@ namespace MediaBrowser.Model.Configuration
         public string? PreferredMetadataLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the preferred image languages as an array (e.g., ["en", "de", "fr", "nolang"]).
+        /// Gets or sets the preferred image languages.
         /// If empty, PreferredMetadataLanguage will be used as fallback.
         /// </summary>
         /// <value>The preferred image languages.</value>
-        public string[] PreferredImageLanguages { get; set; }
+        public ImageLanguageOption[] PreferredImageLanguages { get; set; }
 
         /// <summary>
         /// Gets or sets the metadata country code.

--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -16,7 +16,7 @@ namespace MediaBrowser.Model.Extensions
         /// <param name="remoteImageInfos">The remote image infos.</param>
         /// <param name="requestedLanguage">The requested language for the images.</param>
         /// <returns>The ordered remote image infos.</returns>
-        public static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedLanguage)
+        private static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedLanguage)
         {
             if (string.IsNullOrWhiteSpace(requestedLanguage))
             {
@@ -35,17 +35,63 @@ namespace MediaBrowser.Model.Extensions
 
                     if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
                     {
-                        return 4;
+                        return 3;
                     }
 
                     if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
                     {
-                        return 3;
+                        return 2;
                     }
 
                     if (string.IsNullOrEmpty(i.Language))
                     {
-                        return 2;
+                        return 1;
+                    }
+
+                    return 0;
+                })
+                .ThenByDescending(i => Math.Round(i.CommunityRating ?? 0, 1))
+                .ThenByDescending(i => i.VoteCount ?? 0);
+        }
+
+        /// <summary>
+        /// Orders <see cref="RemoteImageInfo"/> by preferred languages in descending order.
+        /// </summary>
+        /// <param name="remoteImageInfos">The remote image infos.</param>
+        /// <param name="requestedLanguage">The requested language for fallback if no preferred languages are specified.</param>
+        /// <param name="preferredLanguages">Array of preferred languages (e.g., ["en", "de", "fr", "nolang"]). If null or empty, uses requestedLanguage.</param>
+        /// <returns>The ordered remote image infos.</returns>
+        public static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(
+            this IEnumerable<RemoteImageInfo> remoteImageInfos,
+            string requestedLanguage,
+            string[]? preferredLanguages)
+        {
+            // If no preferred languages are configured, fall back to the original behavior
+            if (preferredLanguages is null || preferredLanguages.Length == 0)
+            {
+                return remoteImageInfos.OrderByLanguageDescending(requestedLanguage);
+            }
+
+            return remoteImageInfos.OrderByDescending(i =>
+                {
+                    // Image priority ordering:
+                    //  - Images that match preferred image languages (in order of preference)
+                    //  - Images with no language if nolang is not in preferred image languages
+                    //  - Images that don't match the requested language
+
+                    for (int index = 0; index < preferredLanguages.Length; index++)
+                    {
+                        if (string.Equals(preferredLanguages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
+                            (string.Equals(preferredLanguages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
+                        {
+                            // Return a high priority value, with earlier languages getting higher values
+                            return 1 + (preferredLanguages.Length - index);
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(i.Language))
+                    {
+                        return 1;
                     }
 
                     return 0;

--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -14,14 +14,14 @@ namespace MediaBrowser.Model.Extensions
         /// Orders <see cref="RemoteImageInfo"/> by requested language in descending order, then "en", then no language, over other non-matches.
         /// </summary>
         /// <param name="remoteImageInfos">The remote image infos.</param>
-        /// <param name="requestedLanguage">The requested language for the images.</param>
+        /// <param name="requestedMetadataLanguage">The requested language for the images.</param>
         /// <returns>The ordered remote image infos.</returns>
-        private static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedLanguage)
+        private static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedMetadataLanguage)
         {
-            if (string.IsNullOrWhiteSpace(requestedLanguage))
+            if (string.IsNullOrWhiteSpace(requestedMetadataLanguage))
             {
                 // Default to English if no requested language is specified.
-                requestedLanguage = "en";
+                requestedMetadataLanguage = "en";
             }
 
             return remoteImageInfos.OrderByDescending(i =>
@@ -33,7 +33,7 @@ namespace MediaBrowser.Model.Extensions
                     //  - Images with no language
                     //  - Images that don't match the requested language
 
-                    if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(requestedMetadataLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
                     {
                         return 3;
                     }
@@ -58,18 +58,18 @@ namespace MediaBrowser.Model.Extensions
         /// Orders <see cref="RemoteImageInfo"/> by preferred languages in descending order.
         /// </summary>
         /// <param name="remoteImageInfos">The remote image infos.</param>
-        /// <param name="requestedLanguage">The requested language for fallback if no preferred languages are specified.</param>
-        /// <param name="preferredLanguages">Array of preferred languages (e.g., ["en", "de", "fr", "nolang"]). If null or empty, uses requestedLanguage.</param>
+        /// <param name="requestedMetadataLanguage">The requested metadata language for fallback if no preferred languages are specified.</param>
+        /// <param name="preferredImageLanguages">Array of preferred image languages (e.g., ["en", "de", "fr", "nolang"]). If null or empty, uses requestedLanguage.</param>
         /// <returns>The ordered remote image infos.</returns>
         public static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(
             this IEnumerable<RemoteImageInfo> remoteImageInfos,
-            string requestedLanguage,
-            string[]? preferredLanguages)
+            string requestedMetadataLanguage,
+            string[]? preferredImageLanguages)
         {
-            // If no preferred languages are configured, fall back to the original behavior
-            if (preferredLanguages is null || preferredLanguages.Length == 0)
+            // If no preferred image languages are configured, fall back to the original behavior
+            if (preferredImageLanguages is null || preferredImageLanguages.Length == 0)
             {
-                return remoteImageInfos.OrderByLanguageDescending(requestedLanguage);
+                return remoteImageInfos.OrderByLanguageDescending(requestedMetadataLanguage);
             }
 
             return remoteImageInfos.OrderByDescending(i =>
@@ -79,13 +79,13 @@ namespace MediaBrowser.Model.Extensions
                     //  - Images with no language if nolang is not in preferred image languages
                     //  - Images that don't match the requested language
 
-                    for (int index = 0; index < preferredLanguages.Length; index++)
+                    for (int index = 0; index < preferredImageLanguages.Length; index++)
                     {
-                        if (string.Equals(preferredLanguages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
-                            (string.Equals(preferredLanguages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
+                        if (string.Equals(preferredImageLanguages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
+                            (string.Equals(preferredImageLanguages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
                         {
                             // Return a high priority value, with earlier languages getting higher values
-                            return 1 + (preferredLanguages.Length - index);
+                            return 1 + (preferredImageLanguages.Length - index);
                         }
                     }
 

--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Providers;
 
 namespace MediaBrowser.Model.Extensions
@@ -15,12 +16,14 @@ namespace MediaBrowser.Model.Extensions
         /// </summary>
         /// <param name="remoteImageInfos">The remote image infos.</param>
         /// <param name="requestedMetadataLanguage">The requested metadata language for fallback if no preferred languages are specified.</param>
-        /// <param name="preferredImageLanguages">Array of preferred image languages (e.g., ["en", "de", "fr", "nolang"]). If null or empty, uses requestedLanguage.</param>
+        /// <param name="preferredImageLanguages">Array of preferred image languages. If null or empty, uses requestedMetadataLanguage.</param>
+        /// <param name="originalLanguage">The original language of the media, used for OriginalLanguage option type.</param>
         /// <returns>The ordered remote image infos.</returns>
         public static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(
             this IEnumerable<RemoteImageInfo> remoteImageInfos,
             string requestedMetadataLanguage,
-            string[]? preferredImageLanguages)
+            ImageLanguageOption[]? preferredImageLanguages = null,
+            string? originalLanguage = null)
         {
             if (string.IsNullOrWhiteSpace(requestedMetadataLanguage))
             {
@@ -28,31 +31,54 @@ namespace MediaBrowser.Model.Extensions
                 requestedMetadataLanguage = "en";
             }
 
-            string[] languages = preferredImageLanguages?.Length > 0
-                ? preferredImageLanguages
-                : [requestedMetadataLanguage, "en"];
-
-            return remoteImageInfos.OrderByDescending(i =>
+            if (preferredImageLanguages is null or { Length: 0 })
+            {
+                var languageOptions = new List<ImageLanguageOption>
                 {
-                    // Image priority ordering:
-                    //  - Images that match preferred image languages (in order of preference)
-                    //  - Images with no language if nolang is not in preferred image languages
-                    //  - Images that don't match the requested language
+                    new() { OptionType = ImageLanguageType.LanguageCode, Language = requestedMetadataLanguage }
+                };
 
-                    for (int index = 0; index < languages.Length; index++)
-                    {
-                        if (string.Equals(languages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
-                            (string.Equals(languages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
-                        {
-                            // Return a high priority value, with earlier languages getting higher values
-                            return 1 + (languages.Length - index);
-                        }
-                    }
+                if (!string.Equals(requestedMetadataLanguage, "en", StringComparison.OrdinalIgnoreCase))
+                {
+                    languageOptions.Add(new() { OptionType = ImageLanguageType.LanguageCode, Language = "en" });
+                }
 
-                    return string.IsNullOrEmpty(i.Language) ? 1 : 0;
-                })
+                preferredImageLanguages = languageOptions.ToArray();
+            }
+
+            return remoteImageInfos
+                .OrderByDescending(i => GetLanguagePriority(i.Language, preferredImageLanguages, originalLanguage))
                 .ThenByDescending(i => Math.Round(i.CommunityRating ?? 0, 1))
                 .ThenByDescending(i => i.VoteCount ?? 0);
+        }
+
+        private static int GetLanguagePriority(string? imageLanguage, ImageLanguageOption[] preferredImageLanguages, string? originalLanguage)
+        {
+            // Image priority ordering:
+            //  - Images that match preferred image languages (in order of preference)
+            //  - Images with no language if option type NoLanguage is not in preferred image languages
+            //  - Images that don't match the requested language
+
+            for (int index = 0; index < preferredImageLanguages.Length; index++)
+            {
+                var option = preferredImageLanguages[index];
+
+                bool isMatch = option.OptionType switch
+                {
+                    ImageLanguageType.LanguageCode => !string.IsNullOrEmpty(option.Language) && string.Equals(option.Language, imageLanguage, StringComparison.OrdinalIgnoreCase),
+                    ImageLanguageType.NoLanguage => string.IsNullOrEmpty(imageLanguage),
+                    ImageLanguageType.OriginalLanguage => !string.IsNullOrEmpty(originalLanguage) && string.Equals(originalLanguage, imageLanguage, StringComparison.OrdinalIgnoreCase),
+                    _ => false
+                };
+
+                if (isMatch)
+                {
+                    // Return a high priority value, with earlier languages getting higher values
+                    return 1 + (preferredImageLanguages.Length - index);
+                }
+            }
+
+            return string.IsNullOrEmpty(imageLanguage) ? 1 : 0;
         }
     }
 }

--- a/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
+++ b/MediaBrowser.Model/Extensions/EnumerableExtensions.cs
@@ -11,50 +11,6 @@ namespace MediaBrowser.Model.Extensions
     public static class EnumerableExtensions
     {
         /// <summary>
-        /// Orders <see cref="RemoteImageInfo"/> by requested language in descending order, then "en", then no language, over other non-matches.
-        /// </summary>
-        /// <param name="remoteImageInfos">The remote image infos.</param>
-        /// <param name="requestedMetadataLanguage">The requested language for the images.</param>
-        /// <returns>The ordered remote image infos.</returns>
-        private static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedMetadataLanguage)
-        {
-            if (string.IsNullOrWhiteSpace(requestedMetadataLanguage))
-            {
-                // Default to English if no requested language is specified.
-                requestedMetadataLanguage = "en";
-            }
-
-            return remoteImageInfos.OrderByDescending(i =>
-                {
-                    // Image priority ordering:
-                    //  - Images that match the requested language
-                    //  - TODO: Images that match the original language
-                    //  - Images in English
-                    //  - Images with no language
-                    //  - Images that don't match the requested language
-
-                    if (string.Equals(requestedMetadataLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return 3;
-                    }
-
-                    if (string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return 2;
-                    }
-
-                    if (string.IsNullOrEmpty(i.Language))
-                    {
-                        return 1;
-                    }
-
-                    return 0;
-                })
-                .ThenByDescending(i => Math.Round(i.CommunityRating ?? 0, 1))
-                .ThenByDescending(i => i.VoteCount ?? 0);
-        }
-
-        /// <summary>
         /// Orders <see cref="RemoteImageInfo"/> by preferred languages in descending order.
         /// </summary>
         /// <param name="remoteImageInfos">The remote image infos.</param>
@@ -66,11 +22,15 @@ namespace MediaBrowser.Model.Extensions
             string requestedMetadataLanguage,
             string[]? preferredImageLanguages)
         {
-            // If no preferred image languages are configured, fall back to the original behavior
-            if (preferredImageLanguages is null || preferredImageLanguages.Length == 0)
+            if (string.IsNullOrWhiteSpace(requestedMetadataLanguage))
             {
-                return remoteImageInfos.OrderByLanguageDescending(requestedMetadataLanguage);
+                // Default to English if no requested language is specified.
+                requestedMetadataLanguage = "en";
             }
+
+            string[] languages = preferredImageLanguages?.Length > 0
+                ? preferredImageLanguages
+                : [requestedMetadataLanguage, "en"];
 
             return remoteImageInfos.OrderByDescending(i =>
                 {
@@ -79,22 +39,17 @@ namespace MediaBrowser.Model.Extensions
                     //  - Images with no language if nolang is not in preferred image languages
                     //  - Images that don't match the requested language
 
-                    for (int index = 0; index < preferredImageLanguages.Length; index++)
+                    for (int index = 0; index < languages.Length; index++)
                     {
-                        if (string.Equals(preferredImageLanguages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
-                            (string.Equals(preferredImageLanguages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
+                        if (string.Equals(languages[index], i.Language, StringComparison.OrdinalIgnoreCase) ||
+                            (string.Equals(languages[index], "nolang", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(i.Language)))
                         {
                             // Return a high priority value, with earlier languages getting higher values
-                            return 1 + (preferredImageLanguages.Length - index);
+                            return 1 + (languages.Length - index);
                         }
                     }
 
-                    if (string.IsNullOrEmpty(i.Language))
-                    {
-                        return 1;
-                    }
-
-                    return 0;
+                    return string.IsNullOrEmpty(i.Language) ? 1 : 0;
                 })
                 .ThenByDescending(i => Math.Round(i.CommunityRating ?? 0, 1))
                 .ThenByDescending(i => i.VoteCount ?? 0);

--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -278,7 +278,7 @@ namespace MediaBrowser.Providers.Manager
             IRemoteImageProvider provider,
             ImageRefreshOptions refreshOptions,
             TypeOptions savedOptions,
-            List<string> preferredImageLanguages,
+            List<ImageLanguageOption> preferredImageLanguages,
             int backdropLimit,
             List<ImageType> downloadedImages,
             RefreshResult result,

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -340,8 +340,6 @@ namespace MediaBrowser.Providers.Manager
             CancellationToken cancellationToken,
             ImageType? type = null)
         {
-            bool hasPreferredMetadataLanguage = !string.IsNullOrWhiteSpace(preferredMetadataLanguage);
-            bool hasPreferredImageLanguages = preferredImageLanguages.Length > 0;
             string? originalLanguage = item.GetInheritedOriginalLanguage();
 
             try
@@ -358,37 +356,7 @@ namespace MediaBrowser.Providers.Manager
                     return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages, originalLanguage);
                 }
 
-                {
-                    if (hasPreferredImageLanguages)
-                    {
-                        var validLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        foreach (var opt in preferredImageLanguages)
-                        {
-                            switch (opt.OptionType)
-                            {
-                                case ImageLanguageType.LanguageCode when !string.IsNullOrEmpty(opt.Language):
-                                    validLanguages.Add(opt.Language);
-                                    break;
-                                case ImageLanguageType.OriginalLanguage when !string.IsNullOrEmpty(originalLanguage):
-                                    validLanguages.Add(originalLanguage);
-                                    break;
-                            }
-                        }
-
-                        // Filter out languages that do not match the preferred image languages.
-                        result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
-                                                   validLanguages.Contains(i.Language));
-                    }
-                    else if (hasPreferredMetadataLanguage)
-                    {
-                        // Fallback to metadata language if no image languages configured
-                        //
-                        // TODO: should exception case of "en" (English) eventually be removed?
-                        result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
-                                                   string.Equals(preferredMetadataLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
-                                                   string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
-                    }
-                }
+                result = FilterImagesByLanguage(result, preferredImageLanguages, originalLanguage, preferredMetadataLanguage);
 
                 return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages, originalLanguage);
             }
@@ -401,6 +369,46 @@ namespace MediaBrowser.Providers.Manager
                 _logger.LogError(ex, "{ProviderName} failed in GetImageInfos for type {ItemType} at {ItemPath}", provider.GetType().Name, item.GetType().Name, item.Path);
                 return Enumerable.Empty<RemoteImageInfo>();
             }
+        }
+
+        private static IEnumerable<RemoteImageInfo> FilterImagesByLanguage(
+            IEnumerable<RemoteImageInfo> images,
+            ImageLanguageOption[] preferredImageLanguages,
+            string? originalLanguage,
+            string preferredMetadataLanguage)
+        {
+            if (preferredImageLanguages.Length > 0)
+            {
+                var validLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var opt in preferredImageLanguages)
+                {
+                    switch (opt.OptionType)
+                    {
+                        case ImageLanguageType.LanguageCode when !string.IsNullOrEmpty(opt.Language):
+                            validLanguages.Add(opt.Language);
+                            break;
+                        case ImageLanguageType.OriginalLanguage when !string.IsNullOrEmpty(originalLanguage):
+                            validLanguages.Add(originalLanguage);
+                            break;
+                    }
+                }
+
+                // Filter out languages that do not match the preferred image languages.
+                return images.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
+                                           validLanguages.Contains(i.Language));
+            }
+
+            if (!string.IsNullOrWhiteSpace(preferredMetadataLanguage))
+            {
+                // Fallback to metadata language if no image languages configured
+                //
+                // TODO: should exception case of "en" (English) eventually be removed?
+                return images.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
+                                           string.Equals(preferredMetadataLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
+                                           string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
+            }
+
+            return images;
         }
 
         /// <inheritdoc/>

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -1229,7 +1229,15 @@ namespace MediaBrowser.Providers.Manager
         private async Task RefreshArtist(MusicArtist item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             var albums = _libraryManager
-                .GetItemList(new InternalItemsQuery { IncludeItemTypes = new[] { BaseItemKind.MusicAlbum }, ArtistIds = new[] { item.Id }, DtoOptions = new DtoOptions(false) { EnableImages = false } })
+                .GetItemList(new InternalItemsQuery
+                {
+                    IncludeItemTypes = new[] { BaseItemKind.MusicAlbum },
+                    ArtistIds = new[] { item.Id },
+                    DtoOptions = new DtoOptions(false)
+                    {
+                        EnableImages = false
+                    }
+                })
                 .OfType<MusicAlbum>();
 
             var musicArtists = albums

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -335,13 +335,14 @@ namespace MediaBrowser.Providers.Manager
             BaseItem item,
             IRemoteImageProvider provider,
             string preferredMetadataLanguage,
-            string[] preferredImageLanguages,
+            ImageLanguageOption[] preferredImageLanguages,
             bool includeAllLanguages,
             CancellationToken cancellationToken,
             ImageType? type = null)
         {
             bool hasPreferredMetadataLanguage = !string.IsNullOrWhiteSpace(preferredMetadataLanguage);
-            bool hasPreferredImageLanguages = preferredImageLanguages?.Length > 0;
+            bool hasPreferredImageLanguages = preferredImageLanguages.Length > 0;
+            string? originalLanguage = item.GetInheritedOriginalLanguage();
 
             try
             {
@@ -352,13 +353,31 @@ namespace MediaBrowser.Providers.Manager
                     result = result.Where(i => i.Type == type.Value);
                 }
 
-                if (!includeAllLanguages)
+                if (includeAllLanguages)
+                {
+                    return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages, originalLanguage);
+                }
+
                 {
                     if (hasPreferredImageLanguages)
                     {
+                        var validLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var opt in preferredImageLanguages)
+                        {
+                            switch (opt.OptionType)
+                            {
+                                case ImageLanguageType.LanguageCode when !string.IsNullOrEmpty(opt.Language):
+                                    validLanguages.Add(opt.Language);
+                                    break;
+                                case ImageLanguageType.OriginalLanguage when !string.IsNullOrEmpty(originalLanguage):
+                                    validLanguages.Add(originalLanguage);
+                                    break;
+                            }
+                        }
+
                         // Filter out languages that do not match the preferred image languages.
                         result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
-                                                   preferredImageLanguages!.Contains(i.Language, StringComparer.OrdinalIgnoreCase));
+                                                   validLanguages.Contains(i.Language));
                     }
                     else if (hasPreferredMetadataLanguage)
                     {
@@ -371,7 +390,7 @@ namespace MediaBrowser.Providers.Manager
                     }
                 }
 
-                return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages);
+                return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages, originalLanguage);
             }
             catch (OperationCanceledException)
             {

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -310,9 +310,10 @@ namespace MediaBrowser.Providers.Manager
                 providers = providers.Where(i => i.GetSupportedImages(item).Contains(query.ImageType.Value));
             }
 
-            var preferredLanguage = item.GetPreferredMetadataLanguage();
+            var preferredMetadataLanguage = item.GetPreferredMetadataLanguage();
+            var preferredImageLanguages = item.GetPreferredImageLanguages();
 
-            var tasks = providers.Select(i => GetImages(item, i, preferredLanguage, query.IncludeAllLanguages, cancellationToken, query.ImageType));
+            var tasks = providers.Select(i => GetImages(item, i, preferredMetadataLanguage, preferredImageLanguages, query.IncludeAllLanguages, cancellationToken, query.ImageType));
 
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -324,7 +325,8 @@ namespace MediaBrowser.Providers.Manager
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="provider">The provider.</param>
-        /// <param name="preferredLanguage">The preferred language.</param>
+        /// <param name="preferredMetadataLanguage">The preferred language.</param>
+        /// <param name="preferredImageLanguages">The preferred image languages.</param>
         /// <param name="includeAllLanguages">Whether to include all languages in results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="type">The type.</param>
@@ -332,12 +334,14 @@ namespace MediaBrowser.Providers.Manager
         private async Task<IEnumerable<RemoteImageInfo>> GetImages(
             BaseItem item,
             IRemoteImageProvider provider,
-            string preferredLanguage,
+            string preferredMetadataLanguage,
+            string[] preferredImageLanguages,
             bool includeAllLanguages,
             CancellationToken cancellationToken,
             ImageType? type = null)
         {
-            bool hasPreferredLanguage = !string.IsNullOrWhiteSpace(preferredLanguage);
+            bool hasPreferredMetadataLanguage = !string.IsNullOrWhiteSpace(preferredMetadataLanguage);
+            bool hasPreferredImageLanguages = preferredImageLanguages?.Length > 0;
 
             try
             {
@@ -348,17 +352,26 @@ namespace MediaBrowser.Providers.Manager
                     result = result.Where(i => i.Type == type.Value);
                 }
 
-                if (!includeAllLanguages && hasPreferredLanguage)
+                if (!includeAllLanguages)
                 {
-                    // Filter out languages that do not match the preferred languages.
-                    //
-                    // TODO: should exception case of "en" (English) eventually be removed?
-                    result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
-                                               string.Equals(preferredLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
-                                               string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
+                    if (hasPreferredImageLanguages)
+                    {
+                        // Filter out languages that do not match the preferred image languages.
+                        result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
+                                                   preferredImageLanguages!.Contains(i.Language, StringComparer.OrdinalIgnoreCase));
+                    }
+                    else if (hasPreferredMetadataLanguage)
+                    {
+                        // Fallback to metadata language if no image languages configured
+                        //
+                        // TODO: should exception case of "en" (English) eventually be removed?
+                        result = result.Where(i => string.IsNullOrWhiteSpace(i.Language) ||
+                                                   string.Equals(preferredMetadataLanguage, i.Language, StringComparison.OrdinalIgnoreCase) ||
+                                                   string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase));
+                    }
                 }
 
-                return result.OrderByLanguageDescending(preferredLanguage);
+                return result.OrderByLanguageDescending(preferredMetadataLanguage, preferredImageLanguages);
             }
             catch (OperationCanceledException)
             {
@@ -1216,15 +1229,7 @@ namespace MediaBrowser.Providers.Manager
         private async Task RefreshArtist(MusicArtist item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             var albums = _libraryManager
-                .GetItemList(new InternalItemsQuery
-                {
-                    IncludeItemTypes = new[] { BaseItemKind.MusicAlbum },
-                    ArtistIds = new[] { item.Id },
-                    DtoOptions = new DtoOptions(false)
-                    {
-                        EnableImages = false
-                    }
-                })
+                .GetItemList(new InternalItemsQuery { IncludeItemTypes = new[] { BaseItemKind.MusicAlbum }, ArtistIds = new[] { item.Id }, DtoOptions = new DtoOptions(false) { EnableImages = false } })
                 .OfType<MusicAlbum>();
 
             var musicArtists = albums

--- a/tests/Jellyfin.Model.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
 using Xunit;
@@ -70,7 +71,7 @@ public class EnumerableExtensionsTests
 
         var result = images.OrderByLanguageDescending(null!).ToList();
 
-        // With null requested language, English becomes the preferred language (score 4)
+        // With null requested language, English becomes the preferred language (score 2)
         Assert.Equal("en", result[0].Language);
         Assert.Equal("fr", result[1].Language);
     }
@@ -78,8 +79,8 @@ public class EnumerableExtensionsTests
     [Fact]
     public void OrderByLanguageDescending_EnglishRequested_NoDoubleBoost()
     {
-        // When requested language IS English, "en" gets score 4 (requested match),
-        // no-language gets score 2, others get score 0
+        // When requested language IS English, "en" gets score 2 (requested match),
+        // no-language gets score 1, others get score 0
         var images = new[]
         {
             new RemoteImageInfo { Language = null, CommunityRating = 9.0, VoteCount = 500 },
@@ -112,5 +113,71 @@ public class EnumerableExtensionsTests
         Assert.Equal("en", result[1].Language);
         Assert.Null(result[2].Language);
         Assert.Equal("fr", result[3].Language);
+    }
+
+    [Fact]
+    public void OrderByLanguageDescending_WithPreferredImageLanguages_RespectsCustomOrder()
+    {
+        var images = new[]
+        {
+            new RemoteImageInfo { Language = "fr", CommunityRating = 8.0, VoteCount = 100 },
+            new RemoteImageInfo { Language = "de", CommunityRating = 8.0, VoteCount = 100 },
+            new RemoteImageInfo { Language = "es", CommunityRating = 8.0, VoteCount = 100 },
+        };
+
+        var preferredOptions = new[]
+        {
+            new ImageLanguageOption { OptionType = ImageLanguageType.LanguageCode, Language = "es" },
+            new ImageLanguageOption { OptionType = ImageLanguageType.LanguageCode, Language = "de" }
+        };
+
+        var result = images.OrderByLanguageDescending("en", preferredImageLanguages: preferredOptions).ToList();
+
+        // Should completely ignore the "en" requested fallback and prioritize "es" then "de"
+        Assert.Equal("es", result[0].Language);
+        Assert.Equal("de", result[1].Language);
+        Assert.Equal("fr", result[2].Language);
+    }
+
+    [Fact]
+    public void OrderByLanguageDescending_WithOriginalLanguage_CaseInsensitiveMatch()
+    {
+        var images = new[]
+        {
+            new RemoteImageInfo { Language = "de", CommunityRating = 8.0, VoteCount = 100 },
+            new RemoteImageInfo { Language = "en", CommunityRating = 8.0, VoteCount = 100 },
+        };
+
+        var preferredOptions = new[]
+        {
+            new ImageLanguageOption { OptionType = ImageLanguageType.OriginalLanguage }
+        };
+
+        // Supplying uppercase "DE" to verify case-insensitive string matching introduced in refactoring
+        var result = images.OrderByLanguageDescending("fr", originalLanguage: "DE", preferredImageLanguages: preferredOptions).ToList();
+
+        Assert.Equal("de", result[0].Language);
+        Assert.Equal("en", result[1].Language);
+    }
+
+    [Fact]
+    public void OrderByLanguageDescending_WithNoLanguageOption_PrioritizesImagesWithoutLanguage()
+    {
+        var images = new[]
+        {
+            new RemoteImageInfo { Language = "en", CommunityRating = 8.0, VoteCount = 100 },
+            new RemoteImageInfo { Language = null, CommunityRating = 8.0, VoteCount = 100 },
+        };
+
+        var preferredOptions = new[]
+        {
+            new ImageLanguageOption { OptionType = ImageLanguageType.NoLanguage }
+        };
+
+        var result = images.OrderByLanguageDescending("en", preferredImageLanguages: preferredOptions).ToList();
+
+        // No language should come first based on explicit configuration
+        Assert.Null(result[0].Language);
+        Assert.Equal("en", result[1].Language);
     }
 }

--- a/tests/Jellyfin.Model.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -140,12 +140,12 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
-    public void OrderByLanguageDescending_WithOriginalLanguage_CaseInsensitiveMatch()
+    public void OrderByLanguageDescending_WithOriginalLanguage_PrefersOriginal()
     {
         var images = new[]
         {
             new RemoteImageInfo { Language = "de", CommunityRating = 8.0, VoteCount = 100 },
-            new RemoteImageInfo { Language = "en", CommunityRating = 8.0, VoteCount = 100 },
+            new RemoteImageInfo { Language = "en", CommunityRating = 9.0, VoteCount = 200 },
         };
 
         var preferredOptions = new[]
@@ -153,11 +153,33 @@ public class EnumerableExtensionsTests
             new ImageLanguageOption { OptionType = ImageLanguageType.OriginalLanguage }
         };
 
-        // Supplying uppercase "DE" to verify case-insensitive string matching introduced in refactoring
-        var result = images.OrderByLanguageDescending("fr", originalLanguage: "DE", preferredImageLanguages: preferredOptions).ToList();
+        var result = images.OrderByLanguageDescending("fr", originalLanguage: "de", preferredImageLanguages: preferredOptions).ToList();
 
+        // "de" is the original language and should be preferred, even with a lower rating.
         Assert.Equal("de", result[0].Language);
         Assert.Equal("en", result[1].Language);
+    }
+
+    [Fact]
+    public void OrderByLanguageDescending_WithOriginalLanguage_IgnoresNull()
+    {
+        var images = new[]
+        {
+            new RemoteImageInfo { Language = "en", CommunityRating = 9.0, VoteCount = 200 },
+            new RemoteImageInfo { Language = null, CommunityRating = 8.0, VoteCount = 100 },
+        };
+
+        var preferredOptions = new[]
+        {
+            new ImageLanguageOption { OptionType = ImageLanguageType.OriginalLanguage },
+            new ImageLanguageOption { OptionType = ImageLanguageType.LanguageCode, Language = "en" }
+        };
+
+        // A null originalLanguage should not match the image with no language.
+        var result = images.OrderByLanguageDescending("fr", originalLanguage: null, preferredImageLanguages: preferredOptions).ToList();
+
+        Assert.Equal("en", result[0].Language);
+        Assert.Null(result[1].Language);
     }
 
     [Fact]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->



**Changes**
Implements a new field PreferredImageLanguages in libraryOptions that accepts an array of image language options. These options can be one of three types:
- A specific language
- No language
- The original language of the media

If the array has values, the server will sort images based on this explicit order. It will only fall back to no-language images and not to other languages, to avoid adding images in non-preferred languages. When no preferred image languages are set, it will fall back to the old default behavior.

The PR for jellyfin-web: https://github.com/jellyfin/jellyfin-web/pull/7492

**Features implemented**
https://features.jellyfin.org/posts/2173/image-fetcher-preferred-language
https://features.jellyfin.org/posts/2734/fallback-language-for-posters
https://features.jellyfin.org/posts/3192/logos-should-select-the-correct-language

Closes https://github.com/jellyfin/jellyfin/pull/14078