### PR TITLE
Fix subtitle saving

### DIFF
--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -239,8 +239,7 @@ namespace MediaBrowser.Providers.Subtitles
 
         private async Task TrySaveToFiles(Stream stream, List<string> savePaths, Video video, string extension)
         {
-            if (!_allowedSubtitleFormats.Contains("." + extension, StringComparison.OrdinalIgnoreCase)
-                    && !_allowedSubtitleFormats.Contains(extension, StringComparison.OrdinalIgnoreCase))
+            if (!_allowedSubtitleFormats.Contains(extension, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"Invalid subtitle format: {extension}");
             }


### PR DESCRIPTION
**Changes**
https://github.com/jellyfin/jellyfin/commit/d3907afde7ea0abdf0d3e291b0bd572653bae7ac broke subtitle saving, see issue https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/201

`_allowedSubtitleFormats` contains formats without the `.`, so `"." + extension` will always return false
<img width="1276" height="443" alt="image" src="https://github.com/user-attachments/assets/ab8606fb-4a23-4899-8e4a-20d43248d733" />




**Issues**
Fixes: https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/201
Fixes: #16544
Fixes: https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/202
