### PR TITLE
Fix plugin catalog timeouts and prevent repo fetch failures

### DIFF
--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="BitFaster.Caching" />
     <PackageReference Include="DiscUtils.Udf" />
     <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/Emby.Server.Implementations/Emby.Server.Implementations.csproj
+++ b/Emby.Server.Implementations/Emby.Server.Implementations.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="BitFaster.Caching" />
     <PackageReference Include="DiscUtils.Udf" />
     <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using AsyncKeyedLock;
 using Jellyfin.Data.Events;
 using Jellyfin.Extensions;
 using Jellyfin.Extensions.Json;
@@ -23,6 +24,7 @@ using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Updates;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Updates
@@ -48,6 +50,8 @@ namespace Emby.Server.Implementations.Updates
         /// </summary>
         /// <value>The application host.</value>
         private readonly IServerApplicationHost _applicationHost;
+        private readonly IMemoryCache _memoryCache;
+        private readonly AsyncNonKeyedLocker _cacheLock = new(1);
         private readonly Lock _currentInstallationsLock = new();
 
         /// <summary>
@@ -60,6 +64,8 @@ namespace Emby.Server.Implementations.Updates
         /// </summary>
         private readonly ConcurrentBag<InstallationInfo> _completedInstallationsInternal;
 
+        private int _cacheVersion;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InstallationManager"/> class.
         /// </summary>
@@ -69,6 +75,7 @@ namespace Emby.Server.Implementations.Updates
         /// <param name="eventManager">The <see cref="IEventManager"/>.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
         /// <param name="config">The <see cref="IServerConfigurationManager"/>.</param>
+        /// <param name="memoryCache">The <see cref="IMemoryCache"/>.</param>
         /// <param name="pluginManager">The <see cref="IPluginManager"/>.</param>
         public InstallationManager(
             ILogger<InstallationManager> logger,
@@ -77,6 +84,7 @@ namespace Emby.Server.Implementations.Updates
             IEventManager eventManager,
             IHttpClientFactory httpClientFactory,
             IServerConfigurationManager config,
+            IMemoryCache memoryCache,
             IPluginManager pluginManager)
         {
             _currentInstallations = new List<(InstallationInfo, CancellationTokenSource)>();
@@ -88,6 +96,7 @@ namespace Emby.Server.Implementations.Updates
             _eventManager = eventManager;
             _httpClientFactory = httpClientFactory;
             _config = config;
+            _memoryCache = memoryCache;
             _jsonSerializerOptions = JsonDefaults.Options;
             _pluginManager = pluginManager;
         }
