### PR TITLE
add StartIndex and ParentId to person search

### DIFF
--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -47,6 +47,7 @@ public class PersonsController : BaseJellyfinApiController
     /// <summary>
     /// Gets all persons.
     /// </summary>
+    /// <param name="startIndex">Optional. All items with a lower index will be dropped from the response.</param>
     /// <param name="limit">Optional. The maximum number of records to return.</param>
     /// <param name="searchTerm">The search term.</param>
     /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
@@ -57,6 +58,7 @@ public class PersonsController : BaseJellyfinApiController
     /// <param name="enableImageTypes">Optional. The image types to include in the output.</param>
     /// <param name="excludePersonTypes">Optional. If specified results will be filtered to exclude those containing the specified PersonType. Allows multiple, comma-delimited.</param>
     /// <param name="personTypes">Optional. If specified results will be filtered to include only those containing the specified PersonType. Allows multiple, comma-delimited.</param>
+    /// <param name="parentId">Optional. Specify this to localize the search to a specific library. Omit to use the root.</param>
     /// <param name="appearsInItemId">Optional. If specified, person results will be filtered on items related to said persons.</param>
     /// <param name="userId">User id.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
@@ -65,6 +67,7 @@ public class PersonsController : BaseJellyfinApiController
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<QueryResult<BaseItemDto>> GetPersons(
+        [FromQuery] int? startIndex,
         [FromQuery] int? limit,
         [FromQuery] string? searchTerm,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
@@ -75,6 +78,7 @@ public class PersonsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] enableImageTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] excludePersonTypes,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] personTypes,
+        [FromQuery] Guid? parentId,
         [FromQuery] Guid? appearsInItemId,
         [FromQuery] Guid? userId,
         [FromQuery] bool? enableImages = true)
@@ -96,6 +100,8 @@ public class PersonsController : BaseJellyfinApiController
             User = user,
             IsFavorite = !isFavorite.HasValue && isFavoriteInFilters ? true : isFavorite,
             AppearsInItemId = appearsInItemId ?? Guid.Empty,
+            ParentId = parentId,
+            StartIndex = startIndex,
             Limit = limit ?? 0
         });
 

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -62,7 +62,11 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         using var context = _dbProvider.CreateDbContext();
         var dbQuery = TranslateQuery(context.Peoples.AsNoTracking(), context, filter).Select(e => e.Name).Distinct();
 
-        // dbQuery = dbQuery.OrderBy(e => e.ListOrder);
+        if (filter.StartIndex.HasValue && filter.StartIndex > 0)
+        {
+            dbQuery = dbQuery.Skip(filter.StartIndex.Value);
+        }
+
         if (filter.Limit > 0)
         {
             dbQuery = dbQuery.Take(filter.Limit);
@@ -195,6 +199,11 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         if (!filter.ItemId.IsEmpty())
         {
             query = query.Where(e => e.BaseItems!.Any(w => w.ItemId.Equals(filter.ItemId)));
+        }
+
+        if (filter.ParentId != null)
+        {
+            query = query.Where(e => e.BaseItems!.Any(w => context.AncestorIds.Any(i => i.ParentItemId == filter.ParentId && i.ItemId == w.ItemId)));
         }
 
         if (!filter.AppearsInItemId.IsEmpty())

--- a/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
@@ -21,12 +21,16 @@ namespace MediaBrowser.Controller.Entities
             ExcludePersonTypes = excludePersonTypes;
         }
 
+        public int? StartIndex { get; set; }
+
         /// <summary>
         /// Gets or sets the maximum number of items the query should return.
         /// </summary>
         public int Limit { get; set; }
 
         public Guid ItemId { get; set; }
+
+        public Guid? ParentId { get; set; }
 
         public IReadOnlyList<string> PersonTypes { get; }
 


### PR DESCRIPTION
**Changes**

StartIndex is required for pagination and ParentId is required for library filtering - both are essential to include an Author tab in book libraries. It will also enable us to deprecate the Artist endpoints in the future. I know the nested Any isn't super performant but I wanted to propose a simple solution first.

**Issues**

None