### PR TITLE
Skip mp4toannexb bitstream filters for fMP4 HLS segments during stream copy

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1837,13 +1837,26 @@ public class DynamicHlsController : BaseJellyfinApiController
         // See if we can save come cpu cycles by avoiding encoding.
         if (EncodingHelper.IsCopyCodec(codec))
         {
-            // If h264_mp4toannexb is ever added, do not use it for live tv.
             if (state.VideoStream is not null && !string.Equals(state.VideoStream.NalLengthSize, "0", StringComparison.OrdinalIgnoreCase))
             {
-                string bitStreamArgs = _encodingHelper.GetBitStreamArgs(state, MediaStreamType.Video);
-                if (!string.IsNullOrEmpty(bitStreamArgs))
+                if (string.Equals(segmentContainer, "ts", StringComparison.OrdinalIgnoreCase))
                 {
-                    args += " " + bitStreamArgs;
+                    // TS segments require Annex B NAL format; apply format conversion and optional metadata removal.
+                    string bitStreamArgs = _encodingHelper.GetBitStreamArgs(state, MediaStreamType.Video);
+                    if (!string.IsNullOrEmpty(bitStreamArgs))
+                    {
+                        args += " " + bitStreamArgs;
+                    }
+                }
+                else
+                {
+                    // fMP4 segments use MP4 NAL format natively, no format conversion needed.
+                    // Still apply metadata removal if the client cannot handle DoVi or HDR10+.
+                    string metadataRemovalArgs = _encodingHelper.GetDynamicHdrMetadataRemovalBitStreamArgs(state);
+                    if (!string.IsNullOrEmpty(metadataRemovalArgs))
+                    {
+                        args += " " + metadataRemovalArgs;
+                    }
                 }
             }
 

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1515,6 +1515,48 @@ namespace MediaBrowser.Controller.MediaEncoding
             return null;
         }
 
