### PR TITLE
Set default AudioLanguagePreference to OriginalLanguage

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/User.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Entities/User.cs
@@ -50,7 +50,8 @@ namespace Jellyfin.Database.Implementations.Entities
             RememberSubtitleSelections = true;
             EnableNextEpisodeAutoPlay = true;
             EnableAutoLogin = false;
-            PlayDefaultAudioTrack = true;
+            PlayDefaultAudioTrack = false;
+            AudioLanguagePreference = "OriginalLanguage";
             SubtitleMode = SubtitlePlaybackMode.Default;
             SyncPlayAccess = SyncPlayUserAccessType.CreateAndJoinGroups;
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Now when https://github.com/jellyfin/jellyfin/pull/12579 is merged I personally think that the default settings for a user should change to play Original Language by default and disable `PlayDefaultAudioTrack`. 

I understand why the `PlayDefaultAudioTrack = true` default would have made sense before, even though I don't personally agree with it. However now when you can select Original Language, or any other language for that matter, it will prioritize the default track anyways, so Jellyfin will always pick the best track now and if there is no good choice the `Default` track will be picked anyways, so I believe the `PlayDefaultAudioTrack = true` is not the optimal default anymore. See [this test](https://github.com/jellyfin/jellyfin/blob/e1e18e8da015e7311e62cdb62167d51e90331edd/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs#L57-L148) how the language selection work, I believe it covers all use cases.

**Issues**
N/A
