### PR TITLE
Fix auto-discovery returning loopback address when PublishedServerUrl is set

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
  - [AThomsen](https://github.com/AThomsen)
  - [barongreenback](https://github.com/BaronGreenback)
  - [barronpm](https://github.com/barronpm)
+ - [baykatre](https://github.com/baykatre)
  - [bilde2910](https://github.com/bilde2910)
  - [bfayers](https://github.com/bfayers)
  - [BnMcG](https://github.com/BnMcG)

--- a/src/Jellyfin.Networking/AutoDiscoveryHost.cs
+++ b/src/Jellyfin.Networking/AutoDiscoveryHost.cs
@@ -97,7 +97,11 @@ public sealed class AutoDiscoveryHost : BackgroundService
 
     private async Task RespondToV2Message(IPEndPoint endpoint, UdpClient broadCastUdpClient, CancellationToken cancellationToken)
     {
-        var localUrl = _appHost.GetSmartApiUrl(endpoint.Address);
+        var smartUrl = _appHost.GetSmartApiUrl(endpoint.Address);
+        var localUrl = IsLoopbackUrl(smartUrl)
+            ? _appHost.GetLocalApiUrl(_networkManager.GetBindAddress(endpoint.Address, out _, skipOverrides: true))
+            : smartUrl;
+
         if (string.IsNullOrEmpty(localUrl))
         {
             _logger.LogWarning("Unable to respond to server discovery request because the local ip address could not be determined");
@@ -117,4 +121,9 @@ public sealed class AutoDiscoveryHost : BackgroundService
             _logger.LogError(ex, "Error sending response message");
         }
     }
+
+    private static bool IsLoopbackUrl(string? url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+           && IPAddress.TryParse(uri.Host, out var ip)
+           && IPAddress.IsLoopback(ip);
 }


### PR DESCRIPTION
I was running into this issue on my own setup — my Jellyfin server sits behind a reverse proxy and binds to localhost, so `PublishedServerUrl` was set to `http://localhost:8096`. When I tried discovering the server from my TV on the same LAN, the discovery response came back with `localhost`, which obviously doesn't work from another device.

Dug into it and found that `RespondToV2Message` calls `GetSmartApiUrl`, which returns `PublishedServerUrl` as-is when it's set — no check for whether it actually makes sense for LAN discovery. Same root cause as #15898, where cross-subnet discovery returns `::1`.

The fix is simple: after getting the result from `GetSmartApiUrl`, check if it's a loopback address. If it is, resolve the real interface IP with `GetBindAddress(skipOverrides: true)` and build the URL with `GetLocalApiUrl`. If it's not loopback (custom domain, specific IP, whatever), leave it alone.

To reproduce:
1. Set `PublishedServerUrl` to `http://localhost:8096`
2. From another machine: `echo "who is JellyfinServer?" | socat - udp-datagram:255.255.255.255:7359,broadcast`
3. You'll get `localhost` back — can't connect

After the fix, you get the actual IP.

Addresses #15898
Addresses #11564