### PR TITLE
Add callback for segment data pruning to IMediaSegmentProvider

### DIFF
--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -182,12 +182,6 @@ public class MediaSegmentManager : IMediaSegmentManager
     /// <inheritdoc />
     public async Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken)
     {
-        var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await using (db.ConfigureAwait(false))
-        {
-            await db.MediaSegments.Where(e => e.ItemId.Equals(itemId)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
-        }
-
         foreach (var provider in _segmentProviders)
         {
             try
@@ -198,6 +192,12 @@ public class MediaSegmentManager : IMediaSegmentManager
             {
                 _logger.LogError(ex, "Provider {ProviderName} failed to clean up extracted data for item {ItemId}", provider.Name, itemId);
             }
+        }
+
+        var db = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            await db.MediaSegments.Where(e => e.ItemId.Equals(itemId)).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/MediaBrowser.Controller/MediaSegments/IMediaSegmentProvider.cs
+++ b/MediaBrowser.Controller/MediaSegments/IMediaSegmentProvider.cs
@@ -40,8 +40,5 @@ public interface IMediaSegmentProvider
     /// <param name="itemId">The item whose data is being pruned.</param>
     /// <param name="cancellationToken">Abort token.</param>
     /// <returns>A task representing the asynchronous cleanup operation.</returns>
-    Task CleanupExtractedData(Guid itemId, CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
+    Task CleanupExtractedData(Guid itemId, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
When we remove item data, we should also call the segment providers so they can prune their cached data. This might be necessary if they use related-analysis e.g. when using Chromaprint comparison.