### PR TITLE
Load Jellyfin.MediaEncoding.Keyframes eagerly in GetComposablePartAssemblies

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -38,6 +38,7 @@ using Emby.Server.Implementations.Updates;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Drawing;
 using Jellyfin.MediaEncoding.Hls.Playlist;
+using Jellyfin.MediaEncoding.Keyframes;
 using Jellyfin.Networking.Manager;
 using Jellyfin.Networking.Udp;
 using Jellyfin.Server.Implementations.FullSystemBackup;
@@ -853,6 +854,9 @@ namespace Emby.Server.Implementations
 
             // MediaEncoding
             yield return typeof(MediaBrowser.MediaEncoding.Encoder.MediaEncoder).Assembly;
+
+            // Keyframes — must be loaded eagerly so plugins can resolve it via PluginLoadContext fallback
+            yield return typeof(KeyframeData).Assembly;
 
             // Local metadata
             yield return typeof(BoxSetXmlSaver).Assembly;


### PR DESCRIPTION
PluginLoadContext resolves assemblies only from the plugin's own directory via AssemblyDependencyResolver, falling back to AssemblyLoadContext.Default when an assembly is not found there. Jellyfin.MediaEncoding.Keyframes was only a transitive dependency of Jellyfin.MediaEncoding.Hls and was loaded lazily, so it was not guaranteed to be present in the default context when a plugin first needed it, causing a FileNotFoundException at runtime.

Adding it explicitly to GetComposablePartAssemblies ensures it is loaded into AssemblyLoadContext.Default at server startup, making it reliably available to plugins through the standard fallback path.