### PR TITLE
Allow direct play for M3U with a simultaneous stream limit set

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -145,7 +145,7 @@ namespace Jellyfin.LiveTv.TunerHosts
         {
             var path = channel.Path;
 
-            var supportsDirectPlay = !info.EnableStreamLooping && info.TunerCount == 0;
+            var supportsDirectPlay = !info.EnableStreamLooping;
             var supportsDirectStream = !info.EnableStreamLooping;
 
             var protocol = _mediaSourceManager.GetPathProtocol(path);


### PR DESCRIPTION
_(Updated/Revised) This is now only about the TunerCount == 0 condition in M3UTunerHost._

For M3U Live TV sources, setting a simultaneous stream limit greater than zero causes the server to report that direct play is unsupported, even when the source could otherwise be direct played. This causes playback to fall back to remuxing or transcoding.

Basically, I don't think a configured max stream limit should also mean the source cannot advertise direct play. The tuner count should limit concurrent streams;  it should not change whether direct play is supported. The Live TV stream lifecycle is managed elsewhere, and an over-limit stream should result in a LiveTvConflictException.


**Changes**
Remove the TunerCount == 0 restriction for direct play in M3UTunerHost, since the server already manages tuner lifecycle through the LiveStreamFiles. A LiveTvConflictException would be thrown if the limit is exceeded. 

**Issues**
I believe this is partially related to: 
https://github.com/jellyfin/jellyfin/issues/9813

