### PR TITLE
Use artist images for music library thumbnail

### DIFF
--- a/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
@@ -40,7 +40,7 @@ namespace Emby.Server.Implementations.Images
                     includeItemTypes = new[] { BaseItemKind.Series };
                     break;
                 case CollectionType.music:
-                    includeItemTypes = new[] { BaseItemKind.MusicAlbum };
+                    includeItemTypes = new[] { BaseItemKind.MusicArtist };  // Music albums usually don't have dedicated backdrops, so use artist instead
                     break;
                 case CollectionType.musicvideos:
                     includeItemTypes = new[] { BaseItemKind.MusicVideo };

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -22,7 +22,6 @@ using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
-using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
@@ -2127,17 +2126,6 @@ namespace MediaBrowser.Controller.Entities
                     DateModified = chapter.ImageDateModified,
                     Type = imageType
                 };
-            }
-
-            // Music albums usually don't have dedicated backdrops, so return one from the artist instead
-            if (GetType() == typeof(MusicAlbum) && imageType == ImageType.Backdrop)
-            {
-                var artist = FindParent<MusicArtist>();
-
-                if (artist is not null)
-                {
-                    return artist.GetImages(imageType).ElementAtOrDefault(imageIndex);
-                }
             }
 
             return GetImages(imageType)


### PR DESCRIPTION
**Changes**
Removes the `BaseItem.GetImageInfo` override introduced in #6257 and instead uses `MusicArtist` images directly in `CollectionFolderImageProvider.cs` for music library collages

**Issues**
Fixes  #13119
Closes #13317
