### PR TITLE
Fix NFO saver using wrong provider ID for collectionnumber

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -547,7 +547,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 writer.WriteElementString("aspectratio", hasAspectRatio.AspectRatio);
             }
 
-            if (item.TryGetProviderId(MetadataProvider.Tmdb, out var tmdbCollection))
+            if (item.TryGetProviderId(MetadataProvider.TmdbCollection, out var tmdbCollection))
             {
                 writer.WriteElementString("collectionnumber", tmdbCollection);
                 writtenProviderIds.Add(MetadataProvider.TmdbCollection.ToString());


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

Use `TmdbCollection` instead of `Tmdb` for `collectionnumber`

**Issues**
Fixes: #16447
