### PR TITLE
feat: cross-library series joining

### DIFF
--- a/Emby.Server.Implementations/Library/SearchEngine.cs
+++ b/Emby.Server.Implementations/Library/SearchEngine.cs
@@ -9,6 +9,7 @@ using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Search;
@@ -167,7 +168,8 @@ namespace Emby.Server.Implementations.Library
                         ItemFields.AirTime,
                         ItemFields.DateCreated,
                         ItemFields.ChannelInfo,
-                        ItemFields.ParentId
+                        ItemFields.ParentId,
+                        ItemFields.ProviderIds
                     }
                 }
             };
@@ -191,10 +193,36 @@ namespace Emby.Server.Implementations.Library
                 mediaItems = _libraryManager.GetItemList(searchQuery);
             }
 
+            // Deduplicate cross-library series/season/episode results
+            mediaItems = mediaItems.DistinctBy(GetSearchDedupKey).ToList();
+
             return mediaItems.Select(i => new SearchHintInfo
             {
                 Item = i
             }).ToList();
+        }
+
+        private string GetSearchDedupKey(BaseItem item)
+        {
+            Series? series = item switch
+            {
+                Series s => s,
+                Season s => s.Series,
+                Episode e => e.Series,
+                _ => null
+            };
+
+            if (series is not null
+                && _libraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging)
+            {
+                var keys = item.GetUserDataKeys();
+                if (keys.Count > 1)
+                {
+                    return keys[0];
+                }
+            }
+
+            return item.PresentationUniqueKey ?? item.Id.ToString("N");
         }
     }
 }

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -11,6 +11,7 @@ using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Dto;
@@ -270,6 +271,12 @@ public class ItemsController : BaseJellyfinApiController
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
 
+        // Ensure ProviderIds are loaded when searching, needed for cross-library series dedup
+        if (!string.IsNullOrWhiteSpace(searchTerm) && !dtoOptions.Fields.Contains(ItemFields.ProviderIds))
+        {
+            dtoOptions.Fields = [.. dtoOptions.Fields, ItemFields.ProviderIds];
+        }
+
         if (includeItemTypes.Length == 1
             && includeItemTypes[0] == BaseItemKind.BoxSet)
         {
@@ -525,6 +532,20 @@ public class ItemsController : BaseJellyfinApiController
         {
             var itemsArray = folder.GetChildren(user, true);
             result = new QueryResult<BaseItem>(itemsArray);
+        }
+
+        // Deduplicate cross-library series/season/episode results when searching
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var originalCount = result.Items.Count;
+            var dedupedItems = result.Items.DistinctBy(GetCrossLibraryDedupKey).ToArray();
+            if (dedupedItems.Length < originalCount)
+            {
+                result = new QueryResult<BaseItem>(
+                    result.StartIndex,
+                    result.TotalRecordCount - (originalCount - dedupedItems.Length),
+                    dedupedItems);
+            }
         }
 
         return new QueryResult<BaseItemDto>(
@@ -1069,4 +1090,27 @@ public class ItemsController : BaseJellyfinApiController
         [FromRoute, Required] Guid itemId,
         [FromBody, Required] UpdateUserItemDataDto userDataDto)
         => UpdateItemUserData(userId, itemId, userDataDto);
+
+    private string GetCrossLibraryDedupKey(BaseItem item)
+    {
+        Series? series = item switch
+        {
+            Series s => s,
+            Season s => s.Series,
+            Episode e => e.Series,
+            _ => null
+        };
+
+        if (series is not null
+            && _libraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging)
+        {
+            var keys = item.GetUserDataKeys();
+            if (keys.Count > 1)
+            {
+                return keys[0];
+            }
+        }
+
+        return item.PresentationUniqueKey ?? item.Id.ToString("N");
+    }
 }

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -184,7 +184,14 @@ namespace MediaBrowser.Controller.Entities.TV
         }
 
         public string FindSeriesPresentationUniqueKey()
-            => Series?.PresentationUniqueKey;
+        {
+            var series = Series;
+            return series is null
+                ? null
+                : LibraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging
+                    ? series.GetCrossLibraryKey()
+                    : series.PresentationUniqueKey;
+        }
 
         public string FindSeasonName()
         {

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -135,7 +135,10 @@ namespace MediaBrowser.Controller.Entities.TV
                 var series = Series;
                 if (series is not null)
                 {
-                    return series.PresentationUniqueKey + "-" + IndexNumber.Value.ToString("000", CultureInfo.InvariantCulture);
+                    var seriesKey = LibraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging
+                        ? series.GetCrossLibraryKey()
+                        : series.PresentationUniqueKey;
+                    return seriesKey + "-" + IndexNumber.Value.ToString("000", CultureInfo.InvariantCulture);
                 }
             }
 
@@ -233,7 +236,11 @@ namespace MediaBrowser.Controller.Entities.TV
         public string FindSeriesPresentationUniqueKey()
         {
             var series = Series;
-            return series is null ? null : series.PresentationUniqueKey;
+            return series is null
+                ? null
+                : LibraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging
+                    ? series.GetCrossLibraryKey()
+                    : series.PresentationUniqueKey;
         }
 
         public string FindSeriesName()

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -113,9 +113,28 @@ namespace MediaBrowser.Controller.Entities.TV
             return key + "-" + string.Join('-', folders);
         }
 
