### PR TITLE
better primary selection when merging versions with same resolution

### DIFF
--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -211,6 +211,8 @@ public class VideosController : BaseJellyfinApiController
                     return 0;
                 })
                 .ThenByDescending(i => i.GetDefaultVideoStream()?.Width ?? 0)
+                .ThenByDescending(i => i.GetDefaultVideoStream()?.BitRate ?? 0)
+                .ThenByDescending(i => GetSourceQualityScore(i.Path))
                 .First();
         }
 
@@ -654,5 +656,38 @@ public class VideosController : BaseJellyfinApiController
             context,
             streamOptions,
             enableAudioVbrEncoding);
+    }
+
+    /// <summary>
+    /// Gets a quality score from the file path based on source type keywords.
+    /// Higher score = higher quality source.
+    /// </summary>
+    private static int GetSourceQualityScore(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return 0;
+        }
+
+        var filename = System.IO.Path.GetFileNameWithoutExtension(path.AsSpan());
+
+        if (filename.Contains("remux", StringComparison.OrdinalIgnoreCase))
+        {
+            return 3;
+        }
+
+        if (filename.Contains("bluray", StringComparison.OrdinalIgnoreCase)
+            || filename.Contains("blu-ray", StringComparison.OrdinalIgnoreCase))
+        {
+            return 2;
+        }
+
+        if (filename.Contains("web-dl", StringComparison.OrdinalIgnoreCase)
+            || filename.Contains("webdl", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
When you merge versions and multiple files have the same width (like two 1080p encodes), the current code just picks whatever comes first basically. Theres no tiebreaker after the width check.

This adds bitrate as a secondary sort, and then a basic quality score from the filename as last resort - remux > bluray > web-dl. Not the most elegant thing ever but it works for the common case where you have a remux and a web-dl at the same resolution and you want the remux as primary.

I know parsing filenames is fragile, happy to hear if theres a better approach. The bitrate tiebreak alone should handle most cases anyway since remuxes have higher bitrate.