### PR TITLE
Feat/audiobook tracks

### DIFF
--- a/Emby.Naming/AudioBook/AudioBookFileInfo.cs
+++ b/Emby.Naming/AudioBook/AudioBookFileInfo.cs
@@ -59,16 +59,16 @@ namespace Emby.Naming.AudioBook
                 return 1;
             }
 
-            var chapterNumberComparison = Nullable.Compare(ChapterNumber, other.ChapterNumber);
-            if (chapterNumberComparison != 0)
-            {
-                return chapterNumberComparison;
-            }
-
             var partNumberComparison = Nullable.Compare(PartNumber, other.PartNumber);
             if (partNumberComparison != 0)
             {
                 return partNumberComparison;
+            }
+
+            var chapterNumberComparison = Nullable.Compare(ChapterNumber, other.ChapterNumber);
+            if (chapterNumberComparison != 0)
+            {
+                return chapterNumberComparison;
             }
 
             return string.Compare(Path, other.Path, StringComparison.Ordinal);

--- a/Emby.Naming/AudioBook/AudioBookFilePathParser.cs
+++ b/Emby.Naming/AudioBook/AudioBookFilePathParser.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using Emby.Naming.Audio;
 using Emby.Naming.Common;
 
 namespace Emby.Naming.AudioBook
