### PR TITLE
Fix DateTime serialization using OS calendar instead of Gregorian

### DIFF
--- a/src/Jellyfin.Extensions/Json/Converters/JsonDateTimeConverter.cs
+++ b/src/Jellyfin.Extensions/Json/Converters/JsonDateTimeConverter.cs
@@ -27,7 +27,7 @@ namespace Jellyfin.Extensions.Json.Converters
             }
             else
             {
-                writer.WriteStringValue(value);
+                writer.WriteStringValue(value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffZ", CultureInfo.InvariantCulture));
             }
         }
     }


### PR DESCRIPTION
Fixes #16309

## Summary
When a DateTime value has non-zero milliseconds, `JsonDateTimeConverter` used `writer.WriteStringValue(value)` which delegates to the default `ToString()` that respects the current OS culture and calendar. On Windows systems with Persian (Solar Hijri) calendar enabled, this produced dates like "13/04/2580 (554 years old)" instead of the correct Gregorian "25 January 1959 (66 years old)".

Now both code paths use explicit ISO 8601 formatting with `CultureInfo.InvariantCulture`, ensuring consistent Gregorian dates regardless of OS regional settings.

## Changes
- `JsonDateTimeConverter.cs`: Use explicit format string with InvariantCulture for all DateTime serialization

## Test plan
- Set Windows regional format to Persian (Iran) with Solar Hijri calendar
- Start Jellyfin server and navigate to a Person page
- Verify birth dates are shown correctly in Gregorian calendar