### PR TITLE
Add audio language filter support to Items API

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1474,6 +1474,26 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetItemCounts(query);
         }
 
+        /// <inheritdoc />
+        public IReadOnlyList<string> GetAudioLanguages(InternalItemsQuery query)
+        {
+            if (query.Recursive && !query.ParentId.IsEmpty())
+            {
+                var parent = GetItemById(query.ParentId);
+                if (parent is not null)
+                {
+                    SetTopParentIdsOrAncestors(query, [parent]);
+                }
+            }
+
+            if (query.User is not null)
+            {
+                AddUserToQuery(query, query.User);
+            }
+
+            return _itemRepository.GetAudioLanguages(query);
+        }
+
         public IReadOnlyList<BaseItem> GetItemList(InternalItemsQuery query, List<BaseItem> parents)
         {
             SetTopParentIdsOrAncestors(query, parents);

--- a/Jellyfin.Api/Controllers/FilterController.cs
+++ b/Jellyfin.Api/Controllers/FilterController.cs
@@ -89,6 +89,18 @@ public class FilterController : BaseJellyfinApiController
         }
 
         var itemList = folder.GetItemList(query);
+
+        // Get audio languages using the library manager
+        var audioLanguageQuery = new InternalItemsQuery
+        {
+            User = user,
+            MediaTypes = mediaTypes,
+            IncludeItemTypes = includeItemTypes,
+            Recursive = true,
+            AncestorIds = new[] { folder.Id }
+        };
+        var audioLanguages = _libraryManager.GetAudioLanguages(audioLanguageQuery);
+
         return new QueryFiltersLegacy
         {
             Years = itemList.Select(i => i.ProductionYear ?? -1)
@@ -113,7 +125,9 @@ public class FilterController : BaseJellyfinApiController
                 .Where(i => !string.IsNullOrWhiteSpace(i))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Order()
-                .ToArray()
+                .ToArray(),
+
+            AudioLanguages = audioLanguages.ToArray()
         };
     }
 

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -154,6 +154,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="audioLanguages">Optional. If specified, results will be filtered based on audio language. This allows multiple, comma delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -244,6 +245,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] audioLanguages,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -364,6 +366,7 @@ public class ItemsController : BaseJellyfinApiController
                 Years = years,
                 ImageTypes = imageTypes,
                 VideoTypes = videoTypes,
+                AudioLanguages = audioLanguages,
                 AdjacentTo = adjacentTo,
                 ItemIds = ids,
                 MinCommunityRating = minCommunityRating,
@@ -619,6 +622,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="audioLanguages">Optional. If specified, results will be filtered based on audio language. This allows multiple, comma delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the items.</returns>
@@ -710,6 +714,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] audioLanguages,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
         => GetItems(
@@ -797,6 +802,7 @@ public class ItemsController : BaseJellyfinApiController
             nameLessThan,
             studioIds,
             genreIds,
+            audioLanguages,
             enableTotalRecordCount,
             enableImages);
 

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -113,6 +113,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="nameLessThan">Optional filter by items whose name is equally or lesser than a given input string.</param>
     /// <param name="studioIds">Optional. If specified, results will be filtered based on studio id. This allows multiple, pipe delimited.</param>
     /// <param name="genreIds">Optional. If specified, results will be filtered based on genre id. This allows multiple, pipe delimited.</param>
+    /// <param name="audioLanguages">Optional. If specified, results will be filtered based on audio language. This allows multiple, comma delimited.</param>
     /// <param name="enableTotalRecordCount">Optional. Enable the total record count.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the trailers.</returns>
@@ -201,6 +202,7 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery] string? nameLessThan,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] studioIds,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] genreIds,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] audioLanguages,
         [FromQuery] bool enableTotalRecordCount = true,
         [FromQuery] bool? enableImages = true)
     {
@@ -292,6 +294,7 @@ public class TrailersController : BaseJellyfinApiController
                 nameLessThan,
                 studioIds,
                 genreIds,
+                audioLanguages,
                 enableTotalRecordCount,
                 enableImages);
     }

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -21,6 +21,7 @@ namespace MediaBrowser.Controller.Entities
             AlbumIds = Array.Empty<Guid>();
             AncestorIds = Array.Empty<Guid>();
             ArtistIds = Array.Empty<Guid>();
+            AudioLanguages = Array.Empty<string>();
             BlockUnratedItems = Array.Empty<UnratedItem>();
             BoxSetLibraryFolders = Array.Empty<Guid>();
             ChannelIds = Array.Empty<Guid>();
@@ -184,6 +185,8 @@ namespace MediaBrowser.Controller.Entities
         public string[] Tags { get; set; }
 
         public string[] OfficialRatings { get; set; }
+
+        public string[] AudioLanguages { get; set; }
 
         public DateTime? MinPremiereDate { get; set; }
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -641,6 +641,13 @@ namespace MediaBrowser.Controller.Library
 
         ItemCounts GetItemCounts(InternalItemsQuery query);
 
+        /// <summary>
+        /// Gets distinct audio languages for items matching the query.
+        /// </summary>
+        /// <param name="query">The query filter.</param>
+        /// <returns>List of audio language codes.</returns>
+        IReadOnlyList<string> GetAudioLanguages(InternalItemsQuery query);
+
         Task RunMetadataSavers(BaseItem item, ItemUpdateType updateReason);
 
         BaseItem GetParentItem(Guid? parentId, Guid? userId);

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -109,6 +109,13 @@ public interface IItemRepository
     IReadOnlyList<string> GetAllArtistNames();
 
     /// <summary>
+    /// Gets the distinct audio languages for items matching the filter.
+    /// </summary>
+    /// <param name="filter">The query filter.</param>
+    /// <returns>List of audio language codes.</returns>
+    IReadOnlyList<string> GetAudioLanguages(InternalItemsQuery filter);
+
+    /// <summary>
     /// Checks if an item has been persisted to the database.
     /// </summary>
     /// <param name="id">The id to check.</param>

--- a/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
+++ b/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
@@ -13,6 +13,7 @@ namespace MediaBrowser.Model.Querying
             Tags = Array.Empty<string>();
             OfficialRatings = Array.Empty<string>();
             Years = Array.Empty<int>();
+            AudioLanguages = Array.Empty<string>();
         }
 
         public string[] Genres { get; set; }
@@ -22,5 +23,7 @@ namespace MediaBrowser.Model.Querying
         public string[] OfficialRatings { get; set; }
 
         public int[] Years { get; set; }
+
+        public string[] AudioLanguages { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
  - Add the ability to filter library items by audio track language
  - Add `audioLanguages` parameter to `/Items` endpoint
  - Add `GetAudioLanguages` method to retrieve available languages from media streams
  - Include available audio languages in `/Items/Filters` response

  ## Changes
  - `Jellyfin.Api/Controllers/ItemsController.cs` - Add audioLanguages parameter
  - `Jellyfin.Api/Controllers/FilterController.cs` - Return available audio languages
  - `Jellyfin.Api/Controllers/TrailersController.cs` - Add audioLanguages parameter
  - `MediaBrowser.Controller/Entities/InternalItemsQuery.cs` - Add AudioLanguages property
  - `Jellyfin.Server.Implementations/Item/BaseItemRepository.cs` - Filter and query logic
  - `MediaBrowser.Model/Querying/QueryFiltersLegacy.cs` - Add AudioLanguages to response

  ## Use Case
  Users can filter their movie/series libraries by audio language availability (e.g., show only media with German audio tracks).