### PR TITLE
Fix SessionInfoWebSocketListener not using SessionInfoDto

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -1175,7 +1175,8 @@ namespace Emby.Server.Implementations.Session
             return session;
         }
 
-        private SessionInfoDto ToSessionInfoDto(SessionInfo sessionInfo)
+        /// <inheritdoc />
+        public SessionInfoDto ToSessionInfoDto(SessionInfo sessionInfo)
         {
             return new SessionInfoDto
             {

--- a/MediaBrowser.Controller/Session/ISessionManager.cs
+++ b/MediaBrowser.Controller/Session/ISessionManager.cs
@@ -350,5 +350,12 @@ namespace MediaBrowser.Controller.Session
         /// <param name="sessionIdOrPlaySessionId">The session id or playsession id.</param>
         /// <returns>Task.</returns>
         Task CloseLiveStreamIfNeededAsync(string liveStreamId, string sessionIdOrPlaySessionId);
+
+        /// <summary>
+        /// Gets the dto for session info.
+        /// </summary>
+        /// <param name="sessionInfo">The session info.</param>
+        /// <returns><see cref="SessionInfoDto"/> of the session.</returns>
+        SessionInfoDto ToSessionInfoDto(SessionInfo sessionInfo);
     }
 }


### PR DESCRIPTION
**Changes**

Properly map SessionInfo to its DTO equivalent for WebSocket messaging to avoid leaking internal properties. The `SessionsMessage` type already specifies it uses SessionInfoDto so clients should already expect this type, but it wasn't actually used in the server implementation.

Found this while researching WebSocket behavior for the TypeScript SDK.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
