### PR TITLE
Fix orphan paths remaining  in collection.xml after library removal.

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTask.cs
@@ -27,6 +27,8 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
     private readonly IPlaylistManager _playlistManager;
     private readonly ILogger<CleanupCollectionAndPlaylistPathsTask> _logger;
     private readonly IProviderManager _providerManager;
+    private readonly ILibraryManager _libraryManager;
+    private readonly IFileSystem _fileSystem;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CleanupCollectionAndPlaylistPathsTask"/> class.
@@ -36,18 +38,24 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
     /// <param name="playlistManager">Instance of the <see cref="IPlaylistManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     public CleanupCollectionAndPlaylistPathsTask(
         ILocalizationManager localization,
         ICollectionManager collectionManager,
         IPlaylistManager playlistManager,
         ILogger<CleanupCollectionAndPlaylistPathsTask> logger,
-        IProviderManager providerManager)
+        IProviderManager providerManager,
+        ILibraryManager libraryManager,
+        IFileSystem fileSystem)
     {
         _localization = localization;
         _collectionManager = collectionManager;
         _playlistManager = playlistManager;
         _logger = logger;
         _providerManager = providerManager;
+        _libraryManager = libraryManager;
+        _fileSystem = fileSystem;
     }
 
     /// <inheritdoc />
@@ -66,6 +74,7 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var collectionsFolder = await _collectionManager.GetCollectionsFolder(false).ConfigureAwait(false);
+        var userRootFolders = _libraryManager.GetUserRootFolder().Children.OfType<Folder>().ToList();
         if (collectionsFolder is null)
         {
             _logger.LogDebug("There is no collections folder to be found");
@@ -80,7 +89,7 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
                 var collection = collections[index];
                 _logger.LogDebug("Checking boxset {CollectionName}", collection.Name);
 
-                await CleanupLinkedChildrenAsync(collection, cancellationToken).ConfigureAwait(false);
+                await CleanupLinkedChildrenAsync(collection, userRootFolders, cancellationToken).ConfigureAwait(false);
                 progress.Report(50D / collections.Length * (index + 1));
             }
         }
@@ -100,19 +109,19 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
             var playlist = playlists[index];
             _logger.LogDebug("Checking playlist {PlaylistName}", playlist.Name);
 
-            await CleanupLinkedChildrenAsync(playlist, cancellationToken).ConfigureAwait(false);
+            await CleanupLinkedChildrenAsync(playlist, userRootFolders, cancellationToken).ConfigureAwait(false);
             progress.Report(50D / playlists.Length * (index + 1));
         }
     }
 
