### PR TITLE
Fix filename truncation when bracketed tags appear mid-filename

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -152,8 +152,8 @@ namespace Emby.Naming.Common
 
             CleanStrings =
             [
-                @"^\s*(?<cleaned>.+?)[ _\,\.\(\)\[\]\-](3d|sbs|tab|hsbs|htab|mvc|HDR|HDC|UHD|UltraHD|4k|ac3|dts|custom|dc|divx|divx5|dsr|dsrip|dutch|dvd|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multi|subs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|cd[1-9]|r5|bd5|bd|se|svcd|swedish|german|read.nfo|nfofix|unrated|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|2160p|hrhd|hrhdtv|hddvd|bluray|blu-ray|x264|x265|h264|h265|xvid|xvidvd|xxx|www.www|AAC|DTS|\[.*\])([ _\,\.\(\)\[\]\-]|$)",
-                @"^(?<cleaned>.+?)(\[.*\])",
+                @"^\s*(?<cleaned>.+?)[ _\,\.\(\)\[\]\-](3d|sbs|tab|hsbs|htab|mvc|HDR|HDC|UHD|UltraHD|4k|ac3|dts|custom|dc|divx|divx5|dsr|dsrip|dutch|dvd|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multi|subs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|cd[1-9]|r5|bd5|bd|se|svcd|swedish|german|read.nfo|nfofix|unrated|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|2160p|hrhd|hrhdtv|hddvd|bluray|blu-ray|x264|x265|h264|h265|xvid|xvidvd|xxx|www.www|AAC|DTS)(?=[ _\,\.\(\)\[\]\-]|$)",
+                @"^\s*(?<cleaned>.+?)((\s*\[[^\]]+\]\s*)+)(\.[^\s]+)?$",
                 @"^\s*(?<cleaned>.+?)\WE[0-9]+(-|~)E?[0-9]+(\W|$)",
                 @"^\s*\[[^\]]+\](?!\.\w+$)\s*(?<cleaned>.+)",
                 @"^\s*(?<cleaned>.+?)\s+-\s+[0-9]+\s*$",

--- a/Emby.Naming/Video/CleanStringParser.cs
+++ b/Emby.Naming/Video/CleanStringParser.cs
@@ -44,7 +44,7 @@ namespace Emby.Naming.Video
             var match = expression.Match(name);
             if (match.Success && match.Groups.TryGetValue("cleaned", out var cleaned))
             {
-                newName = cleaned.Value;
+                newName = cleaned.Value.Trim();
                 return true;
             }
 

--- a/tests/Jellyfin.Naming.Tests/Video/CleanStringTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/CleanStringTests.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Naming.Tests.Video
         [InlineData("[OCN] 애타는 로맨스 720p-NEXT", "애타는 로맨스")]
         [InlineData("[tvN] 혼술남녀.E01-E16.720p-NEXT", "혼술남녀")]
         [InlineData("[tvN] 연애말고 결혼 E01~E16 END HDTV.H264.720p-WITH", "연애말고 결혼")]
+        [InlineData("2026年01月10日23時00分00秒-[新]TRIGUN　STARGAZE[字].mp4", "2026年01月10日23時00分00秒-[新]TRIGUN　STARGAZE")]
         // FIXME: [InlineData("After The Sunset - [0004].mkv", "After The Sunset")]
         public void CleanStringTest_NeedsCleaning_Success(string input, string expectedName)
         {
@@ -44,6 +45,7 @@ namespace Jellyfin.Naming.Tests.Video
         [InlineData("American.Psycho.mkv")]
         [InlineData("American Psycho.mkv")]
         [InlineData("Run lola run (lola rennt) (2009).mp4")]
+        [InlineData("2026年01月05日00時55分00秒-[新]違国日記【ＡＮｉＭｉＤＮｉＧＨＴ！！！】＃１.mp4")]
         public void CleanStringTest_DoesntNeedCleaning_False(string? input)
         {
             Assert.False(VideoResolver.TryCleanString(input, _namingOptions, out var newName));


### PR DESCRIPTION
## Changes

This PR fixes an issue where filenames containing bracketed tags (e.g., `[NEW]`, `[HD]`) in the middle of the filename were being incorrectly truncated by `CleanStringParser`.

1. **Improved Regex**: Modified the second `CleanStrings` regex in `NamingOptions.cs` to only match bracketed tags if they appear at the **end** of the filename (optionally followed by a file extension). Tags in the middle of the filename are now safely ignored.
2. **Whitespace Trimming**: Added a `Trim()` call in `CleanStringParser.cs` to prevent trailing whitespace in cleaned strings.

## Issue

Two regexes in [`NamingOptions.CleanStrings`](https://github.com/jellyfin/jellyfin/blob/8b5914001d/Emby.Naming/Common/NamingOptions.cs#L155-L156) contained the overly greedy pattern `\[.*\]`:

1. **[Line 155](https://github.com/jellyfin/jellyfin/blob/8b5914001d/Emby.Naming/Common/NamingOptions.cs#L155)**: The codec/format tag regex included `|\[.*\]` in its alternatives list, allowing any bracketed content to be treated as a codec tag.
2. **[Line 156](https://github.com/jellyfin/jellyfin/blob/8b5914001d/Emby.Naming/Common/NamingOptions.cs#L156)**: `^(?<cleaned>.+?)(\[.*\])` matched any bracketed content anywhere in the filename.

Since [`CleanStringParser.TryClean`](https://github.com/jellyfin/jellyfin/blob/8b5914001d/Emby.Naming/Video/CleanStringParser.cs#L44-L48) only keeps the `cleaned` capture group (the text *before* the match), everything after the first bracket was discarded.

**Examples:**
- `Show [NEW] Episode Title [HD].mp4` → `Show` (Title lost)
- `2026年01月10日23時00分00秒-[新]TRIGUN　STARGAZE[字].mp4` → `2026年01月10日23時00分00秒-` (Title lost)
## Verification

Ran all tests in `CleanStringTests`.
- All existing tests passed.
- Added regression test cases:
    - `2026年01月10日23時00分00秒-[新]TRIGUN　STARGAZE[字].mp4` → Trailing `[字]` correctly removed, title preserved.
    - `2026年01月05日00時55分00秒-[新]違国日記【ＡＮｉＭｉＤＮｉＧＨＴ！！！】＃１.mp4` → No truncation, filename preserved as-is.