### PR TITLE
Add command to run initial wizard setup through command line

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -751,7 +751,7 @@ namespace Emby.Server.Implementations
         /// <summary>
         /// Discovers the types.
         /// </summary>
-        protected void DiscoverTypes()
+        public void DiscoverTypes()
         {
             Logger.LogInformation("Loading assemblies");
 

--- a/Jellyfin.Server/ConfigOptions.cs
+++ b/Jellyfin.Server/ConfigOptions.cs
@@ -1,0 +1,133 @@
+using System.IO;
+using CommandLine;
+
+namespace Jellyfin.Server
+{
+    /// <summary>
+    /// Class used by CommandLine package when parsing the command line arguments.
+    /// </summary>
+    [Verb("config", HelpText = "Configure Jellyfin.")]
+    public class ConfigOptions
+    {
+        private string? _password;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to write the configuration.
+        /// </summary>
+        /// <value>Write configuration.</value>
+        [Option("write", Required = false, Default = false, HelpText = "Write configuration.")]
+        public bool Write { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the data directory.
+        /// </summary>
+        /// <value>The path to the data directory.</value>
+        [Option("datadir", Required = false, HelpText = "Path to use for the data folder (database files, etc.).")]
+        public string? DataDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the config directory.
+        /// </summary>
+        /// <value>The path to the config directory.</value>
+        [Option("configdir", Required = false, HelpText = "Path to use for configuration data (user settings and pictures).")]
+        public string? ConfigDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the cache directory.
+        /// </summary>
+        /// <value>The path to the cache directory.</value>
+        [Option('C', "cachedir", Required = false, HelpText = "Path to use for caching.")]
+        public string? CacheDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the log directory.
+        /// </summary>
+        /// <value>The path to the log directory.</value>
+        [Option('l', "logdir", Required = false, HelpText = "Path to use for writing log files.")]
+        public string? LogDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username of the initial admin user.
+        /// </summary>
+        /// <value>The username.</value>
+        [Option("username", Required = false, HelpText = "Username of the initial admin user.")]
+        public string? Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the password file containing the password of the initial admin user.
+        /// </summary>
+        /// <value>The path to the file containing the password.</value>
+        [Option("password-file", Required = false, HelpText = "Path to a file containing the initial admin user password.")]
+        public string? PasswordFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password of the initial admin user.
+        /// </summary>
+        /// <value>The password contained in the <see cref="ConfigOptions.PasswordFile" /> field.</value>
+        public string? Password
+        {
+            get
+            {
+                if (_password is null && PasswordFile is not null)
+                {
+                    _password = File.ReadAllText(PasswordFile);
+                }
+
+                return _password;
+            }
+
+            set
+            {
+                _password = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the preferred display language.
+        /// </summary>
+        /// <value>The preferred display language.</value>
+        [Option("preferred-display-language", Required = false, HelpText = "Preferred display language.")]
+        public string? PreferredDisplayLanguage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the preferred metadata language.
+        /// </summary>
+        /// <value>The preferred metadata language.</value>
+        [Option("preferred-metadata-language", Required = false, HelpText = "Preferred metadata language.")]
+        public string? PreferredMetadataLanguage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the preferred metadata country region.
+        /// </summary>
+        /// <value>The preferred metadata country region.</value>
+        [Option("preferred-metadata-country-region", Required = false, HelpText = "Preferred metadata country/region.")]
+        public string? PreferredMetadataCountryRegion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether remote connections are allowed or not.
+        /// </summary>
+        /// <value>If remote connections are allowed or not.</value>
+        [Option("enable-remote-access", Required = false, HelpText = "Enable remote connections to the server. Not needed if behind a reverse proxy.")]
+        public bool? EnableRemoteAccess { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether automatic port mapping is required.
+        /// </summary>
+        /// <value>If automatic port mapping is required.</value>
+        [Option("enable-automatic-port-mapping", Required = false, HelpText = "Enable automatic port mapping.")]
+        public bool? EnableAutomaticPortMapping { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the --ffmpeg command line option.
+        /// </summary>
+        [Option("ffmpeg", Required = false, HelpText = "Path to external FFmpeg executable to use in place of default found in PATH.")]
+        public string? FFmpegPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the web directory.
+        /// </summary>
+        /// <value>The path to the web directory.</value>
+        [Option('w', "webdir", Required = false, HelpText = "Path to the Jellyfin web UI resources.")]
+        public string? WebDir { get; set; }
+    }
+}

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -10,20 +10,40 @@ using System.Threading.Tasks;
 using CommandLine;
 using Emby.Server.Implementations;
 using Emby.Server.Implementations.Configuration;
+using Emby.Server.Implementations.Cryptography;
+using Emby.Server.Implementations.IO;
 using Emby.Server.Implementations.Serialization;
+using Jellyfin.Api.Controllers;
 using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Drawing;
+using Jellyfin.Drawing.Skia;
+using Jellyfin.Networking.Manager;
 using Jellyfin.Server.Extensions;
 using Jellyfin.Server.Helpers;
 using Jellyfin.Server.Implementations.DatabaseConfiguration;
+using Jellyfin.Server.Implementations.Events;
 using Jellyfin.Server.Implementations.Extensions;
 using Jellyfin.Server.Implementations.StorageHelpers;
 using Jellyfin.Server.Implementations.SystemBackupService;
+using Jellyfin.Server.Implementations.Users;
 using Jellyfin.Server.Migrations;
 using Jellyfin.Server.Migrations.Stages;
 using Jellyfin.Server.ServerSetupApp;
+using Jellyfin.Server.Wizard;
+using MediaBrowser.Common;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -77,8 +97,11 @@ namespace Jellyfin.Server
             }
 
             // Parse the command line arguments and either start the app or exit indicating error
-            return Parser.Default.ParseArguments<StartupOptions>(args)
-                .MapResult(StartApp, ErrorParsingArguments);
+            return Parser.Default.ParseArguments<ConfigOptions, StartupOptions>(args)
+                .MapResult(
+                    (ConfigOptions opt) => ConfigApp(opt),
+                    (StartupOptions opt) => StartApp(opt),
+                    ErrorParsingArguments);
         }
 
         private static async Task StartApp(StartupOptions options)
@@ -372,6 +395,156 @@ namespace Jellyfin.Server
             var factory = services.GetRequiredService<IDbContextFactory<JellyfinDbContext>>();
             var provider = services.GetRequiredService<IJellyfinDatabaseProvider>();
             provider.DbContextFactory = factory;
+        }
+
+        // Web wizard follows this flow:
+        //   1. POST /Startup/User
+        //   2. GET  /Localization/cultures
+        //   3. GET  /Localization/countries
+        //   4. POST /Startup/Configuration
+        //   5. POST /Startup/RemoteAccess
+        //   6. POST /Startup/Complete
+        private static async Task<int> ConfigApp(ConfigOptions options)
+        {
+            var services = InitWizardServices(options);
+            StartupController? startupController;
+            try
+            {
+                startupController = services.GetRequiredService<StartupController>();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("""
+                  Got an exception during startup. This could mean the Jellyfin server has not been started yet.
+                  You must start the Jellyfin server at least once before running this tool.
+
+                  The exception follows:
+                """);
+                throw;
+            }
+
+            var configurationManager = services.GetRequiredService<IServerConfigurationManager>();
+
+            var firstUser = await startupController.GetFirstUser().ConfigureAwait(true);
+            var startupConfiguration = startupController.GetStartupConfiguration().Value;
+            var networkConfiguration = configurationManager.GetNetworkConfiguration();
+
+            var config = WizardConfig.FromDtos(firstUser, startupConfiguration, networkConfiguration);
+
+            Console.WriteLine($"""
+            Current Configuration:
+
+              {string.Join("\n  ", config.AsLines())}
+
+            """);
+
+            config.Merge(WizardConfig.FromOptions(options));
+
+            Console.WriteLine($"""
+            New Configuration:
+
+              {string.Join("\n  ", config.AsLines())}
+
+            """);
+
+            if (!options.Write)
+            {
+                Console.WriteLine("Use --write to save config.");
+                return 0;
+            }
+
+            if (options.Password is null)
+            {
+                Console.WriteLine("--password-file should not be empty, cannot save config, aborting.");
+                return 1;
+            }
+
+            await startupController.UpdateStartupUser(config.GetStartupUserDto()).ConfigureAwait(true);
+            startupController.UpdateInitialConfiguration(config.GetStartupConfigurationDto());
+            startupController.SetRemoteAccess(config.GetStartupRemoteAccessDto());
+            startupController.CompleteWizard();
+
+            Console.WriteLine("The new configuration has been written. Jellyfin server must be restarted to take it into account.");
+
+            return 0;
+        }
+
+        private static ServiceProvider InitWizardServices(ConfigOptions options)
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton<StartupOptions>(new StartupOptions
+            {
+                DataDir = options.DataDir,
+                ConfigDir = options.ConfigDir,
+                CacheDir = options.CacheDir,
+                LogDir = options.LogDir
+            });
+            services.AddSingleton<IStartupOptions, StartupOptions>();
+            services.AddSingleton<IApplicationPaths>(provider =>
+            {
+                return StartupHelpers.CreateApplicationPaths(provider.GetRequiredService<StartupOptions>());
+            });
+            services.AddSingleton<IServerApplicationPaths>(provider =>
+            {
+                return StartupHelpers.CreateApplicationPaths(provider.GetRequiredService<StartupOptions>());
+            });
+
+            services.AddLogging();
+            services.AddSingleton<ILoggerFactory, SerilogLoggerFactory>();
+            services.AddSingleton<IXmlSerializer, MyXmlSerializer>();
+            services.AddSingleton<IServerConfigurationManager>(provider =>
+            {
+                var appHost = provider.GetRequiredService<CoreAppHost>();
+                var appPaths = provider.GetRequiredService<IApplicationPaths>();
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                var xmlSerializer = provider.GetRequiredService<IXmlSerializer>();
+                var configurationManager = new ServerConfigurationManager(appPaths, loggerFactory, xmlSerializer);
+                appHost.DiscoverTypes();
+                configurationManager.AddParts(appHost.GetExports<IConfigurationFactory>());
+                return configurationManager;
+            });
+
+            services.AddSingleton<CoreAppHost>();
+            services.AddSingleton<IServerApplicationHost, CoreAppHost>();
+            services.AddSingleton<IConfiguration>(provider =>
+            {
+                var startupOptions = provider.GetRequiredService<StartupOptions>();
+                var appPaths = provider.GetRequiredService<IApplicationPaths>();
+                return Jellyfin.Server.Program.CreateAppConfiguration(startupOptions, appPaths);
+            });
+            services.AddSingleton<IApplicationHost, CoreAppHost>();
+            services.AddSingleton<INetworkManager, NetworkManager>();
+            services.AddSingleton<MediaBrowser.Common.Configuration.IConfigurationManager>(provider =>
+            {
+                return provider.GetRequiredService<IServerConfigurationManager>();
+            });
+            services.AddSingleton<IFileSystem, ManagedFileSystem>();
+            services.AddSingleton<IImageProcessor, ImageProcessor>();
+            bool useSkiaEncoder = SkiaEncoder.IsNativeLibAvailable();
+            Type imageEncoderType = useSkiaEncoder
+                ? typeof(SkiaEncoder)
+                : typeof(NullImageEncoder);
+            services.AddSingleton(typeof(IImageEncoder), imageEncoderType);
+            services.AddSingleton<IEventManager, EventManager>();
+
+            services.AddSingleton<ICryptoProvider, CryptographyProvider>();
+            services.AddSingleton<IAuthenticationProvider, DefaultAuthenticationProvider>();
+            services.AddSingleton<IAuthenticationProvider, InvalidAuthProvider>();
+            services.AddSingleton<IPasswordResetProvider, DefaultPasswordResetProvider>();
+            services.AddSingleton<IUserManager, UserManager>();
+
+            services.AddSingleton<IEntityFrameworkCoreLockingBehavior, PessimisticLockBehavior>();
+            services.AddSingleton<IJellyfinDatabaseProvider, SqliteDatabaseProvider>();
+            services.AddDbContextFactory<JellyfinDbContext>((provider, opt) =>
+            {
+                var applicationPaths = provider.GetRequiredService<IApplicationPaths>();
+                opt.UseSqlite($"Filename={Path.Combine(applicationPaths.DataPath, "jellyfin.db")}");
+            });
+
+            services.AddSingleton<StartupController>();
+
+            return services.BuildServiceProvider();
         }
     }
 }

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -9,6 +9,7 @@ namespace Jellyfin.Server
     /// <summary>
     /// Class used by CommandLine package when parsing the command line arguments.
     /// </summary>
