### PR TITLE
change password reset behavior to more closely match other services

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -110,7 +110,7 @@ public class ImageController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!RequestHelpers.AssertCanUpdateUser(HttpContext.User, user, true))
+        if (!RequestHelpers.AssertCanUpdateUser(HttpContext.User, user))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update the image.");
         }
@@ -210,7 +210,7 @@ public class ImageController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!RequestHelpers.AssertCanUpdateUser(HttpContext.User, user, true))
+        if (!RequestHelpers.AssertCanUpdateUser(HttpContext.User, user))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to delete the image.");
         }

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -978,7 +978,7 @@ public class ItemsController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!RequestHelpers.AssertCanUpdateUser(User, user, true))
+        if (!RequestHelpers.AssertCanUpdateUser(User, user))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to view this item user data.");
         }
@@ -1034,7 +1034,7 @@ public class ItemsController : BaseJellyfinApiController
             return NotFound();
         }
 
-        if (!RequestHelpers.AssertCanUpdateUser(User, user, true))
+        if (!RequestHelpers.AssertCanUpdateUser(User, user))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to update this item user data.");
         }

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -435,6 +435,7 @@ public class VideosController : BaseJellyfinApiController
                 cancellationTokenSource.Token)
             .ConfigureAwait(false);
 
+#pragma warning disable CS0618
         if (@static.HasValue && @static.Value && state.DirectStreamProvider is not null)
         {
             var liveStreamInfo = _mediaSourceManager.GetLiveStreamInfo(streamingRequest.LiveStreamId);
@@ -447,6 +448,7 @@ public class VideosController : BaseJellyfinApiController
             // TODO (moved from MediaBrowser.Api): Don't hardcode contentType
             return File(liveStream, MimeTypes.GetMimeType("file.ts"));
         }
+#pragma warning restore CS0618
 
         // Static remote stream
         if (@static.HasValue && @static.Value && state.InputProtocol == MediaProtocol.Http)

--- a/Jellyfin.Api/Helpers/AudioHelper.cs
+++ b/Jellyfin.Api/Helpers/AudioHelper.cs
@@ -99,6 +99,7 @@ public class AudioHelper
                 cancellationTokenSource.Token)
             .ConfigureAwait(false);
 
+#pragma warning disable CS0618
         if (streamingRequest.Static && state.DirectStreamProvider is not null)
         {
             var liveStreamInfo = _mediaSourceManager.GetLiveStreamInfo(streamingRequest.LiveStreamId);
@@ -111,6 +112,7 @@ public class AudioHelper
             // TODO (moved from MediaBrowser.Api): Don't hardcode contentType
             return new FileStreamResult(liveStream, MimeTypes.GetMimeType("file.ts"));
         }
+#pragma warning restore CS0618
 
         // Static remote stream
         if (streamingRequest.Static && state.InputProtocol == MediaProtocol.Http)

--- a/Jellyfin.Api/Helpers/RequestHelpers.cs
+++ b/Jellyfin.Api/Helpers/RequestHelpers.cs
@@ -89,9 +89,8 @@ public static class RequestHelpers
     /// </summary>
     /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> for the current request.</param>
     /// <param name="user">The user id.</param>
-    /// <param name="restrictUserPreferences">Whether to restrict the user preferences.</param>
     /// <returns>A <see cref="bool"/> whether the user can update the entry.</returns>
-    internal static bool AssertCanUpdateUser(ClaimsPrincipal claimsPrincipal, User user, bool restrictUserPreferences)
+    internal static bool AssertCanUpdateUser(ClaimsPrincipal claimsPrincipal, User user)
     {
         var authenticatedUserId = claimsPrincipal.GetUserId();
         var isAdministrator = claimsPrincipal.IsInRole(UserRoles.Administrator);
@@ -102,13 +101,7 @@ public static class RequestHelpers
             return false;
         }
 
-        // TODO the EnableUserPreferenceAccess policy does not seem to be used elsewhere
-        if (!restrictUserPreferences || isAdministrator)
-        {
-            return true;
-        }
-
-        return user.EnableUserPreferenceAccess;
+        return isAdministrator;
     }
 
     /// <summary>

