### PR TITLE
Apply analyzeduration and probesize for subtitle streams to improve codec parameter detection

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1278,7 +1278,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var ffmpegProbeSizeArgument = GetFfmpegProbesizeArg();
                 if (!string.IsNullOrEmpty(ffmpegProbeSizeArgument))
                 {
-                    arg.Append(ffmpegProbeSizeArgument);
+                    arg.Append(' ').Append(ffmpegProbeSizeArgument);
                 }
 
                 // Also seek the external subtitles stream.
@@ -7158,7 +7158,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (!string.IsNullOrEmpty(ffmpegProbeSize))
             {
-                return $" -probesize {ffmpegProbeSize}";
+                return $"-probesize {ffmpegProbeSize}";
             }
 
             return string.Empty;
@@ -7181,7 +7181,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (!string.IsNullOrEmpty(ffmpegProbeSizeArgument))
             {
-                inputModifier += ffmpegProbeSizeArgument;
+                inputModifier += " " + ffmpegProbeSizeArgument;
             }
 
             var userAgentParam = GetUserAgentParam(state);


### PR DESCRIPTION
This small change improves codec parameter detection with subtitle streams inside MKS files. Sometimes resolution is not properly detected. In those cases, I would see the following line in the corresponding transcode logs:
```
[matroska,webm @ 0x7f907ced6800] Could not find codec parameters for stream 0 (Subtitle: hdmv_pgs_subtitle (pgssub)): unspecified size
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
```

**Changes**
Extracts functions for generating analyze duration and probesize arguments to reuse them for subtitle streams, too.

**Issues**
Fixes wrong resolution detected for certain subtitles inside MKS containers.




<del>This small change fixes some encoder hangs that I encountered on my setup (Intel QSV). This only happened with HDMV PGS subtitles in MKS containers. Some of them, for whatever reason, cause the encoder to hang at certain points if jellyfin burned in subtitles.

<del>In those cases, I would see the following line in the corresponding transcode logs:


<del>The encode will run for a certain amount of time and then hangs, while not consuming any resources. The amount it will encode is not random. If a file is affected, it will always hang at the same timestamp. 

<del>When I run the same ffmpeg command manually through SSH, encode also hangs at the same timestamp. Adding analyzeduration and probesize for the subtitle input fixed it for me and transcoding ran without issues. 

<del>x264 does not seem to have this problem at all. QSV does though, at least for me.

<del>**Changes**
<del>Adds `-analyzeduration 200M -probesize 128M` to subtitle inputs.

<del>**Issues**
<del>Fixes encoder hangs with certain PGS subtitles inside MKS files when burning them in during transcode with Intel QSV.</del>
