### PR TITLE
Fix actor images not displayed until clicked

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
@@ -168,55 +169,66 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
 
     private async Task RefreshPeopleImagesAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var people = _libraryManager.GetPeopleNames(new InternalPeopleQuery());
-        var numPeople = people.Count;
-        var numComplete = 0;
-        var numRefreshed = 0;
+        var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+        var personTypeName = typeof(Person).FullName!;
 
-        _logger.LogDebug("Checking {Count} people for missing images", numPeople);
-
-        foreach (var person in people)
+        var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (context.ConfigureAwait(false))
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            var peopleIds = await context.BaseItems
+                .AsNoTracking()
+                .Where(b => b.Type == personTypeName)
+                .Where(b => b.DateLastRefreshed == null || b.DateLastRefreshed < thirtyDaysAgo)
+                .Where(b =>
+                    !b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary) ||
+                    string.IsNullOrEmpty(b.Overview))
+                .Select(b => b.Id)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            try
+            var numPeople = peopleIds.Count;
+            var numComplete = 0;
+            var numRefreshed = 0;
+
+            _logger.LogDebug("Found {Count} people needing image/overview refresh", numPeople);
+
+            foreach (var personId in peopleIds)
             {
-                var item = _libraryManager.GetPerson(person);
-                if (item is null)
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
                 {
-                    continue;
+                    if (_libraryManager.GetItemById(personId) is not Person item)
+                    {
+                        continue;
+                    }
+
+                    var hasImage = item.HasImage(ImageType.Primary, 0);
+                    var hasOverview = !string.IsNullOrWhiteSpace(item.Overview);
+
+                    var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                    {
+                        ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
+                        MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
+                    };
+
+                    await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
+                    numRefreshed++;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error refreshing images for person {PersonId}", personId);
                 }
 
-                var hasImage = item.HasImage(ImageType.Primary, 0);
-                var hasOverview = !string.IsNullOrWhiteSpace(item.Overview);
-
-                if ((hasImage && hasOverview) || (DateTime.UtcNow - item.DateLastRefreshed).TotalDays < 30)
-                {
-                    continue;
-                }
-
-                var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
-                {
-                    ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
-                    MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
-                };
-
-                await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
-                numRefreshed++;
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error refreshing images for {Person}", person);
+                numComplete++;
+                progress.Report(100.0 * numComplete / numPeople);
             }
 
-            numComplete++;
-            progress.Report(100.0 * numComplete / numPeople);
+            _logger.LogInformation("Refreshed metadata for {Count} people missing images or overview", numRefreshed);
         }
-
-        _logger.LogInformation("Refreshed metadata for {Count} people missing images or overview", numRefreshed);
     }
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -4,10 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
@@ -27,6 +29,7 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
     private readonly IDbContextFactory<JellyfinDbContext> _dbContextFactory;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<PeopleValidationTask> _logger;
+    private readonly IItemTypeLookup _itemTypeLookup;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PeopleValidationTask" /> class.
@@ -36,18 +39,21 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
     /// <param name="dbContextFactory">Instance of the <see cref="IDbContextFactory{TContext}"/> interface.</param>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{PeopleValidationTask}"/> interface.</param>
+    /// <param name="itemTypeLookup">Instance of the <see cref="IItemTypeLookup"/> interface.</param>
     public PeopleValidationTask(
         ILibraryManager libraryManager,
         ILocalizationManager localization,
         IDbContextFactory<JellyfinDbContext> dbContextFactory,
         IFileSystem fileSystem,
-        ILogger<PeopleValidationTask> logger)
+        ILogger<PeopleValidationTask> logger,
+        IItemTypeLookup itemTypeLookup)
     {
         _libraryManager = libraryManager;
         _localization = localization;
         _dbContextFactory = dbContextFactory;
         _fileSystem = fileSystem;
         _logger = logger;
+        _itemTypeLookup = itemTypeLookup;
     }
 
     /// <inheritdoc />
@@ -169,60 +175,50 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
     private async Task RefreshPeopleImagesAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
-        var personTypeName = typeof(Person).FullName!;
+        var personTypeName = _itemTypeLookup.BaseItemKindNames[BaseItemKind.Person];
 
         var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await using (context.ConfigureAwait(false))
         {
-            var people = await context.BaseItems
+            const int PartitionSize = 100;
+
+            var numPeople = await context.BaseItems
                 .AsNoTracking()
                 .Where(b => b.Type == personTypeName)
                 .Where(b => b.DateLastRefreshed == null || b.DateLastRefreshed < thirtyDaysAgo)
                 .Where(b =>
                     !b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary) ||
                     string.IsNullOrEmpty(b.Overview))
