### PR TITLE
Fix dummy chapter handling for videos with a single chapter or short duration.

### DIFF
--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -108,7 +108,7 @@ public class ChapterManager : IChapterManager
             sum += chapters[i].StartPositionTicks - chapters[i - 1].StartPositionTicks;
         }
 
-        return sum / (chapters.Count - 1);
+        return sum / chapters.Count;
     }
 
     /// <inheritdoc />

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -128,7 +128,7 @@ public class ChapterManager : IChapterManager
 
         var averageChapterDuration = GetAverageDurationBetweenChapters(chapters);
         var threshold = TimeSpan.FromSeconds(1).Ticks;
-        if (averageChapterDuration < threshold)
+        if (chapters.Count >= 2 && averageChapterDuration < threshold)
         {
             _logger.LogInformation("Skipping chapter image extraction for {Video} as the average chapter duration {AverageDuration} was lower than the minimum threshold {Threshold}", video.Name, averageChapterDuration, threshold);
             extractImages = false;

--- a/Emby.Server.Implementations/Chapters/ChapterManager.cs
+++ b/Emby.Server.Implementations/Chapters/ChapterManager.cs
@@ -108,7 +108,7 @@ public class ChapterManager : IChapterManager
             sum += chapters[i].StartPositionTicks - chapters[i - 1].StartPositionTicks;
         }
 
-        return sum / chapters.Count;
+        return sum / (chapters.Count - 1);
     }
 
     /// <inheritdoc />

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -278,7 +278,7 @@ namespace MediaBrowser.Providers.MediaInfo
             if (options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh
                 || options.MetadataRefreshMode == MetadataRefreshMode.Default)
             {
-                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length == 0 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
+                if (_config.Configuration.DummyChapterDuration > 0 && chapters.Length <= 1 && mediaStreams.Any(i => i.Type == MediaStreamType.Video))
                 {
                     chapters = CreateDummyChapters(video);
                 }
@@ -620,12 +620,8 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             long dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
-            if (runtime <= dummyChapterDuration)
-            {
-                return [];
-            }
 
-            int chapterCount = (int)(runtime / dummyChapterDuration);
+            int chapterCount = Math.Max(1, (int)(runtime / dummyChapterDuration));
             var chapters = new ChapterInfo[chapterCount];
 
             long currentChapterTicks = 0;

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -621,6 +621,11 @@ namespace MediaBrowser.Providers.MediaInfo
 
             long dummyChapterDuration = TimeSpan.FromSeconds(_config.Configuration.DummyChapterDuration).Ticks;
 
+            if (runtime <= 0)
+            {
+                return [];
+            }
+
             int chapterCount = Math.Max(1, (int)(runtime / dummyChapterDuration));
             var chapters = new ChapterInfo[chapterCount];
 

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
@@ -59,4 +59,20 @@ public class FFProbeVideoInfoTests
 
         Assert.Equal(chaptersCount, chapters.Length);
     }
+
+    [Theory]
+    [InlineData(1L)]
+    [InlineData(TimeSpan.TicksPerMinute * 3)]
+    [InlineData(TimeSpan.TicksPerMinute * 5)]
+    [InlineData((TimeSpan.TicksPerMinute * 5) + 1)]
+    [InlineData((TimeSpan.TicksPerMinute * 50) + 1)]
+    public void CreateDummyChapters_PositiveRuntime_NoChapterBeyondRuntime(long runtime)
+    {
+        var chapters = _fFProbeVideoInfo.CreateDummyChapters(new Video()
+                {
+                    RunTimeTicks = runtime
+                });
+
+        Assert.All(chapters, chapter => Assert.True(chapter.StartPositionTicks < runtime));
+    }
 }

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
@@ -45,8 +45,9 @@ public class FFProbeVideoInfoTests
     [Theory]
     [InlineData(null, 0)]
     [InlineData(0L, 0)]
-    [InlineData(1L, 0)]
-    [InlineData(TimeSpan.TicksPerMinute * 5, 0)]
+    [InlineData(1L, 1)]
+    [InlineData(TimeSpan.TicksPerMinute * 3, 1)]
+    [InlineData(TimeSpan.TicksPerMinute * 5, 1)]
     [InlineData((TimeSpan.TicksPerMinute * 5) + 1, 1)]
     [InlineData(TimeSpan.TicksPerMinute * 50, 10)]
     public void CreateDummyChapters_ValidRuntime_CorrectChaptersCount(long? runtime, int chaptersCount)


### PR DESCRIPTION
As mentioned in #14479, I’ve made the change simple and clear. @Bond-009 

**Changes**
Fix dummy chapter handling for videos with a single chapter or short duration.

1. Change the condition that triggers dummy chapter creation from `chapters.Length == 0` to `chapters.Length <= 1` in `FFProbeVideoInfo`. A video with only one chapter spanning its entire duration is effectively unchaptered and should trigger dummy chapter generation.

2. In `CreateDummyChapters`, use `Math.Max(1, ...)` to guarantee at least one chapter is always generated. Previously videos shorter than `DummyChapterDuration` got no dummy chapters at all.

3. In `ChapterManager.RefreshChapterImages`, only apply the average-duration threshold check when there are 2+ chapters. A single chapter has no "average duration between chapters", so the check was incorrectly returning 0 and disabling chapter image extraction with a misleading log message.

**Issues**
Fixes #14478
