### PR TITLE
Prevent full library scan when real-time monitoring detects movie folder changes

### DIFF
--- a/Emby.Server.Implementations/IO/FileRefresher.cs
+++ b/Emby.Server.Implementations/IO/FileRefresher.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Emby.Server.Implementations.Library;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -182,6 +183,11 @@ namespace Emby.Server.Implementations.IO
                         {
                             foreach (var file in Directory.EnumerateFiles(path))
                             {
+                                if (IgnorePatterns.ShouldIgnore(file))
+                                {
+                                    continue;
+                                }
+
                                 var childItem = _libraryManager.FindByPath(file, false);
                                 if (childItem is not null)
                                 {


### PR DESCRIPTION
Fixes #16172

Movie directories are not tracked as separate DB entities unlike TV show/season folders. When real-time file monitoring detects a change inside a movie folder (eg. a new subtitle or replaced movie file), `FileRefresher.GetAffectedBaseItem` walks up the directory tree looking for a DB entry. Since the movie folder itself isn't tracked, it walks all the way up to the library root, triggering an unnecessary full library scan.

This change modifies `GetAffectedBaseItem` to check for known media items inside untracked directories before walking further up. When a directory isn't found in the DB but exists on disk, the method enumerates its files and looks for any that are tracked (eg. the movie file). If found, that item is returned, scoping the refresh to just the affected movie instead of the entire library.

For completely new movies (no files in the directory are tracked yet), the behavior is unchanged - the walk continues up to the library root so the new movie folder can be discovered.

For files directly in the library root, like adding subtitles to an existing movie, the behavior is unchanged and there will be a full library rescan. However, this is not the recommended structure anyway.