### PR TITLE
feat(updates): support algorithm-prefixed checksums

### DIFF
--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -534,8 +534,9 @@ namespace Emby.Server.Implementations.Updates
 #pragma warning disable CA5351
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var hash = Convert.ToHexString(await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false));
-                if (!string.Equals(package.Checksum, hash, StringComparison.OrdinalIgnoreCase))
+                var expectedHash = ParseChecksum(package.Checksum, out var hashAlgorithmName);
+                var hash = await ComputeHashAsync(stream, hashAlgorithmName, cancellationToken).ConfigureAwait(false);
+                if (!string.Equals(expectedHash, hash, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogError(
                         "The checksums didn't match while installing {Package}, expected: {Expected}, got: {Received}",
@@ -570,6 +571,78 @@ namespace Emby.Server.Implementations.Updates
             await _pluginManager.PopulateManifest(package.PackageInfo, package.Version, targetDir, status).ConfigureAwait(false);
 
             _pluginManager.ImportPluginFrom(targetDir);
+        }
+
+        private static string ParseChecksum(string checksum, out string hashAlgorithmName)
+        {
+            if (string.IsNullOrWhiteSpace(checksum))
+            {
+                throw new InvalidDataException("Checksum is missing.");
+            }
+
+            var separator = checksum.IndexOf(':', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                hashAlgorithmName = "md5";
+                ValidateHex(checksum, hashAlgorithmName);
+                return checksum;
+            }
+
+            if (separator == 0 || separator == checksum.Length - 1)
+            {
+                throw new InvalidDataException("Checksum format is invalid. Expected algorithm:hex.");
+            }
+
+            hashAlgorithmName = checksum[..separator].ToLowerInvariant();
+            if (!IsSupportedDigestAlgorithm(hashAlgorithmName))
+            {
+                throw new InvalidDataException($"Checksum algorithm '{hashAlgorithmName}' is not supported.");
+            }
+
+            var hex = checksum[(separator + 1)..];
+            ValidateHex(hex, hashAlgorithmName);
+            return hex;
+        }
+
+        private static bool IsSupportedDigestAlgorithm(string algorithm)
+            => algorithm is "md5" or "sha256" or "sha512";
+
+        private static async Task<string> ComputeHashAsync(Stream stream, string hashAlgorithmName, CancellationToken cancellationToken)
+        {
+            byte[] hash = hashAlgorithmName switch
+            {
+                // CA5351: Do Not Use Broken Cryptographic Algorithms
+                "md5" => await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                "sha256" => await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                "sha512" => await SHA512.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                _ => throw new InvalidDataException($"Checksum algorithm '{hashAlgorithmName}' is not supported.")
+            };
+
+            return Convert.ToHexString(hash);
+        }
+
+        private static void ValidateHex(string hex, string algorithm)
+        {
+            int expectedLength = algorithm switch
+            {
+                "md5" => 32,
+                "sha256" => 64,
+                "sha512" => 128,
+                _ => throw new InvalidDataException($"Checksum algorithm '{algorithm}' is not supported.")
+            };
+
+            if (hex.Length != expectedLength)
+            {
+                throw new InvalidDataException($"Checksum has invalid length for {algorithm}.");
+            }
+
+            foreach (var c in hex)
+            {
+                if (!Uri.IsHexDigit(c))
+                {
+                    throw new InvalidDataException("Checksum contains non-hex characters.");
+                }
+            }
         }
 
         private async Task<bool> InstallPackageInternal(InstallationInfo package, CancellationToken cancellationToken)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -556,8 +556,9 @@ namespace Emby.Server.Implementations.Updates
 #pragma warning disable CA5351
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var hash = Convert.ToHexString(await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false));
-                if (!string.Equals(package.Checksum, hash, StringComparison.OrdinalIgnoreCase))
+                var expectedHash = ParseChecksum(package.Checksum, out var hashAlgorithmName);
+                var hash = await ComputeHashAsync(stream, hashAlgorithmName, cancellationToken).ConfigureAwait(false);
+                if (!string.Equals(expectedHash, hash, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogError(
                         "The checksums didn't match while installing {Package}, expected: {Expected}, got: {Received}",
@@ -612,6 +613,78 @@ namespace Emby.Server.Implementations.Updates
             }
 
             return true;
+        }
+
+        private static string ParseChecksum(string checksum, out string hashAlgorithmName)
+        {
+            if (string.IsNullOrWhiteSpace(checksum))
+            {
+                throw new InvalidDataException("Checksum is missing.");
+            }
+
+            var separator = checksum.IndexOf(':', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                hashAlgorithmName = "md5";
+                ValidateHex(checksum, hashAlgorithmName);
+                return checksum;
+            }
+
+            if (separator == 0 || separator == checksum.Length - 1)
+            {
+                throw new InvalidDataException("Checksum format is invalid. Expected algorithm:hex.");
+            }
+
+            hashAlgorithmName = checksum[..separator].ToLowerInvariant();
+            if (!IsSupportedDigestAlgorithm(hashAlgorithmName))
+            {
+                throw new InvalidDataException($"Checksum algorithm '{hashAlgorithmName}' is not supported.");
+            }
+
+            var hex = checksum[(separator + 1)..];
+            ValidateHex(hex, hashAlgorithmName);
+            return hex;
+        }
+
+        private static bool IsSupportedDigestAlgorithm(string algorithm)
+            => algorithm is "md5" or "sha256" or "sha512";
+
+        private static async Task<string> ComputeHashAsync(Stream stream, string hashAlgorithmName, CancellationToken cancellationToken)
+        {
+            byte[] hash = hashAlgorithmName switch
+            {
+                // CA5351: Do Not Use Broken Cryptographic Algorithms
+                "md5" => await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                "sha256" => await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                "sha512" => await SHA512.HashDataAsync(stream, cancellationToken).ConfigureAwait(false),
+                _ => throw new InvalidDataException($"Checksum algorithm '{hashAlgorithmName}' is not supported.")
+            };
+
+            return Convert.ToHexString(hash);
+        }
+
+        private static void ValidateHex(string hex, string algorithm)
+        {
+            int expectedLength = algorithm switch
+            {
+                "md5" => 32,
+                "sha256" => 64,
+                "sha512" => 128,
+                _ => throw new InvalidDataException($"Checksum algorithm '{algorithm}' is not supported.")
+            };
+
+            if (hex.Length != expectedLength)
+            {
+                throw new InvalidDataException($"Checksum has invalid length for {algorithm}.");
+            }
+
+            foreach (var c in hex)
+            {
+                if (!Uri.IsHexDigit(c))
+                {
+                    throw new InvalidDataException("Checksum contains non-hex characters.");
+                }
+            }
         }
 
         private async Task<bool> InstallPackageInternal(InstallationInfo package, CancellationToken cancellationToken)

--- a/MediaBrowser.Model/Updates/InstallationInfo.cs
+++ b/MediaBrowser.Model/Updates/InstallationInfo.cs
@@ -43,6 +43,7 @@ namespace MediaBrowser.Model.Updates
 
         /// <summary>
         /// Gets or sets a checksum for the binary.
+        /// Supports legacy MD5 as plain hex or digest format algorithm:hex (for example sha256:...).
         /// </summary>
         /// <value>The checksum.</value>
         public string Checksum { get; set; }

--- a/MediaBrowser.Model/Updates/VersionInfo.cs
+++ b/MediaBrowser.Model/Updates/VersionInfo.cs
@@ -50,6 +50,7 @@ namespace MediaBrowser.Model.Updates
 
         /// <summary>
         /// Gets or sets a checksum for the binary.
+        /// Supports legacy MD5 as plain hex or digest format algorithm:hex (for example sha256:...).
         /// </summary>
         /// <value>The checksum.</value>
         [JsonPropertyName("checksum")]

--- a/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
@@ -97,6 +97,32 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
         }
 
         [Fact]
+        public async Task InstallPackage_UnknownChecksumAlgorithm_ThrowsInvalidDataException()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha999:3953e8eec12765950f32ec81cd590ac62825f84a355ee74d542516201519f8ae"
+            };
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task InstallPackage_InvalidChecksumDigestFormat_ThrowsInvalidDataException()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha256"
+            };
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
+
+        [Fact]
         public async Task InstallPackage_Valid_Success()
         {
             var packageInfo = new InstallationInfo()
@@ -104,6 +130,34 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
                 Name = "Test",
                 SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
                 Checksum = "11b5b2f1a9ebc4f66d6ef19018543361"
+            };
+
+            var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task InstallPackage_ValidSha256Digest_Success()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha256:3953e8eec12765950f32ec81cd590ac62825f84a355ee74d542516201519f8ae"
+            };
+
+            var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task InstallPackage_ValidSha512Digest_Success()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha512:a6c651fcbbc74b95dc52647a312c332d9ecf6290821de099fee38797fa1c8057d48f3e99c935601f122d9afac65605515fa014944060177cf9ff18309a28a2d2"
             };
 
             var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));