-                .Select(b => new
-                {
-                    b.Id,
-                    HasImage = b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary),
-                    HasOverview = !string.IsNullOrEmpty(b.Overview)
-                })
-                .ToListAsync(cancellationToken)
+                .CountAsync(cancellationToken)
                 .ConfigureAwait(false);
-
-            var numPeople = people.Count;
-            var numComplete = 0;
-            var numRefreshed = 0;
 
             _logger.LogDebug("Found {Count} people needing image/overview refresh", numPeople);
 
-            foreach (var entry in people)
+            if (numPeople == 0)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                progress.Report(100);
+                return;
+            }
 
-                try
+            var numComplete = 0;
+            var numRefreshed = 0;
+
+            await foreach (var entry in context.BaseItems
+                .AsNoTracking()
+                .Where(b => b.Type == personTypeName)
+                .Where(b => b.DateLastRefreshed == null || b.DateLastRefreshed < thirtyDaysAgo)
+                .Where(b =>
+                    !b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary) ||
+                    string.IsNullOrEmpty(b.Overview))
+                .OrderBy(b => b.Id)
+                .WithPartitionProgress(partition => _logger.LogDebug("Processing people partition {Partition}", partition))
+                .PartitionEagerAsync(PartitionSize, cancellationToken)
+                .WithCancellation(cancellationToken)
+                .ConfigureAwait(false))
+            {
+                if (await RefreshPersonAsync(entry.Id, cancellationToken).ConfigureAwait(false))
                 {
-                    if (_libraryManager.GetItemById(entry.Id) is not Person item)
-                    {
-                        continue;
-                    }
-
-                    var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
-                    {
-                        ImageRefreshMode = entry.HasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
-                        MetadataRefreshMode = entry.HasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
-                    };
-
-                    await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
                     numRefreshed++;
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error refreshing images for person {PersonId}", entry.Id);
                 }
 
                 numComplete++;
@@ -230,6 +226,38 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
             }
 
             _logger.LogInformation("Refreshed metadata for {Count} people missing images or overview", numRefreshed);
+        }
+    }
+
+    private async Task<bool> RefreshPersonAsync(Guid personId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (_libraryManager.GetItemById(personId) is not Person item)
+            {
+                return false;
+            }
+
+            var hasImage = item.HasImage(MediaBrowser.Model.Entities.ImageType.Primary);
+            var hasOverview = !string.IsNullOrEmpty(item.Overview);
+
+            var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            {
+                ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
+                MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
+            };
+
+            await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error refreshing images for person {PersonId}", personId);
+            return false;
         }
     }
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -9,7 +9,6 @@ using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
@@ -175,41 +174,43 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
         var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await using (context.ConfigureAwait(false))
         {
-            var peopleIds = await context.BaseItems
+            var people = await context.BaseItems
                 .AsNoTracking()
                 .Where(b => b.Type == personTypeName)
                 .Where(b => b.DateLastRefreshed == null || b.DateLastRefreshed < thirtyDaysAgo)
                 .Where(b =>
                     !b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary) ||
                     string.IsNullOrEmpty(b.Overview))
-                .Select(b => b.Id)
+                .Select(b => new
+                {
+                    b.Id,
+                    HasImage = b.Images!.Any(i => i.ImageType == ImageInfoImageType.Primary),
+                    HasOverview = !string.IsNullOrEmpty(b.Overview)
+                })
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            var numPeople = peopleIds.Count;
+            var numPeople = people.Count;
             var numComplete = 0;
             var numRefreshed = 0;
 
             _logger.LogDebug("Found {Count} people needing image/overview refresh", numPeople);
 
-            foreach (var personId in peopleIds)
+            foreach (var entry in people)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {
-                    if (_libraryManager.GetItemById(personId) is not Person item)
+                    if (_libraryManager.GetItemById(entry.Id) is not Person item)
                     {
                         continue;
                     }
 
-                    var hasImage = item.HasImage(ImageType.Primary, 0);
-                    var hasOverview = !string.IsNullOrWhiteSpace(item.Overview);
-
                     var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
                     {
-                        ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
-                        MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
+                        ImageRefreshMode = entry.HasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
+                        MetadataRefreshMode = entry.HasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
                     };
 
                     await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
@@ -221,7 +222,7 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error refreshing images for person {PersonId}", personId);
+                    _logger.LogError(ex, "Error refreshing images for person {PersonId}", entry.Id);
                 }
 
                 numComplete++;

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -5,8 +5,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -21,6 +25,7 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly ILocalizationManager _localization;
     private readonly IDbContextFactory<JellyfinDbContext> _dbContextFactory;