--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -144,7 +144,10 @@ public static class StreamingHelpers
         {
             var liveStreamInfo = await mediaSourceManager.GetLiveStreamWithDirectStreamProvider(streamingRequest.LiveStreamId, cancellationToken).ConfigureAwait(false);
             mediaSource = liveStreamInfo.Item1;
+
+#pragma warning disable CS0618
             state.DirectStreamProvider = liveStreamInfo.Item2;
+#pragma warning restore CS0618
 
             // Cap the max bitrate when it is too high. This is usually due to ffmpeg is unable to probe the source liveTV streams' bitrate.
             if (mediaSource.FallbackMaxStreamingBitrate is not null && streamingRequest.VideoBitRate is not null)

--- a/Jellyfin.Api/Models/UserDtos/UpdateUserPassword.cs
+++ b/Jellyfin.Api/Models/UserDtos/UpdateUserPassword.cs
@@ -1,3 +1,6 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
 namespace Jellyfin.Api.Models.UserDtos;
 
 /// <summary>
@@ -8,20 +11,36 @@ public class UpdateUserPassword
     /// <summary>
     /// Gets or sets the current sha1-hashed password.
     /// </summary>
+    [Obsolete("Use SessionPassword")]
     public string? CurrentPassword { get; set; }
+
+    /// <summary>
+    /// Gets or sets a new plain text password for the requested user.
+    /// </summary>
+    [Required]
+    public required string NewPassword { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current plain text password for the user attached to the current session.
+    /// Only required when updating password for the current session or other administrators.
+    /// </summary>
+    public string? SessionPassword { get; set; }
 
     /// <summary>
     /// Gets or sets the current plain text password.
     /// </summary>
+    [Obsolete("Use SessionPassword")]
     public string? CurrentPw { get; set; }
 
     /// <summary>
     /// Gets or sets the new plain text password.
     /// </summary>
+    [Obsolete("Use NewPassword")]
     public string? NewPw { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to reset the password.
     /// </summary>
+    [Obsolete("See SessionPassword")]
     public bool ResetPassword { get; set; }
 }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -342,7 +342,6 @@ namespace Jellyfin.Server.Implementations.Users
                 {
                     MaxParentalRating = user.MaxParentalRatingScore,
                     MaxParentalSubRating = user.MaxParentalRatingSubScore,
-                    EnableUserPreferenceAccess = user.EnableUserPreferenceAccess,
                     RemoteClientBitrateLimit = user.RemoteClientBitrateLimit ?? 0,
                     AuthenticationProviderId = user.AuthenticationProviderId,
                     PasswordResetProviderId = user.PasswordResetProviderId,
@@ -664,7 +663,6 @@ namespace Jellyfin.Server.Implementations.Users
 
                 user.MaxParentalRatingScore = policy.MaxParentalRating;
                 user.MaxParentalRatingSubScore = policy.MaxParentalSubRating;
-                user.EnableUserPreferenceAccess = policy.EnableUserPreferenceAccess;
                 user.RemoteClientBitrateLimit = policy.RemoteClientBitrateLimit;
                 user.AuthenticationProviderId = policy.AuthenticationProviderId;
                 user.PasswordResetProviderId = policy.PasswordResetProviderId;

--- a/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateUserDb.cs
@@ -125,7 +125,6 @@ public class MigrateUserDb : IMigrationRoutine
                     InternalId = entry.GetInt64(0),
                     MaxParentalRatingScore = policy.MaxParentalRating,
                     MaxParentalRatingSubScore = null,
-                    EnableUserPreferenceAccess = policy.EnableUserPreferenceAccess,
                     RemoteClientBitrateLimit = policy.RemoteClientBitrateLimit,
                     InvalidLoginAttemptCount = policy.InvalidLoginAttemptCount,
                     LoginAttemptsBeforeLockout = maxLoginAttempts,

--- a/MediaBrowser.Controller/Streaming/StreamState.cs
+++ b/MediaBrowser.Controller/Streaming/StreamState.cs
@@ -53,9 +53,7 @@ public class StreamState : EncodingJobInfo, IDisposable
     /// <summary>
     /// Gets or sets the direct stream provider.
     /// </summary>
-    /// <remarks>
-    /// Deprecated.
-    /// </remarks>
+    [Obsolete("Deprecated Feature")]
     public IDirectStreamProvider? DirectStreamProvider { get; set; }
 
     /// <summary>

--- a/MediaBrowser.Model/Plugins/PluginStatus.cs
+++ b/MediaBrowser.Model/Plugins/PluginStatus.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediaBrowser.Model.Plugins
 {
     /// <summary>
@@ -39,8 +41,9 @@ namespace MediaBrowser.Model.Plugins
         Superseded = -4,
 
         /// <summary>
-        /// [DEPRECATED] See Superseded.
+        /// This plugin has been superseded by another version.
         /// </summary>
+        [Obsolete("See Superseded")]
         Superceded = -4,
 
         /// <summary>

--- a/MediaBrowser.Model/Users/UserPolicy.cs
+++ b/MediaBrowser.Model/Users/UserPolicy.cs
@@ -43,8 +43,6 @@ namespace MediaBrowser.Model.Users
             AllowedTags = Array.Empty<string>();
             BlockUnratedItems = Array.Empty<UnratedItem>();
 
-            EnableUserPreferenceAccess = true;
-
             AccessSchedules = Array.Empty<AccessSchedule>();
 
             LoginAttemptsBeforeLockout = -1;
@@ -117,6 +115,7 @@ namespace MediaBrowser.Model.Users
 
         public string[] AllowedTags { get; set; }
 
+        [Obsolete("Deprecated Feature")]
         public bool EnableUserPreferenceAccess { get; set; }
 
         public AccessSchedule[] AccessSchedules { get; set; }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/User.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/User.cs
@@ -41,7 +41,6 @@ namespace Jellyfin.Database.Implementations.Entities
             // Set default values
             Id = Guid.NewGuid();
             InvalidLoginAttemptCount = 0;
-            EnableUserPreferenceAccess = true;
             MustUpdatePassword = false;
             DisplayMissingEpisodes = false;
             DisplayCollectionsView = false;
@@ -245,6 +244,7 @@ namespace Jellyfin.Database.Implementations.Entities
         /// <remarks>
         /// Required.
         /// </remarks>
+        [Obsolete("Deprecated Feature")]
         public bool EnableUserPreferenceAccess { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

This pull request deprecates the ResetPassword feature as it sets the user password to an empty string. I'm a bit undecided on *when* authentication should be required for password updates, but I don't think it's good practice to set empty passwords - we even reject them for administrators outside this specific case.

Old Behavior

- all users can change their own password if they know their current one
- admins can change **any** password without authentication except their own

New Behavior

- password resets to empty strings are marked as deprecated
- all users can change their own password if they know their current one
- admins can change user passwords without authentication
- admins can change other admin passwords with **their own** password
- the API should be fully backwards compatible

All bullets are open to change - the goal was simply an improvement over the previous situation. Perhaps requiring admin reauthentication in all situations would be good. I'll open a PR for the web UI if this gains any traction.

**Issues**

None