### PR TITLE
Skip validation for empty landing preferences

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -191,9 +191,17 @@ public class DisplayPreferencesController : BaseJellyfinApiController
 
         foreach (var key in displayPreferences.CustomPrefs.Keys.Where(key => key.StartsWith("landing-", StringComparison.OrdinalIgnoreCase)))
         {
-            if (!Enum.TryParse<ViewType>(displayPreferences.CustomPrefs[key], true, out _))
+            var viewType = displayPreferences.CustomPrefs[key];
+
+            if (string.IsNullOrEmpty(viewType))
             {
-                _logger.LogError("Invalid ViewType: {LandingScreenOption}", displayPreferences.CustomPrefs[key]);
+                displayPreferences.CustomPrefs.Remove(key);
+                continue;
+            }
+
+            if (!Enum.TryParse<ViewType>(viewType, true, out _))
+            {
+                _logger.LogError("Invalid ViewType: {LandingScreenOption}", viewType);
                 displayPreferences.CustomPrefs.Remove(key);
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The WebUI sends empty strings for default landing screens, which were incorrectly being validated and logged as errors. Empty or null strings will now be skipped.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
`[2026-02-03 05:43:40.703 +00:00] [ERR] [62] Jellyfin.Api.Controllers.DisplayPreferencesController: Invalid ViewType: ""`