### PR TITLE
Fix subtitle save path

### DIFF
--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -228,10 +228,11 @@ namespace MediaBrowser.Providers.Subtitles
                     var mediaFolderPath = Path.GetFullPath(Path.Combine(video.ContainingFolderPath, saveFileName));
                     savePaths.Add(mediaFolderPath);
                 }
-
-                var internalPath = Path.GetFullPath(Path.Combine(video.GetInternalMetadataPath(), saveFileName));
-
-                savePaths.Add(internalPath);
+                else
+                {
+                    var internalPath = Path.GetFullPath(Path.Combine(video.GetInternalMetadataPath(), saveFileName));
+                    savePaths.Add(internalPath);
+                }
 
                 await TrySaveToFiles(memoryStream, savePaths, video, response.Format.ToLowerInvariant()).ConfigureAwait(false);
             }


### PR DESCRIPTION
**Changes**
Only save in internal path if `saveInMediaFolder` is not set

**Issues**
Fixes #16508
