### PR TITLE
SyncPlay: add authoritative V2 group-state/snapshot API while preserving legacy route compatibility

### DIFF
--- a/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs
@@ -105,7 +105,9 @@ namespace Jellyfin.Server.Implementations.Security
                 token = queryString["ApiKey"];
             }
 
-            if (_configurationManager.Configuration.EnableLegacyAuthorization && string.IsNullOrEmpty(token))
+            // Keep lowercase query key support for clients that still send `api_key`
+            // on websocket and long-poll requests even when legacy auth is disabled.
+            if (string.IsNullOrEmpty(token))
             {
                 token = queryString["api_key"];
             }

--- a/MediaBrowser.Controller/SyncPlay/ISyncPlayManager.cs
+++ b/MediaBrowser.Controller/SyncPlay/ISyncPlayManager.cs
@@ -56,6 +56,21 @@ namespace MediaBrowser.Controller.SyncPlay
         GroupInfoDto GetGroup(SessionInfo session, Guid groupId);
 
         /// <summary>
+        /// Gets the authoritative V2 group state for the specified group.
+        /// </summary>
+        /// <param name="session">The current session.</param>
+        /// <param name="groupId">The group identifier.</param>
+        /// <returns>The V2 group state, or null when not available.</returns>
+        SyncPlayGroupStateV2Dto GetGroupStateV2(SessionInfo session, Guid groupId);
+
+        /// <summary>
+        /// Gets the authoritative V2 group state for the current session's joined group.
+        /// </summary>
+        /// <param name="session">The current session.</param>
+        /// <returns>The V2 group state, or null when session is not in a group.</returns>
+        SyncPlayGroupStateV2Dto GetJoinedGroupStateV2(SessionInfo session);
+
+        /// <summary>
         /// Handle a request by a session in a group.
         /// </summary>
         /// <param name="session">The session.</param>

--- a/MediaBrowser.Model/SyncPlay/GroupUpdateType.cs
+++ b/MediaBrowser.Model/SyncPlay/GroupUpdateType.cs
@@ -8,46 +8,66 @@ namespace MediaBrowser.Model.SyncPlay
         /// <summary>
         /// The user-joined update. Tells members of a group about a new user.
         /// </summary>
-        UserJoined,
+        UserJoined = 0,
 
         /// <summary>
         /// The user-left update. Tells members of a group that a user left.
         /// </summary>
-        UserLeft,
+        UserLeft = 1,
 
         /// <summary>
         /// The group-joined update. Tells a user that the group has been joined.
         /// </summary>
-        GroupJoined,
+        GroupJoined = 2,
 
         /// <summary>
         /// The group-left update. Tells a user that the group has been left.
         /// </summary>
-        GroupLeft,
+        GroupLeft = 3,
 
         /// <summary>
-        /// The group-state update. Tells members of the group that the state changed.
+        /// The group-update. Updates information about the group.
         /// </summary>
-        StateUpdate,
+        GroupUpdate = 4,
 
         /// <summary>
         /// The play-queue update. Tells a user the playing queue of the group.
         /// </summary>
-        PlayQueue,
+        PlayQueue = 5,
+
+        /// <summary>
+        /// The group-state update. Tells members of the group that the state changed.
+        /// </summary>
+        StateUpdate = 6,
 
         /// <summary>
         /// The not-in-group error. Tells a user that they don't belong to a group.
         /// </summary>
-        NotInGroup,
+        NotInGroup = 7,
 
         /// <summary>
         /// The group-does-not-exist error. Sent when trying to join a non-existing group.
         /// </summary>
-        GroupDoesNotExist,
+        GroupDoesNotExist = 8,
+
+        /// <summary>
+        /// The create-group-denied error. Sent when a user isn't allowed to create groups.
+        /// </summary>
+        CreateGroupDenied = 9,
+
+        /// <summary>
+        /// The join-group-denied error. Sent when a user isn't allowed to join groups.
+        /// </summary>
+        JoinGroupDenied = 10,
 
         /// <summary>
         /// The library-access-denied error. Sent when a user tries to join a group without required access to the library.
         /// </summary>
-        LibraryAccessDenied
+        LibraryAccessDenied = 11,
+
+        /// <summary>
+        /// The group-snapshot update. Sends a full group snapshot to a client.
+        /// </summary>
+        GroupSnapshot = 12
     }
 }

--- a/MediaBrowser.Model/SyncPlay/SyncPlayGroupSnapshotDto.cs
+++ b/MediaBrowser.Model/SyncPlay/SyncPlayGroupSnapshotDto.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace MediaBrowser.Model.SyncPlay;
+
+/// <summary>
+/// Snapshot of a SyncPlay group state for fast client recovery.
+/// </summary>
+public class SyncPlayGroupSnapshotDto
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SyncPlayGroupSnapshotDto"/> class.
+    /// </summary>
+    /// <param name="groupInfo">The group info.</param>
+    /// <param name="playQueue">The play queue snapshot.</param>
+    /// <param name="playingCommand">The current playing command, if any.</param>
+    /// <param name="revision">The monotonic revision for this snapshot.</param>
+    /// <param name="serverUtcNow">The current server UTC time.</param>
+    public SyncPlayGroupSnapshotDto(
+        GroupInfoDto groupInfo,
+        PlayQueueUpdate playQueue,
+        SendCommand? playingCommand,
+        long revision,
+        DateTime serverUtcNow)
+    {
+        GroupInfo = groupInfo;
+        PlayQueue = playQueue;
+        PlayingCommand = playingCommand;
+        Revision = revision;
+        ServerUtcNow = serverUtcNow;
+    }
+
+    /// <summary>
+    /// Gets the group info.
+    /// </summary>
+    public GroupInfoDto GroupInfo { get; }
+
+    /// <summary>
+    /// Gets the play queue snapshot.
+    /// </summary>
+    public PlayQueueUpdate PlayQueue { get; }
+
+    /// <summary>
+    /// Gets the current playing command, if any.
+    /// </summary>
+    public SendCommand? PlayingCommand { get; }
+
+    /// <summary>
+    /// Gets the monotonic revision for this snapshot.
+    /// </summary>
+    public long Revision { get; }
+
+    /// <summary>
+    /// Gets the current server UTC time.
+    /// </summary>
+    public DateTime ServerUtcNow { get; }
+}

