### PR TITLE
Add missing ProducesResponseType(401) to QuickConnectController.InitiateQuickConnect

### DIFF
--- a/Jellyfin.Api/Controllers/QuickConnectController.cs
+++ b/Jellyfin.Api/Controllers/QuickConnectController.cs
@@ -52,6 +52,7 @@ public class QuickConnectController : BaseJellyfinApiController
     /// <returns>A <see cref="QuickConnectResult"/> with a secret and code for future use or an error message.</returns>
     [HttpPost("Initiate")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<QuickConnectResult>> InitiateQuickConnect()
     {
         try


### PR DESCRIPTION

**Changes**
At lines 51 XML doc says this endpoint can return 401 "/// <response code="401">Quick connect is not active on this server. </response>" but the attibutes only declares 200 "[ProducesResponseType(StatusCodes.Status200OK)]
// ← missing: [ProducesResponseType(StatusCodes.Status401Unauthorized)]"-
And in the line 64 the code actually does return 401 "return Unauthorized("Quick connect is disabled");". In short, the XML tells the truth, but the [ProducesResponseType] attribute is missing the 401. This means the auto-generated Swagger/OpenAPI documentation is wrong, it won't show 401 as a possible response for this endpoint.



**Issues**
[HttpPost("Initiate")]
    [ProducesResponseType(StatusCodes.Status200OK)]
    [ProducesResponseType(StatusCodes.Status401K)]