### PR TITLE
Fix trickplay timestamps for interlaced video

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -888,6 +888,21 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
+            // For interlaced content, the reported frame rate may be the field rate (e.g. 50 for 25fps interlaced).
+            // Discounting the field rate avoids producing trickplay images with incorrect timestamps.
+            if (imageStream.IsInterlaced)
+            {
+                if (imageStream.AverageFrameRate.HasValue)
+                {
+                    imageStream.AverageFrameRate /= 2;
+                }
+
+                if (imageStream.RealFrameRate.HasValue)
+                {
+                    imageStream.RealFrameRate /= 2;
+                }
+            }
+
             var baseRequest = new BaseEncodingJobOptions { MaxWidth = maxWidth, MaxFramerate = (float)(1.0 / interval.TotalSeconds) };
             var jobState = new EncodingJobInfo(TranscodingJobType.Progressive)
             {


### PR DESCRIPTION
Fixes #16302

For interlaced content, ffprobe reports the field rate rather than the frame rate (e.g. 50 instead of 25 for PAL interlaced). This causes trickplay image timestamps to be off by 50%.

This halves the reported frame rate for interlaced streams before passing it into the trickplay encoding pipeline, so timestamps are calculated using the actual frame rate.