### PR TITLE
Fix language display for ISO 639-2-only codes (e.g. mul, und, mis, zxx)

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -138,7 +138,7 @@ namespace Emby.Server.Implementations.Localization
                     string twoCharName = parts[2];
                     if (string.IsNullOrWhiteSpace(twoCharName))
                     {
-                        continue;
+                        twoCharName = string.Empty;
                     }
                     else if (twoCharName.Contains('-', StringComparison.OrdinalIgnoreCase))
                     {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -729,6 +729,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.Type = MediaStreamType.Audio;
                 stream.LocalizedDefault = _localization.GetLocalizedString("Default");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
+                stream.LocalizedLanguage = !string.IsNullOrEmpty(stream.Language)
+                    ? _localization.FindLanguageInfo(stream.Language)?.DisplayName
+                    : null;
 
                 stream.Channels = streamInfo.Channels;
 
@@ -767,6 +770,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedForced = _localization.GetLocalizedString("Forced");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
                 stream.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
+                stream.LocalizedLanguage = !string.IsNullOrEmpty(stream.Language)
+                    ? _localization.FindLanguageInfo(stream.Language)?.DisplayName
+                    : null;
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -729,9 +729,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.Type = MediaStreamType.Audio;
                 stream.LocalizedDefault = _localization.GetLocalizedString("Default");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
-                stream.LocalizedLanguage = !string.IsNullOrEmpty(stream.Language)
-                    ? _localization.FindLanguageInfo(stream.Language)?.DisplayName
-                    : null;
+                stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
+                    ? null
+                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName;
 
                 stream.Channels = streamInfo.Channels;
 
@@ -770,9 +770,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedForced = _localization.GetLocalizedString("Forced");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
                 stream.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
-                stream.LocalizedLanguage = !string.IsNullOrEmpty(stream.Language)
-                    ? _localization.FindLanguageInfo(stream.Language)?.DisplayName
-                    : null;
+                stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
+                    ? null
+                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName;
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -41,7 +41,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             await localizationManager.LoadAll();
             var cultures = localizationManager.GetCultures().ToList();
 
-            Assert.Equal(194, cultures.Count);
+            Assert.Equal(496, cultures.Count);
 
             var germany = cultures.FirstOrDefault(x => x.TwoLetterISOLanguageName.Equals("de", StringComparison.Ordinal));
             Assert.NotNull(germany);
@@ -97,6 +97,25 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             Assert.Equal("German", germany.Name);
             Assert.Contains("deu", germany.ThreeLetterISOLanguageNames);
             Assert.Contains("ger", germany.ThreeLetterISOLanguageNames);
+        }
+
+        [Theory]
+        [InlineData("mul", "Multiple languages")]
+        [InlineData("und", "Undetermined")]
+        [InlineData("mis", "Uncoded languages")]
+        [InlineData("zxx", "No linguistic content; Not applicable")]
+        public async Task FindLanguageInfo_ISO6392Only_Success(string code, string expectedDisplayName)
+        {
+            var localizationManager = Setup(new ServerConfiguration
+            {
+                UICulture = "en-US"
+            });
+            await localizationManager.LoadAll();
+
+            var culture = localizationManager.FindLanguageInfo(code);
+            Assert.NotNull(culture);
+            Assert.Equal(expectedDisplayName, culture.DisplayName);
+            Assert.Equal(code, culture.ThreeLetterISOLanguageName);
         }
 
         [Fact]


### PR DESCRIPTION
I had a multi-language subtitle file (combined English/Japanese) that I tagged as `mul` — which is the correct ISO 639-2 code for "Multiple languages". When I uploaded it to Jellyfin it showed up as `mul - Undefined - SUBRIP - External` which (while not terrible) was less than ideal.

While investigating something unrelated earlier, Claude pointed out that y'all have a `iso6392.txt` file that explicitly includes `mul` so  I was confused why it wasn't showing up in the UI.

## What's going on

The problem is in `LoadCultures()`: it skips any entry from `iso6392.txt` that doesn't have a two-letter ISO 639-1 code. That drops 302 of the 496 entries, including `mul`, `und`, `mis`, `zxx`, and a bunch of real languages like Achinese, Akkadian, Aleut, etc. So even though `mul|||Multiple languages|multilingue` is right there in the data file, `FindLanguageInfo("mul")` returns null.

That breaks a couple things downstream:
- `ExternalPathParser` can't recognize `mul` as a language, so a file like `Movie.mul.srt` ends up with `Language = null` and `Title = "mul"` instead of `Language = "mul"`
- `DisplayTitle` falls back to the raw code or "Undefined"

I originally created and tested my fix off the `v10.11.7` tag. When rebasing onto master I noticed #15947 had independently solved the same `DisplayTitle` problem — it added the `LocalizedLanguage` property to `MediaStream`, replaced the inline `CultureInfo` lookups, and wired it up in `MediaStreamRepository`. So those parts of my original fix were already covered. But it didn't fix `LoadCultures()` dropping ISO 639-2-only entries (which is the root cause), and it missed the `ProbeResultNormalizer` path — so ffprobe-detected streams still wouldn't get `LocalizedLanguage` set.

## Changes

- `LoadCultures()`: use empty string for `TwoLetterISOLanguageName` instead of `continue`-ing past entries that lack one
- `ProbeResultNormalizer`: set `LocalizedLanguage` for audio and subtitle streams, same as `MediaStreamRepository` already does
- Update tests and add one for the new behavior

**Before:** `mul - Undefined - SUBRIP - External`  
**After:** `Multiple languages - SUBRIP - External`

## LLM/AI Use

Per [Jellyfin's AI Use Policy](https://jellyfin.org/docs/general/contributing/llm-policies), I
- wrote the entire PR description myself. 
- used Claude Opus 4.6 for the initial investigation, but I attest that I understand the code and am able to address any feedback myself.
- tested this PR based off master locally
  - deployed a version of this fix off `v10.11.7` to my personal Jellyfin server that all my friends use - working great so far.