### PR TITLE
Print warning on invalid Subnets in Network/Proxy configuration

### DIFF
--- a/MediaBrowser.Common/Net/NetworkUtils.cs
+++ b/MediaBrowser.Common/Net/NetworkUtils.cs
@@ -184,7 +184,7 @@ public static partial class NetworkUtils
             {
                 (tmpResult ??= new()).Add(innerResult);
             }
-            else if (logger is not null)
+            else
             {
                 LogInvalidSubnet(logger, values[a]);
             }
@@ -194,8 +194,13 @@ public static partial class NetworkUtils
         return result is not null;
     }
 
-    private static void LogInvalidSubnet(ILogger logger, string value)
+    private static void LogInvalidSubnet(ILogger? logger, string value)
     {
+        if (logger is null)
+        {
+            return;
+        }
+
         var trimmed = value.AsSpan().Trim();
         if (trimmed.StartsWith('!'))
         {

--- a/MediaBrowser.Common/Net/NetworkUtils.cs
+++ b/MediaBrowser.Common/Net/NetworkUtils.cs
@@ -217,10 +217,23 @@ public static partial class NetworkUtils
         var index = value.IndexOf('/');
         if (index != -1)
         {
-            if (IPAddress.TryParse(value[..index], out var address) && IPNetwork.TryParse(value, out var subnet))
+            var addressPart = value[..index];
+            if (IPAddress.TryParse(addressPart, out var address) && IPNetwork.TryParse(value, out var subnet))
             {
                 result = new IPData(address, subnet);
                 return true;
+            }
+
+            // Accept IPv6 prefix-only notation that omits the `::`, e.g. "2001:db8:1234:5600/56".
+            if (addressPart.Contains(':') && addressPart.IndexOf("::", StringComparison.Ordinal) == -1)
+            {
+                var expandedAddress = string.Concat(addressPart, "::");
+                if (IPAddress.TryParse(expandedAddress, out var address2)
+                    && IPNetwork.TryParse(string.Concat(expandedAddress, value[index..]), out var subnet2))
+                {
+                    result = new IPData(address2, subnet2);
+                    return true;
+                }
             }
         }
         else if (IPAddress.TryParse(value, out var address))

--- a/MediaBrowser.Common/Net/NetworkUtils.cs
+++ b/MediaBrowser.Common/Net/NetworkUtils.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using Jellyfin.Extensions;
 using MediaBrowser.Model.Net;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Common.Net;
 
@@ -166,8 +167,9 @@ public static partial class NetworkUtils
     /// <param name="values">Input string array to be parsed.</param>
     /// <param name="result">Collection of <see cref="IPNetwork"/>.</param>
     /// <param name="negated">Boolean signaling if negated or not negated values should be parsed.</param>
+    /// <param name="logger">Optional logger used to warn about entries that fail to parse.</param>
     /// <returns><c>True</c> if parsing was successful.</returns>
-    public static bool TryParseToSubnets(string[] values, [NotNullWhen(true)] out IReadOnlyList<IPData>? result, bool negated = false)
+    public static bool TryParseToSubnets(string[] values, [NotNullWhen(true)] out IReadOnlyList<IPData>? result, bool negated = false, ILogger? logger = null)
     {
         if (values is null || values.Length == 0)
         {
@@ -182,10 +184,38 @@ public static partial class NetworkUtils
             {
                 (tmpResult ??= new()).Add(innerResult);
             }
+            else if (logger is not null)
+            {
+                LogInvalidSubnet(logger, values[a]);
+            }
         }
 
         result = tmpResult;
         return result is not null;
+    }
+
+    private static void LogInvalidSubnet(ILogger logger, string value)
+    {
+        var trimmed = value.AsSpan().Trim();
+        if (trimmed.StartsWith('!'))
+        {
+            trimmed = trimmed[1..];
+        }
+
+        var slash = trimmed.IndexOf('/');
+        if (slash != -1
+            && trimmed.Contains(':')
+            && trimmed.IndexOf("::", StringComparison.Ordinal) == -1)
+        {
+            logger.LogWarning(
+                "Invalid IPv6 subnet '{Subnet}': IPv6 prefix-only notation is not supported. Use the full notation including '::' (e.g. '{Example}::/{Prefix}').",
+                value,
+                trimmed[..slash].ToString(),
+                trimmed[(slash + 1)..].ToString());
+            return;
+        }
+
+        logger.LogWarning("Invalid subnet '{Subnet}' will be ignored.", value);
     }
 
     /// <summary>
@@ -217,23 +247,10 @@ public static partial class NetworkUtils
         var index = value.IndexOf('/');
         if (index != -1)
         {
-            var addressPart = value[..index];
-            if (IPAddress.TryParse(addressPart, out var address) && IPNetwork.TryParse(value, out var subnet))
+            if (IPAddress.TryParse(value[..index], out var address) && IPNetwork.TryParse(value, out var subnet))
             {
                 result = new IPData(address, subnet);
                 return true;
-            }
-
-            // Accept IPv6 prefix-only notation that omits the `::`, e.g. "2001:db8:1234:5600/56".
-            if (addressPart.Contains(':') && addressPart.IndexOf("::", StringComparison.Ordinal) == -1)
-            {
-                var expandedAddress = string.Concat(addressPart, "::");
-                if (IPAddress.TryParse(expandedAddress, out var address2)
-                    && IPNetwork.TryParse(string.Concat(expandedAddress, value[index..]), out var subnet2))
-                {
-                    result = new IPData(address2, subnet2);
-                    return true;
-                }
             }
         }
         else if (IPAddress.TryParse(value, out var address))

--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -316,7 +316,7 @@ public class NetworkManager : INetworkManager, IDisposable
             var subnets = config.LocalNetworkSubnets;
 
             // If no LAN addresses are specified, all private subnets and Loopback are deemed to be the LAN
-            if (!NetworkUtils.TryParseToSubnets(subnets, out var lanSubnets, false) || lanSubnets.Count == 0)
+            if (!NetworkUtils.TryParseToSubnets(subnets, out var lanSubnets, false, _logger) || lanSubnets.Count == 0)
             {
                 _logger.LogDebug("Using LAN interface addresses as user provided no LAN details.");
 
@@ -343,7 +343,7 @@ public class NetworkManager : INetworkManager, IDisposable
                 _lanSubnets = lanSubnets.Select(x => x.Subnet).ToArray();
             }
 
-            _excludedSubnets = NetworkUtils.TryParseToSubnets(subnets, out var excludedSubnets, true)
+            _excludedSubnets = NetworkUtils.TryParseToSubnets(subnets, out var excludedSubnets, true, _logger)
                 ? excludedSubnets.Select(x => x.Subnet).ToArray()
                 : Array.Empty<IPNetwork>();
         }

--- a/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
@@ -20,6 +20,8 @@ namespace Jellyfin.Networking.Tests
         [InlineData("192.168.2.1/24, !192.168.2.122/32", "192.168.2.123")]
         [InlineData("fd23:184f:2029:0::/56", "fd23:184f:2029:0:3139:7386:67d7:d517")]
         [InlineData("fd23:184f:2029:0::/56, !fd23:184f:2029:0:3139:7386:67d7:d518/128", "fd23:184f:2029:0:3139:7386:67d7:d517")]
+        [InlineData("fd23:184f:2029:0100/56", "fd23:184f:2029:0101:d51:2102:e6f0:722c")]
+        [InlineData("10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fd23:184f:2029:0100/56", "fd23:184f:2029:0101:d51:2102:e6f0:722c")]
         public void InNetwork_True_Success(string network, string value)
         {
             var ip = IPAddress.Parse(value);

--- a/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
@@ -20,8 +20,6 @@ namespace Jellyfin.Networking.Tests
         [InlineData("192.168.2.1/24, !192.168.2.122/32", "192.168.2.123")]
         [InlineData("fd23:184f:2029:0::/56", "fd23:184f:2029:0:3139:7386:67d7:d517")]
         [InlineData("fd23:184f:2029:0::/56, !fd23:184f:2029:0:3139:7386:67d7:d518/128", "fd23:184f:2029:0:3139:7386:67d7:d517")]
-        [InlineData("fd23:184f:2029:0100/56", "fd23:184f:2029:0101:d51:2102:e6f0:722c")]
-        [InlineData("10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fd23:184f:2029:0100/56", "fd23:184f:2029:0101:d51:2102:e6f0:722c")]
         public void InNetwork_True_Success(string network, string value)
         {
             var ip = IPAddress.Parse(value);

--- a/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Model.Net;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -78,7 +79,6 @@ namespace Jellyfin.Networking.Tests
         [InlineData("fe80::7add:12ff:febb:c67b%16:123")]
         [InlineData("[fe80::7add:12ff:febb:c67b%16]")]
         [InlineData("fd23:184f:2029:0:3139:7386:67d7:d517/56")]
-        [InlineData("fd23:184f:2029:0100/56")]
         public static void TryParseValidIPStringsTrue(string address)
         {
             Assert.True(NetworkUtils.TryParseToSubnet(address, out _));
@@ -95,8 +95,45 @@ namespace Jellyfin.Networking.Tests
         [InlineData("256.128.0.0.0.1")]
         [InlineData("fd23:184f:2029:0:3139:7386:67d7:d517:1231")]
         [InlineData("[fd23:184f:2029:0:3139:7386:67d7:d517:1231]")]
+        [InlineData("fd23:184f:2029:0100/56")]
         public static void TryParseInvalidIPStringsFalse(string address)
             => Assert.False(NetworkUtils.TryParseToSubnet(address, out _));
+
+        /// <summary>
+        /// Verifies that <see cref="NetworkUtils.TryParseToSubnets"/> emits a targeted warning
+        /// for IPv6 prefix-only notation and a generic warning for other malformed entries.
+        /// </summary>
+        [Fact]
+        public static void TryParseToSubnets_InvalidEntries_LogsWarnings()
+        {
+            var logger = new Mock<ILogger>();
+
+            var values = new[] { "10.0.0.0/8", "fd23:184f:2029:0100/56", "not-an-address" };
+            Assert.True(NetworkUtils.TryParseToSubnets(values, out var result, false, logger.Object));
+            Assert.NotNull(result);
+            Assert.Single(result);
+
+            // IPv6 prefix-only notation should produce a specific, actionable warning.
+            logger.Verify(
+                l => l.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("IPv6 prefix-only", StringComparison.Ordinal)
+                        && state.ToString()!.Contains("fd23:184f:2029:0100/56", StringComparison.Ordinal)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+
+            // Other malformed entries should still produce a generic warning.
+            logger.Verify(
+                l => l.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("not-an-address", StringComparison.Ordinal)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
 
         /// <summary>
         /// Checks if IPv4 address is within a defined subnet.

--- a/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkParseTests.cs
@@ -78,6 +78,7 @@ namespace Jellyfin.Networking.Tests
         [InlineData("fe80::7add:12ff:febb:c67b%16:123")]
         [InlineData("[fe80::7add:12ff:febb:c67b%16]")]
         [InlineData("fd23:184f:2029:0:3139:7386:67d7:d517/56")]
+        [InlineData("fd23:184f:2029:0100/56")]
         public static void TryParseValidIPStringsTrue(string address)
         {
             Assert.True(NetworkUtils.TryParseToSubnet(address, out _));


### PR DESCRIPTION
.NET's `IPAddress.TryParse` and `IPNetwork.TryParse` reject prefix-only IPv6 subnet notation because RFC 4291 requires either 8 groups or `::`.

**Changes**
Add logging, but since this is not RFC conformant, we do not support it

**Issues**
Fixes #16791