### PR TITLE
Fix FFProbeVideoInfo downloading subtitles without considering internal streams

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -194,20 +194,11 @@ namespace MediaBrowser.Providers.MediaInfo
             IReadOnlyList<MediaAttachment> mediaAttachments;
             ChapterInfo[] chapters;
 
-            // Add external streams before adding the streams from the file to preserve stream IDs on remote videos
-            await AddExternalSubtitlesAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
-
             await AddExternalAudioAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
-
-            var startIndex = mediaStreams.Count == 0 ? 0 : (mediaStreams.Max(i => i.Index) + 1);
 
             if (mediaInfo is not null)
             {
-                foreach (var mediaStream in mediaInfo.MediaStreams)
-                {
-                    mediaStream.Index = startIndex++;
-                    mediaStreams.Add(mediaStream);
-                }
+                mediaStreams.AddRange(mediaInfo.MediaStreams);
 
                 mediaAttachments = mediaInfo.MediaAttachments;
                 video.TotalBitrate = mediaInfo.Bitrate;
@@ -231,13 +222,20 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     if (!mediaStream.IsExternal)
                     {
-                        mediaStream.Index = startIndex++;
                         mediaStreams.Add(mediaStream);
                     }
                 }
 
                 mediaAttachments = [];
                 chapters = [];
+            }
+
+            // Download and insert external streams before the streams from the file to preserve stream IDs on remote videos
+            await AddExternalSubtitlesAsync(video, mediaStreams, options, cancellationToken).ConfigureAwait(false);
+
+            for (var i = 0; i < mediaStreams.Count; i++)
+            {
+                mediaStreams[i].Index = i;
             }
 
             var libraryOptions = _libraryManager.GetLibraryOptions(video);
@@ -542,8 +540,7 @@ namespace MediaBrowser.Providers.MediaInfo
             MetadataRefreshOptions options,
             CancellationToken cancellationToken)
         {
-            var startIndex = currentStreams.Count == 0 ? 0 : (currentStreams.Select(i => i.Index).Max() + 1);
-            var externalSubtitleStreams = await _subtitleResolver.GetExternalStreamsAsync(video, startIndex, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
+            var externalSubtitleStreams = await _subtitleResolver.GetExternalStreamsAsync(video, 0, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
 
             var enableSubtitleDownloading = options.MetadataRefreshMode == MetadataRefreshMode.Default ||
                                             options.MetadataRefreshMode == MetadataRefreshMode.FullRefresh;
@@ -569,13 +566,13 @@ namespace MediaBrowser.Providers.MediaInfo
                 // Rescan
                 if (downloadedLanguages.Count > 0)
                 {
-                    externalSubtitleStreams = await _subtitleResolver.GetExternalStreamsAsync(video, startIndex, options.DirectoryService, true, cancellationToken).ConfigureAwait(false);
+                    externalSubtitleStreams = await _subtitleResolver.GetExternalStreamsAsync(video, 0, options.DirectoryService, true, cancellationToken).ConfigureAwait(false);
                 }
             }
 
             video.SubtitleFiles = externalSubtitleStreams.Select(i => i.Path).Distinct().ToArray();
 
-            currentStreams.AddRange(externalSubtitleStreams);
+            currentStreams.InsertRange(0, externalSubtitleStreams);
         }
 
         /// <summary>
@@ -591,8 +588,7 @@ namespace MediaBrowser.Providers.MediaInfo
             MetadataRefreshOptions options,
             CancellationToken cancellationToken)
         {
-            var startIndex = currentStreams.Count == 0 ? 0 : currentStreams.Max(i => i.Index) + 1;
-            var externalAudioStreams = await _audioResolver.GetExternalStreamsAsync(video, startIndex, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
+            var externalAudioStreams = await _audioResolver.GetExternalStreamsAsync(video, 0, options.DirectoryService, false, cancellationToken).ConfigureAwait(false);
 
             video.AudioFiles = externalAudioStreams.Select(i => i.Path).Distinct().ToArray();
 


### PR DESCRIPTION
**Changes**
Currently `Skip if the video already contains embedded subtitles` and `Skip if the default audio track matches the download language` are ignored because the internal tracks are read after downloading (`AddExternalSubtitlesAsync` is called before `currentStreams` is filled)

This is also triggered by the missing subtitles task, after a subtitle is downloaded (`RefreshMetadata` eventually calls it):
https://github.com/jellyfin/jellyfin/blob/8150a512388d3189cf2f3abf789470342ef70175/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs#L199-L204

Simple reproducer: Video file that has english subtitles in it and library download languages is set to english and dutch. Missing subtitles task will download dutch subs and call Fetch, which will unnecessarily download english subs too (this will happen on initial library scan too)

This PR moves the `AddExternalSubtitlesAsync` call so its called  _after_ reading internal streams. Downloaded (and existing external) subtitle streams are inserted at the beginning of `mediaStreams`, after which the StreamIndex is adjusted in the whole list

Since I'm messing with stream indexes I performed multiple tests, I scanned the same movie library using a clean install of 10.11, master and my branch and then exported results of
```sql
SELECT
b.Name, m.StreamIndex,
m.AspectRatio, m.AverageFrameRate, m.BitDepth, m.BitRate,
m.BlPresentFlag, m.ChannelLayout, m.Channels, m.Codec,
m.CodecTimeBase, m.ColorPrimaries, m.ColorSpace,
m.ColorTransfer, m.Comment, m.DvBlSignalCompatibilityId,
m.DvLevel, m.DvProfile, m.DvVersionMajor, m.DvVersionMinor,
m.ElPresentFlag, m.IsAnamorphic, m.IsDefault, m.IsExternal,
m.IsForced, m.IsHearingImpaired, m.IsInterlaced, m.KeyFrames,
m.Language, m.NalLengthSize, m.Path, m.PixelFormat, m.Profile,
m.RealFrameRate, m.RefFrames, m.Rotation, m.RpuPresentFlag,
m.SampleRate, m.StreamType, m.TimeBase, m.Title, m.Hdr10PlusPresentFlag
FROM MediaStreamInfos m LEFT JOIN BaseItems b ON b.Id = m.ItemId;
```
and ran diff on them, all of them had the same stream indexes

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/16638

Clanker used: copilot for autocomplete
