### PR TITLE
Fix backup failing on entities with invalid GUID format

### DIFF
--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -346,6 +346,10 @@ public class BackupService : IBackupService
                                             using var document = JsonSerializer.SerializeToDocument(item, _serializerSettings);
                                             document.WriteTo(jsonSerializer);
                                         }
+                                        catch (FormatException ex)
+                                        {
+                                            _logger.LogWarning(ex, "Skipping entity with invalid data format in {Table}: {Entity}", entityType.SourceName, item);
+                                        }
                                         catch (Exception ex)
                                         {
                                             _logger.LogError(ex, "Could not load entity {Entity}", item);


### PR DESCRIPTION
Fixes #16337

## Summary
When a database entity contains a GUID field with invalid hexadecimal characters, `JsonSerializer.SerializeToDocument` throws a `FormatException` ("Guid string should only contain hexadecimal characters"). Previously this exception was re-thrown, aborting the entire backup.

This fix catches `FormatException` separately and skips the problematic entity with a warning log, allowing the backup to complete with all valid entities preserved.

## Changes
- Added `FormatException` catch clause before the general `Exception` catch in `CreateBackupAsync`
- Logs a warning with the table name and entity details for debugging
- Backup continues instead of aborting

## Test plan
- Create a backup with valid database - should complete normally
- Database with corrupted GUID entries should now produce a backup with warnings instead of failing