### PR TITLE
Reverse check for track changed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -960,7 +960,7 @@ namespace Emby.Server.Implementations.Session
             }
 
             var tracksChanged = UpdatePlaybackSettings(user, info, data);
-            if (!tracksChanged)
+            if (tracksChanged)
             {
                 changed = true;
             }


### PR DESCRIPTION
To fix part of https://github.com/jellyfin/jellyfin/issues/10829
Logic seems to be backwards, causing saves when nothing has changed and vice versa.

Looks like just a typo maybe? Was introduced in a huge update here: https://github.com/jellyfin/jellyfin/commit/48facb797ed912e4ea6b04b17d1ff190ac2daac4#diff-17e6beecf2da4480d320b11358433dae9e681b15e72ce159aa121cb270762116
so it's hard to tell what actually happened