### PR TITLE
Fix keyframe duration overshoot breaking playback

### DIFF
--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
@@ -156,7 +156,7 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
     {
         if (keyframeData.KeyframeTicks.Count > 0 && keyframeData.TotalDuration < keyframeData.KeyframeTicks[^1])
         {
-            throw new ArgumentException("Invalid duration in keyframe data", nameof(keyframeData));
+            keyframeData = new KeyframeData(keyframeData.KeyframeTicks[^1], keyframeData.KeyframeTicks);
         }
 
         long lastKeyframe = 0;
@@ -176,7 +176,12 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
             }
         }
 
-        result.Add(TimeSpan.FromTicks(keyframeData.TotalDuration - lastKeyframe).TotalSeconds);
+        var remaining = keyframeData.TotalDuration - lastKeyframe;
+        if (remaining > 0)
+        {
+            result.Add(TimeSpan.FromTicks(remaining).TotalSeconds);
+        }
+
         return result;
     }
 

--- a/tests/Jellyfin.MediaEncoding.Hls.Tests/Playlist/DynamicHlsPlaylistGeneratorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Hls.Tests/Playlist/DynamicHlsPlaylistGeneratorTests.cs
@@ -15,10 +15,17 @@ namespace Jellyfin.MediaEncoding.Hls.Tests.Playlist
         }
 
         [Fact]
-        public void ComputeSegments_InvalidDuration_ThrowsArgumentException()
+        public void ComputeSegments_ZeroDurationOvershoot_ClampsToDuration()
         {
             var keyframeData = new KeyframeData(0, new[] { MsToTicks(10000) });
-            Assert.Throws<ArgumentException>(() => DynamicHlsPlaylistGenerator.ComputeSegments(keyframeData, 6000));
+            Assert.Equal(new[] { 10.0 }, DynamicHlsPlaylistGenerator.ComputeSegments(keyframeData, 6000));
+        }
+
+        [Fact]
+        public void ComputeSegments_MinorDurationOvershoot_ClampsToDuration()
+        {
+            var keyframeData = new KeyframeData(MsToTicks(9900), new[] { 0L, MsToTicks(5000), MsToTicks(10000) });
+            Assert.Equal(new[] { 10.0 }, DynamicHlsPlaylistGenerator.ComputeSegments(keyframeData, 6000));
         }
 
         [Theory]


### PR DESCRIPTION
**Changes**
Clamp `TotalDuration` to the last keyframe timestamp in `ComputeSegments` instead of throwing `ArgumentException` when the last keyframe slightly exceeds the container-reported duration. This prevents HLS playback failures for files with minor timestamp imprecision, which can occur with files muxed by tools like mkvmerge. Also skips appending a zero-length trailing segment when the clamp makes `TotalDuration` equal to the last keyframe for cleanliness.

**Issues**
Fixes #16703 
