### PR TITLE
Fix HLS playlist generation for transcodes with fractional framerate

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1421,10 +1421,20 @@ public class DynamicHlsController : BaseJellyfinApiController
                 cancellationTokenSource.Token)
             .ConfigureAwait(false);
         var mediaSourceId = state.BaseRequest.MediaSourceId;
+        double fps = state.TargetFramerate ?? 0.0f;
+        int segmentLength = state.SegmentLength * 1000;
+
+        // If framerate is fractional (i.e. 23.976), we need to slightly adjust segment length
+        if (Math.Abs(fps - Math.Floor(fps + 0.001f)) > 0.001)
+        {
+            double nearestIntFramerate = Math.Ceiling(fps);
+            segmentLength = (int)Math.Ceiling(segmentLength * (nearestIntFramerate / fps));
+        }
+
         var request = new CreateMainPlaylistRequest(
             mediaSourceId is null ? null : Guid.Parse(mediaSourceId),
             state.MediaPath,
-            state.SegmentLength * 1000,
+            segmentLength,
             state.RunTimeTicks ?? 0,
             state.Request.SegmentContainer ?? string.Empty,
             "hls1/main/",


### PR DESCRIPTION
**Changes**
Adjusts the desired segment length for HLS Playlist generation, when the video has fraction framerates. This is needed to make sure that the generated playlist has the same amount of segments compared to what ffmpeg outputs.

**Issues**
I found this out while debugging why for some of my users, certain shows did not auto start the next episode, but hung at the end of the episode forever.
I saw that the client requested a segment that did not exist. One episode, for example, had 472 segments encoded, but the playlist which was pre-generated by Jelllyfin listed 473 segments. The client retried to load segment 473 over and over which resulted in timeouts by Jellyfin as the segment does not exist and never will.
This only happend for episodes that needed transcoding. Remux and DirectPlay never caused any trouble in this regard.

The reason: Those episodes has 23.976 FPS (24000/1001). Therefore the default 3s (3000ms) interval is not 100% accurate. ffpmpeg generates 3.003s intervals to match the 72 keyframes which are used for encoding. This leads to enough difference over the whole episode, that the output of ffmpeg was one segment shorter than the HLS playlist reported.
