### PR TITLE
Fix DeleteItem cleanup logic to remove conflicting UserData entries

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -126,6 +126,7 @@ public sealed class BaseItemRepository
             .Where(g => g.Count() > 1)
             .SelectMany(g => g.OrderByDescending(u => u.LastPlayedDate.HasValue)
                 .ThenByDescending(u => u.LastPlayedDate)
+                .ThenByDescending(u => u.ItemId)
                 .Skip(1)
                 .Select(u => new { u.UserId, u.CustomDataKey, u.ItemId }))
             .ToArray();


### PR DESCRIPTION
Prior to PR #14795, the item deletion logic handled single items correctly. When deleting an item, Jellyfin checked if a placeholder entry existed in the UserData table with matching UserId, CustomDataKey, and PlaceholderId as ItemId. If found, it was deleted to prevent constraint violations when updating the item's UserData itemId to the placeholderId.

However, PR #14795 changed the method to accept multiple item IDs for batch deletion, which introduced a new edge case.

When multiple items share the same (UserId, CustomDataKey) combination (e.g., duplicate episodes), the current code does not check for conflicts among the items being deleted.

Example scenario:
1. Two videos of the same episode exist with identical UserId and CustomDataKey but different ItemId values in UserData
2. Both episodes are deleted in the same batch operation
3. The code checks for placeholder conflicts but doesn't detect that both items have the same (UserId, CustomDataKey) pair
4. Both item's UserData entries are updated to use the PlaceholderId as ItemId
5. This violates the unique constraint on (ItemId, UserId, CustomDataKey)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Identifies UserData entries with duplicate (UserId, CustomDataKey) combinations among items being deleted
- Keeps only the entry with the newest LastPlayedDate

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #15343
Fixes #15397 
Fixes #15658 
