### PR TITLE
Fix Null was not checked before using the H264 profile

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -6375,17 +6375,15 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 // Block unsupported H.264 Hi422P and Hi444PP profiles, which can be encoded with 4:2:0 pixel format
-                if (string.Equals(videoStream.Codec, "h264", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(videoStream.Codec, "h264", StringComparison.OrdinalIgnoreCase)
+                    && ((videoStream.Profile?.Contains("4:2:2", StringComparison.OrdinalIgnoreCase) ?? false)
+                        || (videoStream.Profile?.Contains("4:4:4", StringComparison.OrdinalIgnoreCase) ?? false)))
                 {
-                    if (videoStream.Profile.Contains("4:2:2", StringComparison.OrdinalIgnoreCase)
-                        || videoStream.Profile.Contains("4:4:4", StringComparison.OrdinalIgnoreCase))
+                    // VideoToolbox on Apple Silicon has H.264 Hi444PP and theoretically also has Hi422P
+                    if (!(hardwareAccelerationType == HardwareAccelerationType.videotoolbox
+                          && RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64)))
                     {
-                        // VideoToolbox on Apple Silicon has H.264 Hi444PP and theoretically also has Hi422P
-                        if (!(hardwareAccelerationType == HardwareAccelerationType.videotoolbox
-                              && RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64)))
-                        {
-                            return null;
-                        }
+                        return null;
                     }
                 }
 


### PR DESCRIPTION
This is rare, but not impossible.

**Changes**
- Fix Null was not checked before using the H264 profile

**Issues**
- Fixes #16510
