### PR TITLE
Fix folders being identified as seasons in mixed libraries

### DIFF
--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -21,6 +21,9 @@ namespace Emby.Naming.TV
         [GeneratedRegex(@"[sS](\d{1,4})(?!\d|[eE]\d)(?=\.|_|-|\[|\]|\s|$)", RegexOptions.None)]
         private static partial Regex SeasonPrefix();
 
+        [GeneratedRegex(@"(season|staffel|stagione|sæson|temporada|series|kausi|säsong|seizoen|seasong|sezon|sezona|sezóna|sezonul|시즌|シーズン|сезон)", RegexOptions.IgnoreCase)]
+        private static partial Regex SeasonKeyword();
+
         /// <summary>
         /// Attempts to parse season number from path.
         /// </summary>
@@ -91,14 +94,25 @@ namespace Emby.Naming.TV
                 return (val, true);
             }
 
+            bool isMixedLibrary = !supportNumericSeasonFolders && !supportSpecialAliases;
             var preMatch = ProcessPre().Match(filename);
             if (preMatch.Success)
             {
+                if (isMixedLibrary && !SeasonKeyword().IsMatch(fileName))
+                {
+                    return (null, false);
+                }
+
                 return CheckMatch(preMatch);
             }
             else
             {
                 var postMatch = ProcessPost().Match(filename);
+                if (postMatch.Success && isMixedLibrary && !SeasonKeyword().IsMatch(fileName))
+                {
+                    return (null, false);
+                }
+
                 return CheckMatch(postMatch);
             }
         }

--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -10,18 +10,23 @@ namespace Emby.Naming.TV
     /// </summary>
     public static partial class SeasonPathParser
     {
+        private const string SeasonKeywordPattern =
+            @"시즌|シーズン|сезон" +
+            @"|season|sæson|saison|staffel|series|stagione|säsong|seizoen|seasong" +
+            @"|sezon|sezona|sezóna|sezonul|série|séria|serie|seria|temporada|kausi";
+
         private static readonly Regex CleanNameRegex = new(@"[ ._\-\[\]]", RegexOptions.Compiled);
 
-        [GeneratedRegex(@"^\s*((?<seasonnumber>(?>\d+))(?:st|nd|rd|th|\.)*(?!\s*[Ee]\d+))\s*(?:[[시즌]*|[シーズン]*|[sS](?:eason|æson|aison|taffel|eries|tagione|äsong|eizoen|easong|ezon|ezona|ezóna|ezonul|érie|éria|erie|eria)*|[tT](?:emporada)*|[kK](?:ausi)*|[Сс](?:езон)*)\s*(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"^\s*((?<seasonnumber>(?>\d+))(?:st|nd|rd|th|\.)*(?!\s*[Ee]\d+))\s*(?:" + SeasonKeywordPattern + @")\s*(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
         private static partial Regex ProcessPre();
 
-        [GeneratedRegex(@"^\s*(?:[[시즌]*|[シーズン]*|[sS](?:eason|æson|aison|taffel|eries|tagione|äsong|eizoen|easong|ezon|ezona|ezóna|ezonul|érie|éria|erie|eria)*|[tT](?:emporada)*|[kK](?:ausi)*|[Сс](?:езон)*)\s*(?<seasonnumber>\d+?)(?=\d{3,4}p|[^\d]|$)(?!\s*[Ee]\d)(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"^\s*(?:" + SeasonKeywordPattern + @")\s*(?<seasonnumber>\d+?)(?=\d{3,4}p|[^\d]|$)(?!\s*[Ee]\d)(?<rightpart>.*)$", RegexOptions.IgnoreCase)]
         private static partial Regex ProcessPost();
 
         [GeneratedRegex(@"[sS](\d{1,4})(?!\d|[eE]\d)(?=\.|_|-|\[|\]|\s|$)", RegexOptions.None)]
         private static partial Regex SeasonPrefix();
 
-        [GeneratedRegex(@"(season|staffel|stagione|sæson|temporada|series|kausi|säsong|seizoen|seasong|sezon|sezona|sezóna|sezonul|시즌|シーズン|сезон)", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(SeasonKeywordPattern, RegexOptions.IgnoreCase)]
         private static partial Regex SeasonKeyword();
 
         /// <summary>

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
@@ -83,4 +83,26 @@ public class SeasonPathParserTests
         Assert.Equal(seasonNumber, result.SeasonNumber);
         Assert.Equal(isSeasonDirectory, result.IsSeasonFolder);
     }
+
+    [Theory]
+    [InlineData("/Drive/300 Collection/300 (2006)", "/Drive/300 Collection", null, false)]
+    [InlineData("/Drive/300 Collection/300 Rise of an Empire", "/Drive/300 Collection", null, false)]
+    [InlineData("/Drive/300 Collection/1", "/Drive/300 Collection", null, false)]
+    [InlineData("/Drive/300 Collection/300 Disc 1", "/Drive/300 Collection", null, false)]
+    [InlineData("/Drive/28 Years Later Collection/28 Days Later", "/Drive/28 Years Later Collection", null, false)]
+    [InlineData("/Drive/28 Years Later Collection/28 Weeks Later (2007)", "/Drive/28 Years Later Collection", null, false)]
+    [InlineData("/Drive/28 Years Later Collection/28 Years Later 2025", "/Drive/28 Years Later Collection", null, false)]
+    [InlineData("/Drive/300 Collection/Season 1", "/Drive/300 Collection", 1, true)]
+    [InlineData("/Drive/28 Years Later Collection/Season 01", "/Drive/28 Years Later Collection", 1, true)]
+    [InlineData("/Drive/300 Collection/S01", "/Drive/300 Collection", 1, true)]
+    [InlineData("/Drive/300 Collection/S1", "/Drive/300 Collection", 1, true)]
+
+    public void GetSeasonNumberFromPathMixedLibraryTest(string path, string? parentPath, int? seasonNumber, bool isSeasonDirectory)
+    {
+        var result = SeasonPathParser.Parse(path, parentPath, false, false);
+
+        Assert.Equal(result.SeasonNumber is not null, result.Success);
+        Assert.Equal(seasonNumber, result.SeasonNumber);
+        Assert.Equal(isSeasonDirectory, result.IsSeasonFolder);
+    }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Added a guard so that in mixed libraries, numeric folders without explicit season keywords are not misidentified as TV seasons

**Issues**
Fixes: #15676
