### PR TITLE
Skip hidden directories and .ignore paths in library monitoring

### DIFF
--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -352,6 +352,12 @@ namespace Emby.Server.Implementations.IO
                 return;
             }
 
+            var fileInfo = _fileSystem.GetFileSystemInfo(path);
+            if (DotIgnoreIgnoreRule.IsIgnored(fileInfo, null))
+            {
+                return;
+            }
+
             // Ignore certain files, If the parent of an ignored path has a change event, ignore that too
             foreach (var i in _tempIgnoredPaths.Keys)
             {

--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -83,6 +83,7 @@ namespace Emby.Server.Implementations.Library
 
             // Unix hidden files
             "**/.*",
+            "**/.*/**",
 
             // Mac - if you ever remove the above.
             // "**/._*",

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("/media/movies/#recycle", true)]
         [InlineData("thumbs.db", true)]
         [InlineData(@"C:\media\movies\movie.avi", false)]
-        [InlineData("/media/.hiddendir/file.mp4", false)]
+        [InlineData("/media/.hiddendir/file.mp4", true)]
         [InlineData("/media/dir/.hiddenfile.mp4", true)]
         [InlineData("/media/dir/._macjunk.mp4", true)]
         [InlineData("/volume1/video/Series/@eaDir", true)]
@@ -32,7 +32,7 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("/media/music/Foo B.A.R", false)]
         [InlineData("/media/music/Foo B.A.R.", false)]
         [InlineData("/movies/.zfs/snapshot/AutoM-2023-09", true)]
-        public void PathIgnored(string path, bool expected)
+        public void PathIgnored(string path,  bool expected)
         {
             Assert.Equal(expected, IgnorePatterns.ShouldIgnore(path));
         }


### PR DESCRIPTION
Prevents unnecessary library refreshes when files change in ignored directories.

**Changes**
- Check `.ignore` files during file system monitoring
- Add `**/.*/**` pattern to ignore contents of hidden directories

**Issues**
 Fixes #16021
