### PR TITLE
fix: add image/jpg to MIME type extension lookup

### DIFF
--- a/MediaBrowser.Model/Net/MimeTypes.cs
+++ b/MediaBrowser.Model/Net/MimeTypes.cs
@@ -132,6 +132,7 @@ namespace MediaBrowser.Model.Net
 
             // Type image
             new("image/jpeg", ".jpg"),
+            new("image/jpg", ".jpg"),
             new("image/tiff", ".tiff"),
             new("image/x-png", ".png"),
             new("image/x-icon", ".ico"),


### PR DESCRIPTION
## Problem

Several external metadata providers (TMDb, Schedules Direct, and others) return `image/jpg` as the Content-Type for JPEG images instead of the standard `image/jpeg` (RFC 2046).

When Jellyfin encounters this non-standard MIME type during library scans, it throws:
```
System.ArgumentException: Unable to determine image file extension from mime type image/jpg
```

This causes:
- Episode thumbnail downloads to fail silently
- Library scans to accumulate errors and eventually be cancelled
- Repeated scan failures every ~60 minutes on large libraries

## Fix

Add `image/jpg` → `.jpg` to the `_extensionLookup` FrozenDictionary in `MimeTypes.cs`.

## Context

- PR #7052 previously added this mapping but it was lost during the migration to FrozenDictionary
- Issue #13568 reports the same bug in 10.10+
- Issue #7050 was the original report

While `image/jpg` is not a registered MIME type, multiple widely-used providers return it, making this a practical necessity.

## Testing

- Library scan that previously crashed after ~60 minutes now completes successfully
- Episode images that previously failed with `image/jpg` errors now save correctly