### PR TITLE
ci: add OpenSSF Scorecards workflow for supply-chain security

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,42 @@
+name: Scorecards supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ master ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Description
Adds the [OpenSSF Scorecards](https://github.com/ossf/scorecard) workflow to Jellyfin. This automatically runs security health checks on every push and weekly, analyzing:
- Dependency pinning
- Branch protection
- Code review practices
- Token permissions
- Vulnerability detection
- SAST tooling

Results are uploaded to GitHub Code Scanning and optionally published to the OpenSSF REST API for a public badge.

## Impact
- Zero runtime impact — runs in parallel to other CI
- Single workflow file, no config needed
- Results visible in GitHub Security → Code Scanning tab
- Enables the [OpenSSF Scorecard badge](https://api.securityscorecards.dev/projects/github.com/jellyfin/jellyfin) for the README

## Checklist
- [x] Uses SHA-pinned actions matching existing style in repo
- [x] Minimal permissions (read-all default, security-events:write only for SARIF upload)
- [x] Weekly schedule + push + branch protection triggers
- [x] Publishes results for public badge visibility