### PR TITLE
Fix unique people response for query if no item ID is supplied

### DIFF
--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -44,7 +44,15 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         }
         else
         {
-            dbQuery = dbQuery.OrderBy(e => e.Name);
+            // The Peoples table has one row per (Name, PersonType), so the same person can
+            // appear multiple times (e.g. as Actor and GuestStar). Collapse to one row per
+            // name so /Persons doesn't return the same BaseItem id repeatedly.
+            var representativeIds = dbQuery
+                .GroupBy(e => e.Name)
+                .Select(g => g.Min(e => e.Id));
+            dbQuery = context.Peoples.AsNoTracking()
+                .Where(p => representativeIds.Contains(p.Id))
+                .OrderBy(e => e.Name);
         }
 
         var count = dbQuery.Count();


### PR DESCRIPTION
If we query for people without supplying an item ID, we will get duplicates. Since this is mainly used on search, the resulting entite's role is usually irrelevant, so we can simply select only one of the multiple entries.

**Changes**
Make sure people are unique by name and then filter the resulting entites by their IDs.

**Issues**
Fixes #16781