### PR TITLE
Fix HDR tonemapping for BDMV content

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -366,6 +366,8 @@ namespace MediaBrowser.Providers.MediaInfo
                 blurayVideoStream.ColorSpace = ffmpegVideoStream.ColorSpace;
                 blurayVideoStream.ColorTransfer = ffmpegVideoStream.ColorTransfer;
                 blurayVideoStream.ColorPrimaries = ffmpegVideoStream.ColorPrimaries;
+                blurayVideoStream.BitDepth = ffmpegVideoStream.BitDepth;
+                blurayVideoStream.PixelFormat = ffmpegVideoStream.PixelFormat;
             }
         }
 


### PR DESCRIPTION
Addresses a tonemapping failure in HDR BDMV sources.

Video stream bit depth was not being recorded when a BDMV source was scanned, causing a silent omission of the tonemapping filters when the filter chains are being constructed here:
https://github.com/jellyfin/jellyfin/blob/eacdc83fda01b712d2f9821e6624449304395486/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L6178

The lack of bit depth information causes an early escape here:
https://github.com/jellyfin/jellyfin/blob/eacdc83fda01b712d2f9821e6624449304395486/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L360
resulting in a failure to tonemap HDR content during a transcode.

I record the pixel format too, despite it not directly causing this issue. It seems like important info we want to keep.

It seems to have been a field left out of [this ](https://github.com/jellyfin/jellyfin/commit/e063fcb036c5ff7f1bb946d6753c3a7d6b2ed264)commit to add HDR detection, resulting in HDR being detected but not acted upon.

This fixes the problem but I'll leave it up to any reviewers to decide if this is the best place for a fix to live.
In my opinion it may be wiser to modify `IsHwTonemapAvailable` to warn of an incorrectly mastered file if an HDR video range AND 8 bit color depth is detected.
Current behavior causes content correctly identified as HDR to be incorrectly transcoded if a bit depth hasn't been recorded.
