### PR TITLE
Remove deprecated ClientCapabilities

### DIFF
--- a/MediaBrowser.Model/Session/ClientCapabilities.cs
+++ b/MediaBrowser.Model/Session/ClientCapabilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Dlna;
 
@@ -31,15 +30,5 @@ namespace MediaBrowser.Model.Session
         public string AppStoreUrl { get; set; }
 
         public string IconUrl { get; set; }
-
-        // TODO: Remove after 10.9
-        [Obsolete("Unused")]
-        [DefaultValue(false)]
-        public bool? SupportsContentUploading { get; set; } = false;
-
-        // TODO: Remove after 10.9
-        [Obsolete("Unused")]
-        [DefaultValue(false)]
-        public bool? SupportsSync { get; set; } = false;
     }
 }


### PR DESCRIPTION
The comments say to remove after 10.9. Well, it's after 10.9.