--- a/MediaBrowser.Model/SyncPlay/SyncPlayGroupSnapshotUpdate.cs
+++ b/MediaBrowser.Model/SyncPlay/SyncPlayGroupSnapshotUpdate.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel;
+
+namespace MediaBrowser.Model.SyncPlay;
+
+/// <summary>
+/// SyncPlay group snapshot update.
+/// </summary>
+public class SyncPlayGroupSnapshotUpdate : GroupUpdate<SyncPlayGroupSnapshotDto>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SyncPlayGroupSnapshotUpdate"/> class.
+    /// </summary>
+    /// <param name="groupId">The group identifier.</param>
+    /// <param name="data">The snapshot data.</param>
+    public SyncPlayGroupSnapshotUpdate(Guid groupId, SyncPlayGroupSnapshotDto data)
+        : base(groupId, data)
+    {
+    }
+
+    /// <inheritdoc />
+    [DefaultValue(GroupUpdateType.GroupSnapshot)]
+    public override GroupUpdateType Type => GroupUpdateType.GroupSnapshot;
+}

--- a/MediaBrowser.Model/SyncPlay/SyncPlayGroupStateV2Dto.cs
+++ b/MediaBrowser.Model/SyncPlay/SyncPlayGroupStateV2Dto.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace MediaBrowser.Model.SyncPlay;
+
+/// <summary>
+/// V2 authoritative SyncPlay group state payload.
+/// </summary>
+public class SyncPlayGroupStateV2Dto
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SyncPlayGroupStateV2Dto"/> class.
+    /// </summary>
+    /// <param name="groupId">The group identifier.</param>
+    /// <param name="revision">The monotonic server revision for this group state.</param>
+    /// <param name="snapshot">The latest full snapshot.</param>
+    /// <param name="serverUtcNow">Current server UTC time.</param>
+    public SyncPlayGroupStateV2Dto(Guid groupId, long revision, SyncPlayGroupSnapshotDto snapshot, DateTime serverUtcNow)
+    {
+        GroupId = groupId;
+        Revision = revision;
+        Snapshot = snapshot;
+        ServerUtcNow = serverUtcNow;
+    }
+
+    /// <summary>
+    /// Gets the group identifier.
+    /// </summary>
+    public Guid GroupId { get; }
+
+    /// <summary>
+    /// Gets the monotonic revision for this group state.
+    /// </summary>
+    public long Revision { get; }
+
+    /// <summary>
+    /// Gets the latest full snapshot.
+    /// </summary>
+    public SyncPlayGroupSnapshotDto Snapshot { get; }
+
+    /// <summary>
+    /// Gets the current server UTC time.
+    /// </summary>
+    public DateTime ServerUtcNow { get; }
+}

