### PR TITLE
fix(syncPlay): clamp position ticks to prevent overshoot past media duration

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -665,6 +665,9 @@ namespace Emby.Server.Implementations.SyncPlay
                 startPositionTicks += Math.Max(elapsedTime.Ticks, 0);
             }
 
+            // Clamp to valid range to prevent overshoot past media duration.
+            startPositionTicks = Math.Clamp(startPositionTicks, 0, RunTimeTicks);
+
             return new PlayQueueUpdate(
                 reason,
                 PlayQueue.LastChange,

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
@@ -74,6 +74,11 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 // when playback unpause is supposed to happen.
                 // Seek only if playback actually started.
                 context.PositionTicks += Math.Max(elapsedTime.Ticks, 0);
+
+                // Clamp position to media duration to prevent overshoot.
+                // Network delay or processing time can cause the calculated
+                // position to exceed the actual media length.
+                context.PositionTicks = context.SanitizePositionTicks(context.PositionTicks);
             }
 
             // Prepare new session.
@@ -361,6 +366,9 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 // when playback unpause is supposed to happen.
                 // Seek only if playback actually started.
                 context.PositionTicks += Math.Max(elapsedTime.Ticks, 0);
+
+                // Clamp position to media duration to prevent overshoot.
+                context.PositionTicks = context.SanitizePositionTicks(context.PositionTicks);
 
                 // Send pause command to all non-buffering sessions.
                 var command = context.NewSyncPlayCommand(SendCommandType.Pause);

