### PR TITLE
IOException with STRM HTTP URLs

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1679,6 +1679,13 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return;
             }
 
+            // Skip timestamp extration for remote resource (http, rtsp, etc.)
+            // as they cannot be opened with FileStream
+            if (video.Protocol != MediaProtocol.File)
+            {
+                return;
+            }
+
             if (!string.Equals(video.Container, "mpeg2ts", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(video.Container, "m2ts", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(video.Container, "ts", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
# Problem
When extracting MPEG Timestamps, Jellyfin tried to open HTTP URLs as local files with FileStream causing:
```
[2026-02-24 10:41:13.022 +11:00] [ERR] [72] MediaBrowser.MediaEncoding.Encoder.MediaEncoder: Error extracting timestamp info from "http://remote.url/series/8fdb2d71de5e/1e9adb19fb/775378.mp4"
System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'C:\Program Files\Jellyfin\Server\http:\remote.url\series\8fdb2d71de5e\1e9adb19fb\775378.mp4'.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.GetMpegTimestamp(String path)
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.ExtractTimestamp(MediaInfo video)
```

**Changes**
Added a protocol check to skip timestamp extraction for remote resources
**Issues**
fixes #16289 