### PR TITLE
Fix alphanumeric filter for collapsed BoxSets

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1402,8 +1402,15 @@ namespace MediaBrowser.Controller.Entities
                 .Where(e => e.IsVisible(user))
                 .ToArray();
 
+            bool applyNameFilterAfterBoxSetCollapse = user is not null && (!string.IsNullOrEmpty(query.NameStartsWith) || !string.IsNullOrEmpty(query.NameStartsWithOrGreater) || !string.IsNullOrEmpty(query.NameLessThan))
+                && CollapseBoxSetItems(query, this, user, ConfigurationManager);
+
+            InternalItemsQuery filterQuery = applyNameFilterAfterBoxSetCollapse
+                ? new InternalItemsQuery(query.User)
+                : query;
+
             var realChildren = visibleChildren
-                .Where(e => query is null || UserViewBuilder.FilterItem(e, query))
+                .Where(e => UserViewBuilder.FilterItem(e, filterQuery))
                 .ToArray();
 
             var childCount = realChildren.Length;


### PR DESCRIPTION
Certain collections were not displayed in the movie library when boxset collapsing was enabled and the alphanumeric picker was used. This occurred when the collection name did not start with the same letter as the items inside the collection (e.g. *Jump Street Collection* containing *21 Jump Street* and *22 Jump Street*).  

The issue was caused by the name filter being applied to individual items before they were collapsed into a collection, preventing the collection from being evaluated against the filter.

**Changes**
Defer name-based filtering until after boxset collapsing occurs, ensuring the alphanumeric filter is applied to the collapsed collection name rather than individual items.

**Issues**
Fixes #15434

