### PR TITLE
Deduplicate provider IDs during MigrateLibraryDb migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -1163,7 +1163,9 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
                 Item = null!,
                 ProviderId = e[0],
                 ProviderValue = string.Join('|', e.Skip(1))
-            }).ToArray();
+            })
+            .DistinctBy(e => e.ProviderId)
+            .ToArray();
         }
 
         if (reader.TryGetString(index++, out var imageInfos))


### PR DESCRIPTION
Fixes #16134

The `MigrateLibraryDb` migration parses the legacy `ProviderIds` column (a pipe-delimited string like `Tmdb=12345|Imdb=tt0000123`) into individual `BaseItemProvider` entities keyed by `(ItemId, ProviderId)`.

If the legacy string contains duplicate provider keys within the same row (e.g. `Tmdb=12345|Imdb=tt0000123|Tmdb=67890`), the parser produces duplicate entities that violate the primary key constraint, causing the migration to fail with "UNIQUE constraint failed: BaseItemProviders.ItemId, BaseItemProviders.ProviderId" and preventing server startup.

This adds `.DistinctBy(e => e.ProviderId)` to the parsing pipeline, keeping the first occurrence of each provider and discarding duplicates. This is defensive migration code that runs once during upgrade.