### PR TITLE
ci: use workflow_run pattern for PR workflows

### DIFF
--- a/.github/workflows/ci-compat-build.yml
+++ b/.github/workflows/ci-compat-build.yml
@@ -1,0 +1,55 @@
+name: ABI Compatibility Build
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  abi-head:
+    name: ABI - HEAD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build
+        run: dotnet build Jellyfin.Server -o ./out
+
+      - name: Upload Head
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: abi-head
+          retention-days: 1
+          if-no-files-found: error
+          path: out/
+
+  abi-base:
+    name: ABI - BASE
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build
+        run: dotnet build Jellyfin.Server -o ./out
+
+      - name: Upload Base
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: abi-base
+          retention-days: 1
+          if-no-files-found: error
+          path: out/

--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -1,87 +1,20 @@
-﻿name: ABI Compatibility
+name: ABI Compatibility
+
 on:
-  pull_request_target:
+  workflow_run:
+    workflows: ["ABI Compatibility Build"]
+    types: [completed]
 
 permissions: {}
 
 jobs:
-  abi-head:
-    name: ABI - HEAD
-    runs-on: ubuntu-latest
-    permissions: read-all
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Build
-        run: |
-          dotnet build Jellyfin.Server -o ./out
-
-      - name: Upload Head
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: abi-head
-          retention-days: 14
-          if-no-files-found: error
-          path: out/
-
-  abi-base:
-    name: ABI - BASE
-    if: ${{ github.base_ref != '' }}
-    runs-on: ubuntu-latest
-    permissions: read-all
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Checkout common ancestor
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}
-          git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules upstream +refs/heads/*:refs/remotes/upstream/* +refs/tags/*:refs/tags/*
-          ANCESTOR_REF=$(git merge-base upstream/${{ github.base_ref }} origin/$HEAD_REF)
-          git checkout --progress --force $ANCESTOR_REF
-
-      - name: Build
-        run: |
-          dotnet build Jellyfin.Server -o ./out
-
-      - name: Upload Head
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: abi-base
-          retention-days: 14
-          if-no-files-found: error
-          path: out/
-
   abi-diff:
     permissions:
-      pull-requests: write  #  to create or update comment (peter-evans/create-or-update-comment)
+      pull-requests: write
 
     name: ABI - Difference
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs:
-      - abi-head
-      - abi-base
 
     steps:
       - name: Download abi-head
@@ -89,12 +22,16 @@ jobs:
         with:
           name: abi-head
           path: abi-head
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download abi-base
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: abi-base
           path: abi-base
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup ApiCompat
         run: |
@@ -118,7 +55,7 @@ jobs:
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           direction: last
           body-includes: abi-diff-workflow-comment
 
@@ -126,7 +63,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: ${{ steps.diff.outputs.body != '' }}
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           token: ${{ secrets.JF_BOT_TOKEN }}
@@ -145,7 +82,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: ${{ steps.diff.outputs.body == '' && steps.find-comment.outputs.comment-id != '' }}
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/ci-openapi-build.yml
+++ b/.github/workflows/ci-openapi-build.yml
@@ -1,0 +1,55 @@
+name: OpenAPI Build
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  openapi-head:
+    name: OpenAPI - HEAD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Generate openapi.json
+        run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: openapi-head
+          retention-days: 1
+          if-no-files-found: error
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net10.0/openapi.json
+
+  openapi-base:
+    name: OpenAPI - BASE
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Generate openapi.json
+        run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
+
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: openapi-base
+          retention-days: 1
+          if-no-files-found: error
+          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net10.0/openapi.json

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -1,30 +1,31 @@
 name: OpenAPI
+
 on:
   push:
     branches:
       - master
     tags:
       - 'v*'
-  pull_request_target:
+  workflow_run:
+    workflows: ["OpenAPI Build"]
+    types: [completed]
 
 permissions: {}
 
 jobs:
   openapi-head:
     name: OpenAPI - HEAD
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
         with:
           dotnet-version: '10.0.x'
+
       - name: Generate openapi.json
         run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
 
@@ -32,43 +33,6 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: openapi-head
-          retention-days: 14
-          if-no-files-found: error
-          path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net10.0/openapi.json
-
-  openapi-base:
-    name: OpenAPI - BASE
-    if: ${{ github.base_ref != '' }}
-    runs-on: ubuntu-latest
-    permissions: read-all
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-
-      - name: Checkout common ancestor
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}
-          git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules upstream +refs/heads/*:refs/remotes/upstream/* +refs/tags/*:refs/tags/*
-          ANCESTOR_REF=$(git merge-base upstream/${{ github.base_ref }} origin/$HEAD_REF)
-          git checkout --progress --force $ANCESTOR_REF
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
-        with:
-          dotnet-version: '10.0.x'
-      - name: Generate openapi.json
-        run: dotnet test tests/Jellyfin.Server.Integration.Tests/Jellyfin.Server.Integration.Tests.csproj -c Release --filter "Jellyfin.Server.Integration.Tests.OpenApiSpecTests"
-
-      - name: Upload openapi.json
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: openapi-base
           retention-days: 14
           if-no-files-found: error
           path: tests/Jellyfin.Server.Integration.Tests/bin/Release/net10.0/openapi.json
@@ -78,23 +42,24 @@ jobs:
       pull-requests: write
 
     name: OpenAPI - Difference
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs:
-      - openapi-head
-      - openapi-base
     steps:
       - name: Download openapi-head
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: openapi-head
           path: openapi-head
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download openapi-base
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: openapi-base
           path: openapi-base
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Detect OpenAPI changes
         id: openapi-diff
@@ -105,11 +70,12 @@ jobs:
           markdown: openapi-changelog.md
           add-pr-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
 
 
   publish-unstable:
     name: OpenAPI - Publish Unstable Spec
-    if: ${{ github.event_name != 'pull_request_target' && !startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
+    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
     runs-on: ubuntu-latest
     needs:
       - openapi-head
@@ -170,7 +136,7 @@ jobs:
 
   publish-stable:
     name: OpenAPI - Publish Stable Spec
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
     runs-on: ubuntu-latest
     needs:
       - openapi-head


### PR DESCRIPTION
## Summary

Refactor CI workflows to use the `workflow_run` pattern for PR builds.

## Changes

- Build jobs run on `pull_request` trigger with minimal permissions
- Deploy/privileged jobs run on `workflow_run`, consuming artifacts
- No functional changes to build or deploy behavior