### PR TITLE
Fix contradictory IsFolder/IsNotFolder filters overwriting each other

### DIFF
--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -200,10 +200,10 @@ public class ArtistsController : BaseJellyfinApiController
                 case ItemFilter.IsFavoriteOrLikes:
                     query.IsFavoriteOrLiked = true;
                     break;
-                case ItemFilter.IsFolder:
+                case ItemFilter.IsFolder when !filters.Contains(ItemFilter.IsNotFolder):
                     query.IsFolder = true;
                     break;
-                case ItemFilter.IsNotFolder:
+                case ItemFilter.IsNotFolder when !filters.Contains(ItemFilter.IsFolder):
                     query.IsFolder = false;
                     break;
                 case ItemFilter.IsPlayed:
@@ -403,10 +403,10 @@ public class ArtistsController : BaseJellyfinApiController
                 case ItemFilter.IsFavoriteOrLikes:
                     query.IsFavoriteOrLiked = true;
                     break;
-                case ItemFilter.IsFolder:
+                case ItemFilter.IsFolder when !filters.Contains(ItemFilter.IsNotFolder):
                     query.IsFolder = true;
                     break;
-                case ItemFilter.IsNotFolder:
+                case ItemFilter.IsNotFolder when !filters.Contains(ItemFilter.IsFolder):
                     query.IsFolder = false;
                     break;
                 case ItemFilter.IsPlayed:

--- a/Jellyfin.Api/Controllers/ChannelsController.cs
+++ b/Jellyfin.Api/Controllers/ChannelsController.cs
@@ -146,10 +146,10 @@ public class ChannelsController : BaseJellyfinApiController
         {
             switch (filter)
             {
-                case ItemFilter.IsFolder:
+                case ItemFilter.IsFolder when !filters.Contains(ItemFilter.IsNotFolder):
                     query.IsFolder = true;
                     break;
-                case ItemFilter.IsNotFolder:
+                case ItemFilter.IsNotFolder when !filters.Contains(ItemFilter.IsFolder):
                     query.IsFolder = false;
                     break;
                 case ItemFilter.IsUnplayed:
@@ -219,10 +219,10 @@ public class ChannelsController : BaseJellyfinApiController
         {
             switch (filter)
             {
-                case ItemFilter.IsFolder:
+                case ItemFilter.IsFolder when !filters.Contains(ItemFilter.IsNotFolder):
                     query.IsFolder = true;
                     break;
-                case ItemFilter.IsNotFolder:
+                case ItemFilter.IsNotFolder when !filters.Contains(ItemFilter.IsFolder):
                     query.IsFolder = false;
                     break;
                 case ItemFilter.IsUnplayed:

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -399,10 +399,10 @@ public class ItemsController : BaseJellyfinApiController
                     case ItemFilter.IsFavoriteOrLikes:
                         query.IsFavoriteOrLiked = true;
                         break;
-                    case ItemFilter.IsFolder:
+                    case ItemFilter.IsFolder when !filters.Contains(ItemFilter.IsNotFolder):
                         query.IsFolder = true;
                         break;
-                    case ItemFilter.IsNotFolder:
+                    case ItemFilter.IsNotFolder when !filters.Contains(ItemFilter.IsFolder):
                         query.IsFolder = false;
                         break;
                     case ItemFilter.IsPlayed:


### PR DESCRIPTION
  When both IsFolder and IsNotFolder filters are present in a request,
  the sequential switch statement would let IsNotFolder silently overwrite
  IsFolder. Add 'when' guards so contradictory filters cancel out, leaving
  query.IsFolder as null (no folder filtering) instead of applying the
  wrong constraint.

  Fixes #16299