### PR TITLE
Use generic Enum overloads to resolve CA2263 warnings

### DIFF
--- a/MediaBrowser.Model/Dlna/ConditionProcessor.cs
+++ b/MediaBrowser.Model/Dlna/ConditionProcessor.cs
@@ -324,7 +324,7 @@ namespace MediaBrowser.Model.Dlna
                 return !condition.IsRequired;
             }
 
-            var expected = (TransportStreamTimestamp)Enum.Parse(typeof(TransportStreamTimestamp), condition.Value, true);
+            var expected = Enum.Parse<TransportStreamTimestamp>(condition.Value, true);
 
             switch (condition.Condition)
             {

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -2009,7 +2009,7 @@ namespace MediaBrowser.Model.Dlna
                             }
                             else if (condition.Condition == ProfileConditionType.NotEquals)
                             {
-                                item.SetOption(qualifier, "rangetype", string.Join(',', Enum.GetNames(typeof(VideoRangeType)).Except(values)));
+                                item.SetOption(qualifier, "rangetype", string.Join(',', Enum.GetNames<VideoRangeType>().Except(values)));
                             }
                             else if (condition.Condition == ProfileConditionType.EqualsAny)
                             {


### PR DESCRIPTION
**Changes**
Replace non-generic `Enum.Parse(typeof(T), ...)` and `Enum.GetNames(typeof(T))` with their generic counterparts `Enum.Parse<T>()` and `Enum.GetNames<T>()` in `MediaBrowser.Model/Dlna`, resolving all CA2263 analyzer warnings.

**Issues**
Contributes to #2149