@@ -11,6 +12,7 @@ namespace Emby.Naming.AudioBook
     public class AudioBookFilePathParser
     {
         private readonly NamingOptions _options;
+        private readonly AlbumParser _albumParser;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioBookFilePathParser"/> class.
@@ -19,13 +21,16 @@ namespace Emby.Naming.AudioBook
         public AudioBookFilePathParser(NamingOptions options)
         {
             _options = options;
+            _albumParser = new AlbumParser(options);
         }
 
         /// <summary>
         /// Based on regex determines if filename includes part/chapter number.
+        /// When a part number is not found in the filename, the parent folder name is also
+        /// checked so that files inside "Part 1/", "Part 2/" subfolders inherit the part number.
         /// </summary>
         /// <param name="path">Path to audiobook file.</param>
-        /// <returns>Returns <see cref="AudioBookFilePathParser"/> object.</returns>
+        /// <returns>Returns <see cref="AudioBookFilePathParserResult"/> object.</returns>
         public AudioBookFilePathParserResult Parse(string path)
         {
             AudioBookFilePathParserResult result = default;
@@ -55,6 +60,37 @@ namespace Emby.Naming.AudioBook
                             if (int.TryParse(value.ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                             {
                                 result.PartNumber = intValue;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // If the filename itself didn't yield a part number, check whether the immediate
+            // parent folder is a named part folder (e.g. "Part 1", "Part 2"). This mirrors how
+            // MusicAlbumResolver treats disc subfolders, and allows organizing audiobooks as:
+            //   Book/Part 1/Chapter 01.mp3
+            //   Book/Part 2/Chapter 01.mp3
+            // AlbumParser.IsMultiPart is used as a gate so that only unambiguous part folder
+            // names (those starting with a known stacking prefix) contribute a part number,
+            // preventing generic trailing-number patterns from misidentifying chapter folders.
+            if (!result.PartNumber.HasValue)
+            {
+                var parentFolderPath = Path.GetDirectoryName(path);
+                var parentFolder = Path.GetFileName(parentFolderPath);
+                if (!string.IsNullOrEmpty(parentFolder) && !string.IsNullOrEmpty(parentFolderPath)
+                    && _albumParser.IsMultiPart(parentFolderPath))
+                {
+                    foreach (var expression in _options.AudioBookPartsExpressions)
+                    {
+                        var match = Regex.Match(parentFolder, expression, RegexOptions.IgnoreCase);
+                        if (match.Success)
+                        {
+                            var value = match.Groups["part"];
+                            if (value.Success && int.TryParse(value.ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+                            {
+                                result.PartNumber = intValue;
+                                break;
                             }
                         }
                     }

--- a/Emby.Naming/AudioBook/AudioBookListResolver.cs
+++ b/Emby.Naming/AudioBook/AudioBookListResolver.cs
@@ -77,8 +77,10 @@ namespace Emby.Naming.AudioBook
             {
                 if (group.Key.ChapterNumber is null && group.Key.PartNumber is null)
                 {
-                    if (group.Count() > 1 || haveChaptersOrPages)
+                    if (haveChaptersOrPages)
                     {
+                        // Other files have chapter/part info from filenames but these don't.
+                        // Classify untagged stragglers as extras or alternates.
                         List<AudioBookFileInfo>? ex = null;
                         List<AudioBookFileInfo>? alt = null;
 
@@ -121,6 +123,11 @@ namespace Emby.Naming.AudioBook
                             alternativeVersions.AddRange(alternatives);
                         }
                     }
+
+                    // When NO files have chapter/part info from filenames, keep all as
+                    // main files. The directory is the grouping signal; ordering and
+                    // metadata are enriched later via WORK / MOVEMENTNAME /
+                    // MOVEMENTNUMBER tags during audio probing.
                 }
                 else if (group.Count() > 1)
                 {

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -244,6 +244,7 @@ public class ChapterManager : IChapterManager
           _logger.LogWarning("Attempted to save chapters for unsupported item type {Type}: {Name} ({Id})", item.GetType().Name, item.Name, item.Id);
           return;
        }
+       
         // Remove any chapters that are outside of the runtime of the item
         var validChapters = chapters.Where(c => c.StartPositionTicks < item.RunTimeTicks).ToList();
         _chapterRepository.SaveChapters(item.Id, validChapters);

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -239,10 +239,15 @@ public class ChapterManager : IChapterManager
     /// <inheritdoc />
     public void SaveChapters(BaseItem item, IReadOnlyList<ChapterInfo> chapters)
     {
+        if (!Supports(item))
+       {
+          _logger.LogWarning("Attempted to save chapters for unsupported item type {Type}: {Name} ({Id})", item.GetType().Name, item.Name, item.Id);
+          return;
+       }
         // Remove any chapters that are outside of the runtime of the item
         var validChapters = chapters.Where(c => c.StartPositionTicks < item.RunTimeTicks).ToList();
         _chapterRepository.SaveChapters(item.Id, validChapters);
-    }
+}
 
     /// <inheritdoc />
     public ChapterInfo? GetChapter(Guid baseItemId, int index)

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
@@ -230,6 +231,10 @@ public class ChapterManager : IChapterManager
 
         return success;
     }
+
+    /// <inheritdoc />
+    public bool Supports(BaseItem item)
+        => item is Video or Audio;
 
     /// <inheritdoc />
     public void SaveChapters(BaseItem item, IReadOnlyList<ChapterInfo> chapters)

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -232,11 +232,11 @@ public class ChapterManager : IChapterManager
     }
 
     /// <inheritdoc />
-    public void SaveChapters(Video video, IReadOnlyList<ChapterInfo> chapters)
+    public void SaveChapters(BaseItem item, IReadOnlyList<ChapterInfo> chapters)
     {
-        // Remove any chapters that are outside of the runtime of the video
-        var validChapters = chapters.Where(c => c.StartPositionTicks < video.RunTimeTicks).ToList();
-        _chapterRepository.SaveChapters(video.Id, validChapters);
+        // Remove any chapters that are outside of the runtime of the item
+        var validChapters = chapters.Where(c => c.StartPositionTicks < item.RunTimeTicks).ToList();
+        _chapterRepository.SaveChapters(item.Id, validChapters);
     }
 
     /// <inheritdoc />

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -244,7 +244,7 @@ public class ChapterManager : IChapterManager
           _logger.LogWarning("Attempted to save chapters for unsupported item type {Type}: {Name} ({Id})", item.GetType().Name, item.Name, item.Id);
           return;
        }
-       
+
         // Remove any chapters that are outside of the runtime of the item
         var validChapters = chapters.Where(c => c.StartPositionTicks < item.RunTimeTicks).ToList();
         _chapterRepository.SaveChapters(item.Id, validChapters);

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1123,11 +1123,6 @@ namespace Emby.Server.Implementations.Dto
                     }
                 }
 
-                if (options.ContainsField(ItemFields.Chapters))
-                {
-                    dto.Chapters = _chapterManager.GetChapters(item.Id).ToList();
-                }
-
                 if (options.ContainsField(ItemFields.Trickplay))
                 {
                     var trickplay = _trickplayManager.GetTrickplayManifest(item).GetAwaiter().GetResult();
@@ -1139,6 +1134,11 @@ namespace Emby.Server.Implementations.Dto
                 }
 
                 dto.ExtraType = video.ExtraType;
+            }
+
+            if (options.ContainsField(ItemFields.Chapters))
+            {
+                dto.Chapters = _chapterManager.GetChapters(item.Id).ToList();
             }
 
             if (options.ContainsField(ItemFields.MediaStreams))

--- a/Emby.Server.Implementations/Images/AudioBookImageProvider.cs
+++ b/Emby.Server.Implementations/Images/AudioBookImageProvider.cs
@@ -1,0 +1,29 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+
+namespace Emby.Server.Implementations.Images
+{
+    public class AudioBookImageProvider : BaseFolderImageProvider<AudioBook>
+    {
+        public AudioBookImageProvider(IFileSystem fileSystem, IProviderManager providerManager, IApplicationPaths applicationPaths, IImageProcessor imageProcessor, ILibraryManager libraryManager)
+            : base(fileSystem, providerManager, applicationPaths, imageProcessor, libraryManager)
+        {
+        }
+
+        protected override IReadOnlyList<BaseItem> GetItemsWithImages(BaseItem item)
+        {
+            var items = base.GetItemsWithImages(item);
+
+            // Ignore any folders because they can have generated collages
+            return items.Where(i => i is not Folder).ToList();
+        }
+    }
+}

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioBookResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioBookResolver.cs
@@ -1,0 +1,110 @@
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Naming.Audio;
+using Emby.Naming.Common;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Resolvers;
+using MediaBrowser.Model.IO;
+
+namespace Emby.Server.Implementations.Library.Resolvers.Audio
+{
+    /// <summary>
+    /// Resolves directories containing audio files in a books library as <see cref="AudioBook"/> folders.
+    /// Follows the same pattern as <see cref="MusicAlbumResolver"/> for music albums.
+    /// </summary>
+    public class AudioBookResolver : ItemResolver<AudioBook>
+    {
+        private readonly NamingOptions _namingOptions;
+        private readonly IDirectoryService _directoryService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioBookResolver"/> class.
+        /// </summary>
+        /// <param name="namingOptions">The naming options.</param>
+        /// <param name="directoryService">The directory service.</param>
+        public AudioBookResolver(NamingOptions namingOptions, IDirectoryService directoryService)
+        {
+            _namingOptions = namingOptions;
+            _directoryService = directoryService;
+        }
+
+        /// <inheritdoc />
+        public override ResolverPriority Priority => ResolverPriority.Third;
+
+        /// <inheritdoc />
+        protected override AudioBook Resolve(ItemResolveArgs args)
+        {
+            if (!args.IsDirectory)
+            {
+                return null;
+            }
+
+            if (args.GetCollectionType() != CollectionType.books)
+            {
+                return null;
+            }
+
+            // Avoid nested audiobooks
+            if (args.HasParent<AudioBook>())
+            {
+                return null;
+            }
+
+            if (args.Parent is null || args.Parent.IsRoot)
+            {
+                return null;
+            }
+
+            return ContainsAudioBook(args.FileSystemChildren) ? new AudioBook() : null;
+        }
+
+        /// <summary>
+        /// Determines whether the file list represents an audiobook, either as a flat collection
+        /// of audio files or as part subfolders (e.g. "Part 1/", "Part 2/") each containing audio files.
+        /// Mirrors the multi-disc subfolder detection in <see cref="MusicAlbumResolver"/>.
+        /// </summary>
+        private bool ContainsAudioBook(ICollection<FileSystemMetadata> list)
+        {
+            // A flat directory with at least one audio file is an audiobook.
+            if (list.Any(f => !f.IsDirectory && AudioFileParser.IsAudioFile(f.FullName, _namingOptions)))
+            {
+                return true;
+            }
+
+            // Check for part subfolders (e.g. "Part 1/", "Part 2/") that each contain audio files.
+            var partSubfolderCount = 0;
+            var parser = new AlbumParser(_namingOptions);
+
+            var directories = list.Where(f => f.IsDirectory);
+
+            var result = Parallel.ForEach(directories, (dir, state) =>
+            {
+                var children = _directoryService.GetFileSystemEntries(dir.FullName);
+                var hasAudio = children.Any(f => !f.IsDirectory && AudioFileParser.IsAudioFile(f.FullName, _namingOptions));
+
+                if (hasAudio)
+                {
+                    if (parser.IsMultiPart(dir.FullName))
+                    {
+                        Interlocked.Increment(ref partSubfolderCount);
+                    }
+                    else
+                    {
+                        // A subfolder with audio that is not a part folder means this is not a
+                        // multi-part audiobook; it would be a nested audiobook, which we don't support.
+                        state.Stop();
+                    }
+                }
+            });
+
+            return result.IsCompleted && partSubfolderCount > 0;
+        }
+    }
+}

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -3,26 +3,20 @@
 #pragma warning disable CS1591
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Emby.Naming.Audio;
-using Emby.Naming.AudioBook;
 using Emby.Naming.Common;
 using Emby.Naming.Video;
 using Jellyfin.Data.Enums;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Resolvers;
-using MediaBrowser.Model.IO;
 
 namespace Emby.Server.Implementations.Library.Resolvers.Audio
 {
     /// <summary>
     /// Class AudioResolver.
     /// </summary>
-    public class AudioResolver : ItemResolver<MediaBrowser.Controller.Entities.Audio.Audio>, IMultiItemResolver
+    public class AudioResolver : ItemResolver<MediaBrowser.Controller.Entities.Audio.Audio>
     {
         private readonly NamingOptions _namingOptions;
 
@@ -37,38 +31,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
         /// <value>The priority.</value>
         public override ResolverPriority Priority => ResolverPriority.Fifth;
 
-        public MultiItemResolverResult ResolveMultiple(
-            Folder parent,
-            List<FileSystemMetadata> files,
-            CollectionType? collectionType,
-            IDirectoryService directoryService)
-        {
-            var result = ResolveMultipleInternal(parent, files, collectionType);
-
-            if (result is not null)
-            {
-                foreach (var item in result.Items)
-                {
-                    SetInitialItemValues((MediaBrowser.Controller.Entities.Audio.Audio)item, null);
-                }
-            }
-
-            return result;
-        }
-
-        private MultiItemResolverResult ResolveMultipleInternal(
-            Folder parent,
-            List<FileSystemMetadata> files,
-            CollectionType? collectionType)
-        {
-            if (collectionType == CollectionType.books)
-            {
-                return ResolveMultipleAudio(parent, files, true);
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Resolves the specified args.
         /// </summary>
@@ -82,14 +44,10 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             var isBooksCollectionType = collectionType == CollectionType.books;
 
+            // Directories in book collections are handled by AudioBookResolver
             if (args.IsDirectory)
             {
-                if (!isBooksCollectionType)
-                {
-                    return null;
-                }
-
-                return FindAudioBook(args, false);
+                return null;
             }
 
             if (AudioFileParser.IsAudioFile(args.Path, _namingOptions))
@@ -112,18 +70,14 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
                 MediaBrowser.Controller.Entities.Audio.Audio item = null;
 
-                var isMusicCollectionType = collectionType == CollectionType.music;
-
-                // Use regular audio type for mixed libraries, owned items and music
+                // All audio files (including in book collections) resolve as Audio.
+                // In book collections, the parent AudioBook folder provides the grouping.
                 if (isMixedCollectionType ||
                     args.Parent is null ||
-                    isMusicCollectionType)
+                    collectionType == CollectionType.music ||
+                    isBooksCollectionType)
                 {
                     item = new MediaBrowser.Controller.Entities.Audio.Audio();
-                }
-                else if (isBooksCollectionType)
-                {
-                    item = new AudioBook();
                 }
 
                 if (item is not null)
@@ -137,104 +91,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
             }
 
             return null;
-        }
-
-        private AudioBook FindAudioBook(ItemResolveArgs args, bool parseName)
-        {
-            // TODO: Allow GetMultiDiscMovie in here
-            var result = ResolveMultipleAudio(args.Parent, args.GetActualFileSystemChildren(), parseName);
-
-            if (result is null || result.Items.Count != 1 || result.Items[0] is not AudioBook item)
-            {
-                return null;
-            }
-
-            // If we were supporting this we'd be checking filesFromOtherItems
-            item.IsInMixedFolder = false;
-            item.Name = Path.GetFileName(item.ContainingFolderPath);
-            return item;
-        }
-
-        private MultiItemResolverResult ResolveMultipleAudio(Folder parent, IEnumerable<FileSystemMetadata> fileSystemEntries, bool parseName)
-        {
-            var files = new List<FileSystemMetadata>();
-            var leftOver = new List<FileSystemMetadata>();
-
-            // Loop through each child file/folder and see if we find a video
-            foreach (var child in fileSystemEntries)
-            {
-                if (child.IsDirectory)
-                {
-                    leftOver.Add(child);
-                }
-                else
-                {
-                    files.Add(child);
-                }
-            }
-
-            var resolver = new AudioBookListResolver(_namingOptions);
-            var resolverResult = resolver.Resolve(files).ToList();
-
-            var result = new MultiItemResolverResult
-            {
-                ExtraFiles = leftOver,
-                Items = new List<BaseItem>()
-            };
-
-            var isInMixedFolder = resolverResult.Count > 1 || (parent is not null && parent.IsTopParent);
-
-            foreach (var resolvedItem in resolverResult)
-            {
-                if (resolvedItem.Files.Count > 1)
-                {
-                    // For now, until we sort out naming for multi-part books
-                    continue;
-                }
-
-                // Until multi-part books are handled letting files stack hides them from browsing in the client
-                if (resolvedItem.Files.Count == 0 || resolvedItem.Extras.Count > 0 || resolvedItem.AlternateVersions.Count > 0)
-                {
-                    continue;
-                }
-
-                var firstMedia = resolvedItem.Files[0];
-
-                var libraryItem = new AudioBook
-                {
-                    Path = firstMedia.Path,
-                    IsInMixedFolder = isInMixedFolder,
-                    ProductionYear = resolvedItem.Year,
-                    Name = parseName ?
-                        resolvedItem.Name :
-                        Path.GetFileNameWithoutExtension(firstMedia.Path),
-                    // AdditionalParts = resolvedItem.Files.Skip(1).Select(i => i.Path).ToArray(),
-                    // LocalAlternateVersions = resolvedItem.AlternateVersions.Select(i => i.Path).ToArray()
-                };
-
-                result.Items.Add(libraryItem);
-            }
-
-            result.ExtraFiles.AddRange(files.Where(i => !ContainsFile(resolverResult, i)));
-
-            return result;
-        }
-
-        private static bool ContainsFile(IEnumerable<AudioBookInfo> result, FileSystemMetadata file)
-        {
-            return result.Any(i => ContainsFile(i, file));
-        }
-
-        private static bool ContainsFile(AudioBookInfo result, FileSystemMetadata file)
-        {
-            return result.Files.Any(i => ContainsFile(i, file)) ||
-                result.AlternateVersions.Any(i => ContainsFile(i, file)) ||
-                result.Extras.Any(i => ContainsFile(i, file));
-        }
-
-        private static bool ContainsFile(AudioBookFileInfo result, FileSystemMetadata file)
-        {
-            return string.Equals(result.Path, file.FullName, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
@@ -16,7 +16,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Books
 {
     public class BookResolver : ItemResolver<Book>
     {
-        private readonly string[] _validExtensions = { ".azw", ".azw3", ".cb7", ".cbr", ".cbt", ".cbz", ".epub", ".mobi", ".pdf", ".m4b", ".m4a", ".aac", ".flac", ".mp3", ".opus" };
+        private readonly string[] _validExtensions = { ".azw", ".azw3", ".cb7", ".cbr", ".cbt", ".cbz", ".epub", ".mobi", ".pdf" };
 
         protected override Book Resolve(ItemResolveArgs args)
         {

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -325,7 +325,7 @@ namespace Emby.Server.Implementations.Library
                     }
                 }
             }
-            else if (positionTicks > 0 && hasRuntime && item is AudioBook)
+            else if (positionTicks > 0 && hasRuntime && item.FindParent<AudioBook>() is not null)
             {
                 var playbackPositionInMinutes = TimeSpan.FromTicks(positionTicks).TotalMinutes;
                 var remainingTimeInMinutes = TimeSpan.FromTicks(runtimeTicks - positionTicks).TotalMinutes;

--- a/Emby.Server.Implementations/Library/Validators/AudioBookPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/AudioBookPostScanTask.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+
+namespace Emby.Server.Implementations.Library.Validators;
+
+/// <summary>
+/// Refreshes AudioBook folder metadata after all children have been scanned.
+/// On initial library scan, AudioBook folders are refreshed before their child
+/// tracks are probed, so metadata propagation from children is empty.
+/// This post-scan task triggers a second refresh to populate the parent.
+/// </summary>
+public class AudioBookPostScanTask : ILibraryPostScanTask
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<AudioBookPostScanTask> _logger;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioBookPostScanTask"/> class.
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileSystem">The file system.</param>
+    public AudioBookPostScanTask(
+        ILibraryManager libraryManager,
+        ILogger<AudioBookPostScanTask> logger,
+        IFileSystem fileSystem)
+    {
+        _libraryManager = libraryManager;
+        _logger = logger;
+        _fileSystem = fileSystem;
+    }
+
+    /// <inheritdoc />
+    public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var audioBooks = _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.AudioBook],
+            Recursive = true,
+            DtoOptions = new DtoOptions(true)
+        });
+
+        if (audioBooks.Count == 0)
+        {
+            progress.Report(100);
+            return;
+        }
+
+        _logger.LogInformation("Refreshing metadata for {Count} audiobooks", audioBooks.Count);
+
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+        {
+            MetadataRefreshMode = MetadataRefreshMode.Default,
+            ForceSave = true
+        };
+
+        for (var i = 0; i < audioBooks.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await audioBooks[i].RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
+
+            progress.Report((double)(i + 1) / audioBooks.Count * 100);
+        }
+    }
+}

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -990,7 +990,7 @@ public class LibraryController : BaseJellyfinApiController
             CollectionType.playlists => new[] { "Playlist" },
             CollectionType.movies => new[] { "Movie" },
             CollectionType.tvshows => new[] { "Series", "Season", "Episode" },
-            CollectionType.books => new[] { "Book" },
+            CollectionType.books => new[] { "Book", "AudioBook" },
             CollectionType.music => new[] { "MusicArtist", "MusicAlbum", "Audio", "MusicVideo" },
             CollectionType.homevideos => new[] { "Video", "Photo" },
             CollectionType.photos => new[] { "Video", "Photo" },

--- a/Jellyfin.Data/Enums/PersonKind.cs
+++ b/Jellyfin.Data/Enums/PersonKind.cs
@@ -129,5 +129,10 @@ public enum PersonKind
     /// <summary>
     /// A person who renders a text from one language into another.
     /// </summary>
-    Translator
+    Translator,
+
+    /// <summary>
+    /// A person who narrates a book or other work.
+    /// </summary>
+    Narrator
 }

