### PR TITLE
Embed external subtitles into MKV when transcoding

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3104,8 +3104,19 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 if (state.SubtitleStream.IsExternal)
                 {
-                    // External subtitle file is added as second FFmpeg input
-                    args += " -map 1:0";
+                    // External subtitle file is added as second FFmpeg input.
+                    // For single-stream files (SRT/ASS/VTT) the in-file index is always 0.
+                    // For multi-stream containers (MKS) we count how many streams from
+                    // the same file appear before the selected one.
+                    var inFileIndex = state.MediaSource.MediaStreams
+                        .Where(s => string.Equals(s.Path, state.SubtitleStream.Path, StringComparison.Ordinal))
+                        .TakeWhile(s => s.Index != state.SubtitleStream.Index)
+                        .Count();
+
+                    args += string.Format(
+                        CultureInfo.InvariantCulture,
+                        " -map 1:{0}",
+                        inFileIndex);
                 }
                 else
                 {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1267,22 +1267,23 @@ namespace MediaBrowser.Controller.MediaEncoding
                     .Append(_mediaEncoder.GetInputPathArgument(state));
             }
 
-            // sub2video for external graphical subtitles
-            if (state.SubtitleStream is not null
-                && ShouldEncodeSubtitle(state)
-                && !state.SubtitleStream.IsTextSubtitleStream
-                && state.SubtitleStream.IsExternal)
+            if (NeedsExternalSubtitleMuxing(state))
             {
                 var subtitlePath = state.SubtitleStream.Path;
-                var subtitleExtension = Path.GetExtension(subtitlePath.AsSpan());
+                var isGraphicalBurnIn = ShouldEncodeSubtitle(state) && !state.SubtitleStream.IsTextSubtitleStream;
 
-                // dvdsub/vobsub graphical subtitles use .sub+.idx pairs
-                if (subtitleExtension.Equals(".sub", StringComparison.OrdinalIgnoreCase))
+                if (isGraphicalBurnIn)
                 {
-                    var idxFile = Path.ChangeExtension(subtitlePath, ".idx");
-                    if (File.Exists(idxFile))
+                    var subtitleExtension = Path.GetExtension(subtitlePath.AsSpan());
+
+                    // dvdsub/vobsub graphical subtitles use .sub+.idx pairs
+                    if (subtitleExtension.Equals(".sub", StringComparison.OrdinalIgnoreCase))
                     {
-                        subtitlePath = idxFile;
+                        var idxFile = Path.ChangeExtension(subtitlePath, ".idx");
+                        if (File.Exists(idxFile))
+                        {
+                            subtitlePath = idxFile;
+                        }
                     }
                 }
 
@@ -1307,7 +1308,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     arg.Append(' ').Append(seekSubParam);
                 }
 
-                if (!string.IsNullOrEmpty(canvasArgs))
+                if (isGraphicalBurnIn && !string.IsNullOrEmpty(canvasArgs))
                 {
                     arg.Append(canvasArgs);
                 }