--- a/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -97,6 +97,32 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
         }
 
         [Fact]
+        public async Task InstallPackage_UnknownChecksumAlgorithm_ThrowsInvalidDataException()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha999:3953e8eec12765950f32ec81cd590ac62825f84a355ee74d542516201519f8ae"
+            };
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task InstallPackage_InvalidChecksumDigestFormat_ThrowsInvalidDataException()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha256"
+            };
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
+
+        [Fact]
         public async Task InstallPackage_Valid_Success()
         {
             var packageInfo = new InstallationInfo()
@@ -132,6 +158,34 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
             };
 
             await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task InstallPackage_ValidSha256Digest_Success()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha256:3953e8eec12765950f32ec81cd590ac62825f84a355ee74d542516201519f8ae"
+            };
+
+            var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task InstallPackage_ValidSha512Digest_Success()
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = "Test",
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "sha512:a6c651fcbbc74b95dc52647a312c332d9ecf6290821de099fee38797fa1c8057d48f3e99c935601f122d9afac65605515fa014944060177cf9ff18309a28a2d2"
+            };
+
+            var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+            Assert.Null(ex);
         }
     }
 }


### PR DESCRIPTION
Allow package checksum values in the `algorithm:digest` format, while retaining plain hex for legacy MD5 purposes to ensure backward compatibility. This follows the RFC 6920 format of  `<hash-algorithm>:<hash-value>` and is also used for example for Docker images, as well as for GitHub release API hashing of every file with `sha256`. 

My goal is to either use GitHub hashes directly or easily compare them with the manifest. This also future-proofs the system.

**Changes**
add support algorithm:digest format in manifest files. Support for:

- MD5
- sha256
- sha512

 **Code assistance**
Claude Opus 5 for Tests and rebasing/fixing merge condlicts