### PR TITLE
Add startup mode to migrate or seed the database on cmd

### DIFF
--- a/Jellyfin.Server/Configuration/StartupMode.cs
+++ b/Jellyfin.Server/Configuration/StartupMode.cs
@@ -13,12 +13,12 @@ public enum StartupMode
     MediaServer = 0,
 
     /// <summary>
-    /// Attempts to Migrate the selected database only then shuts down.
+    /// Attempts to Migrate the system only then shuts down.
     /// </summary>
-    MigrateDatabase = 1,
+    MigrateSystem = 1,
 
     /// <summary>
     /// Runs the Database seed function regardless of <see cref="BaseApplicationConfiguration.IsStartupWizardCompleted"/> state.
     /// </summary>
-    SeedDatabase = 2
+    SeedSystem = 2
 }

--- a/Jellyfin.Server/Configuration/StartupMode.cs
+++ b/Jellyfin.Server/Configuration/StartupMode.cs
@@ -1,0 +1,24 @@
+using MediaBrowser.Model.Configuration;
+
+namespace Jellyfin.Server.Configuration;
+
+/// <summary>
+/// Defines types for usage with the <see cref="StartupOptions.StartupMode"/>.
+/// </summary>
+public enum StartupMode
+{
+    /// <summary>
+    /// Default startup mode, runs the jellyfin server in normal operation.
+    /// </summary>
+    MediaServer = 0,
+
+    /// <summary>
+    /// Attempts to Migrate the selected database only then shuts down.
+    /// </summary>
+    MigrateDatabase = 1,
+
+    /// <summary>
+    /// Runs the Database seed function regardless of <see cref="BaseApplicationConfiguration.IsStartupWizardCompleted"/> state.
+    /// </summary>
+    SeedDatabase = 2
+}

--- a/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
+++ b/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
@@ -98,7 +98,7 @@ internal class JellyfinMigrationService
         var serverConfig = File.Exists(appPaths.SystemConfigurationFilePath)
             ? (ServerConfiguration)xmlSerializer.DeserializeFromFile(typeof(ServerConfiguration), appPaths.SystemConfigurationFilePath)!
             : new ServerConfiguration();
