### PR TITLE
UpdatedBitrate Detection Order

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -968,20 +968,13 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
+            // Get stream bitrate
             int bitrate = 0;
 
-            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate), only for Matroska.
-            if ((streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
-                && formatInfo?.FormatName is not null
-                && formatInfo.FormatName.Contains("matroska", StringComparison.OrdinalIgnoreCase))
+            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
+            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
             {
                 bitrate = GetBPSFromTags(streamInfo);
-            }
-
-            // Use the standard stream bitrate field
-            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
-            {
-                bitrate = streamVal;
             }
 
             // FALLBACK Calculate BPS from total bytes and duration tags
@@ -996,13 +989,16 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
             }
 
-            // Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null)
+            // FALLBACK B: Use the standard stream bitrate field
+            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
             {
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-                {
-                    bitrate = formatVal;
-                }
+                bitrate = streamVal;
+            }
+
+            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
+            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+            {
+                bitrate = formatVal;
             }
 
             if (bitrate > 0)
@@ -1228,19 +1224,23 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private static int GetBPSFromTags(MediaStreamInfo streamInfo)
         {
+            // 1. Check for null streamInfo or Tags
             if (streamInfo?.Tags is null)
             {
-                return 0;
+                return 0; // Changed from null
             }
 
+            // 2. Fetch the value from the dictionary
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
 
+            // 3. Try to parse and return the integer
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            return 0;
+            // 4. Final fallback if parsing fails
+            return 0; // Changed from null
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -996,9 +996,12 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+            if (bitrate <= 0 && formatInfo != null)
             {
-                bitrate = formatVal;
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+                {
+                    bitrate = formatVal;
+                }
             }
 
             if (bitrate > 0)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -997,12 +997,9 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null)
+            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
             {
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-                {
-                    bitrate = formatVal;
-                }
+                bitrate = formatVal;
             }
 
             if (bitrate > 0)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -993,28 +993,19 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.BitRate = bitrate;
             }
 
-            // Extract bitrate info from tag "BPS" if possible.
+            // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
             if (!stream.BitRate.HasValue
                 && (streamInfo.CodecType == CodecType.Audio
                     || streamInfo.CodecType == CodecType.Video))
             {
-                var bps = GetBPSFromTags(streamInfo);
-                if (bps > 0)
+                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                var bytes = GetNumberOfBytesFromTags(streamInfo);
+                if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
                 {
-                    stream.BitRate = bps;
-                }
-                else
-                {
-                    // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
-                    var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                    var bytes = GetNumberOfBytesFromTags(streamInfo);
-                    if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
+                    var bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
+                    if (bps > 0)
                     {
-                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
-                        if (bps > 0)
-                        {
-                            stream.BitRate = bps;
-                        }
+                        stream.BitRate = bps;
                     }
                 }
             }

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -996,12 +996,9 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null)
+            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
             {
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-                {
-                    bitrate = formatVal;
-                }
+                bitrate = formatVal;
             }
 
             if (bitrate > 0)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1259,9 +1259,15 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             var duration = GetDictionaryValue(streamInfo.Tags, "DURATION-eng") ?? GetDictionaryValue(streamInfo.Tags, "DURATION");
-            if (TimeSpan.TryParse(duration, out var parsedDuration))
+
+            if (!string.IsNullOrEmpty(duration))
             {
-                return parsedDuration.TotalSeconds;
+                duration = Regex.Replace(duration, @"(\.\d{7})\d+", "$1");
+                if (TimeSpan.TryParse(duration, out var parsedDuration))
+                {
+                    Console.WriteLine("Duration is" + parsedDuration.TotalSeconds);
+                    return parsedDuration.TotalSeconds;
+                }
             }
 
             return null;

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -968,13 +968,20 @@ namespace MediaBrowser.MediaEncoding.Probing
                 return null;
             }
 
-            // Get stream bitrate
             int bitrate = 0;
 
