### PR TITLE
Fix Segment Provider Configuration

### DIFF
--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -54,7 +54,7 @@ public class MediaSegmentManager : IMediaSegmentManager
     public async Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken)
     {
         var providers = _segmentProviders
-            .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
+            .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
             .OrderBy(i =>
                 {
                     var index = libraryOptions.MediaSegmentProviderOrder.IndexOf(i.Name);
@@ -224,7 +224,7 @@ public class MediaSegmentManager : IMediaSegmentManager
             if (filterByProvider)
             {
                 var providerIds = _segmentProviders
-                    .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
+                    .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
                     .Select(f => GetProviderId(f.Name))
                     .ToArray();
                 if (providerIds.Length == 0)


### PR DESCRIPTION
The Media Segment Scan task ignored the per-library "disabled" toggle for media segment plugins because of a name vs. ID mismatch.

**Changes**
* Filter providers by Name (case-insensitive), not by hashed provider ID

**Issues**
Fixes #16794
