### PR TITLE
Fix use of thread-unsafe List<T>.Sort()

### DIFF
--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -105,7 +105,7 @@ namespace MediaBrowser.Controller.Providers
         public IReadOnlyList<string> GetFilePaths(string path)
             => GetFilePaths(path, false);
 
-        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false)
+        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache)
         {
             if (clearCache)
             {
@@ -118,7 +118,7 @@ namespace MediaBrowser.Controller.Providers
                 {
                     try
                     {
-                        return fileSystem.GetFilePaths(p).ToList();
+                        return fileSystem.GetFilePaths(p).OrderBy(x => x).ToList();
                     }
                     catch (DirectoryNotFoundException)
                     {
@@ -126,11 +126,6 @@ namespace MediaBrowser.Controller.Providers
                     }
                 },
                 _fileSystem);
-
-            if (sort)
-            {
-                filePaths.Sort();
-            }
 
             return filePaths;
         }

--- a/MediaBrowser.Controller/Providers/IDirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/IDirectoryService.cs
@@ -21,7 +21,7 @@ namespace MediaBrowser.Controller.Providers
 
         IReadOnlyList<string> GetFilePaths(string path);
 
-        IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort = false);
+        IReadOnlyList<string> GetFilePaths(string path, bool clearCache);
 
         bool IsAccessible(string path);
     }

--- a/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
+++ b/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs
@@ -218,12 +218,12 @@ namespace MediaBrowser.Providers.MediaInfo
                 return Array.Empty<ExternalPathParserResult>();
             }
 
-            var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
+            var files = directoryService.GetFilePaths(folder, clearCache).ToList();
             files.Remove(video.Path);
             var internalMetadataPath = video.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))
             {
-                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache, true));
+                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
             }
 
             if (files.Count == 0)
@@ -270,12 +270,12 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             string folder = audio.ContainingFolderPath;
-            var files = directoryService.GetFilePaths(folder, clearCache, true).ToList();
+            var files = directoryService.GetFilePaths(folder, clearCache).ToList();
             files.Remove(audio.Path);
             var internalMetadataPath = audio.GetInternalMetadataPath();
             if (_fileSystem.DirectoryExists(internalMetadataPath))
             {
-                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache, true));
+                files.AddRange(directoryService.GetFilePaths(internalMetadataPath, clearCache));
             }
 
             if (files.Count == 0)

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/MediaInfoResolverTests.cs
@@ -123,13 +123,13 @@ public class MediaInfoResolverTests
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
         // any path other than test target exists and provides an empty listing
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         _subtitleResolver.GetExternalFiles(video.Object, directoryService.Object, false);
 
         directoryService.Verify(
-            ds => ds.GetFilePaths(It.IsRegex(pathNotFoundRegex), It.IsAny<bool>(), It.IsAny<bool>()),
+            ds => ds.GetFilePaths(It.IsRegex(pathNotFoundRegex), It.IsAny<bool>()),
             Times.Never);
     }
 
@@ -196,7 +196,7 @@ public class MediaInfoResolverTests
         };
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsAny<string>(), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         var mediaEncoder = Mock.Of<IMediaEncoder>(MockBehavior.Strict);
@@ -341,9 +341,9 @@ public class MediaInfoResolverTests
         }
 
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>()))
             .Returns(files);
-        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+        directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>()))
             .Returns(Array.Empty<string>());
 
         List<MediaStream> GenerateMediaStreams()
@@ -413,16 +413,16 @@ public class MediaInfoResolverTests
         var directoryService = new Mock<IDirectoryService>(MockBehavior.Strict);
         if (useMetadataDirectory)
         {
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>()))
                 .Returns(Array.Empty<string>());
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>()))
                 .Returns(new[] { MetadataDirectoryPath + "/" + file });
         }
         else
         {
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(VideoDirectoryRegex), It.IsAny<bool>()))
                 .Returns(new[] { VideoDirectoryPath + "/" + file });
-            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>(), It.IsAny<bool>()))
+            directoryService.Setup(ds => ds.GetFilePaths(It.IsRegex(MetadataDirectoryRegex), It.IsAny<bool>()))
                 .Returns(Array.Empty<string>());
         }
 


### PR DESCRIPTION
**Changes**
`List<T>.Sort()` changes the underlying list and is not threadsafe. Using it in `DirectoryService.GetFilePaths()` was corrupting the list because it gets called simultaneously in multiple threads when doing a library rescan. This caused file names to be lost.

I found this as a result of trying to figure out why Jellyfin was downloading duplicate subtitle files. Turns out, it would do so because the existing subtitle files randomly disappeared from the file cache (`_filePathCache`). When debugging and inspecting the cached file list used when looking for subtitle files (in `MediaInfoResolver.GetExternalFiles()`), I saw some files listed twice and some not at all. When I commented out the sort in `DirectoryService.GetFilePaths()`, it did not download any duplicate subtitles.

I changed it to use `.OrderBy()` once and save the sorted list, and I removed the `sort` parameter. I did that because, previously, calling `Sort()` once would change the underlying list, so any subsequent calls with `sort = false` were still getting a sorted list anyway.

**Issues**
Fixes #12434 - this was closed a few weeks ago, and I'm sure that fixed something, but I was still seeing the issue in 10.11.8
