### PR TITLE
Fix "Because you watched X" returning identical recs for every seed

### DIFF
--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -261,7 +261,7 @@ public class MoviesController : BaseJellyfinApiController
         }
     }
 
-    private IEnumerable<RecommendationDto> GetSimilarTo(User? user, IEnumerable<BaseItem> baselineItems, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
+    internal IEnumerable<RecommendationDto> GetSimilarTo(User? user, IEnumerable<BaseItem> baselineItems, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
     {
         var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
         if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
@@ -277,6 +277,10 @@ public class MoviesController : BaseJellyfinApiController
                 Limit = itemLimit,
                 IncludeItemTypes = itemTypes.ToArray(),
                 IsMovie = true,
+                Genres = item.Genres,
+                Tags = item.Tags,
+                ExcludeItemIds = [item.Id],
+                OrderBy = [(ItemSortBy.Random, SortOrder.Ascending)],
                 EnableGroupByMetadataKey = true,
                 DtoOptions = dtoOptions
             });

--- a/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Api.Controllers;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class MoviesControllerTests
+{
+    // Regression test: GetSimilarTo previously built an InternalItemsQuery that did
+    // not reference the seed item, so every seed produced the same recommendations.
+    [Fact]
+    public void GetSimilarTo_PropagatesSeedMetadataIntoQuery()
+    {
+        var libraryManager = new Mock<ILibraryManager>();
+        var dtoService = new Mock<IDtoService>();
+        var serverConfig = new Mock<IServerConfigurationManager>();
+        var userManager = new Mock<IUserManager>();
+
+        serverConfig.SetupGet(c => c.Configuration)
+            .Returns(new ServerConfiguration { EnableExternalContentInSuggestions = false });
+
+        var capturedQueries = new List<InternalItemsQuery>();
+        libraryManager
+            .Setup(m => m.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Callback<InternalItemsQuery>(q => capturedQueries.Add(q))
+            .Returns(new List<BaseItem>());
+
+        var controller = new MoviesController(
+            userManager.Object,
+            libraryManager.Object,
+            dtoService.Object,
+            serverConfig.Object);
+
+        var seedA = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Mannequin",
+            Genres = new[] { "Comedy", "Romance" },
+            Tags = new[] { "1980s" }
+        };
+        var seedB = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Sin City",
+            Genres = new[] { "Crime", "Thriller" },
+            Tags = new[] { "noir", "graphic-novel" }
+        };
+
+        // Materialize: GetSimilarTo uses yield return, so the queries only fire on enumeration.
+        controller.GetSimilarTo(
+            user: null,
+            baselineItems: new BaseItem[] { seedA, seedB },
+            itemLimit: 8,
+            dtoOptions: new DtoOptions(),
+            type: RecommendationType.SimilarToRecentlyPlayed).ToList();
+
+        Assert.Equal(2, capturedQueries.Count);
+
+        AssertQueryMatchesSeed(capturedQueries[0], seedA);
+        AssertQueryMatchesSeed(capturedQueries[1], seedB);
+
+        // The core regression: dissimilar seeds must not produce identical queries.
+        Assert.NotEqual(capturedQueries[0].Genres, capturedQueries[1].Genres);
+        Assert.NotEqual(capturedQueries[0].Tags, capturedQueries[1].Tags);
+        Assert.NotEqual(capturedQueries[0].ExcludeItemIds, capturedQueries[1].ExcludeItemIds);
+    }
+
+    private static void AssertQueryMatchesSeed(InternalItemsQuery query, BaseItem seed)
+    {
+        Assert.Equal(seed.Genres, query.Genres);
+        Assert.Equal(seed.Tags, query.Tags);
+        Assert.Contains(seed.Id, query.ExcludeItemIds);
+        Assert.Contains(query.OrderBy, o => o.OrderBy == ItemSortBy.Random);
+    }
+}


### PR DESCRIPTION
**Changes**

`MoviesController.GetSimilarTo` builds an `InternalItemsQuery` that never references the seed item, so every "Because you watched X" card runs the same generic query and returns the same items regardless of X. The fix filters by the seed's genres and tags, excludes the seed itself, and randomizes order, mirroring `LibraryController.GetSimilarItems`. A new `MoviesControllerTests` captures the per-seed query and asserts seed metadata propagation; it fails against the pre-fix controller.

**Issues**

Fixes #14088