### PR TITLE
Fix cached thumbnails spinning up HDDs by deferring source image File.Exists to cache-miss path

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -211,6 +211,7 @@
  - [martenumberto](https://github.com/martenumberto)
  - [ZeusCraft10](https://github.com/ZeusCraft10)
  - [MarcoCoreDuo](https://github.com/MarcoCoreDuo)
+ - [glic3rinu](https://github.com/glic3rinu)
 
 # Emby Contributors
 

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -135,16 +135,6 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
             return (originalImagePath, mimeType, dateModified);
         }
 
-        var supportedImageInfo = await GetSupportedImage(originalImagePath, dateModified).ConfigureAwait(false);
-        originalImagePath = supportedImageInfo.Path;
-
-        // Original file doesn't exist, or original file is gif.
-        if (!File.Exists(originalImagePath) || string.Equals(mimeType, MediaTypeNames.Image.Gif, StringComparison.OrdinalIgnoreCase))
-        {
-            return (originalImagePath, mimeType, dateModified);
-        }
-
-        dateModified = supportedImageInfo.DateModified;
         bool requiresTransparency = _transparentImageTypes.Contains(Path.GetExtension(originalImagePath));
 
         bool autoOrient = false;
@@ -197,6 +187,13 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
         {
             if (!File.Exists(cacheFilePath))
             {
+                // Only access source filesystem on cache miss
+                if (!File.Exists(originalImagePath)
+                    || string.Equals(mimeType, MediaTypeNames.Image.Gif, StringComparison.OrdinalIgnoreCase))
+                {
+                    return (originalImagePath, mimeType, dateModified);
+                }
+
                 string resultPath;
 
                 // Limit number of parallel (more precisely: concurrent) image encodings to prevent a high memory usage


### PR DESCRIPTION
`ProcessImage` calls `File.Exists(originalImagePath)` unconditionally before checking if a cached resize exists. This stats the source filesystem on every image request even when the cache is warm.

On systems with HDD media storage and spindown enabled, this wakes drives on every page load. The `dateModified` used in the cache key comes from the database (set during library scans), so the stat provides no cache-invalidation value.


Setup:
- media on large HDD array, spun down on idle to reduce power/noise
- cache on NVMe

User Issue:
- browsing jellyfin media always spin up drives, even if everything is cached.


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Move the `File.Exists` check inside the cache-miss branch so it only runs when the image actually needs to be read and encoded. Also removes the no-op `GetSupportedImage` call whose both branches return their input unchanged.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
