### PR TITLE
basic api versioning on all endpoints

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <!-- Run "dotnet list package (dash,dash)outdated" to see the latest versions of each package.-->
   <ItemGroup Label="Package Dependencies">
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageVersion Include="AsyncKeyedLock" Version="8.0.2" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />

--- a/Jellyfin.Api/Constants/ApiVersions.cs
+++ b/Jellyfin.Api/Constants/ApiVersions.cs
@@ -6,19 +6,13 @@ namespace Jellyfin.Api.Constants;
 /// <summary>
 /// API versions available for use in the current server binary.
 /// As a general rule only N - 1 versions are supported and changes are only made in major releases.
-/// Format is major version followed by release type and the date of publication.
 /// </summary>
 public static class ApiVersions
 {
     /// <summary>
-    /// Version 10 published on 2026-02-24 as a stable release.
+    /// Version 12.0 of the Jellyfin API specification.
     /// </summary>
-    public const string V1020260224 = "10-stable20260224";
-
-    /// <summary>
-    /// Version 12 published on 2026-02-24 as a stable release.
-    /// </summary>
-    public const string V1220260224 = "12-stable20260224";
+    public const string V1200 = "12.0";
 
     /// <summary>
     /// Returns a new instance of the <see cref="ApiVersion"/> class.
@@ -27,8 +21,8 @@ public static class ApiVersions
     /// <returns>An <see cref="ApiVersion"/> instance.</returns>
     public static ApiVersion Parse(string version)
     {
-        var parts = version.Split("-", 2);
+        var parts = version.Split(".", 2);
 
-        return new ApiVersion(int.Parse(parts[0], CultureInfo.InvariantCulture), 0, parts[1]);
+        return new ApiVersion(int.Parse(parts[0], CultureInfo.InvariantCulture), int.Parse(parts[1], CultureInfo.InvariantCulture));
     }
 }

--- a/Jellyfin.Api/Constants/ApiVersions.cs
+++ b/Jellyfin.Api/Constants/ApiVersions.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using Asp.Versioning;
+
+namespace Jellyfin.Api.Constants;
+
+/// <summary>
+/// API versions available for use in the current server binary.
+/// As a general rule only N - 1 versions are supported and changes are only made in major releases.
+/// Format is major version followed by release type and the date of publication.
+/// </summary>
+public static class ApiVersions
+{
+    /// <summary>
+    /// Version 10 published on 2026-02-24 as a stable release.
+    /// </summary>
+    public const string V1020260224 = "10-stable20260224";
+
+    /// <summary>
+    /// Version 12 published on 2026-02-24 as a stable release.
+    /// </summary>
+    public const string V1220260224 = "12-stable20260224";
+
+    /// <summary>
+    /// Returns a new instance of the <see cref="ApiVersion"/> class.
+    /// </summary>
+    /// <param name="version">A version string selected from the above constants.</param>
+    /// <returns>An <see cref="ApiVersion"/> instance.</returns>
+    public static ApiVersion Parse(string version)
+    {
+        var parts = version.Split("-", 2);
+
+        return new ApiVersion(int.Parse(parts[0], CultureInfo.InvariantCulture), 0, parts[1]);
+    }
+}

--- a/Jellyfin.Api/Jellyfin.Api.csproj
+++ b/Jellyfin.Api/Jellyfin.Api.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Swashbuckle.AspNetCore" />

--- a/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
@@ -71,7 +71,7 @@ namespace Jellyfin.Server.Extensions
                 .UseReDoc(c =>
                 {
                     c.DocumentTitle = "Jellyfin API";
-                    c.SpecUrl($"/{baseUrl}api-docs/v{ApiVersions.V1020260224}/openapi.json");
+                    c.SpecUrl($"/{baseUrl}api-docs/v{ApiVersions.V1200}/openapi.json");
                     c.InjectStylesheet($"/{baseUrl}api-docs/redoc/custom.css");
                     c.RoutePrefix = "api-docs/redoc";
                 });

--- a/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Asp.Versioning.ApiExplorer;
+using Jellyfin.Api.Constants;
 using Jellyfin.Api.Middleware;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Configuration;
@@ -16,10 +18,12 @@ namespace Jellyfin.Server.Extensions
         /// Adds swagger and swagger UI to the application pipeline.
         /// </summary>
         /// <param name="applicationBuilder">The application builder.</param>
