### PR TITLE
Mitigate pull_request_target privilege escalation

### DIFF
--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -1,6 +1,6 @@
 ﻿name: ABI Compatibility
 on:
-  pull_request_target:
+  pull_request:
 
 permissions: {}
 
@@ -77,7 +77,7 @@ jobs:
       pull-requests: write  #  to create or update comment (peter-evans/create-or-update-comment)
 
     name: ABI - Difference
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs:
       - abi-head

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -5,7 +5,7 @@ on:
       - master
     tags:
       - 'v*'
-  pull_request_target:
+  pull_request:
 
 permissions: {}
 
@@ -78,7 +78,7 @@ jobs:
       pull-requests: write
 
     name: OpenAPI - Difference
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs:
       - openapi-head
@@ -109,7 +109,7 @@ jobs:
 
   publish-unstable:
     name: OpenAPI - Publish Unstable Spec
-    if: ${{ github.event_name != 'pull_request_target' && !startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'jellyfin') }}
     runs-on: ubuntu-latest
     needs:
       - openapi-head

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,7 +4,7 @@ on:
     types:
       - created
       - edited
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - synchronize

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
   issue_comment:
 
 permissions: {}

--- a/.github/workflows/pull-request-conflict.yml
+++ b/.github/workflows/pull-request-conflict.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
   issue_comment:
 
 permissions: {}
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Apply label
         uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
-        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request_target'}}
+        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request'}}
         with:
           dirtyLabel: 'merge conflict'
           commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'


### PR DESCRIPTION
Hotfix: replace `pull_request_target` with `pull_request` to stop granting write permissions and secret access to fork PRs.

Some workflows will break (PR comments, labeling, deploy previews). Can be restored later with `workflow_run`.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

See also: https://github.com/jellyfin/jellyfin/pull/16162