### PR TITLE
Add environment variable to set the server name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -288,3 +288,4 @@
  - [Michael McElroy](https://github.com/mcmcelro)
  - [Soumyadip Auddy](https://github.com/SoumyadipAuddy)
  - [DerMaddis](https://github.com/dermaddis)
+ - [Etai Choset](https://github.com/etaichoset)

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -266,10 +266,21 @@ namespace Emby.Server.Implementations
         /// <inheritdoc/>
         public bool ListenWithHttps => Certificate is not null && ConfigurationManager.GetNetworkConfiguration().EnableHttps;
 
-        public string FriendlyName =>
-            string.IsNullOrEmpty(ConfigurationManager.Configuration.ServerName)
-                ? Environment.MachineName
-                : ConfigurationManager.Configuration.ServerName;
+        public string FriendlyName
+        {
+            get
+            {
+                var nameFromEnvVar = Environment.GetEnvironmentVariable("JELLYFIN_SERVER_NAME");
+                if (!string.IsNullOrWhiteSpace(nameFromEnvVar))
+                {
+                    return nameFromEnvVar;
+                }
+
+                return string.IsNullOrEmpty(ConfigurationManager.Configuration.ServerName)
+                    ? Environment.MachineName
+                    : ConfigurationManager.Configuration.ServerName;
+            }
+        }
 
         public string RestoreBackupPath { get; set; }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Add logic in `Emby.Server.Implementations.ApplicationHost` that reads from environment variable `JELLYFIN_SERVER_NAME` to set the server name. This take precedence over the machine name and the configuration.

**Issues**
Fixes [16261](https://github.com/jellyfin/jellyfin/issues/16261)
