### PR TITLE
Fix near-1:1 SAR values falsely flagged as anamorphic

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1161,6 +1161,8 @@ namespace MediaBrowser.MediaEncoding.Probing
         /// A 1% tolerance safely covers encoder rounding artifacts while preserving detection
         /// of genuine anamorphic content (closest standard is PAL 4:3 at 16:15 = 6.67% off).
         /// </summary>
+        /// <param name="sar">The sample aspect ratio string in "N:D" format.</param>
+        /// <returns><c>true</c> if the SAR is within 1% of 1:1; otherwise <c>false</c>.</returns>
         internal static bool IsNearSquarePixelSar(string sar)
         {
             if (string.IsNullOrEmpty(sar))

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -40,20 +40,20 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
             => Assert.Equal(expected, ProbeResultNormalizer.GetFrameRate(value));
 
         [Theory]
-        [InlineData("1:1", true)]           // exact square pixels
-        [InlineData("3201:3200", true)]     // 0.03% off — encoder rounding artifact (4K HEVC)
-        [InlineData("1215:1216", true)]     // 0.08% off — encoder rounding artifact
-        [InlineData("1001:1000", true)]     // 0.1% off — encoder rounding artifact
-        [InlineData("16:15", false)]        // 6.67% off — PAL DVD 4:3, genuinely anamorphic
-        [InlineData("8:9", false)]          // 11.1% off — NTSC DVD 4:3
-        [InlineData("32:27", false)]        // 18.5% off — NTSC DVD 16:9
-        [InlineData("10:11", false)]        // 9.1% off — DV NTSC
-        [InlineData("64:45", false)]        // 42.2% off — PAL DVD 16:9
-        [InlineData("4:3", false)]          // 33.3% off — classic anamorphic
-        [InlineData("0:1", false)]          // invalid/unknown SAR
-        [InlineData("", false)]             // empty
-        [InlineData(null, false)]           // null
-        public void IsNearSquarePixelSar_DetectsCorrectly(string sar, bool expected)
+        [InlineData("1:1", true)]
+        [InlineData("3201:3200", true)]
+        [InlineData("1215:1216", true)]
+        [InlineData("1001:1000", true)]
+        [InlineData("16:15", false)]
+        [InlineData("8:9", false)]
+        [InlineData("32:27", false)]
+        [InlineData("10:11", false)]
+        [InlineData("64:45", false)]
+        [InlineData("4:3", false)]
+        [InlineData("0:1", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsNearSquarePixelSar_DetectsCorrectly(string? sar, bool expected)
             => Assert.Equal(expected, ProbeResultNormalizer.IsNearSquarePixelSar(sar));
 
         [Fact]


### PR DESCRIPTION
Encoders sometimes produce sample aspect ratios like `3201:3200` (0.03% off square) for content that has effectively square pixels. The exact string comparison against `"1:1"` in `ProbeResultNormalizer` marks these as anamorphic, triggering unnecessary transcoding on every client profile that requires non-anamorphic video.

This parses the SAR numerically and treats values within 1% of 1:1 as square pixels. The threshold is conservative — the closest genuine anamorphic SAR is PAL 4:3 at 16:15 (6.67% off).

Fixes a false `AnamorphicVideoNotSupported` transcode reason on 4K HEVC content with these rounding-artifact SARs.