@@ -171,20 +180,66 @@ namespace Emby.Server.Implementations.Updates
         /// <inheritdoc />
         public async Task<IReadOnlyList<PackageInfo>> GetAvailablePackages(CancellationToken cancellationToken = default)
         {
-            var result = new List<PackageInfo>();
-            foreach (RepositoryInfo repository in _config.Configuration.PluginRepositories)
+            var enabledRepos = _config.Configuration.PluginRepositories
+                .Where(r => r.Enabled && r.Url is not null)
+                .ToArray();
+
+            if (enabledRepos.Length == 0)
             {
-                if (repository.Enabled && repository.Url is not null)
+                return Array.Empty<PackageInfo>();
+            }
+
+            var cacheVersion = _cacheVersion;
+            var cacheKey = "PluginCatalog-" + cacheVersion + "-" + string.Join('\n', enabledRepos.Select(r => (r.Name ?? string.Empty) + "|" + r.Url));
+
+            if (_memoryCache.TryGetValue<IReadOnlyList<PackageInfo>>(cacheKey, out var cached) && cached is not null)
+            {
+                return cached.ToList();
+            }
+
+            var fetchTasks = enabledRepos.Select(async repo =>
+            {
+                using var repoCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                repoCts.CancelAfter(TimeSpan.FromSeconds(20));
+
+                try
                 {
-                    // Where repositories have the same content, the details from the first is taken.
-                    foreach (var package in await GetPackages(repository.Name ?? "Unnamed Repo", repository.Url, true, cancellationToken).ConfigureAwait(true))
+                    return await GetPackages(
+                        repo.Name ?? "Unnamed Repo",
+                        repo.Url!,
+                        true,
+                        repoCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (repoCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Timeout fetching plugin manifest for {Repo}", repo.Url);
+                    return Array.Empty<PackageInfo>();
+                }
+            }).ToArray();
+
+            var repoResults = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+
+            // If the caller cancelled, Task.WhenAll already threw. This is just defensive.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (await _cacheLock.LockAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_memoryCache.TryGetValue<IReadOnlyList<PackageInfo>>(cacheKey, out cached) && cached is not null)
+                {
+                    return cached.ToList();
+                }
+
+                // Merge results sequentially (preserves existing deduplication logic).
+                var result = new List<PackageInfo>();
+                for (var i = 0; i < repoResults.Length; i++)
+                {
+                    foreach (var package in repoResults[i])
                     {
                         var existing = FilterPackages(result, package.Name, package.Id).FirstOrDefault();
 
-                        // Remove invalid versions from the valid package.
-                        for (var i = package.Versions.Count - 1; i >= 0; i--)
+                        for (var j = package.Versions.Count - 1; j >= 0; j--)
                         {
-                            var version = package.Versions[i];
+                            var version = package.Versions[j];
 
                             var plugin = _pluginManager.GetPlugin(package.Id, version.VersionNumber);
                             if (plugin is not null)
@@ -192,14 +247,12 @@ namespace Emby.Server.Implementations.Updates
                                 await _pluginManager.PopulateManifest(package, version.VersionNumber, plugin.Path, plugin.Manifest.Status).ConfigureAwait(false);
                             }
 
-                            // Remove versions with a target ABI greater than the current application version.
                             if (Version.TryParse(version.TargetAbi, out var targetAbi) && _applicationHost.ApplicationVersion < targetAbi)
                             {
-                                package.Versions.RemoveAt(i);
+                                package.Versions.RemoveAt(j);
                             }
                         }
 
-                        // Don't add a package that doesn't have any compatible versions.
                         if (package.Versions.Count == 0)
                         {
                             continue;
@@ -207,7 +260,6 @@ namespace Emby.Server.Implementations.Updates
 
                         if (existing is not null)
                         {
-                            // Assumption is both lists are ordered, so slot these into the correct place.
                             MergeSortedList(existing.Versions, package.Versions);
                         }
                         else
@@ -216,9 +268,16 @@ namespace Emby.Server.Implementations.Updates
                         }
                     }
                 }
-            }
 
-            return result;
+                // Defensive clone: callers receive mutable PackageInfo/VersionInfo objects,
+                // so cache a deep copy to prevent external mutation from corrupting the cache.
+                var clonedResult = JsonSerializer.Deserialize<List<PackageInfo>>(
+                    JsonSerializer.Serialize(result, _jsonSerializerOptions),
+                    _jsonSerializerOptions)!;
+
+                _memoryCache.Set(cacheKey, clonedResult, TimeSpan.FromMinutes(5));
+                return clonedResult.ToList();
+            }
         }
 
         /// <inheritdoc />
@@ -326,6 +385,7 @@ namespace Emby.Server.Implementations.Updates
                 }
 
                 _completedInstallationsInternal.Add(package);
