### PR TITLE
Fix triple digit episode number handling

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -379,6 +379,14 @@ namespace Emby.Naming.Common
                     IsNamed = true
                 },
 
+                // "Name - 101.mkv", "Name - 101 [720p].mkv", "Name - 101 (2020).mkv"
+                // Handles absolute episode numbers with hyphen delimiter (common in anime)
+                // Without brackets (bracketed version handled above)
+                new EpisodeExpression(@".*[\\\/](?<seriesname>[^\\\/]+?)[\s_]+-[\s_]+(?<epnumber>[0-9]+)[\s_]*(?:\[.*?\]|\(.*?\))*[\s_]*(?:\.\w+)?$")
+                {
+                    IsNamed = true
+                },
+
                 // /server/anything_102.mp4
                 // /server/james.corden.2017.04.20.anne.hathaway.720p.hdtv.x264-crooks.mkv
                 // /server/anything_1996.11.14.mp4

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberTests.cs
@@ -80,7 +80,9 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("[VCB-Studio] Re Zero kara Hajimeru Isekai Seikatsu [21][Ma10p_1080p][x265_flac].mkv", 21)]
         [InlineData("[CASO&Sumisora][Oda_Nobuna_no_Yabou][04][BDRIP][1920x1080][x264_AAC][7620E503].mp4", 4)]
 
-        // [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", 317)] // triple digit episode number
+        [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", 317)] // triple digit episode number
+        [InlineData("Season 2/Hunter X Hunter - 101.mkv", 101)] // triple digit episode number without brackets
+        [InlineData("Season 1/Show Name - 1234 [720p].mkv", 1234)] // four digit episode number with quality tag
         // TODO: [InlineData("Season 2/16 12 Some Title.avi", 16)]
         // TODO: [InlineData("Season 4/Uchuu.Senkan.Yamato.2199.E03.avi", 3)]
         // TODO: [InlineData("Season 2/7 12 Angry Men.avi", 7)]

--- a/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData(2, "The Simpsons/The Simpsons - 02.avi")]
         [InlineData(2, "The Simpsons/The Simpsons - 02 Ep Name.avi")]
         [InlineData(7, "GJ Club (2013)/GJ Club - 07.mkv")]
-        [InlineData(17, "Case Closed (1996-2007)/Case Closed - 317.mkv")]
+        [InlineData(317, "Case Closed (1996-2007)/Case Closed - 317.mkv")]
         // TODO: [InlineData(2, @"The Simpsons/The Simpsons 5 - 02 - Ep Name.avi")]
         // TODO: [InlineData(2, @"The Simpsons/The Simpsons 5 - 02 Ep Name.avi")]
         // TODO: [InlineData(7, @"Seinfeld/Seinfeld 0807 The Checks.avi")]

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonNumberTests.cs
@@ -52,7 +52,7 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("Season 2009/S2009E23-E24-E26 - The Woman.mp4", 2009)]
         [InlineData("Series/1-12 - The Woman.mp4", 1)]
         [InlineData("Running Man/Running Man S2017E368.mkv", 2017)]
-        [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", 3)]
+        [InlineData("Case Closed (1996-2007)/Case Closed - 317.mkv", null)]
         // TODO: [InlineData(@"Seinfeld/Seinfeld 0807 The Checks.avi", 8)]
         public void GetSeasonNumberFromEpisodeFileTest(string path, int? expected)
         {


### PR DESCRIPTION
The existing regex cascade splits non-prefixed multi-digit episode numbers (e.g. "101") into season + 2-digit episode (S1E01). Files using Name - NNN format (common in anime) without bracket prefixes fell through to this buggy regex.

**Changes**
* Add a new regex that handles this specific schema

**Issues**
Fixes #16406

**Comments**
Technically a behaviour change but IMO it's a bad thing to arbitrarily parse a triple digint inside a folder as a season+episode