### PR TITLE
Fix TMDB language handling: support full ISO 639-1 + ISO 3166-1 codes (e.g. zh-CN, zh-TW)

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -117,14 +117,6 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 preferredLanguage = NormalizeLanguage(preferredLanguage, countryCode);
 
                 languages.Add(preferredLanguage);
-
-                if (preferredLanguage.Length == 5) // Like en-US
-                {
-                    // Currently, TMDb supports 2-letter language codes only.
-                    // They are planning to change this in the future, thus we're
-                    // supplying both codes if we're having a 5-letter code.
-                    languages.Add(preferredLanguage.Substring(0, 2));
-                }
             }
 
             languages.Add("null");


### PR DESCRIPTION
Currently, Jellyfin’s TmdbUtils.cs contains the following logic:

```csharp
if (preferredLanguage.Length == 5) // Like en-US
{
    // Currently, TMDb supports 2-letter language codes only.
    // They are planning to change this in the future, thus we're
    // supplying both codes if we're having a 5-letter code.
    languages.Add(preferredLanguage.Substring(0, 2));
}
```
This code truncates full language-region codes such as zh-CN or en-US into two-letter language codes (zh, en).
However, TMDB now officially supports full ISO 639-1 + ISO 3166-1 combinations (e.g. zh-CN, zh-TW, pt-BR). See https://developer.themoviedb.org/docs/languages

## Problem
When users set zh-CN in Jellyfin, the TMDB plugin sends zh instead.

This causes TMDB to return Traditional Chinese resources instead of Simplified Chinese.

The issue has been reported (see Issue #16069).

## Changes
Removed the truncation logic for 5-character language codes.

Full xx-YY language-region codes are now passed directly to TMDB.

Two-letter language codes (e.g. en) continue to work as before.

## Impact
Only affects TMDB plugin language handling.

No impact on other metadata providers.