--- a/MediaBrowser.Controller/Chapters/IChapterManager.cs
+++ b/MediaBrowser.Controller/Chapters/IChapterManager.cs
@@ -16,9 +16,9 @@ public interface IChapterManager
     /// <summary>
     /// Saves the chapters.
     /// </summary>
-    /// <param name="video">The video.</param>
+    /// <param name="item">The item.</param>
     /// <param name="chapters">The set of chapters.</param>
-    void SaveChapters(Video video, IReadOnlyList<ChapterInfo> chapters);
+    void SaveChapters(BaseItem item, IReadOnlyList<ChapterInfo> chapters);
 
     /// <summary>
     /// Gets a single chapter of a BaseItem on a specific index.

--- a/MediaBrowser.Controller/Chapters/IChapterManager.cs
+++ b/MediaBrowser.Controller/Chapters/IChapterManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 
@@ -18,7 +19,15 @@ public interface IChapterManager
     /// </summary>
     /// <param name="item">The item to check.</param>
     /// <returns><c>true</c> if the item type supports chapters; otherwise, <c>false</c>.</returns>
-    bool Supports(BaseItem item);
+    bool Supports(BaseItem item) => item is Video or Audio;
+
+    /// <summary>
+    /// Saves the chapters.
+    /// </summary>
+    /// <param name="video">The video.</param>
+    /// <param name="chapters">The set of chapters.</param>
+    void SaveChapters(Video video, IReadOnlyList<ChapterInfo> chapters)
+        => SaveChapters((BaseItem)video, chapters);
 
     /// <summary>
     /// Saves the chapters.

