### PR TITLE
fix: use symmetric 15s default for skip forward/backward lengths

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -157,13 +157,13 @@ public class DisplayPreferencesController : BaseJellyfinApiController
         existingDisplayPreferences.SkipBackwardLength = displayPreferences.CustomPrefs.TryGetValue("skipBackLength", out var skipBackLength)
                                                         && !string.IsNullOrEmpty(skipBackLength)
             ? int.Parse(skipBackLength, CultureInfo.InvariantCulture)
-            : 10000;
+            : 15000;
         displayPreferences.CustomPrefs.Remove("skipBackLength");
 
         existingDisplayPreferences.SkipForwardLength = displayPreferences.CustomPrefs.TryGetValue("skipForwardLength", out var skipForwardLength)
                                                        && !string.IsNullOrEmpty(skipForwardLength)
             ? int.Parse(skipForwardLength, CultureInfo.InvariantCulture)
-            : 30000;
+            : 15000;
         displayPreferences.CustomPrefs.Remove("skipForwardLength");
 
         existingDisplayPreferences.DashboardTheme = displayPreferences.CustomPrefs.TryGetValue("dashboardTheme", out var theme)


### PR DESCRIPTION
**Problem**
The server-side default for SkipForwardLength is 30 000 ms (30 s) while SkipBackwardLength defaults to 10 000 ms (10 s). This asymmetry is hardcoded in DisplayPreferencesController.cs and propagates to all clients (Android, Android TV, web) that read these user settings from the server.

**Solution**
Set both defaults to 15 000 ms (15 s). This gives a predictable, symmetric seek experience out of the box while still allowing users to customize the values per-client in their profile settings.

**Files changed**
Jellyfin.Api/Controllers/DisplayPreferencesController.cs — 2 lines