### PR TITLE
Molten Hub Code: Reduce Codebase And Centralize Classes

### DIFF
--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginActivityLogConsumer.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginActivityLogConsumer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Model.Activity;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Notifications;
+
+namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
+{
+    public abstract class PluginActivityLogConsumer<TEventArgs> : IEventConsumer<TEventArgs>
+        where TEventArgs : EventArgs
+    {
+        private readonly ILocalizationManager _localizationManager;
+        private readonly IActivityManager _activityManager;
+        private readonly string _nameLocalizationKey;
+        private readonly NotificationType _notificationType;
+        private readonly Func<TEventArgs, string> _getName;
+        private readonly Func<TEventArgs, object?>? _getVersion;
+        private readonly Func<TEventArgs, string?>? _getOverview;
+
+        protected PluginActivityLogConsumer(
+            ILocalizationManager localizationManager,
+            IActivityManager activityManager,
+            string nameLocalizationKey,
+            NotificationType notificationType,
+            Func<TEventArgs, string> getName,
+            Func<TEventArgs, object?>? getVersion = null,
+            Func<TEventArgs, string?>? getOverview = null)
+        {
+            _localizationManager = localizationManager;
+            _activityManager = activityManager;
+            _nameLocalizationKey = nameLocalizationKey;
+            _notificationType = notificationType;
+            _getName = getName;
+            _getVersion = getVersion;
+            _getOverview = getOverview;
+        }
+
+        public async Task OnEvent(TEventArgs eventArgs)
+        {
+            var activityLog = new ActivityLog(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    _localizationManager.GetLocalizedString(_nameLocalizationKey),
+                    _getName(eventArgs)),
+                _notificationType.ToString(),
+                Guid.Empty);
+
+            if (_getVersion is not null)
+            {
+                activityLog.ShortOverview = string.Format(
+                    CultureInfo.InvariantCulture,
+                    _localizationManager.GetLocalizedString("VersionNumber"),
+                    _getVersion(eventArgs));
+            }
+
+            if (_getOverview is not null)
+            {
+                activityLog.Overview = _getOverview(eventArgs);
+            }
+
+            await _activityManager.CreateAsync(activityLog).ConfigureAwait(false);
+        }
+    }
+}

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationCancelledNotifier.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationCancelledNotifier.cs
@@ -1,32 +1,25 @@
-using System.Threading;
-using System.Threading.Tasks;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using MediaBrowser.Model.Updates;
 
 namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
 {
     /// <summary>
     /// Notifies admin users when a plugin installation is cancelled.
     /// </summary>
-    public class PluginInstallationCancelledNotifier : IEventConsumer<PluginInstallationCancelledEventArgs>
+    public class PluginInstallationCancelledNotifier : PluginNotificationConsumer<PluginInstallationCancelledEventArgs, InstallationInfo>
     {
-        private readonly ISessionManager _sessionManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstallationCancelledNotifier"/> class.
         /// </summary>
         /// <param name="sessionManager">The session manager.</param>
         public PluginInstallationCancelledNotifier(ISessionManager sessionManager)
+            : base(sessionManager, SessionMessageType.PackageInstallationCancelled)
         {
-            _sessionManager = sessionManager;
         }
 
         /// <inheritdoc />
-        public async Task OnEvent(PluginInstallationCancelledEventArgs eventArgs)
-        {
-            await _sessionManager.SendMessageToAdminSessions(SessionMessageType.PackageInstallationCancelled, eventArgs.Argument, CancellationToken.None).ConfigureAwait(false);
-        }
+        protected override InstallationInfo GetMessageData(PluginInstallationCancelledEventArgs eventArgs) => eventArgs.Argument;
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationFailedLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationFailedLogger.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Globalization;
-using System.Threading.Tasks;
-using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Common.Updates;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Notifications;
@@ -13,39 +8,23 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
     /// <summary>
     /// Creates an entry in the activity log when a package installation fails.
     /// </summary>
-    public class PluginInstallationFailedLogger : IEventConsumer<InstallationFailedEventArgs>
+    public class PluginInstallationFailedLogger : PluginActivityLogConsumer<InstallationFailedEventArgs>
     {
-        private readonly ILocalizationManager _localizationManager;
-        private readonly IActivityManager _activityManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstallationFailedLogger"/> class.
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="activityManager">The activity manager.</param>
         public PluginInstallationFailedLogger(ILocalizationManager localizationManager, IActivityManager activityManager)
+            : base(
+                localizationManager,
+                activityManager,
+                "NameInstallFailed",
+                NotificationType.InstallationFailed,
+                eventArgs => eventArgs.InstallationInfo.Name,
+                eventArgs => eventArgs.InstallationInfo.Version,
+                eventArgs => eventArgs.Exception.Message)
         {
-            _localizationManager = localizationManager;
-            _activityManager = activityManager;
-        }
-
-        /// <inheritdoc />
-        public async Task OnEvent(InstallationFailedEventArgs eventArgs)
-        {
-            await _activityManager.CreateAsync(new ActivityLog(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("NameInstallFailed"),
-                    eventArgs.InstallationInfo.Name),
-                NotificationType.InstallationFailed.ToString(),
-                Guid.Empty)
-            {
-                ShortOverview = string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("VersionNumber"),
-                    eventArgs.InstallationInfo.Version),
-                Overview = eventArgs.Exception.Message
-            }).ConfigureAwait(false);
         }
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationFailedNotifier.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallationFailedNotifier.cs
@@ -1,32 +1,25 @@
-using System.Threading;
-using System.Threading.Tasks;
 using MediaBrowser.Common.Updates;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using MediaBrowser.Model.Updates;
 
 namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
 {
     /// <summary>
     /// Notifies admin users when a plugin installation fails.
     /// </summary>
-    public class PluginInstallationFailedNotifier : IEventConsumer<InstallationFailedEventArgs>
+    public class PluginInstallationFailedNotifier : PluginNotificationConsumer<InstallationFailedEventArgs, InstallationInfo>
     {
-        private readonly ISessionManager _sessionManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstallationFailedNotifier"/> class.
         /// </summary>
         /// <param name="sessionManager">The session manager.</param>
         public PluginInstallationFailedNotifier(ISessionManager sessionManager)
+            : base(sessionManager, SessionMessageType.PackageInstallationFailed)
         {
-            _sessionManager = sessionManager;
         }
 
         /// <inheritdoc />
-        public async Task OnEvent(InstallationFailedEventArgs eventArgs)
-        {
-            await _sessionManager.SendMessageToAdminSessions(SessionMessageType.PackageInstallationFailed, eventArgs.InstallationInfo, CancellationToken.None).ConfigureAwait(false);
-        }
+        protected override InstallationInfo GetMessageData(InstallationFailedEventArgs eventArgs) => eventArgs.InstallationInfo;
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstalledLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstalledLogger.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Globalization;
-using System.Threading.Tasks;
-using Jellyfin.Database.Implementations.Entities;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Globalization;
@@ -13,38 +8,22 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
     /// <summary>
     /// Creates an entry in the activity log when a plugin is installed.
     /// </summary>
-    public class PluginInstalledLogger : IEventConsumer<PluginInstalledEventArgs>
+    public class PluginInstalledLogger : PluginActivityLogConsumer<PluginInstalledEventArgs>
     {
-        private readonly ILocalizationManager _localizationManager;
-        private readonly IActivityManager _activityManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstalledLogger"/> class.
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="activityManager">The activity manager.</param>
         public PluginInstalledLogger(ILocalizationManager localizationManager, IActivityManager activityManager)
+            : base(
+                localizationManager,
+                activityManager,
+                "PluginInstalledWithName",
+                NotificationType.PluginInstalled,
+                eventArgs => eventArgs.Argument.Name,
+                eventArgs => eventArgs.Argument.Version)
         {
-            _localizationManager = localizationManager;
-            _activityManager = activityManager;
-        }
-
-        /// <inheritdoc />
-        public async Task OnEvent(PluginInstalledEventArgs eventArgs)
-        {
-            await _activityManager.CreateAsync(new ActivityLog(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("PluginInstalledWithName"),
-                    eventArgs.Argument.Name),
-                NotificationType.PluginInstalled.ToString(),
-                Guid.Empty)
-            {
-                ShortOverview = string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("VersionNumber"),
-                    eventArgs.Argument.Version)
-            }).ConfigureAwait(false);
         }
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstalledNotifier.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstalledNotifier.cs
@@ -1,32 +1,25 @@
-using System.Threading;
-using System.Threading.Tasks;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using MediaBrowser.Model.Updates;
 
 namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
 {
     /// <summary>
     /// Notifies admin users when a plugin is installed.
     /// </summary>
-    public class PluginInstalledNotifier : IEventConsumer<PluginInstalledEventArgs>
+    public class PluginInstalledNotifier : PluginNotificationConsumer<PluginInstalledEventArgs, InstallationInfo>
     {
-        private readonly ISessionManager _sessionManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstalledNotifier"/> class.
         /// </summary>
         /// <param name="sessionManager">The session manager.</param>
         public PluginInstalledNotifier(ISessionManager sessionManager)
+            : base(sessionManager, SessionMessageType.PackageInstallationCompleted)
         {
-            _sessionManager = sessionManager;
         }
 
         /// <inheritdoc />
-        public async Task OnEvent(PluginInstalledEventArgs eventArgs)
-        {
-            await _sessionManager.SendMessageToAdminSessions(SessionMessageType.PackageInstallationCompleted, eventArgs.Argument, CancellationToken.None).ConfigureAwait(false);
-        }
+        protected override InstallationInfo GetMessageData(PluginInstalledEventArgs eventArgs) => eventArgs.Argument;
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallingNotifier.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginInstallingNotifier.cs
@@ -1,32 +1,25 @@
-using System.Threading;
-using System.Threading.Tasks;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using MediaBrowser.Model.Updates;
 
 namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
 {
     /// <summary>
     /// Notifies admin users when a plugin is being installed.
     /// </summary>
-    public class PluginInstallingNotifier : IEventConsumer<PluginInstallingEventArgs>
+    public class PluginInstallingNotifier : PluginNotificationConsumer<PluginInstallingEventArgs, InstallationInfo>
     {
-        private readonly ISessionManager _sessionManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstallingNotifier"/> class.
         /// </summary>
         /// <param name="sessionManager">The session manager.</param>
         public PluginInstallingNotifier(ISessionManager sessionManager)
+            : base(sessionManager, SessionMessageType.PackageInstalling)
         {
-            _sessionManager = sessionManager;
         }
 
         /// <inheritdoc />
-        public async Task OnEvent(PluginInstallingEventArgs eventArgs)
-        {
-            await _sessionManager.SendMessageToAdminSessions(SessionMessageType.PackageInstalling, eventArgs.Argument, CancellationToken.None).ConfigureAwait(false);
-        }
+        protected override InstallationInfo GetMessageData(PluginInstallingEventArgs eventArgs) => eventArgs.Argument;
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginNotificationConsumer.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginNotificationConsumer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+
+namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
+{
+    public abstract class PluginNotificationConsumer<TEventArgs, TMessageData> : IEventConsumer<TEventArgs>
+        where TEventArgs : EventArgs
+    {
+        private readonly ISessionManager _sessionManager;
+        private readonly SessionMessageType _messageType;
+
+        protected PluginNotificationConsumer(ISessionManager sessionManager, SessionMessageType messageType)
+        {
+            _sessionManager = sessionManager;
+            _messageType = messageType;
+        }
+
+        public async Task OnEvent(TEventArgs eventArgs)
+        {
+            await _sessionManager.SendMessageToAdminSessions(_messageType, GetMessageData(eventArgs), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected abstract TMessageData GetMessageData(TEventArgs eventArgs);
+    }
+}

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUninstalledLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUninstalledLogger.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Globalization;
-using System.Threading.Tasks;
-using Jellyfin.Database.Implementations.Entities;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Globalization;
@@ -13,33 +8,21 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
     /// <summary>
     /// Creates an entry in the activity log when a plugin is uninstalled.
     /// </summary>
-    public class PluginUninstalledLogger : IEventConsumer<PluginUninstalledEventArgs>
+    public class PluginUninstalledLogger : PluginActivityLogConsumer<PluginUninstalledEventArgs>
     {
-        private readonly ILocalizationManager _localizationManager;
-        private readonly IActivityManager _activityManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginUninstalledLogger"/> class.
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="activityManager">The activity manager.</param>
         public PluginUninstalledLogger(ILocalizationManager localizationManager, IActivityManager activityManager)
+            : base(
+                localizationManager,
+                activityManager,
+                "PluginUninstalledWithName",
+                NotificationType.PluginUninstalled,
+                eventArgs => eventArgs.Argument.Name)
         {
-            _localizationManager = localizationManager;
-            _activityManager = activityManager;
-        }
-
-        /// <inheritdoc />
-        public async Task OnEvent(PluginUninstalledEventArgs eventArgs)
-        {
-            await _activityManager.CreateAsync(new ActivityLog(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        _localizationManager.GetLocalizedString("PluginUninstalledWithName"),
-                        eventArgs.Argument.Name),
-                    NotificationType.PluginUninstalled.ToString(),
-                    Guid.Empty))
-                .ConfigureAwait(false);
         }
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUninstalledNotifier.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUninstalledNotifier.cs
@@ -1,8 +1,6 @@
-using System.Threading;
-using System.Threading.Tasks;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Session;
 
 namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
@@ -10,23 +8,18 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
     /// <summary>
     /// Notifies admin users when a plugin is uninstalled.
     /// </summary>
-    public class PluginUninstalledNotifier : IEventConsumer<PluginUninstalledEventArgs>
+    public class PluginUninstalledNotifier : PluginNotificationConsumer<PluginUninstalledEventArgs, PluginInfo>
     {
-        private readonly ISessionManager _sessionManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginUninstalledNotifier"/> class.
         /// </summary>
         /// <param name="sessionManager">The session manager.</param>
         public PluginUninstalledNotifier(ISessionManager sessionManager)
+            : base(sessionManager, SessionMessageType.PackageUninstalled)
         {
-            _sessionManager = sessionManager;
         }
 
         /// <inheritdoc />
-        public async Task OnEvent(PluginUninstalledEventArgs eventArgs)
-        {
-            await _sessionManager.SendMessageToAdminSessions(SessionMessageType.PackageUninstalled, eventArgs.Argument, CancellationToken.None).ConfigureAwait(false);
-        }
+        protected override PluginInfo GetMessageData(PluginUninstalledEventArgs eventArgs) => eventArgs.Argument;
     }
 }

--- a/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUpdatedLogger.cs
+++ b/Jellyfin.Server.Implementations/Events/Consumers/Updates/PluginUpdatedLogger.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Globalization;
-using System.Threading.Tasks;
-using Jellyfin.Database.Implementations.Entities;
-using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Updates;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Globalization;
@@ -13,39 +8,23 @@ namespace Jellyfin.Server.Implementations.Events.Consumers.Updates
     /// <summary>
     /// Creates an entry in the activity log when a plugin is updated.
     /// </summary>
-    public class PluginUpdatedLogger : IEventConsumer<PluginUpdatedEventArgs>
+    public class PluginUpdatedLogger : PluginActivityLogConsumer<PluginUpdatedEventArgs>
     {
-        private readonly ILocalizationManager _localizationManager;
-        private readonly IActivityManager _activityManager;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginUpdatedLogger"/> class.
         /// </summary>
         /// <param name="localizationManager">The localization manager.</param>
         /// <param name="activityManager">The activity manager.</param>
         public PluginUpdatedLogger(ILocalizationManager localizationManager, IActivityManager activityManager)
+            : base(
+                localizationManager,
+                activityManager,
+                "PluginUpdatedWithName",
+                NotificationType.PluginUpdateInstalled,
+                eventArgs => eventArgs.Argument.Name,
+                eventArgs => eventArgs.Argument.Version,
+                eventArgs => eventArgs.Argument.Changelog)
         {
-            _localizationManager = localizationManager;
-            _activityManager = activityManager;
-        }
-
-        /// <inheritdoc />
-        public async Task OnEvent(PluginUpdatedEventArgs eventArgs)
-        {
-            await _activityManager.CreateAsync(new ActivityLog(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("PluginUpdatedWithName"),
-                    eventArgs.Argument.Name),
-                NotificationType.PluginUpdateInstalled.ToString(),
-                Guid.Empty)
-            {
-                ShortOverview = string.Format(
-                    CultureInfo.InvariantCulture,
-                    _localizationManager.GetLocalizedString("VersionNumber"),
-                    eventArgs.Argument.Version),
-                Overview = eventArgs.Argument.Changelog
-            }).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Proposed changes from Molten.Bot

This PR implements the requested changes described below.
Built using an AI augmented engineering and reviewed before submission.
Only relevant files were modified.

Original task prompt:
```text
Refactor this repository to reduce the codebase size and centralize duplicated classes, types, and shared logic.

Task:
- Use the most appropriate existing abstractions.
- Remove redundancy instead of layering new wrappers.
- Preserve behavior.
- Avoid regressions.
- Keep the diff focused on the reduction/centralization goal.

Validation:
- Validate the result with focused tests and any existing local verification the repository supports before finishing.
- If local test or validation tooling is unavailable in this runtime, for example `command not found`, do not fail solely for that. Continue with any alternative checks available and clearly report the validation gap.

Failure reporting:
- If failures occur, send a response back to the calling agent with these fields:
  `Failure:` <short failure summary>
  `Error details:` <failing command, log detail, or concrete blocker>.
```

Curious how this was built? See how AI agents can help with your own projects: [MoltenBot Code](https://molten.bot/code?source=pr)