--- a/MediaBrowser.Controller/Chapters/IChapterManager.cs
+++ b/MediaBrowser.Controller/Chapters/IChapterManager.cs
@@ -14,6 +14,13 @@ namespace MediaBrowser.Controller.Chapters;
 public interface IChapterManager
 {
     /// <summary>
+    /// Gets a value indicating whether the specified item type is supported for chapter operations.
+    /// </summary>
+    /// <param name="item">The item to check.</param>
+    /// <returns><c>true</c> if the item type supports chapters; otherwise, <c>false</c>.</returns>
+    bool Supports(BaseItem item);
+
+    /// <summary>
     /// Saves the chapters.
     /// </summary>
     /// <param name="item">The item.</param>

--- a/MediaBrowser.Controller/Entities/Audio/Audio.cs
+++ b/MediaBrowser.Controller/Entities/Audio/Audio.cs
@@ -55,7 +55,7 @@ namespace MediaBrowser.Controller.Entities.Audio
         protected override bool SupportsOwnedItems => false;
 
         [JsonIgnore]
-        public override Folder LatestItemsIndexContainer => AlbumEntity;
+        public override Folder LatestItemsIndexContainer => AlbumEntity ?? (Folder)FindParent<AudioBook>();
 
         [JsonIgnore]
         public MusicAlbum AlbumEntity => FindParent<MusicAlbum>();

--- a/MediaBrowser.Controller/Entities/AudioBook.cs
+++ b/MediaBrowser.Controller/Entities/AudioBook.cs
@@ -3,20 +3,38 @@
 #pragma warning disable CA1724, CS1591
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Providers;
 
 namespace MediaBrowser.Controller.Entities
 {
+    /// <summary>
+    /// Represents an audiobook as a folder containing audio track children.
+    /// Follows the same parent-child pattern as MusicAlbum.
+    /// </summary>
     [Common.RequiresSourceSerialisation]
-    public class AudioBook : Audio.Audio, IHasSeries, IHasLookupInfo<SongInfo>
+    public class AudioBook : Folder, IHasSeries, IHasLookupInfo<BookInfo>
     {
+        /// <summary>
+        /// Gets the audio tracks belonging to this audiobook.
+        /// </summary>
         [JsonIgnore]
-        public override bool SupportsPositionTicksResume => true;
+        public IEnumerable<Audio.Audio> Tracks => GetRecursiveChildren(i => i is Audio.Audio).Cast<Audio.Audio>();
+
+        [JsonIgnore]
+        public override bool SupportsAddingToPlaylist => true;
 
         [JsonIgnore]
         public override bool SupportsPlayedStatus => true;
+
+        [JsonIgnore]
+        public override bool SupportsCumulativeRunTimeTicks => true;
+
+        [JsonIgnore]
+        public override bool SupportsPeople => true;
 
         [JsonIgnore]
         public string SeriesPresentationUniqueKey { get; set; }
@@ -60,6 +78,13 @@ namespace MediaBrowser.Controller.Entities
         public override UnratedItem GetBlockUnratedType()
         {
             return UnratedItem.Book;
+        }
+
+        public BookInfo GetLookupInfo()
+        {
+            var info = GetItemLookupInfo<BookInfo>();
+            info.SeriesName = SeriesName;
+            return info;
         }
     }
 }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -414,7 +414,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <inheritdoc />
         public Task<MediaInfo> GetMediaInfo(MediaInfoRequest request, CancellationToken cancellationToken)
         {
-            var extractChapters = request.MediaType == DlnaProfileType.Video && request.ExtractChapters;
+            var extractChapters = request.ExtractChapters;
             var extraArgs = GetExtraArguments(request);
 
             return GetMediaInfoInternal(

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -194,6 +194,11 @@ namespace MediaBrowser.MediaEncoding.Probing
                 info.ProductionYear = info.PremiereDate.Value.Year;
             }
 
+            if (data.Chapters is not null)
+            {
+                info.Chapters = data.Chapters.Select(GetChapterInfo).ToArray();
+            }
+
             // Set mediaType-specific metadata
             if (isAudio)
             {
@@ -237,11 +242,6 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
 
                 FetchWtvInfo(info, data);
-
-                if (data.Chapters is not null)
-                {
-                    info.Chapters = data.Chapters.Select(GetChapterInfo).ToArray();
-                }
 
                 ExtractTimestamp(info);
 

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1427,6 +1427,35 @@ namespace MediaBrowser.MediaEncoding.Probing
             mb = GetMultipleMusicBrainzId(tags.GetValueOrDefault("MusicBrainz Release Track Id"))
                  ?? GetMultipleMusicBrainzId(tags.GetValueOrDefault("MUSICBRAINZ_RELEASETRACKID"));
             audio.TrySetProviderId(MetadataProvider.MusicBrainzTrack, mb);
+
+            // Work / Grouping — identifies the larger work this track belongs to (e.g. audiobook title).
+            // FFprobe exposes ID3v2 TIT1 as "grouping", WORK as "work", and iTunes ©grp as "grouping".
+            audio.WorkName = tags.GetFirstNotNullNorWhiteSpaceValue("work", "WORK", "grouping", "GROUPING");
+
+            // Movement name — the chapter/movement title within the work.
+            audio.MovementName = tags.GetFirstNotNullNorWhiteSpaceValue("movement_name", "MOVEMENTNAME", "MVNM");
+
+            // Movement number — the chapter/movement index within the work.
+            var movementNum = tags.GetFirstNotNullNorWhiteSpaceValue("movement_number", "MOVEMENTNUMBER", "MVIN");
+            if (!string.IsNullOrEmpty(movementNum)
+                && int.TryParse(movementNum.Split('/')[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var movementIndex))
+            {
+                audio.MovementNumber = movementIndex;
+            }
+
+            // Movement total — total number of chapters/movements.
+            var movementTot = tags.GetFirstNotNullNorWhiteSpaceValue("movement_total", "MOVEMENTTOTAL");
+            if (string.IsNullOrEmpty(movementTot) && !string.IsNullOrEmpty(movementNum) && movementNum.Contains('/', StringComparison.Ordinal))
+            {
+                // MVIN format can be "number/total"
+                movementTot = movementNum.Split('/').ElementAtOrDefault(1);
+            }
+
+            if (!string.IsNullOrEmpty(movementTot)
+                && int.TryParse(movementTot, NumberStyles.Integer, CultureInfo.InvariantCulture, out var totalMovements))
+            {
+                audio.MovementTotal = totalMovements;
+            }
         }
 
         private static string GetMultipleMusicBrainzId(string value)

--- a/MediaBrowser.Model/MediaInfo/MediaInfo.cs
+++ b/MediaBrowser.Model/MediaInfo/MediaInfo.cs
@@ -82,5 +82,29 @@ namespace MediaBrowser.Model.MediaInfo
         /// </summary>
         /// <value>The overview.</value>
         public string Overview { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work name (e.g. the audiobook title that groups multiple track files).
+        /// Sourced from the WORK / TIT1 / GROUPING tag.
+        /// </summary>
+        public string WorkName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the movement name (e.g. the chapter title within a multi-track audiobook).
+        /// Sourced from the MOVEMENTNAME / MVNM tag.
+        /// </summary>
+        public string MovementName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the movement number (e.g. chapter number within a multi-track audiobook).
+        /// Sourced from the MOVEMENTNUMBER / MVIN tag.
+        /// </summary>
+        public int? MovementNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of movements.
+        /// Sourced from the MOVEMENTTOTAL tag.
+        /// </summary>
+        public int? MovementTotal { get; set; }
     }
 }

--- a/MediaBrowser.Providers/Books/AudioBookMetadataService.cs
+++ b/MediaBrowser.Providers/Books/AudioBookMetadataService.cs
@@ -1,5 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Persistence;
@@ -14,7 +21,7 @@ namespace MediaBrowser.Providers.Books;
 /// <summary>
 /// Service to manage audiobook metadata.
 /// </summary>
-public class AudioBookMetadataService : MetadataService<AudioBook, SongInfo>
+public class AudioBookMetadataService : MetadataService<AudioBook, BookInfo>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AudioBookMetadataService"/> class.
@@ -39,6 +46,56 @@ public class AudioBookMetadataService : MetadataService<AudioBook, SongInfo>
     }
 
     /// <inheritdoc />
+    protected override bool EnableUpdatingPremiereDateFromChildren => true;
+
+    /// <inheritdoc />
+    protected override bool EnableUpdatingGenresFromChildren => true;
+
+    /// <inheritdoc />
+    protected override bool EnableUpdatingStudiosFromChildren => true;
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<BaseItem> GetChildrenForMetadataUpdates(AudioBook item)
+        => item.GetRecursiveChildren(i => i is Audio);
+
+    /// <inheritdoc />
+    protected override ItemUpdateType UpdateMetadataFromChildren(AudioBook item, IReadOnlyList<BaseItem> children, bool isFullRefresh, ItemUpdateType currentUpdateType)
+    {
+        var updateType = base.UpdateMetadataFromChildren(item, children, isFullRefresh, currentUpdateType);
+
+        if (item.IsLocked)
+        {
+            return updateType;
+        }
+
+        if (isFullRefresh || currentUpdateType > ItemUpdateType.None)
+        {
+            // Propagate Overview from first child track
+            if (!item.LockedFields.Contains(MetadataField.Overview))
+            {
+                var firstTrack = children.FirstOrDefault(c => !string.IsNullOrEmpty(c.Overview));
+                if (firstTrack is not null && !string.Equals(item.Overview, firstTrack.Overview, StringComparison.Ordinal))
+                {
+                    item.Overview = firstTrack.Overview;
+                    updateType |= ItemUpdateType.MetadataEdit;
+                }
+            }
+        }
+
+        return updateType;
+    }
+
+    /// <inheritdoc />
+    protected override Task AfterMetadataRefresh(AudioBook item, MetadataRefreshOptions refreshOptions, CancellationToken cancellationToken)
+    {
+        base.AfterMetadataRefresh(item, refreshOptions, cancellationToken);
+
+        SetPeopleFromChildren(item);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     protected override void MergeData(
         MetadataResult<AudioBook> source,
         MetadataResult<AudioBook> target,
@@ -47,18 +104,40 @@ public class AudioBookMetadataService : MetadataService<AudioBook, SongInfo>
         bool mergeMetadataSettings)
     {
         base.MergeData(source, target, lockedFields, replaceData, mergeMetadataSettings);
+    }
 
-        var sourceItem = source.Item;
-        var targetItem = target.Item;
-
-        if (replaceData || targetItem.Artists.Count == 0)
+    private void SetPeopleFromChildren(AudioBook item)
+    {
+        if (item.IsLocked)
         {
-            targetItem.Artists = sourceItem.Artists;
+            return;
         }
 
-        if (replaceData || string.IsNullOrEmpty(targetItem.Album))
+        var children = item.GetRecursiveChildren(i => i is Audio);
+        var childPeople = new List<PersonInfo>();
+        foreach (var child in children)
         {
-            targetItem.Album = sourceItem.Album;
+            foreach (var person in LibraryManager.GetPeople(child))
+            {
+                if (!childPeople.Exists(p => string.Equals(p.Name, person.Name, StringComparison.OrdinalIgnoreCase) && p.Type == person.Type))
+                {
+                    childPeople.Add(person);
+                }
+            }
         }
+
+        if (childPeople.Count == 0)
+        {
+            return;
+        }
+
+        var existingPeople = LibraryManager.GetPeople(item);
+        if (existingPeople.Count == childPeople.Count
+            && existingPeople.All(e => childPeople.Exists(c => string.Equals(c.Name, e.Name, StringComparison.OrdinalIgnoreCase) && c.Type == e.Type)))
+        {
+            return;
+        }
+
+        LibraryManager.UpdatePeople(item, childPeople);
     }
 }

--- a/MediaBrowser.Providers/Books/OpenPackagingFormat/OpfReader.cs
+++ b/MediaBrowser.Providers/Books/OpenPackagingFormat/OpfReader.cs
@@ -260,6 +260,8 @@ namespace MediaBrowser.Providers.Books.OpenPackagingFormat
                     return PersonKind.Lyricist;
                 case "mus":
                     return PersonKind.AlbumArtist;
+                case "nrt":
+                    return PersonKind.Narrator;
                 case "oth":
                     return PersonKind.Unknown;
                 case "trl":

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -158,7 +158,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             _mediaStreamRepository.SaveMediaStreams(audio.Id, mediaStreams, cancellationToken);
 
-            if (audio is AudioBook && mediaInfo.Chapters is not null && mediaInfo.Chapters.Length > 0)
+            if (audio is AudioBook && mediaInfo.Chapters is { Length: > 0 })
             {
                 _chapterManager.SaveChapters(audio, mediaInfo.Chapters);
             }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using ATL;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
@@ -38,6 +39,7 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly LyricResolver _lyricResolver;
         private readonly ILyricManager _lyricManager;
         private readonly IMediaStreamRepository _mediaStreamRepository;
+        private readonly IChapterManager _chapterManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioFileProber"/> class.
@@ -49,6 +51,7 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <param name="lyricResolver">Instance of the <see cref="LyricResolver"/> interface.</param>
         /// <param name="lyricManager">Instance of the <see cref="ILyricManager"/> interface.</param>
         /// <param name="mediaStreamRepository">Instance of the <see cref="IMediaStreamRepository"/>.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
         public AudioFileProber(
             ILogger<AudioFileProber> logger,
             IMediaSourceManager mediaSourceManager,
@@ -56,7 +59,8 @@ namespace MediaBrowser.Providers.MediaInfo
             ILibraryManager libraryManager,
             LyricResolver lyricResolver,
             ILyricManager lyricManager,
-            IMediaStreamRepository mediaStreamRepository)
+            IMediaStreamRepository mediaStreamRepository,
+            IChapterManager chapterManager)
         {
             _mediaEncoder = mediaEncoder;
             _libraryManager = libraryManager;
@@ -65,6 +69,7 @@ namespace MediaBrowser.Providers.MediaInfo
             _lyricResolver = lyricResolver;
             _lyricManager = lyricManager;
             _mediaStreamRepository = mediaStreamRepository;
+            _chapterManager = chapterManager;
             ATL.Settings.DisplayValueSeparator = InternalValueSeparator;
             ATL.Settings.UseFileNameWhenNoTitle = false;
             ATL.Settings.ID3v2_separatev2v3Values = false;
@@ -99,6 +104,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     new MediaInfoRequest
                     {
                         MediaType = DlnaProfileType.Audio,
+                        ExtractChapters = item is AudioBook,
                         MediaSource = new MediaSourceInfo
                         {
                             Path = path,
@@ -151,6 +157,11 @@ namespace MediaBrowser.Providers.MediaInfo
             audio.HasLyrics = mediaStreams.Any(s => s.Type == MediaStreamType.Lyric);
 
             _mediaStreamRepository.SaveMediaStreams(audio.Id, mediaStreams, cancellationToken);
+
+            if (audio is AudioBook && mediaInfo.Chapters is not null && mediaInfo.Chapters.Length > 0)
+            {
+                _chapterManager.SaveChapters(audio, mediaInfo.Chapters);
+            }
         }
 
         /// <summary>
@@ -212,18 +223,6 @@ namespace MediaBrowser.Providers.MediaInfo
                     albumArtists = albumArtists.SelectMany(a => SplitWithCustomDelimiter(a, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
 
-                foreach (var albumArtist in albumArtists)
-                {
-                    if (!string.IsNullOrWhiteSpace(albumArtist))
-                    {
-                        PeopleHelper.AddPerson(people, new PersonInfo
-                        {
-                            Name = albumArtist,
-                            Type = PersonKind.AlbumArtist
-                        });
-                    }
-                }
-
                 string[]? performers = null;
                 if (libraryOptions.PreferNonstandardArtistsTag)
                 {
@@ -244,29 +243,133 @@ namespace MediaBrowser.Providers.MediaInfo
                     performers = performers.SelectMany(p => SplitWithCustomDelimiter(p, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
 
-                foreach (var performer in performers)
-                {
-                    if (!string.IsNullOrWhiteSpace(performer))
-                    {
-                        PeopleHelper.AddPerson(people, new PersonInfo
-                        {
-                            Name = performer,
-                            Type = PersonKind.Artist
-                        });
-                    }
-                }
+                var isAudioBook = audio is AudioBook;
 
-                if (!string.IsNullOrWhiteSpace(trackComposer))
+                if (isAudioBook)
                 {
-                    foreach (var composer in trackComposer.Split(InternalValueSeparator))
+                    // For audiobooks: AlbumArtists/Performers = Author, NARRATOR tag = Narrator,
+                    // ILLUSTRATOR tag = Illustrator, Composer = fallback Narrator, other performers = Cast.
+                    // If album_artist is missing, fall back to artist/performers for the author role.
+                    var authorSource = albumArtists.Length > 0 ? albumArtists : performers;
+                    var authorNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var author in authorSource)
                     {
-                        if (!string.IsNullOrWhiteSpace(composer))
+                        if (!string.IsNullOrWhiteSpace(author))
+                        {
+                            authorNames.Add(author.Trim());
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = author.Trim(),
+                                Type = PersonKind.Author
+                            });
+                        }
+                    }
+
+                    // Read narrator from format-specific custom tag (TXXX:NARRATOR, Vorbis NARRATOR, Apple NARRATOR, etc.)
+                    TryGetSanitizedAdditionalFields(track, "NARRATOR", out var narratorTag);
+                    var hasNarrator = !string.IsNullOrWhiteSpace(narratorTag);
+                    if (hasNarrator)
+                    {
+                        foreach (var narrator in narratorTag!.Split(InternalValueSeparator))
+                        {
+                            if (!string.IsNullOrWhiteSpace(narrator))
+                            {
+                                PeopleHelper.AddPerson(people, new PersonInfo
+                                {
+                                    Name = narrator.Trim(),
+                                    Type = PersonKind.Narrator
+                                });
+                            }
+                        }
+                    }
+
+                    // Fall back to Composer tag for narrator if no NARRATOR tag is present
+                    // (Audiobookshelf and other tools use Composer for narrator)
+                    if (!hasNarrator && !string.IsNullOrWhiteSpace(trackComposer))
+                    {
+                        foreach (var composer in trackComposer.Split(InternalValueSeparator))
+                        {
+                            if (!string.IsNullOrWhiteSpace(composer))
+                            {
+                                PeopleHelper.AddPerson(people, new PersonInfo
+                                {
+                                    Name = composer.Trim(),
+                                    Type = PersonKind.Narrator
+                                });
+                            }
+                        }
+                    }
+
+                    // Read illustrator from format-specific custom tag
+                    TryGetSanitizedAdditionalFields(track, "ILLUSTRATOR", out var illustratorTag);
+                    if (!string.IsNullOrWhiteSpace(illustratorTag))
+                    {
+                        foreach (var illustrator in illustratorTag!.Split(InternalValueSeparator))
+                        {
+                            if (!string.IsNullOrWhiteSpace(illustrator))
+                            {
+                                PeopleHelper.AddPerson(people, new PersonInfo
+                                {
+                                    Name = illustrator.Trim(),
+                                    Type = PersonKind.Illustrator
+                                });
+                            }
+                        }
+                    }
+
+                    // Any performers not already listed as authors get added as cast
+                    foreach (var performer in performers)
+                    {
+                        if (!string.IsNullOrWhiteSpace(performer) && !authorNames.Contains(performer.Trim()))
                         {
                             PeopleHelper.AddPerson(people, new PersonInfo
                             {
-                                Name = composer,
-                                Type = PersonKind.Composer
+                                Name = performer.Trim(),
+                                Type = PersonKind.Actor
                             });
+                        }
+                    }
+                }
+                else
+                {
+                    // Standard music track handling
+                    foreach (var albumArtist in albumArtists)
+                    {
+                        if (!string.IsNullOrWhiteSpace(albumArtist))
+                        {
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = albumArtist,
+                                Type = PersonKind.AlbumArtist
+                            });
+                        }
+                    }
+
+                    foreach (var performer in performers)
+                    {
+                        if (!string.IsNullOrWhiteSpace(performer))
+                        {
+                            PeopleHelper.AddPerson(people, new PersonInfo
+                            {
+                                Name = performer,
+                                Type = PersonKind.Artist
+                            });
+                        }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(trackComposer))
+                    {
+                        foreach (var composer in trackComposer.Split(InternalValueSeparator))
+                        {
+                            if (!string.IsNullOrWhiteSpace(composer))
+                            {
+                                PeopleHelper.AddPerson(people, new PersonInfo
+                                {
+                                    Name = composer,
+                                    Type = PersonKind.Composer
+                                });
+                            }
                         }
                     }
                 }
@@ -356,6 +459,46 @@ namespace MediaBrowser.Providers.MediaInfo
                 if (options.ReplaceAllMetadata || audio.Genres is null || audio.Genres.Length == 0 || audio.Genres.All(string.IsNullOrWhiteSpace))
                 {
                     audio.Genres = genres;
+                }
+            }
+
+            // Audiobook-specific metadata: Overview, Publisher, Series
+            if (audio is AudioBook audioBook)
+            {
+                if (!audio.LockedFields.Contains(MetadataField.Overview))
+                {
+                    var trackDescription = GetSanitizedStringTag(track.Description, audio.Path);
+                    var trackComment = GetSanitizedStringTag(track.Comment, audio.Path);
+                    var overview = !string.IsNullOrWhiteSpace(trackDescription) ? trackDescription : trackComment;
+
+                    if (!string.IsNullOrWhiteSpace(overview))
+                    {
+                        if (options.ReplaceAllMetadata || string.IsNullOrEmpty(audio.Overview))
+                        {
+                            audio.Overview = overview;
+                        }
+                    }
+                }
+
+                // Publisher → Studio (Xiph uses LABEL, others use tag.Publisher)
+                var trackPublisher = GetSanitizedStringTag(track.Publisher, audio.Path);
+                if (string.IsNullOrWhiteSpace(trackPublisher))
+                {
+                    TryGetSanitizedAdditionalFields(track, "LABEL", out trackPublisher);
+                }
+
+                if (!string.IsNullOrWhiteSpace(trackPublisher)
+                    && (options.ReplaceAllMetadata || audio.Studios is null || audio.Studios.Length == 0))
+                {
+                    audio.SetStudios(new[] { trackPublisher! });
+                }
+
+                // Series name from SERIES tag (Calibre/Readarr convention)
+                TryGetSanitizedAdditionalFields(track, "SERIES", out var seriesTag);
+                if (!string.IsNullOrWhiteSpace(seriesTag)
+                    && (options.ReplaceAllMetadata || string.IsNullOrEmpty(audioBook.SeriesName)))
+                {
+                    audioBook.SeriesName = seriesTag;
                 }
             }
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -104,7 +104,7 @@ namespace MediaBrowser.Providers.MediaInfo
                     new MediaInfoRequest
                     {
                         MediaType = DlnaProfileType.Audio,
-                        ExtractChapters = item is AudioBook,
+                        ExtractChapters = item.FindParent<AudioBook>() is not null,
                         MediaSource = new MediaSourceInfo
                         {
                             Path = path,
@@ -158,7 +158,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             _mediaStreamRepository.SaveMediaStreams(audio.Id, mediaStreams, cancellationToken);
 
-            if (audio is AudioBook && mediaInfo.Chapters is { Length: > 0 })
+            if (audio.FindParent<AudioBook>() is not null && mediaInfo.Chapters is { Length: > 0 })
             {
                 _chapterManager.SaveChapters(audio, mediaInfo.Chapters);
             }
@@ -199,6 +199,8 @@ namespace MediaBrowser.Providers.MediaInfo
             var trackArist = GetSanitizedStringTag(track.Artist, audio.Path);
             var trackComposer = GetSanitizedStringTag(track.Composer, audio.Path);
             var trackGenre = GetSanitizedStringTag(track.Genre, audio.Path);
+
+            var isAudioBook = audio.FindParent<AudioBook>() is not null;
 
             if (audio.SupportsPeople && !audio.LockedFields.Contains(MetadataField.Cast))
             {
@@ -242,8 +244,6 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     performers = performers.SelectMany(p => SplitWithCustomDelimiter(p, libraryOptions.GetCustomTagDelimiters(), libraryOptions.DelimiterWhitelist)).ToArray();
                 }
-
-                var isAudioBook = audio is AudioBook;
 
                 if (isAudioBook)
                 {
@@ -426,8 +426,8 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            // Audiobook-specific metadata: Overview, Publisher, Series
-            if (audio is AudioBook audioBook)
+            // Audiobook-specific metadata: Overview, Publisher, Movement tags
+            if (isAudioBook)
             {
                 if (!audio.LockedFields.Contains(MetadataField.Overview))
                 {
@@ -450,6 +450,51 @@ namespace MediaBrowser.Providers.MediaInfo
                     && (options.ReplaceAllMetadata || audio.Studios is null || audio.Studios.Length == 0))
                 {
                     audio.SetStudios(new[] { trackPublisher! });
+                }
+
+                // Movement tags: map to standard Audio fields for proper track ordering.
+                // MOVEMENTNUMBER → IndexNumber (chapter/track number) as fallback
+                // MOVEMENTNAME → Name (chapter title) as fallback
+                if (TryGetSanitizedAdditionalFields(track, "MOVEMENTNUMBER", out var movementNumStr)
+                    || TryGetSanitizedAdditionalFields(track, "MVIN", out movementNumStr))
+                {
+                    if (!string.IsNullOrWhiteSpace(movementNumStr))
+                    {
+                        var parts = movementNumStr.Split('/');
+                        if (int.TryParse(parts[0].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var movNum))
+                        {
+                            if (options.ReplaceAllMetadata || !audio.IndexNumber.HasValue)
+                            {
+                                audio.IndexNumber = movNum;
+                            }
+                        }
+                    }
+                }
+
+                // Fall back to FFprobe MovementNumber for IndexNumber
+                if (!audio.IndexNumber.HasValue && mediaInfo.MovementNumber.HasValue)
+                {
+                    audio.IndexNumber = mediaInfo.MovementNumber;
+                }
+
+                if (TryGetSanitizedAdditionalFields(track, "MOVEMENTNAME", out var movementName)
+                    || TryGetSanitizedAdditionalFields(track, "MVNM", out movementName))
+                {
+                    if (!string.IsNullOrWhiteSpace(movementName))
+                    {
+                        if (!audio.LockedFields.Contains(MetadataField.Name)
+                            && (options.ReplaceAllMetadata || string.IsNullOrEmpty(audio.Name)))
+                        {
+                            audio.Name = movementName;
+                        }
+                    }
+                }
+
+                if (!audio.LockedFields.Contains(MetadataField.Name)
+                    && string.IsNullOrEmpty(audio.Name)
+                    && !string.IsNullOrEmpty(mediaInfo.MovementName))
+                {
+                    audio.Name = mediaInfo.MovementName;
                 }
             }
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -266,27 +266,8 @@ namespace MediaBrowser.Providers.MediaInfo
                         }
                     }
 
-                    // Read narrator from format-specific custom tag (TXXX:NARRATOR, Vorbis NARRATOR, Apple NARRATOR, etc.)
-                    TryGetSanitizedAdditionalFields(track, "NARRATOR", out var narratorTag);
-                    var hasNarrator = !string.IsNullOrWhiteSpace(narratorTag);
-                    if (hasNarrator)
-                    {
-                        foreach (var narrator in narratorTag!.Split(InternalValueSeparator))
-                        {
-                            if (!string.IsNullOrWhiteSpace(narrator))
-                            {
-                                PeopleHelper.AddPerson(people, new PersonInfo
-                                {
-                                    Name = narrator.Trim(),
-                                    Type = PersonKind.Narrator
-                                });
-                            }
-                        }
-                    }
-
-                    // Fall back to Composer tag for narrator if no NARRATOR tag is present
-                    // (Audiobookshelf and other tools use Composer for narrator)
-                    if (!hasNarrator && !string.IsNullOrWhiteSpace(trackComposer))
+                    // Composer tag = Narrator (Audiobookshelf and other tools use Composer for narrator)
+                    if (!string.IsNullOrWhiteSpace(trackComposer))
                     {
                         foreach (var composer in trackComposer.Split(InternalValueSeparator))
                         {
@@ -296,23 +277,6 @@ namespace MediaBrowser.Providers.MediaInfo
                                 {
                                     Name = composer.Trim(),
                                     Type = PersonKind.Narrator
-                                });
-                            }
-                        }
-                    }
-
-                    // Read illustrator from format-specific custom tag
-                    TryGetSanitizedAdditionalFields(track, "ILLUSTRATOR", out var illustratorTag);
-                    if (!string.IsNullOrWhiteSpace(illustratorTag))
-                    {
-                        foreach (var illustrator in illustratorTag!.Split(InternalValueSeparator))
-                        {
-                            if (!string.IsNullOrWhiteSpace(illustrator))
-                            {
-                                PeopleHelper.AddPerson(people, new PersonInfo
-                                {
-                                    Name = illustrator.Trim(),
-                                    Type = PersonKind.Illustrator
                                 });
                             }
                         }
@@ -480,25 +444,12 @@ namespace MediaBrowser.Providers.MediaInfo
                     }
                 }
 
