### PR TITLE
Fix restore backup metadata location

### DIFF
--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -118,14 +118,20 @@ public class BackupService : IBackupService
                 throw new NotSupportedException($"The loaded archive '{archivePath}' is made for a newer version of Jellyfin ({manifest.ServerVersion}) and cannot be loaded in this version.");
             }
 
-            void CopyDirectory(string source, string target)
+            void CopyDirectory(string source, string target, string? exclude = null)
             {
                 var fullSourcePath = NormalizePathSeparator(Path.GetFullPath(source) + Path.DirectorySeparatorChar);
                 var fullTargetRoot = Path.GetFullPath(target) + Path.DirectorySeparatorChar;
+                var excludePath = exclude is null ? null : $"{source}/{exclude}/";
                 foreach (var item in zipArchive.Entries)
                 {
                     var sourcePath = NormalizePathSeparator(Path.GetFullPath(item.FullName));
                     var targetPath = Path.GetFullPath(Path.Combine(target, Path.GetRelativePath(source, item.FullName)));
+
+                    if (excludePath is not null && item.FullName.StartsWith(excludePath, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
 
                     if (!sourcePath.StartsWith(fullSourcePath, StringComparison.Ordinal)
                         || !targetPath.StartsWith(fullTargetRoot, StringComparison.Ordinal)
@@ -142,8 +148,9 @@ public class BackupService : IBackupService
             }
 
             CopyDirectory("Config", _applicationPaths.ConfigurationDirectoryPath);
-            CopyDirectory("Data", _applicationPaths.DataPath);
+            CopyDirectory("Data", _applicationPaths.DataPath, exclude: "metadata");
             CopyDirectory("Root", _applicationPaths.RootFolderPath);
+            CopyDirectory("Data/metadata", _applicationPaths.InternalMetadataPath);
 
             if (manifest.Options.Database)
             {

--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -118,17 +118,17 @@ public class BackupService : IBackupService
                 throw new NotSupportedException($"The loaded archive '{archivePath}' is made for a newer version of Jellyfin ({manifest.ServerVersion}) and cannot be loaded in this version.");
             }
 
-            void CopyDirectory(string source, string target, string? exclude = null)
+            void CopyDirectory(string source, string target, string[]? exclude = null)
             {
                 var fullSourcePath = NormalizePathSeparator(Path.GetFullPath(source) + Path.DirectorySeparatorChar);
                 var fullTargetRoot = Path.GetFullPath(target) + Path.DirectorySeparatorChar;
-                var excludePath = exclude is null ? null : $"{source}/{exclude}/";
+                var excludePaths = exclude?.Select(e => $"{source}/{e}/").ToArray();
                 foreach (var item in zipArchive.Entries)
                 {
                     var sourcePath = NormalizePathSeparator(Path.GetFullPath(item.FullName));
                     var targetPath = Path.GetFullPath(Path.Combine(target, Path.GetRelativePath(source, item.FullName)));
 
-                    if (excludePath is not null && item.FullName.StartsWith(excludePath, StringComparison.Ordinal))
+                    if (excludePaths is not null && excludePaths.Any(e => item.FullName.StartsWith(e, StringComparison.Ordinal)))
                     {
                         continue;
                     }
@@ -148,9 +148,10 @@ public class BackupService : IBackupService
             }
 
             CopyDirectory("Config", _applicationPaths.ConfigurationDirectoryPath);
-            CopyDirectory("Data", _applicationPaths.DataPath, exclude: "metadata");
+            CopyDirectory("Data", _applicationPaths.DataPath, exclude: ["metadata", "metadata-default"]);
             CopyDirectory("Root", _applicationPaths.RootFolderPath);
             CopyDirectory("Data/metadata", _applicationPaths.InternalMetadataPath);
+            CopyDirectory("Data/metadata-default", _applicationPaths.DefaultInternalMetadataPath);
 
             if (manifest.Options.Database)
             {
@@ -410,6 +411,15 @@ public class BackupService : IBackupService
                 if (backupOptions.Metadata)
                 {
                     CopyDirectory(Path.Combine(_applicationPaths.InternalMetadataPath), Path.Combine("Data", "metadata"));
+
+                    // If a custom metadata path is configured, the default location may still contain data.
+                    if (!string.Equals(
+                            Path.GetFullPath(_applicationPaths.DefaultInternalMetadataPath),
+                            Path.GetFullPath(_applicationPaths.InternalMetadataPath),
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        CopyDirectory(Path.Combine(_applicationPaths.DefaultInternalMetadataPath), Path.Combine("Data", "metadata-default"));
+                    }
                 }
 
                 var manifestStream = zipArchive.CreateEntry(ManifestEntryName).Open();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

- Restore metadata to `InternalMetadataPath` instead of `Data/metadata/`
- Backup and restore `DefaultInternalMetadataPath` when it differs from `InternalMetadataPath` to preserve metadata written before a custom path was configured

**Issues**
Fixes: #15829
