### PR TITLE
fix person TotalRecordCount when limit is applied

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -34,14 +34,11 @@ using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaEncoding;
-using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Resolvers;
 using MediaBrowser.Controller.Sorting;
-using MediaBrowser.Controller.Trickplay;
 using MediaBrowser.Model.Configuration;
-using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -2918,7 +2915,7 @@ namespace Emby.Server.Implementations.Library
 
         public IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery query)
         {
-            return _peopleRepository.GetPeople(query);
+            return _peopleRepository.GetPeople(query).Items;
         }
 
         public IReadOnlyList<PersonInfo> GetPeople(BaseItem item)
@@ -2939,24 +2936,33 @@ namespace Emby.Server.Implementations.Library
             return [];
         }
 
-        public IReadOnlyList<Person> GetPeopleItems(InternalPeopleQuery query)
+        public QueryResult<BaseItem> GetPeopleItems(InternalPeopleQuery query)
         {
-            return _peopleRepository.GetPeopleNames(query)
-            .Select(i =>
+            var queryResult = _peopleRepository.GetPeople(query);
+            var baseItems = queryResult.Items.Select(i =>
+                {
+                    try
+                    {
+                        return GetPerson(i.Name);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "error retrieving BaseItem for person: {0}", i.Name);
+                        return null;
+                    }
+                })
+                .Where(i => i is not null)
+                .Where(i => query.User is null || i!.IsVisible(query.User))
+                .OfType<BaseItem>()
+                .ToList()
+                .AsReadOnly();
+
+            return new QueryResult<BaseItem>
             {
-                try
-                {
-                    return GetPerson(i);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error getting person");
-                    return null;
-                }
-            })
-            .Where(i => i is not null)
-            .Where(i => query.User is null || i!.IsVisible(query.User))
-            .ToList()!; // null values are filtered out
+                StartIndex = queryResult.StartIndex,
+                TotalRecordCount = queryResult.TotalRecordCount,
+                Items = baseItems,
+            };
         }
 
         public IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery query)

--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -106,9 +106,11 @@ public class PersonsController : BaseJellyfinApiController
         });
 
         return new QueryResult<BaseItemDto>(
-            peopleItems
-            .Select(person => _dtoService.GetItemByNameDto(person, dtoOptions, null, user))
-            .ToArray());
+            peopleItems.StartIndex,
+            peopleItems.TotalRecordCount,
+            peopleItems.Items
+                .Select(person => _dtoService.GetItemByNameDto(person, dtoOptions, null, user))
+                .ToArray());
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
-using Jellyfin.Database.Implementations.Entities.Libraries;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Model.Querying;
 using Microsoft.EntityFrameworkCore;
 
 namespace Jellyfin.Server.Implementations.Item;
@@ -30,7 +29,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider = dbProvider;
 
     /// <inheritdoc/>
-    public IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter)
+    public QueryResult<PersonInfo> GetPeople(InternalPeopleQuery filter)
     {
         using var context = _dbProvider.CreateDbContext();
         var dbQuery = TranslateQuery(context.Peoples.AsNoTracking(), context, filter);
@@ -48,12 +47,23 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
             dbQuery = dbQuery.OrderBy(e => e.Name);
         }
 
+        var count = dbQuery.Count();
+        if (filter.StartIndex.HasValue && filter.StartIndex > 0)
+        {
+            dbQuery = dbQuery.Skip(filter.StartIndex.Value);
+        }
+
         if (filter.Limit > 0)
         {
             dbQuery = dbQuery.Take(filter.Limit);
         }
 
-        return dbQuery.AsEnumerable().Select(Map).ToArray();
+        return new QueryResult<PersonInfo>
+        {
+            StartIndex = filter.StartIndex ?? 0,
+            TotalRecordCount = count,
+            Items = dbQuery.AsEnumerable().Select(Map).ToArray(),
+        };
     }
 
     /// <inheritdoc/>

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -514,7 +514,7 @@ namespace MediaBrowser.Controller.Library
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>List&lt;Person&gt;.</returns>
-        IReadOnlyList<Person> GetPeopleItems(InternalPeopleQuery query);
+        QueryResult<BaseItem> GetPeopleItems(InternalPeopleQuery query);
 
         /// <summary>
         /// Updates the people.

--- a/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
@@ -1,13 +1,15 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Querying;
 
 namespace MediaBrowser.Controller.Persistence;
 
+/// <summary>
+/// Provides methods for accessing Peoples.
+/// </summary>
 public interface IPeopleRepository
 {
     /// <summary>
@@ -15,7 +17,7 @@ public interface IPeopleRepository
     /// </summary>
     /// <param name="filter">The query.</param>
     /// <returns>The list of people matching the filter.</returns>
-    IReadOnlyList<PersonInfo> GetPeople(InternalPeopleQuery filter);
+    QueryResult<PersonInfo> GetPeople(InternalPeopleQuery filter);
 
     /// <summary>
     /// Updates the people.


### PR DESCRIPTION
**Changes**

Right now TotalRecordCount for the Persons API will always return the limit when present since we don't return a QueryResult with the required information. This breaks pagination on the web client.

I tried to limit the blast radius of changes for a 12.0 inclusion. We can't pass QueryResult<BaseItem> from PeopleRepository because a number of other locations expect PersonInfo. I have subsequent pull requests to add prefix filtering and maybe sort order.

**Issues**

None