-                // Publisher → Studio (Xiph uses LABEL, others use tag.Publisher)
+                // Publisher → Studio
                 var trackPublisher = GetSanitizedStringTag(track.Publisher, audio.Path);
-                if (string.IsNullOrWhiteSpace(trackPublisher))
-                {
-                    TryGetSanitizedAdditionalFields(track, "LABEL", out trackPublisher);
-                }
-
                 if (!string.IsNullOrWhiteSpace(trackPublisher)
                     && (options.ReplaceAllMetadata || audio.Studios is null || audio.Studios.Length == 0))
                 {
                     audio.SetStudios(new[] { trackPublisher! });
-                }
-
-                // Series name from SERIES tag (Calibre/Readarr convention)
-                TryGetSanitizedAdditionalFields(track, "SERIES", out var seriesTag);
-                if (!string.IsNullOrWhiteSpace(seriesTag)
-                    && (options.ReplaceAllMetadata || string.IsNullOrEmpty(audioBook.SeriesName)))
-                {
-                    audioBook.SeriesName = seriesTag;
                 }
             }
 

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -110,7 +110,8 @@ namespace MediaBrowser.Providers.MediaInfo
                 libraryManager,
                 _lyricResolver,
                 lyricManager,
-                mediaStreamRepository);
+                mediaStreamRepository,
+                chapterManager);
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -36,7 +36,6 @@ namespace MediaBrowser.Providers.MediaInfo
         ICustomMetadataProvider<Trailer>,
         ICustomMetadataProvider<Video>,
         ICustomMetadataProvider<Audio>,
