### PR TITLE
More robust date handling in Library DB migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLibraryDb.cs
@@ -540,7 +540,7 @@ internal class MigrateLibraryDb : IDatabaseMigrationRoutine
             && unixTimestamp > 0
             && unixTimestamp <= DateTimeOffset.MaxValue.ToUnixTimeSeconds())
         {
-            return DateTime.SpecifyKind(DateTimeOffset.FromUnixTimeSeconds(unixTimestamp).DateTime, DateTimeKind.Utc);
+            return DateTimeOffset.FromUnixTimeSeconds(unixTimestamp).UtcDateTime;
         }
 
         return null;


### PR DESCRIPTION
**Changes**
Try parsing dates not only as date strings but als unix epochs and just use null if parsing fails

**Issues**
Fixes #15519