### PR TITLE
Add PreferOriginalReleaseDate option for music

### DIFF
--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -35,6 +35,7 @@ namespace MediaBrowser.Model.Configuration
             SeasonZeroDisplayName = "Specials";
 
             PreferNonstandardArtistsTag = false;
+            PreferOriginalReleaseDate = false;
             UseCustomTagDelimiters = false;
             CustomTagDelimiters = _defaultTagDelimiters;
             DelimiterWhitelist = Array.Empty<string>();
@@ -123,6 +124,9 @@ namespace MediaBrowser.Model.Configuration
 
         [DefaultValue(false)]
         public bool PreferNonstandardArtistsTag { get; set; }
+
+        [DefaultValue(false)]
+        public bool PreferOriginalReleaseDate { get; set; }
 
         [DefaultValue(false)]
         public bool UseCustomTagDelimiters { get; set; }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Jellyfin right now uses only `track.Date`, which is trying to mainly use the recording date for the metadata: https://github.com/Zeugma440/atldotnet/blob/5b1966200449df6d3cb8d2208b9adfeaad5e69ef/ATL/Entities/MetadataHolder.cs#L130.

My changes tries to get the actual original release date: https://github.com/Zeugma440/atldotnet/blob/5b1966200449df6d3cb8d2208b9adfeaad5e69ef/ATL/Entities/MetadataHolder.cs#L222
or the publishing date: https://github.com/Zeugma440/atldotnet/blob/5b1966200449df6d3cb8d2208b9adfeaad5e69ef/ATL/Entities/MetadataHolder.cs#L262 before then trying the normal date at the end again

It also sets the production year from the premierdate, since that is also done for albums but is kept as a last fallback as well.

So I believe overall no metadata should get lost, only the earlier dates filled for the production

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

The issue is that if releases have specific version info tagged, jellyfin tries to use that instead of the original date, its mostly a non issue for newer music, where there is the digital release and thats it, but especially for older music with different versions that may be released much later than the original release, it leads to these issues:

Before (basically random numbers of when the specific issue was released, which leads to odd sortings):
<img width="2164" height="1130" alt="image" src="https://github.com/user-attachments/assets/aaeb4d3f-1b76-41c3-b56d-be797d4ff7ec" />

After (original release dates):
<img width="995" height="539" alt="image" src="https://github.com/user-attachments/assets/8518892e-14aa-4556-b0c9-be09d2f0ba19" />

