### PR TITLE
add transcode bitrate limit

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -160,6 +160,7 @@
  - [ThreeFive-O](https://github.com/ThreeFive-O)
  - [tjwalkr3](https://github.com/tjwalkr3)
  - [TrisMcC](https://github.com/TrisMcC)
+ - [Truman Miller](https://github.com/trumanmiller)
  - [trumblejoe](https://github.com/trumblejoe)
  - [TtheCreator](https://github.com/TtheCreator)
  - [twinkybot](https://github.com/twinkybot)

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -12,6 +12,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Configuration;
@@ -245,6 +246,7 @@ public class MediaInfoHelper
         }
 
         options.MaxBitrate = GetMaxBitrate(maxBitrate, user, ipAddress);
+        options.VideoTranscodeBitrateLimit = _serverConfigurationManager.GetEncodingOptions().TranscodeBitrateLimit;
 
         if (!options.ForceDirectStream)
         {

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -43,6 +43,7 @@ public class EncodingOptions
         VppTonemappingContrast = 1;
         H264Crf = 23;
         H265Crf = 28;
+        TranscodeBitrateLimit = 0;
         EncoderPreset = EncoderPreset.auto;
         DeinterlaceDoubleRate = false;
         DeinterlaceMethod = DeinterlaceMethod.yadif;
@@ -214,6 +215,11 @@ public class EncodingOptions
     /// Gets or sets the H265 CRF.
     /// </summary>
     public int H265Crf { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Transcode bitrate limit.
+    /// </summary>
+    public int TranscodeBitrateLimit { get; set; }
 
     /// <summary>
     /// Gets or sets the encoder preset.

--- a/MediaBrowser.Model/Dlna/MediaOptions.cs
+++ b/MediaBrowser.Model/Dlna/MediaOptions.cs
@@ -91,6 +91,11 @@ namespace MediaBrowser.Model.Dlna
         public int? MaxBitrate { get; set; }
 
         /// <summary>
+        /// Gets or sets the bitrate limit applied to intensive transcodes.
+        /// </summary>
+        public int? VideoTranscodeBitrateLimit { get; set; }
+
+        /// <summary>
         /// Gets or sets the context.
         /// </summary>
         /// <value>The context.</value>

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -837,6 +837,22 @@ namespace MediaBrowser.Model.Dlna
             return playlistItem;
         }
 
+        private static int? GetVideoTranscodeBitrateLimit(MediaOptions options, StreamInfo playlistItem)
+        {
+            var maxBitrate = options.GetMaxBitrate(false);
+            var transcodeBitrateLimit = options.VideoTranscodeBitrateLimit;
+            if (!maxBitrate.HasValue
+                || !transcodeBitrateLimit.HasValue
+                || transcodeBitrateLimit <= 0
+                || maxBitrate.Value <= transcodeBitrateLimit.Value
+                || (playlistItem.TranscodeReasons & (VideoReasons | TranscodeReason.ContainerBitrateExceedsLimit)) == 0)
+            {
+                return maxBitrate;
+            }
+
+            return transcodeBitrateLimit.Value;
+        }
+
         private (TranscodingProfile? Profile, PlayMethod? PlayMethod) GetVideoTranscodeProfile(
             MediaSourceInfo item,
             MediaOptions options,
@@ -1118,7 +1134,7 @@ namespace MediaBrowser.Model.Dlna
                 }
             }
 
-            var maxBitrateSetting = options.GetMaxBitrate(false);
+            var maxBitrateSetting = GetVideoTranscodeBitrateLimit(options, playlistItem);
             // Honor max rate
             if (maxBitrateSetting.HasValue)
             {

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -729,5 +729,18 @@ namespace Jellyfin.Model.Tests
 
             Assert.Equal(expectedMethod, result.Method);
         }
+
+        [Theory]
+        [InlineData("Firefox", "mp4-hevc-aac-srt-15200k", TranscodeReason.VideoCodecNotSupported, "Transcode", "HLS.mp4")]
+        public async Task BuildVideoItemWithVideoTranscodeBitrateLimit(string deviceName, string mediaSource, TranscodeReason why, string transcodeMode, string transcodeProtocol)
+        {
+            var cappedOptions = await GetMediaOptions(deviceName, mediaSource);
+            cappedOptions.MaxBitrate = 20_000_000;
+            cappedOptions.VideoTranscodeBitrateLimit = 5_000_000;
+
+            var cappedStreamInfo = BuildVideoItemSimpleTest(cappedOptions, PlayMethod.Transcode, why, transcodeMode, transcodeProtocol);
+
+            Assert.True(cappedStreamInfo?.VideoBitrate <= cappedOptions.VideoTranscodeBitrateLimit);
+        }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

add logic to rerun video stream calculations with a lower MaxBitrate if the reason for transcode would require intensive transcoding and bitrate is over TranscodeBitrateLimit

playback info with limit set to 5mbps

interlaced video, limit is applied:
<img width="414" height="617" alt="image" src="https://github.com/user-attachments/assets/becb5e30-1c9d-4803-888e-efff6525a27b" />

direct play, bitrate limit is not applied:
<img width="338" height="311" alt="image" src="https://github.com/user-attachments/assets/f3ffcc23-ea49-4873-987c-8c1e5bc86bc9" />


jellyfin-web PR: https://github.com/jellyfin/jellyfin-web/pull/7775

**Feature Requests**

adds feature requested by:
https://features.jellyfin.org/posts/2596/separate-bitrate-limit-for-direct-stream-and-transcoding
https://features.jellyfin.org/posts/3763/server-side-maximum-resolution-cap-for-transcoded-video