### PR TITLE
Guard against null-overwrite of saved audio/subtitle track selections

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -973,7 +973,7 @@ namespace Emby.Server.Implementations.Session
 
             if (user.RememberAudioSelections)
             {
-                if (data.AudioStreamIndex != info.AudioStreamIndex)
+                if (info.AudioStreamIndex.HasValue && data.AudioStreamIndex != info.AudioStreamIndex)
                 {
                     data.AudioStreamIndex = info.AudioStreamIndex;
                     changed = true;
@@ -990,7 +990,7 @@ namespace Emby.Server.Implementations.Session
 
             if (user.RememberSubtitleSelections)
             {
-                if (data.SubtitleStreamIndex != info.SubtitleStreamIndex)
+                if (info.SubtitleStreamIndex.HasValue && data.SubtitleStreamIndex != info.SubtitleStreamIndex)
                 {
                     data.SubtitleStreamIndex = info.SubtitleStreamIndex;
                     changed = true;


### PR DESCRIPTION
Some clients omit AudioStreamIndex or SubtitleStreamIndex in playback progress reports and it causes previously saved track selections to be erased. 

Add .HasValue checks so only explicit track changes are persisted.