@@ -3072,11 +3073,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 int audioStreamIndex = FindIndex(state.MediaSource.MediaStreams, state.AudioStream);
                 if (state.AudioStream.IsExternal)
                 {
-                    bool hasExternalGraphicsSubs = state.SubtitleStream is not null
-                        && ShouldEncodeSubtitle(state)
-                        && state.SubtitleStream.IsExternal
-                        && !state.SubtitleStream.IsTextSubtitleStream;
-                    int externalAudioMapIndex = hasExternalGraphicsSubs ? 2 : 1;
+                    bool hasExternalSubAsInput = NeedsExternalSubtitleMuxing(state);
+                    int externalAudioMapIndex = hasExternalSubAsInput ? 2 : 1;
 
                     args += string.Format(
                         CultureInfo.InvariantCulture,
@@ -3104,12 +3102,20 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
             else if (subtitleMethod == SubtitleDeliveryMethod.Embed)
             {
-                int subtitleStreamIndex = FindIndex(state.MediaSource.MediaStreams, state.SubtitleStream);
+                if (state.SubtitleStream.IsExternal)
+                {
+                    // External subtitle file is added as second FFmpeg input
+                    args += " -map 1:0";
+                }
+                else
+                {
+                    int subtitleStreamIndex = FindIndex(state.MediaSource.MediaStreams, state.SubtitleStream);
 
-                args += string.Format(
-                    CultureInfo.InvariantCulture,
-                    " -map 0:{0}",
-                    subtitleStreamIndex);
+                    args += string.Format(
+                        CultureInfo.InvariantCulture,
+                        " -map 0:{0}",
+                        subtitleStreamIndex);
+                }
             }
             else if (state.SubtitleStream.IsExternal && !state.SubtitleStream.IsTextSubtitleStream)
             {
@@ -7884,6 +7890,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             return state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Encode
                    || (state.BaseRequest.AlwaysBurnInSubtitleWhenTranscoding && !IsCopyCodec(state.OutputVideoCodec));
+        }
+
+        private static bool NeedsExternalSubtitleMuxing(EncodingJobInfo state)
+        {
+            return state.SubtitleStream is not null
+                && state.SubtitleStream.IsExternal
+                && (state.SubtitleDeliveryMethod == SubtitleDeliveryMethod.Embed
+                    || (ShouldEncodeSubtitle(state) && !state.SubtitleStream.IsTextSubtitleStream));
         }
 
         public static string GetVideoSyncOption(string videoSync, Version encoderVersion)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1272,18 +1272,14 @@ namespace MediaBrowser.Controller.MediaEncoding
                 var subtitlePath = state.SubtitleStream.Path;
                 var isGraphicalBurnIn = ShouldEncodeSubtitle(state) && !state.SubtitleStream.IsTextSubtitleStream;
 
-                if (isGraphicalBurnIn)
+                // dvdsub/vobsub graphical subtitles use .sub+.idx pairs
+                var subtitleExtension = Path.GetExtension(subtitlePath.AsSpan());
+                if (subtitleExtension.Equals(".sub", StringComparison.OrdinalIgnoreCase))
                 {
-                    var subtitleExtension = Path.GetExtension(subtitlePath.AsSpan());
-
-                    // dvdsub/vobsub graphical subtitles use .sub+.idx pairs
-                    if (subtitleExtension.Equals(".sub", StringComparison.OrdinalIgnoreCase))
+                    var idxFile = Path.ChangeExtension(subtitlePath, ".idx");
+                    if (File.Exists(idxFile))
                     {
-                        var idxFile = Path.ChangeExtension(subtitlePath, ".idx");
-                        if (File.Exists(idxFile))
-                        {
-                            subtitlePath = idxFile;
-                        }
+                        subtitlePath = idxFile;
                     }
                 }
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1451,7 +1451,7 @@ namespace MediaBrowser.Model.Dlna
             string? outputContainer,
             MediaStreamProtocol? transcodingSubProtocol)
         {
-            if (!subtitleStream.IsExternal && (playMethod != PlayMethod.Transcode || transcodingSubProtocol != MediaStreamProtocol.hls))
+            if (CanConsiderEmbedSubtitle(subtitleStream, playMethod, transcodingSubProtocol, outputContainer))
             {
                 // Look for supported embedded subs of the same format
                 foreach (var profile in subtitleProfiles)
@@ -1538,6 +1538,19 @@ namespace MediaBrowser.Model.Dlna
             }
 
             return false;
+        }
+
+        private static bool CanConsiderEmbedSubtitle(MediaStream subtitleStream, PlayMethod playMethod, MediaStreamProtocol? transcodingSubProtocol, string? outputContainer)
+        {
+            if (subtitleStream.IsExternal)
+            {
+                return playMethod == PlayMethod.Transcode
+                    && transcodingSubProtocol != MediaStreamProtocol.hls
+                    && IsSubtitleEmbedSupported(outputContainer);
+            }
+
+            return playMethod != PlayMethod.Transcode
+                || transcodingSubProtocol != MediaStreamProtocol.hls;
         }
 
         private static SubtitleProfile? GetExternalSubtitleProfile(MediaSourceInfo mediaSource, MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod, ITranscoderSupport transcoderSupport, bool allowConversion)

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Moq;
+using Xunit;
+
+using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding
+{
+    public class EncodingHelperTests
+    {
+        [Fact]
+        public void GetMapArgs_NoSubtitle_ExcludesAllSubs()
+        {
+            var state = BuildState(subtitle: null, deliveryMethod: null);
+            var args = CreateHelper().GetMapArgs(state);
+
+            Assert.Contains("-map -0:s", args, StringComparison.Ordinal);
+            Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_InternalSrt_MapsFromPrimaryInput()
+        {
+            var sub = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
+            var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
+            var args = CreateHelper().GetMapArgs(state);
+
+            Assert.Contains("-map 0:2", args, StringComparison.Ordinal);
+            Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_InternalSubAtHigherIndex_MapsCorrectIndex()
+        {
+            var sub0 = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
+            var sub1 = new MediaStream { Index = 3, Type = MediaStreamType.Subtitle, Codec = "ass" };
+            var state = BuildState(sub1, SubtitleDeliveryMethod.Embed, additionalStreams: [sub0, sub1]);
+            var args = CreateHelper().GetMapArgs(state);
+
+            Assert.Contains("-map 0:3", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_ExternalSrt_MapsFirstStreamFromInput1()
+        {
+            var sub = new MediaStream
+            {
+                Index = 2,
+                Type = MediaStreamType.Subtitle,
+                Codec = "srt",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.en.srt"
+            };
+            var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
+            var args = CreateHelper().GetMapArgs(state);
+
+            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_SecondExternalSrt_StillMaps1Colon0()
+        {
+            var ext1 = new MediaStream
+            {
+                Index = 2,
+                Type = MediaStreamType.Subtitle,
+                Codec = "srt",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.en.srt"
+            };
+            var ext2 = new MediaStream
+            {
+                Index = 3,
+                Type = MediaStreamType.Subtitle,
+                Codec = "srt",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.fr.srt"
+            };
+            var state = BuildState(ext2, SubtitleDeliveryMethod.Embed, additionalStreams: [ext1, ext2]);
+            var args = CreateHelper().GetMapArgs(state);
+
+            // Different file from ext1, so in-file index is 0
+            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_MksFirstTrack_MapsInFileIndex0()
+        {
+            var mks0 = new MediaStream
+            {
+                Index = 2,
+                Type = MediaStreamType.Subtitle,
+                Codec = "subrip",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.mks"
+            };
+            var mks1 = new MediaStream
+            {
+                Index = 3,
+                Type = MediaStreamType.Subtitle,
+                Codec = "ass",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.mks"
+            };
+            var state = BuildState(mks0, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1]);
+            var args = CreateHelper().GetMapArgs(state);
+
+            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetMapArgs_MksSecondTrack_MapsInFileIndex1()
+        {
+            var mks0 = new MediaStream
+            {
+                Index = 2,
+                Type = MediaStreamType.Subtitle,
+                Codec = "subrip",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.mks"
+            };
+            var mks1 = new MediaStream
+            {
+                Index = 3,
+                Type = MediaStreamType.Subtitle,
+                Codec = "ass",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.mks"
+            };
+            var mks2 = new MediaStream
+            {
+                Index = 4,
+                Type = MediaStreamType.Subtitle,
+                Codec = "subrip",
+                IsExternal = true,
+                SupportsExternalStream = true,
+                Path = "/media/movie.mks"
+            };
+            var state = BuildState(mks1, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1, mks2]);
+            var args = CreateHelper().GetMapArgs(state);
+
+            // Second track in the same .mks file → in-file index 1
+            Assert.Contains("-map 1:1", args, StringComparison.Ordinal);
+        }
+
+        private static EncodingJobInfo BuildState(
+            MediaStream? subtitle,
+            SubtitleDeliveryMethod? deliveryMethod,
+            MediaStream[]? additionalStreams = null)
+        {
+            var video = new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "h264" };
+            var audio = new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "aac" };
+            var streams = new List<MediaStream> { video, audio };
+
+            if (additionalStreams is not null)
+            {
+                streams.AddRange(additionalStreams);
+            }
+            else if (subtitle is not null)
+            {
+                streams.Add(subtitle);
+            }
+
+            return new EncodingJobInfo(TranscodingJobType.Progressive)
+            {
+                MediaSource = new MediaSourceInfo
+                {
+                    Container = "mkv",
+                    MediaStreams = streams,
+                },
+                VideoStream = video,
+                AudioStream = audio,
+                SubtitleStream = subtitle,
+                SubtitleDeliveryMethod = deliveryMethod ?? SubtitleDeliveryMethod.Drop,
+                BaseRequest = new VideoRequestDto(),
+                IsVideoRequest = true,
+                IsInputVideo = true,
+            };
+        }
+
+        private static EncodingHelper CreateHelper()
+        {
+            var appPaths = Mock.Of<IApplicationPaths>();
+            var mediaEncoder = new Mock<IMediaEncoder>();
+            var subtitleEncoder = new Mock<ISubtitleEncoder>();
+            var config = new Mock<IConfiguration>();
+            var configurationManager = new Mock<IConfigurationManager>();
+            var pathManager = new Mock<IPathManager>();
+
+            return new EncodingHelper(
+                appPaths,
+                mediaEncoder.Object,
+                subtitleEncoder.Object,
+                config.Object,
+                configurationManager.Object,
+                pathManager.Object);
+        }
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -71,6 +73,8 @@ namespace Jellyfin.Controller.Tests.MediaEncoding
         [Fact]
         public void GetMapArgs_SecondExternalSrt_StillMaps1Colon0()
         {
+            // Two separate .srt files — selecting the second one still maps 1:0
+            // because Jellyfin feeds only the selected file as ffmpeg input 1.
             var ext1 = new MediaStream
             {
                 Index = 2,
@@ -92,7 +96,6 @@ namespace Jellyfin.Controller.Tests.MediaEncoding
             var state = BuildState(ext2, SubtitleDeliveryMethod.Embed, additionalStreams: [ext1, ext2]);
             var args = CreateHelper().GetMapArgs(state);
 
-            // Different file from ext1, so in-file index is 0
             Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
         }
 
@@ -156,8 +159,48 @@ namespace Jellyfin.Controller.Tests.MediaEncoding
             var state = BuildState(mks1, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1, mks2]);
             var args = CreateHelper().GetMapArgs(state);
 
-            // Second track in the same .mks file → in-file index 1
             Assert.Contains("-map 1:1", args, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData(SubtitleDeliveryMethod.Embed, true, "movie.idx")]
+        [InlineData(SubtitleDeliveryMethod.Encode, true, "movie.idx")]
+        [InlineData(SubtitleDeliveryMethod.Embed, false, "movie.sub")]
+        [InlineData(SubtitleDeliveryMethod.Encode, false, "movie.sub")]
+        public void GetInputArgument_VobSub_UsesCorrectPath(
+            SubtitleDeliveryMethod deliveryMethod,
+            bool createIdxFile,
+            string expectedFilename)
+        {
+            var tempDir = Directory.CreateTempSubdirectory("jellyfin-test-");
+            try
+            {
+                var subFile = Path.Combine(tempDir.FullName, "movie.sub");
+                File.WriteAllText(subFile, "dummy");
+
+                if (createIdxFile)
+                {
+                    File.WriteAllText(Path.Combine(tempDir.FullName, "movie.idx"), "dummy");
+                }
+
+                var sub = new MediaStream
+                {
+                    Index = 2,
+                    Type = MediaStreamType.Subtitle,
+                    Codec = "dvdsub",
+                    IsExternal = true,
+                    SupportsExternalStream = true,
+                    Path = subFile
+                };
+                var state = BuildState(sub, deliveryMethod);
+                var inputArgs = CreateHelper().GetInputArgument(state, new EncodingOptions(), null);
+
+                Assert.Contains(expectedFilename, inputArgs, StringComparison.Ordinal);
+            }
+            finally
+            {
+                tempDir.Delete(true);
+            }
         }
 
         private static EncodingJobInfo BuildState(

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -16,244 +16,243 @@ using Xunit;
 
 using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
-namespace Jellyfin.Controller.Tests.MediaEncoding
+namespace Jellyfin.Controller.Tests.MediaEncoding;
+
+public class EncodingHelperTests
 {
-    public class EncodingHelperTests
+    [Fact]
+    public void GetMapArgs_NoSubtitle_ExcludesAllSubs()
     {
-        [Fact]
-        public void GetMapArgs_NoSubtitle_ExcludesAllSubs()
+        var state = BuildState(subtitle: null, deliveryMethod: null);
+        var args = CreateHelper().GetMapArgs(state);
+
+        Assert.Contains("-map -0:s", args, StringComparison.Ordinal);
+        Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetMapArgs_InternalSrt_MapsFromPrimaryInput()
+    {
+        var sub = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
+        var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
+        var args = CreateHelper().GetMapArgs(state);
+
+        Assert.Contains("-map 0:2", args, StringComparison.Ordinal);
+        Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetMapArgs_InternalSubAtHigherIndex_MapsCorrectIndex()
+    {
+        var sub0 = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
+        var sub1 = new MediaStream { Index = 3, Type = MediaStreamType.Subtitle, Codec = "ass" };
+        var state = BuildState(sub1, SubtitleDeliveryMethod.Embed, additionalStreams: [sub0, sub1]);
+        var args = CreateHelper().GetMapArgs(state);
+
+        Assert.Contains("-map 0:3", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetMapArgs_ExternalSrt_MapsFirstStreamFromInput1()
+    {
+        var sub = new MediaStream
         {
-            var state = BuildState(subtitle: null, deliveryMethod: null);
-            var args = CreateHelper().GetMapArgs(state);
+            Index = 2,
+            Type = MediaStreamType.Subtitle,
+            Codec = "srt",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.en.srt"
+        };
+        var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
+        var args = CreateHelper().GetMapArgs(state);
 
-            Assert.Contains("-map -0:s", args, StringComparison.Ordinal);
-            Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
-        }
+        Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+    }
 
-        [Fact]
-        public void GetMapArgs_InternalSrt_MapsFromPrimaryInput()
+    [Fact]
+    public void GetMapArgs_SecondExternalSrt_StillMaps1Colon0()
+    {
+        // Two separate .srt files — selecting the second one still maps 1:0
+        // because Jellyfin feeds only the selected file as ffmpeg input 1.
+        var ext1 = new MediaStream
         {
-            var sub = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
-            var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
-            var args = CreateHelper().GetMapArgs(state);
-
-            Assert.Contains("-map 0:2", args, StringComparison.Ordinal);
-            Assert.DoesNotContain("-map 1:", args, StringComparison.Ordinal);
-        }
-
-        [Fact]
-        public void GetMapArgs_InternalSubAtHigherIndex_MapsCorrectIndex()
+            Index = 2,
+            Type = MediaStreamType.Subtitle,
+            Codec = "srt",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.en.srt"
+        };
+        var ext2 = new MediaStream
         {
-            var sub0 = new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "srt" };
-            var sub1 = new MediaStream { Index = 3, Type = MediaStreamType.Subtitle, Codec = "ass" };
-            var state = BuildState(sub1, SubtitleDeliveryMethod.Embed, additionalStreams: [sub0, sub1]);
-            var args = CreateHelper().GetMapArgs(state);
+            Index = 3,
+            Type = MediaStreamType.Subtitle,
+            Codec = "srt",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.fr.srt"
+        };
+        var state = BuildState(ext2, SubtitleDeliveryMethod.Embed, additionalStreams: [ext1, ext2]);
+        var args = CreateHelper().GetMapArgs(state);
 
-            Assert.Contains("-map 0:3", args, StringComparison.Ordinal);
-        }
+        Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+    }
 
-        [Fact]
-        public void GetMapArgs_ExternalSrt_MapsFirstStreamFromInput1()
+    [Fact]
+    public void GetMapArgs_MksFirstTrack_MapsInFileIndex0()
+    {
+        var mks0 = new MediaStream
         {
+            Index = 2,
+            Type = MediaStreamType.Subtitle,
+            Codec = "subrip",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.mks"
+        };
+        var mks1 = new MediaStream
+        {
+            Index = 3,
+            Type = MediaStreamType.Subtitle,
+            Codec = "ass",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.mks"
+        };
+        var state = BuildState(mks0, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1]);
+        var args = CreateHelper().GetMapArgs(state);
+
+        Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetMapArgs_MksSecondTrack_MapsInFileIndex1()
+    {
+        var mks0 = new MediaStream
+        {
+            Index = 2,
+            Type = MediaStreamType.Subtitle,
+            Codec = "subrip",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.mks"
+        };
+        var mks1 = new MediaStream
+        {
+            Index = 3,
+            Type = MediaStreamType.Subtitle,
+            Codec = "ass",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.mks"
+        };
+        var mks2 = new MediaStream
+        {
+            Index = 4,
+            Type = MediaStreamType.Subtitle,
+            Codec = "subrip",
+            IsExternal = true,
+            SupportsExternalStream = true,
+            Path = "/media/movie.mks"
+        };
+        var state = BuildState(mks1, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1, mks2]);
+        var args = CreateHelper().GetMapArgs(state);
+
+        Assert.Contains("-map 1:1", args, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(SubtitleDeliveryMethod.Embed, true, "movie.idx")]
+    [InlineData(SubtitleDeliveryMethod.Encode, true, "movie.idx")]
+    [InlineData(SubtitleDeliveryMethod.Embed, false, "movie.sub")]
+    [InlineData(SubtitleDeliveryMethod.Encode, false, "movie.sub")]
+    public void GetInputArgument_VobSub_UsesCorrectPath(
+        SubtitleDeliveryMethod deliveryMethod,
+        bool createIdxFile,
+        string expectedFilename)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("jellyfin-test-");
+        try
+        {
+            var subFile = Path.Combine(tempDir.FullName, "movie.sub");
+            File.WriteAllText(subFile, "dummy");
+
+            if (createIdxFile)
+            {
+                File.WriteAllText(Path.Combine(tempDir.FullName, "movie.idx"), "dummy");
+            }
+
             var sub = new MediaStream
             {
                 Index = 2,
                 Type = MediaStreamType.Subtitle,
-                Codec = "srt",
+                Codec = "dvdsub",
                 IsExternal = true,
                 SupportsExternalStream = true,
-                Path = "/media/movie.en.srt"
+                Path = subFile
             };
-            var state = BuildState(sub, SubtitleDeliveryMethod.Embed);
-            var args = CreateHelper().GetMapArgs(state);
+            var state = BuildState(sub, deliveryMethod);
+            var inputArgs = CreateHelper().GetInputArgument(state, new EncodingOptions(), null);
 
-            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+            Assert.Contains(expectedFilename, inputArgs, StringComparison.Ordinal);
         }
-
-        [Fact]
-        public void GetMapArgs_SecondExternalSrt_StillMaps1Colon0()
+        finally
         {
-            // Two separate .srt files — selecting the second one still maps 1:0
-            // because Jellyfin feeds only the selected file as ffmpeg input 1.
-            var ext1 = new MediaStream
-            {
-                Index = 2,
-                Type = MediaStreamType.Subtitle,
-                Codec = "srt",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.en.srt"
-            };
-            var ext2 = new MediaStream
-            {
-                Index = 3,
-                Type = MediaStreamType.Subtitle,
-                Codec = "srt",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.fr.srt"
-            };
-            var state = BuildState(ext2, SubtitleDeliveryMethod.Embed, additionalStreams: [ext1, ext2]);
-            var args = CreateHelper().GetMapArgs(state);
-
-            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+            tempDir.Delete(true);
         }
+    }
 
-        [Fact]
-        public void GetMapArgs_MksFirstTrack_MapsInFileIndex0()
+    private static EncodingJobInfo BuildState(
+        MediaStream? subtitle,
+        SubtitleDeliveryMethod? deliveryMethod,
+        MediaStream[]? additionalStreams = null)
+    {
+        var video = new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "h264" };
+        var audio = new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "aac" };
+        var streams = new List<MediaStream> { video, audio };
+
+        if (additionalStreams is not null)
         {
-            var mks0 = new MediaStream
-            {
-                Index = 2,
-                Type = MediaStreamType.Subtitle,
-                Codec = "subrip",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.mks"
-            };
-            var mks1 = new MediaStream
-            {
-                Index = 3,
-                Type = MediaStreamType.Subtitle,
-                Codec = "ass",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.mks"
-            };
-            var state = BuildState(mks0, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1]);
-            var args = CreateHelper().GetMapArgs(state);
-
-            Assert.Contains("-map 1:0", args, StringComparison.Ordinal);
+            streams.AddRange(additionalStreams);
         }
-
-        [Fact]
-        public void GetMapArgs_MksSecondTrack_MapsInFileIndex1()
+        else if (subtitle is not null)
         {
-            var mks0 = new MediaStream
-            {
-                Index = 2,
-                Type = MediaStreamType.Subtitle,
-                Codec = "subrip",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.mks"
-            };
-            var mks1 = new MediaStream
-            {
-                Index = 3,
-                Type = MediaStreamType.Subtitle,
-                Codec = "ass",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.mks"
-            };
-            var mks2 = new MediaStream
-            {
-                Index = 4,
-                Type = MediaStreamType.Subtitle,
-                Codec = "subrip",
-                IsExternal = true,
-                SupportsExternalStream = true,
-                Path = "/media/movie.mks"
-            };
-            var state = BuildState(mks1, SubtitleDeliveryMethod.Embed, additionalStreams: [mks0, mks1, mks2]);
-            var args = CreateHelper().GetMapArgs(state);
-
-            Assert.Contains("-map 1:1", args, StringComparison.Ordinal);
+            streams.Add(subtitle);
         }
 
-        [Theory]
-        [InlineData(SubtitleDeliveryMethod.Embed, true, "movie.idx")]
-        [InlineData(SubtitleDeliveryMethod.Encode, true, "movie.idx")]
-        [InlineData(SubtitleDeliveryMethod.Embed, false, "movie.sub")]
-        [InlineData(SubtitleDeliveryMethod.Encode, false, "movie.sub")]
-        public void GetInputArgument_VobSub_UsesCorrectPath(
-            SubtitleDeliveryMethod deliveryMethod,
-            bool createIdxFile,
-            string expectedFilename)
+        return new EncodingJobInfo(TranscodingJobType.Progressive)
         {
-            var tempDir = Directory.CreateTempSubdirectory("jellyfin-test-");
-            try
+            MediaSource = new MediaSourceInfo
             {
-                var subFile = Path.Combine(tempDir.FullName, "movie.sub");
-                File.WriteAllText(subFile, "dummy");
+                Container = "mkv",
+                MediaStreams = streams,
+            },
+            VideoStream = video,
+            AudioStream = audio,
+            SubtitleStream = subtitle,
+            SubtitleDeliveryMethod = deliveryMethod ?? SubtitleDeliveryMethod.Drop,
+            BaseRequest = new VideoRequestDto(),
+            IsVideoRequest = true,
+            IsInputVideo = true,
+        };
+    }
 
-                if (createIdxFile)
-                {
-                    File.WriteAllText(Path.Combine(tempDir.FullName, "movie.idx"), "dummy");
-                }
+    private static EncodingHelper CreateHelper()
+    {
+        var appPaths = Mock.Of<IApplicationPaths>();
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        var subtitleEncoder = new Mock<ISubtitleEncoder>();
+        var config = new Mock<IConfiguration>();
+        var configurationManager = new Mock<IConfigurationManager>();
+        var pathManager = new Mock<IPathManager>();
 
-                var sub = new MediaStream
-                {
-                    Index = 2,
-                    Type = MediaStreamType.Subtitle,
-                    Codec = "dvdsub",
-                    IsExternal = true,
-                    SupportsExternalStream = true,
-                    Path = subFile
-                };
-                var state = BuildState(sub, deliveryMethod);
-                var inputArgs = CreateHelper().GetInputArgument(state, new EncodingOptions(), null);
-
-                Assert.Contains(expectedFilename, inputArgs, StringComparison.Ordinal);
-            }
-            finally
-            {
-                tempDir.Delete(true);
-            }
-        }
-
-        private static EncodingJobInfo BuildState(
-            MediaStream? subtitle,
-            SubtitleDeliveryMethod? deliveryMethod,
-            MediaStream[]? additionalStreams = null)
-        {
-            var video = new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "h264" };
-            var audio = new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "aac" };
-            var streams = new List<MediaStream> { video, audio };
-
-            if (additionalStreams is not null)
-            {
-                streams.AddRange(additionalStreams);
-            }
-            else if (subtitle is not null)
-            {
-                streams.Add(subtitle);
-            }
-
-            return new EncodingJobInfo(TranscodingJobType.Progressive)
-            {
-                MediaSource = new MediaSourceInfo
-                {
-                    Container = "mkv",
-                    MediaStreams = streams,
-                },
-                VideoStream = video,
-                AudioStream = audio,
-                SubtitleStream = subtitle,
-                SubtitleDeliveryMethod = deliveryMethod ?? SubtitleDeliveryMethod.Drop,
-                BaseRequest = new VideoRequestDto(),
-                IsVideoRequest = true,
-                IsInputVideo = true,
-            };
-        }
-
-        private static EncodingHelper CreateHelper()
-        {
-            var appPaths = Mock.Of<IApplicationPaths>();
-            var mediaEncoder = new Mock<IMediaEncoder>();
-            var subtitleEncoder = new Mock<ISubtitleEncoder>();
-            var config = new Mock<IConfiguration>();
-            var configurationManager = new Mock<IConfigurationManager>();
-            var pathManager = new Mock<IPathManager>();
-
-            return new EncodingHelper(
-                appPaths,
-                mediaEncoder.Object,
-                subtitleEncoder.Object,
-                config.Object,
-                configurationManager.Object,
-                pathManager.Object);
-        }
+        return new EncodingHelper(
+            appPaths,
+            mediaEncoder.Object,
+            subtitleEncoder.Object,
+            config.Object,
+            configurationManager.Object,
+            pathManager.Object);
     }
 }

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -675,5 +675,59 @@ namespace Jellyfin.Model.Tests
 
             Assert.Equal(expectedMethod, result.Method);
         }
