### PR TITLE
Fix artist metadata not being fetched on initial library scan

### DIFF
--- a/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
@@ -50,6 +50,10 @@ public class ArtistsValidator
     public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var names = _itemRepo.GetAllArtistNames();
+        var existingArtistIds = _libraryManager.GetItemIds(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.MusicArtist]
+        }).ToHashSet();
 
         var numComplete = 0;
         var count = names.Count;
@@ -59,8 +63,13 @@ public class ArtistsValidator
             try
             {
                 var item = _libraryManager.GetArtist(name);
+                var isNew = !existingArtistIds.Contains(item.Id);
+                var neverRefreshed = item.DateLastRefreshed == DateTime.MinValue;
 
-                await item.RefreshMetadata(cancellationToken).ConfigureAwait(false);
+                if (isNew || neverRefreshed)
+                {
+                    await item.RefreshMetadata(cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
@@ -64,7 +64,7 @@ public class ArtistsValidator
             {
                 var item = _libraryManager.GetArtist(name);
                 var isNew = !existingArtistIds.Contains(item.Id);
-                var neverRefreshed = item.DateLastRefreshed == DateTime.MinValue;
+                var neverRefreshed = item.DateLastRefreshed == default;
 
                 if (isNew || neverRefreshed)
                 {

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -487,6 +487,13 @@ namespace MediaBrowser.Providers.Manager
                 return true;
             }
 
+            // Artists without a folder structure that are derived from metadata have no real path in the library,
+            // so GetLibraryOptions returns null. Allow all providers through rather than blocking them.
+            if (item is MusicArtist && libraryTypeOptions is null)
+            {
+                return true;
+            }
+
             return _baseItemManager.IsMetadataFetcherEnabled(item, libraryTypeOptions, provider.Name);
         }
 

--- a/MediaBrowser.Providers/Plugins/AudioDb/AudioDbArtistProvider.cs
+++ b/MediaBrowser.Providers/Plugins/AudioDb/AudioDbArtistProvider.cs
@@ -125,7 +125,9 @@ namespace MediaBrowser.Providers.Plugins.AudioDb
 
             if (string.IsNullOrWhiteSpace(overview))
             {
-                overview = result.strBiographyEN;
+                overview = string.IsNullOrWhiteSpace(result.strBiographyEN)
+                    ? result.strBiography
+                    : result.strBiographyEN;
             }
 
             item.Overview = (overview ?? string.Empty).StripHtml();
@@ -223,6 +225,8 @@ namespace MediaBrowser.Providers.Plugins.AudioDb
             public string strFacebook { get; set; }
 
             public string strTwitter { get; set; }
+
+            public string strBiography { get; set; }
 
             public string strBiographyEN { get; set; }
 

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
@@ -22,7 +22,7 @@ namespace MediaBrowser.Providers.Plugins.MusicBrainz;
 /// <summary>
 /// MusicBrainz artist provider.
 /// </summary>
-public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, ArtistInfo>, IDisposable
+public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, ArtistInfo>, IDisposable, IHasOrder
 {
     private readonly ILogger<MusicBrainzArtistProvider> _logger;
     private Query _musicBrainzQuery;
@@ -41,6 +41,10 @@ public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, Ar
 
     /// <inheritdoc />
     public string Name => "MusicBrainz";
+
+    /// <inheritdoc />
+    /// Runs first to populate the MusicBrainz artist ID used by downstream providers.
+    public int Order => 0;
 
     private void ReloadConfig(object? sender, BasePluginConfiguration e)
     {


### PR DESCRIPTION
**Changes**
AudioDB artist metadata had several issues preventing it from populating correctly on initial scan or at all:

1. Recent requests to the AudioDB API return biography as `strBiography` instead of `strBiographyEN`. Added `strBiography` as a fallback when `strBiographyEN` is empty.

2. `AudioDbArtistProvider` ran before `MusicBrainzArtistProvider`, so the MusicBrainz ID needed for AudioDB lookup was always null on first scan. Fixed by implementing `IHasOrder` on `MusicBrainzArtistProvider` with `Order = 0`.

3. Artists derived from audio tags rather than a folder structure have no real library path, causing `GetLibraryOptions` to return null and AudioDB being filtered out of the provider list. Fixed by allowing all providers through when the item is a `MusicArtist` and `libraryTypeOptions` is null.

4. On the performance branch (yet to be merged), `ArtistsValidator` only refreshes new items. However, artists derived from audio tags failed this condition. Added a condition to refresh artists that have never been refreshed (`DateLastRefreshed == DateTime.MinValue`).

**Issues**
Fixes: #16599