### PR TITLE
Fix nullref in Season.GetEpisodes when the season is detached from a series

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -201,12 +201,17 @@ namespace MediaBrowser.Controller.Entities.TV
 
         public List<BaseItem> GetEpisodes(Series series, User user, IEnumerable<Episode> allSeriesEpisodes, DtoOptions options, bool shouldIncludeMissingEpisodes)
         {
+            if (series is null)
+            {
+                return [];
+            }
+
             return series.GetSeasonEpisodes(this, user, allSeriesEpisodes, options, shouldIncludeMissingEpisodes);
         }
 
         public List<BaseItem> GetEpisodes()
         {
-            return Series.GetSeasonEpisodes(this, null, null, new DtoOptions(true), true);
+            return GetEpisodes(Series, null, null, new DtoOptions(true), true);
         }
 
         public override List<BaseItem> GetChildren(User user, bool includeLinkedChildren, InternalItemsQuery query)


### PR DESCRIPTION
Fixes #16061

This is a simple fix for a nullref. Other code in the Season class also has null checks for the Season, so there's existing precedent for detached seasons.

I also decided to change the `public List<BaseItem> GetEpisodes()` overload to just call another overload instead of duplicating logic.