### PR TITLE
Rehydrate cached UserData after reattachment

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -753,10 +753,10 @@ public sealed class BaseItemRepository
 
         var dbContext = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        await using (dbContext)
+        await using (dbContext.ConfigureAwait(false))
         {
             var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-            await using (transaction)
+            await using (transaction.ConfigureAwait(false))
             {
                 var userKeys = item.GetUserDataKeys().ToArray();
                 var retentionDate = (DateTime?)null;
@@ -774,7 +774,6 @@ public sealed class BaseItemRepository
                 item.UserData = await dbContext.UserData
                     .AsNoTracking()
                     .Where(e => e.ItemId == item.Id)
-                    .Where(e => userKeys.Contains(e.CustomDataKey))
                     .ToArrayAsync(cancellationToken)
                     .ConfigureAwait(false);
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
After renaming media items, the GetItem API returns cached items without the reattached UserData. This occurs because ReattachUserDataAsync updates the database but does not rehydrate the in-memory item instance. As a result, navigating to a movie or episode page incorrectly shows the item as not played.

**Changes**
- Rehydrate item.UserData after database update in ReattachUserDataAsync by reloading UserData from the database
- Wrap the operation in a transaction

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://forum.jellyfin.org/t-new-jellyfin-server-web-release-10-11-6?pid=69525#pid69525
