### PR TITLE
Add multi-version support for Shows

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -211,6 +211,7 @@
  - [martenumberto](https://github.com/martenumberto)
  - [ZeusCraft10](https://github.com/ZeusCraft10)
  - [MarcoCoreDuo](https://github.com/MarcoCoreDuo)
+ - [eebette](https://github.com/eebette)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -228,7 +228,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
 
             if (collectionType == CollectionType.tvshows)
             {
-                return ResolveVideos<Episode>(parent, files, false, collectionType, true);
+                return ResolveVideos<Episode>(parent, files, true, collectionType, true);
             }
 
             return null;
@@ -274,7 +274,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 .Where(f => f is not null)
                 .ToList();
 
-            var resolverResult = VideoListResolver.Resolve(videoInfos, NamingOptions, supportMultiEditions, parseName, parent.ContainingFolderPath);
+            var resolverResult = VideoListResolver.Resolve(videoInfos, NamingOptions, supportMultiEditions, parseName, parent.ContainingFolderPath, supportEpisodeGrouping: collectionType == CollectionType.tvshows);
 
             var result = new MultiItemResolverResult
             {

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1226,6 +1226,24 @@ namespace MediaBrowser.Controller.Entities
                 if (HasLocalAlternateVersions)
                 {
                     var containingFolderName = System.IO.Path.GetFileName(ContainingFolderPath);
+
+                    if (this.GetBaseItemKind() == Jellyfin.Data.Enums.BaseItemKind.Episode)
+                    {
+                        var grandparentContainingFolderName = System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(ContainingFolderPath));
+                        if (!displayName.StartsWith(containingFolderName, StringComparison.OrdinalIgnoreCase) && displayName.StartsWith(grandparentContainingFolderName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            containingFolderName = grandparentContainingFolderName;
+                        }
+
+                        var episodeMatch = System.Text.RegularExpressions.Regex.Match(displayName, @"S\d+E\d+(-E\d+)*", System.Text.RegularExpressions.RegexOptions.None, TimeSpan.FromSeconds(1));
+                        if (episodeMatch.Success)
+                        {
+                            displayName = string.Concat(
+                                displayName.AsSpan(0, containingFolderName.Length),
+                                displayName.AsSpan(episodeMatch.Index + episodeMatch.Length));
+                        }
+                    }
+
                     if (displayName.Length > containingFolderName.Length && displayName.StartsWith(containingFolderName, StringComparison.OrdinalIgnoreCase))
                     {
                         var name = displayName.AsSpan(containingFolderName.Length).TrimStart([' ', '-']);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Enable multiple versions of the same episode (e.g. different quality/format releases) to be automatically grouped together in the UI, matching the existing behavior for movies. This is a re-write of #8004 on the updated master branch.

Example:

* **/library/Shows/Knuckles (2024) [tvdbid-417393]/Season 01/Knuckles (2024) [tvdbid-417393] - S01E01 -** _[Bluray-2160p][EAC3 Atmos 5.1][DV HDR10][x265].mkv_
* **/library/Shows/Knuckles (2024) [tvdbid-417393]/Season 01/Knuckles (2024) [tvdbid-417393] - S01E01 -** _[Dolby Vision Compatibility][Bluray-2160p][EAC3 Atmos 5.1][DV HDR10][x265].mp4_
* **/library/Shows/Knuckles (2024) [tvdbid-417393]/Season 01/Knuckles (2024) [tvdbid-417393] - S01E01 -** _[WEBDL-1080p][EAC3 Atmos 5.1][h264]-NTb.mkv_

<img width="1363" height="586" alt="image" src="https://github.com/user-attachments/assets/6215c1ee-2fbb-49bb-a6f2-1316c04dddee" />

Works with or without a season folder.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
[Feature Request](https://features.jellyfin.org/posts/251/multiple-versions-drop-down-on-tv-series)
Related discussion #16063 
Closes/Obsoletes #8004 

**Tests** 
- [x] Unit tests pass for episode multi-version grouping (same episode grouped, different episodes/seasons not grouped, disabled flag respected, multi-episode files supported)
- [x] Manual testing with real library containing multiple quality versions of episodes
- [x] Verify version dropdown shows only suffix labels, not full filenames
- [x] Verify movies continue to work as before

For posterity, here's the Docker image I used for testing: https://hub.docker.com/repository/docker/ebette1/jellyfin-groupseries

**AI Usage Disclaimer**
An AI Coding Agent (Claude Code Opus 4.6) helped me write a non-trivial portion of this code.

I have read, abide by, and agree with the [Jellyfin LLM/"AI" Development Policy](https://jellyfin.org/docs/general/contributing/llm-policies/).

I have reviewed, refactored (or rewritten), and understand **all** of the code generated by the coding agent while developing this feature.

I wrote the entirety of the git commit messages and this PR body without the use of an AI coding agent.

I am a professional developer that uses AI Assistants every day and have a good knowledge of their benefits and limitations.

I have a high degree of appreciation and respect for high coding standards in FOSS libraries such as Jellyfin.