### PR TITLE
Ignore season directories with no video for TV Shows

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
@@ -1,6 +1,8 @@
 #nullable disable
 
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using Emby.Naming.Common;
 using Emby.Naming.TV;
 using MediaBrowser.Controller.Entities.TV;
@@ -75,6 +77,14 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                             episodeInfo.SeasonNumber.Value,
                             episodeInfo.EpisodeNumber.Value);
 
+                        return null;
+                    }
+
+                    var hasAnyVideo = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
+                        .Any(file => _namingOptions.VideoFileExtensions.Contains(Path.GetExtension(file)));
+
+                    if (!hasAnyVideo)
+                    {
                         return null;
                     }
                 }


### PR DESCRIPTION
**Changes**
Modified the logic of `SeasonResolver` to only treat a sub-directory as a season when the directory contains any video file (by checking the extension).