### PR TITLE
Add playback speed property to session state APIs

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -447,6 +447,7 @@ namespace Emby.Server.Implementations.Session
             session.PlayState.CanSeek = info.CanSeek;
             session.PlayState.IsMuted = info.IsMuted;
             session.PlayState.VolumeLevel = info.VolumeLevel;
+            session.PlayState.Speed = info.Speed;
             session.PlayState.AudioStreamIndex = info.AudioStreamIndex;
             session.PlayState.SubtitleStreamIndex = info.SubtitleStreamIndex;
             session.PlayState.PlayMethod = info.PlayMethod;

--- a/Jellyfin.Api/Controllers/PlaystateController.cs
+++ b/Jellyfin.Api/Controllers/PlaystateController.cs
@@ -347,6 +347,7 @@ public class PlaystateController : BaseJellyfinApiController
     /// <param name="repeatMode">The repeat mode.</param>
     /// <param name="isPaused">Indicates if the player is paused.</param>
     /// <param name="isMuted">Indicates if the player is muted.</param>
+    /// <param name="speed">The playback speed.</param>
     /// <response code="204">Play progress recorded.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("PlayingItems/{itemId}/Progress")]
@@ -364,7 +365,8 @@ public class PlaystateController : BaseJellyfinApiController
         [FromQuery] string? playSessionId,
         [FromQuery] RepeatMode? repeatMode,
         [FromQuery] bool isPaused = false,
-        [FromQuery] bool isMuted = false)
+        [FromQuery] bool isMuted = false,
+        [FromQuery] float? speed = null)
     {
         var playbackProgressInfo = new PlaybackProgressInfo
         {
@@ -376,6 +378,7 @@ public class PlaystateController : BaseJellyfinApiController
             AudioStreamIndex = audioStreamIndex,
             SubtitleStreamIndex = subtitleStreamIndex,
             VolumeLevel = volumeLevel,
+            Speed = speed,
             PlayMethod = playMethod ?? PlayMethod.Transcode,
             PlaySessionId = playSessionId,
             LiveStreamId = liveStreamId,
@@ -404,6 +407,7 @@ public class PlaystateController : BaseJellyfinApiController
     /// <param name="repeatMode">The repeat mode.</param>
     /// <param name="isPaused">Indicates if the player is paused.</param>
     /// <param name="isMuted">Indicates if the player is muted.</param>
+    /// <param name="speed">The playback speed.</param>
     /// <response code="204">Play progress recorded.</response>
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpPost("Users/{userId}/PlayingItems/{itemId}/Progress")]
@@ -424,8 +428,9 @@ public class PlaystateController : BaseJellyfinApiController
         [FromQuery] string? playSessionId,
         [FromQuery] RepeatMode? repeatMode,
         [FromQuery] bool isPaused = false,
-        [FromQuery] bool isMuted = false)
-        => OnPlaybackProgress(itemId, mediaSourceId, positionTicks, audioStreamIndex, subtitleStreamIndex, volumeLevel, playMethod, liveStreamId, playSessionId, repeatMode, isPaused, isMuted);
+        [FromQuery] bool isMuted = false,
+        [FromQuery] float? speed = null)
+        => OnPlaybackProgress(itemId, mediaSourceId, positionTicks, audioStreamIndex, subtitleStreamIndex, volumeLevel, playMethod, liveStreamId, playSessionId, repeatMode, isPaused, isMuted, speed);
 
     /// <summary>
     /// Reports that a session has stopped playing an item.

--- a/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
+++ b/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
@@ -81,6 +81,12 @@ namespace MediaBrowser.Model.Session
 
         public int? Brightness { get; set; }
 
+        /// <summary>
+        /// Gets or sets the playback speed.
+        /// </summary>
+        /// <value>The playback speed. 1.0 is normal speed.</value>
+        public float? Speed { get; set; }
+
         public string AspectRatio { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Session/PlayerStateInfo.cs
+++ b/MediaBrowser.Model/Session/PlayerStateInfo.cs
@@ -54,6 +54,12 @@ namespace MediaBrowser.Model.Session
         public string MediaSourceId { get; set; }
 
         /// <summary>
+        /// Gets or sets the playback speed.
+        /// </summary>
+        /// <value>The playback speed. 1.0 is normal speed.</value>
+        public float? Speed { get; set; }
+
+        /// <summary>
         /// Gets or sets the play method.
         /// </summary>
         /// <value>The play method.</value>


### PR DESCRIPTION
Adds a nullable `Speed` float property to `PlaybackProgressInfo`, `PlayerStateInfo`, and the legacy query-parameter progress endpoints so clients can report and query the current playback rate.

The value flows through `SessionManager.UpdateNowPlayingItem` into the session play state and is automatically included in `SessionInfoDto` responses and WebSocket broadcasts.

`PlaybackStartInfo` inherits `PlaybackProgressInfo` so it picks up the property without changes. The JSON-body endpoints (`ReportPlaybackStart`, `ReportPlaybackProgress`) accept it automatically; the legacy query-parameter endpoints get an explicit `speed` parameter.

Closes #8971