### PR TITLE
Return text subtitles early while extraction continues in background

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -195,7 +195,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
             }
 
-            return AsyncFile.OpenRead(fileInfo.Path);
+            var fileStream = AsyncFile.OpenRead(fileInfo.Path);
+            if (fileInfo.ExtractionTask is not null && !fileInfo.ExtractionTask.IsCompleted)
+            {
+                return new TailingFileStream(fileStream, fileInfo.ExtractionTask);
+            }
+
+            return fileStream;
         }
 
         internal async Task<SubtitleInfo> GetReadableFile(
@@ -977,14 +983,18 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
 
             // For text-based subtitles (SRT, SSA): return as soon as the output file has data on disk.
-            // With -flush_packets 1, ffmpeg writes data within ~1 second. The client gets a valid partial
-            // subtitle file immediately instead of waiting minutes for full extraction to complete.
+            // With -flush_packets 1, ffmpeg writes data within ~1 second. The HTTP response is then
+            // wrapped in a TailingFileStream so it streams progressively as ffmpeg keeps writing,
+            // delivering the full file in a single connection without blocking on extraction.
             // ASS is excluded because SetAssFont rewrites the file after extraction (race condition).
             // PGS is excluded because it's a binary bitmap format that needs the complete file.
-            if (IsEarlyReturnSubtitleFormat(outputFormat)
-                && await TryReturnEarly(mediaSource, outputPath).ConfigureAwait(false))
+            if (IsEarlyReturnSubtitleFormat(outputFormat))
             {
-                return info;
+                var extractionTask = await TryReturnEarly(mediaSource, outputPath).ConfigureAwait(false);
+                if (extractionTask is not null)
+                {
+                    return info with { ExtractionTask = extractionTask };
+                }
             }
 
             // PGS (binary), ASS (needs SetAssFont post-processing), or early-return timed out:
@@ -995,9 +1005,10 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
         /// <summary>
         /// Starts background extraction and waits for the output file to have data.
-        /// Returns true if the file is ready and extraction should continue in the background.
+        /// Returns the still-running extraction task if the file is ready, or null if early return
+        /// was not possible (extraction finished synchronously, or file did not appear in time).
         /// </summary>
-        private async Task<bool> TryReturnEarly(MediaSourceInfo mediaSource, string outputPath)
+        private async Task<Task?> TryReturnEarly(MediaSourceInfo mediaSource, string outputPath)
         {
             // Use CancellationToken.None so extraction continues even if this HTTP request completes
             var extractionTask = ExtractAllExtractableSubtitles(mediaSource, CancellationToken.None);
@@ -1025,12 +1036,12 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     },
                     TaskScheduler.Default);
 
-                return true;
+                return extractionTask;
             }
 
             // Extraction finished first (fast storage) or file data timed out — await for error handling
             await extractionTask.ConfigureAwait(false);
-            return false;
+            return null;
         }
 
         /// <summary>
@@ -1159,6 +1170,121 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             public string Format { get; init; }
 
             public bool IsExternal { get; init; }
