### PR TITLE
fix: cap GetVideoBitrateParamValue at 400 Mbps

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2614,8 +2614,16 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
             }
 
-            // Cap the max target bitrate to intMax/2 to satisfy the bufsize=bitrate*2.
-            return Math.Min(bitrate ?? 0, int.MaxValue / 2);
+            // Cap the max target bitrate to 400 Mbps.
+            // No consumer or professional hardware transcode target exceeds this value
+            // (Intel QSV tops out at ~300 Mbps for H.264; HEVC High Tier Level 5.x is ~240 Mbps).
+            // Without this cap, plugin-provided MPEG-TS streams with no usable bitrate metadata
+            // can produce unreasonably large -bufsize/-maxrate values for the encoder.
+            // Note: the existing FallbackMaxStreamingBitrate mechanism (default 30 Mbps) only
+            // applies when a LiveStreamId is set (M3U/HDHR sources). Plugin streams and other
+            // sources that bypass the LiveTV pipeline are not covered by it.
+            const int maxSaneBitrate = 400_000_000; // 400 Mbps
+            return Math.Min(bitrate ?? 0, maxSaneBitrate);
         }
 
         private int GetMinBitrate(int sourceBitrate, int requestedBitrate)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2622,8 +2622,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Note: the existing FallbackMaxStreamingBitrate mechanism (default 30 Mbps) only
             // applies when a LiveStreamId is set (M3U/HDHR sources). Plugin streams and other
             // sources that bypass the LiveTV pipeline are not covered by it.
-            const int maxSaneBitrate = 400_000_000; // 400 Mbps
-            return Math.Min(bitrate ?? 0, maxSaneBitrate);
+            const int MaxSaneBitrate = 400_000_000; // 400 Mbps
+            return Math.Min(bitrate ?? 0, MaxSaneBitrate);
         }
 
         private int GetMinBitrate(int sourceBitrate, int requestedBitrate)


### PR DESCRIPTION
## Context

Follow-up to #16376, which fixed int32 overflow in QSV rate-control parameter computation using long arithmetic. While reviewing that fix, @nyanmisaka pointed out that the root cause lies one step upstream: \GetVideoBitrateParamValue\ currently caps at \int.MaxValue / 2\ (~1073 Mbps)  far beyond any realistic transcode target  and that replacing it with a 400 Mbps sanity cap would address the problem for all encoder paths at once.

## The Problem

Without a reasonable cap, plugin-provided MPEG-TS streams or any source that lacks reliable bitrate metadata can pass unreasonably high values into the encoder pipeline. The result is FFmpeg parameters like \-bufsize 4294967292\ or, before #16376, a negative \-bufsize -4\ due to int32 overflow.

The existing \FallbackMaxStreamingBitrate\ mechanism (default 30 Mbps) provides a similar guard but only when \LiveStreamId\ is set  M3U and HDHR sources. Plugin streams and other sources that bypass the LiveTV pipeline are not covered by it, and it is not practical to require every plugin to set \FallbackMaxStreamingBitrate\ correctly.

## What this PR does

Replace the \int.MaxValue / 2\ cap in \GetVideoBitrateParamValue()\ with a **400 Mbps constant**. This is a single-line change in one method, codec-agnostic, and applies before any encoder-specific logic runs.

400 Mbps is sufficient headroom for all current hardware transcode scenarios:

| Encoder | Practical max | Fits within 400 Mbps? |
|---|---|---|
| Intel QSV H.264 | ~300 Mbps (High 5.1 CPB = 168.75 Mbit) | Yes |
| Intel QSV HEVC | High Tier Level 5.x ~240 Mbps | Yes |
| Intel QSV AV1 | No meaningful hardware constraint at this level | Yes |
| libx264 / libx265 | Software-only, no hardware ceiling | Yes |
| AMF / VAAPI / VideoToolbox | Hardware-limited well below 400 Mbps | Yes |

## What this PR does NOT do

- No behavioral change for any normal transcode (all realistic bitrates are well below 400 Mbps)
- No new methods, no refactoring, no tests

cc @nyanmisaka  as suggested in your review of #16376.