### PR TITLE
Skip image checks for empty folders

### DIFF
--- a/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
+++ b/Emby.Server.Implementations/Images/BaseDynamicImageProvider.cs
@@ -267,22 +267,24 @@ namespace Emby.Server.Implementations.Images
         {
             var image = item.GetImageInfo(type, 0);
 
-            if (image is not null)
+            if (image is null)
             {
-                if (!image.IsLocalFile)
-                {
-                    return false;
-                }
+                return GetItemsWithImages(item).Count is not 0;
+            }
 
-                if (!FileSystem.ContainsSubPath(item.GetInternalMetadataPath(), image.Path))
-                {
-                    return false;
-                }
+            if (!image.IsLocalFile)
+            {
+                return false;
+            }
 
-                if (!HasChangedByDate(item, image))
-                {
-                    return false;
-                }
+            if (!FileSystem.ContainsSubPath(item.GetInternalMetadataPath(), image.Path))
+            {
+                return false;
+            }
+
+            if (!HasChangedByDate(item, image))
+            {
+                return false;
             }
 
             return true;


### PR DESCRIPTION
During library scans, if a folder was empty or skipped due to ignore patterns such as `sample` or `subs`, it would repeatedly be flagged as changed on every library scan. This was also affecting `GenreImageProvider`, `MusicGenreImageProvider` and `ArtistImageProvider`. This was due to `HasChanged` in `BaseDynamicImageProvider` returning true when no image existed, assuming a new one should be generated, even when there were no child items to generate one from.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Updated `HasChanged` in the `BaseDynamicImageProvider` to:

- Returns false when no image exists and there are no child items
- Returns true when child items exist but no image has been generated yet 
- Defers to the base date check when an image already exists

**Issues**
Fixes: [comment](https://github.com/jellyfin/jellyfin/issues/15070#issuecomment-3892677735)