-            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
-            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
+            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate), only for Matroska.
+            if ((streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
+                && formatInfo?.FormatName is not null
+                && formatInfo.FormatName.Contains("matroska", StringComparison.OrdinalIgnoreCase))
             {
                 bitrate = GetBPSFromTags(streamInfo);
+            }
+
+            // Use the standard stream bitrate field
+            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
+            {
+                bitrate = streamVal;
             }
 
             // FALLBACK Calculate BPS from total bytes and duration tags
@@ -989,16 +996,13 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
             }
 
-            // FALLBACK B: Use the standard stream bitrate field
-            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
+            // Use the global format info (useful for FLAC or single-stream containers)
+            if (bitrate <= 0 && formatInfo != null)
             {
-                bitrate = streamVal;
-            }
-
-            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-            {
-                bitrate = formatVal;
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+                {
+                    bitrate = formatVal;
+                }
             }
 
             if (bitrate > 0)
@@ -1224,23 +1228,19 @@ namespace MediaBrowser.MediaEncoding.Probing
 
         private static int GetBPSFromTags(MediaStreamInfo streamInfo)
         {
-            // 1. Check for null streamInfo or Tags
             if (streamInfo?.Tags is null)
             {
-                return 0; // Changed from null
+                return 0;
             }
 
-            // 2. Fetch the value from the dictionary
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
 
-            // 3. Try to parse and return the integer
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            // 4. Final fallback if parsing fails
-            return 0; // Changed from null
+            return 0;
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -969,44 +969,54 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // Get stream bitrate
-            int bitrate = 0;
+            var bitrate = 0;
 
-            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
-            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
+            if (int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
             {
-                bitrate = GetBPSFromTags(streamInfo);
+                bitrate = value;
             }
 
-            // FALLBACK Calculate BPS from total bytes and duration tags
-            if (bitrate <= 0)
+            // The bitrate info of FLAC musics and some videos is included in formatInfo.
+            if (bitrate == 0
+                && formatInfo is not null
+                && (stream.Type == MediaStreamType.Video || (isAudio && stream.Type == MediaStreamType.Audio)))
             {
-                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                var bytes = GetNumberOfBytesFromTags(streamInfo);
-
-                if (durationInSeconds is { } dur && dur >= 1 && bytes is { } totalBytes)
+                // If the stream info doesn't have a bitrate get the value from the media format info
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out value))
                 {
-                    bitrate = Convert.ToInt32(totalBytes * 8 / dur, CultureInfo.InvariantCulture);
-                }
-            }
-
-            // FALLBACK B: Use the standard stream bitrate field
-            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
-            {
-                bitrate = streamVal;
-            }
-
-            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null)
-            {
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
-                {
-                    bitrate = formatVal;
+                    bitrate = value;
                 }
             }
 
             if (bitrate > 0)
             {
                 stream.BitRate = bitrate;
+            }
+
+            // Extract bitrate info from tag "BPS" if possible.
+            if (!stream.BitRate.HasValue
+                && (streamInfo.CodecType == CodecType.Audio
+                    || streamInfo.CodecType == CodecType.Video))
+            {
+                var bps = GetBPSFromTags(streamInfo);
+                if (bps > 0)
+                {
+                    stream.BitRate = bps;
+                }
+                else
+                {
+                    // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
+                    var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                    var bytes = GetNumberOfBytesFromTags(streamInfo);
+                    if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
+                    {
+                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
+                        if (bps > 0)
+                        {
+                            stream.BitRate = bps;
+                        }
+                    }
+                }
             }
 
             var disposition = streamInfo.Disposition;
@@ -1225,25 +1235,20 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
         }
 