+    [Verb("server", isDefault: true, HelpText = "Start Jellyfin server.")]
     public class StartupOptions : IStartupOptions
     {
         /// <summary>

--- a/Jellyfin.Server/Wizard/WizardConfig.cs
+++ b/Jellyfin.Server/Wizard/WizardConfig.cs
@@ -1,0 +1,126 @@
+using Jellyfin.Api.Models.StartupDtos;
+using MediaBrowser.Common.Net;
+
+namespace Jellyfin.Server.Wizard
+{
+    /// <summary>
+    /// Class containing the aggregated configuration for the wizard.
+    /// </summary>
+    public class WizardConfig
+    {
+        private string? username;
+        private string? password;
+        private string? preferredDisplayLanguage;
+        private string? preferredMetadataCountryRegion;
+        private string? preferredMetadataLanguage;
+        private bool? enableRemoteAccess;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WizardConfig"/> class.
+        /// </summary>
+        /// <param name="firstUser">Instance of the <see cref="StartupUserDto"/> class.</param>
+        /// <param name="startupConfiguration">Instance of the <see cref="StartupConfigurationDto"/> class.</param>
+        /// <param name="networkConfiguration">Instance of the <see cref="NetworkConfiguration"/> class.</param>
+        /// <returns>WizardConfig.</returns>
+        public static WizardConfig FromDtos(StartupUserDto? firstUser, StartupConfigurationDto? startupConfiguration, NetworkConfiguration? networkConfiguration)
+        {
+            return new WizardConfig
+            {
+                username = firstUser?.Name,
+                password = firstUser?.Password,
+                preferredDisplayLanguage = startupConfiguration?.UICulture,
+                preferredMetadataCountryRegion = startupConfiguration?.MetadataCountryCode,
+                preferredMetadataLanguage = startupConfiguration?.PreferredMetadataLanguage,
+                enableRemoteAccess = networkConfiguration?.EnableRemoteAccess,
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WizardConfig"/> class.
+        /// </summary>
+        /// <param name="options">Instance of the <see cref="ConfigOptions"/> class.</param>
+        /// <returns>WizardConfig.</returns>
+        public static WizardConfig FromOptions(ConfigOptions options)
+        {
+            return new WizardConfig
+            {
+                username = options.Username,
+                password = options.Password,
+                preferredDisplayLanguage = options.PreferredDisplayLanguage,
+                preferredMetadataCountryRegion = options.PreferredMetadataCountryRegion,
+                preferredMetadataLanguage = options.PreferredMetadataLanguage,
+                enableRemoteAccess = options.EnableRemoteAccess,
+            };
+        }
+
+        /// <summary>
+        /// Pretty prints the config.
+        /// </summary>
+        /// <returns>string.</returns>
+        public string[] AsLines()
+        {
+            var redactedPassword = password?.StartsWith("$PBKDF2", System.StringComparison.Ordinal) ?? true ? password : "<new password redacted>";
+            return [
+              $"Username:                        {username}",
+              $"Password:                        {redactedPassword}",
+              $"PreferredDisplayLanguage:        {preferredDisplayLanguage}",
+              $"PreferredMetadataCountryRegion:  {preferredMetadataCountryRegion}",
+              $"PreferredMetadataLanguage:       {preferredMetadataLanguage}",
+              $"EnableRemoteAccess:              {enableRemoteAccess}",
+            ];
+        }
+
+        /// <summary>
+        /// Merges the current config with another one, only overriding if fields that are not null in the other config.
+        /// </summary>
+        /// <param name="other">Instance of the <see cref="WizardConfig"/> class.</param>
+        public void Merge(WizardConfig other)
+        {
+            username = other.username ?? username;
+            password = other.password ?? password;
+            preferredDisplayLanguage = other.preferredDisplayLanguage ?? preferredDisplayLanguage;
+            preferredMetadataCountryRegion = other.preferredMetadataCountryRegion ?? preferredMetadataCountryRegion;
+            preferredMetadataLanguage = other.preferredMetadataLanguage ?? preferredMetadataLanguage;
+            enableRemoteAccess = other.enableRemoteAccess ?? enableRemoteAccess;
+        }
+
+        /// <summary>
+        /// Returns an instance of <see cref="StartupUserDto" /> with fields filled from the config.
+        /// </summary>
+        /// <returns>StartupUserDto.</returns>
+        public StartupUserDto GetStartupUserDto()
+        {
+            return new StartupUserDto
+            {
+                Name = username,
+                Password = password
+            };
+        }
+
+        /// <summary>
+        /// Returns an instance of <see cref="StartupConfigurationDto" /> with fields filled from the config.
+        /// </summary>
+        /// <returns>StartupConfigurationDto.</returns>
+        public StartupConfigurationDto GetStartupConfigurationDto()
+        {
+            return new StartupConfigurationDto
+            {
+                UICulture = preferredDisplayLanguage,
+                MetadataCountryCode = preferredMetadataCountryRegion,
+                PreferredMetadataLanguage = preferredMetadataLanguage
+            };
+        }
+
+        /// <summary>
+        /// Returns an instance of <see cref="StartupRemoteAccessDto" /> with fields filled from the config.
+        /// </summary>
+        /// <returns>StartupRemoteAccessDto.</returns>
+        public StartupRemoteAccessDto GetStartupRemoteAccessDto()
+        {
+            return new StartupRemoteAccessDto
+            {
+                EnableRemoteAccess = enableRemoteAccess ?? false,
+            };
+        }
+    }
+}


### PR DESCRIPTION
Follow up on #14422 and #14813 which this time adds a `config` verb directly to the `jellyfin` binary instead of having a separate binary. The PR targets the `release-10.11.z` branch.

Copying from the description of #14422:

The implementation directly taps into Jellyfin server libraries which makes it less brittle than existing CLI tools. Also, for going through the initial setup, the API is not used since it requires creating an API key which is not possible without a user.

One caveat: the Jellyfin server must be started before running the cli and must also be restarted afterwards. I do not plan to fix the restarting issue in this PR. A solution could be sending a `SIGUSR1` to the server.

**Usage**

```
$ `dotnet run --project Jellyfin.Server -- --help`
Jellyfin.Server 10.11.6.0
Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License

  config     Configure Jellyfin.

  server     (Default Verb) Start Jellyfin server.

  help       Display more information on a specific command.

  version    Display version information.
```

The `server` verb is optional and the default one. So this works:

```
$ jellyfin --nowebclient --datadir $PWD/tmp
```

```
$ jellyfin config --help
Jellyfin.Server 10.11.6.0
Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License

  --write                                (Default: false) Write configuration.

  --datadir                              Path to use for the data folder (database files, etc.).

  --configdir                            Path to use for configuration data (user settings and pictures).

  -C, --cachedir                         Path to use for caching.

  -l, --logdir                           Path to use for writing log files.

  --username                             Username of the initial admin user.

  --password-file                        Path to a file containing the initial admin user password.

  --preferred-display-language           Preferred display language.

  --preferred-metadata-language          Preferred metadata language.

  --preferred-metadata-country-region    Preferred metadata country/region.

  --enable-remote-access                 Enable remote connections to the server. Not needed if behind a
                                         reverse proxy.

  --enable-automatic-port-mapping        Enable automatic port mapping.

  --ffmpeg                               Path to external FFmpeg executable to use in place of default found
                                         in PATH.

  -w, --webdir                           Path to the Jellyfin web UI resources.

  --help                                 Display this help screen.

  --version                              Display version information.
```


```
$ mkdir $PWD/tmp

$ jellyfin --nowebclient --datadir $PWD/tmp
[ ... ]

$ echo admin > ./tmp/mypassword
```

```
$ jellyfin config --datadir $PWD/tmp/ --password-file ./tmp/mypassword
Current Configuration:

  Username:                        jellyfin
  Password:                        
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

New Configuration:

  Username:                        jellyfin
  Password:                        <new password redacted>
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

Use --write to save config.
```

```
$ jellyfin config --datadir $PWD/tmp/ --password-file ./tmp/mypassword --write

Current Configuration:

  Username:                        jellyfin
  Password:                        
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

New Configuration:

  Username:                        jellyfin
  Password:                        <new password redacted>
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

The new configuration has been written. Jellyfin server must be restarted to take it into account.
```

```
$ jellyfin config --datadir $PWD/tmp/ --password-file ./tmp/mypassword

Current Configuration:

  Username:                        timi
  Password:                        $PBKDF2-SHA512$iterations=210000$5788376199C0F7F533E1F93E55DAB253$B54D9484DBA1081860BF16E2BDCB662CE90BE96EC9E8AC26A7D0E128A07668CCE45ECD842E1660279AE9E281DD61AB4E9D7F7676513A1E0CF2B6B6EBE5425950
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

New Configuration:

  Username:                        timi
  Password:                        <new password redacted>
  PreferredDisplayLanguage:        en-US
  PreferredMetadataCountryRegion:  US
  PreferredMetadataLanguage:       en
  EnableRemoteAccess:              True
  EnableAutomaticPortMapping:      False

Use --write to save config.
```

**Issues**

No issues but other cli implementations exist. They all suffer from the same issue in my opinion which is they are implemented outside of the Jellyfin codebase which makes them brittle and require reverse engineering what the Jellyfin server is doing.

This implementation relies directly on the Jellyfin server libraries which makes it much less brittle and easier to extend.

Prior work:
- https://github.com/LSchallot/JellyRoller (Rust)
- https://github.com/Smiley-McSmiles/jellyman (Shell)
- https://pypi.org/project/Jellyfin-CLI (Python)
- https://gist.github.com/nwithan8/34c36c615a347dd576e0a8d157f69fc0 (Shell)
- https://github.com/Sveske-Juice/declarative-jellyfin (Nix/Shell)

Questions about cli:
- https://www.reddit.com/r/jellyfin/comments/gy27i6/how_do_i_trigger_a_library_scan_from_the_command/
- https://forum.jellyfin.org/t-how-to-enable-ipv6-on-command-line?highlight=command%2Bline

Btw I tried to search the forum for "cli" but that returns 200 pages because it includes results like "client". I can't find a way to just search for a word.