### PR TITLE
return music artists from person endpoints

### DIFF
--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -87,6 +87,7 @@ public class ArtistsController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the artists.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [Obsolete("Use GetPersons")]
     public ActionResult<QueryResult<BaseItemDto>> GetArtists(
         [FromQuery] double? minCommunityRating,
         [FromQuery] int? startIndex,
@@ -258,6 +259,7 @@ public class ArtistsController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the album artists.</returns>
     [HttpGet("AlbumArtists")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [Obsolete("Use GetPersons")]
     public ActionResult<QueryResult<BaseItemDto>> GetAlbumArtists(
         [FromQuery] double? minCommunityRating,
         [FromQuery] int? startIndex,
@@ -399,6 +401,7 @@ public class ArtistsController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the artist.</returns>
     [HttpGet("{name}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [Obsolete("Use GetPerson")]
     public ActionResult<BaseItemDto> GetArtistByName([FromRoute, Required] string name, [FromQuery] Guid? userId)
     {
         userId = RequestHelpers.GetUserId(User, userId);

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -119,7 +119,6 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
             .ToArray();
 
         var toAdd = people
-            .Where(e => e.Type is not PersonKind.Artist && e.Type is not PersonKind.AlbumArtist)
             .Where(e => !existingPersons.Any(f => string.Equals(f.Name, e.Name, StringComparison.OrdinalIgnoreCase) && f.PersonType == e.Type.ToString()))
             .Select(Map);
         context.Peoples.AddRange(toAdd);
@@ -133,11 +132,6 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         foreach (var person in people)
         {
-            if (person.Type == PersonKind.Artist || person.Type == PersonKind.AlbumArtist)
-            {
-                continue;
-            }
-
             var entityPerson = personsEntities.First(e => string.Equals(e.Name, person.Name, StringComparison.OrdinalIgnoreCase) && e.PersonType == person.Type.ToString());
             var existingMap = existingMaps.FirstOrDefault(e => string.Equals(e.People.Name, person.Name, StringComparison.OrdinalIgnoreCase) && e.People.PersonType == person.Type.ToString() && e.Role == person.Role);
             if (existingMap is null)

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -100,7 +100,6 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
             .ToArray();
 
         var toAdd = people
-            .Where(e => e.Type is not PersonKind.Artist && e.Type is not PersonKind.AlbumArtist)
             .Where(e => !existingPersons.Any(f => f.Name == e.Name && f.PersonType == e.Type.ToString()))
             .Select(Map);
         context.Peoples.AddRange(toAdd);
@@ -114,11 +113,6 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         foreach (var person in people)
         {
-            if (person.Type == PersonKind.Artist || person.Type == PersonKind.AlbumArtist)
-            {
-                continue;
-            }
-
             var entityPerson = personsEntities.First(e => e.Name == person.Name && e.PersonType == person.Type.ToString());
             var existingMap = existingMaps.FirstOrDefault(e => e.People.Name == person.Name && e.People.PersonType == person.Type.ToString() && e.Role == person.Role);
             if (existingMap is null)


### PR DESCRIPTION
**Changes**

Scans triggered after this pull request is merged will populate the Peoples table with Artist and AlbumArtist entities from all music libraries. The goal is to improve person management and migrate away from hacks that have been used to store people as BaseItem entities. We use PremiereDate for DateOfBirth, ProductionLocations for PlaceOfBirth, Overview for Biography, and lack support for other common fields like DateOfDeath. It will also more closely match APIs from popular metadata providers as seen below.

**Are there separate endpoints for artist "groups" versus individual performers?**

MusicBrainz: Same endpoint with a Person / Group / Orchestra / Band / etc type field.
TheAudioDB: Same endpoint with an intMembers field.
IMDb: Groups and individuals use the `nm*` entity but are not nested.
TheTVDB: Groups don't exist.
OpenLibrary: Groups don't exist.
Goodreads: Groups don't exist.

**Do companies have their own entity or are they only tracked with a field? Relevant for `Studios` endpoint.**

MusicBrainz: Distributors, publishers, labels, etc are stored in a unique entity.
TheAudioDB: Labels are tracked as `strLabel` and `idLabel` on artist and album endpoints.
IMDb: Very comprehensive support with a separate `co*` endpoint.
TheTVDB: Same as IMDb with a unique endpoint and CompanyType field.
OpenLibrary: Publishers tracked in an array on individual book editions.
Goodreads: Publishers (not distributors) are only saved as a string field on books.

**Issues**

None