### PR TITLE
Use non-root permissions in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,8 +38,7 @@
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
             "dockerDashComposeVersion": "v2"
         },
-        "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {}
+        "ghcr.io/devcontainers/features/github-cli:1": {}
     },
     "hostRequirements": {
         "memory": "8gb",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,10 @@
     "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
     "service": "app",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "containerUser": "vscode",
+    "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/",
     // restores nuget packages, installs the dotnet workloads and installs the dev https certificate
-    "postStartCommand": "sudo dotnet restore; sudo dotnet workload update; sudo dotnet dev-certs https --trust; sudo bash \"./.devcontainer/install-ffmpeg.sh\"",
+    "postStartCommand": "dotnet restore; dotnet workload update; dotnet dev-certs https --trust; bash \"./.devcontainer/install-ffmpeg.sh\"",
     // The previous way of installing extensions via the vs command dont work on selfhosted devcontainers
     "customizations": {
         "vscode": {

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -211,6 +211,7 @@
  - [martenumberto](https://github.com/martenumberto)
  - [ZeusCraft10](https://github.com/ZeusCraft10)
  - [MarcoCoreDuo](https://github.com/MarcoCoreDuo)
+ - [danloveg](https://github.com/danloveg)
 
 # Emby Contributors
 


### PR DESCRIPTION
**Changes**

Fix permissions in the devcontainer so that `sudo` is not needed to run post-start commands.

I want to start contributing to Jellyfin, and the devcontainer seemed like a great choice because I don't need to install all the project dependencies locally. But there were a number of issues I came across which all stemmed from the fact that all files are owned by `root:root`, but the container user is `vscode`. For example, `dotnet build` returns a permission denied error and so the VSCode test runner cannot discover tests. These changes explicitly change the owner to `vscode:vscode` so that sudo is not needed to run the build/install commands.

For context, I am on Windows.

I also removed the `jq` feature since it is no longer required after #16202 was merged in.

**Issues**

Closes #15842