### PR TITLE
Preserve ffprobe stream indices so the subtitle cache stays aligned

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -194,20 +194,17 @@ namespace MediaBrowser.Providers.MediaInfo
             IReadOnlyList<MediaAttachment> mediaAttachments;
             ChapterInfo[] chapters;
 
-            // Add external streams before adding the streams from the file to preserve stream IDs on remote videos
-            await AddExternalSubtitlesAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
-
-            await AddExternalAudioAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
-
-            var startIndex = mediaStreams.Count == 0 ? 0 : (mediaStreams.Max(i => i.Index) + 1);
-
+            // Add embedded streams FIRST, preserving the ffprobe-native stream indices
+            // stored in MediaStream.Index. The subtitle cache on disk is keyed by this
+            // Index (see SubtitleEncoder.GetSubtitleCachePath), and FindIndex-based
+            // ffmpeg `-map 0:N` extraction also depends on Index matching the physical
+            // stream position. If we renumber embedded streams after externals have
+            // claimed low indices, a later refresh that adds or removes an external
+            // subtitle will shift all embedded Index values and the cache files will be
+            // served under the wrong labels (e.g. selecting "Spanish" shows Thai).
             if (mediaInfo is not null)
             {
-                foreach (var mediaStream in mediaInfo.MediaStreams)
-                {
-                    mediaStream.Index = startIndex++;
-                    mediaStreams.Add(mediaStream);
-                }
+                mediaStreams.AddRange(mediaInfo.MediaStreams);
 
                 mediaAttachments = mediaInfo.MediaAttachments;
                 video.TotalBitrate = mediaInfo.Bitrate;
@@ -231,7 +228,6 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     if (!mediaStream.IsExternal)
                     {
-                        mediaStream.Index = startIndex++;
                         mediaStreams.Add(mediaStream);
                     }
                 }
@@ -239,6 +235,14 @@ namespace MediaBrowser.Providers.MediaInfo
                 mediaAttachments = [];
                 chapters = [];
             }
+
+            // External streams get Index values AFTER the embedded range.
+            // AddExternalSubtitlesAsync / AddExternalAudioAsync already compute their
+            // startIndex as `max(existing Index) + 1`, so they fall in sequence after
+            // the highest embedded stream.
+            await AddExternalSubtitlesAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
+
+            await AddExternalAudioAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
 
             var libraryOptions = _libraryManager.GetLibraryOptions(video);
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -44,6 +44,13 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly IMediaAttachmentRepository _mediaAttachmentRepository;
         private readonly IMediaStreamRepository _mediaStreamRepository;
 
