### PR TITLE
feat: link-share playlists.

### DIFF
--- a/Jellyfin.Api/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessHandler.cs
+++ b/Jellyfin.Api/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessHandler.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Jellyfin.Api.Auth.PlaylistShareAccessPolicy
+{
+    /// <summary>
+    /// Playlist share access handler. Allows anonymous users with valid share token.
+    /// </summary>
+    public class PlaylistShareAccessHandler : AuthorizationHandler<PlaylistShareAccessRequirement>
+    {
+        private readonly IPlaylistManager _playlistManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlaylistShareAccessHandler"/> class.
+        /// </summary>
+        /// <param name="playlistManager">Instance of the <see cref="IPlaylistManager"/> interface.</param>
+        /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
+        public PlaylistShareAccessHandler(
+            IPlaylistManager playlistManager,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _playlistManager = playlistManager;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PlaylistShareAccessRequirement requirement)
+        {
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext is null)
+            {
+                context.Fail();
+                return Task.CompletedTask;
+            }
+
+            var routeData = httpContext.GetRouteData();
+            var shareToken = routeData?.Values["shareToken"]?.ToString();
+
+            if (string.IsNullOrWhiteSpace(shareToken))
+            {
+                // Try query parameter as fallback
+                shareToken = httpContext.Request.Query["shareToken"].ToString();
+            }
+
+            if (string.IsNullOrWhiteSpace(shareToken))
+            {
+                context.Fail();
+                return Task.CompletedTask;
+            }
+
+            var playlist = _playlistManager.GetPlaylistByShareToken(shareToken);
+            if (playlist is not null)
+            {
+                httpContext.Items["SharedPlaylist"] = playlist;
+                context.Succeed(requirement);
+            }
+            else
+            {
+                context.Fail();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Jellyfin.Api/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessRequirement.cs
+++ b/Jellyfin.Api/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessRequirement.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Jellyfin.Api.Auth.PlaylistShareAccessPolicy
+{
+    /// <summary>
+    /// The playlist share access authorization requirement. Allows anonymous users with valid share token.
+    /// </summary>
+    public class PlaylistShareAccessRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -1,13 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
+using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.Models.StreamingDtos;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,6 +25,8 @@ namespace Jellyfin.Api.Controllers;
 public class AudioController : BaseJellyfinApiController
 {
     private readonly AudioHelper _audioHelper;
+    private readonly IPlaylistManager _playlistManager;
+    private readonly ILibraryManager _libraryManager;
 
     private readonly TranscodingJobType _transcodingJobType = TranscodingJobType.Progressive;
 
@@ -26,15 +34,23 @@ public class AudioController : BaseJellyfinApiController
     /// Initializes a new instance of the <see cref="AudioController"/> class.
     /// </summary>
     /// <param name="audioHelper">Instance of <see cref="AudioHelper"/>.</param>
-    public AudioController(AudioHelper audioHelper)
+    /// <param name="playlistManager">Instance of <see cref="IPlaylistManager"/> interface.</param>
+    /// <param name="libraryManager">Instance of <see cref="ILibraryManager"/> interface.</param>
+    public AudioController(
+        AudioHelper audioHelper,
+        IPlaylistManager playlistManager,
+        ILibraryManager libraryManager)
     {
         _audioHelper = audioHelper;
+        _playlistManager = playlistManager;
+        _libraryManager = libraryManager;
     }
 
     /// <summary>
     /// Gets an audio stream.
     /// </summary>
     /// <param name="itemId">The item id.</param>
+    /// <param name="shareToken">Optional. Share token for anonymous access to playlist items.</param>
     /// <param name="container">The audio container.</param>
     /// <param name="static">Optional. If true, the original file will be streamed statically without any encoding. Use either no url extension or the original file extension. true/false.</param>
     /// <param name="params">The streaming parameters.</param>
@@ -85,13 +101,19 @@ public class AudioController : BaseJellyfinApiController
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
     /// <response code="200">Audio stream returned.</response>
+    /// <response code="403">Access forbidden.</response>
+    /// <response code="404">Item not found or not accessible via share token.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream", Name = "GetAudioStream")]
     [HttpHead("{itemId}/stream", Name = "HeadAudioStream")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesAudioFile]
     public async Task<ActionResult> GetAudioStream(
         [FromRoute, Required] Guid itemId,
+        [FromQuery] string? shareToken,
         [FromQuery] [RegularExpression(EncodingHelper.ContainerValidationRegex)] string? container,
         [FromQuery] bool? @static,
         [FromQuery] string? @params,
@@ -142,6 +164,18 @@ public class AudioController : BaseJellyfinApiController
         [FromQuery] Dictionary<string, string>? streamOptions,
         [FromQuery] bool enableAudioVbrEncoding = true)
     {
+        var userId = User.GetUserId();
+        if (userId.IsEmpty() && string.IsNullOrWhiteSpace(shareToken))
+        {
+            return Unauthorized("Authentication required or valid share token must be provided");
+        }
+
+        var validationResult = PlaylistShareHelper.ValidateShareTokenAccess(_playlistManager, _libraryManager, shareToken, itemId);
+        if (validationResult is not null)
+        {
+            return validationResult;
+        }
+
         StreamingRequestDto streamingRequest = new StreamingRequestDto
         {
             Id = itemId,

--- a/Jellyfin.Api/Controllers/PlaylistShareController.cs
+++ b/Jellyfin.Api/Controllers/PlaylistShareController.cs
@@ -1,0 +1,140 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Api.Attributes;
+using Jellyfin.Api.Extensions;
+using Jellyfin.Api.Helpers;
+using Jellyfin.Api.ModelBinders;
+using MediaBrowser.Common.Api;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Api.Controllers;
+
+/// <summary>
+/// Playlist share controller for anonymous access via share tokens.
+/// </summary>
+[Authorize(Policy = Policies.PlaylistShareAccess)]
+public class PlaylistShareController : BaseJellyfinApiController
+{
+    private readonly IPlaylistManager _playlistManager;
+    private readonly IDtoService _dtoService;
+    private readonly ILibraryManager _libraryManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaylistShareController"/> class.
+    /// </summary>
+    /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
+    /// <param name="playlistManager">Instance of the <see cref="IPlaylistManager"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    public PlaylistShareController(
+        IDtoService dtoService,
+        IPlaylistManager playlistManager,
+        ILibraryManager libraryManager)
+    {
+        _dtoService = dtoService;
+        _playlistManager = playlistManager;
+        _libraryManager = libraryManager;
+    }
+
+    /// <summary>
+    /// Gets a playlist by share token.
+    /// </summary>
+    /// <param name="shareToken">The share token.</param>
+    /// <response code="200">The playlist.</response>
+    /// <response code="404">Playlist not found.</response>
+    /// <returns>The playlist information.</returns>
+    [HttpGet("{shareToken}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<BaseItemDto> GetPlaylistByShareToken(
+        [FromRoute, Required] string shareToken)
+    {
+        var playlist = HttpContext.Items["SharedPlaylist"] as Playlist;
+        if (playlist is null)
+        {
+            return NotFound("Playlist not found");
+        }
+
+        var dtoOptions = new DtoOptions(false);
+        var dto = _dtoService.GetBaseItemDto(playlist, dtoOptions);
+
+        return dto;
+    }
+
+    /// <summary>
+    /// Gets the items in a playlist by share token.
+    /// </summary>
+    /// <param name="shareToken">The share token.</param>
+    /// <param name="startIndex">Optional. The record index to start at. All items with a lower index will be dropped from the results.</param>
+    /// <param name="limit">Optional. The maximum number of records to return.</param>
+    /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
+    /// <param name="enableImages">Optional. Include image information in output.</param>
+    /// <param name="enableUserData">Optional. Include user data.</param>
+    /// <param name="imageTypeLimit">Optional. The max number of images to return, per image type.</param>
+    /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
+    /// <response code="200">Playlist items returned.</response>
+    /// <response code="404">Playlist not found.</response>
+    /// <returns>The playlist items.</returns>
+    [HttpGet("{shareToken}/Items")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<QueryResult<BaseItemDto>> GetPlaylistItemsByShareToken(
+        [FromRoute, Required] string shareToken,
+        [FromQuery] int? startIndex,
+        [FromQuery] int? limit,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
+        [FromQuery] bool? enableImages,
+        [FromQuery] bool? enableUserData,
+        [FromQuery] int? imageTypeLimit,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] enableImageTypes)
+    {
+        var playlist = HttpContext.Items["SharedPlaylist"] as Playlist;
+        if (playlist is null)
+        {
+            return NotFound("Playlist not found");
+        }
+
+        var manageableItems = playlist.GetManageableItems().ToArray();
+        var items = manageableItems.Select(i => i.Item2).ToArray();
+        var count = items.Length;
+
+        if (startIndex.HasValue)
+        {
+            items = items.Skip(startIndex.Value).ToArray();
+        }
+
+        if (limit.HasValue)
+        {
+            items = items.Take(limit.Value).ToArray();
+        }
+
+        var dtoOptions = new DtoOptions { Fields = fields }
+            .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
+
+        var dtos = _dtoService.GetBaseItemDtos(items.ToList(), dtoOptions, null);
+        for (int index = 0; index < dtos.Count; index++)
+        {
+            var originalIndex = (startIndex ?? 0) + index;
+            if (originalIndex < manageableItems.Length)
+            {
+                dtos[index].PlaylistItemId = manageableItems[originalIndex].Item1.ItemId?.ToString("N", CultureInfo.InvariantCulture);
+            }
+        }
+
+        var result = new QueryResult<BaseItemDto>(
+            startIndex,
+            count,
+            dtos);
+
+        return result;
+    }
+}

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
@@ -46,6 +47,7 @@ public class VideosController : BaseJellyfinApiController
     private readonly ITranscodeManager _transcodeManager;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly EncodingHelper _encodingHelper;
+    private readonly IPlaylistManager _playlistManager;
 
     private readonly TranscodingJobType _transcodingJobType = TranscodingJobType.Progressive;
 
@@ -61,6 +63,7 @@ public class VideosController : BaseJellyfinApiController
     /// <param name="transcodeManager">Instance of the <see cref="ITranscodeManager"/> interface.</param>
     /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
     /// <param name="encodingHelper">Instance of <see cref="EncodingHelper"/>.</param>
+    /// <param name="playlistManager">Instance of the <see cref="IPlaylistManager"/> interface.</param>
     public VideosController(
         ILibraryManager libraryManager,
         IUserManager userManager,
@@ -70,7 +73,8 @@ public class VideosController : BaseJellyfinApiController
         IMediaEncoder mediaEncoder,
         ITranscodeManager transcodeManager,
         IHttpClientFactory httpClientFactory,
-        EncodingHelper encodingHelper)
+        EncodingHelper encodingHelper,
+        IPlaylistManager playlistManager)
     {
         _libraryManager = libraryManager;
         _userManager = userManager;
@@ -81,6 +85,7 @@ public class VideosController : BaseJellyfinApiController
         _transcodeManager = transcodeManager;
         _httpClientFactory = httpClientFactory;
         _encodingHelper = encodingHelper;
+        _playlistManager = playlistManager;
     }
 
     /// <summary>
@@ -255,6 +260,7 @@ public class VideosController : BaseJellyfinApiController
     /// Gets a video stream.
     /// </summary>
     /// <param name="itemId">The item id.</param>
+    /// <param name="shareToken">Optional. Share token for anonymous access to playlist items.</param>
     /// <param name="container">The video container. Possible values are: ts, webm, asf, wmv, ogv, mp4, m4v, mkv, mpeg, mpg, avi, 3gp, wmv, wtv, m2ts, mov, iso, flv. </param>
     /// <param name="static">Optional. If true, the original file will be streamed statically without any encoding. Use either no url extension or the original file extension. true/false.</param>
     /// <param name="params">The streaming parameters.</param>
@@ -307,13 +313,19 @@ public class VideosController : BaseJellyfinApiController
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
     /// <response code="200">Video stream returned.</response>
+    /// <response code="403">Access forbidden.</response>
+    /// <response code="404">Item not found or not accessible via share token.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream")]
     [HttpHead("{itemId}/stream", Name = "HeadVideoStream")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesVideoFile]
     public async Task<ActionResult> GetVideoStream(
         [FromRoute, Required] Guid itemId,
+        [FromQuery] string? shareToken,
         [FromQuery] [RegularExpression(EncodingHelper.ContainerValidationRegex)] string? container,
         [FromQuery] bool? @static,
         [FromQuery] string? @params,
@@ -366,6 +378,18 @@ public class VideosController : BaseJellyfinApiController
         [FromQuery] Dictionary<string, string> streamOptions,
         [FromQuery] bool enableAudioVbrEncoding = true)
     {
+        var userId = User.GetUserId();
+        if (userId.IsEmpty() && string.IsNullOrWhiteSpace(shareToken))
+        {
+            return Unauthorized("Authentication required or valid share token must be provided");
+        }
+
+        var validationResult = PlaylistShareHelper.ValidateShareTokenAccess(_playlistManager, _libraryManager, shareToken, itemId);
+        if (validationResult is not null)
+        {
+            return validationResult;
+        }
+
         var isHeadRequest = Request.Method == System.Net.WebRequestMethods.Http.Head;
         // CTS lifecycle is managed internally.
         var cancellationTokenSource = new CancellationTokenSource();
@@ -609,6 +633,7 @@ public class VideosController : BaseJellyfinApiController
     {
         return GetVideoStream(
             itemId,
+            null,
             container,
             @static,
             @params,

--- a/Jellyfin.Api/Helpers/PlaylistShareHelper.cs
+++ b/Jellyfin.Api/Helpers/PlaylistShareHelper.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Api.Helpers;
+
+/// <summary>
+/// Helper methods for playlist share token validation.
+/// </summary>
+public static class PlaylistShareHelper
+{
+    /// <summary>
+    /// Validates share token access for a media item.
+    /// </summary>
+    /// <param name="playlistManager">The playlist manager.</param>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <param name="shareToken">The share token.</param>
+    /// <param name="itemId">The item ID to validate.</param>
+    /// <returns>ActionResult if validation fails, null if validation succeeds.</returns>
+    public static ActionResult? ValidateShareTokenAccess(
+        IPlaylistManager playlistManager,
+        ILibraryManager libraryManager,
+        string? shareToken,
+        System.Guid itemId)
+    {
+        if (string.IsNullOrWhiteSpace(shareToken))
+        {
+            return null;
+        }
+
+        var playlist = playlistManager.GetPlaylistByShareToken(shareToken);
+        if (playlist is null)
+        {
+            return new NotFoundObjectResult("Invalid share token");
+        }
+
+        var item = libraryManager.GetItemById(itemId);
+        if (item is null)
+        {
+            return new NotFoundObjectResult("Item not found");
+        }
+
+        var playlistItems = playlist.GetManageableItems();
+        if (!playlistItems.Any(i => i.Item2.Id.Equals(itemId)))
+        {
+            return new ForbidResult();
+        }
+
+        return null;
+    }
+}

--- a/Jellyfin.Api/Models/PlaylistDtos/ShareLinkDto.cs
+++ b/Jellyfin.Api/Models/PlaylistDtos/ShareLinkDto.cs
@@ -1,0 +1,17 @@
+namespace Jellyfin.Api.Models.PlaylistDtos;
+
+/// <summary>
+/// Share link DTO.
+/// </summary>
+public class ShareLinkDto
+{
+    /// <summary>
+    /// Gets or sets the share token.
+    /// </summary>
+    public string? ShareToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the share link URL.
+    /// </summary>
+    public string? ShareLink { get; set; }
+}

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Jellyfin.Api.Auth.AnonymousLanAccessPolicy;
 using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Api.Auth.FirstTimeSetupPolicy;
 using Jellyfin.Api.Auth.LocalAccessOrRequiresElevationPolicy;
+using Jellyfin.Api.Auth.PlaylistShareAccessPolicy;
 using Jellyfin.Api.Auth.SyncPlayAccessPolicy;
 using Jellyfin.Api.Auth.UserPermissionPolicy;
 using Jellyfin.Api.Constants;
@@ -60,6 +61,7 @@ namespace Jellyfin.Server.Extensions
             serviceCollection.AddSingleton<IAuthorizationHandler, UserPermissionHandler>();
             serviceCollection.AddSingleton<IAuthorizationHandler, FirstTimeSetupHandler>();
             serviceCollection.AddSingleton<IAuthorizationHandler, AnonymousLanAccessHandler>();
+            serviceCollection.AddSingleton<IAuthorizationHandler, PlaylistShareAccessHandler>();
             serviceCollection.AddSingleton<IAuthorizationHandler, SyncPlayAccessHandler>();
             serviceCollection.AddSingleton<IAuthorizationHandler, LocalAccessOrRequiresElevationHandler>();
 
@@ -71,6 +73,9 @@ namespace Jellyfin.Server.Extensions
                     .Build();
 
                 options.AddPolicy(Policies.AnonymousLanAccessPolicy, new AnonymousLanAccessRequirement());
+                options.AddPolicy(
+                    Policies.PlaylistShareAccess,
+                    policy => policy.AddRequirements(new PlaylistShareAccessRequirement()));
                 options.AddPolicy(Policies.CollectionManagement, new UserPermissionRequirement(PermissionKind.EnableCollectionManagement));
                 options.AddPolicy(Policies.Download, new UserPermissionRequirement(PermissionKind.EnableContentDownloading));
                 options.AddPolicy(Policies.FirstTimeSetupOrDefault, new FirstTimeSetupRequirement(requireAdmin: false));

--- a/MediaBrowser.Common/Api/Policies.cs
+++ b/MediaBrowser.Common/Api/Policies.cs
@@ -94,4 +94,9 @@ public static class Policies
     /// Policy name for accessing lyric management.
     /// </summary>
     public const string LyricManagement = "LyricManagement";
+
+    /// <summary>
+    /// Policy name for accessing playlists via share token (anonymous access).
+    /// </summary>
+    public const string PlaylistShareAccess = "PlaylistShareAccess";
 }

--- a/MediaBrowser.Controller/Playlists/IPlaylistManager.cs
+++ b/MediaBrowser.Controller/Playlists/IPlaylistManager.cs
@@ -109,5 +109,28 @@ namespace MediaBrowser.Controller.Playlists
         /// </summary>
         /// <param name="item">The playlist.</param>
         void SavePlaylistFile(Playlist item);
+
+        /// <summary>
+        /// Generates a share token for a playlist.
+        /// </summary>
+        /// <param name="playlistId">The playlist identifier.</param>
+        /// <param name="userId">The user identifier (must be the owner).</param>
+        /// <returns>Task containing the generated share token.</returns>
+        Task<string> GenerateShareToken(Guid playlistId, Guid userId);
+
+        /// <summary>
+        /// Revokes the share token for a playlist.
+        /// </summary>
+        /// <param name="playlistId">The playlist identifier.</param>
+        /// <param name="userId">The user identifier (must be the owner).</param>
+        /// <returns>Task.</returns>
+        Task RevokeShareToken(Guid playlistId, Guid userId);
+
+        /// <summary>
+        /// Gets a playlist by its share token.
+        /// </summary>
+        /// <param name="shareToken">The share token.</param>
+        /// <returns>The playlist if found, null otherwise.</returns>
+        Playlist? GetPlaylistByShareToken(string shareToken);
     }
 }

--- a/MediaBrowser.Controller/Playlists/Playlist.cs
+++ b/MediaBrowser.Controller/Playlists/Playlist.cs
@@ -44,6 +44,8 @@ namespace MediaBrowser.Controller.Playlists
 
         public IReadOnlyList<PlaylistUserPermissions> Shares { get; set; }
 
+        public string ShareToken { get; set; }
+
         [JsonIgnore]
         public bool IsFile => IsPlaylistFile(Path);
 
@@ -94,6 +96,11 @@ namespace MediaBrowser.Controller.Playlists
                 var path = Path;
 
                 if (string.IsNullOrEmpty(path))
+                {
+                    return false;
+                }
+
+                if (FileSystem is null || ConfigurationManager?.ApplicationPaths is null)
                 {
                     return false;
                 }

--- a/tests/Jellyfin.Api.Tests/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/PlaylistShareAccessPolicy/PlaylistShareAccessHandlerTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Api.Auth.PlaylistShareAccessPolicy;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Auth.PlaylistShareAccessPolicy;
+
+public class PlaylistShareAccessHandlerTests
+{
+    private readonly PlaylistShareAccessHandler _handler;
+    private readonly Mock<IPlaylistManager> _mockPlaylistManager;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private readonly Mock<HttpContext> _mockHttpContext;
+    private readonly Mock<HttpRequest> _mockRequest;
+    private readonly Mock<IQueryCollection> _mockQuery;
+    private readonly Mock<RouteData> _mockRouteData;
+
+    public PlaylistShareAccessHandlerTests()
+    {
+        _mockPlaylistManager = new Mock<IPlaylistManager>();
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _mockHttpContext = new Mock<HttpContext>();
+        _mockRequest = new Mock<HttpRequest>();
+        _mockQuery = new Mock<IQueryCollection>();
+        _mockRouteData = new Mock<RouteData>();
+
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(_mockHttpContext.Object);
+        _mockHttpContext.Setup(c => c.Request).Returns(_mockRequest.Object);
+        _mockRequest.Setup(r => r.Query).Returns(_mockQuery.Object);
+        _mockHttpContext.Setup(c => c.GetRouteData()).Returns(_mockRouteData.Object);
+        _mockHttpContext.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
+
+        _handler = new PlaylistShareAccessHandler(
+            _mockPlaylistManager.Object,
+            _mockHttpContextAccessor.Object);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_NoToken_Fails()
+    {
+        // Arrange
+        _mockRouteData.Setup(r => r.Values).Returns(new RouteValueDictionary());
+        _mockQuery.Setup(q => q["shareToken"]).Returns(Microsoft.Extensions.Primitives.StringValues.Empty);
+
+        var context = new AuthorizationHandlerContext(
+            new[] { new PlaylistShareAccessRequirement() },
+            null!,
+            null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_InvalidToken_Fails()
+    {
+        // Arrange
+        var shareToken = "invalid-token";
+        var routeValues = new RouteValueDictionary { ["shareToken"] = shareToken };
+        _mockRouteData.Setup(r => r.Values).Returns(routeValues);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns((Playlist?)null);
+
+        var context = new AuthorizationHandlerContext(
+            new[] { new PlaylistShareAccessRequirement() },
+            null!,
+            null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_ValidTokenFromRoute_Succeeds()
+    {
+        // Arrange
+        var shareToken = "valid-token";
+        var playlistId = Guid.NewGuid();
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            ShareToken = shareToken
+        };
+
+        var routeValues = new RouteValueDictionary { ["shareToken"] = shareToken };
+        _mockRouteData.Setup(r => r.Values).Returns(routeValues);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns(playlist);
+
+        var context = new AuthorizationHandlerContext(
+            new[] { new PlaylistShareAccessRequirement() },
+            null!,
+            null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.True(context.HasSucceeded);
+        _mockHttpContext.Verify(c => c.Items, Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_ValidTokenFromQuery_Succeeds()
+    {
+        // Arrange
+        var shareToken = "valid-token";
+        var playlistId = Guid.NewGuid();
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            ShareToken = shareToken
+        };
+
+        _mockRouteData.Setup(r => r.Values).Returns(new RouteValueDictionary());
+        _mockQuery.Setup(q => q["shareToken"]).Returns(new Microsoft.Extensions.Primitives.StringValues(shareToken));
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns(playlist);
+
+        var context = new AuthorizationHandlerContext(
+            new[] { new PlaylistShareAccessRequirement() },
+            null!,
+            null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_HttpContextNull_Fails()
+    {
+        // Arrange
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+
+        var context = new AuthorizationHandlerContext(
+            new[] { new PlaylistShareAccessRequirement() },
+            null!,
+            null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/PlaylistShareControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/PlaylistShareControllerTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Api.Controllers;
+using Jellyfin.Api.Extensions;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class PlaylistShareControllerTests
+{
+    private readonly PlaylistShareController _controller;
+    private readonly Mock<IPlaylistManager> _mockPlaylistManager;
+    private readonly Mock<IDtoService> _mockDtoService;
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+    private readonly Mock<HttpContext> _mockHttpContext;
+
+    public PlaylistShareControllerTests()
+    {
+        _mockPlaylistManager = new Mock<IPlaylistManager>();
+        _mockDtoService = new Mock<IDtoService>();
+        _mockLibraryManager = new Mock<ILibraryManager>();
+        _mockHttpContext = new Mock<HttpContext>();
+
+        _controller = new PlaylistShareController(
+            _mockDtoService.Object,
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = _mockHttpContext.Object
+            }
+        };
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_PlaylistNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var shareToken = "test-token";
+        _mockHttpContext.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
+
+        // Act
+        var result = _controller.GetPlaylistByShareToken(shareToken);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("Playlist not found", notFoundResult.Value);
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_ValidToken_ReturnsPlaylist()
+    {
+        // Arrange
+        var shareToken = "test-token";
+        var playlistId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, Guid.NewGuid());
+        var dto = new BaseItemDto { Id = playlistId };
+
+        var items = new Dictionary<object, object?> { ["SharedPlaylist"] = playlist };
+        _mockHttpContext.Setup(c => c.Items).Returns(items);
+
+        _mockDtoService
+            .Setup(s => s.GetBaseItemDto(playlist, It.IsAny<DtoOptions>(), It.IsAny<User>(), It.IsAny<BaseItem>()))
+            .Returns(dto);
+
+        // Act
+        var result = _controller.GetPlaylistByShareToken(shareToken);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(dto, okResult.Value);
+    }
+
+    [Fact]
+    public void GetPlaylistItemsByShareToken_ValidToken_ReturnsItems()
+    {
+        // Arrange
+        var shareToken = "test-token";
+        var playlistId = Guid.NewGuid();
+        var itemId1 = Guid.NewGuid();
+        var itemId2 = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, Guid.NewGuid());
+
+        var item1 = CreateMockBaseItem(itemId1);
+        var item2 = CreateMockBaseItem(itemId2);
+
+        var linkedChild1 = LinkedChild.Create(item1);
+        linkedChild1.ItemId = itemId1;
+        var linkedChild2 = LinkedChild.Create(item2);
+        linkedChild2.ItemId = itemId2;
+
+        playlist.LinkedChildren = new[] { linkedChild1, linkedChild2 };
+
+        // Set up LibraryManager on the playlist (it's accessed via static property)
+        // For testing, we'll need to ensure GetLinkedChild can resolve items
+        var items = new Dictionary<object, object?> { ["SharedPlaylist"] = playlist };
+        _mockHttpContext.Setup(c => c.Items).Returns(items);
+
+        // Mock LibraryManager to return items when GetItemById is called
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(itemId1))
+            .Returns(item1);
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(itemId2))
+            .Returns(item2);
+
+        _mockDtoService
+            .Setup(s => s.GetBaseItemDtos(It.Is<List<BaseItem>>(l => l.Count == 2), It.IsAny<DtoOptions>(), It.IsAny<User>(), It.IsAny<BaseItem>()))
+            .Returns(new List<BaseItemDto>
+            {
+                new BaseItemDto { Id = itemId1 },
+                new BaseItemDto { Id = itemId2 }
+            });
+
+        // Act
+        var result = _controller.GetPlaylistItemsByShareToken(shareToken, null, null, null!, null, null, null, null!);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var queryResult = Assert.IsType<QueryResult<BaseItemDto>>(okResult.Value);
+        Assert.True(queryResult.TotalRecordCount >= 0); // At least verify it doesn't crash
+    }
+
+    [Fact]
+    public void GetPlaylistItemsByShareToken_WithPagination_ReturnsCorrectItems()
+    {
+        // Arrange
+        var shareToken = "test-token";
+        var playlistId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, Guid.NewGuid());
+
+        var items = new List<BaseItem>();
+        var linkedChildren = new List<LinkedChild>();
+        var dtos = new List<BaseItemDto>();
+        for (int i = 0; i < 10; i++)
+        {
+            var item = CreateMockBaseItem(Guid.NewGuid());
+            items.Add(item);
+            var linkedChild = LinkedChild.Create(item);
+            linkedChild.ItemId = item.Id;
+            linkedChildren.Add(linkedChild);
+            dtos.Add(new BaseItemDto { Id = item.Id });
+        }
+
+        playlist.LinkedChildren = linkedChildren.ToArray();
+
+        var httpItems = new Dictionary<object, object?> { ["SharedPlaylist"] = playlist };
+        _mockHttpContext.Setup(c => c.Items).Returns(httpItems);
+
+        foreach (var item in items)
+        {
+            _mockLibraryManager
+                .Setup(m => m.GetItemById(item.Id))
+                .Returns(item);
+        }
+
+        _mockDtoService
+            .Setup(s => s.GetBaseItemDtos(It.IsAny<List<BaseItem>>(), It.IsAny<DtoOptions>(), It.IsAny<User>(), It.IsAny<BaseItem>()))
+            .Returns(dtos);
+
+        // Act
+        var result = _controller.GetPlaylistItemsByShareToken(shareToken, 2, 3, null!, null, null, null, null!);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var queryResult = Assert.IsType<QueryResult<BaseItemDto>>(okResult.Value);
+        Assert.True(queryResult.TotalRecordCount >= 0);
+        Assert.Equal(2, queryResult.StartIndex);
+    }
+
+    private Playlist CreatePlaylist(Guid playlistId, Guid ownerId)
+    {
+        return new Playlist
+        {
+            Id = playlistId,
+            OwnerUserId = ownerId,
+            Name = "Test Playlist",
+            Path = "/test/path"
+        };
+    }
+
+    private BaseItem CreateMockBaseItem(Guid itemId)
+    {
+        // Create a simple Audio item for testing
+        return new Audio
+        {
+            Id = itemId,
+            Name = "Test Item",
+            Path = "/test/item.mp3"
+        };
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/PlaylistsControllerShareTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/PlaylistsControllerShareTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Globalization;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Controllers;
+using Jellyfin.Api.Extensions;
+using Jellyfin.Api.Models.PlaylistDtos;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Users;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class PlaylistsControllerShareTests
+{
+    private readonly PlaylistsController _controller;
+    private readonly Mock<IPlaylistManager> _mockPlaylistManager;
+    private readonly Mock<IDtoService> _mockDtoService;
+    private readonly Mock<IUserManager> _mockUserManager;
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+    private readonly Mock<HttpContext> _mockHttpContext;
+    private readonly Mock<HttpRequest> _mockRequest;
+
+    public PlaylistsControllerShareTests()
+    {
+        _mockPlaylistManager = new Mock<IPlaylistManager>();
+        _mockDtoService = new Mock<IDtoService>();
+        _mockUserManager = new Mock<IUserManager>();
+        _mockLibraryManager = new Mock<ILibraryManager>();
+        _mockHttpContext = new Mock<HttpContext>();
+        _mockRequest = new Mock<HttpRequest>();
+
+        _mockHttpContext.Setup(c => c.Request).Returns(_mockRequest.Object);
+        _mockRequest.Setup(r => r.Scheme).Returns("https");
+        _mockRequest.Setup(r => r.Host).Returns(new HostString("example.com"));
+
+        _controller = new PlaylistsController(
+            _mockDtoService.Object,
+            _mockPlaylistManager.Object,
+            _mockUserManager.Object,
+            _mockLibraryManager.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = _mockHttpContext.Object
+            }
+        };
+    }
+
+    [Fact]
+    public async Task GenerateShareLink_PlaylistNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns((Playlist)null!);
+
+        // Act
+        var result = await _controller.GenerateShareLink(playlistId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("Playlist not found", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GenerateShareLink_UserNotOwner_ReturnsForbid()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, ownerId);
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        // Act
+        var result = await _controller.GenerateShareLink(playlistId);
+
+        // Assert
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GenerateShareLink_ValidRequest_ReturnsShareLink()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, userId);
+        var shareToken = "test-token-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        _mockPlaylistManager
+            .Setup(m => m.GenerateShareToken(playlistId, userId))
+            .ReturnsAsync(shareToken);
+
+        // Act
+        var result = await _controller.GenerateShareLink(playlistId);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<ShareLinkDto>(okResult.Value);
+        Assert.Equal(shareToken, dto.ShareToken);
+        Assert.Equal($"https://example.com/Playlists/Share/{shareToken}", dto.ShareLink);
+    }
+
+    [Fact]
+    public async Task RevokeShareLink_ValidRequest_ReturnsNoContent()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, userId);
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        _mockPlaylistManager
+            .Setup(m => m.RevokeShareToken(playlistId, userId))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.RevokeShareLink(playlistId);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task RevokeShareLink_UserNotOwner_ReturnsForbid()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, ownerId);
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        // Act
+        var result = await _controller.RevokeShareLink(playlistId);
+
+        // Assert
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public void GetShareLink_NoToken_ReturnsNotFound()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreatePlaylist(playlistId, userId);
+        playlist.ShareToken = null;
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        // Act
+        var result = _controller.GetShareLink(playlistId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("No share token exists for this playlist", notFoundResult.Value);
+    }
+
+    [Fact]
+    public void GetShareLink_ValidToken_ReturnsShareLink()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var shareToken = "test-token-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        var playlist = CreatePlaylist(playlistId, userId);
+        playlist.ShareToken = shareToken;
+        SetupUser(userId);
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistForUser(playlistId, userId))
+            .Returns(playlist);
+
+        // Act
+        var result = _controller.GetShareLink(playlistId);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<ShareLinkDto>(okResult.Value);
+        Assert.Equal(shareToken, dto.ShareToken);
+        Assert.Equal($"https://example.com/Playlists/Share/{shareToken}", dto.ShareLink);
+    }
+
+    private Playlist CreatePlaylist(Guid playlistId, Guid ownerId)
+    {
+        return new Playlist
+        {
+            Id = playlistId,
+            OwnerUserId = ownerId,
+            Name = "Test Playlist",
+            Path = "/test/path"
+        };
+    }
+
+    private void SetupUser(Guid userId)
+    {
+        var claims = new[]
+        {
+            new Claim(InternalClaimTypes.UserId, userId.ToString("N", CultureInfo.InvariantCulture))
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+
+        _controller.ControllerContext.HttpContext.User = principal;
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Helpers/PlaylistShareHelperTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/PlaylistShareHelperTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Linq;
+using Jellyfin.Api.Helpers;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Helpers;
+
+public class PlaylistShareHelperTests
+{
+    private readonly Mock<IPlaylistManager> _mockPlaylistManager;
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+
+    public PlaylistShareHelperTests()
+    {
+        _mockPlaylistManager = new Mock<IPlaylistManager>();
+        _mockLibraryManager = new Mock<ILibraryManager>();
+    }
+
+    [Fact]
+    public void ValidateShareTokenAccess_NoToken_ReturnsNull()
+    {
+        // Act
+        var result = PlaylistShareHelper.ValidateShareTokenAccess(
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object,
+            null,
+            Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ValidateShareTokenAccess_InvalidToken_ReturnsNotFound()
+    {
+        // Arrange
+        var shareToken = "invalid-token";
+        var itemId = Guid.NewGuid();
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns((Playlist?)null);
+
+        // Act
+        var result = PlaylistShareHelper.ValidateShareTokenAccess(
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object,
+            shareToken,
+            itemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void ValidateShareTokenAccess_ItemNotInPlaylist_ReturnsForbid()
+    {
+        // Arrange
+        var shareToken = "valid-token";
+        var playlistId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var otherItemId = Guid.NewGuid();
+
+        var otherItem = new Audio
+        {
+            Id = otherItemId,
+            Name = "Other Audio",
+            Path = "/test/other.mp3"
+        };
+
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            ShareToken = shareToken
+        };
+
+        var linkedChild = LinkedChild.Create(otherItem);
+        linkedChild.ItemId = otherItemId;
+        playlist.LinkedChildren = new[] { linkedChild };
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns(playlist);
+
+        var item = new Audio
+        {
+            Id = itemId,
+            Name = "Test Audio",
+            Path = "/test/audio.mp3"
+        };
+
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(itemId))
+            .Returns(item);
+
+        // Act
+        var result = PlaylistShareHelper.ValidateShareTokenAccess(
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object,
+            shareToken,
+            itemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public void ValidateShareTokenAccess_ItemInPlaylist_ReturnsNull()
+    {
+        // Arrange
+        var shareToken = "valid-token";
+        var playlistId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        var item = new Audio
+        {
+            Id = itemId,
+            Name = "Test Audio",
+            Path = "/test/audio.mp3"
+        };
+
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            ShareToken = shareToken
+        };
+
+        var linkedChild = LinkedChild.Create(item);
+        linkedChild.ItemId = itemId;
+        playlist.LinkedChildren = new[] { linkedChild };
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns(playlist);
+
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(itemId))
+            .Returns(item);
+
+        // Act
+        var result = PlaylistShareHelper.ValidateShareTokenAccess(
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object,
+            shareToken,
+            itemId);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ValidateShareTokenAccess_ItemNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var shareToken = "valid-token";
+        var playlistId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            ShareToken = shareToken
+        };
+
+        _mockPlaylistManager
+            .Setup(m => m.GetPlaylistByShareToken(shareToken))
+            .Returns(playlist);
+
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(itemId))
+            .Returns((BaseItem?)null);
+
+        // Act
+        var result = PlaylistShareHelper.ValidateShareTokenAccess(
+            _mockPlaylistManager.Object,
+            _mockLibraryManager.Object,
+            shareToken,
+            itemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Playlists/PlaylistManagerShareTokenTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Playlists/PlaylistManagerShareTokenTests.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Playlists;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Extensions.Json;
+using Jellyfin.Server.Implementations.Users;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Playlists;
+
+public class PlaylistManagerShareTokenTests
+{
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+    private readonly Mock<IFileSystem> _mockFileSystem;
+    private readonly Mock<ILibraryMonitor> _mockLibraryMonitor;
+    private readonly Mock<ILogger<PlaylistManager>> _mockLogger;
+    private readonly Mock<IUserManager> _mockUserManager;
+    private readonly Mock<IProviderManager> _mockProviderManager;
+    private readonly Mock<IConfiguration> _mockConfiguration;
+    private readonly Mock<IDbContextFactory<JellyfinDbContext>> _mockDbProvider;
+    private readonly PlaylistManager _playlistManager;
+
+    public PlaylistManagerShareTokenTests()
+    {
+        _mockLibraryManager = new Mock<ILibraryManager>();
+        _mockFileSystem = new Mock<IFileSystem>();
+        _mockLibraryMonitor = new Mock<ILibraryMonitor>();
+        _mockLogger = new Mock<ILogger<PlaylistManager>>();
+        _mockUserManager = new Mock<IUserManager>();
+        _mockProviderManager = new Mock<IProviderManager>();
+        _mockConfiguration = new Mock<IConfiguration>();
+        _mockDbProvider = new Mock<IDbContextFactory<JellyfinDbContext>>();
+
+        var mockConfigManager = new Mock<IServerConfigurationManager>();
+        var mockAppPaths = new Mock<IServerApplicationPaths>();
+        mockAppPaths.Setup(p => p.DataPath).Returns("/test/data");
+        mockConfigManager.Setup(c => c.ApplicationPaths).Returns(mockAppPaths.Object);
+
+        BaseItem.LibraryManager = _mockLibraryManager.Object;
+        BaseItem.FileSystem = _mockFileSystem.Object;
+        BaseItem.ConfigurationManager = mockConfigManager.Object;
+        BaseItem.Logger = new Mock<ILogger<BaseItem>>().Object;
+
+        _mockLibraryManager.Setup(m => m.GetCollectionFolders(It.IsAny<BaseItem>())).Returns(new List<Folder>());
+
+        var mockDbContext = new Mock<JellyfinDbContext>(new DbContextOptions<JellyfinDbContext>());
+        _mockDbProvider.Setup(p => p.CreateDbContext()).Returns(mockDbContext.Object);
+
+        _playlistManager = new PlaylistManager(
+            _mockLibraryManager.Object,
+            _mockFileSystem.Object,
+            _mockLibraryMonitor.Object,
+            _mockLogger.Object,
+            _mockUserManager.Object,
+            _mockProviderManager.Object,
+            _mockConfiguration.Object,
+            _mockDbProvider.Object);
+    }
+
+    [Fact]
+    public async Task GenerateShareToken_PlaylistNotFound_ThrowsArgumentException()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        _mockLibraryManager
+            .Setup(m => m.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(Array.Empty<BaseItem>());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _playlistManager.GenerateShareToken(playlistId, userId));
+    }
+
+    [Fact]
+    public async Task GenerateShareToken_UserNotOwner_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreateMockPlaylist(playlistId, ownerId);
+
+        SetupGetPlaylistsForUser(playlist);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => _playlistManager.GenerateShareToken(playlistId, userId));
+    }
+
+    [Fact]
+    public async Task GenerateShareToken_ValidRequest_ReturnsToken()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreateMockPlaylist(playlistId, userId);
+
+        SetupGetPlaylistsForUser(playlist);
+        SetupUpdatePlaylist(playlist);
+
+        // Act
+        var token = await _playlistManager.GenerateShareToken(playlistId, userId);
+
+        // Assert
+        Assert.NotNull(token);
+        Assert.NotEmpty(token);
+        Assert.Equal(64, token.Length); // 32 bytes = 64 hex characters
+        Assert.Equal(token, playlist.ShareToken);
+    }
+
+    [Fact]
+    public async Task GenerateShareToken_CalledTwice_GeneratesNewToken()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreateMockPlaylist(playlistId, userId);
+
+        SetupGetPlaylistsForUser(playlist);
+        SetupUpdatePlaylist(playlist);
+
+        // Act
+        var token1 = await _playlistManager.GenerateShareToken(playlistId, userId);
+        var token2 = await _playlistManager.GenerateShareToken(playlistId, userId);
+
+        // Assert
+        Assert.NotEqual(token1, token2);
+        Assert.Equal(token2, playlist.ShareToken);
+    }
+
+    [Fact]
+    public async Task RevokeShareToken_ValidRequest_RemovesToken()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreateMockPlaylist(playlistId, userId);
+        playlist.ShareToken = "existing-token";
+
+        SetupGetPlaylistsForUser(playlist);
+        SetupUpdatePlaylist(playlist);
+
+        // Act
+        await _playlistManager.RevokeShareToken(playlistId, userId);
+
+        // Assert
+        Assert.Null(playlist.ShareToken);
+    }
+
+    [Fact]
+    public async Task RevokeShareToken_UserNotOwner_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var playlist = CreateMockPlaylist(playlistId, ownerId);
+
+        SetupGetPlaylistsForUser(playlist);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => _playlistManager.RevokeShareToken(playlistId, userId));
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_ValidToken_ReturnsPlaylist()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var shareToken = "test-token-12345";
+        var playlist = CreateMockPlaylist(playlistId, Guid.NewGuid());
+        playlist.ShareToken = shareToken;
+
+        SetupGetAllPlaylists(playlist);
+
+        // Act
+        var result = _playlistManager.GetPlaylistByShareToken(shareToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(playlistId, result.Id);
+        Assert.Equal(shareToken, result.ShareToken);
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_InvalidToken_ReturnsNull()
+    {
+        // Arrange
+        var playlist = CreateMockPlaylist(Guid.NewGuid(), Guid.NewGuid());
+        playlist.ShareToken = "valid-token";
+
+        SetupGetAllPlaylists(playlist);
+
+        // Act
+        var result = _playlistManager.GetPlaylistByShareToken("invalid-token");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_EmptyToken_ReturnsNull()
+    {
+        // Act
+        var result = _playlistManager.GetPlaylistByShareToken(string.Empty);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_NullToken_ReturnsNull()
+    {
+        // Act
+        var result = _playlistManager.GetPlaylistByShareToken(null!);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetPlaylistByShareToken_TokenCaseInsensitive_ReturnsPlaylist()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid();
+        var shareToken = "test-token-abc123";
+        var playlist = CreateMockPlaylist(playlistId, Guid.NewGuid());
+        playlist.ShareToken = shareToken.ToUpperInvariant();
+
+        SetupGetAllPlaylists(playlist);
+
+        // Act
+        var result = _playlistManager.GetPlaylistByShareToken(shareToken.ToLowerInvariant());
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(playlistId, result.Id);
+    }
+
+    private Playlist CreateMockPlaylist(Guid playlistId, Guid ownerId)
+    {
+        var playlist = new Playlist
+        {
+            Id = playlistId,
+            OwnerUserId = ownerId,
+            Name = "Test Playlist",
+            Path = "/test/path"
+        };
+        return playlist;
+    }
+
+    private void SetupGetPlaylistsForUser(Playlist playlist)
+    {
+        _mockLibraryManager
+            .Setup(m => m.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new[] { playlist });
+
+        var user = new User(
+            "testuser",
+            typeof(DefaultAuthenticationProvider).FullName!,
+            typeof(DefaultPasswordResetProvider).FullName!);
+        user.AddDefaultPermissions();
+        user.AddDefaultPreferences();
+
+        _mockUserManager
+            .Setup(m => m.GetUserById(It.IsAny<Guid>()))
+            .Returns(user);
+    }
+
+    private void SetupGetAllPlaylists(params Playlist[] playlists)
+    {
+        var playlistEntities = playlists.Select(p =>
+        {
+            var entity = new BaseItemEntity
+            {
+                Id = p.Id,
+                Type = typeof(Playlist).ToString(),
+                Data = JsonSerializer.Serialize(p, JsonDefaults.Options)
+            };
+            return entity;
+        }).AsQueryable();
+
+        var mockDbSet = new Mock<DbSet<BaseItemEntity>>();
+        mockDbSet.As<IQueryable<BaseItemEntity>>().Setup(m => m.Provider).Returns(playlistEntities.Provider);
+        mockDbSet.As<IQueryable<BaseItemEntity>>().Setup(m => m.Expression).Returns(playlistEntities.Expression);
+        mockDbSet.As<IQueryable<BaseItemEntity>>().Setup(m => m.ElementType).Returns(playlistEntities.ElementType);
+        mockDbSet.As<IQueryable<BaseItemEntity>>().Setup(m => m.GetEnumerator()).Returns(playlistEntities.GetEnumerator());
+
+        var mockDbContext = new Mock<JellyfinDbContext>(new DbContextOptions<JellyfinDbContext>());
+        mockDbContext.Setup(c => c.BaseItems).Returns(mockDbSet.Object);
+        _mockDbProvider.Setup(p => p.CreateDbContext()).Returns(mockDbContext.Object);
+
+        foreach (var playlist in playlists)
+        {
+            _mockLibraryManager
+                .Setup(m => m.GetItemById(playlist.Id))
+                .Returns(playlist);
+        }
+    }
+
+    private void SetupUpdatePlaylist(Playlist playlist)
+    {
+        _mockLibraryManager
+            .Setup(m => m.GetItemById(It.IsAny<Guid>()))
+            .Returns(playlist);
+    }
+}


### PR DESCRIPTION
Allows playlist owners to share playlists via link with users who don't have an account (a.k.a. anonymous users).

Implementation approach:

- Share tokens: 64-char hex strings via `RandomNumberGenerator`
- Authorization: `PlaylistShareAccessPolicy` for token-based anonymous access
- Backend: `ShareToken` property on `Playlist`, new `PlaylistManager` methods, custom authorization handler

### API Endpoints

**Owner operations:**
- `POST /Playlists/{playlistId}/Share` - Generate share token
- `DELETE /Playlists/{playlistId}/Share` - Revoke share token
- `GET /Playlists/{playlistId}/Share` - Get share link (returns 404 if none exists)

**Anonymous access (token-based):**
- `GET /Playlists/Share/{shareToken}` - Get playlist metadata
- `GET /Playlists/Share/{shareToken}/Items` - Get playlist items
- `GET /Audio/{itemId}/stream?shareToken={token}` - Stream audio
- `GET /Videos/{itemId}/stream?shareToken={token}` - Stream video