--- a/docs/syncplay/FILE_INDEX.md
+++ b/docs/syncplay/FILE_INDEX.md
@@ -1,0 +1,135 @@
+# SyncPlay File Index
+
+This index maps every SyncPlay-related area in the repository to its role.
+
+## Client Runtime (`Client/jellyfin-web-master/src`)
+
+### Toolbar + React hooks
+
+- `apps/experimental/components/AppToolbar/SyncPlayButton.tsx`
+  - Toolbar entrypoint and visibility/access gating.
+- `apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx`
+  - Group create/join/leave/start-stop/settings actions.
+- `hooks/useSyncPlayGroups.ts`
+  - React-query polling hook for `/SyncPlay/V2/List`.
+
+### Plugin bootstrap
+
+- `plugins/syncPlay/plugin.ts`
+  - Registers wrappers and initializes SyncPlay manager.
+- `plugins/syncPlay/core/index.js`
+  - Exports shared runtime instances.
+
+### Core orchestration
+
+- `plugins/syncPlay/core/Manager.js`
+  - Top-level coordinator, v2 reconcile loop, snapshot/command application.
+- `plugins/syncPlay/core/Controller.js`
+  - User-driven sync actions and command throttling/gates.
+- `plugins/syncPlay/core/PlaybackCore.js`
+  - Local command scheduling and sync correction mechanics.
+- `plugins/syncPlay/core/QueueCore.js`
+  - Queue update handling and playback bootstrap.
+- `plugins/syncPlay/core/Helper.js`
+  - Playback item/event helper utilities.
+- `plugins/syncPlay/core/Settings.js`
+  - SyncPlay namespaced app settings.
+- `plugins/syncPlay/core/V2Api.js`
+  - Protocol write helpers for `/SyncPlay/V2/*`.
+
+### Time sync
+
+- `plugins/syncPlay/core/timeSync/TimeSync.js`
+  - Generic offset/ping estimation engine.
+- `plugins/syncPlay/core/timeSync/TimeSyncCore.js`
+  - Time sync facade used by manager/playback.
+- `plugins/syncPlay/core/timeSync/TimeSyncServer.js`
+  - Server-time ping transport implementation.
+
+### Player abstractions
+
+- `plugins/syncPlay/core/players/PlayerFactory.js`
+  - Wrapper resolution for active player type.
+- `plugins/syncPlay/core/players/GenericPlayer.js`
+  - Base wrapper contract for sync control.
+- `plugins/syncPlay/ui/players/NoActivePlayer.js`
+  - Fallback wrapper when no local player is bound.
+- `plugins/syncPlay/ui/players/HtmlVideoPlayer.js`
+  - Video-specific wrapper behavior/events.
+- `plugins/syncPlay/ui/players/HtmlAudioPlayer.js`
+  - Audio-specific wrapper behavior/events.
+- `plugins/syncPlay/ui/players/QueueManager.js`
+  - Local queue interaction helpers for wrappers.
+
+### Legacy/group sheet + settings UI
+
+- `plugins/syncPlay/ui/groupSelectionMenu.js`
+  - Legacy-style group selection action sheet.
+- `plugins/syncPlay/ui/groupSelectionMenu.scss`
+  - Styling for the legacy group menu.
+- `plugins/syncPlay/ui/playbackPermissionManager.js`
+  - Permission checks for syncplay playback actions.
+- `plugins/syncPlay/ui/settings/SettingsEditor.js`
+  - SyncPlay settings editor logic and profiles.
+- `plugins/syncPlay/ui/settings/editor.html`
+  - Settings editor template.
+
+## Server API + Orchestration
+
+### API boundary (`Jellyfin.Api`)
+
+- `Jellyfin.Api/Controllers/SyncPlayController.cs`
+  - All SyncPlay HTTP endpoints and request mapping.
+- `Jellyfin.Api/Auth/SyncPlayAccessPolicy/SyncPlayAccessRequirement.cs`
+- `Jellyfin.Api/Auth/SyncPlayAccessPolicy/SyncPlayAccessHandler.cs`
+  - Access policy requirements and enforcement.
+- `Jellyfin.Api/Models/SyncPlayDtos/*.cs`
+  - API request DTO contracts for queue/transport/group actions.
+
+### Group/session orchestrator (`Emby.Server.Implementations`)
+
+- `Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs`
+  - Group registry, session membership mapping, request dispatch.
+- `Emby.Server.Implementations/SyncPlay/Group.cs`
+  - Per-group state machine context, revisioned snapshots, participant state.
+
+### Domain contracts and state machine (`MediaBrowser.Controller`)
+
+- `MediaBrowser.Controller/SyncPlay/ISyncPlayManager.cs`
+- `MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs`
+- `MediaBrowser.Controller/SyncPlay/IGroupState.cs`
+- `MediaBrowser.Controller/SyncPlay/ISyncPlayRequest.cs`
+- `MediaBrowser.Controller/SyncPlay/IGroupPlaybackRequest.cs`
+  - Core SyncPlay interfaces.
+- `MediaBrowser.Controller/SyncPlay/GroupMember.cs`
+  - Per-session group member tracking fields.
+- `MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs`
+  - Queue mutation and current-item positioning.
+- `MediaBrowser.Controller/SyncPlay/GroupStates/*.cs`
+  - Idle/Waiting/Playing/Paused behavior implementations.
+- `MediaBrowser.Controller/SyncPlay/PlaybackRequests/*.cs`
+  - Typed action handlers (Pause/Seek/Queue/Ready/Ping/etc.).
+- `MediaBrowser.Controller/SyncPlay/Requests/*.cs`
+  - Group-level request contracts (New/Join/Leave/List).
+- `MediaBrowser.Controller/Net/WebSocketMessages/Outbound/SyncPlayCommandMessage.cs`
+  - WebSocket envelope for SyncPlay command updates.
+
+### Shared model contracts (`MediaBrowser.Model`)
+
+- `MediaBrowser.Model/SyncPlay/*.cs`
+  - Shared SyncPlay DTOs/events/enums used by API, server, and clients.
+  - Includes v2 snapshot/state contracts (`SyncPlayGroupStateV2Dto`, `SyncPlayGroupSnapshotDto`).
+
+### Data enums
+
+- `src/Jellyfin.Database/Jellyfin.Database.Implementations/Enums/SyncPlayUserAccessType.cs`
+- `Jellyfin.Data/Enums/SyncPlayAccessRequirementType.cs`
+  - Access-level and policy enum types.
+
+## Tests
+
+- `tests/Jellyfin.Api.Tests/Controllers/SyncPlayControllerTests.cs`
+  - Controller request/response coverage.
+- `tests/Jellyfin.Server.Implementations.Tests/SyncPlay/GroupV2StateTests.cs`
+  - Group snapshot/revision/state behavior coverage.
+