-        private static string GetUniqueSeriesKey(BaseItem series)
+        private static string GetUniqueSeriesKey(BaseItem item)
         {
-            return series.GetPresentationUniqueKey();
+            if (item is Series series)
+            {
+                return LibraryManager.GetLibraryOptions(series).EnableCrossLibrarySeriesMerging
+                    ? series.GetCrossLibraryKey()
+                    : series.GetPresentationUniqueKey();
+            }
+
+            return item.GetPresentationUniqueKey();
+        }
+
+        /// <summary>
+        /// Gets the raw provider-based key for cross-library series matching.
+        /// Returns the first provider ID (e.g. "tvdb-81189") or falls back to PresentationUniqueKey
+        /// if no provider IDs exist.
+        /// </summary>
+        /// <returns>The cross-library matching key.</returns>
+        internal string GetCrossLibraryKey()
+        {
+            var keys = GetUserDataKeys();
+            return keys.Count > 1 ? keys[0] : PresentationUniqueKey;
         }
 
         public override int GetChildCount(User user)
@@ -204,7 +223,14 @@ namespace MediaBrowser.Controller.Entities.TV
 
             SetSeasonQueryOptions(query, user);
 
-            return LibraryManager.GetItemList(query);
+            var items = LibraryManager.GetItemList(query);
+
+            if (LibraryManager.GetLibraryOptions(this).EnableCrossLibrarySeriesMerging)
+            {
+                return items.DistinctBy(i => i.PresentationUniqueKey).ToList();
+            }
+
+            return items;
         }
 
         private void SetSeasonQueryOptions(InternalItemsQuery query, User user)
@@ -258,12 +284,23 @@ namespace MediaBrowser.Controller.Entities.TV
                 }
 
                 query.IsVirtualItem = false;
-                return LibraryManager.GetItemsResult(query);
+                return DedupCrossLibraryResult(LibraryManager.GetItemsResult(query));
             }
 
             SetSeasonQueryOptions(query, user);
 
-            return LibraryManager.GetItemsResult(query);
+            return DedupCrossLibraryResult(LibraryManager.GetItemsResult(query));
+        }
+
+        private QueryResult<BaseItem> DedupCrossLibraryResult(QueryResult<BaseItem> result)
+        {
+            if (!LibraryManager.GetLibraryOptions(this).EnableCrossLibrarySeriesMerging)
+            {
+                return result;
+            }
+
+            var deduped = result.Items.DistinctBy(i => i.PresentationUniqueKey).ToArray();
+            return new QueryResult<BaseItem>(result.StartIndex, deduped.Length, deduped);
         }
 
         public IEnumerable<BaseItem> GetEpisodes(User user, DtoOptions options, bool shouldIncludeMissingEpisodes)
@@ -288,7 +325,13 @@ namespace MediaBrowser.Controller.Entities.TV
 
             var allSeriesEpisodes = allItems.OfType<Episode>().ToList();
 
-            var allEpisodes = allItems.OfType<Season>()
+            var seasons = (IEnumerable<Season>)allItems.OfType<Season>();
+            if (LibraryManager.GetLibraryOptions(this).EnableCrossLibrarySeriesMerging)
+            {
+                seasons = seasons.DistinctBy(s => s.PresentationUniqueKey);
+            }
+
+            var allEpisodes = seasons
                 .SelectMany(i => i.GetEpisodes(this, user, allSeriesEpisodes, options, shouldIncludeMissingEpisodes))
                 .Reverse();
 
@@ -419,6 +462,11 @@ namespace MediaBrowser.Controller.Entities.TV
             }
 
             var episodes = FilterEpisodesBySeason(allSeriesEpisodes, parentSeason, ConfigurationManager.Configuration.DisplaySpecialsWithinSeasons);
+
+            if (LibraryManager.GetLibraryOptions(this).EnableCrossLibrarySeriesMerging)
+            {
+                episodes = episodes.DistinctBy(e => e.IndexNumber);
+            }
 
             var sortBy = (parentSeason.IndexNumber ?? -1) == 0 ? ItemSortBy.SortName : ItemSortBy.AiredEpisodeOrder;
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -65,6 +65,13 @@ namespace MediaBrowser.Model.Configuration
 
         public bool EnableAutomaticSeriesGrouping { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether series with matching provider IDs
+        /// should be merged across different libraries, combining their seasons and episodes
+        /// into a single unified view.
+        /// </summary>
+        public bool EnableCrossLibrarySeriesMerging { get; set; }
+
         public bool EnableEmbeddedTitles { get; set; }
 
         public bool EnableEmbeddedExtrasTitles { get; set; }


### PR DESCRIPTION
like the "join together series in multiple folders" but across libraries instead of folders

Changes

This is a draft to get the basic concept established, and ask for some guidance on exact implementation details.

A setting that allows series to be grouped across libraries, by provider ID. This solves a very annoying issue where an ingestion library would get a new season of a series, and the archived / curated / long term storage library would contain the old seasons, leading to users having a series fragmented across two libraries.

I have this change deployed on my server at the moment, and it works great. There are considerations to make around permissions issues, as well as the granularity of the feature (do all libraries emit series, and the only toggle is on consumption, the other way around, both, globally, per-library, etc).