### PR TITLE
Fix VttWriter to convert ASS alignment tags to WebVTT cue position settings

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEditParser.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEditParser.cs
@@ -85,7 +85,10 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 trackEvents[i] = new SubtitleTrackEvent(p.Number.ToString(CultureInfo.InvariantCulture), p.Text)
                 {
                     StartPositionTicks = p.StartTime.TimeSpan.Ticks,
-                    EndPositionTicks = p.EndTime.TimeSpan.Ticks
+                    EndPositionTicks = p.EndTime.TimeSpan.Ticks,
+                    // Preserve VTT cue settings (e.g. "line:10% align:center") parsed by libse.
+                    // This allows VttWriter to write them back without re-parsing the text.
+                    VttCueSettings = p.Style
                 };
             }
 

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -36,8 +36,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             foreach (var (tag, position) in _assTagToCuePosition)
             {
                 if (text.StartsWith(tag, StringComparison.Ordinal))
+                {
                     return position;
+                }
             }
+
             return "region:subtitle line:90%";
         }
 
@@ -60,6 +63,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     {
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
                     }
+
                     var text = trackEvent.Text;
                     // TODO: Not sure how to handle these
                     text = NewlineEscapeRegex().Replace(text, " ");

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -13,222 +12,12 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     /// </summary>
     public partial class VttWriter : ISubtitleWriter
     {
-        // Mapping of ASS alignment tags to WebVTT cue settings.
-        // The ",end" suffix is only added to line:90% values because:
-        // - ExoPlayer requires it for proper positioning at the bottom
-        // - Other players might break when ",end" is used with other line values (e.g., line:50%,end)
-        private static readonly Dictionary<string, string> _assTagToCuePosition = new()
-        {
-            ["{\\an1}"] = "position:20% line:90%,end",
-            ["{\\an2}"] = "line:90%,end",
-            ["{\\an3}"] = "position:80% line:90%,end",
-            ["{\\an4}"] = "position:20% line:50%",
-            ["{\\an5}"] = "line:50%",
-            ["{\\an6}"] = "position:80% line:50%",
-            ["{\\an7}"] = "position:20% line:10%",
-            ["{\\an8}"] = "line:10%",
-            ["{\\an9}"] = "position:80% line:10%",
-        };
-
-        // Matches any ASS block: {contents}
-        private static readonly Regex _assBlockRegex = new Regex(@"\{([^}]*)\}", RegexOptions.Compiled);
-
         /// <summary>
-        /// Regex to match ASS newline escapes (\n or \N).
+        /// Matches ASS alignment tags (e.g. {\an8}) introduced by libse during VTT parsing.
+        /// These are stripped from the text since position is already preserved in VttCueSettings.
         /// </summary>
-        [GeneratedRegex(@"\\[nN]")]
-        private static partial Regex NewlineEscapeRegex();
-
-        /// <summary>
-        /// Returns the opening or closing HTML tag string for a given ASS formatting character.
-        /// Supported characters: i (italic), b (bold), u (underline).
-        /// </summary>
-        /// <param name="tag">The formatting character: 'i', 'b', or 'u'.</param>
-        /// <param name="closing">True to return a closing tag, false for an opening tag.</param>
-        /// <returns>The HTML tag string, e.g. "&lt;i&gt;" or "&lt;/b&gt;".</returns>
-        private static string GetHtmlTag(char tag, bool closing)
-        {
-            if (closing)
-            {
-                return tag switch
-                {
-                    'i' => "</i>",
-                    'b' => "</b>",
-                    _ => "</u>",
-                };
-            }
-
-            return tag switch
-            {
-                'i' => "<i>",
-                'b' => "<b>",
-                _ => "<u>",
-            };
-        }
-
-        /// <summary>
-        /// Processes a single ASS block's inner content (the text between braces).
-        /// Extracts \anN to update the cue position and converts \i1/\i0, \b1/\b0, \u1/\u0
-        /// to HTML tags. Unrecognized tags are stripped silently.
-        /// </summary>
-        /// <param name="inner">The content inside the ASS block braces.</param>
-        /// <param name="capturedPosition">Updated with the cue position if an \anN tag is found.</param>
-        /// <returns>The HTML output for this block (may be empty if only alignment was present).</returns>
-        private static string ProcessAssBlock(string inner, ref string capturedPosition)
-        {
-            var output = new StringBuilder();
-            int i = 0;
-            while (i < inner.Length)
-            {
-                if (inner[i] != '\\')
-                {
-                    i++;
-                    continue;
-                }
-
-                if (i + 1 >= inner.Length)
-                {
-                    i++;
-                    continue;
-                }
-
-                char tag = inner[i + 1];
-
-                // \anN — alignment tag
-                if (tag == 'a' && i + 3 < inner.Length && inner[i + 2] == 'n' && char.IsDigit(inner[i + 3]))
-                {
-                    var key = $"{{\\an{inner[i + 3]}}}";
-                    if (_assTagToCuePosition.TryGetValue(key, out var pos))
-                    {
-                        capturedPosition = pos;
-                    }
-
-                    i += 4;
-                    continue;
-                }
-
-                // \i1, \i0, \b1, \b0, \u1, \u0
-                if ((tag == 'i' || tag == 'b' || tag == 'u') && i + 2 < inner.Length)
-                {
-                    char val = inner[i + 2];
-                    if (val == '1' || val == '0')
-                    {
-                        output.Append(GetHtmlTag(tag, val == '0'));
-                        i += 3;
-                        continue;
-                    }
-                }
-
-                // Unknown tag — skip backslash and keep going
-                i++;
-            }
-
-            return output.ToString();
-        }
-
-        /// <summary>
-        /// Processes all ASS {...} blocks in the text, extracting alignment and
-        /// converting formatting tags to HTML.
-        /// Specifically:
-        /// - Extracts the \anN alignment tag (first one found) to determine cue position.
-        /// - Converts \i1/\i0, \b1/\b0, \u1/\u0 inside blocks to &lt;i&gt;/&lt;b&gt;/&lt;u&gt; HTML tags.
-        /// - Strips unrecognized tags silently.
-        /// - Blocks that only contained the alignment tag are removed entirely.
-        /// Also handles HTML tags already present in the text (e.g. &lt;i&gt;, &lt;b&gt;).
-        /// </summary>
-        /// <param name="text">Raw subtitle text from the SRT/ASS track.</param>
-        /// <param name="cuePosition">Output: WebVTT cue position string.</param>
-        /// <returns>Cleaned text with HTML formatting tags.</returns>
-        private static string ProcessAssBlocks(string text, out string cuePosition)
-        {
-            // out params cannot be captured in lambdas; use a local variable and assign at the end.
-            string capturedPosition = "line:90%,end";
-
-            var result = _assBlockRegex.Replace(text, match =>
-                ProcessAssBlock(match.Groups[1].Value, ref capturedPosition));
-
-            cuePosition = capturedPosition;
-            return result;
-        }
-
-        /// <summary>
-        /// Tries to parse a simple HTML formatting tag (&lt;i&gt;, &lt;b&gt;, &lt;u&gt; or their closing forms)
-        /// at the given position in the text.
-        /// </summary>
-        /// <param name="text">The text to inspect.</param>
-        /// <param name="i">The index of the '&lt;' character.</param>
-        /// <param name="isClosing">True if the tag is a closing tag.</param>
-        /// <param name="tag">The formatting character: 'i', 'b', or 'u'.</param>
-        /// <param name="nextIndex">The index after the closing '&gt;'.</param>
-        /// <returns>True if a valid formatting tag was found.</returns>
-        private static bool TryParseHtmlTag(string text, int i, out bool isClosing, out char tag, out int nextIndex)
-        {
-            isClosing = false;
-            tag = '\0';
-            nextIndex = i;
-
-            if (i + 2 >= text.Length || text[i] != '<')
-            {
-                return false;
-            }
-
-            isClosing = text[i + 1] == '/';
-            int tagStart = isClosing ? i + 2 : i + 1;
-
-            if (tagStart >= text.Length
-                || (text[tagStart] != 'i' && text[tagStart] != 'b' && text[tagStart] != 'u')
-                || tagStart + 1 >= text.Length
-                || text[tagStart + 1] != '>')
-            {
-                return false;
-            }
-
-            tag = text[tagStart];
-            nextIndex = tagStart + 2;
-            return true;
-        }
-
-        /// <summary>
-        /// Automatically closes any unclosed HTML tags in the text using a LIFO stack,
-        /// so nested tags like &lt;i&gt;&lt;b&gt;text are closed as &lt;/b&gt;&lt;/i&gt; in the correct order.
-        /// </summary>
-        private static string AutoCloseHtmlTags(string text)
-        {
-            var stack = new Stack<char>();
-            int i = 0;
-            while (i < text.Length)
-            {
-                if (TryParseHtmlTag(text, i, out bool isClosing, out char tag, out int nextIndex))
-                {
-                    if (!isClosing)
-                    {
-                        stack.Push(tag);
-                    }
-                    else if (stack.Count > 0 && stack.Peek() == tag)
-                    {
-                        stack.Pop();
-                    }
-
-                    i = nextIndex;
-                    continue;
-                }
-
-                i++;
-            }
-
-            if (stack.Count == 0)
-            {
-                return text;
-            }
-
-            var result = new StringBuilder(text);
-            foreach (var tag in stack)
-            {
-                result.Append("</").Append(tag).Append('>');
-            }
-
-            return result.ToString();
-        }
+        [GeneratedRegex(@"^\{\\an\d\}")]
+        private static partial Regex AssAlignmentTagRegex();
 
         /// <inheritdoc />
         public void Write(SubtitleTrackInfo info, Stream stream, CancellationToken cancellationToken)
@@ -236,7 +25,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
             {
                 writer.WriteLine("WEBVTT");
-                writer.WriteLine();
                 writer.WriteLine();
                 foreach (var trackEvent in info.TrackEvents)
                 {
@@ -250,18 +38,24 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
                     }
 
+                    // Use cue settings from the original VTT file if available, otherwise default to bottom center.
+                    var cueSettings = string.IsNullOrEmpty(trackEvent.VttCueSettings)
+                        ? "line:90%,end"
+                        : trackEvent.VttCueSettings;
+
                     var text = trackEvent.Text;
 
-                    // Replace ASS newline escapes (\n or \N) with spaces
-                    text = NewlineEscapeRegex().Replace(text, " ");
+                    // Strip {\anN} tags introduced by libse during VTT parsing only when cue settings
+                    // are present — position is already preserved in VttCueSettings.
+                    if (!string.IsNullOrEmpty(trackEvent.VttCueSettings))
+                    {
+                        text = AssAlignmentTagRegex().Replace(text, string.Empty);
+                    }
 
-                    // Process all ASS {...} blocks: extract alignment, convert formatting to HTML
-                    text = ProcessAssBlocks(text, out var cuePosition);
+                    // Preserve existing newlines as-is - the SubtitleEdit parser already handled them correctly
+                    // No newline transformation is needed here
 
-                    // Ensure all HTML tags are properly closed
-                    text = AutoCloseHtmlTags(text);
-
-                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cuePosition);
+                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cueSettings);
                     writer.WriteLine(text);
                     writer.WriteLine();
                 }

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -77,4 +77,3 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         }
     }
 }
