### PR TITLE
hide HLS controllers and deprecate unused endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Api.Controllers;
 /// </summary>
 [Route("")]
 [Authorize]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class DynamicHlsController : BaseJellyfinApiController
 {
     private const EncoderPreset DefaultVodEncoderPreset = EncoderPreset.veryfast;

--- a/Jellyfin.Api/Controllers/HlsSegmentController.cs
+++ b/Jellyfin.Api/Controllers/HlsSegmentController.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Api.Controllers;
 /// The hls segment controller.
 /// </summary>
 [Route("")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class HlsSegmentController : BaseJellyfinApiController
 {
     private readonly IFileSystem _fileSystem;

--- a/Jellyfin.Api/Controllers/InstantMixController.cs
+++ b/Jellyfin.Api/Controllers/InstantMixController.cs
@@ -320,6 +320,7 @@ public class InstantMixController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Use GetInstantMixFromArtists")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromArtists2(
         [FromQuery, Required] Guid id,
         [FromQuery] Guid? userId,
@@ -358,6 +359,7 @@ public class InstantMixController : BaseJellyfinApiController
     [HttpGet("MusicGenres/InstantMix")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [Obsolete("Use GetInstantMixFromMusicGenreByName")]
     public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromMusicGenreById(
         [FromQuery, Required] Guid id,
         [FromQuery] Guid? userId,

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -114,20 +114,6 @@ public class LibraryController : BaseJellyfinApiController
     }
 
     /// <summary>
-    /// Gets critic review for an item.
-    /// </summary>
-    /// <response code="200">Critic reviews returned.</response>
-    /// <returns>The list of critic reviews.</returns>
-    [HttpGet("Items/{itemId}/CriticReviews")]
-    [Authorize]
-    [Obsolete("This endpoint is obsolete.")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<QueryResult<BaseItemDto>> GetCriticReviews()
-    {
-        return new QueryResult<BaseItemDto>();
-    }
-
-    /// <summary>
     /// Get theme songs for an item.
     /// </summary>
     /// <param name="itemId">The item id.</param>

--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -344,6 +344,7 @@ public class LiveTvController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [Authorize(Policy = Policies.LiveTvAccess)]
     [Obsolete("This endpoint is obsolete.")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "channelId", Justification = "Imported from ServiceStack")]
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "userId", Justification = "Imported from ServiceStack")]
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "groupId", Justification = "Imported from ServiceStack")]
@@ -387,6 +388,7 @@ public class LiveTvController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [Authorize(Policy = Policies.LiveTvAccess)]
     [Obsolete("This endpoint is obsolete.")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "userId", Justification = "Imported from ServiceStack")]
     public ActionResult<QueryResult<BaseItemDto>> GetRecordingGroups([FromQuery] Guid? userId)
     {
@@ -942,20 +944,6 @@ public class LiveTvController : BaseJellyfinApiController
     {
         await _liveTvManager.CreateSeriesTimer(seriesTimerInfo, CancellationToken.None).ConfigureAwait(false);
         return NoContent();
-    }
-
-    /// <summary>
-    /// Get recording group.
-    /// </summary>
-    /// <param name="groupId">Group id.</param>
-    /// <returns>A <see cref="NotFoundResult"/>.</returns>
-    [HttpGet("Recordings/Groups/{groupId}")]
-    [Authorize(Policy = Policies.LiveTvAccess)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [Obsolete("This endpoint is obsolete.")]
-    public ActionResult<BaseItemDto> GetRecordingGroup([FromRoute, Required] Guid groupId)
-    {
-        return NotFound();
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/MusicGenresController.cs
+++ b/Jellyfin.Api/Controllers/MusicGenresController.cs
@@ -73,6 +73,7 @@ public class MusicGenresController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the queryresult of music genres.</returns>
     [HttpGet]
     [Obsolete("Use GetGenres instead")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public ActionResult<QueryResult<BaseItemDto>> GetMusicGenres(
         [FromQuery] int? startIndex,
         [FromQuery] int? limit,
@@ -145,6 +146,7 @@ public class MusicGenresController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing a <see cref="BaseItemDto"/> with the music genre.</returns>
     [HttpGet("{genreName}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [Obsolete("Use GetGenre instead")]
     public ActionResult<BaseItemDto> GetMusicGenre([FromRoute, Required] string genreName, [FromQuery] Guid? userId)
     {
         userId = RequestHelpers.GetUserId(User, userId);

--- a/Jellyfin.Api/Controllers/PlaystateController.cs
+++ b/Jellyfin.Api/Controllers/PlaystateController.cs
@@ -273,6 +273,7 @@ public class PlaystateController : BaseJellyfinApiController
     [HttpPost("PlayingItems/{itemId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [Obsolete("This endpoint is obsolete. Use ReportPlaybackStart instead")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult> OnPlaybackStart(
         [FromRoute, Required] Guid itemId,
         [FromQuery] string? mediaSourceId,
@@ -352,6 +353,7 @@ public class PlaystateController : BaseJellyfinApiController
     [HttpPost("PlayingItems/{itemId}/Progress")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [Obsolete("This endpoint is obsolete. Use ReportPlaybackProgress instead")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult> OnPlaybackProgress(
         [FromRoute, Required] Guid itemId,
         [FromQuery] string? mediaSourceId,
@@ -441,6 +443,7 @@ public class PlaystateController : BaseJellyfinApiController
     [HttpDelete("PlayingItems/{itemId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [Obsolete("This endpoint is obsolete. Use ReportPlaybackStop instead")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult> OnPlaybackStopped(
         [FromRoute, Required] Guid itemId,
         [FromQuery] string? mediaSourceId,

--- a/Jellyfin.Api/Controllers/PluginsController.cs
+++ b/Jellyfin.Api/Controllers/PluginsController.cs
@@ -136,7 +136,6 @@ public class PluginsController : BaseJellyfinApiController
     [HttpDelete("{pluginId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [Obsolete("Please use the UninstallPluginByVersion API.")]
     public ActionResult UninstallPlugin([FromRoute, Required] Guid pluginId)
     {
         // If no version is given, return the current instance.

--- a/MediaBrowser.Providers/Plugins/Tmdb/Api/TmdbController.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/Api/TmdbController.cs
@@ -14,6 +14,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.Api
     [Authorize]
     [Route("[controller]")]
     [Produces(MediaTypeNames.Application.Json)]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public class TmdbController : ControllerBase
     {
         private readonly TmdbClientManager _tmdbClientManager;


### PR DESCRIPTION
**Changes**

The most notable change here is the removal of the internal HLS endpoints, but I also hid existing obsolete endpoints and added a few more to the list.

MusicGenres/InstantMix: Seems to be unused in the web client. Superceded by a different route.
MusicGenres/genreName: Also unused and replaced by the corresponding `Genres/genreName` endpoint.
TmdbController: Part of a plugin that we don't want to see in the OpenAPI specification file.

**Issues**

None