### PR TITLE
Fix: Prioritize existing filename.nfo over movie.nfo when saving metadata

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -52,6 +52,11 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 yield return Path.Combine(path, "VIDEO_TS", "VIDEO_TS.nfo");
             }
 
+            if (File.Exists(Path.ChangeExtension(item.Path, ".nfo")))
+            {
+                yield return Path.ChangeExtension(item.Path, ".nfo");
+            }
+
             // only allow movie object to read movie.nfo, not owned videos (which will be itemtype video, not movie)
             if (!item.IsInMixedFolder && item.ItemType == typeof(Movie))
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Currently, saving metadata defaults to creating `movie.nfo` in non-mixed folders, ignoring existing file-specific NFOs. This change adds a check to prioritize the file-specific NFO (e.g., `filename.nfo`) if it already exists on disk. This prevents the creation of duplicate NFO files during metadata updates.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #16105 
