### PR TITLE
Fix malformed query string in StreamInfo.ToUrl() causing 500 error via proxies

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -268,7 +268,7 @@ public static class StreamingHelpers
         Dictionary<string, string?> streamOptions = new Dictionary<string, string?>();
         foreach (var param in queryString)
         {
-            if (char.IsLower(param.Key[0]))
+            if (param.Key.Length > 0 && char.IsLower(param.Key[0]))
             {
                 // This was probably not parsed initially and should be a StreamOptions
                 // or the generated URL should correctly serialize it

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -895,7 +895,7 @@ public class StreamInfo
 
         if (SubProtocol == MediaStreamProtocol.hls)
         {
-            sb.Append("/master.m3u8?");
+            sb.Append("/master.m3u8");
         }
         else
         {
@@ -906,9 +906,9 @@ public class StreamInfo
                 sb.Append('.');
                 sb.Append(Container);
             }
-
-            sb.Append('?');
         }
+
+        var queryStart = sb.Length;
 
         if (!string.IsNullOrEmpty(DeviceProfileId))
         {
@@ -1131,6 +1131,12 @@ public class StreamInfo
         if (!string.IsNullOrEmpty(query))
         {
             sb.Append(query);
+        }
+
+        // Replace the first '&' with '?' to form a valid query string.
+        if (sb.Length > queryStart)
+        {
+            sb[queryStart] = '?';
         }
 
         return sb.ToString();

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamInfoTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamInfoTests.cs
@@ -216,8 +216,7 @@ public class StreamInfoTests
 
         string legacyUrl = streamInfo.ToUrl_Original(BaseUrl, "123");
 
-        // New version will return and & after the ? due to optional parameters.
-        string newUrl = streamInfo.ToUrl(BaseUrl, "123", null).Replace("?&", "?", StringComparison.OrdinalIgnoreCase);
+        string newUrl = streamInfo.ToUrl(BaseUrl, "123", null);
 
         Assert.Equal(legacyUrl, newUrl, ignoreCase: true);
     }
@@ -234,8 +233,7 @@ public class StreamInfoTests
             FillAllProperties(streamInfo);
             string legacyUrl = streamInfo.ToUrl_Original(BaseUrl, "123");
 
-            // New version will return and & after the ? due to optional parameters.
-            string newUrl = streamInfo.ToUrl(BaseUrl, "123", null).Replace("?&", "?", StringComparison.OrdinalIgnoreCase);
+            string newUrl = streamInfo.ToUrl(BaseUrl, "123", null);
 
             Assert.Equal(legacyUrl, newUrl, ignoreCase: true);
         }


### PR DESCRIPTION
This fix was made by claude under my supervision. I read the [llm policy](https://jellyfin.org/docs/general/contributing/llm-policies/)  
The fix is self-contained and pretty straight forward. 

I hit this bug when loading jellyfin from HomeAssistant using the [jellyfin addon](https://github.com/alexbelgium/hassio-addons/tree/master/jellyfin) 

It took me a while to figure out the culprit for this and in the process I learned more than I wanted to know about HA/Addons/Jellyfin. 

HomeAssistant ingress [uses yarl](https://github.com/home-assistant/supervisor/blob/main/supervisor/api/ingress.py#L243) to parse and reconstruct the proxied request. 

HA transforms requests with `?&Foo` to `?=Foo` and this blows up in jellyfin. Arguably jellyfin should not generate this kind of query strings as they are nonsensical. 

## Summary

- `StreamInfo.ToUrl()` generated URLs like `/master.m3u8?&DeviceId=...` (note `?&`) because `?` was appended to the path and all parameters started with `&`. When the first optional parameter (`DeviceProfileId`) was null — the common case for web clients — the result was a malformed query string.
- This is harmless when clients hit Jellyfin directly (ASP.NET Core tolerates `?&`), but when accessed through a reverse proxy that parses and re-serializes the URL (e.g. Home Assistant ingress via aiohttp/yarl), `?&` becomes `?=&` — introducing an empty-key query parameter.
- `ParseStreamOptions` then crashes on `param.Key[0]` with `IndexOutOfRangeException`, returning HTTP 500.

## Changes

- **`StreamInfo.ToUrl()`**: Track query start position and replace the first `&` with `?` after all parameters are appended, producing valid query strings
- **`ParseStreamOptions`**: Guard against empty query parameter keys (defensive fix)
- **Tests**: Remove `.Replace("?&", "?")` workaround that masked the bug

## Reproduction

Access Jellyfin through Home Assistant ingress proxy and play any video that requires transcoding. The server returns 500:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Jellyfin.Api.Helpers.StreamingHelpers.ParseStreamOptions(IQueryCollection queryString)
```

The URL arrives at Jellyfin as `master.m3u8?=&DeviceId=...` because aiohttp/yarl (used by HA's ingress proxy) parses `?&` into a MultiDict with an empty key `{"": "", "DeviceId": "..."}` and re-serializes it as `?=&`.

Verified with:
```python
from yarl import URL
url = URL("/master.m3u8?&DeviceId=test")
print(dict(url.query))          # {'': '', 'DeviceId': 'test'}
rebuilt = URL.build(path=url.path, query=url.query)
print(rebuilt.query_string)      # =&DeviceId=test
```

