### PR TITLE
Prefer specific type in FindByPath

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -946,12 +946,15 @@ namespace Emby.Server.Implementations.Library
                 Path = path,
                 IsFolder = isFolder,
                 OrderBy = [(ItemSortBy.DateCreated, SortOrder.Descending)],
-                Limit = 1,
                 DtoOptions = new DtoOptions(true)
             };
 
-            return GetItemList(query)
-                .FirstOrDefault();
+            var items = GetItemList(query);
+
+            // When multiple items exist at the same path with different types
+            // (e.g. both a Series and a Folder), prefer the more specific type.
+            return items.FirstOrDefault(i => i.GetType() != typeof(Folder))
+                ?? items.FirstOrDefault();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Please read my detailed reply on the issue [here](https://github.com/jellyfin/jellyfin/issues/16215#issuecomment-3940646402), on why this might be needed. 
This could potentially be solved with a migration instead.

**Changes**
`FindByPath` will now prefer a more specific type, but fallback to the current behavior.

**Issues**
Fixes #16215
