### PR TITLE
Remove -copyts and add -flush_packets 1 to subtitle extraction

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -569,7 +569,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var outputPaths = new List<string>();
                 var args = string.Format(
                     CultureInfo.InvariantCulture,
-                    "-i {0} -copyts",
+                    "-i {0}",
                     inputPath);
 
                 foreach (var subtitleStream in subtitleStreams)
@@ -594,7 +594,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     outputPaths.Add(outputPath);
                     args += string.Format(
                         CultureInfo.InvariantCulture,
-                        " -map 0:{0} -an -vn -c:s {1} \"{2}\"",
+                        " -map 0:{0} -an -vn -c:s {1} -flush_packets 1 \"{2}\"",
                         streamIndex,
                         outputCodec,
                         outputPath);
@@ -613,7 +613,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             var outputPaths = new List<string>();
             var args = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i {0} -copyts",
+                "-i {0}",
                 inputPath);
 
             foreach (var subtitleStream in subtitleStreams)
@@ -639,7 +639,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 outputPaths.Add(outputPath);
                 args += string.Format(
                     CultureInfo.InvariantCulture,
-                    " -map 0:{0} -an -vn -c:s {1} \"{2}\"",
+                    " -map 0:{0} -an -vn -c:s {1} -flush_packets 1 \"{2}\"",
                     streamIndex,
                     outputCodec,
                     outputPath);


### PR DESCRIPTION
**Changes**

  Remove `-copyts` and add `-flush_packets 1` (per-output) to subtitle extraction in `SubtitleEncoder.cs`.

  `-copyts` is unnecessary for `-c:s copy` to SRT (SRT has its own text-based timestamps) and forces ffmpeg to sequentially demux the entire video, making extraction ~5x slower. Without `-flush_packets 1`, ffmpeg's SRT muxer
  buffers all output until the process exits — leaving `.srt` files at 0 bytes for minutes while the web player shows no subtitles.

  With both changes, subtitle files have valid data within 3 seconds of extraction starting.

  | | Current (`-copyts`, no flush) | This PR (no `-copyts`, `-flush_packets 1`) |
  |---|---|---|
  | File has data after | never (0 bytes until exit) | **3 seconds** |
  | Extraction speed | ~8x realtime | ~44x realtime |

  Complements #16257, which handles stale 0-byte files from *failed* extractions. This PR prevents 0-byte files during *successful* extractions.

  **Issues**

  Fixes #16438