### PR TITLE
Added .avif support to image types

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -53,7 +53,7 @@ namespace MediaBrowser.Controller.Entities
         /// The supported image extensions.
         /// </summary>
         public static readonly string[] SupportedImageExtensions
-            = [".png", ".jpg", ".jpeg", ".webp", ".tbn", ".gif", ".svg"];
+            = [".png", ".jpg", ".jpeg", ".webp", ".tbn", ".gif", ".svg", ".avif"];
 
         private static readonly List<string> _supportedExtensions = new List<string>(SupportedImageExtensions)
         {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -968,44 +968,55 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            int bitrate = 0;
+            // Get stream bitrate
+            var bitrate = 0;
 
-            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
-            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
+            if (int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
             {
-                bitrate = GetBPSFromTags(streamInfo);
+                bitrate = value;
             }
 
-            // FALLBACK Calculate BPS from total bytes and duration tags
-            if (bitrate <= 0)
+            // The bitrate info of FLAC musics and some videos is included in formatInfo.
+            if (bitrate == 0
+                && formatInfo is not null
+                && (stream.Type == MediaStreamType.Video || (isAudio && stream.Type == MediaStreamType.Audio)))
             {
-                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                var bytes = GetNumberOfBytesFromTags(streamInfo);
-
-                if (durationInSeconds is { } dur && dur >= 1 && bytes is { } totalBytes)
+                // If the stream info doesn't have a bitrate get the value from the media format info
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out value))
                 {
-                    bitrate = Convert.ToInt32(totalBytes * 8 / dur, CultureInfo.InvariantCulture);
-                }
-            }
-
-            // FALLBACK B: Use the standard stream bitrate field
-            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
-            {
-                bitrate = streamVal;
-            }
-
-            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null)
-            {
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-                {
-                    bitrate = formatVal;
+                    bitrate = value;
                 }
             }
 
             if (bitrate > 0)
             {
                 stream.BitRate = bitrate;
+            }
+
+            // Extract bitrate info from tag "BPS" if possible.
+            if (!stream.BitRate.HasValue
+                && (streamInfo.CodecType == CodecType.Audio
+                    || streamInfo.CodecType == CodecType.Video))
+            {
+                var bps = GetBPSFromTags(streamInfo);
+                if (bps > 0)
+                {
+                    stream.BitRate = bps;
+                }
+                else
+                {
+                    // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
+                    var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                    var bytes = GetNumberOfBytesFromTags(streamInfo);
+                    if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
+                    {
+                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
+                        if (bps > 0)
+                        {
+                            stream.BitRate = bps;
+                        }
+                    }
+                }
             }
 
             var disposition = streamInfo.Disposition;
@@ -1196,21 +1207,20 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
         }
 
-        private static int GetBPSFromTags(MediaStreamInfo streamInfo)
+        private static int? GetBPSFromTags(MediaStreamInfo streamInfo)
         {
             if (streamInfo?.Tags is null)
             {
-                return 0;
+                return null;
             }
 
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
-
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            return 0;
+            return null;
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -968,55 +968,44 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            // Get stream bitrate
-            var bitrate = 0;
+            int bitrate = 0;
 
-            if (int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
+            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
+            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
             {
-                bitrate = value;
+                bitrate = GetBPSFromTags(streamInfo);
             }
 
-            // The bitrate info of FLAC musics and some videos is included in formatInfo.
-            if (bitrate == 0
-                && formatInfo is not null
-                && (stream.Type == MediaStreamType.Video || (isAudio && stream.Type == MediaStreamType.Audio)))
+            // FALLBACK Calculate BPS from total bytes and duration tags
+            if (bitrate <= 0)
             {
-                // If the stream info doesn't have a bitrate get the value from the media format info
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out value))
+                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                var bytes = GetNumberOfBytesFromTags(streamInfo);
+
+                if (durationInSeconds is { } dur && dur >= 1 && bytes is { } totalBytes)
                 {
-                    bitrate = value;
+                    bitrate = Convert.ToInt32(totalBytes * 8 / dur, CultureInfo.InvariantCulture);
+                }
+            }
+
+            // FALLBACK B: Use the standard stream bitrate field
+            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
+            {
+                bitrate = streamVal;
+            }
+
+            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
+            if (bitrate <= 0 && formatInfo != null)
+            {
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+                {
+                    bitrate = formatVal;
                 }
             }
 
             if (bitrate > 0)
             {
                 stream.BitRate = bitrate;
-            }
-
-            // Extract bitrate info from tag "BPS" if possible.
-            if (!stream.BitRate.HasValue
-                && (streamInfo.CodecType == CodecType.Audio
-                    || streamInfo.CodecType == CodecType.Video))
-            {
-                var bps = GetBPSFromTags(streamInfo);
-                if (bps > 0)
-                {
-                    stream.BitRate = bps;
-                }
-                else
-                {
-                    // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
-                    var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                    var bytes = GetNumberOfBytesFromTags(streamInfo);
-                    if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
-                    {
-                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
-                        if (bps > 0)
-                        {
-                            stream.BitRate = bps;
-                        }
-                    }
-                }
             }
 
             var disposition = streamInfo.Disposition;
@@ -1207,20 +1196,21 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
         }
 
-        private static int? GetBPSFromTags(MediaStreamInfo streamInfo)
+        private static int GetBPSFromTags(MediaStreamInfo streamInfo)
         {
             if (streamInfo?.Tags is null)
             {
-                return null;
+                return 0;
             }
 
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
+
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            return null;
+            return 0;
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)


### PR DESCRIPTION
Added .avif file type to supported image types. Issue #16295

Added .avif files to SupportedImageExtensions in BaseItem.cs to allow avif images to be found in scans.


**Changes**
Added support for .avif image files, in case users want to replace or convert files to .avif for space saving.

**Issues**
Fixes Issue #16295 and #12412
