### PR TITLE
guard against empty alternate versions in MovieResolver

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -302,7 +302,9 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                     ProductionYear = video.Year,
                     Name = parseName ? video.Name : firstVideo.Name,
                     AdditionalParts = additionalParts,
-                    LocalAlternateVersions = video.AlternateVersions.Select(i => i.Path).ToArray()
+                    LocalAlternateVersions = video.AlternateVersions.Count > 0
+                        ? video.AlternateVersions.Select(i => i.Path).ToArray()
+                        : Array.Empty<string>()
                 };
 
                 SetVideoType(videoItem, firstVideo);


### PR DESCRIPTION
When a video has no alternate versions, video.AlternateVersions.Select(...).ToArray() still allocates an unnecessary array. This adds a simple count check and returns Array.Empty<string>() instead, which is consistent with how other arrays are handled in the codebase (AdditionalParts etc).

Small thing I noticed while looking at the resolver code.