### PR TITLE
Add the filename to exceptions in DeserializeFromFile()

### DIFF
--- a/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
+++ b/Emby.Server.Implementations/Serialization/MyXmlSerializer.cs
@@ -85,9 +85,17 @@ namespace Emby.Server.Implementations.Serialization
         /// <returns>System.Object.</returns>
         public object? DeserializeFromFile(Type type, string file)
         {
-            using (var stream = File.OpenRead(file))
+            try
             {
-                return DeserializeFromStream(type, stream);
+                using (var stream = File.OpenRead(file))
+                {
+                    return DeserializeFromStream(type, stream);
+                }
+            }
+            catch (Exception ex)
+            {
+                ex.Data.Add("Filename", file);
+                throw;
             }
         }
 


### PR DESCRIPTION
**Changes**
When the deserializer crashes, no filename was given in the stack trace in the logs. This try/catch block makes error resolution easier by adding the filename to the exception raised.

**Issues**
See #12254, #9508