-

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -13,12 +13,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     /// </summary>
     public partial class VttWriter : ISubtitleWriter
     {
-        [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
-        private static partial Regex NewlineEscapeRegex();
-
-        [GeneratedRegex(@"^\{\\an\d\}")]
-        private static partial Regex AssAlignTagRegex();
-
         private static readonly Dictionary<string, string> _assTagToCuePosition = new()
         {
             ["{\\an1}"] = "position:20%",
@@ -31,6 +25,12 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ["{\\an9}"] = "position:80% line:10%",
         };
 
+        [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
+        private static partial Regex NewlineEscapeRegex();
+
+        [GeneratedRegex(@"^\{\\an\d\}")]
+        private static partial Regex AssAlignTagRegex();
+
         private static string GetCuePositionFromAssTag(string text)
         {
             foreach (var (tag, position) in _assTagToCuePosition)
@@ -38,7 +38,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 if (text.StartsWith(tag, StringComparison.Ordinal))
                     return position;
             }
-
             return "region:subtitle line:90%";
         }
 
@@ -54,26 +53,19 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 foreach (var trackEvent in info.TrackEvents)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-
                     var startTime = TimeSpan.FromTicks(trackEvent.StartPositionTicks);
                     var endTime = TimeSpan.FromTicks(trackEvent.EndPositionTicks);
-
                     // make sure the start and end times are different and sequential
                     if (endTime.TotalMilliseconds <= startTime.TotalMilliseconds)
                     {
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
                     }
-
                     var text = trackEvent.Text;
-
                     // TODO: Not sure how to handle these
                     text = NewlineEscapeRegex().Replace(text, " ");
-
                     var cuePosition = GetCuePositionFromAssTag(text);
                     text = AssAlignTagRegex().Replace(text, string.Empty);
-
                     writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cuePosition);
-
                     writer.WriteLine(text);
                     writer.WriteLine();
                 }

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -13,11 +13,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     /// </summary>
     public partial class VttWriter : ISubtitleWriter
     {
+        // Mapping of ASS alignment tags to WebVTT cue settings.
+        // The ",end" suffix is only added to line:90% values because:
+        // - ExoPlayer requires it for proper positioning at the bottom
+        // - Other players might break when ",end" is used with other line values (e.g., line:50%,end)
         private static readonly Dictionary<string, string> _assTagToCuePosition = new()
         {
-            ["{\\an1}"] = "position:20% line:90%",
-            ["{\\an2}"] = "line:90%",
-            ["{\\an3}"] = "position:80% line:90%",
+            ["{\\an1}"] = "position:20% line:90%,end",
+            ["{\\an2}"] = "line:90%,end",
+            ["{\\an3}"] = "position:80% line:90%,end",
             ["{\\an4}"] = "position:20% line:50%",
             ["{\\an5}"] = "line:50%",
             ["{\\an6}"] = "position:80% line:50%",
@@ -26,23 +30,146 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ["{\\an9}"] = "position:80% line:10%",
         };
 
-        [GeneratedRegex(@"\\n")]
+        // Matches any ASS block: {contents}
+        private static readonly Regex _assBlockRegex = new Regex(@"\{([^}]*)\}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Regex to match ASS newline escapes (\n or \N). Case-insensitive to catch both.
+        /// </summary>
+        [GeneratedRegex(@"\\[nN]")]
         private static partial Regex NewlineEscapeRegex();
 
-        [GeneratedRegex(@"^\{\\an\d\}")]
-        private static partial Regex AssAlignTagRegex();
-
-        private static string GetCuePositionFromAssTag(string text)
+        /// <summary>
+        /// Processes all ASS {...} blocks in the text, extracting alignment and
+        /// converting formatting tags to HTML.
+        /// Specifically:
+        /// - Extracts the \anN alignment tag (first one found) to determine cue position.
+        /// - Converts \i1/\i0, \b1/\b0, \u1/\u0 inside blocks to &lt;i&gt;/&lt;b&gt;/&lt;u&gt; HTML tags.
+        /// - Strips unrecognized tags silently.
+        /// - Blocks that only contained the alignment tag are removed entirely.
+        /// Also handles HTML tags already present in the text (e.g. &lt;i&gt;, &lt;b&gt;).
+        /// </summary>
+        /// <param name="text">Raw subtitle text from the SRT/ASS track.</param>
+        /// <param name="cuePosition">Output: WebVTT cue position string.</param>
+        /// <returns>Cleaned text with HTML formatting tags.</returns>
+        private static string ProcessAssBlocks(string text, out string cuePosition)
         {
-            foreach (var (tag, position) in _assTagToCuePosition)
+            // out params cannot be captured in lambdas; use a local variable and assign at the end.
+            string capturedPosition = "line:90%,end";
+
+            var result = _assBlockRegex.Replace(text, match =>
             {
-                if (text.StartsWith(tag, StringComparison.Ordinal))
+                var inner = match.Groups[1].Value;
+                var output = new StringBuilder();
+
+                int i = 0;
+                while (i < inner.Length)
                 {
-                    return position;
+                    if (inner[i] != '\\')
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (i + 1 >= inner.Length)
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    char tag = inner[i + 1];
+
+                    // \anN — alignment tag
+                    if (tag == 'a' && i + 3 < inner.Length && inner[i + 2] == 'n' && char.IsDigit(inner[i + 3]))
+                    {
+                        var key = $"{{\\an{inner[i + 3]}}}";
+                        if (_assTagToCuePosition.TryGetValue(key, out var pos))
+                        {
+                            capturedPosition = pos;
+                        }
+
+                        i += 4;
+                        continue;
+                    }
+
+                    // \i1, \i0, \b1, \b0, \u1, \u0
+                    if ((tag == 'i' || tag == 'b' || tag == 'u') && i + 2 < inner.Length)
+                    {
+                        char val = inner[i + 2];
+                        if (val == '1')
+                        {
+                            output.Append(tag == 'i' ? "<i>" : tag == 'b' ? "<b>" : "<u>");
+                            i += 3;
+                            continue;
+                        }
+                        else if (val == '0')
+                        {
+                            output.Append(tag == 'i' ? "</i>" : tag == 'b' ? "</b>" : "</u>");
+                            i += 3;
+                            continue;
+                        }
+                    }
+
+                    // Unknown tag — skip backslash and keep going
+                    i++;
                 }
+
+                return output.ToString();
+            });
+
+            cuePosition = capturedPosition;
+            return result;
+        }
+
+        /// <summary>
+        /// Automatically closes any unclosed HTML tags in the text using a LIFO stack,
+        /// so nested tags like &lt;i&gt;&lt;b&gt;text are closed as &lt;/b&gt;&lt;/i&gt; in the correct order.
+        /// </summary>
+        private static string AutoCloseHtmlTags(string text)
+        {
+            var stack = new Stack<char>();
+            int i = 0;
+            while (i < text.Length)
+            {
+                if (text[i] == '<' && i + 2 < text.Length)
+                {
+                    bool isClosing = text[i + 1] == '/';
+                    int tagStart = isClosing ? i + 2 : i + 1;
+                    if (tagStart < text.Length
+                        && (text[tagStart] == 'i' || text[tagStart] == 'b' || text[tagStart] == 'u')
+                        && tagStart + 1 < text.Length && text[tagStart + 1] == '>')
+                    {
+                        char tag = text[tagStart];
+                        if (!isClosing)
+                        {
+                            stack.Push(tag);
+                            i = tagStart + 2;
+                            continue;
+                        }
+                        else if (stack.Count > 0 && stack.Peek() == tag)
+                        {
+                            stack.Pop();
+                            i = tagStart + 2;
+                            continue;
+                        }
+                    }
+                }
+
+                i++;
             }
 
-            return "region:subtitle line:90%,end";
+            if (stack.Count == 0)
+            {
+                return text;
+            }
+
+            var result = new StringBuilder(text);
+            foreach (var tag in stack)
+            {
+                result.Append("</").Append(tag).Append('>');
+            }
+
+            return result.ToString();
         }
 
         /// <inheritdoc />
@@ -52,7 +179,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 writer.WriteLine("WEBVTT");
                 writer.WriteLine();
-                writer.WriteLine("Region: id:subtitle width:80% lines:3 regionanchor:50%,100% viewportanchor:50%,90%");
                 writer.WriteLine();
                 foreach (var trackEvent in info.TrackEvents)
                 {
@@ -61,7 +187,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     var startTime = TimeSpan.FromTicks(trackEvent.StartPositionTicks);
                     var endTime = TimeSpan.FromTicks(trackEvent.EndPositionTicks);
 
-                    // make sure the start and end times are different and sequential
                     if (endTime.TotalMilliseconds <= startTime.TotalMilliseconds)
                     {
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
@@ -69,11 +194,14 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
                     var text = trackEvent.Text;
 
-                    // TODO: Not sure how to handle these
+                    // Replace ASS newline escapes (\n or \N) with spaces
                     text = NewlineEscapeRegex().Replace(text, " ");
 
-                    var cuePosition = GetCuePositionFromAssTag(text);
-                    text = AssAlignTagRegex().Replace(text, string.Empty);
+                    // Process all ASS {...} blocks: extract alignment, convert formatting to HTML
+                    text = ProcessAssBlocks(text, out var cuePosition);
+
+                    // Ensure all HTML tags are properly closed
+                    text = AutoCloseHtmlTags(text);
 
                     writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cuePosition);
                     writer.WriteLine(text);

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -15,17 +15,18 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     {
         private static readonly Dictionary<string, string> _assTagToCuePosition = new()
         {
-            ["{\\an1}"] = "position:20% line:90%,end",
-            ["{\\an3}"] = "position:80% line:90%,end",
-            ["{\\an4}"] = "position:20% line:50%,center",
-            ["{\\an5}"] = "line:50%,center",
-            ["{\\an6}"] = "position:80% line:50%,center",
-            ["{\\an7}"] = "position:20% line:10%,start",
-            ["{\\an8}"] = "line:10%,start",
-            ["{\\an9}"] = "position:80% line:10%,start",
+            ["{\\an1}"] = "position:20% line:90%",
+            ["{\\an2}"] = "line:90%",
+            ["{\\an3}"] = "position:80% line:90%",
+            ["{\\an4}"] = "position:20% line:50%",
+            ["{\\an5}"] = "line:50%",
+            ["{\\an6}"] = "position:80% line:50%",
+            ["{\\an7}"] = "position:20% line:10%",
+            ["{\\an8}"] = "line:10%",
+            ["{\\an9}"] = "position:80% line:10%",
         };
 
-        [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"\\n")]
         private static partial Regex NewlineEscapeRegex();
 
         [GeneratedRegex(@"^\{\\an\d\}")]
@@ -56,8 +57,10 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 foreach (var trackEvent in info.TrackEvents)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
                     var startTime = TimeSpan.FromTicks(trackEvent.StartPositionTicks);
                     var endTime = TimeSpan.FromTicks(trackEvent.EndPositionTicks);
+
                     // make sure the start and end times are different and sequential
                     if (endTime.TotalMilliseconds <= startTime.TotalMilliseconds)
                     {
@@ -65,10 +68,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
 
                     var text = trackEvent.Text;
+
                     // TODO: Not sure how to handle these
                     text = NewlineEscapeRegex().Replace(text, " ");
+
                     var cuePosition = GetCuePositionFromAssTag(text);
                     text = AssAlignTagRegex().Replace(text, string.Empty);
+
                     writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cuePosition);
                     writer.WriteLine(text);
                     writer.WriteLine();

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -34,10 +34,97 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private static readonly Regex _assBlockRegex = new Regex(@"\{([^}]*)\}", RegexOptions.Compiled);
 
         /// <summary>
-        /// Regex to match ASS newline escapes (\n or \N). Case-insensitive to catch both.
+        /// Regex to match ASS newline escapes (\n or \N).
         /// </summary>
         [GeneratedRegex(@"\\[nN]")]
         private static partial Regex NewlineEscapeRegex();
+
+        /// <summary>
+        /// Returns the opening or closing HTML tag string for a given ASS formatting character.
+        /// Supported characters: i (italic), b (bold), u (underline).
+        /// </summary>
+        /// <param name="tag">The formatting character: 'i', 'b', or 'u'.</param>
+        /// <param name="closing">True to return a closing tag, false for an opening tag.</param>
+        /// <returns>The HTML tag string, e.g. "&lt;i&gt;" or "&lt;/b&gt;".</returns>
+        private static string GetHtmlTag(char tag, bool closing)
+        {
+            if (closing)
+            {
+                return tag switch
+                {
+                    'i' => "</i>",
+                    'b' => "</b>",
+                    _ => "</u>",
+                };
+            }
+
+            return tag switch
+            {
+                'i' => "<i>",
+                'b' => "<b>",
+                _ => "<u>",
+            };
+        }
+
+        /// <summary>
+        /// Processes a single ASS block's inner content (the text between braces).
+        /// Extracts \anN to update the cue position and converts \i1/\i0, \b1/\b0, \u1/\u0
+        /// to HTML tags. Unrecognized tags are stripped silently.
+        /// </summary>
+        /// <param name="inner">The content inside the ASS block braces.</param>
+        /// <param name="capturedPosition">Updated with the cue position if an \anN tag is found.</param>
+        /// <returns>The HTML output for this block (may be empty if only alignment was present).</returns>
+        private static string ProcessAssBlock(string inner, ref string capturedPosition)
+        {
+            var output = new StringBuilder();
+            int i = 0;
+            while (i < inner.Length)
+            {
+                if (inner[i] != '\\')
+                {
+                    i++;
+                    continue;
+                }
+
+                if (i + 1 >= inner.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                char tag = inner[i + 1];
+
+                // \anN — alignment tag
+                if (tag == 'a' && i + 3 < inner.Length && inner[i + 2] == 'n' && char.IsDigit(inner[i + 3]))
+                {
+                    var key = $"{{\\an{inner[i + 3]}}}";
+                    if (_assTagToCuePosition.TryGetValue(key, out var pos))
+                    {
+                        capturedPosition = pos;
+                    }
+
+                    i += 4;
+                    continue;
+                }
+
+                // \i1, \i0, \b1, \b0, \u1, \u0
+                if ((tag == 'i' || tag == 'b' || tag == 'u') && i + 2 < inner.Length)
+                {
+                    char val = inner[i + 2];
+                    if (val == '1' || val == '0')
+                    {
+                        output.Append(GetHtmlTag(tag, val == '0'));
+                        i += 3;
+                        continue;
+                    }
+                }
+
+                // Unknown tag — skip backslash and keep going
+                i++;
+            }
+
+            return output.ToString();
+        }
 
         /// <summary>
         /// Processes all ASS {...} blocks in the text, extracting alignment and
@@ -58,67 +145,47 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             string capturedPosition = "line:90%,end";
 
             var result = _assBlockRegex.Replace(text, match =>
-            {
-                var inner = match.Groups[1].Value;
-                var output = new StringBuilder();
-
-                int i = 0;
-                while (i < inner.Length)
-                {
-                    if (inner[i] != '\\')
-                    {
-                        i++;
-                        continue;
-                    }
-
-                    if (i + 1 >= inner.Length)
-                    {
-                        i++;
-                        continue;
-                    }
-
-                    char tag = inner[i + 1];
-
-                    // \anN — alignment tag
-                    if (tag == 'a' && i + 3 < inner.Length && inner[i + 2] == 'n' && char.IsDigit(inner[i + 3]))
-                    {
-                        var key = $"{{\\an{inner[i + 3]}}}";
-                        if (_assTagToCuePosition.TryGetValue(key, out var pos))
-                        {
-                            capturedPosition = pos;
-                        }
-
-                        i += 4;
-                        continue;
-                    }
-
-                    // \i1, \i0, \b1, \b0, \u1, \u0
-                    if ((tag == 'i' || tag == 'b' || tag == 'u') && i + 2 < inner.Length)
-                    {
-                        char val = inner[i + 2];
-                        if (val == '1')
-                        {
-                            output.Append(tag == 'i' ? "<i>" : tag == 'b' ? "<b>" : "<u>");
-                            i += 3;
-                            continue;
-                        }
-                        else if (val == '0')
-                        {
-                            output.Append(tag == 'i' ? "</i>" : tag == 'b' ? "</b>" : "</u>");
-                            i += 3;
-                            continue;
-                        }
-                    }
-
-                    // Unknown tag — skip backslash and keep going
-                    i++;
-                }
-
-                return output.ToString();
-            });
+                ProcessAssBlock(match.Groups[1].Value, ref capturedPosition));
 
             cuePosition = capturedPosition;
             return result;
+        }
+
+        /// <summary>
+        /// Tries to parse a simple HTML formatting tag (&lt;i&gt;, &lt;b&gt;, &lt;u&gt; or their closing forms)
+        /// at the given position in the text.
+        /// </summary>
+        /// <param name="text">The text to inspect.</param>
+        /// <param name="i">The index of the '&lt;' character.</param>
+        /// <param name="isClosing">True if the tag is a closing tag.</param>
+        /// <param name="tag">The formatting character: 'i', 'b', or 'u'.</param>
+        /// <param name="nextIndex">The index after the closing '&gt;'.</param>
+        /// <returns>True if a valid formatting tag was found.</returns>
+        private static bool TryParseHtmlTag(string text, int i, out bool isClosing, out char tag, out int nextIndex)
+        {
+            isClosing = false;
+            tag = '\0';
+            nextIndex = i;
+
+            if (i + 2 >= text.Length || text[i] != '<')
+            {
+                return false;
+            }
+
+            isClosing = text[i + 1] == '/';
+            int tagStart = isClosing ? i + 2 : i + 1;
+
+            if (tagStart >= text.Length
+                || (text[tagStart] != 'i' && text[tagStart] != 'b' && text[tagStart] != 'u')
+                || tagStart + 1 >= text.Length
+                || text[tagStart + 1] != '>')
+            {
+                return false;
+            }
+
+            tag = text[tagStart];
+            nextIndex = tagStart + 2;
+            return true;
         }
 
         /// <summary>
@@ -131,28 +198,19 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             int i = 0;
             while (i < text.Length)
             {
-                if (text[i] == '<' && i + 2 < text.Length)
+                if (TryParseHtmlTag(text, i, out bool isClosing, out char tag, out int nextIndex))
                 {
-                    bool isClosing = text[i + 1] == '/';
-                    int tagStart = isClosing ? i + 2 : i + 1;
-                    if (tagStart < text.Length
-                        && (text[tagStart] == 'i' || text[tagStart] == 'b' || text[tagStart] == 'u')
-                        && tagStart + 1 < text.Length && text[tagStart + 1] == '>')
+                    if (!isClosing)
                     {
-                        char tag = text[tagStart];
-                        if (!isClosing)
-                        {
-                            stack.Push(tag);
-                            i = tagStart + 2;
-                            continue;
-                        }
-                        else if (stack.Count > 0 && stack.Peek() == tag)
-                        {
-                            stack.Pop();
-                            i = tagStart + 2;
-                            continue;
-                        }
+                        stack.Push(tag);
                     }
+                    else if (stack.Count > 0 && stack.Peek() == tag)
+                    {
+                        stack.Pop();
+                    }
+
+                    i = nextIndex;
+                    continue;
                 }
 
                 i++;

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -15,14 +15,14 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     {
         private static readonly Dictionary<string, string> _assTagToCuePosition = new()
         {
-            ["{\\an1}"] = "position:20%",
-            ["{\\an3}"] = "position:80%",
-            ["{\\an4}"] = "position:20% line:50%",
-            ["{\\an5}"] = "line:50%",
-            ["{\\an6}"] = "position:80% line:50%",
-            ["{\\an7}"] = "position:20% line:10%",
-            ["{\\an8}"] = "line:10%",
-            ["{\\an9}"] = "position:80% line:10%",
+            ["{\\an1}"] = "position:20% line:90%,end",
+            ["{\\an3}"] = "position:80% line:90%,end",
+            ["{\\an4}"] = "position:20% line:50%,center",
+            ["{\\an5}"] = "line:50%,center",
+            ["{\\an6}"] = "position:80% line:50%,center",
+            ["{\\an7}"] = "position:20% line:10%,start",
+            ["{\\an8}"] = "line:10%,start",
+            ["{\\an9}"] = "position:80% line:10%,start",
         };
 
         [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
@@ -41,7 +41,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
             }
 
-            return "region:subtitle line:90%";
+            return "region:subtitle line:90%,end";
         }
 
         /// <inheritdoc />
@@ -77,3 +77,4 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         }
     }
 }
