### PR TITLE
Fix NRE in FixLibrarySubtitleDownloadLanguages migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/FixLibrarySubtitleDownloadLanguages.cs
+++ b/Jellyfin.Server/Migrations/Routines/FixLibrarySubtitleDownloadLanguages.cs
@@ -49,6 +49,11 @@ internal class FixLibrarySubtitleDownloadLanguages : IAsyncMigrationRoutine
 
         foreach (var virtualFolder in virtualFolders)
         {
+            if (virtualFolder is null || virtualFolder.LibraryOptions is null)
+            {
+                continue;
+            }
+
             var options = virtualFolder.LibraryOptions;
             if (options.SubtitleDownloadLanguages is null || options.SubtitleDownloadLanguages.Length == 0)
             {


### PR DESCRIPTION
**Changes**
Couldn't reproduce but added null checks where possible

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/16531

Used vscode autocompelte thing