+        /// <param name="apiVersionDescriptionProvider">The API version description provider.</param>
         /// <param name="serverConfigurationManager">The server configuration.</param>
         /// <returns>The updated application builder.</returns>
         public static IApplicationBuilder UseJellyfinApiSwagger(
             this IApplicationBuilder applicationBuilder,
+            IApiVersionDescriptionProvider apiVersionDescriptionProvider,
             IServerConfigurationManager serverConfigurationManager)
         {
             // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
@@ -32,11 +36,22 @@ namespace Jellyfin.Server.Extensions
                 baseUrl += '/';
             }
 
+            foreach (var description in apiVersionDescriptionProvider.ApiVersionDescriptions)
+            {
+                applicationBuilder.UseReDoc(c =>
+                {
+                    c.DocumentTitle = "Jellyfin API";
+                    c.SpecUrl($"/{baseUrl}api-docs/{description.GroupName}/openapi.json");
+                    c.InjectStylesheet($"/{baseUrl}api-docs/redoc/custom.css");
+                    c.RoutePrefix = $"api-docs/redoc/{description.GroupName}";
+                });
+            }
+
             return applicationBuilder
                 .UseSwagger(c =>
                 {
                     // Custom path requires {documentName}, SwaggerDoc documentName is 'api-docs'
-                    c.RouteTemplate = "{documentName}/openapi.json";
+                    c.RouteTemplate = "api-docs/{documentName}/openapi.json";
                     c.PreSerializeFilters.Add((swagger, httpReq) =>
                     {
                         swagger.Servers = new List<OpenApiServer> { new OpenApiServer { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}{apiDocBaseUrl}" } };
@@ -44,15 +59,19 @@ namespace Jellyfin.Server.Extensions
                 })
                 .UseSwaggerUI(c =>
                 {
+                    foreach (var description in apiVersionDescriptionProvider.ApiVersionDescriptions)
+                    {
+                        c.SwaggerEndpoint($"/{baseUrl}api-docs/{description.GroupName}/openapi.json", $"Jellyfin API {description.GroupName}");
+                    }
+
                     c.DocumentTitle = "Jellyfin API";
-                    c.SwaggerEndpoint($"/{baseUrl}api-docs/openapi.json", "Jellyfin API");
                     c.InjectStylesheet($"/{baseUrl}api-docs/swagger/custom.css");
                     c.RoutePrefix = "api-docs/swagger";
                 })
                 .UseReDoc(c =>
                 {
                     c.DocumentTitle = "Jellyfin API";
-                    c.SpecUrl($"/{baseUrl}api-docs/openapi.json");
+                    c.SpecUrl($"/{baseUrl}api-docs/v{ApiVersions.V1020260224}/openapi.json");
                     c.InjectStylesheet($"/{baseUrl}api-docs/redoc/custom.css");
                     c.RoutePrefix = "api-docs/redoc";
                 });

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -165,14 +165,14 @@ namespace Jellyfin.Server.Extensions
             serviceCollection
                 .AddApiVersioning(options =>
                 {
+                    options.DefaultApiVersion = ApiVersions.Parse(ApiVersions.V1200);
                     options.ApiVersionReader = new HeaderApiVersionReader("Api-Version");
-                    options.DefaultApiVersion = ApiVersions.Parse(ApiVersions.V1020260224);
                     options.ReportApiVersions = true;
                     options.AssumeDefaultVersionWhenUnspecified = true;
                 })
                 .AddApiExplorer(options =>
                 {
-                    options.GroupNameFormat = "'v'VVV";
+                    options.GroupNameFormat = "'v'VVVV";
                     options.SubstituteApiVersionInUrl = true;
                 })
                 .AddMvc(options =>
@@ -187,7 +187,7 @@ namespace Jellyfin.Server.Extensions
                     {
                         if (controller.GetCustomAttributes(typeof(ApiVersionAttribute), true).Length == 0)
                         {
-                            foreach (var version in new[] { ApiVersions.V1020260224, ApiVersions.V1220260224 })
+                            foreach (var version in new[] { ApiVersions.V1200 })
                             {
                                 options.Conventions.Controller(controller).HasApiVersion(ApiVersions.Parse(version));
                             }

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -6,7 +6,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Claims;
-using Emby.Server.Implementations;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Jellyfin.Api.Auth;
 using Jellyfin.Api.Auth.AnonymousLanAccessPolicy;
 using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
@@ -26,16 +27,14 @@ using Jellyfin.Server.Filters;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Session;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -163,6 +162,39 @@ namespace Jellyfin.Server.Extensions
                 mvcBuilder.AddApplicationPart(pluginAssembly);
             }
 
+            serviceCollection
+                .AddApiVersioning(options =>
+                {
+                    options.ApiVersionReader = new HeaderApiVersionReader("Api-Version");
+                    options.DefaultApiVersion = ApiVersions.Parse(ApiVersions.V1020260224);
+                    options.ReportApiVersions = true;
+                    options.AssumeDefaultVersionWhenUnspecified = true;
+                })
+                .AddApiExplorer(options =>
+                {
+                    options.GroupNameFormat = "'v'VVV";
+                    options.SubstituteApiVersionInUrl = true;
+                })
+                .AddMvc(options =>
+                {
+                    var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "Jellyfin.Api");
+                    if (assembly == null)
+                    {
+                        return;
+                    }
+
+                    foreach (var controller in assembly.GetTypes().Where(t => typeof(ControllerBase).IsAssignableFrom(t) && !t.IsAbstract))
+                    {
+                        if (controller.GetCustomAttributes(typeof(ApiVersionAttribute), true).Length == 0)
+                        {
+                            foreach (var version in new[] { ApiVersions.V1020260224, ApiVersions.V1220260224 })
+                            {
+                                options.Conventions.Controller(controller).HasApiVersion(ApiVersions.Parse(version));
+                            }
+                        }
+                    }
+                });
+
             return mvcBuilder.AddControllersAsServices();
         }
 
@@ -199,19 +231,14 @@ namespace Jellyfin.Server.Extensions
         {
             return serviceCollection.AddSwaggerGen(c =>
             {
-                var version = typeof(ApplicationHost).Assembly.GetName().Version?.ToString(3) ?? "0.0.1";
-                c.SwaggerDoc("api-docs", new OpenApiInfo
+                foreach (var description in serviceCollection.BuildServiceProvider().GetRequiredService<IApiVersionDescriptionProvider>().ApiVersionDescriptions)
                 {
-                    Title = "Jellyfin API",
-                    Version = version,
-                    Extensions = new Dictionary<string, IOpenApiExtension>
+                    c.SwaggerDoc(description.GroupName, new OpenApiInfo
                     {
-                        {
-                            "x-jellyfin-version",
-                            new OpenApiString(version)
-                        }
-                    }
-                });
+                        Title = "Jellyfin API",
+                        Version = description.GroupName
+                    });
+                }
 
                 c.AddSecurityDefinition(AuthenticationSchemes.CustomAuthentication, new OpenApiSecurityScheme
                 {

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
+using Asp.Versioning.ApiExplorer;
 using Emby.Server.Implementations.EntryPoints;
 using Jellyfin.Api.Middleware;
 using Jellyfin.Database.Implementations;
@@ -140,10 +141,12 @@ namespace Jellyfin.Server
         /// </summary>
         /// <param name="app">The application builder.</param>
         /// <param name="env">The webhost environment.</param>
+        /// <param name="apiVersionDescriptionProvider">The API version description provider.</param>
         /// <param name="appConfig">The application config.</param>
         public void Configure(
             IApplicationBuilder app,
             IWebHostEnvironment env,
+            IApiVersionDescriptionProvider apiVersionDescriptionProvider,
             IConfiguration appConfig)
         {
             app.UseBaseUrlRedirection();
@@ -204,7 +207,7 @@ namespace Jellyfin.Server
 
                 mainApp.UseStaticFiles();
                 mainApp.UseAuthentication();
-                mainApp.UseJellyfinApiSwagger(_serverConfigurationManager);
+                mainApp.UseJellyfinApiSwagger(apiVersionDescriptionProvider, _serverConfigurationManager);
                 mainApp.UseQueryStringDecoding();
                 mainApp.UseRouting();
                 mainApp.UseAuthorization();


### PR DESCRIPTION
**Changes**

I didn't like my own solution for API backwards compatibility in #16276 so I reimplemented #5121 with some changes.

- version is read from a custom header with PascalCase
- unversioned endpoints are made available on all API versions (feels a bit hacky but automation is nice)
- redoc is served from multiple endpoints for version support

I think the best versioning would just be tracking major versions on the server, but I implemented a suffix in case a hotfix release is required. I don't think it's *strictly* necessary though, and would love to just use v10 et cetera.

**Issues**

None