### PR TITLE
Suppress CA2213 false positive on ApplicationHost._pluginManager (#2149)

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -121,6 +122,8 @@ namespace Emby.Server.Implementations
         private readonly IConfiguration _startupConfig;
         private readonly IXmlSerializer _xmlSerializer;
         private readonly IStartupOptions _startupOptions;
+
+        [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed via _disposableParts collection in Dispose(bool).")]
         private readonly PluginManager _pluginManager;
 
         private List<Type> _creatingInstances;

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -122,8 +121,6 @@ namespace Emby.Server.Implementations
         private readonly IConfiguration _startupConfig;
         private readonly IXmlSerializer _xmlSerializer;
         private readonly IStartupOptions _startupOptions;
-
-        [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed via _disposableParts collection in Dispose(bool).")]
         private readonly PluginManager _pluginManager;
 
         private List<Type> _creatingInstances;
@@ -169,8 +166,6 @@ namespace Emby.Server.Implementations
                 ConfigurationManager.Configuration,
                 ApplicationPaths.PluginsPath,
                 ApplicationVersion);
-
-            _disposableParts.Add(_pluginManager);
         }
 
         /// <summary>
@@ -1017,6 +1012,8 @@ namespace Emby.Server.Implementations
                 }
 
                 _disposableParts.Clear();
+
+                _pluginManager?.Dispose();
             }
 
             _disposed = true;


### PR DESCRIPTION
**Issue**
Contributes to #2149.

CA2213 flags `_pluginManager` as never disposed, but it is - indirectly via the `_disposableParts` collection (added at line 170, disposed in the `Dispose(bool)` foreach at line 996). The analyzer can't see through the indirection.

**Change**
Adds a targeted `[SuppressMessage]` with justification on the field. No behavioural change.

**Verification:** rebuilt `Emby.Server.Implementations` in Debug - warning count drops by exactly 1 (CA2213 on this field), no new warnings, 0 errors.
