### PR TITLE
Restore weekly refresh for library folder images

### DIFF
--- a/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
@@ -98,5 +98,11 @@ namespace Emby.Server.Implementations.Images
 
             return base.CreateImage(item, itemsWithImages, outputPath, imageType, imageIndex);
         }
+
+        protected override bool HasChangedByDate(BaseItem item, ItemImageInfo image)
+        {
+            var age = DateTime.UtcNow - image.DateModified;
+            return age.TotalDays > 7;
+        }
     }
 }


### PR DESCRIPTION
Due to a regression from #14347,  library folder images no longer automatically refresh after 7 days and only update after a manual scan.

**Changes**
Add an override to `HasChangedByDate` in `CollectionFolderImageProvider` to restore periodic image refresh.

**Issues**
Reported on various platforms 