-        private static int GetBPSFromTags(MediaStreamInfo streamInfo)
+        private static int? GetBPSFromTags(MediaStreamInfo streamInfo)
         {
-            // 1. Check for null streamInfo or Tags
             if (streamInfo?.Tags is null)
             {
-                return 0; // Changed from null
+                return null;
             }
 
-            // 2. Fetch the value from the dictionary
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
-
-            // 3. Try to parse and return the integer
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            // 4. Final fallback if parsing fails
-            return 0; // Changed from null
+            return null;
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1253,7 +1253,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             if (!string.IsNullOrEmpty(duration))
             {
-                duration = Regex.Replace(duration, @"(\.\d{7})\d+", "$1");
+                duration = Regex.Replace(duration, @"(\.\d{7})\d+", "$1", RegexOptions.None, TimeSpan.FromSeconds(1));
                 if (TimeSpan.TryParse(duration, out var parsedDuration))
                 {
                     return parsedDuration.TotalSeconds;

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -969,54 +969,44 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // Get stream bitrate
-            var bitrate = 0;
+            int bitrate = 0;
 
-            if (int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
+            // Extract bitrate from "BPS" tag (FFPROBE per-stream data rate)
+            if (streamInfo.CodecType == CodecType.Audio || streamInfo.CodecType == CodecType.Video)
             {
-                bitrate = value;
+                bitrate = GetBPSFromTags(streamInfo);
             }
 
-            // The bitrate info of FLAC musics and some videos is included in formatInfo.
-            if (bitrate == 0
-                && formatInfo is not null
-                && (stream.Type == MediaStreamType.Video || (isAudio && stream.Type == MediaStreamType.Audio)))
+            // FALLBACK Calculate BPS from total bytes and duration tags
+            if (bitrate <= 0)
             {
-                // If the stream info doesn't have a bitrate get the value from the media format info
-                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out value))
+                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                var bytes = GetNumberOfBytesFromTags(streamInfo);
+
+                if (durationInSeconds is { } dur && dur >= 1 && bytes is { } totalBytes)
                 {
-                    bitrate = value;
+                    bitrate = Convert.ToInt32(totalBytes * 8 / dur, CultureInfo.InvariantCulture);
+                }
+            }
+
+            // FALLBACK B: Use the standard stream bitrate field
+            if (bitrate <= 0 && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var streamVal))
+            {
+                bitrate = streamVal;
+            }
+
+            // FALLBACK C: Use the global format info (useful for FLAC or single-stream containers)
+            if (bitrate <= 0 && formatInfo != null)
+            {
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+                {
+                    bitrate = formatVal;
                 }
             }
 
             if (bitrate > 0)
             {
                 stream.BitRate = bitrate;
-            }
-
-            // Extract bitrate info from tag "BPS" if possible.
-            if (!stream.BitRate.HasValue
-                && (streamInfo.CodecType == CodecType.Audio
-                    || streamInfo.CodecType == CodecType.Video))
-            {
-                var bps = GetBPSFromTags(streamInfo);
-                if (bps > 0)
-                {
-                    stream.BitRate = bps;
-                }
-                else
-                {
-                    // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
-                    var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                    var bytes = GetNumberOfBytesFromTags(streamInfo);
-                    if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
-                    {
-                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
-                        if (bps > 0)
-                        {
-                            stream.BitRate = bps;
-                        }
-                    }
-                }
             }
 
             var disposition = streamInfo.Disposition;
@@ -1235,20 +1225,25 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
         }
 
-        private static int? GetBPSFromTags(MediaStreamInfo streamInfo)
+        private static int GetBPSFromTags(MediaStreamInfo streamInfo)
         {
+            // 1. Check for null streamInfo or Tags
             if (streamInfo?.Tags is null)
             {
-                return null;
+                return 0; // Changed from null
             }
 
+            // 2. Fetch the value from the dictionary
             var bps = GetDictionaryValue(streamInfo.Tags, "BPS-eng") ?? GetDictionaryValue(streamInfo.Tags, "BPS");
+
+            // 3. Try to parse and return the integer
             if (int.TryParse(bps, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBps))
             {
                 return parsedBps;
             }
 
-            return null;
+            // 4. Final fallback if parsing fails
+            return 0; // Changed from null
         }
 
         private static double? GetRuntimeSecondsFromTags(MediaStreamInfo streamInfo)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -997,9 +997,12 @@ namespace MediaBrowser.MediaEncoding.Probing
             }
 
             // Use the global format info (useful for FLAC or single-stream containers)
