### PR TITLE
Revert hidden directory ignore pattern

### DIFF
--- a/Emby.Server.Implementations/Library/IgnorePatterns.cs
+++ b/Emby.Server.Implementations/Library/IgnorePatterns.cs
@@ -50,6 +50,10 @@ namespace Emby.Server.Implementations.Library
             "**/lost+found",
             "**/subs/**",
             "**/subs",
+            "**/.snapshots/**",
+            "**/.snapshots",
+            "**/.snapshot/**",
+            "**/.snapshot",
 
             // Trickplay files
             "**/*.trickplay",
@@ -83,7 +87,6 @@ namespace Emby.Server.Implementations.Library
 
             // Unix hidden files
             "**/.*",
-            "**/.*/**",
 
             // Mac - if you ever remove the above.
             // "**/._*",

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/IgnorePatternsTests.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("/media/movies/#recycle", true)]
         [InlineData("thumbs.db", true)]
         [InlineData(@"C:\media\movies\movie.avi", false)]
-        [InlineData("/media/.hiddendir/file.mp4", true)]
+        [InlineData("/media/.hiddendir/file.mp4", false)]
         [InlineData("/media/dir/.hiddenfile.mp4", true)]
         [InlineData("/media/dir/._macjunk.mp4", true)]
         [InlineData("/volume1/video/Series/@eaDir", true)]
@@ -32,7 +32,7 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("/media/music/Foo B.A.R", false)]
         [InlineData("/media/music/Foo B.A.R.", false)]
         [InlineData("/movies/.zfs/snapshot/AutoM-2023-09", true)]
-        public void PathIgnored(string path,  bool expected)
+        public void PathIgnored(string path, bool expected)
         {
             Assert.Equal(expected, IgnorePatterns.ShouldIgnore(path));
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
Reverts the hidden directory ignore pattern introduced in #16029, due to undesired behavioral changes for library paths:

```
10.10.x
\media\.Movies\  Works
\.media\Movies\  Works

10.11.5
\media\.Movies\  Library ignored
\.media\Movies\  Works

10.11.6
\media\.Movies\  Library ignored
\.media\Movies\  Library ignored
```
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Remove `**/.*/**` from ignore patterns
Add `.snapshots` patterns to ignore snapshot directories and their contents


**Issues**
Fixes: #16075
