### PR TITLE
Add configurable JPEG quality for image encoding

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1900,7 +1900,7 @@ public class ImageController : BaseJellyfinApiController
             MaxWidth = maxWidth,
             FillHeight = fillHeight,
             FillWidth = fillWidth,
-            Quality = quality ?? 100,
+            Quality = quality ?? _serverConfigurationManager.Configuration.ImageJpegQuality,
             Width = width,
             PercentPlayed = percentPlayed ?? 0,
             UnplayedCount = unplayedCount,

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -285,6 +285,12 @@ public class ServerConfiguration : BaseApplicationConfiguration
     public TrickplayOptions TrickplayOptions { get; set; } = new TrickplayOptions();
 
     /// <summary>
+    /// Gets or sets the JPEG quality for image encoding.
+    /// </summary>
+    /// <value>The JPEG quality (0-100). Default is 96.</value>
+    public int ImageJpegQuality { get; set; } = 96;
+
+    /// <summary>
     /// Gets or sets a value indicating whether old authorization methods are allowed.
     /// </summary>
     public bool EnableLegacyAuthorization { get; set; }


### PR DESCRIPTION
## Summary
- Add ImageJpegQuality property to ServerConfiguration (default 96)
- Update ImageController to use server configuration for default JPEG quality instead of hardcoded 100
- Allows administrators to control JPEG compression quality server-wide

## Behavior
- Clients can still override quality per-request with the quality query parameter
- Server-wide default is used when no quality parameter is provided
- Default quality of 96 provides good compression while maintaining visual quality

## Testing
- Verify ImageJpegQuality property is readable/writable in configuration
- Confirm ImageController uses ImageJpegQuality as default when quality parameter is not provided
- Test that explicit quality parameters still override the server default
- Verify image encoding uses the configured quality value