### PR TITLE
Fix MusicBrainz test.

### DIFF
--- a/tests/Jellyfin.Providers.Tests/ExternalId/MusicBrainzExternalUrlProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/ExternalId/MusicBrainzExternalUrlProviderTests.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Serialization;
 using MediaBrowser.Providers.Plugins.MusicBrainz;
 using MediaBrowser.Providers.Plugins.MusicBrainz.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -41,7 +42,7 @@ namespace Jellyfin.Providers.Tests.ExternalId
             appHostMock.Setup(h => h.ApplicationVersionString).Returns("1.0.0");
             appHostMock.Setup(h => h.ApplicationUserAgentAddress).Returns("localhost");
 
-            _ = new Plugin(appPathsMock.Object, xmlSerializerMock.Object, appHostMock.Object);
+            _ = new Plugin(appPathsMock.Object, xmlSerializerMock.Object, appHostMock.Object, NullLogger<Plugin>.Instance);
         }
 
         public void Dispose()


### PR DESCRIPTION
`Plugin` now requires an ILogger<Plugin> see PR #16780

**Changes**

Add `NullLogger<Plugin>.Instance` to the test.

**Issues**
Corrects build issues noticed in PR #16433 caused by merge of PR #16780