### PR TITLE
Fix parental ratings not working on music albums

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicArtist.cs
@@ -154,11 +154,6 @@ namespace MediaBrowser.Controller.Entities.Audio
             return "Artist-" + (Name ?? string.Empty).RemoveDiacritics();
         }
 
-        protected override bool GetBlockUnratedValue(User user)
-        {
-            return user.GetPreferenceValues<UnratedItem>(PreferenceKind.BlockUnratedItems).Contains(UnratedItem.Music);
-        }
-
         public override UnratedItem GetBlockUnratedType()
         {
             return UnratedItem.Music;


### PR DESCRIPTION
When a user has a music library organized by artist folders (see below), a `MusicArtist` entry is created for each artist folder with the `isFolder` flag set to true. We normally [don't block folder containers](https://github.com/jellyfin/jellyfin/blob/9e489cd41fb7ca55855d5ce84316c5b966bcc4a7/MediaBrowser.Controller/Entities/BaseItem.cs#L1710) so the media within is what determines what gets blocked. However, `MusicArtist` has an unnecessary `GetBlockUnratedValue` override that skips this check. So when a user tries to browse a music album with the correct parental rating set and block unrated items enabled, they are blocked because the parent `MusicArtist` folder is unrated.
```
Music
├── Some Artist\
│   ├── Album A\
│       ├── Song 1.flac
│       ├── Song 2.flac
│       └── Song 3.flac
```


**Changes**
Remove the unnecessary override. 

**Issues**
Fixes: #15952
