### PR TITLE
Add Jetson nvmpi support

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -56,7 +56,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "mpeg4_rkmpp",
             "vp8_rkmpp",
             "vp9_rkmpp",
-            "av1_rkmpp"
+            "av1_rkmpp",
+            "h264_nvmpi",
+            "hevc_nvmpi",
+            "mpeg2_nvmpi",
+            "mpeg4_nvmpi",
+            "vp8_nvmpi",
+            "vp9_nvmpi"
         ];
 
         private static readonly string[] _requiredEncoders =
@@ -96,7 +102,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "mjpeg_videotoolbox",
             "h264_rkmpp",
             "hevc_rkmpp",
-            "mjpeg_rkmpp"
+            "mjpeg_rkmpp",
+            "h264_nvmpi",
+            "hevc_nvmpi"
         ];
 
         private static readonly string[] _requiredFilters =

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -854,7 +854,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
                                            || (hardwareAccelerationType == HardwareAccelerationType.qsv && options.PreferSystemNativeHwDecoder)
                                            || hardwareAccelerationType == HardwareAccelerationType.vaapi
                                            || hardwareAccelerationType == HardwareAccelerationType.videotoolbox
-                                           || hardwareAccelerationType == HardwareAccelerationType.rkmpp;
+                                           || hardwareAccelerationType == HardwareAccelerationType.rkmpp
+                                           || hardwareAccelerationType == HardwareAccelerationType.nvmpi;
                 if (!supportsKeyFrameOnly)
                 {
                     // Disable hardware acceleration when the hardware decoder does not support keyframe only mode.

--- a/MediaBrowser.Model/Entities/HardwareAccelerationType.cs
+++ b/MediaBrowser.Model/Entities/HardwareAccelerationType.cs
@@ -45,5 +45,10 @@ public enum HardwareAccelerationType
     /// <summary>
     /// Rockchip Media Process Platform (RKMPP).
     /// </summary>
-    rkmpp = 7
+    rkmpp = 7,
+
+    /// <summary>
+    /// NVIDIA Jetson.
+    /// </summary>
+    nvmpi = 8
 }


### PR DESCRIPTION
**Changes**
I've added the support for Jetson nvmpi hardware encoding and decoding. I've tested it by reducing the minimum bitrate on the test videos and ensuring that the proper encoders are used (via jtop).

**Issues**
I guess this is related to https://features.jellyfin.org/posts/1118/add-jetson-ffmpeg-nvmpi-support
This PR is blocked by https://github.com/jellyfin/jellyfin-ffmpeg/pull/653