-        if (!serverConfig.IsStartupWizardCompleted || startupOptions.StartupMode is Configuration.StartupMode.SeedDatabase)
+        if (!serverConfig.IsStartupWizardCompleted || startupOptions.StartupMode is Configuration.StartupMode.SeedSystem)
         {
             logger.LogInformation("System initialization detected. Seed data. Startup mode is: {StartupMode}", startupOptions.StartupMode ?? Configuration.StartupMode.MediaServer);
             var flatApplyMigrations = Migrations.SelectMany(e => e.Where(f => !f.Metadata.RunMigrationOnSetup)).ToArray();

--- a/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
+++ b/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
@@ -90,7 +90,7 @@ internal class JellyfinMigrationService
 
     private HashSet<MigrationStage> Migrations { get; set; }
 
-    public async Task CheckFirstTimeRunOrMigration(IApplicationPaths appPaths)
+    public async Task CheckFirstTimeRunOrMigration(IApplicationPaths appPaths, StartupOptions startupOptions)
     {
         var logger = _startupLogger.With(_loggerFactory.CreateLogger<JellyfinMigrationService>()).BeginGroup($"Migration Startup");
         logger.LogInformation("Initialise Migration service.");
@@ -98,9 +98,9 @@ internal class JellyfinMigrationService
         var serverConfig = File.Exists(appPaths.SystemConfigurationFilePath)
             ? (ServerConfiguration)xmlSerializer.DeserializeFromFile(typeof(ServerConfiguration), appPaths.SystemConfigurationFilePath)!
             : new ServerConfiguration();
-        if (!serverConfig.IsStartupWizardCompleted)
+        if (!serverConfig.IsStartupWizardCompleted || startupOptions.StartupMode is Configuration.StartupMode.SeedDatabase)
         {
-            logger.LogInformation("System initialisation detected. Seed data.");
+            logger.LogInformation("System initialization detected. Seed data. Startup mode is: {StartupMode}", startupOptions.StartupMode ?? Configuration.StartupMode.MediaServer);
             var flatApplyMigrations = Migrations.SelectMany(e => e.Where(f => !f.Metadata.RunMigrationOnSetup)).ToArray();
 
             var dbContext = await _dbContextFactory.CreateDbContextAsync().ConfigureAwait(false);

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -251,7 +251,11 @@ namespace Jellyfin.Server
                 if (_setupServer!.IsAlive && !configurationCompleted)
                 {
                     _setupServer!.SoftStop();
-                    await Task.Delay(TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+                    if (options.StartupMode is null or Configuration.StartupMode.MediaServer)
+                    {
+                        await Task.Delay(TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+                    }
+
                     await _setupServer!.StopAsync().ConfigureAwait(false);
                 }
             }

--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -137,7 +137,7 @@ namespace Jellyfin.Server
 
             StartupHelpers.PerformStaticInitialization();
 
-            await ApplyStartupMigrationAsync(appPaths, startupConfig).ConfigureAwait(false);
+            await ApplyStartupMigrationAsync(appPaths, startupConfig, options).ConfigureAwait(false);
 
             do
             {
@@ -214,13 +214,17 @@ namespace Jellyfin.Server
                 {
                     configurationCompleted = true;
                     await _setupServer!.StopAsync().ConfigureAwait(false);
-                    await _jellyfinHost.StartAsync().ConfigureAwait(false);
 
-                    if (!OperatingSystem.IsWindows() && startupConfig.UseUnixSocket())
+                    if (options.StartupMode is null or Configuration.StartupMode.MediaServer)
                     {
-                        var socketPath = StartupHelpers.GetUnixSocketPath(startupConfig, appPaths);
+                        await _jellyfinHost.StartAsync().ConfigureAwait(false);
 
-                        StartupHelpers.SetUnixSocketPermissions(startupConfig, socketPath, _logger);
+                        if (!OperatingSystem.IsWindows() && startupConfig.UseUnixSocket())
+                        {
+                            var socketPath = StartupHelpers.GetUnixSocketPath(startupConfig, appPaths);
+
+                            StartupHelpers.SetUnixSocketPermissions(startupConfig, socketPath, _logger);
+                        }
                     }
                 }
                 catch (Exception)
@@ -229,11 +233,14 @@ namespace Jellyfin.Server
                     throw;
                 }
 
-                await appHost.RunStartupTasksAsync().ConfigureAwait(false);
+                if (options.StartupMode is null or Configuration.StartupMode.MediaServer)
+                {
+                    await appHost.RunStartupTasksAsync().ConfigureAwait(false);
+                    _logger.LogInformation("Startup complete {Time:g}", Stopwatch.GetElapsedTime(_startTimestamp));
 
-                _logger.LogInformation("Startup complete {Time:g}", Stopwatch.GetElapsedTime(_startTimestamp));
+                    await _jellyfinHost.WaitForShutdownAsync().ConfigureAwait(false);
+                }
 
-                await _jellyfinHost.WaitForShutdownAsync().ConfigureAwait(false);
                 _restartOnShutdown = appHost.ShouldRestart;
                 _restoreFromBackup = appHost.RestoreBackupPath;
             }
@@ -274,8 +281,9 @@ namespace Jellyfin.Server
         /// </remarks>
         /// <param name="appPaths">Application Paths.</param>
         /// <param name="startupConfig">Startup Config.</param>
+        /// <param name="startupOptions">The applications startup options.</param>
         /// <returns>A task.</returns>
-        public static async Task ApplyStartupMigrationAsync(ServerApplicationPaths appPaths, IConfiguration startupConfig)
+        public static async Task ApplyStartupMigrationAsync(ServerApplicationPaths appPaths, IConfiguration startupConfig, StartupOptions startupOptions)
         {
             _migrationLogger = StartupLogger.Logger.BeginGroup<JellyfinMigrationService>($"Migration Service");
             var startupConfigurationManager = new ServerConfigurationManager(appPaths, _loggerFactory, new MyXmlSerializer());
@@ -293,7 +301,7 @@ namespace Jellyfin.Server
             PrepareDatabaseProvider(startupService);
 
             var jellyfinMigrationService = ActivatorUtilities.CreateInstance<JellyfinMigrationService>(startupService);
-            await jellyfinMigrationService.CheckFirstTimeRunOrMigration(appPaths).ConfigureAwait(false);
+            await jellyfinMigrationService.CheckFirstTimeRunOrMigration(appPaths, startupOptions).ConfigureAwait(false);
             await jellyfinMigrationService.MigrateStepAsync(Migrations.Stages.JellyfinMigrationStageTypes.PreInitialisation, startupService).ConfigureAwait(false);
         }
 

--- a/Jellyfin.Server/StartupOptions.cs
+++ b/Jellyfin.Server/StartupOptions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using CommandLine;
 using Emby.Server.Implementations;
+using Jellyfin.Server.Configuration;
 using static MediaBrowser.Controller.Extensions.ConfigurationExtensions;
 
 namespace Jellyfin.Server
@@ -78,6 +79,13 @@ namespace Jellyfin.Server
         /// </summary>
         [Option("restore-archive", Required = false, HelpText = "Path to a Jellyfin backup archive to restore from")]
         public string? RestoreArchive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the mode of operation the server should perform when started.
+        /// Defaults to: <see cref="StartupMode.MediaServer"/>.
+        /// </summary>
+        [Option("mode", Required = false, HelpText = "Mode which selects what action the jellyfin server should perform when started.")]
+        public StartupMode? StartupMode { get; set; }
 
         /// <summary>
         /// Gets the command line options as a dictionary that can be used in the .NET configuration system.

--- a/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/JellyfinApplicationFactory.cs
@@ -111,7 +111,7 @@ namespace Jellyfin.Server.Integration.Tests
             var appHost = (TestAppHost)host.Services.GetRequiredService<IApplicationHost>();
             appHost.ServiceProvider = host.Services;
             var applicationPaths = appHost.ServiceProvider.GetRequiredService<IApplicationPaths>();
-            Program.ApplyStartupMigrationAsync((ServerApplicationPaths)applicationPaths, appHost.ServiceProvider.GetRequiredService<IConfiguration>()).GetAwaiter().GetResult();
+            Program.ApplyStartupMigrationAsync((ServerApplicationPaths)applicationPaths, appHost.ServiceProvider.GetRequiredService<IConfiguration>(), new()).GetAwaiter().GetResult();
             Program.ApplyCoreMigrationsAsync(appHost.ServiceProvider, Migrations.Stages.JellyfinMigrationStageTypes.CoreInitialisation).GetAwaiter().GetResult();
             appHost.InitializeServices(Mock.Of<IConfiguration>()).GetAwaiter().GetResult();
             Program.ApplyCoreMigrationsAsync(appHost.ServiceProvider, Migrations.Stages.JellyfinMigrationStageTypes.AppInitialisation).GetAwaiter().GetResult();


### PR DESCRIPTION
Adds an optional mode selector to the process arguments to run the server in the following modes:

- MediaServer: default. Normal pre-existing operations
- MigrateSystem: Runs only the migration system, then stops the server
- SeedSystem: Runs the migration tooling to seed the datastructures regardless of the `IsStartupWizardCompleted` flag, then stops the server


This will be helpful with external database providers to more easily migrate from an sqlite db to another provider which first requires the new database to be seeded before a data migration can take place. This seeding operation is not otherwise easily possible.