+        // External subtitle / audio streams are assigned Index values starting at
+        // this offset so they (a) never collide with ffprobe-native indices on the
+        // embedded streams and (b) stay invariant to the embedded stream count, which
+        // is unknown for .strm shortcuts during the no-probe metadata scan. ffprobe
+        // never returns indices anywhere near this magnitude for real media files.
+        private const int ExternalStreamIndexBase = 1_000_000;
+
         public FFProbeVideoInfo(
             ILogger<FFProbeVideoInfo> logger,
             IMediaSourceManager mediaSourceManager,
@@ -202,6 +209,15 @@ namespace MediaBrowser.Providers.MediaInfo
             // claimed low indices, a later refresh that adds or removes an external
             // subtitle will shift all embedded Index values and the cache files will be
             // served under the wrong labels (e.g. selecting "Spanish" shows Thai).
+            //
+            // For .strm shortcuts, the first metadata refresh runs without a remote
+            // probe (mediaInfo is null) and internal streams are unknown until playback
+            // forces a re-probe; the assignment of external Index values must therefore
+            // be invariant to the internal stream count, otherwise externals would shift
+            // between the no-probe and post-probe snapshots. AddExternalSubtitlesAsync /
+            // AddExternalAudioAsync use ExternalStreamIndexBase below to anchor external
+            // Index values past any plausible ffprobe-native index, keeping external
+            // stream IDs stable for remote videos as the original code intended.
             if (mediaInfo is not null)
             {
                 mediaStreams.AddRange(mediaInfo.MediaStreams);
@@ -236,10 +252,10 @@ namespace MediaBrowser.Providers.MediaInfo
                 chapters = [];
             }
 
-            // External streams get Index values AFTER the embedded range.
-            // AddExternalSubtitlesAsync / AddExternalAudioAsync already compute their
-            // startIndex as `max(existing Index) + 1`, so they fall in sequence after
-            // the highest embedded stream.
+            // External streams are assigned Index values starting at
+            // ExternalStreamIndexBase (well past any plausible ffprobe-native index),
+            // so they never collide with embedded streams and stay stable across the
+            // no-probe → probe transition for .strm files.
             await AddExternalSubtitlesAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
 
             await AddExternalAudioAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
@@ -546,7 +562,7 @@ namespace MediaBrowser.Providers.MediaInfo
             MetadataRefreshOptions options,
             CancellationToken cancellationToken)
         {
-            var startIndex = currentStreams.Count == 0 ? 0 : (currentStreams.Select(i => i.Index).Max() + 1);
+            var startIndex = GetExternalStartIndex(currentStreams);
             var externalSubtitleStreams = await _subtitleResolver.GetExternalStreamsAsync(video, startIndex, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
 
             var enableSubtitleDownloading = options.MetadataRefreshMode == MetadataRefreshMode.Default ||
@@ -595,12 +611,30 @@ namespace MediaBrowser.Providers.MediaInfo
             MetadataRefreshOptions options,
             CancellationToken cancellationToken)
         {
-            var startIndex = currentStreams.Count == 0 ? 0 : currentStreams.Max(i => i.Index) + 1;
+            var startIndex = GetExternalStartIndex(currentStreams);
             var externalAudioStreams = await _audioResolver.GetExternalStreamsAsync(video, startIndex, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
 
             video.AudioFiles = externalAudioStreams.Select(i => i.Path).Distinct().ToArray();
 
             currentStreams.AddRange(externalAudioStreams);
+        }
+
+        /// <summary>
+        /// Computes the starting Index for newly-resolved external streams.
+        /// External streams are anchored at <see cref="ExternalStreamIndexBase"/> so
+        /// they don't collide with ffprobe-native indices on embedded streams and stay
+        /// stable across refreshes regardless of internal stream count (in particular,
+        /// across the no-probe → probe transition for .strm shortcuts).
+        /// </summary>
+        private static int GetExternalStartIndex(List<MediaStream> currentStreams)
+        {
+            if (currentStreams.Count == 0)
+            {
+                return ExternalStreamIndexBase;
+            }
+
+            var maxExisting = currentStreams.Max(i => i.Index);
+            return Math.Max(maxExisting + 1, ExternalStreamIndexBase);
         }
 
         /// <summary>

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -30,6 +30,13 @@ namespace MediaBrowser.Providers.MediaInfo
 {
     public class FFProbeVideoInfo
     {
+        // External subtitle / audio streams are assigned Index values starting at
+        // this offset so they (a) never collide with ffprobe-native indices on the
+        // embedded streams and (b) stay invariant to the embedded stream count, which
+        // is unknown for .strm shortcuts during the no-probe metadata scan. ffprobe
+        // never returns indices anywhere near this magnitude for real media files.
+        private const int ExternalStreamIndexBase = 1_000_000;
+
         private readonly ILogger<FFProbeVideoInfo> _logger;
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly IMediaEncoder _mediaEncoder;
@@ -43,13 +50,6 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly SubtitleResolver _subtitleResolver;
         private readonly IMediaAttachmentRepository _mediaAttachmentRepository;
         private readonly IMediaStreamRepository _mediaStreamRepository;
-
-        // External subtitle / audio streams are assigned Index values starting at
-        // this offset so they (a) never collide with ffprobe-native indices on the
-        // embedded streams and (b) stay invariant to the embedded stream count, which
-        // is unknown for .strm shortcuts during the no-probe metadata scan. ffprobe
-        // never returns indices anywhere near this magnitude for real media files.
-        private const int ExternalStreamIndexBase = 1_000_000;
 
         public FFProbeVideoInfo(
             ILogger<FFProbeVideoInfo> logger,


### PR DESCRIPTION
**Changes**

Stop renumbering embedded `MediaStream.Index` in `FFProbeVideoInfo.Fetch`.
Embedded streams are added to the working list first and keep the native
ffprobe stream index they were given by `ProbeResultNormalizer`; external
subtitle / audio streams are then appended afterwards, where
`AddExternalSubtitlesAsync` / `AddExternalAudioAsync` already compute
`startIndex = max(existing Index) + 1`, so they land past the embedded
range instead of colliding with it.

**Why**

`MediaStream.Index` is both the cache key under
`/config/data/data/subtitles/<dir>/<itemId>/<Index>.<ext>` and the value
the subtitle extractor uses (via `EncodingHelper.FindIndex`) to compute
the ffmpeg `-map 0:N` argument. Both paths implicitly assume it matches
the physical stream position in the file.

Previously, when external subs were appended to a freshly-probed item,
they claimed `Index=0` and every embedded stream's `Index` was bumped
sequentially — silently discarding the real ffprobe index. Extracted
subtitle cache files on disk were keyed by the *old* `Index`, but the
next request read them back by the *new* `Index`, so the controller
started serving mismatched content. Concretely: after dropping an
`.srt` sibling beside an MKV that already had its embedded subs
extracted, selecting a given embedded subtitle track renders the
content of whichever stream used to live at that `Index` — not the one
the label points at.

**Reproduction (Jellyfin 10.11.8)**

1. Play an MKV with several embedded text subtitle tracks, letting
   Jellyfin extract and cache them to
   ` /config/data/data/subtitles/…/<id>/<Index>.ass `.
2. Drop an external `.srt` sibling next to the video (or have the
   OpenSubtitles downloader do it) and refresh metadata.
3. The external SRT is appended with `Index=0`; every embedded stream's
   `Index` shifts by +1; cache files on disk are untouched.
4. Request `/Videos/{item}/{src}/Subtitles/<Index>/0/Stream.<ext>` for
   any embedded subtitle — the response is the *previous* occupant of
   that `Index`. For a file with English / Spanish / Thai / Vietnamese
   subs, selecting \"Spanish (Spain)\" returns the Thai bytes, etc.

**Compatibility**

External streams move from low `Index` values (typically 0, 1, …) to
positions past the highest embedded index (e.g. 21, 22, …).
`MediaStream.Index` is documented as \"Stream index\" (ffprobe-native),
not \"offset in the MediaStreams array\", and a \`grep -rn\` across the
server codebase turns up no caller that assumes externals sit at low
indices — existing consumers look up by \`Index == N\` or iterate.

Previously-cached subtitle files that were extracted *while* the bug
was active will remain mis-keyed until manually wiped (delete
\`/config/data/data/subtitles/<dir>/<itemId>/\` for the affected item,
or the whole subtitle cache root, and let Jellyfin re-extract on next
playback). Happy to follow up with a one-time cache-invalidation
migration if reviewers think that's warranted.

**Issues**

(no existing issue; this was bisected from a downstream client report)