### PR TITLE
Handle year 0000 dates in JsonDateTimeConverter

### DIFF
--- a/src/Jellyfin.Extensions/Json/Converters/JsonDateTimeConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonDateTimeConverter.cs
@@ -14,7 +14,22 @@ namespace Jellyfin.Extensions.Json.Converters
         /// <inheritdoc />
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.GetDateTime();
+            if (reader.TryGetDateTime(out var result) )
+            {
+                return result;
+            }
+            else
+            {
+                // it failed, let's look at the string value, and if it looks like a zero date, return DateTime.MinValue
+                var text = reader.GetString();
+                if (text != null && System.Text.RegularExpressions.Regex.IsMatch(text, @"^0000-\d{2}-\d{2}"))
+                {
+                    return DateTime.MinValue;
+                }
+
+                // We tried. Let's just throw the original exception for backwards compatiblity.
+                return reader.GetDateTime();
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Clients, like AndroidTV in particular, are submitting date strings with a year of 0000 which .Net will not parse (0001 is the min). This is occuring due to timezone offsets or other date math issues elsewhere that submit a year of 0000 in JSON payloads.,

It would seem ISO-8601 permits 0000 years,  Java.time (thus Kotlin) permits 0000 years, C#.Net uses gregorian calendar which only allows dates starting at year 0001. 

**Changes**
Put regex pattern matching into C#.net date parsing to make an assumption that if the year is 0000, what you really want is the minimum date possible from .Net. 

**Issues**
https://github.com/jellyfin/jellyfin/issues/16190
https://github.com/jellyfin/jellyfin-androidtv/issues/4371