+                Interlocked.Increment(ref _cacheVersion);
 
                 if (isUpdate)
                 {
@@ -396,6 +456,7 @@ namespace Emby.Server.Implementations.Updates
 
             // Remove it the quick way for now
             _pluginManager.RemovePlugin(plugin);
+            Interlocked.Increment(ref _cacheVersion);
 
             _eventManager.Publish(new PluginUninstalledEventArgs(plugin.GetPluginInfo()));
 
@@ -434,6 +495,8 @@ namespace Emby.Server.Implementations.Updates
         {
             if (dispose)
             {
+                _cacheLock?.Dispose();
+
                 lock (_currentInstallationsLock)
                 {
                     foreach (var (info, token) in _currentInstallations)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -10,7 +10,6 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using AsyncKeyedLock;
 using Jellyfin.Data.Events;
 using Jellyfin.Extensions;
 using Jellyfin.Extensions.Json;
@@ -24,7 +23,6 @@ using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Updates;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Updates
@@ -50,8 +48,6 @@ namespace Emby.Server.Implementations.Updates
         /// </summary>
         /// <value>The application host.</value>
         private readonly IServerApplicationHost _applicationHost;
-        private readonly IMemoryCache _memoryCache;
-        private readonly AsyncNonKeyedLocker _cacheLock = new(1);
         private readonly Lock _currentInstallationsLock = new();
 
         /// <summary>
@@ -64,8 +60,6 @@ namespace Emby.Server.Implementations.Updates
         /// </summary>
         private readonly ConcurrentBag<InstallationInfo> _completedInstallationsInternal;
 
-        private int _cacheVersion;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InstallationManager"/> class.
         /// </summary>
@@ -75,7 +69,6 @@ namespace Emby.Server.Implementations.Updates
         /// <param name="eventManager">The <see cref="IEventManager"/>.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
         /// <param name="config">The <see cref="IServerConfigurationManager"/>.</param>
-        /// <param name="memoryCache">The <see cref="IMemoryCache"/>.</param>
         /// <param name="pluginManager">The <see cref="IPluginManager"/>.</param>
         public InstallationManager(
             ILogger<InstallationManager> logger,
@@ -84,7 +77,6 @@ namespace Emby.Server.Implementations.Updates
             IEventManager eventManager,
             IHttpClientFactory httpClientFactory,
             IServerConfigurationManager config,
-            IMemoryCache memoryCache,
             IPluginManager pluginManager)
         {
             _currentInstallations = new List<(InstallationInfo, CancellationTokenSource)>();
@@ -96,7 +88,6 @@ namespace Emby.Server.Implementations.Updates
             _eventManager = eventManager;
             _httpClientFactory = httpClientFactory;
             _config = config;
-            _memoryCache = memoryCache;
             _jsonSerializerOptions = JsonDefaults.Options;
             _pluginManager = pluginManager;
         }
@@ -180,66 +171,20 @@ namespace Emby.Server.Implementations.Updates
         /// <inheritdoc />
         public async Task<IReadOnlyList<PackageInfo>> GetAvailablePackages(CancellationToken cancellationToken = default)
         {
-            var enabledRepos = _config.Configuration.PluginRepositories
-                .Where(r => r.Enabled && r.Url is not null)
-                .ToArray();
-
-            if (enabledRepos.Length == 0)
+            var result = new List<PackageInfo>();
+            foreach (RepositoryInfo repository in _config.Configuration.PluginRepositories)
             {
-                return Array.Empty<PackageInfo>();
-            }
-
-            var cacheVersion = _cacheVersion;
-            var cacheKey = "PluginCatalog-" + cacheVersion + "-" + string.Join('\n', enabledRepos.Select(r => (r.Name ?? string.Empty) + "|" + r.Url));
-
-            if (_memoryCache.TryGetValue<IReadOnlyList<PackageInfo>>(cacheKey, out var cached) && cached is not null)
-            {
-                return cached.ToList();
-            }
-
-            var fetchTasks = enabledRepos.Select(async repo =>
-            {
-                using var repoCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                repoCts.CancelAfter(TimeSpan.FromSeconds(20));
-
-                try
+                if (repository.Enabled && repository.Url is not null)
                 {
-                    return await GetPackages(
-                        repo.Name ?? "Unnamed Repo",
-                        repo.Url!,
-                        true,
-                        repoCts.Token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (repoCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    _logger.LogWarning("Timeout fetching plugin manifest for {Repo}", repo.Url);
-                    return Array.Empty<PackageInfo>();
-                }
-            }).ToArray();
-
-            var repoResults = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
-
-            // If the caller cancelled, Task.WhenAll already threw. This is just defensive.
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using (await _cacheLock.LockAsync(cancellationToken).ConfigureAwait(false))
-            {
-                if (_memoryCache.TryGetValue<IReadOnlyList<PackageInfo>>(cacheKey, out cached) && cached is not null)
-                {
-                    return cached.ToList();
-                }
-
-                // Merge results sequentially (preserves existing deduplication logic).
-                var result = new List<PackageInfo>();
-                for (var i = 0; i < repoResults.Length; i++)
-                {
-                    foreach (var package in repoResults[i])
+                    // Where repositories have the same content, the details from the first is taken.
+                    foreach (var package in await GetPackages(repository.Name ?? "Unnamed Repo", repository.Url, true, cancellationToken).ConfigureAwait(true))
                     {
                         var existing = FilterPackages(result, package.Name, package.Id).FirstOrDefault();
 
-                        for (var j = package.Versions.Count - 1; j >= 0; j--)
+                        // Remove invalid versions from the valid package.
+                        for (var i = package.Versions.Count - 1; i >= 0; i--)
                         {
-                            var version = package.Versions[j];
+                            var version = package.Versions[i];
 
                             var plugin = _pluginManager.GetPlugin(package.Id, version.VersionNumber);
                             if (plugin is not null)
@@ -247,12 +192,14 @@ namespace Emby.Server.Implementations.Updates
                                 await _pluginManager.PopulateManifest(package, version.VersionNumber, plugin.Path, plugin.Manifest.Status).ConfigureAwait(false);
                             }
 
+                            // Remove versions with a target ABI greater than the current application version.
                             if (Version.TryParse(version.TargetAbi, out var targetAbi) && _applicationHost.ApplicationVersion < targetAbi)
                             {
-                                package.Versions.RemoveAt(j);
+                                package.Versions.RemoveAt(i);
                             }
                         }
 
+                        // Don't add a package that doesn't have any compatible versions.
                         if (package.Versions.Count == 0)
                         {
                             continue;
@@ -260,6 +207,7 @@ namespace Emby.Server.Implementations.Updates
 
                         if (existing is not null)
                         {
+                            // Assumption is both lists are ordered, so slot these into the correct place.
                             MergeSortedList(existing.Versions, package.Versions);
                         }
                         else
@@ -268,16 +216,9 @@ namespace Emby.Server.Implementations.Updates
                         }
                     }
                 }
-
-                // Defensive clone: callers receive mutable PackageInfo/VersionInfo objects,
-                // so cache a deep copy to prevent external mutation from corrupting the cache.
-                var clonedResult = JsonSerializer.Deserialize<List<PackageInfo>>(
-                    JsonSerializer.Serialize(result, _jsonSerializerOptions),
-                    _jsonSerializerOptions)!;
-
-                _memoryCache.Set(cacheKey, clonedResult, TimeSpan.FromMinutes(5));
-                return clonedResult.ToList();
             }
+
+            return result;
         }
 
         /// <inheritdoc />
@@ -385,7 +326,6 @@ namespace Emby.Server.Implementations.Updates
                 }
 
                 _completedInstallationsInternal.Add(package);
-                Interlocked.Increment(ref _cacheVersion);
 
                 if (isUpdate)
                 {
@@ -456,7 +396,6 @@ namespace Emby.Server.Implementations.Updates
 
             // Remove it the quick way for now
             _pluginManager.RemovePlugin(plugin);
-            Interlocked.Increment(ref _cacheVersion);
 
             _eventManager.Publish(new PluginUninstalledEventArgs(plugin.GetPluginInfo()));
 
@@ -495,8 +434,6 @@ namespace Emby.Server.Implementations.Updates
         {
             if (dispose)
             {
-                _cacheLock?.Dispose();
-
                 lock (_currentInstallationsLock)
                 {
                     foreach (var (info, token) in _currentInstallations)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -171,49 +171,80 @@ namespace Emby.Server.Implementations.Updates
         /// <inheritdoc />
         public async Task<IReadOnlyList<PackageInfo>> GetAvailablePackages(CancellationToken cancellationToken = default)
         {
-            var result = new List<PackageInfo>();
-            foreach (RepositoryInfo repository in _config.Configuration.PluginRepositories)
+            var enabledRepos = _config.Configuration.PluginRepositories
+                .Where(r => r.Enabled && r.Url is not null)
+                .ToArray();
+
+            if (enabledRepos.Length == 0)
             {
-                if (repository.Enabled && repository.Url is not null)
+                return Array.Empty<PackageInfo>();
+            }
+
+            var fetchTasks = enabledRepos.Select(async repo =>
+            {
+                using var repoCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                repoCts.CancelAfter(TimeSpan.FromSeconds(20));
+
+                try
                 {
-                    // Where repositories have the same content, the details from the first is taken.
-                    foreach (var package in await GetPackages(repository.Name ?? "Unnamed Repo", repository.Url, true, cancellationToken).ConfigureAwait(true))
+                    return await GetPackages(
+                        repo.Name ?? "Unnamed Repo",
+                        repo.Url!,
+                        true,
+                        repoCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (repoCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Timeout fetching plugin manifest for {Repo}", repo.Url);
+                    return Array.Empty<PackageInfo>();
+                }
+            }).ToArray();
+
+            var repoResults = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+
+            // If the caller cancelled, Task.WhenAll already threw. This is just defensive.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Merge results sequentially (preserves existing deduplication logic).
+            var result = new List<PackageInfo>();
+            for (var i = 0; i < repoResults.Length; i++)
+            {
+                foreach (var package in repoResults[i])
+                {
+                    var existing = FilterPackages(result, package.Name, package.Id).FirstOrDefault();
+
+                    // Remove invalid versions from the valid package.
+                    for (var j = package.Versions.Count - 1; j >= 0; j--)
                     {
-                        var existing = FilterPackages(result, package.Name, package.Id).FirstOrDefault();
+                        var version = package.Versions[j];
 
-                        // Remove invalid versions from the valid package.
-                        for (var i = package.Versions.Count - 1; i >= 0; i--)
+                        var plugin = _pluginManager.GetPlugin(package.Id, version.VersionNumber);
+                        if (plugin is not null)
                         {
-                            var version = package.Versions[i];
-
-                            var plugin = _pluginManager.GetPlugin(package.Id, version.VersionNumber);
-                            if (plugin is not null)
-                            {
-                                await _pluginManager.PopulateManifest(package, version.VersionNumber, plugin.Path, plugin.Manifest.Status).ConfigureAwait(false);
-                            }
-
-                            // Remove versions with a target ABI greater than the current application version.
-                            if (Version.TryParse(version.TargetAbi, out var targetAbi) && _applicationHost.ApplicationVersion < targetAbi)
-                            {
-                                package.Versions.RemoveAt(i);
-                            }
+                            await _pluginManager.PopulateManifest(package, version.VersionNumber, plugin.Path, plugin.Manifest.Status).ConfigureAwait(false);
                         }
 
-                        // Don't add a package that doesn't have any compatible versions.
-                        if (package.Versions.Count == 0)
+                        // Remove versions with a target ABI greater than the current application version.
+                        if (Version.TryParse(version.TargetAbi, out var targetAbi) && _applicationHost.ApplicationVersion < targetAbi)
                         {
-                            continue;
+                            package.Versions.RemoveAt(j);
                         }
+                    }
 
-                        if (existing is not null)
-                        {
-                            // Assumption is both lists are ordered, so slot these into the correct place.
-                            MergeSortedList(existing.Versions, package.Versions);
-                        }
-                        else
-                        {
-                            result.Add(package);
-                        }
+                    // Don't add a package that doesn't have any compatible versions.
+                    if (package.Versions.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    if (existing is not null)
+                    {
+                        // Assumption is both lists are ordered, so slot these into the correct place.
+                        MergeSortedList(existing.Versions, package.Versions);
+                    }
+                    else
+                    {
+                        result.Add(package);
                     }
                 }
             }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -180,25 +180,11 @@ namespace Emby.Server.Implementations.Updates
                 return Array.Empty<PackageInfo>();
             }
 
-            var fetchTasks = enabledRepos.Select(async repo =>
+            var fetchTasks = new List<Task<PackageInfo[]>>(enabledRepos.Length);
+            foreach (var repo in enabledRepos)
             {
-                using var repoCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                repoCts.CancelAfter(TimeSpan.FromSeconds(20));
-
-                try
-                {
-                    return await GetPackages(
-                        repo.Name ?? "Unnamed Repo",
-                        repo.Url!,
-                        true,
-                        repoCts.Token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (repoCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    _logger.LogWarning("Timeout fetching plugin manifest for {Repo}", repo.Url);
-                    return Array.Empty<PackageInfo>();
-                }
-            }).ToArray();
+                fetchTasks.Add(FetchRepositoryPackagesAsync(repo, cancellationToken));
+            }
 
             var repoResults = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
 
@@ -250,6 +236,26 @@ namespace Emby.Server.Implementations.Updates
             }
 
             return result;
+        }
+
+        private async Task<PackageInfo[]> FetchRepositoryPackagesAsync(RepositoryInfo repo, CancellationToken cancellationToken)
+        {
+            using var repoCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            repoCts.CancelAfter(TimeSpan.FromSeconds(20));
+
+            try
+            {
+                return await GetPackages(
+                    repo.Name ?? "Unnamed Repo",
+                    repo.Url!,
+                    true,
+                    repoCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (repoCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning(ex, "Timeout fetching plugin manifest for {Repo}", repo.Url);
+                return Array.Empty<PackageInfo>();
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
**Changes**
This PR improves the reliability of the plugin catalog endpoint by fetching plugin repositories in parallel instead of sequentially. It also isolates failures so that a slow or unreachable repository does not cause the entire /Packages endpoint to fail or time out.

Each repository is fetched independently with a per-repository timeout, ensuring that a single failing source does not block the rest.

**Issues**
Fixes #15796