+

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -16,7 +16,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
         private static partial Regex NewlineEscapeRegex();
 
-        [GeneratedRegex(@"^\{\\an\d\}", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"^\{\\an\d\}")]
         private static partial Regex AssAlignTagRegex();
 
         private static readonly Dictionary<string, string> _assTagToCuePosition = new()

--- a/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -14,6 +15,32 @@ namespace MediaBrowser.MediaEncoding.Subtitles
     {
         [GeneratedRegex(@"\\n", RegexOptions.IgnoreCase)]
         private static partial Regex NewlineEscapeRegex();
+
+        [GeneratedRegex(@"^\{\\an\d\}", RegexOptions.IgnoreCase)]
+        private static partial Regex AssAlignTagRegex();
+
+        private static readonly Dictionary<string, string> _assTagToCuePosition = new()
+        {
+            ["{\\an1}"] = "position:20%",
+            ["{\\an3}"] = "position:80%",
+            ["{\\an4}"] = "position:20% line:50%",
+            ["{\\an5}"] = "line:50%",
+            ["{\\an6}"] = "position:80% line:50%",
+            ["{\\an7}"] = "position:20% line:10%",
+            ["{\\an8}"] = "line:10%",
+            ["{\\an9}"] = "position:80% line:10%",
+        };
+
+        private static string GetCuePositionFromAssTag(string text)
+        {
+            foreach (var (tag, position) in _assTagToCuePosition)
+            {
+                if (text.StartsWith(tag, StringComparison.Ordinal))
+                    return position;
+            }
+
+            return "region:subtitle line:90%";
+        }
 
         /// <inheritdoc />
         public void Write(SubtitleTrackInfo info, Stream stream, CancellationToken cancellationToken)
@@ -37,12 +64,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         endTime = startTime.Add(TimeSpan.FromMilliseconds(1));
                     }
 
