### PR TITLE
Cache rules of .ignore files

### DIFF
--- a/Emby.Server.Implementations/Library/DotIgnoreFile.cs
+++ b/Emby.Server.Implementations/Library/DotIgnoreFile.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Emby.Server.Implementations.Library;
+
+/// <summary>
+/// Record that holds the cached ignore rules of a .ignore file.
+/// </summary>
+public record DotIgnoreFile(string Path, DateTime ChangedDate, Ignore.Ignore? IgnoreRules);


### PR DESCRIPTION
Added a simple cache for ignore rules to prevent unnecessary re-creations of the same rule set over and over on each IsIgnored check.
This has massively reduced the scan times of one of my libraries that makes heavy use of a large .ignore rule set.
(see linked issue for more info).

**Changes**
- added a dictionary that functions as a simple cache for ignore rules
- after the content of an .ignore file is checked for ignore-rules, the resulting rule list is saved together with the path and change date of the .ignore file
- on subsequent checks the change date of the .ignore file is compared to the one in the cache and if no there are no changes the rule set is loaded from the cache
- if the file changed, the rules in the cache are updated

**Issues**
Fixes #16163
