### PR TITLE
build: add Jellyfin.MediaEncoding.Keyframes reference

### DIFF
--- a/Jellyfin.Server/Jellyfin.Server.csproj
+++ b/Jellyfin.Server/Jellyfin.Server.csproj
@@ -64,6 +64,7 @@
     <ProjectReference Include="..\src\Jellyfin.Drawing.Skia\Jellyfin.Drawing.Skia.csproj" />
     <ProjectReference Include="..\src\Jellyfin.LiveTv\Jellyfin.LiveTv.csproj" />
     <ProjectReference Include="..\Jellyfin.Server.Implementations\Jellyfin.Server.Implementations.csproj" />
+    <ProjectReference Include="..\src\Jellyfin.MediaEncoding.Keyframes\Jellyfin.MediaEncoding.Keyframes.csproj" />
     <ProjectReference Include="..\src\Jellyfin.MediaEncoding.Hls\Jellyfin.MediaEncoding.Hls.csproj" />
     <ProjectReference Include="..\src\Jellyfin.Database\Jellyfin.Database.Implementations\Jellyfin.Database.Implementations.csproj" />
   </ItemGroup>


### PR DESCRIPTION
**Changes**
Added a project reference to `Jellyfin.MediaEncoding.Keyframes` in `Jellyfin.Server.csproj` to expose the keyframes assembly to plugins. The assembly is now copied to the server's output directory, allowing plugins like IntroSkipper to load and use `Jellyfin.MediaEncoding.Keyframes.KeyframeData`.

**Issues**
Plugins cannot load `Jellyfin.MediaEncoding.Keyframes` assembly (FileNotFoundException)

> IntroSkipper.ScheduledTasks.DetectSegmentsTask: An unexpected error occurred during analysis.
System.IO.FileNotFoundException: Could not load file or assembly 'Jellyfin.MediaEncoding.Keyframes, Version=10.11.6.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.