### PR TITLE
Fix hls segment length adjustment for remuxed content

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1424,8 +1424,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         double fps = state.TargetFramerate ?? 0.0f;
         int segmentLength = state.SegmentLength * 1000;
 
-        // If framerate is fractional (i.e. 23.976), we need to slightly adjust segment length
-        if (Math.Abs(fps - Math.Floor(fps + 0.001f)) > 0.001)
+        // If video is transcoded and framerate is fractional (i.e. 23.976), we need to slightly adjust segment length
+        if (!EncodingHelper.IsCopyCodec(state.OutputVideoCodec) && Math.Abs(fps - Math.Floor(fps + 0.001f)) > 0.001)
         {
             double nearestIntFramerate = Math.Ceiling(fps);
             segmentLength = (int)Math.Ceiling(segmentLength * (nearestIntFramerate / fps));


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
PR #16053 introduced a slight adjustment to the segment length for 23.976 fps content. That makes sense for transcoded content.  However, when video is remuxed, Jellyfin generates the playlist based on key-frames, so the segment length used for generating the manifest must match what FFmpeg is using. Otherwise, we can end up with a playlist whose advertised durations don’t correspond to the segments generated by FFmpeg. Also we can end up with different number of segments generated by FFmpeg compared to the Jellyfin manifest. Some native HLS clients may stall during playback if the actual segment durations differ significantly from what the manifest announces.

**Issues**
Fixes [#327](https://github.com/jellyfin/jellyfin-webos/issues/327) 