### PR TITLE
Handle folders without associated library in FixLibrarySubtitleDownloadLanguages

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/FixLibrarySubtitleDownloadLanguages.cs
+++ b/Jellyfin.Server/Migrations/Routines/FixLibrarySubtitleDownloadLanguages.cs
@@ -7,7 +7,6 @@ using Jellyfin.Server.ServerSetupApp;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Globalization;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Server.Migrations.Routines;
@@ -50,7 +49,7 @@ internal class FixLibrarySubtitleDownloadLanguages : IAsyncMigrationRoutine
         foreach (var virtualFolder in virtualFolders)
         {
             var options = virtualFolder.LibraryOptions;
-            if (options.SubtitleDownloadLanguages is null || options.SubtitleDownloadLanguages.Length == 0)
+            if (options?.SubtitleDownloadLanguages is null || options.SubtitleDownloadLanguages.Length == 0)
             {
                 continue;
             }


### PR DESCRIPTION
`GetVirtualFolders` returns a `VirtualFolderInfo` for every directory in the library views path, but `LibraryOptions` is only populated when there's a matching library folder in the database. If a directory exists without a corresponding database entry (orphaned folder), `LibraryOptions` is null, and accessing `.SubtitleDownloadLanguages` on it throws.

**Issues**
Fixes #16531