-    private async Task CleanupLinkedChildrenAsync<T>(T folder, CancellationToken cancellationToken)
+    private async Task CleanupLinkedChildrenAsync<T>(T folder, IReadOnlyCollection<Folder> userRootFolders, CancellationToken cancellationToken)
         where T : Folder
     {
         List<LinkedChild>? itemsToRemove = null;
         foreach (var linkedChild in folder.LinkedChildren)
         {
             var path = linkedChild.Path;
-            if (!File.Exists(path) && !Directory.Exists(path))
+            if (IsItemInCollectionNotValid(linkedChild, userRootFolders))
             {
                 _logger.LogInformation("Item in {FolderName} cannot be found at {ItemPath}", folder.Name, path);
                 (itemsToRemove ??= new List<LinkedChild>()).Add(linkedChild);
@@ -126,6 +135,67 @@ public class CleanupCollectionAndPlaylistPathsTask : IScheduledTask
             await _providerManager.SaveMetadataAsync(folder, ItemUpdateType.MetadataEdit).ConfigureAwait(false);
             await folder.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private bool IsItemInCollectionNotValid(LinkedChild linkedChild, IReadOnlyCollection<Folder> userRootFolders)
+    {
+        var path = linkedChild.Path;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            var isDir = Directory.Exists(path);
+            if (!isDir && !File.Exists(path))
+            {
+                return true;
+            }
+
+            var linkedItem = _libraryManager.FindByPath(path, isDir);
+            if (linkedItem is not null)
+            {
+                return _libraryManager.GetCollectionFolders(linkedItem, userRootFolders).Count == 0;
+            }
+
+            return !IsPathInActiveLibrary(path, userRootFolders);
+        }
+
+        var linkedItemById = GetLinkedChildById(linkedChild);
+        return linkedItemById is null || _libraryManager.GetCollectionFolders(linkedItemById, userRootFolders).Count == 0;
+    }
+
+    private BaseItem? GetLinkedChildById(LinkedChild linkedChild)
+    {
+        if (linkedChild.ItemId.HasValue)
+        {
+            return _libraryManager.GetItemById(linkedChild.ItemId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(linkedChild.LibraryItemId)
+            && Guid.TryParse(linkedChild.LibraryItemId, out var libraryItemId))
+        {
+            return _libraryManager.GetItemById(libraryItemId);
+        }
+
+        return null;
+    }
+
+    private bool IsPathInActiveLibrary(string path, IReadOnlyCollection<Folder> userRootFolders)
+    {
+        foreach (var rootFolder in userRootFolders)
+        {
+            if (_fileSystem.AreEqual(rootFolder.Path, path) || _fileSystem.ContainsSubPath(rootFolder.Path, path))
+            {
+                return true;
+            }
+
+            foreach (var location in rootFolder.PhysicalLocations)
+            {
+                if (_fileSystem.AreEqual(location, path) || _fileSystem.ContainsSubPath(location, path))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <inheritdoc />

--- a/tests/Jellyfin.Server.Implementations.Tests/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTaskTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/ScheduledTasks/Tasks/CleanupCollectionAndPlaylistPathsTaskTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.ScheduledTasks.Tasks;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Collections;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.LocalMetadata.Savers;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.ScheduledTasks.Tasks;
+
+public class CleanupCollectionAndPlaylistPathsTaskTests
+{
+    [Fact]
+    public async Task ExecuteAsync_RemovesStaleLinkedChild_FromCollectionXml()
+    {
+        // Asserting Test
+        var collectionDir = Directory.CreateTempSubdirectory();
+        var mediaDir = Directory.CreateTempSubdirectory();
+        var staleMediaPath = Path.Combine(mediaDir.FullName, "movie.mkv");
+        await File.WriteAllTextAsync(staleMediaPath, "test").ConfigureAwait(true);
+
+        var collection = new Mock<BoxSet> { CallBase = true };
+        collection.Object.Name = "Collection Test";
+        collection.Object.Path = collectionDir.FullName;
+        collection.Object.LinkedChildren = [
+            new LinkedChild
+            {
+                Path = staleMediaPath,
+                Type = LinkedChildType.Manual
+            }
+        ];
+
+        collection
+            .Setup(x => x.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var collectionsFolder = new Folder
+        {
+            Children = [collection.Object]
+        };
+
+        var userRootFolder = new Folder
+        {
+            Children = Array.Empty<BaseItem>()
+        };
+
+        var localizationMock = new Mock<ILocalizationManager>();
+        var collectionManagerMock = new Mock<ICollectionManager>();
+        var playlistManagerMock = new Mock<IPlaylistManager>();
+        var loggerMock = new Mock<ILogger<CleanupCollectionAndPlaylistPathsTask>>();
+        var providerManagerMock = new Mock<IProviderManager>();
+        var libraryManagerMock = new Mock<ILibraryManager>();
+        var fileSystemMock = new Mock<IFileSystem>();
+        var configManagerMock = new Mock<IServerConfigurationManager>();
+
+        configManagerMock.SetupGet(x => x.Configuration).Returns(new ServerConfiguration());
+
+        playlistManagerMock
+            .Setup(x => x.GetPlaylistsFolder())
+            .Returns(new Folder { Children = Array.Empty<BaseItem>() });
+
+        libraryManagerMock
+            .Setup(x => x.GetUserRootFolder())
+            .Returns(userRootFolder);
+
+        libraryManagerMock
+            .Setup(x => x.FindByPath(staleMediaPath, false))
+            .Returns(new Movie { Path = staleMediaPath });
+
+        libraryManagerMock
+            .Setup(x => x.GetCollectionFolders(It.IsAny<BaseItem>(), It.IsAny<IEnumerable<Folder>>()))
+            .Returns(new List<Folder>());
+
+        libraryManagerMock
+            .Setup(x => x.GetPeople(It.IsAny<BaseItem>()))
+            .Returns(Array.Empty<PersonInfo>());
+
+        collectionManagerMock
+            .Setup(x => x.GetCollectionsFolder(false))
+            .ReturnsAsync(collectionsFolder);
+
+        var xmlSaver = new BoxSetXmlSaver(
+            fileSystemMock.Object,
+            configManagerMock.Object,
+            libraryManagerMock.Object,
+            NullLogger<BoxSetXmlSaver>.Instance);
+
+        providerManagerMock
+            .Setup(x => x.SaveMetadataAsync(It.IsAny<BaseItem>(), ItemUpdateType.MetadataEdit))
+            .Returns<BaseItem, ItemUpdateType>((item, _) => xmlSaver.SaveAsync(item, CancellationToken.None));
+
+        var task = new CleanupCollectionAndPlaylistPathsTask(
+            localizationMock.Object,
+            collectionManagerMock.Object,
+            playlistManagerMock.Object,
+            loggerMock.Object,
+            providerManagerMock.Object,
+            libraryManagerMock.Object,
+            fileSystemMock.Object);
+
+        // Execute
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None).ConfigureAwait(true);
+
+        // Verify Results
+        var collectionXmlPath = Path.Combine(collectionDir.FullName, "collection.xml");
+
+        Assert.True(File.Exists(collectionXmlPath));
+
+        var xml = await File.ReadAllTextAsync(collectionXmlPath).ConfigureAwait(true);
+        Assert.DoesNotContain(staleMediaPath, xml, StringComparison.Ordinal);
+        Assert.DoesNotContain("<CollectionItem>", xml, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(collection.Object.LinkedChildren);
+
+        providerManagerMock.Verify(x => x.SaveMetadataAsync(collection.Object, ItemUpdateType.MetadataEdit), Times.Once);
+        collection.Verify(x => x.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
**Problem**
When a Library with movies is removed, if an arbitrary number of movies belonged to a collection, the collection.xml structure would keep the Paths of those movies without being valid. 

**Changes**
Fixed `CleanupCollectionAndPlaylistPathsTask` so Paths that do not belong to a valid Library, do not stay  in the `collection.xml`.
The verification for a valid Path in the `collection.xml` is now done by using the `IFileSystem` and `ILibraryManager` as helper classes, and new functions `GetLinkedChildById` and `IsPathInActiveLibrary`, to better define which Items should be valid for the collection or not. 
The CleanupCollectionsAndPlaylistTask will now remove Orphan Entries, such as: `<Path>/Invalid/path/to/movie<Path>`, where the item does not belong to any Library, even if the file still exists on disk. 
Created a respective unit test to better verify the expected behavior.

**Issues**
Fixes #15497 