+        public string GetDynamicHdrMetadataRemovalBitStreamArgs(EncodingJobInfo state)
+        {
+            if (state?.VideoStream is null)
+            {
+                return null;
+            }
+
+            var stream = state.VideoStream;
+
+            if (IsH265(stream))
+            {
+                switch (ShouldRemoveDynamicHdrMetadata(state))
+                {
+                    case DynamicHdrMetadataRemovalPlan.RemoveDovi:
+                        return _mediaEncoder.SupportsBitStreamFilterWithOption(BitStreamFilterOptionType.HevcMetadataRemoveDovi)
+                            ? "-bsf:v hevc_metadata=remove_dovi=1"
+                            : "-bsf:v dovi_rpu=strip=1";
+                    case DynamicHdrMetadataRemovalPlan.RemoveHdr10Plus:
+                        return "-bsf:v hevc_metadata=remove_hdr10plus=1";
+                    default:
+                        return null;
+                }
+            }
+
+            if (IsAv1(stream))
+            {
+                switch (ShouldRemoveDynamicHdrMetadata(state))
+                {
+                    case DynamicHdrMetadataRemovalPlan.RemoveDovi:
+                        return _mediaEncoder.SupportsBitStreamFilterWithOption(BitStreamFilterOptionType.Av1MetadataRemoveDovi)
+                            ? "-bsf:v av1_metadata=remove_dovi=1"
+                            : "-bsf:v dovi_rpu=strip=1";
+                    case DynamicHdrMetadataRemovalPlan.RemoveHdr10Plus:
+                        return "-bsf:v av1_metadata=remove_hdr10plus=1";
+                    default:
+                        return null;
+                }
+            }
+
+            return null;
+        }
+
         public string GetAudioBitStreamArguments(EncodingJobInfo state, string segmentContainer, string mediaSourceContainer)
         {
             var bitStreamArgs = string.Empty;


### PR DESCRIPTION
## Summary

`DynamicHlsController.GetVideoArguments` applies `mp4toannexb` bitstream filters (`hevc_mp4toannexb` for HEVC, `h264_mp4toannexb` for H.264) unconditionally when copy-streaming to HLS, without checking the segment container type. For HEVC this converts HVCC extradata to Annex B format, which the fMP4 muxer must then reconstruct back into an hvcC box for the init segment. The round-trip corrupts the codec configuration and breaks Dolby Vision signaling (the dvvC box depends on a correct hvcC), causing playback failures on devices receiving fMP4 HLS segments. The same unnecessary conversion applies to H.264 with AVCC-to-Annex B, though without the DoVi breakage.

TS segments genuinely need Annex B conversion — the TS muxer requires start-code-delimited NALs. fMP4 segments use the same MP4 NAL format as the source, so the conversion is both unnecessary and harmful.

`EncodingHelper` already guards this correctly for progressive streams (`OutputContainer == "ts"` at line 7549), but `DynamicHlsController` was missing the equivalent check despite having `segmentContainer` available as a parameter.

### References

- **FFmpeg `hevc_mp4toannexb` docs** — ["Converts an HEVC/H.265 bitstream from length-prefixed mode to start code prefixed mode, as required by some streaming formats like MPEG-2 transport stream."](https://ffmpeg.org/ffmpeg-bitstream-filters.html#hevc_005fmp4toannexb) — explicitly scoped to TS, not MP4/fMP4.
- **ISO 14496-12 (ISOBMFF)** — fMP4 stores NAL units in length-prefixed format with codec configuration in `hvcC` box, same as MKV's `HEVCDecoderConfigurationRecord`. No Annex B conversion involved.
- **ISO 14496-15 §8.3.2** — Defines `hvcC` (HEVC Configuration Box) using `HEVCDecoderConfigurationRecord` with `lengthSizeMinusOne` for NAL unit length fields. This is the format both MKV and fMP4 use natively.
- **MPEG-2 TS (ISO 13818-1)** — Transport stream PES packets carry HEVC in Annex B format (start code `0x00000001` delimited NALs with in-band parameter sets), which is why `hevc_mp4toannexb` exists.
- **Dolby Vision ISOBMFF spec** — The `dvvC`/`dvwC` configuration boxes are stored alongside `hvcC` in the sample entry. When `hevc_mp4toannexb` strips the HVCC extradata to Annex B, the fMP4 muxer reconstructs `hvcC` from in-band parameter sets but cannot reconstruct the `dvvC` box, losing DoVi signaling.
- **EncodingHelper.cs line 7549** — Jellyfin's own progressive stream path already applies the same TS-only guard: `string.Equals(state.OutputContainer, "ts", ...)`. The HLS path was inconsistent.

## Changes

- **`DynamicHlsController.cs`**: Add `segmentContainer` check around the BSF block:
  - TS: unchanged — full BSF chain (`h264_mp4toannexb`/`hevc_mp4toannexb` format conversion + optional metadata removal)
  - fMP4: skip all `mp4toannexb` format conversion, apply only metadata removal when the client cannot handle DoVi or HDR10+

- **`EncodingHelper.cs`**: Add `GetDynamicHdrMetadataRemovalBitStreamArgs` — returns only the metadata removal BSF arguments without the `hevc_mp4toannexb` prefix. The CBS-based filters (`hevc_metadata`, `dovi_rpu`) can parse MP4-format packets directly via HVCC extradata detection and do not depend on `hevc_mp4toannexb` as a prerequisite.

## Impact

| Scenario | TS segments | fMP4 segments |
|----------|-------------|---------------|
| HEVC copy, no metadata removal needed | `hevc_mp4toannexb` | No BSFs (passthrough) |
| HEVC copy, client needs DoVi stripped | `hevc_mp4toannexb,hevc_metadata=remove_dovi=1` | `hevc_metadata=remove_dovi=1` |
| HEVC copy, client needs HDR10+ stripped | `hevc_mp4toannexb,hevc_metadata=remove_hdr10plus=1` | `hevc_metadata=remove_hdr10plus=1` |
| AV1 copy, no metadata removal needed | No BSFs | No BSFs |
| AV1 copy, client needs DoVi stripped | `av1_metadata=remove_dovi=1` | `av1_metadata=remove_dovi=1` |
| AV1 copy, client needs HDR10+ stripped | `av1_metadata=remove_hdr10plus=1` | `av1_metadata=remove_hdr10plus=1` |
| H264 copy | `h264_mp4toannexb` | No BSFs (passthrough) |
| Any codec, NalLengthSize == 0 (Annex B source) | No BSFs (block skipped) | No BSFs (block skipped) |
| Transcode (any codec) | No change — BSF block not entered | No change — BSF block not entered |

## Test plan

- [ ] Play DoVi P5 MKV via fMP4 HLS (copy codec) — verify no `hevc_mp4toannexb` in FFmpeg command, dvvC box intact in init segment
- [ ] Play DoVi P8 MKV via fMP4 HLS (copy codec) — same verification
- [ ] Play HEVC MKV via TS HLS (copy codec) — verify `hevc_mp4toannexb` still present
- [ ] Play HEVC content where DoVi must be stripped (client lacks support) via fMP4 — verify standalone `hevc_metadata=remove_dovi=1` without `hevc_mp4toannexb` prefix
- [ ] Play H264 content via TS HLS — verify `h264_mp4toannexb` still applied

Relates to #16092
Relates to #16179