-            if (bitrate <= 0 && formatInfo != null && int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+            if (bitrate <= 0 && formatInfo != null)
             {
-                bitrate = formatVal;
+                if (int.TryParse(formatInfo.BitRate, CultureInfo.InvariantCulture, out var formatVal))
+                {
+                    bitrate = formatVal;
+                }
             }
 
             if (bitrate > 0)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -971,7 +971,24 @@ namespace MediaBrowser.MediaEncoding.Probing
             // Get stream bitrate
             var bitrate = 0;
 
-            if (int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
+            // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
+            if (streamInfo.CodecType == CodecType.Audio
+                    || streamInfo.CodecType == CodecType.Video)
+            {
+                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
+                var bytes = GetNumberOfBytesFromTags(streamInfo);
+                if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
+                {
+                    var bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
+                    if (bps > 0)
+                    {
+                        bitrate = bps;
+                    }
+                }
+            }
+
+            if (bitrate == 0
+                && int.TryParse(streamInfo.BitRate, CultureInfo.InvariantCulture, out var value))
             {
                 bitrate = value;
             }
@@ -991,23 +1008,6 @@ namespace MediaBrowser.MediaEncoding.Probing
             if (bitrate > 0)
             {
                 stream.BitRate = bitrate;
-            }
-
-            // Get average bitrate info from tag "NUMBER_OF_BYTES" and "DURATION" if possible.
-            if (!stream.BitRate.HasValue
-                && (streamInfo.CodecType == CodecType.Audio
-                    || streamInfo.CodecType == CodecType.Video))
-            {
-                var durationInSeconds = GetRuntimeSecondsFromTags(streamInfo);
-                var bytes = GetNumberOfBytesFromTags(streamInfo);
-                if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
-                {
-                    var bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
-                    if (bps > 0)
-                    {
-                        stream.BitRate = bps;
-                    }
-                }
             }
 
             var disposition = streamInfo.Disposition;
@@ -1256,7 +1256,6 @@ namespace MediaBrowser.MediaEncoding.Probing
                 duration = Regex.Replace(duration, @"(\.\d{7})\d+", "$1");
                 if (TimeSpan.TryParse(duration, out var parsedDuration))
                 {
-                    Console.WriteLine("Duration is" + parsedDuration.TotalSeconds);
                     return parsedDuration.TotalSeconds;
                 }
             }


### PR DESCRIPTION
Summary
I’ve restructured how we determine the bitrate for media streams. Previously, the logic preffered the Bitrate that the file provided instead of the per-stream variable returned by FFPROBE.  This PR re-orders the system so that ensures we grab the most granular data (the stream-level BPS tag) before falling back to rougher estimates like container-level info or manual calculations based on file size and length. All previous logic is preserved, just reordered.

What’s changing?
Prioritizing Metadata: The code now looks for BPS-eng or BPS tags first. These are provided by FFprobe and are generally the most reliable for individual streams.

Cleaner Fallback Logic: I’ve organized the logic into a clear hierarchy. If the BPS tag is missing, it cascades down through:

A manual calculation using (Total Bytes * 8) / Duration.

The standard streamInfo.BitRate field.

The global formatInfo.BitRate (useful for single-stream files like FLAC), this was the existing logic. 

Simplified Types: I updated GetBPSFromTags to return a standard int instead of int?. This cleans up the calling code since we can now just check if bitrate > 0 rather than dealing with null checks. If the ffprobe returns null, it gets assigned as 0 so that the fallback calculations can take place.

Why?
The previous logic wasn't accurately checking video bitrate, it was reporting the entire container's bitrate as the audio. Now it reports as expected. 

Before: as per Issue #16248
<img width="776" height="739" alt="Screenshot 2026-03-05 at 2 49 48 PM" src="https://github.com/user-attachments/assets/d7421ea7-10e4-443c-b07d-e8a809033bd7" />
 
After: 
<img width="954" height="506" alt="Screenshot 2026-03-05 at 2 12 01 PM" src="https://github.com/user-attachments/assets/3b6e73ca-9c31-4084-9cca-b25a63f3faf3" />


This solves issue #16248 