+
+        [Theory]
+        // External text subs embedded into MKV when transcoding (#16403)
+        [InlineData("srt", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        [InlineData("ass", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        // External graphical subs embedded into MKV when transcoding
+        [InlineData("pgssub", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        [InlineData("dvdsub", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        // External subs remain external when transcoding to non-MKV containers
+        [InlineData("srt", true, PlayMethod.Transcode, "mp4", MediaStreamProtocol.hls, SubtitleDeliveryMethod.External)]
+        [InlineData("srt", true, PlayMethod.Transcode, "ts", MediaStreamProtocol.hls, SubtitleDeliveryMethod.External)]
+        // External subs remain external during DirectPlay even with MKV
+        [InlineData("srt", true, PlayMethod.DirectPlay, "mkv", null, SubtitleDeliveryMethod.External)]
+        // Internal subs still embedded into MKV when transcoding (existing behavior)
+        [InlineData("srt", false, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        [InlineData("pgssub", false, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
+        public void GetSubtitleProfile_ReturnsExpectedDeliveryMethod(
+            string codec,
+            bool isExternal,
+            PlayMethod playMethod,
+            string outputContainer,
+            MediaStreamProtocol? transcodingSubProtocol,
+            SubtitleDeliveryMethod expectedMethod)
+        {
+            var mediaSource = new MediaSourceInfo();
+            var subtitleStream = new MediaStream
+            {
+                Codec = codec,
+                Language = "eng",
+                IsExternal = isExternal,
+                Type = MediaStreamType.Subtitle,
+                SupportsExternalStream = true
+            };
+
+            var subtitleProfiles = new[]
+            {
+                new SubtitleProfile { Format = codec, Method = SubtitleDeliveryMethod.Embed },
+                new SubtitleProfile { Format = codec, Method = SubtitleDeliveryMethod.External }
+            };
+
+            var transcoderSupport = new Mock<ITranscoderSupport>();
+            transcoderSupport.Setup(x => x.CanExtractSubtitles(It.IsAny<string>())).Returns(true);
+
+            var result = StreamBuilder.GetSubtitleProfile(
+                mediaSource,
+                subtitleStream,
+                subtitleProfiles,
+                playMethod,
+                transcoderSupport.Object,
+                outputContainer,
+                transcodingSubProtocol);
+
+            Assert.Equal(expectedMethod, result.Method);
+        }
     }
 }


### PR DESCRIPTION
Allow external subtitle files (SRT, ASS, PGS, etc.) to be muxed into MKV output containers when the device profile requests Embed delivery.

Previously, the IsExternal guard in GetSubtitleProfile excluded external subtitles from Embed consideration entirely, forcing them to be served as separate sidecar files even when the output container supports embedding.

**Changes**

- Extract CanConsiderEmbedSubtitle in StreamBuilder to allow external subs through when transcoding to MKV
- Add external subtitle file as FFmpeg input (-i) for Embed delivery
- Map external embedded subs from the correct FFmpeg input index
- Fix external audio map index to account for the new subtitle input
- Extract NeedsExternalSubtitleMuxing in EncodingHelper to deduplicate the external subtitle input check

**Issues**

Fixes #16403

**Manual testing**

Generated with ffmpeg — 5-second h264+aac test videos at 320x240, organized in Jellyfin's movie folder structure (`Movie Name (Year)/Movie Name (Year).ext`):

| Movie | Internal subs | External subs |
|-------|--------------|---------------|
| Video Nosubs (2024) | none | `.en.srt`, `.fr.srt` |
| Video IntSrt (2024) | 1 SRT (English) | `.en.srt` |
| Video Int2Srt (2024) | 2 SRT (English, French) | none |
| Video ExtMks (2024) | none | `.mks` with 2 tracks (English, French) |

## PlaybackInfo — `POST /Items/{id}/PlaybackInfo`

Full `MediaSources[0].MediaStreams` response for each test video.

### Video Nosubs — no internal subs, 2 external SRTs
```json
[
  { "Index": 0, "Type": "Subtitle", "Codec": "subrip", "Language": "eng", "IsExternal": true,  "IsDefault": false, "DisplayTitle": "English - SUBRIP - External", "Path": "Video Nosubs (2024).en.srt" },
  { "Index": 1, "Type": "Subtitle", "Codec": "subrip", "Language": "fra", "IsExternal": true,  "IsDefault": false, "DisplayTitle": "French - SUBRIP - External",  "Path": "Video Nosubs (2024).fr.srt" },
  { "Index": 2, "Type": "Video",    "Codec": "h264",   "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "240p H264 SDR",               "Path": null },
  { "Index": 3, "Type": "Audio",    "Codec": "aac",    "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "AAC - Mono",                  "Path": null }
]
```

### Video IntSrt — 1 internal SRT + 1 external SRT
```json
[
  { "Index": 0, "Type": "Subtitle", "Codec": "subrip", "Language": "eng", "IsExternal": true,  "IsDefault": false, "DisplayTitle": "English - SUBRIP - External", "Path": "Video IntSrt (2024).en.srt" },
  { "Index": 1, "Type": "Video",    "Codec": "h264",   "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "240p H264 SDR",               "Path": null },
  { "Index": 2, "Type": "Audio",    "Codec": "aac",    "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "AAC - Mono",                  "Path": null },
  { "Index": 3, "Type": "Subtitle", "Codec": "subrip", "Language": "eng", "IsExternal": false, "IsDefault": false, "DisplayTitle": "English - SUBRIP",            "Path": null }
]
```
External SRT gets index 0. Internal subtitle (in-container position 2) gets Jellyfin index 3. `Path` is null for internal streams.

### Video Int2Srt — 2 internal SRTs, no external
```json
[
  { "Index": 0, "Type": "Video",    "Codec": "h264",   "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "240p H264 SDR",               "Path": null },
  { "Index": 1, "Type": "Audio",    "Codec": "aac",    "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "AAC - Mono",                  "Path": null },
  { "Index": 2, "Type": "Subtitle", "Codec": "subrip", "Language": "eng", "IsExternal": false, "IsDefault": true,  "DisplayTitle": "English - Default - SUBRIP",  "Path": null },
  { "Index": 3, "Type": "Subtitle", "Codec": "subrip", "Language": "fra", "IsExternal": false, "IsDefault": false, "DisplayTitle": "French - SUBRIP",             "Path": null }
]
```
No external subs — indices match the MKV container layout: video=0, audio=1, sub=2, sub=3.

### Video ExtMks — no internal subs, 1 external MKS with 2 subtitle tracks
```json
[
  { "Index": 0, "Type": "Subtitle", "Codec": "subrip", "Language": "eng", "IsExternal": true,  "IsDefault": true,  "DisplayTitle": "English - Default - SUBRIP - External", "Path": "Video ExtMks (2024).mks" },
  { "Index": 1, "Type": "Subtitle", "Codec": "subrip", "Language": "fra", "IsExternal": true,  "IsDefault": false, "DisplayTitle": "French - SUBRIP - External",            "Path": "Video ExtMks (2024).mks" },
  { "Index": 2, "Type": "Video",    "Codec": "h264",   "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "240p H264 SDR",                         "Path": null },
  { "Index": 3, "Type": "Audio",    "Codec": "aac",    "Language": null,  "IsExternal": false, "IsDefault": false, "DisplayTitle": "AAC - Mono",                             "Path": null }
]
```
Both subtitle streams share the same `Path` — Jellyfin probes the `.mks` with ffprobe, discovers 2 tracks, and creates a `MediaStream` per track. The in-file index (0 for English, 1 for French) is not stored on the model; it's computed at transcode time by counting siblings with the same `Path`.

## Test results

Each test:
1. Requests `GET /Videos/{id}/stream.mkv?SubtitleStreamIndex={idx}&SubtitleMethod=Embed&PlaySessionId={unique}`
2. Downloads the first 2 MB of the output MKV
3. Verifies with ffprobe that a subtitle stream is present
4. Extracts subtitle text content with ffmpeg and compares against expected value

Transcode cache was cleared between each request to prevent false positives (Jellyfin caches transcoded output by item ID).

| # | Video | Subtitle | Jellyfin idx | Expected text | ffmpeg `-map` | Output text |
|---|-------|----------|-------------|---------------|---------------|-------------|
| 1 | Nosubs | External EN (.srt) | 0 | "English subtitle" | `-map 1:0` | "English subtitle" |
| 2 | Nosubs | External FR (.srt) | 1 | "French subtitle" | `-map 1:0` | "French subtitle" |
| 3 | IntSrt | Internal EN | 3 | "Internal English" | `-map 0:2` | "Internal English" |
| 4 | IntSrt | External EN (.srt) | 0 | "External English" | `-map 1:0` | "External English" |
| 5 | Int2Srt | Internal EN | 2 | "Internal English" | `-map 0:2` | "Internal English" |
| 6 | Int2Srt | Internal FR | 3 | "Internal French" | `-map 0:3` | "Internal French" |
| 7 | ExtMks | MKS EN (track 0) | 0 | "MKS English" | `-map 1:0` | "MKS English" |
| 8 | ExtMks | MKS FR (track 1) | 1 | "MKS French" | `-map 1:1` | "MKS French" |

## ffmpeg commands generated by Jellyfin

Captured from Jellyfin server log (`TranscodeManager: ffmpeg ...`). Shortened for readability — full commands include `-analyzeduration 200M -probesize 1G -fflags +genpts -map_metadata -1 -map_chapters -1 -threads 0`.

### Test 1 — External EN SRT, no internal subs
```
ffmpeg -i file:"Video Nosubs (2024).mkv" -i file:"Video Nosubs (2024).en.srt"
  -map 0:0 -map 0:1 -map 1:0
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```

### Test 2 — External FR SRT (second external file)
```
ffmpeg -i file:"Video Nosubs (2024).mkv" -i file:"Video Nosubs (2024).fr.srt"
  -map 0:0 -map 0:1 -map 1:0
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```
Jellyfin adds only the **selected** external file as input 1. Different file from test 1, same `-map 1:0` — because each `.srt` has exactly one stream at index 0.

### Test 3 — Internal SRT
```
ffmpeg -i file:"Video IntSrt (2024).mkv"
  -map 0:0 -map 0:1 -map 0:2
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```
No second input — internal subtitle mapped from the primary file at its container position.

### Test 4 — External SRT alongside internal sub
```
ffmpeg -i file:"Video IntSrt (2024).mkv" -i file:"Video IntSrt (2024).en.srt"
  -map 0:0 -map 0:1 -map 1:0
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```
Even though the video has an internal subtitle, the user chose the external one — only the external is embedded.

### Test 5 — First internal sub (2 internal subs available)
```
ffmpeg -i file:"Video Int2Srt (2024).mkv"
  -map 0:0 -map 0:1 -map 0:2
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```

### Test 6 — Second internal sub
```
ffmpeg -i file:"Video Int2Srt (2024).mkv"
  -map 0:0 -map 0:1 -map 0:3
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```
`-map 0:3` picks the French subtitle, not English. Only the selected subtitle is included in the output.

### Test 7 — MKS first track (multi-stream external container)
```
ffmpeg -i file:"Video ExtMks (2024).mkv" -i file:"Video ExtMks (2024).mks"
  -map 0:0 -map 0:1 -map 1:0
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```

### Test 8 — MKS second track
```
ffmpeg -i file:"Video ExtMks (2024).mkv" -i file:"Video ExtMks (2024).mks"
  -map 0:0 -map 0:1 -map 1:1
  -codec:v:0 copy -codec:a:0 copy -codec:s:0 copy -disposition:s:0 default
  -y output.mkv
```
`-map 1:1` selects the second subtitle track from the `.mks` file. The in-file index is computed by counting `MediaStream` entries with the same `Path` that appear before the selected one in Jellyfin's stream list.

## ffprobe verification of output files

All output MKVs contain exactly 3 streams: video (h264), audio (aac), subtitle (subrip).

```
test1: streams=[video/h264, audio/aac, subtitle/subrip] content="English subtitle"
test2: streams=[video/h264, audio/aac, subtitle/subrip] content="French subtitle"
test3: streams=[video/h264, audio/aac, subtitle/subrip] content="Internal English"
test4: streams=[video/h264, audio/aac, subtitle/subrip] content="External English"
test5: streams=[video/h264, audio/aac, subtitle/subrip] content="Internal English"
test6: streams=[video/h264, audio/aac, subtitle/subrip] content="Internal French"
test7: streams=[video/h264, audio/aac, subtitle/subrip] content="MKS English"
test8: streams=[video/h264, audio/aac, subtitle/subrip] content="MKS French"
```

## Comparison with master

The same tests run against `master` branch (code checked out via `git checkout master -- EncodingHelper.cs StreamBuilder.cs`, rebuilt, same test media and server data):

| # | Video | Subtitle | master | feature branch |
|---|-------|----------|--------|----------------|
| 1 | Nosubs | Ext EN | **0 sub streams** | 1 sub stream |
| 2 | Nosubs | Ext FR | **0 sub streams** | 1 sub stream |
| 3 | IntSrt | Internal | 1 sub stream | 1 sub stream |
| 4 | IntSrt | Ext EN | 1 sub stream | 1 sub stream |
| 5 | Int2Srt | Int EN | 1 sub stream | 1 sub stream |
| 6 | Int2Srt | Int FR | 1 sub stream | 1 sub stream |
| 7 | ExtMks | MKS EN | **0 sub streams** | 1 sub stream |
| 8 | ExtMks | MKS FR | **0 sub streams** | 1 sub stream |

