### PR TITLE
Fix BoxSet parentId being ignored in item queries

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -11,6 +11,7 @@ using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Dto;
@@ -270,14 +271,16 @@ public class ItemsController : BaseJellyfinApiController
         var dtoOptions = new DtoOptions { Fields = fields }
             .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
 
-        if (includeItemTypes.Length == 1
-            && includeItemTypes[0] == BaseItemKind.BoxSet)
-        {
-            parentId = null;
-        }
-
         var item = _libraryManager.GetParentItem(parentId, userId);
         QueryResult<BaseItem> result;
+
+        if (includeItemTypes.Length == 1
+            && includeItemTypes[0] == BaseItemKind.BoxSet
+            && item is not BoxSet)
+        {
+            parentId = null;
+            item = _libraryManager.GetUserRootFolder();
+        }
 
         if (item is not Folder folder)
         {


### PR DESCRIPTION

**Changes**
Check what parentId resolves to. If it's a BoxSet, keep it so the query scopes correctly to that collection. Otherwise, null it and reset to root, preserving the existing behavior.

**Issues**
Fixes: #16454
