### PR TITLE
Fix audio/subtitle track selection not persisting across episodes

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -23,6 +23,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaEncoding;
@@ -453,7 +454,6 @@ namespace Emby.Server.Implementations.Library
 
         public void SetDefaultAudioAndSubtitleStreamIndices(BaseItem item, MediaSourceInfo source, User user)
         {
-            // Item would only be null if the app didn't supply ItemId as part of the live stream open request
             var mediaType = item?.MediaType ?? MediaType.Video;
 
             if (mediaType == MediaType.Video)
@@ -461,6 +461,15 @@ namespace Emby.Server.Implementations.Library
                 var userData = item is null ? null : _userDataManager.GetUserData(user, item);
 
                 var allowRememberingSelection = item is null || item.EnableRememberingTrackSelections;
+
+                if (allowRememberingSelection
+                    && userData is not null
+                    && !userData.AudioStreamIndex.HasValue
+                    && !userData.SubtitleStreamIndex.HasValue
+                    && item is Episode episode)
+                {
+                    userData = GetPreviousEpisodeUserData(episode, user) ?? userData;
+                }
 
                 SetDefaultAudioStreamIndex(source, userData, user, allowRememberingSelection);
                 SetDefaultSubtitleStreamIndex(source, userData, user, allowRememberingSelection);
@@ -474,6 +483,68 @@ namespace Emby.Server.Implementations.Library
                     source.DefaultAudioStreamIndex = audio.Index;
                 }
             }
+        }
+
+        /// <summary>
+        /// Finds the most recently watched episode in the same series and returns its UserData,
+        /// allowing audio/subtitle track selections to carry over to a new episode.
+        /// </summary>
+        private UserItemData GetPreviousEpisodeUserData(Episode episode, User user)
+        {
+            var seasonNumber = episode.ParentIndexNumber;
+            var episodeNumber = episode.IndexNumber;
+            var seriesId = episode.SeriesId;
+
+            if (seriesId.IsEmpty() || !seasonNumber.HasValue || !episodeNumber.HasValue)
+            {
+                return null;
+            }
+
+            // Look for the immediately preceding episode (same season, previous number)
+            var previousEpisodeNumber = episodeNumber.Value - 1;
+            BaseItem previousEpisode = null;
+
+            if (previousEpisodeNumber >= 1)
+            {
+                var candidates = _libraryManager.GetItemList(new InternalItemsQuery
+                {
+                    IncludeItemTypes = [BaseItemKind.Episode],
+                    AncestorIds = [seriesId],
+                    ParentIndexNumber = seasonNumber.Value,
+                    IndexNumber = previousEpisodeNumber,
+                    Limit = 1
+                });
+
+                previousEpisode = candidates.FirstOrDefault();
+            }
+
+            // If we're at episode 1, try the last episode of the previous season
+            if (previousEpisode is null && previousEpisodeNumber < 1 && seasonNumber.Value > 1)
+            {
+                var candidates = _libraryManager.GetItemList(new InternalItemsQuery
+                {
+                    IncludeItemTypes = [BaseItemKind.Episode],
+                    AncestorIds = [seriesId],
+                    ParentIndexNumber = seasonNumber.Value - 1,
+                    OrderBy = [(ItemSortBy.IndexNumber, SortOrder.Descending)],
+                    Limit = 1
+                });
+
+                previousEpisode = candidates.FirstOrDefault();
+            }
+
+            if (previousEpisode is null)
+            {
+                return null;
+            }
+
+            var prevUserData = _userDataManager.GetUserData(user, previousEpisode);
+            if (prevUserData?.AudioStreamIndex.HasValue == true || prevUserData?.SubtitleStreamIndex.HasValue == true)
+            {
+                return prevUserData;
+            }
+
+            return null;
         }
 
         private static IEnumerable<MediaSourceInfo> SortMediaSources(IEnumerable<MediaSourceInfo> sources)

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -973,7 +973,7 @@ namespace Emby.Server.Implementations.Session
 
             if (user.RememberAudioSelections)
             {
-                if (data.AudioStreamIndex != info.AudioStreamIndex)
+                if (info.AudioStreamIndex.HasValue && data.AudioStreamIndex != info.AudioStreamIndex)
                 {
                     data.AudioStreamIndex = info.AudioStreamIndex;
                     changed = true;
@@ -990,7 +990,7 @@ namespace Emby.Server.Implementations.Session
 
             if (user.RememberSubtitleSelections)
             {
-                if (data.SubtitleStreamIndex != info.SubtitleStreamIndex)
+                if (info.SubtitleStreamIndex.HasValue && data.SubtitleStreamIndex != info.SubtitleStreamIndex)
                 {
                     data.SubtitleStreamIndex = info.SubtitleStreamIndex;
                     changed = true;


### PR DESCRIPTION
## Summary
Audio and subtitle track selections do not persist when playing the next episode in a TV series, and can be lost when resuming playback. This is a long-standing issue affecting all clients.
### Root causes and fixes
**Bug 1 — Null-overwrite in progress reports (`SessionManager.cs`)**
Some clients send playback progress reports without `AudioStreamIndex`/`SubtitleStreamIndex`. The existing code would overwrite previously saved selections with `null`. Added `.HasValue` guards so only explicit track changes are saved.
**Bug 2 — No cross-episode track inheritance (`MediaSourceManager.cs`)**
When starting a new episode with no saved track preferences, the server had no logic to look up what the user chose on the previous episode. Added `GetPreviousEpisodeUserData()` which finds the preceding episode in the same series (handling season boundaries) and inherits its audio/subtitle selections. This is gated by the existing `allowRememberingSelection` and `RememberAudioSelections`/`RememberSubtitleSelections` user settings.
### Why server-side
The web client had a client-side workaround in `playbackmanager.js`, but this only worked for the web player. This server-side fix benefits **all clients** (web, Android TV, iOS, Roku, etc.) without requiring any client changes.
## Testing
- Built a custom Docker image based on `v10.11.8` with these changes
- Tested on a Synology DS1821+ running Jellyfin 10.11.8
- Verified audio track inheritance when skipping to next episode
- Verified track selections survive stop/resume
- Verified new episodes with no saved data inherit from the previous episode
- Verified the fix respects `RememberAudioSelections`/`RememberSubtitleSelections` user settings
Fixes #13087, #11974, #9141
