### PR TITLE
improve openapi endpoint categorization

### DIFF
--- a/Jellyfin.Api/Controllers/ActivityLogController.cs
+++ b/Jellyfin.Api/Controllers/ActivityLogController.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("System/ActivityLog")]
 [Authorize(Policy = Policies.RequiresElevation)]
+[Tags("System")]
 public class ActivityLogController : BaseJellyfinApiController
 {
     private readonly IActivityManager _activityManager;

--- a/Jellyfin.Api/Controllers/ApiKeyController.cs
+++ b/Jellyfin.Api/Controllers/ApiKeyController.cs
@@ -14,6 +14,7 @@ namespace Jellyfin.Api.Controllers;
 /// Authentication controller.
 /// </summary>
 [Route("Auth")]
+[Tags("Authentication")]
 public class ApiKeyController : BaseJellyfinApiController
 {
     private readonly IAuthenticationManager _authenticationManager;

--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("Artists")]
 [Authorize]
+[Tags("Artist")]
 public class ArtistsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/ChannelsController.cs
+++ b/Jellyfin.Api/Controllers/ChannelsController.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Api.Controllers;
 /// Channels Controller.
 /// </summary>
 [Authorize]
+[Tags("Channel")]
 public class ChannelsController : BaseJellyfinApiController
 {
     private readonly IChannelManager _channelManager;

--- a/Jellyfin.Api/Controllers/ClientLogController.cs
+++ b/Jellyfin.Api/Controllers/ClientLogController.cs
@@ -15,6 +15,7 @@ namespace Jellyfin.Api.Controllers;
 /// Client log controller.
 /// </summary>
 [Authorize]
+[Tags("System")]
 public class ClientLogController : BaseJellyfinApiController
 {
     private const int MaxDocumentSize = 1_000_000;

--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("System")]
 [Authorize]
+[Tags("System")]
 public class ConfigurationController : BaseJellyfinApiController
 {
     private readonly IServerConfigurationManager _configurationManager;

--- a/Jellyfin.Api/Controllers/DevicesController.cs
+++ b/Jellyfin.Api/Controllers/DevicesController.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Api.Controllers;
 /// Devices Controller.
 /// </summary>
 [Authorize(Policy = Policies.RequiresElevation)]
+[Tags("Device")]
 public class DevicesController : BaseJellyfinApiController
 {
     private readonly IDeviceManager _deviceManager;

--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// Display Preferences Controller.
 /// </summary>
 [Authorize]
+[Tags("DisplayPreference")]
 public class DisplayPreferencesController : BaseJellyfinApiController
 {
     private readonly IDisplayPreferencesManager _displayPreferencesManager;

--- a/Jellyfin.Api/Controllers/GenresController.cs
+++ b/Jellyfin.Api/Controllers/GenresController.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Api.Controllers;
 /// The genres controller.
 /// </summary>
 [Authorize]
+[Tags("Genre")]
 public class GenresController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -30,6 +30,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[Tags("Item")]
 public class ItemsController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/LyricsController.cs
+++ b/Jellyfin.Api/Controllers/LyricsController.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Api.Helpers;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities.Audio;
@@ -27,6 +26,7 @@ namespace Jellyfin.Api.Controllers;
 /// Lyrics controller.
 /// </summary>
 [Route("")]
+[Tags("Lyric")]
 public class LyricsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/MediaSegmentsController.cs
+++ b/Jellyfin.Api/Controllers/MediaSegmentsController.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// Media Segments api.
 /// </summary>
 [Authorize]
+[Tags("MediaSegment")]
 public class MediaSegmentsController : BaseJellyfinApiController
 {
     private readonly IMediaSegmentManager _mediaSegmentManager;

--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Data.Enums;
@@ -18,6 +17,7 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Api.Controllers;
@@ -26,6 +26,7 @@ namespace Jellyfin.Api.Controllers;
 /// Movies controller.
 /// </summary>
 [Authorize]
+[Tags("Movie")]
 public class MoviesController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/MusicGenresController.cs
+++ b/Jellyfin.Api/Controllers/MusicGenresController.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Api.Controllers;
 /// The music genres controller.
 /// </summary>
 [Authorize]
+[Tags("MusicGenre")]
 public class MusicGenresController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/PackageController.cs
+++ b/Jellyfin.Api/Controllers/PackageController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
-using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Updates;
 using MediaBrowser.Controller.Configuration;
@@ -19,6 +18,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize(Policy = Policies.RequiresElevation)]
+[Tags("Plugin")]
 public class PackageController : BaseJellyfinApiController
 {
     private readonly IInstallationManager _installationManager;

--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -22,6 +22,7 @@ namespace Jellyfin.Api.Controllers;
 /// Persons controller.
 /// </summary>
 [Authorize]
+[Tags("Person")]
 public class PersonsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/PlaylistsController.cs
+++ b/Jellyfin.Api/Controllers/PlaylistsController.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Api.Controllers;
 /// Playlists controller.
 /// </summary>
 [Authorize]
+[Tags("Playlist")]
 public class PlaylistsController : BaseJellyfinApiController
 {
     private readonly IPlaylistManager _playlistManager;

--- a/Jellyfin.Api/Controllers/PlaystateController.cs
+++ b/Jellyfin.Api/Controllers/PlaystateController.cs
@@ -6,7 +6,6 @@ using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Database.Implementations.Entities;
-using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
@@ -25,6 +24,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[Tags("Session")]
 public class PlaystateController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
-using Jellyfin.Api.Constants;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Plugins;
@@ -23,6 +22,7 @@ namespace Jellyfin.Api.Controllers;
 /// Plugins controller.
 /// </summary>
 [Authorize(Policy = Policies.RequiresElevation)]
+[Tags("Plugin")]
 public class PluginsController : BaseJellyfinApiController
 {
     private readonly IInstallationManager _installationManager;

--- a/Jellyfin.Api/Controllers/QuickConnectController.cs
+++ b/Jellyfin.Api/Controllers/QuickConnectController.cs
@@ -16,6 +16,7 @@ namespace Jellyfin.Api.Controllers;
 /// <summary>
 /// Quick connect controller.
 /// </summary>
+[Tags("Authentication")]
 public class QuickConnectController : BaseJellyfinApiController
 {
     private readonly IQuickConnect _quickConnect;

--- a/Jellyfin.Api/Controllers/ScheduledTasksController.cs
+++ b/Jellyfin.Api/Controllers/ScheduledTasksController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Model.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -15,6 +14,7 @@ namespace Jellyfin.Api.Controllers;
 /// Scheduled Tasks Controller.
 /// </summary>
 [Authorize(Policy = Policies.RequiresElevation)]
+[Tags("ScheduledTask")]
 public class ScheduledTasksController : BaseJellyfinApiController
 {
     private readonly ITaskManager _taskManager;

--- a/Jellyfin.Api/Controllers/StudiosController.cs
+++ b/Jellyfin.Api/Controllers/StudiosController.cs
@@ -22,6 +22,7 @@ namespace Jellyfin.Api.Controllers;
 /// Studios controller.
 /// </summary>
 [Authorize]
+[Tags("Studio")]
 public class StudiosController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/SuggestionsController.cs
+++ b/Jellyfin.Api/Controllers/SuggestionsController.cs
@@ -23,6 +23,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[Tags("Suggestion")]
 public class SuggestionsController : BaseJellyfinApiController
 {
     private readonly IDtoService _dtoService;

--- a/Jellyfin.Api/Controllers/TimeSyncController.cs
+++ b/Jellyfin.Api/Controllers/TimeSyncController.cs
@@ -9,6 +9,7 @@ namespace Jellyfin.Api.Controllers;
 /// The time sync controller.
 /// </summary>
 [Route("")]
+[Tags("System")]
 public class TimeSyncController : BaseJellyfinApiController
 {
     /// <summary>

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -15,6 +15,7 @@ namespace Jellyfin.Api.Controllers;
 /// The trailers controller.
 /// </summary>
 [Authorize]
+[Tags("Trailer")]
 public class TrailersController : BaseJellyfinApiController
 {
     private readonly ItemsController _itemsController;

--- a/Jellyfin.Api/Controllers/TrickplayController.cs
+++ b/Jellyfin.Api/Controllers/TrickplayController.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Api.Attributes;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Api.Helpers;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Trickplay;
@@ -21,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[Tags("TrickPlay")]
 public class TrickplayController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -27,6 +27,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("Shows")]
 [Authorize]
+[Tags("Show")]
 public class TvShowsController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Api.Controllers;
 /// The universal audio controller.
 /// </summary>
 [Route("")]
+[Tags("Audio")]
 public class UniversalAudioController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/UserViewsController.cs
+++ b/Jellyfin.Api/Controllers/UserViewsController.cs
@@ -26,6 +26,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[Tags("UserView")]
 public class UserViewsController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;

--- a/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
+++ b/Jellyfin.Api/Controllers/VideoAttachmentsController.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Api.Controllers;
 /// Attachments controller.
 /// </summary>
 [Route("Videos")]
+[Tags("Video")]
 public class VideoAttachmentsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -35,6 +35,7 @@ namespace Jellyfin.Api.Controllers;
 /// <summary>
 /// The videos controller.
 /// </summary>
+[Tags("Video")]
 public class VideosController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;

--- a/Jellyfin.Api/Controllers/YearsController.cs
+++ b/Jellyfin.Api/Controllers/YearsController.cs
@@ -26,6 +26,7 @@ namespace Jellyfin.Api.Controllers;
 /// Years controller.
 /// </summary>
 [Authorize]
+[Tags("Year")]
 public class YearsController : BaseJellyfinApiController
 {
     private readonly ILibraryManager _libraryManager;


### PR DESCRIPTION
**Changes**

Initial effort to better categorize endpoints in the OpenAPI specification. This commit only includes the low hanging fruit but there are a number of other potential changes that require some discussion.

1. Should *all* images go to their respective categories? Or just endpoints like `/Branding` which have existing controllers?
2. Merge `HlsSegment` and `DynamicHls` into `HLS` or move to `Audio` and `Video` respectively?
3. Should the password / QuickConnect / reset endpoints move to `Auth` or stay in the `Users` category?
4. We have a mix of singular and plural category names - which one is preferable?

**Issues**

None