### PR TITLE
Use FFmpeg bluray: protocol for Blu-ray disc playback

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1231,7 +1231,21 @@ namespace MediaBrowser.Controller.MediaEncoding
                 arg.Append(canvasArgs);
             }
 
-            if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
+            if (state.MediaSource.VideoType == VideoType.BluRay)
+            {
+                var (discRoot, playlistNumber) = ParseBlurayPath(state.MediaPath);
+
+                if (playlistNumber.HasValue)
+                {
+                    arg.Append(" -playlist ")
+                        .Append(playlistNumber.Value);
+                }
+
+                arg.Append(" -i bluray:\"")
+                    .Append(discRoot.Replace("\"", "\\\"", StringComparison.Ordinal))
+                    .Append("\" ");
+            }
+            else if (state.MediaSource.VideoType == VideoType.Dvd)
             {
                 var concatFilePath = Path.Join(_configurationManager.CommonApplicationPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
                 if (!File.Exists(concatFilePath))
@@ -1382,6 +1396,42 @@ namespace MediaBrowser.Controller.MediaEncoding
             return rangeType is VideoRangeType.HDR10Plus
                        or VideoRangeType.DOVIWithHDR10Plus
                        or VideoRangeType.DOVIWithELHDR10Plus;
+        }
+
+        /// <summary>
+        /// Parses a Blu-ray path into the disc root directory and an optional playlist number.
+        /// Handles BDMV directories, disc root directories, and .mpls playlist file paths.
+        /// </summary>
+        /// <param name="path">A path to a disc root, BDMV directory, or .mpls file.</param>
+        /// <returns>The disc root directory and an optional playlist number.</returns>
+        public static (string DiscRoot, int? PlaylistNumber) ParseBlurayPath(string path)
+        {
+            if (path.EndsWith(".mpls", StringComparison.OrdinalIgnoreCase))
+            {
+                var fileName = Path.GetFileNameWithoutExtension(path);
+                int? playlistNumber = int.TryParse(fileName, NumberStyles.None, CultureInfo.InvariantCulture, out var num) ? num : null;
+
+                var playlistDir = Path.GetDirectoryName(path);
+                var bdmvDir = playlistDir is not null ? Path.GetDirectoryName(playlistDir) : null;
+                var discRoot = bdmvDir is not null ? Path.GetDirectoryName(bdmvDir) : null;
+
+                if (discRoot is not null)
+                {
+                    return (discRoot, playlistNumber);
+                }
+            }
+
+            var trimmedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (trimmedPath.EndsWith("BDMV", StringComparison.OrdinalIgnoreCase))
+            {
+                var discRoot = Path.GetDirectoryName(trimmedPath);
+                if (discRoot is not null)
+                {
+                    return (discRoot, null);
+                }
+            }
+
+            return (path, null);
         }
 
         /// <summary>

--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
@@ -33,6 +33,17 @@ public class BdInfoExaminer : IBlurayExaminer
     /// <returns>BlurayDiscInfo.</returns>
     public BlurayDiscInfo GetDiscInfo(string path)
     {
+        return GetDiscInfoInternal(path, null);
+    }
+
+    /// <inheritdoc />
+    public BlurayDiscInfo GetDiscInfo(string path, string playlistName)
+    {
+        return GetDiscInfoInternal(path, playlistName);
+    }
+
+    private BlurayDiscInfo GetDiscInfoInternal(string path, string? playlistName)
+    {
         if (string.IsNullOrWhiteSpace(path))
         {
             throw new ArgumentNullException(nameof(path));
@@ -42,8 +53,18 @@ public class BdInfoExaminer : IBlurayExaminer
 
         bdrom.Scan();
 
-        // Get the longest playlist
-        var playlist = bdrom.PlaylistFiles.Values.OrderByDescending(p => p.TotalLength).FirstOrDefault(p => p.IsValid);
+        TSPlaylistFile? playlist;
+        if (playlistName is not null)
+        {
+            // Look up the specific playlist by name
+            playlist = bdrom.PlaylistFiles.Values.FirstOrDefault(
+                p => p.IsValid && string.Equals(p.Name, playlistName, StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            // Get the longest playlist
+            playlist = bdrom.PlaylistFiles.Values.OrderByDescending(p => p.TotalLength).FirstOrDefault(p => p.IsValid);
+        }
 
         var outputStream = new BlurayDiscInfo
         {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -464,6 +464,15 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 extraArgs += " -rtsp_transport tcp+udp -rtsp_flags prefer_tcp";
             }
 
+            if (request.MediaSource.VideoType == VideoType.BluRay)
+            {
+                var (_, playlistNumber) = EncodingHelper.ParseBlurayPath(request.MediaSource.Path);
+                if (playlistNumber.HasValue)
+                {
+                    extraArgs += " -playlist " + playlistNumber.Value;
+                }
+            }
+
             return extraArgs;
         }
 
@@ -476,13 +485,41 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public string GetInputArgument(string inputFile, MediaSourceInfo mediaSource)
         {
-            var prefix = "file";
             if (mediaSource.IsoType == IsoType.BluRay)
             {
-                prefix = "bluray";
+                // ISOs are always handled via the bluray protocol directly
+                return EncodingUtils.GetInputArgument("bluray", new[] { inputFile }, mediaSource.Protocol);
             }
 
-            return EncodingUtils.GetInputArgument(prefix, new[] { inputFile }, mediaSource.Protocol);
+            if (mediaSource.VideoType == VideoType.BluRay && IsBlurayPath(inputFile))
+            {
+                var (discRoot, _) = EncodingHelper.ParseBlurayPath(inputFile);
+                return EncodingUtils.GetInputArgument("bluray", new[] { discRoot }, mediaSource.Protocol);
+            }
+
+            return EncodingUtils.GetInputArgument("file", new[] { inputFile }, mediaSource.Protocol);
+        }
+
+        /// <summary>
+        /// Checks whether the given path points to a Blu-ray disc structure
+        /// rather than a sidecar file (concat, mks, etc.).
+        /// </summary>
+        private static bool IsBlurayPath(string path)
+        {
+            if (path.EndsWith(".mpls", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (path.EndsWith("BDMV", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith("BDMV/", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith("BDMV\\", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Check if this looks like a disc root (has a BDMV subdirectory)
+            return Directory.Exists(Path.Combine(path, "BDMV"));
         }
 
         /// <inheritdoc />
@@ -625,11 +662,21 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             var inputArgument = GetInputPathArgument(inputFile, mediaSource);
 
+            var extraInputArgs = string.Empty;
+            if (mediaSource.VideoType == VideoType.BluRay)
+            {
+                var (_, playlistNumber) = EncodingHelper.ParseBlurayPath(inputFile);
+                if (playlistNumber.HasValue)
+                {
+                    extraInputArgs = "-playlist " + playlistNumber.Value + " ";
+                }
+            }
+
             if (!isAudio)
             {
                 try
                 {
-                    return await ExtractImageInternal(inputArgument, container, videoStream, imageStreamIndex, threedFormat, offset, true, targetFormat, false, cancellationToken).ConfigureAwait(false);
+                    return await ExtractImageInternal(extraInputArgs, inputArgument, container, videoStream, imageStreamIndex, threedFormat, offset, true, targetFormat, false, cancellationToken).ConfigureAwait(false);
                 }
                 catch (ArgumentException)
                 {
@@ -641,7 +688,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
-            return await ExtractImageInternal(inputArgument, container, videoStream, imageStreamIndex, threedFormat, offset, false, targetFormat, isAudio, cancellationToken).ConfigureAwait(false);
+            return await ExtractImageInternal(extraInputArgs, inputArgument, container, videoStream, imageStreamIndex, threedFormat, offset, false, targetFormat, isAudio, cancellationToken).ConfigureAwait(false);
         }
 
         private string GetImageResolutionParameter()
@@ -668,6 +715,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         private async Task<string> ExtractImageInternal(
+            string extraInputArgs,
             string inputPath,
             string container,
             MediaStream videoStream,
@@ -745,7 +793,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var mapArg = imageStreamIndex.HasValue ? (" -map 0:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
             var args = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i {0}{1} -threads {2} -v quiet -vframes 1 -vf {3}{4}{5} -f image2 \"{6}\"",
+                "{0}-i {1}{2} -threads {3} -v quiet -vframes 1 -vf {4}{5}{6} -f image2 \"{7}\"",
+                extraInputArgs,
                 inputPath,
                 mapArg,
                 _threads,
@@ -1277,7 +1326,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return mediaSource.VideoType switch
             {
                 VideoType.Dvd => GetInputArgument(GetPrimaryPlaylistVobFiles(path, null), mediaSource),
-                VideoType.BluRay => GetInputArgument(GetPrimaryPlaylistM2tsFiles(path), mediaSource),
+                VideoType.BluRay => GetInputArgument(path, mediaSource),
                 _ => GetInputArgument(path, mediaSource)
             };
         }

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -619,9 +619,21 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
             var outputPaths = new List<string>();
+
+            var extraInputArgs = string.Empty;
+            if (mediaSource.VideoType == VideoType.BluRay)
+            {
+                var (_, playlistNumber) = EncodingHelper.ParseBlurayPath(mediaSource.Path);
+                if (playlistNumber.HasValue)
+                {
+                    extraInputArgs = "-playlist " + playlistNumber.Value + " ";
+                }
+            }
+
             var args = string.Format(
                 CultureInfo.InvariantCulture,
-                "-i {0}",
+                "{0}-i {1}",
+                extraInputArgs,
                 inputPath);
 
             foreach (var subtitleStream in subtitleStreams)

--- a/MediaBrowser.Model/MediaInfo/IBlurayExaminer.cs
+++ b/MediaBrowser.Model/MediaInfo/IBlurayExaminer.cs
@@ -11,4 +11,13 @@ public interface IBlurayExaminer
     /// <param name="path">The path.</param>
     /// <returns>BlurayDiscInfo.</returns>
     BlurayDiscInfo GetDiscInfo(string path);
+
+    /// <summary>
+    /// Gets the disc info for a specific playlist.
+    /// </summary>
+    /// <param name="path">The disc root path.</param>
+    /// <param name="playlistName">The playlist filename (e.g. "00202.mpls").</param>
+    /// <returns>BlurayDiscInfo.</returns>
+    BlurayDiscInfo GetDiscInfo(string path, string playlistName)
+        => GetDiscInfo(path);
 }

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -124,23 +125,17 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
                 else if (item.VideoType == VideoType.BluRay)
                 {
-                    // Get BD disc information
-                    blurayDiscInfo = GetBDInfo(item.Path);
+                    // Use bluray: protocol via ffprobe — libbluray handles playlist
+                    // selection and stream demuxing natively
+                    mediaInfoResult = await GetMediaInfo(item, cancellationToken).ConfigureAwait(false);
 
-                    // Return if no playable .m2ts files are found
-                    if (blurayDiscInfo is null || blurayDiscInfo.Files.Length == 0)
-                    {
-                        _logger.LogError("No playable .m2ts files found in Blu-ray structure, skipping FFprobe.");
-                        return ItemUpdateType.MetadataImport;
-                    }
-
-                    // Fetch metadata of first .m2ts file
-                    mediaInfoResult = await GetMediaInfo(
-                        new Video
-                        {
-                            Path = blurayDiscInfo.Files[0]
-                        },
-                        cancellationToken).ConfigureAwait(false);
+                    // BDInfo is still needed for chapter marks, which libbluray
+                    // does not expose through ffprobe.
+                    var (discRoot, _) = EncodingHelper.ParseBlurayPath(item.Path);
+                    var playlistName = item.Path.EndsWith(".mpls", StringComparison.OrdinalIgnoreCase)
+                        ? Path.GetFileName(item.Path)
+                        : null;
+                    blurayDiscInfo = GetBDInfo(discRoot, playlistName);
                 }
                 else
                 {
@@ -318,28 +313,14 @@ namespace MediaBrowser.Providers.MediaInfo
             }
         }
 
+        /// <summary>
+        /// Extracts chapter information from BDInfo. Stream metadata and runtime
+        /// are handled by ffprobe via the bluray: protocol, so only chapters
+        /// (which libbluray does not expose through ffprobe) are taken from BDInfo.
+        /// </summary>
         private void FetchBdInfo(Video video, ref ChapterInfo[] chapters, List<MediaStream> mediaStreams, BlurayDiscInfo blurayInfo)
         {
-            var ffmpegVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
-            var externalStreams = mediaStreams.Where(s => s.IsExternal).ToList();
-
-            // Fill video properties from the BDInfo result
-            mediaStreams.Clear();
-
-            // Rebuild the list with external streams first
-            int index = 0;
-            foreach (var stream in externalStreams.Concat(blurayInfo.MediaStreams))
-            {
-                stream.Index = index++;
-                mediaStreams.Add(stream);
-            }
-
-            if (blurayInfo.RunTimeTicks.HasValue && blurayInfo.RunTimeTicks.Value > 0)
-            {
-                video.RunTimeTicks = blurayInfo.RunTimeTicks;
-            }
-
-            if (blurayInfo.Chapters is not null)
+            if (blurayInfo.Chapters is not null && blurayInfo.Chapters.Length > 0)
             {
                 double[] brChapter = blurayInfo.Chapters;
                 chapters = new ChapterInfo[brChapter.Length];
@@ -351,36 +332,23 @@ namespace MediaBrowser.Providers.MediaInfo
                     };
                 }
             }
-
-            var blurayVideoStream = mediaStreams.FirstOrDefault(s => s.Type == MediaStreamType.Video);
-
-            // Use the ffprobe values if these are empty
-            if (blurayVideoStream is not null && ffmpegVideoStream is not null)
-            {
-                // Always use ffmpeg's detected codec since that is what the rest of the codebase expects.
-                blurayVideoStream.Codec = ffmpegVideoStream.Codec;
-                blurayVideoStream.BitRate = blurayVideoStream.BitRate.GetValueOrDefault() == 0 ? ffmpegVideoStream.BitRate : blurayVideoStream.BitRate;
-                blurayVideoStream.Width = blurayVideoStream.Width.GetValueOrDefault() == 0 ? ffmpegVideoStream.Width : blurayVideoStream.Width;
-                blurayVideoStream.Height = blurayVideoStream.Height.GetValueOrDefault() == 0 ? ffmpegVideoStream.Height : blurayVideoStream.Height;
-                blurayVideoStream.ColorRange = ffmpegVideoStream.ColorRange;
-                blurayVideoStream.ColorSpace = ffmpegVideoStream.ColorSpace;
-                blurayVideoStream.ColorTransfer = ffmpegVideoStream.ColorTransfer;
-                blurayVideoStream.ColorPrimaries = ffmpegVideoStream.ColorPrimaries;
-            }
         }
 
         /// <summary>
-        /// Gets information about the longest playlist on a bdrom.
+        /// Gets Blu-ray disc info, optionally for a specific playlist.
         /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>VideoStream.</returns>
-        private BlurayDiscInfo? GetBDInfo(string path)
+        /// <param name="path">The disc root path.</param>
+        /// <param name="playlistName">Optional playlist filename (e.g. "00202.mpls"). If null, uses the longest playlist.</param>
+        /// <returns>BlurayDiscInfo.</returns>
+        private BlurayDiscInfo? GetBDInfo(string path, string? playlistName = null)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
 
             try
             {
-                return _blurayExaminer.GetDiscInfo(path);
+                return playlistName is not null
+                    ? _blurayExaminer.GetDiscInfo(path, playlistName)
+                    : _blurayExaminer.GetDiscInfo(path);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
**Changes**

Replace the BDInfo-based approach for Blu-ray playback (which manually picked .m2ts files and built concat lists) with FFmpeg's native `bluray:` protocol. This lets ffmpeg/ffprobe handle playlist selection and stream demuxing via libbluray directly, producing more reliable metadata and playback for BDMV folders and `.mpls` playlist files.

- Add `ParseBlurayPath` to `EncodingHelper` for extracting disc root and playlist number from BDMV paths (`.mpls` files, `BDMV` dirs, disc roots), used by `MediaEncoder`, `SubtitleEncoder`, and `EncodingHelper` itself
- Pass `-playlist` flag to ffmpeg when the media path is an `.mpls` file
- Use `bluray:` input protocol in `MediaEncoder`, `EncodingHelper`, and `SubtitleEncoder`
- Simplify `FetchBdInfo` to only extract chapter marks (libbluray handles streams and runtime via ffprobe)
- Add `IBlurayExaminer.GetDiscInfo(path, playlistName)` overload (with default interface method for ABI compatibility) so BDInfo looks up the specific playlist for chapter marks instead of always using the longest one

## User-facing behavior changes

**BDMV folders** (the existing default): Behavior is largely unchanged for users who add BDMV folders to their libraries the standard way. Jellyfin still auto-selects the main playlist via libbluray (the same library mpv and VLC use), but now delegates stream demuxing to ffmpeg rather than manually selecting `.m2ts` files. This should improve reliability for discs  with complex playlist structures (seamless branching, multi-angle, etc.) and produce more accurate stream metadata (codec details, HDR info, runtime) since ffprobe reads them directly from the transport stream.

**`.mpls` playlist files**: This change adds support for resolving individual `.mpls` files as playable items. When a `.mpls` path is used (e.g., `/disc/BDMV/PLAYLIST/00202.mpls`), Jellyfin extracts the playlist number and passes it to ffmpeg via `-playlist N -i bluray:/disc/root`. This enables plugins to split a single Blu-ray disc into multiple library items (e.g., individual episodes from a TV show disc) by pointing each item at a different `.mpls` file. Chapter marks are looked up per-playlist.

**Planned plugin**: I'm developing a companion plugin
([jellyfin-plugin-thediscdb](https://github.com/u6bkep/jellyfin-plugin-thediscdb)) that uses [TheDiscDb](https://github.com/TheDiscDb/data) to resolve BDMV folders into individual episodes. It computes a content hash  from the disc's `.m2ts` files, looks up the disc in TheDiscDb's database, and creates Episode items pointing to the correct `.mpls` playlist files. This PR provides the server-side foundation that makes that plugin possible.

**Issues**

Addresses Blu-ray disc (BDMV) playback — currently Jellyfin uses BDInfo to find `.m2ts` files and builds concat file lists, which is fragile for multi-clip playlists and misses libbluray features like seamless branching. The `bluray:` protocol delegates all of this to ffmpeg's libbluray integration.