-                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} region:subtitle line:90%", startTime, endTime);
-
                     var text = trackEvent.Text;
 
                     // TODO: Not sure how to handle these
                     text = NewlineEscapeRegex().Replace(text, " ");
+
+                    var cuePosition = GetCuePositionFromAssTag(text);
+                    text = AssAlignTagRegex().Replace(text, string.Empty);
+
+                    writer.WriteLine(@"{0:hh\:mm\:ss\.fff} --> {1:hh\:mm\:ss\.fff} {2}", startTime, endTime, cuePosition);
 
                     writer.WriteLine(text);
                     writer.WriteLine();

--- a/MediaBrowser.Model/MediaInfo/SubtitleTrackEvent.cs
+++ b/MediaBrowser.Model/MediaInfo/SubtitleTrackEvent.cs
@@ -17,5 +17,11 @@ namespace MediaBrowser.Model.MediaInfo
         public long StartPositionTicks { get; set; }
 
         public long EndPositionTicks { get; set; }
+
+        /// <summary>
+        /// Gets or sets the WebVTT cue settings (e.g. "line:10% align:center").
+        /// Populated from the cue timing line when parsing VTT files.
+        /// </summary>
+        public string? VttCueSettings { get; set; }
     }
 }


### PR DESCRIPTION
VttWriter was hardcoding `line:90%` for all cues and writing ASS alignment tags (e.g. `{\an8}`) as literal text in the output. These tags are introduced by libse when parsing VTT files with position cues, but were never converted 
back to valid VTT cue settings when writing the output.

This fix preserves VTT cue settings through the subtitle pipeline without parsing any subtitle format tags in the writer:

- Adds `VttCueSettings` to `SubtitleTrackEvent` to carry cue settings 
  through the pipeline
- `SubtitleEditParser` maps `p.Style` from libse to the new field — libse 
  already populates this with the raw cue settings string (e.g. 
  `"line:10% align:center"`) when parsing VTT files
- `VttWriter` writes `VttCueSettings` directly to the timing line with no 
  additional parsing, falling back to `line:90%,end` when not present
- `{\anN}` tags introduced by libse are stripped from the text only when 
  `VttCueSettings` is present, leaving SRT and other formats untouched

Tested with VTT files containing line/position cues on Jellyfin Android TV and Android app (integrated player) . Before: tags visible as text, all subtitles at bottom.
After: subtitles appear at correct position, no tag artifacts.