-        ICustomMetadataProvider<AudioBook>,
         IHasOrder,
         IForcedProvider,
         IPreRefreshProvider,
@@ -204,12 +203,6 @@ namespace MediaBrowser.Providers.MediaInfo
 
         /// <inheritdoc />
         public Task<ItemUpdateType> FetchAsync(Audio item, MetadataRefreshOptions options, CancellationToken cancellationToken)
-        {
-            return FetchAudioInfo(item, options, cancellationToken);
-        }
-
-        /// <inheritdoc />
-        public Task<ItemUpdateType> FetchAsync(AudioBook item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchAudioInfo(item, options, cancellationToken);
         }

--- a/tests/Jellyfin.Naming.Tests/AudioBook/AudioBookFileInfoTests.cs
+++ b/tests/Jellyfin.Naming.Tests/AudioBook/AudioBookFileInfoTests.cs
@@ -26,5 +26,32 @@ namespace Jellyfin.Naming.Tests.AudioBook
             var info2 = new AudioBookFileInfo(string.Empty, string.Empty);
             Assert.Equal(0, info1.CompareTo(info2));
         }
+
+        [Fact]
+        public void CompareTo_DifferentParts_SortsByPart()
+        {
+            // Part is the outer grouping (like disc), chapter is inner (like track).
+            // Part 2 Chapter 1 must sort after Part 1 Chapter 99.
+            var part1ch99 = new AudioBookFileInfo("a", "mp3", partNumber: 1, chapterNumber: 99);
+            var part2ch1 = new AudioBookFileInfo("b", "mp3", partNumber: 2, chapterNumber: 1);
+            Assert.True(part1ch99.CompareTo(part2ch1) < 0);
+            Assert.True(part2ch1.CompareTo(part1ch99) > 0);
+        }
+
+        [Fact]
+        public void CompareTo_SamePart_SortsByChapter()
+        {
+            var part1ch1 = new AudioBookFileInfo("a", "mp3", partNumber: 1, chapterNumber: 1);
+            var part1ch2 = new AudioBookFileInfo("b", "mp3", partNumber: 1, chapterNumber: 2);
+            Assert.True(part1ch1.CompareTo(part1ch2) < 0);
+        }
+
+        [Fact]
+        public void CompareTo_NullPartBeforeNumberedPart_Success()
+        {
+            var noPart = new AudioBookFileInfo("a", "mp3", partNumber: null, chapterNumber: 1);
+            var part1 = new AudioBookFileInfo("b", "mp3", partNumber: 1, chapterNumber: 1);
+            Assert.True(noPart.CompareTo(part1) < 0);
+        }
     }
 }

