### PR TITLE
Reattach user data after item removal during library scan

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -452,6 +452,7 @@ namespace MediaBrowser.Controller.Entities
                 // That's all the new and changed ones - now see if any have been removed and need cleanup
                 var itemsRemoved = currentChildren.Values.Except(validChildren).ToList();
                 var shouldRemove = !IsRoot || allowRemoveRoot;
+                var actuallyRemoved = new List<BaseItem>();
                 // If it's an AggregateFolder, don't remove
                 if (shouldRemove && itemsRemoved.Count > 0)
                 {
@@ -467,6 +468,7 @@ namespace MediaBrowser.Controller.Entities
                         {
                             Logger.LogDebug("Removed item: {Path}", item.Path);
 
+                            actuallyRemoved.Add(item);
                             item.SetParent(null);
                             LibraryManager.DeleteItem(item, new DeleteOptions { DeleteFileLocation = false }, this, false);
                         }
@@ -476,6 +478,20 @@ namespace MediaBrowser.Controller.Entities
                 if (newItems.Count > 0)
                 {
                     LibraryManager.CreateItems(newItems, this, cancellationToken);
+                }
+
+                // After removing items, reattach any detached user data to remaining children
+                // that share the same user data keys (eg. same episode replaced with a new file).
+                if (actuallyRemoved.Count > 0)
+                {
+                    var removedKeys = actuallyRemoved.SelectMany(i => i.GetUserDataKeys()).ToHashSet();
+                    foreach (var child in validChildren)
+                    {
+                        if (child.GetUserDataKeys().Any(removedKeys.Contains))
+                        {
+                            await child.ReattachUserDataAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                    }
                 }
             }
             else


### PR DESCRIPTION
Fixes #16149

When an episode file is replaced and both versions temporarily coexist, watch state is lost. This occurs because:
1. When the new file is first scanned, `ReattachUserDataAsync` runs during its first metadata refresh but finds nothing - the old file's user data hasn't been detached yet.
2. When the old file is later deleted, `DeleteItem` detaches its user data to the placeholder. But the replacement file is now an existing item, so `ReattachUserDataAsync` never runs again.

This fix adds a reattachment step in `ValidateChildrenInternal2` immediately after the item removal loop. It collects the user data keys of deleted items and checks if any remaining valid children share those keys (eg. same episode identified by series provider ID + season/episode number). If a match is found, `ReattachUserDataAsync` is called to transfer the detached user data to the replacement item.

The reattachment only runs when items were actually removed, minimizing performance impact during normal scans.