### PR TITLE
Fix #16308: Community ratings not updating after changing .nfo file.

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -806,7 +806,7 @@ namespace MediaBrowser.Providers.Manager
                                 refreshResult.UpdateType |= ItemUpdateType.ImageUpdate;
                             }
 
-                            MergeData(localItem, temp, [], false, true);
+                            MergeData(localItem, temp, [], options.ReplaceAllMetadata, true);
                             refreshResult.UpdateType |= ItemUpdateType.MetadataImport;
 
                             break;

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -806,7 +806,7 @@ namespace MediaBrowser.Providers.Manager
                                 refreshResult.UpdateType |= ItemUpdateType.ImageUpdate;
                             }
 
-                            MergeData(localItem, temp, [], options.ReplaceAllMetadata, true);
+                            MergeData(localItem, temp, [], false, true);
                             refreshResult.UpdateType |= ItemUpdateType.MetadataImport;
 
                             break;

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -543,6 +543,16 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                 case "ratings":
                     FetchFromRatingsNode(reader, item);
                     break;
+                // For NFO files that have a separate community rating tag instead of using the ratings node with a name, or standard rating tag
+                case "communityrating":
+                    var communityRatingText = reader.ReadElementContentAsString().Replace(',', '.');
+                    if (float.TryParse(communityRatingText, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var communityRatingValue)
+                    && communityRatingValue >= 0 && communityRatingValue <= 10)
+                    {
+                        item.CommunityRating = communityRatingValue;
+                    }
+
+                    break;
                 case "aired":
                 case "formed":
                 case "premiered":

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -294,5 +294,48 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             // Verify that the lowercase "tmdbcol" is NOT in the provider IDs
             Assert.False(item.ProviderIds.ContainsKey("tmdbcol"));
         }
+
+        [Fact]
+        public void Parse_CommunityRating_ValidRating_Success()
+        {
+            var result = new MetadataResult<Video>()
+            {
+                Item = new Movie()
+            };
+
+            _parser.Fetch(result, "Test Data/CommunityRating.nfo", CancellationToken.None);
+            var item = (Movie)result.Item;
+
+            Assert.Equal(7.5f, item.CommunityRating);
+        }
+
+        [Fact]
+        public void Parse_CommunityRating_OutOfRange_Ignored()
+        {
+            var result = new MetadataResult<Video>()
+            {
+                Item = new Movie()
+            };
+
+            _parser.Fetch(result, "Test Data/CommunityRating_OutOfRange.nfo", CancellationToken.None);
+            var item = (Movie)result.Item;
+
+            // Rating should not be set if outside 0-10 range
+            Assert.Null(item.CommunityRating);
+        }
+
+        [Fact]
+        public void Parse_CommunityRating_Comma()
+        {
+            var result = new MetadataResult<Video>()
+            {
+                Item = new Movie()
+            };
+
+            _parser.Fetch(result, "Test Data/CommunityRating_Comma.nfo", CancellationToken.None);
+            var item = (Movie)result.Item;
+
+            Assert.Equal(7.5f, item.CommunityRating);
+        }
     }
 }

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating.nfo
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<movie>
+    <title>Test Movie</title>
+    <communityrating>7.5</communityrating>
+</movie>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating_Comma.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating_Comma.nfo
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<movie>
+    <title>Test Movie</title>
+    <communityrating>7,5</communityrating>
+</movie>

--- a/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating_OutOfRange.nfo
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Test Data/CommunityRating_OutOfRange.nfo
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<movie>
+    <title>Test Movie</title>
+    <communityrating>15.5</communityrating>
+</movie>


### PR DESCRIPTION
<!--
Fix #16308: Community ratings not updating after changing local .nfo file.

When "replace all metadata" was issued on a film, with the Web metadata scrapers and "save to local metadata" disabled, after changing the .nfo file, 'Community rating' was not updated in the server, remaining the cached value.

-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixed by changing the flag on the 'MergeData' call (line 809 - MetadataService.cs) to use the option defined by the user and not the erroneous absolute 'false' value.

Also, in the .nfo parser an option for 'communityrating' was added along with value conformity verifiers.

Validation tests were added.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 
#16308
