### PR TITLE
Allow tmdb as an alias for tmdbid provider id

### DIFF
--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -70,6 +70,12 @@ namespace Emby.Server.Implementations.Library
                 return match ? imdbId.ToString() : null;
             }
 
+            // Allow tmdb as an alias for tmdbid
+            if (attribute.Equals("tmdbid", StringComparison.OrdinalIgnoreCase))
+            {
+                return str.GetAttributeValue("tmdb");
+            }
+
             return null;
         }
 

--- a/Emby.Server.Implementations/Library/PathExtensions.cs
+++ b/Emby.Server.Implementations/Library/PathExtensions.cs
@@ -73,7 +73,11 @@ namespace Emby.Server.Implementations.Library
             // Allow tmdb as an alias for tmdbid
             if (attribute.Equals("tmdbid", StringComparison.OrdinalIgnoreCase))
             {
-                return str.GetAttributeValue("tmdb");
+                var tmdbValue = str.GetAttributeValue("tmdb");
+                if (tmdbValue is not null)
+                {
+                    return tmdbValue;
+                }
             }
 
             return null;


### PR DESCRIPTION
**Changes**
Allow tmdb as an alias for tmdbid provider id

**Issues**
Combined with https://github.com/jellyfin/jellyfin/pull/14927
Fixes: #14928 , [feature request](https://features.jellyfin.org/posts/3727/support-for-plex-style-of-provider-id-in-names) 