--- a/tests/Jellyfin.Naming.Tests/AudioBook/AudioBookFilePathParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/AudioBook/AudioBookFilePathParserTests.cs
@@ -1,0 +1,43 @@
+using Emby.Naming.AudioBook;
+using Emby.Naming.Common;
+using Xunit;
+
+namespace Jellyfin.Naming.Tests.AudioBook
+{
+    public class AudioBookFilePathParserTests
+    {
+        private readonly NamingOptions _namingOptions = new NamingOptions();
+
+        [Theory]
+        [InlineData("/Book/Part 1/Chapter 01.mp3", 1, 1)]
+        [InlineData("/Book/Part 2/Chapter 03.mp3", 2, 3)]
+        [InlineData("/Book/Part 2/Chapter 05.mp3", 2, 5)]
+        [InlineData("/Book/part 1/ch01.mp3", 1, 1)]
+        [InlineData("/Book/Part 01/Chapter 1.mp3", 1, 1)]
+        public void Parse_FileInPartSubfolder_ExtractsPartFromFolder(string path, int expectedPart, int expectedChapter)
+        {
+            var result = new AudioBookFilePathParser(_namingOptions).Parse(path);
+            Assert.Equal(expectedPart, result.PartNumber);
+            Assert.Equal(expectedChapter, result.ChapterNumber);
+        }
+
+        [Theory]
+        [InlineData("/Book/Part 99/Part 1 Chapter 3.mp3", 1, 3)]
+        public void Parse_FileWithPartInName_FilenamePartTakesPrecedenceOverFolder(string path, int expectedPart, int expectedChapter)
+        {
+            var result = new AudioBookFilePathParser(_namingOptions).Parse(path);
+            Assert.Equal(expectedPart, result.PartNumber);
+            Assert.Equal(expectedChapter, result.ChapterNumber);
+        }
+
+        [Theory]
+        [InlineData("/Book/Chapter 01.mp3", null, 1)]
+        [InlineData("/Book/extras/bonus.mp3", null, null)]
+        public void Parse_FileNotInPartSubfolder_NoPartNumber(string path, int? expectedPart, int? expectedChapter)
+        {
+            var result = new AudioBookFilePathParser(_namingOptions).Parse(path);
+            Assert.Equal(expectedPart, result.PartNumber);
+            Assert.Equal(expectedChapter, result.ChapterNumber);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Emby.Naming.Common;
 using Emby.Server.Implementations.Library.Resolvers.Audio;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
@@ -14,43 +16,127 @@ public class AudioResolverTests
 {
     private static readonly NamingOptions _namingOptions = new();
 
+    /// <summary>
+    /// AudioBookResolver resolves directories containing audio files as AudioBook folders.
+    /// </summary>
     [Theory]
-    [InlineData("words.mp3")] // single non-tagged file
+    [InlineData("words.mp3")]
     [InlineData("chapter 01.mp3")]
     [InlineData("part 1.mp3")]
     [InlineData("chapter 01.mp3", "non-media.txt")]
-    [InlineData("title.mp3", "title.epub")]
-    [InlineData("01.mp3", "subdirectory/")] // single media file with sub-directory - note that this will hide any contents in the subdirectory
-    public void Resolve_AudiobookDirectory_SingleResult(params string[] children)
-    {
-        var resolved = TestResolveChildren("/parent/title", children);
-        Assert.NotNull(resolved);
-    }
-
-    [Theory]
-    /* Results that can't be displayed as an audio book. */
-    [InlineData] // no contents
-    [InlineData("subdirectory/")]
-    [InlineData("non-media.txt")]
-    /* Names don't indicate parts of a single book. */
-    [InlineData("Name.mp3", "Another Name.mp3")]
-    /* Results that are an audio book but not currently navigable as such (multiple chapters and/or parts). */
+    [InlineData("01.mp3", "subdirectory/")]
     [InlineData("01.mp3", "02.mp3")]
     [InlineData("chapter 01.mp3", "chapter 02.mp3")]
-    [InlineData("part 1.mp3", "part 2.mp3")]
-    [InlineData("chapter 01 part 01.mp3", "chapter 01 part 02.mp3")]
-    /* Mismatched chapters, parts, and named files. */
-    [InlineData("chapter 01.mp3", "part 2.mp3")]
-    [InlineData("book title.mp3", "chapter name.mp3")] // "book title" resolves as alternate version of book based on directory name
-    [InlineData("01 Content.mp3", "01 Credits.mp3")] // resolves as alternate versions of chapter 1
-    [InlineData("Chapter Name.mp3", "Part 1.mp3")]
-    public void Resolve_AudiobookDirectory_NoResult(params string[] children)
+    [InlineData("Name.mp3", "Another Name.mp3")]
+    [InlineData("familyhappiness_1_tolstoy.mp3", "familyhappiness_2_tolstoy.mp3")]
+    [InlineData("cossacks_01_tolstoy.mp3", "cossacks_02_tolstoy.mp3")]
+    public void AudioBookResolver_DirectoryWithAudio_ReturnsAudioBook(params string[] children)
     {
-        var resolved = TestResolveChildren("/parent/book title", children);
+        var resolved = ResolveDirectory("/parent/book title", children);
+        Assert.NotNull(resolved);
+        Assert.IsType<AudioBook>(resolved);
+    }
+
+    /// <summary>
+    /// AudioBookResolver returns null for directories without audio files.
+    /// </summary>
+    [Theory]
+    [InlineData]
+    [InlineData("subdirectory/")]
+    [InlineData("non-media.txt")]
+    public void AudioBookResolver_DirectoryWithoutAudio_ReturnsNull(params string[] children)
+    {
+        var resolved = ResolveDirectory("/parent/book title", children);
         Assert.Null(resolved);
     }
 
-    private Audio? TestResolveChildren(string parent, string[] children)
+    /// <summary>
+    /// AudioBookResolver resolves directories whose only audio is inside part subfolders as AudioBook.
+    /// </summary>
+    [Theory]
+    [InlineData("Part 1/", "Part 2/")]
+    [InlineData("part 1/", "part 2/")]
+    [InlineData("Part 01/", "Part 02/")]
+    public void AudioBookResolver_DirectoryWithPartSubfolders_ReturnsAudioBook(params string[] partFolders)
+    {
+        // Each part subfolder contains at least one audio file.
+        var partFolderAudio = partFolders.ToDictionary(
+            f => "/parent/book title/" + f.TrimEnd('/'),
+            f => new[] { new FileSystemMetadata { FullName = "/parent/book title/" + f.TrimEnd('/') + "/chapter 01.mp3", IsDirectory = false } });
+
+        var resolved = ResolveDirectoryWithSubfolderAudio("/parent/book title", partFolders, partFolderAudio);
+        Assert.NotNull(resolved);
+        Assert.IsType<AudioBook>(resolved);
+    }
+
+    /// <summary>
+    /// AudioBookResolver returns null when subfolders exist but are not part folders.
+    /// </summary>
+    [Theory]
+    [InlineData("extras/")]
+    [InlineData("bonus/")]
+    public void AudioBookResolver_DirectoryWithNonPartSubfolders_ReturnsNull(params string[] subfolders)
+    {
+        var subfolderAudio = subfolders.ToDictionary(
+            f => "/parent/book title/" + f.TrimEnd('/'),
+            f => new[] { new FileSystemMetadata { FullName = "/parent/book title/" + f.TrimEnd('/') + "/track.mp3", IsDirectory = false } });
+
+        var resolved = ResolveDirectoryWithSubfolderAudio("/parent/book title", subfolders, subfolderAudio);
+        Assert.Null(resolved);
+    }
+
+    /// <summary>
+    /// AudioResolver resolves individual audio files in a books collection as Audio items.
+    /// </summary>
+    [Theory]
+    [InlineData("track.mp3")]
+    [InlineData("chapter 01.mp3")]
+    [InlineData("familyhappiness_1_tolstoy.mp3")]
+    public void AudioResolver_FileInBooksCollection_ReturnsAudio(string fileName)
+    {
+        var resolver = new AudioResolver(_namingOptions);
+        var itemResolveArgs = new ItemResolveArgs(
+            null,
+            Mock.Of<ILibraryManager>())
+        {
+            CollectionType = CollectionType.books,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = "/parent/book/" + fileName,
+                IsDirectory = false
+            },
+            Path = "/parent/book/" + fileName
+        };
+
+        var result = resolver.Resolve(itemResolveArgs);
+        Assert.NotNull(result);
+        Assert.IsType<Audio>(result);
+    }
+
+    /// <summary>
+    /// AudioResolver returns null for directories in a books collection (handled by AudioBookResolver).
+    /// </summary>
+    [Fact]
+    public void AudioResolver_DirectoryInBooksCollection_ReturnsNull()
+    {
+        var resolver = new AudioResolver(_namingOptions);
+        var itemResolveArgs = new ItemResolveArgs(
+            null,
+            Mock.Of<ILibraryManager>())
+        {
+            CollectionType = CollectionType.books,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = "/parent/book title",
+                IsDirectory = true
+            }
+        };
+
+        var result = resolver.Resolve(itemResolveArgs);
+        Assert.Null(result);
+    }
+
+    private static AudioBook? ResolveDirectory(string parent, string[] children)
     {
         var childrenMetadata = children.Select(name => new FileSystemMetadata
         {
@@ -58,12 +144,51 @@ public class AudioResolverTests
             IsDirectory = name.EndsWith('/')
         }).ToArray();
 
-        var resolver = new AudioResolver(_namingOptions);
+        var directoryService = Mock.Of<IDirectoryService>();
+        var parentFolder = new Folder { Path = "/parent" };
+        var resolver = new AudioBookResolver(_namingOptions, directoryService);
         var itemResolveArgs = new ItemResolveArgs(
             null,
             Mock.Of<ILibraryManager>())
         {
             CollectionType = CollectionType.books,
+            Parent = parentFolder,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = parent,
+                IsDirectory = true
+            },
+            FileSystemChildren = childrenMetadata
+        };
+
+        return resolver.Resolve(itemResolveArgs);
+    }
+
+    private static AudioBook? ResolveDirectoryWithSubfolderAudio(
+        string parent,
+        string[] subfolders,
+        Dictionary<string, FileSystemMetadata[]> subfolderContents)
+    {
+        var childrenMetadata = subfolders.Select(name => new FileSystemMetadata
+        {
+            FullName = parent + "/" + name.TrimEnd('/'),
+            IsDirectory = true
+        }).ToArray();
+
+        var directoryServiceMock = new Mock<IDirectoryService>();
+        foreach (var (path, contents) in subfolderContents)
+        {
+            directoryServiceMock.Setup(d => d.GetFileSystemEntries(path)).Returns(contents);
+        }
+
+        var parentFolder = new Folder { Path = "/parent" };
+        var resolver = new AudioBookResolver(_namingOptions, directoryServiceMock.Object);
+        var itemResolveArgs = new ItemResolveArgs(
+            null,
+            Mock.Of<ILibraryManager>())
+        {
+            CollectionType = CollectionType.books,
+            Parent = parentFolder,
             FileInfo = new FileSystemMetadata
             {
                 FullName = parent,


### PR DESCRIPTION
initial attempt to add tracks-as-chapters comprehension to audiobooks including part subfolders

Audiobooks with multiple parts (e.g. "Part 1/", "Part 2/" subfolders) are now resolved correctly by the library scanner, mirroring how multi-disc music albums have always worked. Files inside a part subfolder automatically inherit the part number, so you can organize an audiobook as Book/Part 1/Chapter 01.mp3 without needing to encode the part number in every filename. The sort order for audiobook tracks has also been fixed: parts are now the outer grouping and chapters the inner one, so "Part 1 Chapter 99" correctly sorts before "Part 2 Chapter 1" — previously this was inverted.

tmk no issues are currently related.