--- a/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/GroupTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/GroupTests.cs
@@ -1,0 +1,85 @@
+using System;
+using Emby.Server.Implementations.SyncPlay;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.SyncPlay;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.SyncPlay
+{
+    public sealed class GroupTests : IDisposable
+    {
+        private readonly NullLoggerFactory _loggerFactory = new();
+
+        public void Dispose()
+        {
+            _loggerFactory.Dispose();
+        }
+
+        private Group CreateGroup()
+        {
+            var userManager = new Mock<IUserManager>();
+            var sessionManager = new Mock<ISessionManager>();
+            var libraryManager = new Mock<ILibraryManager>();
+
+            return new Group(
+                _loggerFactory,
+                userManager.Object,
+                sessionManager.Object,
+                libraryManager.Object);
+        }
+
+        [Fact]
+        public void SanitizePositionTicks_ClampsToRunTimeTicks()
+        {
+            var group = CreateGroup();
+            // RunTimeTicks defaults to 0 when no item is playing.
+            // SanitizePositionTicks should clamp to [0, RunTimeTicks].
+            var result = group.SanitizePositionTicks(100);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void SanitizePositionTicks_ClampsNegativeToZero()
+        {
+            var group = CreateGroup();
+            var result = group.SanitizePositionTicks(-100);
+            Assert.Equal(0, result);
+        }
+
+        /// <summary>
+        /// Regression test: GetPlayQueueUpdate should clamp startPositionTicks
+        /// to [0, RunTimeTicks] to prevent overshoot past media duration.
+        /// </summary>
+        [Fact]
+        public void GetPlayQueueUpdate_ClampsPositionToRunTimeTicks()
+        {
+            var group = CreateGroup();
+
+            // Set position beyond what RunTimeTicks would allow.
+            // RunTimeTicks is 0 (no item loaded), so any positive PositionTicks should be clamped.
+            group.PositionTicks = 600_000_000_0; // 60 seconds in ticks
+            group.LastActivity = DateTime.UtcNow;
+
+            var update = group.GetPlayQueueUpdate(PlayQueueUpdateReason.NewPlaylist);
+
+            // Since RunTimeTicks is 0, startPositionTicks should be clamped to 0.
+            Assert.Equal(0, update.StartPositionTicks);
+        }
+
+        [Fact]
+        public void GetPlayQueueUpdate_DoesNotClampWithinValidRange()
+        {
+            var group = CreateGroup();
+
+            // PositionTicks is 0 and RunTimeTicks is 0, so it should stay 0.
+            group.PositionTicks = 0;
+            group.LastActivity = DateTime.UtcNow;
+
+            var update = group.GetPlayQueueUpdate(PlayQueueUpdateReason.NewPlaylist);
+            Assert.Equal(0, update.StartPositionTicks);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/WaitingGroupStateTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/WaitingGroupStateTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.SyncPlay;
+using MediaBrowser.Controller.SyncPlay.GroupStates;
+using MediaBrowser.Model.SyncPlay;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.SyncPlay
+{
+    public sealed class WaitingGroupStateTests : IDisposable
+    {
+        private readonly NullLoggerFactory _loggerFactory = new();
+
+        public void Dispose()
+        {
+            _loggerFactory.Dispose();
+        }
+
+        private Mock<IGroupStateContext> CreateMockContext(
+            long positionTicks,
+            long runTimeTicks,
+            DateTime lastActivity)
+        {
+            var context = new Mock<IGroupStateContext>();
+
+            context.SetupProperty(c => c.PositionTicks, positionTicks);
+            context.SetupProperty(c => c.LastActivity, lastActivity);
+
+            // SanitizePositionTicks clamps to [0, runTimeTicks].
+            context.Setup(c => c.SanitizePositionTicks(It.IsAny<long>()))
+                .Returns((long ticks) => Math.Clamp(ticks, 0, runTimeTicks));
+
+            // GetPlayQueueUpdate returns a minimal update.
+            var playQueueUpdate = new PlayQueueUpdate(
+                PlayQueueUpdateReason.NewPlaylist,
+                DateTime.UtcNow,
+                Array.Empty<SyncPlayQueueItem>(),
+                -1,
+                0,
+                false,
+                GroupShuffleMode.Sorted,
+                GroupRepeatMode.RepeatNone);
+            context.Setup(c => c.GetPlayQueueUpdate(It.IsAny<PlayQueueUpdateReason>()))
+                .Returns(playQueueUpdate);
+
+            context.Setup(c => c.GroupId).Returns(Guid.NewGuid());
+            context.Setup(c => c.SendGroupUpdate(
+                It.IsAny<SessionInfo>(),
+                It.IsAny<SyncPlayBroadcastType>(),
+                It.IsAny<GroupUpdate<PlayQueueUpdate>>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            context.Setup(c => c.SetBuffering(It.IsAny<SessionInfo>(), It.IsAny<bool>()));
+            context.Setup(c => c.NewSyncPlayCommand(It.IsAny<SendCommandType>()))
+                .Returns(new SendCommand(
+                    Guid.NewGuid(),
+                    Guid.Empty,
+                    DateTime.UtcNow,
+                    SendCommandType.Pause,
+                    0,
+                    DateTime.UtcNow));
+            context.Setup(c => c.SendCommand(
+                It.IsAny<SessionInfo>(),
+                It.IsAny<SyncPlayBroadcastType>(),
+                It.IsAny<SendCommand>(),
+                It.IsAny<CancellationToken>()));
+
+            return context;
+        }
+
+        private static SessionInfo CreateSession()
+        {
+            return new SessionInfo(null, new NullLogger<SessionInfo>()) { Id = "test-session" };
+        }
+
+        /// <summary>
+        /// Regression test: when a session joins a group that was in Playing state,
+        /// the position should be clamped to RunTimeTicks to prevent overshoot.
+        /// Before the fix, network delay could cause PositionTicks to exceed
+        /// the media duration, causing the client to seek past the end of the video.
+        /// </summary>
+        [Fact]
+        public void SessionJoined_FromPlaying_ClampsPositionToRunTimeTicks()
+        {
+            var state = new WaitingGroupState(_loggerFactory);
+
+            long videoDurationTicks = 600_000_000_0; // 60 seconds
+            long initialPositionTicks = 550_000_000_0; // 55 seconds
+
+            // Set LastActivity to 10 seconds ago, simulating network delay.
+            // After adding elapsed time, position would be ~65 seconds - past the end.
+            var context = CreateMockContext(
+                initialPositionTicks,
+                videoDurationTicks,
+                DateTime.UtcNow.AddSeconds(-10));
+
+            var session = CreateSession();
+
+            // Act: session joins from Playing state.
+            state.SessionJoined(context.Object, GroupStateType.Playing, session, CancellationToken.None);
+
+            // Assert: position should be clamped to video duration.
+            Assert.True(
+                context.Object.PositionTicks <= videoDurationTicks,
+                $"PositionTicks ({context.Object.PositionTicks}) should not exceed RunTimeTicks ({videoDurationTicks})");
+
+            // Verify SanitizePositionTicks was called (our fix).
+            context.Verify(c => c.SanitizePositionTicks(It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        public void SessionJoined_FromPaused_DoesNotModifyPosition()
+        {
+            var state = new WaitingGroupState(_loggerFactory);
+
+            long initialPositionTicks = 300_000_000_0; // 30 seconds
+
+            var context = CreateMockContext(
+                initialPositionTicks,
+                600_000_000_0, // 60 seconds
+                DateTime.UtcNow);
+
+            var session = CreateSession();
+
+            // Act: session joins from Paused state (no position update expected).
+            state.SessionJoined(context.Object, GroupStateType.Paused, session, CancellationToken.None);
+
+            // Assert: position should remain unchanged.
+            Assert.Equal(initialPositionTicks, context.Object.PositionTicks);
+
+            // SanitizePositionTicks should NOT be called since we're not in Playing state.
+            context.Verify(c => c.SanitizePositionTicks(It.IsAny<long>()), Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When a session joins a SyncPlay group or reports buffering while the group is in the Playing state, the server calculates the current playback position by adding elapsed time to the last known position. Network delays or processing time can cause this calculation to produce a position that exceeds the media's total duration, which is then sent to clients causing them to seek past the end of the video and trigger a "next episode" transition.

This PR adds position clamping via `SanitizePositionTicks` (which uses `Math.Clamp(ticks, 0, RunTimeTicks)`) in three places:

- **`WaitingGroupState.SessionJoined()`**: after computing elapsed position when transitioning from Playing state
- **`WaitingGroupState.HandleRequest(BufferGroupRequest)`**: same pattern when a buffering request arrives during playback
- **`Group.GetPlayQueueUpdate()`**: clamps `startPositionTicks` before sending the queue update to clients (defense in depth)

## Related Issues

- Fixes https://github.com/jellyfin/jellyfin/issues/12422 (joining group causes next episode to play)
- Related to https://github.com/jellyfin/jellyfin/issues/4953 (stream freezes for participants)
- Companion client-side PR: https://github.com/jellyfin/jellyfin-web/pull/7830

## Test Plan

- [x] Added xUnit regression test proving `SessionJoined` from Playing state clamps position to `RunTimeTicks`
- [x] Added xUnit test verifying `SessionJoined` from Paused state does NOT modify position
- [x] Added xUnit tests for `Group.GetPlayQueueUpdate` clamping and `SanitizePositionTicks`
- [x] All 6 new tests pass
- [ ] Manual testing: join SyncPlay group mid-playback with 2+ users

🤖 Generated with [Claude Code](https://claude.com/claude-code)