### PR TITLE
Fix filter detection in FFmpeg 8.1

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -693,7 +693,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         [GeneratedRegex("^\\s\\S{6}\\s(?<codec>[\\w|-]+)\\s+.+$", RegexOptions.Multiline)]
         private static partial Regex CodecRegex();
 
-        [GeneratedRegex("^\\s\\S{3}\\s(?<filter>[\\w|-]+)\\s+.+$", RegexOptions.Multiline)]
+        [GeneratedRegex("^\\s\\S{2,3}\\s(?<filter>[\\w|-]+)\\s+.+$", RegexOptions.Multiline)]
         private static partial Regex FilterRegex();
     }
 }


### PR DESCRIPTION
**Changes**
- Fix filter detection in FFmpeg 8.1

**Issues**
- Fix compatibility issue for a seamless upgrade to jellyfin-ffmpeg8 in the future

```
// ff >= 8
 .. scale             V->V       Scale the input video size and/or convert the image format.
```
```
// ff <= 7.1
 ..C scale             V->V       Scale the input video size and/or convert the image format.
```