+
+            /// <summary>
+            /// Gets the background extraction task when the file is being served while ffmpeg
+            /// is still writing it. When non-null, the file stream should be wrapped in a
+            /// <see cref="TailingFileStream"/> so the HTTP response keeps reading newly written
+            /// bytes until extraction completes, ensuring the client receives the full file
+            /// in a single connection.
+            /// </summary>
+            public Task? ExtractionTask { get; init; }
+        }
+
+        /// <summary>
+        /// A read-only stream that wraps a <see cref="FileStream"/> for a file currently being
+        /// written by ffmpeg. When the inner read returns 0 bytes (consumer caught up to writer),
+        /// it waits briefly and retries until the supplied extraction task has completed, then
+        /// drains any remaining bytes and returns real EOF.
+        /// </summary>
+        internal sealed class TailingFileStream : Stream
+        {
+            private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(50);
+            private static readonly TimeSpan MaxWait = TimeSpan.FromMinutes(5);
+            private readonly FileStream _inner;
+            private readonly Task _extractionTask;
+
+            public TailingFileStream(FileStream inner, Task extractionTask)
+            {
+                _inner = inner;
+                _extractionTask = extractionTask;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => _inner.Length;
+
+            public override long Position
+            {
+                get => _inner.Position;
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var sw = Stopwatch.StartNew();
+                while (true)
+                {
+                    var read = _inner.Read(buffer, offset, count);
+                    if (read > 0)
+                    {
+                        return read;
+                    }
+
+                    if (_extractionTask.IsCompleted)
+                    {
+                        // One last drain in case bytes were written between our read and IsCompleted check
+                        return _inner.Read(buffer, offset, count);
+                    }
+
+                    if (sw.Elapsed > MaxWait)
+                    {
+                        return 0;
+                    }
+
+                    Thread.Sleep(PollInterval);
+                }
+            }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                var sw = Stopwatch.StartNew();
+                while (true)
+                {
+                    var read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (read > 0)
+                    {
+                        return read;
+                    }
+
+                    if (_extractionTask.IsCompleted)
+                    {
+                        return await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    if (sw.Elapsed > MaxWait)
+                    {
+                        return 0;
+                    }
+
+                    await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override void Flush() => _inner.Flush();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -205,11 +205,76 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             if (!subtitleStream.IsExternal || subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
             {
-                await ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
-
                 var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
                 var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
                 var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension);
+
+                // Fast path: subtitle already extracted and cached
+                if (File.Exists(outputPath) && _fileSystem.GetFileInfo(outputPath).Length > 0)
+                {
+                    return new SubtitleInfo()
+                    {
+                        Path = outputPath,
+                        Protocol = MediaProtocol.File,
+                        Format = outputFormat,
+                        IsExternal = false
+                    };
+                }
+
+                // For text-based subtitles (SRT, SSA): return as soon as the output file has data on disk.
+                // With -flush_packets 1, ffmpeg writes data within ~1 second. The client gets a valid partial
+                // subtitle file immediately instead of waiting minutes for full extraction to complete.
+                // ASS is excluded because SetAssFont rewrites the file after extraction (race condition).
+                // PGS is excluded because it's a binary bitmap format that needs the complete file.
+                if (IsEarlyReturnSubtitleFormat(outputFormat))
+                {
+                    // Use CancellationToken.None so extraction continues even if this HTTP request completes
+                    var extractionTask = ExtractAllExtractableSubtitles(mediaSource, CancellationToken.None);
+                    var fileReadyTask = WaitForFileDataAsync(outputPath, TimeSpan.FromSeconds(30));
+
+                    var completedTask = await Task.WhenAny(extractionTask, fileReadyTask).ConfigureAwait(false);
+
+                    if (completedTask == fileReadyTask)
+                    {
+                        var dataReady = await fileReadyTask.ConfigureAwait(false);
+                        if (dataReady)
+                        {
+                            _logger.LogInformation(
+                                "Subtitle file has data, returning early while extraction continues in background: {Path}",
+                                outputPath);
+
+                            // Let extraction finish in background (holds locks, cleans up, extracts remaining streams)
+                            _ = extractionTask.ContinueWith(
+                                t =>
+                                {
+                                    if (t.IsFaulted)
+                                    {
+                                        _logger.LogWarning(
+                                            t.Exception,
+                                            "Background subtitle extraction completed with errors: {Path}",
+                                            outputPath);
+                                    }
+                                },
+                                TaskScheduler.Default);
+
+                            return new SubtitleInfo()
+                            {
+                                Path = outputPath,
+                                Protocol = MediaProtocol.File,
+                                Format = outputFormat,
+                                IsExternal = false
+                            };
+                        }
+                    }
+
+                    // Extraction finished first (fast storage) or file data timed out — await for error handling
+                    await extractionTask.ConfigureAwait(false);
+                }
+                else
+                {
+                    // PGS (binary) and ASS (needs SetAssFont post-processing): wait for full extraction
+                    await ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
+                }
 
                 return new SubtitleInfo()
                 {
@@ -963,6 +1028,49 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines if the subtitle format supports early return (serving a partial file while extraction continues).
+        /// Only text-based formats without post-processing are eligible.
+        /// </summary>
+        private static bool IsEarlyReturnSubtitleFormat(string format)
+        {
+            // SRT: simple text format, self-contained entries, no post-processing needed
+            // SSA: text-based, no post-processing (unlike ASS which requires SetAssFont)
+            return string.Equals(format, "srt", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(format, "ssa", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Polls for a file to exist with non-zero size. Returns true when data is available, false on timeout.
+        /// Used with -flush_packets 1 which causes ffmpeg to write subtitle data to disk within ~1 second.
+        /// </summary>
+        private static async Task<bool> WaitForFileDataAsync(string path, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < timeout)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        var info = new FileInfo(path);
+                        if (info.Length > 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                catch (IOException)
+                {
+                    // File may be in the process of being created, retry
+                }
+
+                await Task.Delay(100).ConfigureAwait(false);
+            }
+
+            return false;
         }
 
         private string GetSubtitleCachePath(MediaSourceInfo mediaSource, int subtitleStreamIndex, string outputSubtitleExtension)

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -205,84 +205,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             if (!subtitleStream.IsExternal || subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
             {
-                var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
-                var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
-                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension);
-
-                // Fast path: subtitle already extracted and cached
-                if (File.Exists(outputPath) && _fileSystem.GetFileInfo(outputPath).Length > 0)
-                {
-                    return new SubtitleInfo()
-                    {
-                        Path = outputPath,
-                        Protocol = MediaProtocol.File,
-                        Format = outputFormat,
-                        IsExternal = false
-                    };
-                }
-
-                // For text-based subtitles (SRT, SSA): return as soon as the output file has data on disk.
-                // With -flush_packets 1, ffmpeg writes data within ~1 second. The client gets a valid partial
-                // subtitle file immediately instead of waiting minutes for full extraction to complete.
-                // ASS is excluded because SetAssFont rewrites the file after extraction (race condition).
-                // PGS is excluded because it's a binary bitmap format that needs the complete file.
-                if (IsEarlyReturnSubtitleFormat(outputFormat))
-                {
-                    // Use CancellationToken.None so extraction continues even if this HTTP request completes
-                    var extractionTask = ExtractAllExtractableSubtitles(mediaSource, CancellationToken.None);
-                    var fileReadyTask = WaitForFileDataAsync(outputPath, TimeSpan.FromSeconds(30));
-
-                    var completedTask = await Task.WhenAny(extractionTask, fileReadyTask).ConfigureAwait(false);
-
-                    if (completedTask == fileReadyTask)
-                    {
-                        var dataReady = await fileReadyTask.ConfigureAwait(false);
-                        if (dataReady)
-                        {
-                            _logger.LogInformation(
-                                "Subtitle file has data, returning early while extraction continues in background: {Path}",
-                                outputPath);
-
-                            // Let extraction finish in background (holds locks, cleans up, extracts remaining streams)
-                            _ = extractionTask.ContinueWith(
-                                t =>
-                                {
-                                    if (t.IsFaulted)
-                                    {
-                                        _logger.LogWarning(
-                                            t.Exception,
-                                            "Background subtitle extraction completed with errors: {Path}",
-                                            outputPath);
-                                    }
-                                },
-                                TaskScheduler.Default);
-
-                            return new SubtitleInfo()
-                            {
-                                Path = outputPath,
-                                Protocol = MediaProtocol.File,
-                                Format = outputFormat,
-                                IsExternal = false
-                            };
-                        }
-                    }
-
-                    // Extraction finished first (fast storage) or file data timed out — await for error handling
-                    await extractionTask.ConfigureAwait(false);
-                }
-                else
-                {
-                    // PGS (binary) and ASS (needs SetAssFont post-processing): wait for full extraction
-                    await ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
-                }
-
-                return new SubtitleInfo()
-                {
-                    Path = outputPath,
-                    Protocol = MediaProtocol.File,
-                    Format = outputFormat,
-                    IsExternal = false
-                };
+                return await GetExtractedSubtitle(mediaSource, subtitleStream, cancellationToken).ConfigureAwait(false);
             }
 
             var currentFormat = subtitleStream.Codec ?? Path.GetExtension(subtitleStream.Path)
@@ -1028,6 +951,86 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
                 }
             }
+        }
+
+        private async Task<SubtitleInfo> GetExtractedSubtitle(
+            MediaSourceInfo mediaSource,
+            MediaStream subtitleStream,
+            CancellationToken cancellationToken)
+        {
+            var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
+            var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
+            var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension);
+
+            var info = new SubtitleInfo()
+            {
+                Path = outputPath,
+                Protocol = MediaProtocol.File,
+                Format = outputFormat,
+                IsExternal = false
+            };
+
+            // Fast path: subtitle already extracted and cached
+            if (File.Exists(outputPath) && _fileSystem.GetFileInfo(outputPath).Length > 0)
+            {
+                return info;
+            }
+
+            // For text-based subtitles (SRT, SSA): return as soon as the output file has data on disk.
+            // With -flush_packets 1, ffmpeg writes data within ~1 second. The client gets a valid partial
+            // subtitle file immediately instead of waiting minutes for full extraction to complete.
+            // ASS is excluded because SetAssFont rewrites the file after extraction (race condition).
+            // PGS is excluded because it's a binary bitmap format that needs the complete file.
+            if (IsEarlyReturnSubtitleFormat(outputFormat)
+                && await TryReturnEarly(mediaSource, outputPath).ConfigureAwait(false))
+            {
+                return info;
+            }
+
+            // PGS (binary), ASS (needs SetAssFont post-processing), or early-return timed out:
+            // wait for full extraction to complete.
+            await ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
+            return info;
+        }
+
+        /// <summary>
+        /// Starts background extraction and waits for the output file to have data.
+        /// Returns true if the file is ready and extraction should continue in the background.
+        /// </summary>
+        private async Task<bool> TryReturnEarly(MediaSourceInfo mediaSource, string outputPath)
+        {
+            // Use CancellationToken.None so extraction continues even if this HTTP request completes
+            var extractionTask = ExtractAllExtractableSubtitles(mediaSource, CancellationToken.None);
+            var fileReadyTask = WaitForFileDataAsync(outputPath, TimeSpan.FromSeconds(30));
+
+            var completedTask = await Task.WhenAny(extractionTask, fileReadyTask).ConfigureAwait(false);
+
+            if (completedTask == fileReadyTask && await fileReadyTask.ConfigureAwait(false))
+            {
+                _logger.LogInformation(
+                    "Subtitle file has data, returning early while extraction continues in background: {Path}",
+                    outputPath);
+
+                // Let extraction finish in background (holds locks, cleans up, extracts remaining streams)
+                _ = extractionTask.ContinueWith(
+                    t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            _logger.LogWarning(
+                                t.Exception,
+                                "Background subtitle extraction completed with errors: {Path}",
+                                outputPath);
+                        }
+                    },
+                    TaskScheduler.Default);
+
+                return true;
+            }
+
+            // Extraction finished first (fast storage) or file data timed out — await for error handling
+            await extractionTask.ConfigureAwait(false);
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
  ## What this fixes

On cold cache, text subtitle requests block the HTTP response until ffmpeg finishes extracting *every* subtitle stream in the file. On a large MKV with many tracks, that's 30–60+ seconds (in my setup, often 3+ minutes when HLS transcoding is running in parallel). The client sees a hung request and in practice most players either time out or show a spinner long enough that the user just gives up. Issue #2547, referenced by several downstream reports.
## Changes

### commits
  1. return text subtitles early while extraction continues in background
  2. refactor `GetReadableFile` to reduce cognitive complexity
  3. wrap the returned stream in `TailingFileStream` so the HTTP response delivers the complete file in a single connection

  For text subtitles (SRT, SSA), `GetReadableFile` now returns as soon as the output file exists on disk instead of blocking until ffmpeg exits.
  Combined with `-flush_packets 1` (#16440), first bytes land within ~1 second. Extraction continues in the background, locks are held, remaining streams finish, cleanup runs normally. Falls back to the old blocking path for ASS (needs `SetAssFont` post-processing) and PGS (binary format).
  On slow storage with concurrent HLS transcoding, this reduces subtitle load time from 3+ minutes to <1 second.

## Scope — what this PR does NOT fix

The **convert path** (client requests `.vtt` or `.js`, source is `.srt`) is **unchanged** by this PR. `ConvertSubtitles` → `SubtitleEditParser.Parse` does a synchronous `stream.ReadAllLines().ToList()` before emitting any cues, so the tailing stream is drained fully before the response starts. **Jellyfin Web requests `.js`**, meaning web users see no improvement from this PR alone. A follow-up PR adding an incremental SRT parser + pull-based stream adapter is in progress and will be submitted separately once this one lands.

  ## LLM/AI Use

Per [Jellyfin's AI Use Policy](https://jellyfin.org/docs/general/contributing/llm-policies):
  - I wrote the entire PR description myself.
  - I used Claude (Opus 4.6) to help me navigate the subtitle extraction codepaths during investigation, brainstorm the`TailingFileStream` approach after @gnattu pointed out the truncation bug, and build the test harness I used. The code in the three commits was reviewed by me end-to-end; I understand what each piece is doing and why, and I'm able to address review feedback myself.
  - I tested this PR locally against `v10.11.7` (what my personal Jellyfin server runs) and confirmed it builds cleanly against `master` before submitting. It's been running on my server for a few days with a handful of real users and is holding up well.
