### PR TITLE
Fix IsFavorite always false in /Artists and /AlbumArtists list endpoints

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -1334,6 +1334,11 @@ public sealed class BaseItemRepository
             .AsSingleQuery()
             .Where(e => masterQuery.Contains(e.Id));
 
+        if (filter.DtoOptions.EnableUserData)
+        {
+            query = query.Include(e => e.UserData);
+        }
+
         query = ApplyOrder(query, filter, context);
 
         var result = new QueryResult<(BaseItemDto, ItemCounts?)>();


### PR DESCRIPTION
**Changes**

The `GetItemValues` method in `BaseItemRepository` (used by `/Artists`, `/AlbumArtists`, `/Studios`, `/Genres`, and `/MusicGenres` list endpoints) was not including `UserData` in its EF Core query. This meant `item.UserData` was always `null` when these items were mapped, so `UserDataManager.GetUserData` fell back to a default `UserItemData()` with `IsFavorite = false`.

Added the same conditional `.Include(e => e.UserData)` check that already exists in the regular `GetItemList`/`GetItems` code path (around line 447-450), so that when `EnableUserData` is true the navigation property is loaded and favorites are reported correctly.

**Issues**

Fixes #16284