+    private readonly IFileSystem _fileSystem;
     private readonly ILogger<PeopleValidationTask> _logger;
 
     /// <summary>
@@ -29,12 +34,19 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="dbContextFactory">Instance of the <see cref="IDbContextFactory{TContext}"/> interface.</param>
+    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{PeopleValidationTask}"/> interface.</param>
-    public PeopleValidationTask(ILibraryManager libraryManager, ILocalizationManager localization, IDbContextFactory<JellyfinDbContext> dbContextFactory, ILogger<PeopleValidationTask> logger)
+    public PeopleValidationTask(
+        ILibraryManager libraryManager,
+        ILocalizationManager localization,
+        IDbContextFactory<JellyfinDbContext> dbContextFactory,
+        IFileSystem fileSystem,
+        ILogger<PeopleValidationTask> logger)
     {
         _libraryManager = libraryManager;
         _localization = localization;
         _dbContextFactory = dbContextFactory;
+        _fileSystem = fileSystem;
         _logger = logger;
     }
 
@@ -83,10 +95,11 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
             return;
         }
 
+        // Phase 1: Deduplicate and remove orphaned people (0-33%)
         var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await using (context.ConfigureAwait(false))
         {
-            IProgress<double> subProgress = new Progress<double>((val) => progress.Report(val / 2));
+            IProgress<double> subProgress = new Progress<double>((val) => progress.Report(val / 3));
             var dupQuery = context.Peoples
                     .GroupBy(e => new { e.Name, e.PersonType })
                     .Where(e => e.Count() > 1)
@@ -141,9 +154,69 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
             subProgress.Report(100);
         }
 
-        IProgress<double> validateProgress = new Progress<double>((val) => progress.Report((val / 2) + 50));
+        // Phase 2: Validate people (33-66%). Runs after orphaned PeopleBaseItemMap entries are
+        // cleaned up above, so dead people are removed in a single pass instead of requiring a second run.
+        IProgress<double> validateProgress = new Progress<double>((val) => progress.Report((val / 3) + 33));
         await _libraryManager.ValidatePeopleAsync(validateProgress, cancellationToken).ConfigureAwait(false);
 
+        // Phase 3: Refresh images for people missing them (66-100%)
+        IProgress<double> refreshProgress = new Progress<double>((val) => progress.Report((val / 3) + 66));
+        await RefreshPeopleImagesAsync(refreshProgress, cancellationToken).ConfigureAwait(false);
+
         progress.Report(100);
+    }
+
+    private async Task RefreshPeopleImagesAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var people = _libraryManager.GetPeopleNames(new InternalPeopleQuery());
+        var numPeople = people.Count;
+        var numComplete = 0;
+        var numRefreshed = 0;
+
+        _logger.LogDebug("Checking {Count} people for missing images", numPeople);
+
+        foreach (var person in people)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var item = _libraryManager.GetPerson(person);
+                if (item is null)
+                {
+                    continue;
+                }
+
+                var hasImage = item.HasImage(ImageType.Primary, 0);
+                var hasOverview = !string.IsNullOrWhiteSpace(item.Overview);
+
+                if ((hasImage && hasOverview) || (DateTime.UtcNow - item.DateLastRefreshed).TotalDays < 30)
+                {
+                    continue;
+                }
+
+                var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                {
+                    ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
+                    MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
+                };
+
+                await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);
+                numRefreshed++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error refreshing images for {Person}", person);
+            }
+
+            numComplete++;
+            progress.Report(100.0 * numComplete / numPeople);
+        }
+
+        _logger.LogInformation("Refreshed metadata for {Count} people missing images or overview", numRefreshed);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The "Refresh People" scheduled task used ValidationOnly mode, which skips all remote providers, so it never fetched images or metadata from TMDB. 

Clicking an actor is the only way to populate the image data, because the UI triggers a `FullRefresh`. 

The fix uses `FullRefresh` for people missing an image or overview, with a 30-day cooldown so TMDB isn't hammered for people it has no data for. The 30 day cooldown is also nice, because tmbd may add data over time.

I tested this with my own library:

1. Stock Jellyfin (11.10.8): Ran "Refresh People" -> 34,845 people missing images before, 34,845 after (Zero change).
2. Patched Jellyfin with this PR. Ran "Refresh People" -> 34,845 missing before, 23,805 missing after. ** 11,040 people got images.** (The remaining without images are more obscure people that TMDB doesn't have a photo for)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #8103