### PR TITLE
Return created API key from POST /Auth/Keys endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/ApiKeyController.cs
+++ b/Jellyfin.Api/Controllers/ApiKeyController.cs
@@ -46,16 +46,16 @@ public class ApiKeyController : BaseJellyfinApiController
     /// Create a new api key.
     /// </summary>
     /// <param name="app">Name of the app using the authentication key.</param>
-    /// <response code="204">Api key created.</response>
-    /// <returns>A <see cref="NoContentResult"/>.</returns>
+    /// <response code="200">Api key created.</response>
+    /// <returns>An <see cref="AuthenticationInfo"/> containing the new api key.</returns>
     [HttpPost("Keys")]
     [Authorize(Policy = Policies.RequiresElevation)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> CreateKey([FromQuery, Required] string app)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AuthenticationInfo>> CreateKey([FromQuery, Required] string app)
     {
-        await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
+        var key = await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
 
-        return NoContent();
+        return Ok(key);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
@@ -23,14 +23,25 @@ namespace Jellyfin.Server.Implementations.Security
         }
 
         /// <inheritdoc />
-        public async Task CreateApiKey(string name)
+        public async Task<AuthenticationInfo> CreateApiKey(string name)
         {
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                dbContext.ApiKeys.Add(new ApiKey(name));
+                var newKey = new ApiKey(name);
+                dbContext.ApiKeys.Add(newKey);
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                return new AuthenticationInfo
+                {
+                    AppName = newKey.Name,
+                    AccessToken = newKey.AccessToken,
+                    DateCreated = newKey.DateCreated,
+                    DeviceId = string.Empty,
+                    DeviceName = string.Empty,
+                    AppVersion = string.Empty
+                };
             }
         }
 

--- a/MediaBrowser.Controller/Security/IAuthenticationManager.cs
+++ b/MediaBrowser.Controller/Security/IAuthenticationManager.cs
@@ -12,8 +12,8 @@ namespace MediaBrowser.Controller.Security
         /// Creates an API key.
         /// </summary>
         /// <param name="name">The name of the key.</param>
-        /// <returns>A task representing the creation of the key.</returns>
-        Task CreateApiKey(string name);
+        /// <returns>A task representing the creation of the key, containing the created key info.</returns>
+        Task<AuthenticationInfo> CreateApiKey(string name);
 
         /// <summary>
         /// Gets the API keys.


### PR DESCRIPTION
**Changes**

The `POST /Auth/Keys` endpoint currently returns `204 No Content` after creating an API key, which means callers have no way to get the generated access token back without making a follow-up `GET /Auth/Keys` request and filtering by app name (which isn't guaranteed unique). This changes the endpoint to return `200 OK` with the created `AuthenticationInfo`, matching the shape already used by `GET /Auth/Keys`. The `IAuthenticationManager.CreateApiKey` interface and its implementation are updated to return the new key info.

**Issues**

Fixes #16258