--- a/docs/syncplay/README.md
+++ b/docs/syncplay/README.md
@@ -1,0 +1,245 @@
+# SyncPlay V2 Developer Reference
+
+This document is the implementation map for SyncPlay in this repository.
+It is written to let a new contributor start from zero, trace the request path end-to-end, and make safe changes without breaking group sync.
+
+## Scope
+
+This covers:
+- Client SyncPlay runtime and UI (`Client/jellyfin-web-master/src/plugins/syncPlay` and related toolbar/hooks).
+- Server SyncPlay API and orchestration (`Jellyfin.Api`, `Emby.Server.Implementations/SyncPlay`, `MediaBrowser.Controller/SyncPlay`).
+- SyncPlay V2 authoritative state flow (`/SyncPlay/V2/*` endpoints and snapshot/revision model).
+
+Related index:
+- `docs/syncplay/FILE_INDEX.md` for a complete path-by-path map of SyncPlay code.
+
+This does not cover:
+- General Jellyfin playback pipeline internals outside SyncPlay wrappers.
+- Non-SyncPlay plugin architecture details.
+
+## Mental Model
+
+SyncPlay is a server-coordinated, client-executed sync system:
+- The server is the source of truth for group membership, queue, state, and state revision.
+- Clients execute actual media control locally and continuously reconcile with server state.
+- V2 snapshot endpoints (`/SyncPlay/V2/Joined`, `/SyncPlay/V2/{id}`) are authoritative and used for recovery.
+
+### Why V2 matters
+
+Legacy event streams can arrive out of order. V2 protects correctness by:
+- Using a monotonic server revision.
+- Letting clients pull the latest snapshot when they detect stale/conflicting updates.
+- Making queue + playback command reconciliation explicit.
+
+## End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Manager/Controller)
+    participant API as SyncPlayController
+    participant M as SyncPlayManager
+    participant G as Group
+
+    C->>API: POST /SyncPlay/V2/New
+    API->>M: NewGroup(session, request)
+    M->>G: CreateGroup(...)
+    G-->>C: GroupJoined + Snapshot update
+    C->>API: GET /SyncPlay/V2/Joined
+    API->>M: GetJoinedGroupStateV2
+    M->>G: GetStateV2()
+    G-->>C: Snapshot(Revision, GroupInfo, PlayQueue, PlayingCommand)
+    C->>C: applyJoinedGroupStateV2 + applySnapshot
+```
+
+```mermaid
+sequenceDiagram
+    participant User as User Action
+    participant C as Client Controller
+    participant API as SyncPlayController
+    participant G as Group State
+    participant C2 as Other Client
+
+    User->>C: Pause / Seek / Unpause
+    C->>API: POST /SyncPlay/V2/{Command}
+    API->>G: HandleRequest(...)
+    G-->>C2: Snapshot update (new Revision)
+    C2->>C2: Apply command at server-aligned time
+    C2->>API: POST /SyncPlay/V2/Ping + Ready/Buffering
+```
+
+## Client Architecture
+
+### Bootstrap and top-level wiring
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/plugin.ts`
+  - Registers player wrappers.
+  - Binds playback manager `playerchange` events.
+  - Initializes and rebinds SyncPlay manager when active API client changes.
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/index.js`
+  - Constructs singleton-style SyncPlay module objects (`Manager`, `PlayerFactory`).
+
+### Runtime coordinator
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/Manager.js`
+  - Central coordinator.
+  - Owns: group state, reconciliation loop, pending commands, player wrapper binding.
+  - Key invariants:
+    - Ignore stale snapshots/updates by revision.
+    - Never apply playback commands while SyncPlay is not ready.
+    - Queue updates are applied before playback command execution.
+  - Recovery behavior:
+    - On stale queue/command signals, pulls `/SyncPlay/V2/Joined`.
+    - Rehydrates membership before disabling SyncPlay.
+
+### Control and playback execution
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/Controller.js`
+  - User-originated actions (pause/unpause/seek/queue/etc.).
+  - Applies command cooldown and optional ready-gate before unpause.
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/PlaybackCore.js`
+  - Schedules and executes group playback commands locally.
+  - Handles sync correction (`SpeedToSync` / `SkipToSync`) and late command handling.
+  - Reports buffering/ready state back to server.
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/QueueCore.js`
+  - Applies server queue updates and triggers local playback entry points.
+  - Rejects old queue updates and forces authoritative recovery.
+
+### Time sync
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/timeSync/TimeSync.js`
+  - Generic offset/ping estimation.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/timeSync/TimeSyncServer.js`
+  - Uses `/GetUTCTime` to estimate RTT/offset.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/timeSync/TimeSyncCore.js`
+  - Bridges manager to time sync source and settings (`extraTimeOffset`).
+
+### Transport helpers and utils
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/V2Api.js`
+  - All client-side SyncPlay writes target `/SyncPlay/V2/*`.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/Helper.js`
+  - Event waiting, playback item translation, playback query helpers.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/Settings.js`
+  - Namespaced settings read/write (`syncPlay` prefix).
+
+### UI surfaces
+
+- `Client/jellyfin-web-master/src/apps/experimental/components/AppToolbar/SyncPlayButton.tsx`
+  - Toolbar visibility/access gate and menu anchor.
+- `Client/jellyfin-web-master/src/apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx`
+  - Group create/join/leave/start-stop/settings actions.
+  - Group list polling while menu is open and not currently joined.
+- `Client/jellyfin-web-master/src/hooks/useSyncPlayGroups.ts`
+  - React-query wrapper for `/SyncPlay/V2/List`.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/settings/SettingsEditor.js`
+  - SyncPlay settings editor and profile system.
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/settings/editor.html`
+  - Settings form template.
+
+### Player wrappers
+
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/players/PlayerFactory.js`
+- `Client/jellyfin-web-master/src/plugins/syncPlay/core/players/GenericPlayer.js`
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/players/NoActivePlayer.js`
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js`
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/players/HtmlAudioPlayer.js`
+- `Client/jellyfin-web-master/src/plugins/syncPlay/ui/players/QueueManager.js`
+
+These adapters isolate SyncPlay runtime logic from concrete media player APIs.
+
+## Server Architecture
+
+### API boundary
+
+- `Jellyfin.Api/Controllers/SyncPlayController.cs`
+  - REST surface for all SyncPlay requests.
+  - V2 routes are first-class and coexist with legacy aliases.
+  - Route categories:
+    - Membership: `New`, `Join`, `Leave`, `List`, `V2/Joined`, `V2/{id}`
+    - Queue/transport: `SetNewQueue`, `Queue`, `Pause`, `Unpause`, `Seek`, etc.
+    - Sync signals: `Ready`, `Buffering`, `Ping`, `SetIgnoreWait`
+
+### Session/group orchestration
+
+- `Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs`
+  - Owns:
+    - Group registry.
+    - Session-to-group mapping.
+    - Active session counters.
+  - Concurrency rule:
+    - `_groupsLock` guards cross-group state and mapping mutation.
+    - Group instance lock guards per-group mutable state.
+    - Lock ordering must remain `_groupsLock` -> `group lock`.
+
+- `Emby.Server.Implementations/SyncPlay/Group.cs`
+  - Per-group state machine context.
+  - Owns participants, queue manager, position, revision, and current group state implementation.
+  - Emits group updates and snapshots.
+  - `Revision` is incremented on state-changing operations and used by V2 snapshots.
+
+### Domain state machine and requests
+
+- `MediaBrowser.Controller/SyncPlay/GroupStates/*`
+  - Idle / Waiting / Playing / Paused behaviors.
+- `MediaBrowser.Controller/SyncPlay/PlaybackRequests/*`
+  - Typed request handlers (Pause, Seek, Queue, Ping, Ready, etc.).
+- `MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs`
+  - Queue mutation and playback index maintenance.
+
+## State and Revision Invariants
+
+When changing SyncPlay behavior, keep these invariants:
+- Server revision must increase on any mutation that clients must reconcile.
+- Client must not apply stale snapshot/queue updates (`incomingRevision < latestRevision`).
+- Client should prefer authoritative pull (`/V2/Joined`) on inconsistency, not local guessing.
+- Queue update side effects must be deterministic and idempotent for duplicate events.
+- Ready/buffering signals must include the same queue/playback identity expected by server.
+
+## Settings Reference (Client)
+
+Primary keys under `syncPlay.*`:
+- `syncProfile`
+- `enableSyncCorrection`
+- `enforceReadyBeforeUnpause`
+- `commandCooldownMs`
+- `bufferingThresholdMillis`
+- `useSpeedToSync`
+- `useSkipToSync`
+- `minDelaySpeedToSync`
+- `maxDelaySpeedToSync`
+- `speedToSyncDuration`
+- `minDelaySkipToSync`
+- `maxLateCommandMillis`
+- `maxLateSeekRecoveryMillis`
+- `seekReadySettleDelayMs`
+- `maxSeekSettleDiffMillis`
+- `seekReadyEventTimeoutMs`
+- `zeroSeekAnchorMillis`
+- `extraTimeOffset`
+
+## Where to start for common changes
+
+- Add/adjust transport behavior:
+  - `Controller.js` + `PlaybackCore.js` + `SyncPlayController.cs` request route.
+- Add new server authoritative state field:
+  - `Group.cs` snapshot model -> API DTO -> client `Manager.applySnapshot`.
+- Adjust queue transitions:
+  - `PlayQueueManager.cs` + `QueueCore.js`.
+- Tune latency/desync behavior:
+  - `TimeSync*` + `PlaybackCore` thresholds + settings editor.
+
+## Test checklist
+
+- Create/join/leave group from two browser sessions.
+- Start playback from idle and verify both enter ready/wait/playing transitions.
+- Pause/unpause spam test with cooldown.
+- Multiple seeks including near `0:00` and during transcode.
+- One direct-play + one transcode participant seek convergence.
+- Group recovery:
+  - close/reopen tab.
+  - disconnect/reconnect websocket.
+  - stale queue update scenario -> verify `/V2/Joined` recovery.
+- Confirm no stale revision applies in logs.

--- a/tests/Jellyfin.Api.Tests/Controllers/SyncPlayControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/SyncPlayControllerTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Controllers;
+using Jellyfin.Api.Results;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.SyncPlay;
+using MediaBrowser.Model.SyncPlay;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class SyncPlayControllerTests
+{
+    [Fact]
+    public async Task SyncPlayGetJoinedGroupStateV2_WhenStateExists_ReturnsOk()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var sessionManagerMock = new Mock<ISessionManager>();
+        var syncPlayManagerMock = new Mock<ISyncPlayManager>();
+        var userManagerMock = new Mock<IUserManager>();
+        var session = CreateSession(sessionManagerMock.Object, userId, "session-joined");
+        var state = CreateGroupState(groupId, 7);
+
+        SetupRequestSession(sessionManagerMock, userManagerMock, session, userId);
+        syncPlayManagerMock
+            .Setup(x => x.GetJoinedGroupStateV2(session))
+            .Returns(state);
+
+        var subject = CreateSubject(sessionManagerMock, syncPlayManagerMock, userManagerMock, userId);
+
+        var result = await subject.SyncPlayGetJoinedGroupStateV2();
+
+        var okResult = Assert.IsType<OkResult<SyncPlayGroupStateV2Dto>>(result.Result);
+        var payload = Assert.IsType<SyncPlayGroupStateV2Dto>(okResult.Value);
+        Assert.Equal(groupId, payload.GroupId);
+        Assert.Equal(7, payload.Revision);
+    }
+
+    [Fact]
+    public async Task SyncPlayGetJoinedGroupStateV2_WhenStateMissing_ReturnsNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var sessionManagerMock = new Mock<ISessionManager>();
+        var syncPlayManagerMock = new Mock<ISyncPlayManager>();
+        var userManagerMock = new Mock<IUserManager>();
+        var session = CreateSession(sessionManagerMock.Object, userId, "session-notfound");
+
+        SetupRequestSession(sessionManagerMock, userManagerMock, session, userId);
+        syncPlayManagerMock
+            .Setup(x => x.GetJoinedGroupStateV2(session))
+            .Returns((SyncPlayGroupStateV2Dto)null!);
+
+        var subject = CreateSubject(sessionManagerMock, syncPlayManagerMock, userManagerMock, userId);
+
+        var result = await subject.SyncPlayGetJoinedGroupStateV2();
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task SyncPlayGetGroupStateV2_WhenStateExists_ReturnsOk()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var sessionManagerMock = new Mock<ISessionManager>();
+        var syncPlayManagerMock = new Mock<ISyncPlayManager>();
+        var userManagerMock = new Mock<IUserManager>();
+        var session = CreateSession(sessionManagerMock.Object, userId, "session-group");
+        var state = CreateGroupState(groupId, 12);
+
+        SetupRequestSession(sessionManagerMock, userManagerMock, session, userId);
+        syncPlayManagerMock
+            .Setup(x => x.GetGroupStateV2(session, groupId))
+            .Returns(state);
+
+        var subject = CreateSubject(sessionManagerMock, syncPlayManagerMock, userManagerMock, userId);
+
+        var result = await subject.SyncPlayGetGroupStateV2(groupId);
+
+        var okResult = Assert.IsType<OkResult<SyncPlayGroupStateV2Dto>>(result.Result);
+        var payload = Assert.IsType<SyncPlayGroupStateV2Dto>(okResult.Value);
+        Assert.Equal(groupId, payload.GroupId);
+        Assert.Equal(12, payload.Revision);
+    }
+
+    [Fact]
+    public async Task SyncPlayGetGroupStateV2_WhenStateMissing_ReturnsNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var sessionManagerMock = new Mock<ISessionManager>();
+        var syncPlayManagerMock = new Mock<ISyncPlayManager>();
+        var userManagerMock = new Mock<IUserManager>();
+        var session = CreateSession(sessionManagerMock.Object, userId, "session-group-notfound");
+
+        SetupRequestSession(sessionManagerMock, userManagerMock, session, userId);
+        syncPlayManagerMock
+            .Setup(x => x.GetGroupStateV2(session, groupId))
+            .Returns((SyncPlayGroupStateV2Dto)null!);
+
+        var subject = CreateSubject(sessionManagerMock, syncPlayManagerMock, userManagerMock, userId);
+
+        var result = await subject.SyncPlayGetGroupStateV2(groupId);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    private static SyncPlayController CreateSubject(
+        Mock<ISessionManager> sessionManagerMock,
+        Mock<ISyncPlayManager> syncPlayManagerMock,
+        Mock<IUserManager> userManagerMock,
+        Guid userId)
+    {
+        var httpContext = BuildHttpContext(userId);
+        return new SyncPlayController(sessionManagerMock.Object, syncPlayManagerMock.Object, userManagerMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+    }
+
+    private static void SetupRequestSession(
+        Mock<ISessionManager> sessionManagerMock,
+        Mock<IUserManager> userManagerMock,
+        SessionInfo session,
+        Guid userId)
+    {
+        userManagerMock
+            .Setup(x => x.GetUserById(userId))
+            .Returns(new User("jellyfin", "default", "default"));
+
+        sessionManagerMock
+            .Setup(x => x.LogSessionActivity(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<User>()))
+            .ReturnsAsync(session);
+    }
+
+    private static SessionInfo CreateSession(ISessionManager sessionManager, Guid userId, string sessionId)
+    {
+        return new SessionInfo(sessionManager, NullLogger<SessionInfo>.Instance)
+        {
+            Id = sessionId,
+            UserId = userId,
+            UserName = "jellyfin",
+            Client = "web",
+            DeviceId = "device-id",
+            DeviceName = "device-name"
+        };
+    }
+
+    private static DefaultHttpContext BuildHttpContext(Guid userId)
+    {
+        var claims = new[]
+        {
+            new Claim(InternalClaimTypes.UserId, userId.ToString("N")),
+            new Claim(InternalClaimTypes.Client, "web"),
+            new Claim(InternalClaimTypes.Version, "10.12.0"),
+            new Claim(InternalClaimTypes.DeviceId, "device-id"),
+            new Claim(InternalClaimTypes.Device, "device-name")
+        };
+
+        var context = new DefaultHttpContext();
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        context.Connection.RemoteIpAddress = IPAddress.Loopback;
+        return context;
+    }
+
+    private static SyncPlayGroupStateV2Dto CreateGroupState(Guid groupId, long revision)
+    {
+        var groupInfo = new GroupInfoDto(groupId, "Test Group", GroupStateType.Idle, ["jellyfin"], DateTime.UtcNow);
+        var queueUpdate = new PlayQueueUpdate(
+            PlayQueueUpdateReason.NewPlaylist,
+            DateTime.UtcNow,
+            Array.Empty<SyncPlayQueueItem>(),
+            -1,
+            0,
+            false,
+            GroupShuffleMode.Sorted,
+            GroupRepeatMode.RepeatNone);
+        var snapshot = new SyncPlayGroupSnapshotDto(groupInfo, queueUpdate, null, revision, DateTime.UtcNow);
+        return new SyncPlayGroupStateV2Dto(groupId, revision, snapshot, DateTime.UtcNow);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/GroupV2StateTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/GroupV2StateTests.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.SyncPlay;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.SyncPlay.PlaybackRequests;
+using MediaBrowser.Controller.SyncPlay.Requests;
+using MediaBrowser.Model.SyncPlay;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.SyncPlay;
+
+public class GroupV2StateTests
+{
+    [Fact]
+    public void GetStateV2_RevisionMatchesGroupAndSnapshot()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var session = CreateSession(sessionManagerMock.Object, Guid.NewGuid(), "session-revision");
+
+        group.CreateGroup(session, new NewGroupRequest("Group"), CancellationToken.None);
+        var state = group.GetStateV2();
+
+        Assert.True(state.Revision > 0);
+        Assert.Equal(group.Revision, state.Revision);
+        Assert.Equal(group.Revision, state.Snapshot.Revision);
+        Assert.Equal(group.GroupId, state.GroupId);
+    }
+
+    [Fact]
+    public void SetIgnoreGroupWait_IncrementsRevisionOnlyOnValueChange()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var session = CreateSession(sessionManagerMock.Object, Guid.NewGuid(), "session-ignore");
+        group.CreateGroup(session, new NewGroupRequest("Group"), CancellationToken.None);
+
+        var initialRevision = group.Revision;
+
+        group.SetIgnoreGroupWait(session, false);
+        Assert.Equal(initialRevision, group.Revision);
+
+        group.SetIgnoreGroupWait(session, true);
+        Assert.Equal(initialRevision + 1, group.Revision);
+
+        group.SetIgnoreGroupWait(session, true);
+        Assert.Equal(initialRevision + 1, group.Revision);
+    }
+
+    [Fact]
+    public void SetAllBuffering_IncrementsRevisionOnlyOnValueChange()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var session = CreateSession(sessionManagerMock.Object, Guid.NewGuid(), "session-buffer");
+        group.CreateGroup(session, new NewGroupRequest("Group"), CancellationToken.None);
+
+        var initialRevision = group.Revision;
+
+        group.SetAllBuffering(false);
+        Assert.Equal(initialRevision, group.Revision);
+
+        group.SetAllBuffering(true);
+        Assert.Equal(initialRevision + 1, group.Revision);
+
+        group.SetAllBuffering(true);
+        Assert.Equal(initialRevision + 1, group.Revision);
+    }
+
+    [Fact]
+    public void SessionJoin_SendsSnapshotToAllParticipants()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var userOne = Guid.NewGuid();
+        var userTwo = Guid.NewGuid();
+        var sessionOne = CreateSession(sessionManagerMock.Object, userOne, "session-one");
+        var sessionTwo = CreateSession(sessionManagerMock.Object, userTwo, "session-two");
+
+        group.CreateGroup(sessionOne, new NewGroupRequest("Group"), CancellationToken.None);
+        sessionManagerMock.Invocations.Clear();
+
+        group.SessionJoin(sessionTwo, new JoinGroupRequest(group.GroupId), CancellationToken.None);
+
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionOne.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionTwo.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public void SessionLeave_SendsSnapshotToRemainingParticipantsOnly()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var userOne = Guid.NewGuid();
+        var userTwo = Guid.NewGuid();
+        var sessionOne = CreateSession(sessionManagerMock.Object, userOne, "session-leave-one");
+        var sessionTwo = CreateSession(sessionManagerMock.Object, userTwo, "session-leave-two");
+
+        group.CreateGroup(sessionOne, new NewGroupRequest("Group"), CancellationToken.None);
+        group.SessionJoin(sessionTwo, new JoinGroupRequest(group.GroupId), CancellationToken.None);
+        sessionManagerMock.Invocations.Clear();
+
+        group.SessionLeave(sessionTwo, new LeaveGroupRequest(), CancellationToken.None);
+
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionOne.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionTwo.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void HandleRequest_WhenRevisionChanges_SendsSnapshotToGroup()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var userOne = Guid.NewGuid();
+        var userTwo = Guid.NewGuid();
+        var sessionOne = CreateSession(sessionManagerMock.Object, userOne, "session-request-one");
+        var sessionTwo = CreateSession(sessionManagerMock.Object, userTwo, "session-request-two");
+
+        group.CreateGroup(sessionOne, new NewGroupRequest("Group"), CancellationToken.None);
+        group.SessionJoin(sessionTwo, new JoinGroupRequest(group.GroupId), CancellationToken.None);
+        sessionManagerMock.Invocations.Clear();
+
+        group.HandleRequest(sessionOne, new IgnoreWaitGroupRequest(true), CancellationToken.None);
+
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionOne.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                sessionTwo.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCommand_EmitsSnapshotAndDoesNotUseLegacyCommandChannel()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var session = CreateSession(sessionManagerMock.Object, Guid.NewGuid(), "session-command");
+
+        group.CreateGroup(session, new NewGroupRequest("Group"), CancellationToken.None);
+        sessionManagerMock.Invocations.Clear();
+
+        var command = group.NewSyncPlayCommand(SendCommandType.Pause);
+        await group.SendCommand(session, SyncPlayBroadcastType.CurrentSession, command, CancellationToken.None);
+
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                session.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update =>
+                    update.Type == GroupUpdateType.GroupSnapshot
+                    && update.Data.PlayingCommand != null
+                    && update.Data.PlayingCommand.Command == SendCommandType.Pause),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayCommand(
+                It.IsAny<string>(),
+                It.IsAny<SendCommand>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendGroupUpdate_PlayQueueUpdate_EmitsSnapshotInsteadOfLegacyPayload()
+    {
+        var sessionManagerMock = CreateSessionManagerMock();
+        var group = CreateGroup(sessionManagerMock.Object);
+        var session = CreateSession(sessionManagerMock.Object, Guid.NewGuid(), "session-queue");
+
+        group.CreateGroup(session, new NewGroupRequest("Group"), CancellationToken.None);
+        sessionManagerMock.Invocations.Clear();
+
+        var playQueueUpdate = group.GetPlayQueueUpdate(PlayQueueUpdateReason.NewPlaylist);
+        var legacyUpdate = new SyncPlayPlayQueueUpdate(group.GroupId, playQueueUpdate);
+        await group.SendGroupUpdate(session, SyncPlayBroadcastType.CurrentSession, legacyUpdate, CancellationToken.None);
+
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                session.Id,
+                It.Is<GroupUpdate<SyncPlayGroupSnapshotDto>>(update => update.Type == GroupUpdateType.GroupSnapshot),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        sessionManagerMock.Verify(
+            x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<GroupUpdate<PlayQueueUpdate>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static Group CreateGroup(ISessionManager sessionManager)
+    {
+        return new Group(
+            NullLoggerFactory.Instance,
+            Mock.Of<IUserManager>(),
+            sessionManager,
+            Mock.Of<ILibraryManager>());
+    }
+
+    private static SessionInfo CreateSession(ISessionManager sessionManager, Guid userId, string sessionId)
+    {
+        return new SessionInfo(sessionManager, NullLogger<SessionInfo>.Instance)
+        {
+            Id = sessionId,
+            UserId = userId,
+            UserName = "jellyfin",
+            Client = "web",
+            DeviceId = "device-id",
+            DeviceName = "device-name"
+        };
+    }
+
+    private static Mock<ISessionManager> CreateSessionManagerMock()
+    {
+        var sessionManagerMock = new Mock<ISessionManager>();
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.GroupUpdate<MediaBrowser.Model.SyncPlay.GroupInfoDto>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.GroupUpdate<string>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.GroupUpdate<MediaBrowser.Model.SyncPlay.SyncPlayGroupSnapshotDto>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.GroupUpdate<MediaBrowser.Model.SyncPlay.PlayQueueUpdate>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayGroupUpdate(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.GroupUpdate<MediaBrowser.Model.SyncPlay.GroupStateUpdate>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        sessionManagerMock
+            .Setup(x => x.SendSyncPlayCommand(
+                It.IsAny<string>(),
+                It.IsAny<MediaBrowser.Model.SyncPlay.SendCommand>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return sessionManagerMock;
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the SyncPlay V2 server protocol surface and state model used by the new web client, while keeping existing SyncPlay routes available for backward compatibility.

## What Changed

- Added authoritative V2 state contracts:
  - `SyncPlayGroupSnapshotDto`
  - `SyncPlayGroupSnapshotUpdate`
  - `SyncPlayGroupStateV2Dto`
- Added V2 read endpoints:
  - `GET /SyncPlay/V2/Joined`
  - `GET /SyncPlay/V2/{id}`
- Added V2 aliases for existing SyncPlay operations:
  - `New`, `Join`, `Leave`, `List`, `SetNewQueue`, `SetPlaylistItem`, `RemoveFromPlaylist`, `MovePlaylistItem`, `Queue`, `Pause`, `Unpause`, `Stop`, `Seek`, `Ready`, `Buffering`, `SetIgnoreWait`, `NextItem`, `PreviousItem`, `SetRepeatMode`, `SetShuffleMode`, `Ping`
- Updated group/server flow to emit snapshot-based updates and revisioned state for deterministic client recovery.
- Updated authorization routing to include new V2 paths.
- Added/updated tests for V2 endpoints and V2 snapshot/group-state behavior.
- Added SyncPlay docs and file index for maintainability.

## Compatibility

- No breaking API removal in this PR.
- Legacy `/SyncPlay/*` routes remain exposed.
- `/SyncPlay/V2/*` is the authoritative protocol for modern clients.

## Validation

- Built solution in Debug.
- Ran SyncPlay-focused API tests.
- Ran SyncPlay-focused server implementation tests.


Client Side : https://github.com/jellyfin/jellyfin-web/pull/7566
