### PR TITLE
Fix TMDB image URLs missing size parameter

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -518,7 +518,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 return null;
             }
 
-            return _tmDbClient.GetImageUrl(size, path, true).ToString();
+            // Use "original" as default size if size is null or empty to prevent malformed URLs
+            var imageSize = string.IsNullOrEmpty(size) ? "original" : size;
+
+            return _tmDbClient.GetImageUrl(imageSize, path, true).ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

When TMDB plugin configuration size values (PosterSize, BackdropSize, etc.) 
are null or empty, the GetUrl() method now defaults to "original" instead of 
passing null/empty to the TMDb client. This prevents malformed URLs like 
"https://image.tmdb.org/t/p//filename.jpg" and ensures proper format 
"https://image.tmdb.org/t/p/original/filename.jpg".

Fixes remote image search failing to display TMDB images in Edit Images modal.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fix TMDB image URLs missing size parameter #16102 
