### PR TITLE
Add "MaxParallelism" Trickplay option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -229,6 +229,7 @@
  - [LiHRaM](https://github.com/LiHRaM)
  - [MSalman5230](https://github.com/MSalman5230)
  - [dwandw](https://github.com/dwandw)
+ - [Starkiller21321](https://github.com/Starkiller21321)
 
 # Emby Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -239,6 +239,7 @@
  - [rwebster85](https://github.com/rwebster85)
  - [Florin-Popescu](https://github.com/Florin-Popescu)
  - [martin-77](https://github.com/martin-77)
+ - [Starkiller21321](https://github.com/Starkiller21321)
 
 # Emby Contributors
 

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Server.Implementations.Trickplay;
 /// <summary>
 /// ITrickplayManager implementation.
 /// </summary>
-public class TrickplayManager : ITrickplayManager
+public class TrickplayManager : ITrickplayManager, IDisposable
 {
     private readonly ILogger<TrickplayManager> _logger;
     private readonly IMediaEncoder _mediaEncoder;
@@ -40,8 +40,9 @@ public class TrickplayManager : ITrickplayManager
     private readonly IApplicationPaths _appPaths;
     private readonly IPathManager _pathManager;
 
-    private static readonly AsyncNonKeyedLocker _resourcePool = new(1);
+    private readonly AsyncNonKeyedLocker _resourcePool;
     private static readonly string[] _trickplayImgExtensions = [".jpg"];
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrickplayManager"/> class.
@@ -75,6 +76,33 @@ public class TrickplayManager : ITrickplayManager
         _dbProvider = dbProvider;
         _appPaths = appPaths;
         _pathManager = pathManager;
+        _resourcePool = new(config.Configuration.TrickplayOptions.MaxParallelism);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases unmanaged and optionally managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _resourcePool?.Dispose();
+        }
+
+        _disposed = true;
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Server.Implementations.Trickplay;
 /// <summary>
 /// ITrickplayManager implementation.
 /// </summary>
-public partial class TrickplayManager : ITrickplayManager
+public sealed partial class TrickplayManager : ITrickplayManager, IDisposable
 {
     private readonly ILogger<TrickplayManager> _logger;
     private readonly IMediaEncoder _mediaEncoder;
@@ -41,7 +41,7 @@ public partial class TrickplayManager : ITrickplayManager
     private readonly IApplicationPaths _appPaths;
     private readonly IPathManager _pathManager;
 
-    private static readonly AsyncNonKeyedLocker _resourcePool = new(1);
+    private readonly AsyncNonKeyedLocker _resourcePool;
     private static readonly string[] _trickplayImgExtensions = [".jpg"];
 
     /// <summary>
@@ -76,6 +76,20 @@ public partial class TrickplayManager : ITrickplayManager
         _dbProvider = dbProvider;
         _appPaths = appPaths;
         _pathManager = pathManager;
+        var maxParallelism = config.Configuration.TrickplayOptions.MaxParallelism;
+        if (maxParallelism < 1)
+        {
+            _logger.LogWarning("Trickplay max parallelism {MaxParallelism} is too small, using value of 1", maxParallelism);
+            maxParallelism = 1;
+        }
+
+        _resourcePool = new(maxParallelism);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _resourcePool.Dispose();
     }
 
     /// <inheritdoc />
@@ -295,86 +309,92 @@ public partial class TrickplayManager : ITrickplayManager
             await DiscoverExistingTrickplayAsync(video, saveWithMedia, cancellationToken).ConfigureAwait(false);
         }
 
-        var dbContext = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await using (dbContext.ConfigureAwait(false))
-        {
-            var trickplayDirectory = _pathManager.GetTrickplayDirectory(video, saveWithMedia);
+        var trickplayDirectory = _pathManager.GetTrickplayDirectory(video, saveWithMedia);
 
-            // When extraction is disabled and files live next to media, treat them as user-managed:
-            // discovery above already catalogued whatever is on disk, leave it alone.
-            if (!libraryOptions.EnableTrickplayImageExtraction && !replace && saveWithMedia)
+        // When extraction is disabled and files live next to media, treat them as user-managed:
+        // discovery above already catalogued whatever is on disk, leave it alone.
+        if (!libraryOptions.EnableTrickplayImageExtraction && !replace && saveWithMedia)
+        {
+            return;
+        }
+
+        if (!libraryOptions.EnableTrickplayImageExtraction || replace)
+        {
+            // Prune existing data
+            if (Directory.Exists(trickplayDirectory))
             {
-                return;
+                try
+                {
+                    Directory.Delete(trickplayDirectory, true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Unable to clear trickplay directory: {Directory}: {Exception}", trickplayDirectory, ex);
+                }
             }
 
-            if (!libraryOptions.EnableTrickplayImageExtraction || replace)
+            var pruneContext = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (pruneContext.ConfigureAwait(false))
             {
-                // Prune existing data
-                if (Directory.Exists(trickplayDirectory))
-                {
-                    try
-                    {
-                        Directory.Delete(trickplayDirectory, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning("Unable to clear trickplay directory: {Directory}: {Exception}", trickplayDirectory, ex);
-                    }
-                }
-
-                await dbContext.TrickplayInfos
+                await pruneContext.TrickplayInfos
                         .Where(i => i.ItemId.Equals(video.Id))
                         .ExecuteDeleteAsync(cancellationToken)
                         .ConfigureAwait(false);
-
-                if (!replace)
-                {
-                    return;
-                }
             }
 
-            _logger.LogDebug("Trickplay refresh for {ItemId} (replace existing: {Replace})", video.Id, replace);
-
-            if (options.Interval < 1000)
+            if (!replace)
             {
-                _logger.LogWarning("Trickplay image interval {Interval} is too small, reset to the minimum valid value of 1000", options.Interval);
-                options.Interval = 1000;
+                return;
             }
+        }
 
-            foreach (var width in options.WidthResolutions)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await RefreshTrickplayDataInternal(
-                    video,
-                    replace,
-                    width,
-                    options,
-                    saveWithMedia,
-                    cancellationToken).ConfigureAwait(false);
-            }
+        _logger.LogDebug("Trickplay refresh for {ItemId} (replace existing: {Replace})", video.Id, replace);
 
-            // Cleanup old trickplay files
-            if (Directory.Exists(trickplayDirectory))
+        if (options.Interval < 1000)
+        {
+            _logger.LogWarning("Trickplay image interval {Interval} is too small, reset to the minimum valid value of 1000", options.Interval);
+            options.Interval = 1000;
+        }
+
+        foreach (var width in options.WidthResolutions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await RefreshTrickplayDataInternal(
+                video,
+                replace,
+                width,
+                options,
+                saveWithMedia,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Cleanup old trickplay files
+        if (Directory.Exists(trickplayDirectory))
+        {
+            var existingFolders = Directory.GetDirectories(trickplayDirectory);
+            List<TrickplayInfo> trickplayInfos;
+            var cleanupContext = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (cleanupContext.ConfigureAwait(false))
             {
-                var existingFolders = Directory.GetDirectories(trickplayDirectory);
-                var trickplayInfos = await dbContext.TrickplayInfos
+                trickplayInfos = await cleanupContext.TrickplayInfos
                         .AsNoTracking()
                         .Where(i => i.ItemId.Equals(video.Id))
                         .ToListAsync(cancellationToken)
                         .ConfigureAwait(false);
-                var expectedFolders = trickplayInfos.Select(i => GetTrickplayDirectory(video, i.TileWidth, i.TileHeight, i.Width, saveWithMedia));
-                var foldersToRemove = existingFolders.Except(expectedFolders);
-                foreach (var folder in foldersToRemove)
+            }
+
+            var expectedFolders = trickplayInfos.Select(i => GetTrickplayDirectory(video, i.TileWidth, i.TileHeight, i.Width, saveWithMedia));
+            var foldersToRemove = existingFolders.Except(expectedFolders);
+            foreach (var folder in foldersToRemove)
+            {
+                try
                 {
-                    try
-                    {
-                        _logger.LogWarning("Pruning trickplay files for {Item}", video.Path);
-                        Directory.Delete(folder, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning("Unable to remove trickplay directory: {Directory}: {Exception}", folder, ex);
-                    }
+                    _logger.LogWarning("Pruning trickplay files for {Item}", video.Path);
+                    Directory.Delete(folder, true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Unable to remove trickplay directory: {Directory}: {Exception}", folder, ex);
                 }
             }
         }

--- a/MediaBrowser.Model/Configuration/TrickplayOptions.cs
+++ b/MediaBrowser.Model/Configuration/TrickplayOptions.cs
@@ -68,4 +68,9 @@ public class TrickplayOptions
     /// Gets or sets the number of threads to be used by ffmpeg.
     /// </summary>
     public int ProcessThreads { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the max number of trickplay images that can be processed concurrently.
+    /// </summary>
+    public int MaxParallelism { get; set; } = 1;
 }

--- a/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
@@ -92,24 +92,24 @@ public class TrickplayImagesTask : IScheduledTask
             query.StartIndex = startIndex;
             var videos = _libraryManager.GetItemList(query).OfType<Video>();
 
-            foreach (var video in videos)
+            await Parallel.ForEachAsync(
+            videos,
+            new ParallelOptions() { CancellationToken = cancellationToken },
+            async (video, ct) =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 try
                 {
                     var libraryOptions = _libraryManager.GetLibraryOptions(video);
-                    await _trickplayManager.RefreshTrickplayDataAsync(video, false, libraryOptions, cancellationToken).ConfigureAwait(false);
+                    await _trickplayManager.RefreshTrickplayDataAsync(video, false, libraryOptions, ct).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error creating trickplay files for {ItemName}", video.Name);
                 }
 
-                numComplete++;
-                progress.Report(100d * numComplete / numberOfVideos);
-            }
-
+                var completed = Interlocked.Increment(ref numComplete);
+                progress.Report(100d * completed / numberOfVideos);
+            }).ConfigureAwait(false);
             startIndex += QueryPageLimit;
         }
 

--- a/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Trickplay;
@@ -24,6 +25,7 @@ public class TrickplayImagesTask : IScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly ILocalizationManager _localization;
     private readonly ITrickplayManager _trickplayManager;
+    private readonly IServerConfigurationManager _config;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrickplayImagesTask"/> class.
@@ -32,16 +34,19 @@ public class TrickplayImagesTask : IScheduledTask
     /// <param name="libraryManager">The library manager.</param>
     /// <param name="localization">The localization manager.</param>
     /// <param name="trickplayManager">The trickplay manager.</param>
+    /// <param name="config">The server configuration manager.</param>
     public TrickplayImagesTask(
         ILogger<TrickplayImagesTask> logger,
         ILibraryManager libraryManager,
         ILocalizationManager localization,
-        ITrickplayManager trickplayManager)
+        ITrickplayManager trickplayManager,
+        IServerConfigurationManager config)
     {
         _libraryManager = libraryManager;
         _logger = logger;
         _localization = localization;
         _trickplayManager = trickplayManager;
+        _config = config;
     }
 
     /// <inheritdoc />
@@ -87,30 +92,36 @@ public class TrickplayImagesTask : IScheduledTask
 
         var startIndex = 0;
         var numComplete = 0;
+        var maxParallelism = _config.Configuration.TrickplayOptions.MaxParallelism;
+        if (maxParallelism < 1)
+        {
+            _logger.LogWarning("Trickplay max parallelism {MaxParallelism} is too small, using value of 1", maxParallelism);
+            maxParallelism = 1;
+        }
 
         while (startIndex < numberOfVideos)
         {
             query.StartIndex = startIndex;
             var videos = _libraryManager.GetItemList(query).OfType<Video>();
 
-            foreach (var video in videos)
+            await Parallel.ForEachAsync(
+            videos,
+            new ParallelOptions() { CancellationToken = cancellationToken, MaxDegreeOfParallelism = maxParallelism },
+            async (video, ct) =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 try
                 {
                     var libraryOptions = _libraryManager.GetLibraryOptions(video);
-                    await _trickplayManager.RefreshTrickplayDataAsync(video, false, libraryOptions, cancellationToken).ConfigureAwait(false);
+                    await _trickplayManager.RefreshTrickplayDataAsync(video, false, libraryOptions, ct).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogError(ex, "Error creating trickplay files for {ItemName}", video.Name);
                 }
 
-                numComplete++;
-                progress.Report(100d * numComplete / numberOfVideos);
-            }
-
+                var completed = Interlocked.Increment(ref numComplete);
+                progress.Report(100d * completed / numberOfVideos);
+            }).ConfigureAwait(false);
             startIndex += QueryPageLimit;
         }
 


### PR DESCRIPTION
Adds configurable "MaxParallelism" trickplay option.

Feature request: [https://features.jellyfin.org/posts/3498/multicore-trickplay-generation-by-default](https://features.jellyfin.org/posts/3498/multicore-trickplay-generation-by-default)

**Changes**
- Adds new MaxParallelism option to `TrickplayOptions` (default is set to 1). 
- Replaces the sequential foreach loop in `TrickplayImagesTask` with a `Parallel.ForEachAsync` allowing concurrent processing.
- Changes `TrickplayManager._resourcePool` to an instance-level semaphore initialized from the new `MaxParallelism` config value. 

**Issues**
https://github.com/jellyfin/jellyfin/issues/16584
