### PR TITLE
Fix disabling media segment plugin does not work

### DIFF
--- a/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
+++ b/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs
@@ -54,7 +54,7 @@ public class MediaSegmentManager : IMediaSegmentManager
     public async Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken)
     {
         var providers = _segmentProviders
-            .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
+            .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
             .OrderBy(i =>
                 {
                     var index = libraryOptions.MediaSegmentProviderOrder.IndexOf(i.Name);
@@ -212,7 +212,7 @@ public class MediaSegmentManager : IMediaSegmentManager
             if (filterByProvider)
             {
                 var providerIds = _segmentProviders
-                    .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(GetProviderId(e.Name)))
+                    .Where(e => !libraryOptions.DisabledMediaSegmentProviders.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
                     .Select(f => GetProviderId(f.Name))
                     .ToArray();
                 if (providerIds.Length == 0)


### PR DESCRIPTION
This PR fixes an issue where configured **disabled media segment providers** were not correctly excluded during segment processing. The logic for filtering out disabled providers previously relied on matching provider identifiers using a custom `GetProviderId(...)`, which could fail and result in disabled providers still running.

The filtering logic has been simplified and corrected to directly compare provider names in a **case-insensitive** manner (`StringComparer.OrdinalIgnoreCase`), ensuring that disabled providers are properly excluded.

Same as `DisabledLyricFetchers`:
https://github.com/jellyfin/jellyfin/blob/82b51a60a5b0bb45d8d32b00ccc661201147337a/MediaBrowser.Providers/Lyric/LyricManager.cs#L96

**Changes**

In `MediaSegmentManager`:

* Updated provider filtering to use the provider’s **Name** with a case-insensitive comparison against the disabled list.
* Replaced calls to `GetProviderId(e.Name)` with direct name comparison to `libraryOptions.DisabledMediaSegmentProviders`.
* This change was applied in both:

  * the **segment execution pipeline**
  * the **segment listing/filtering logic**

**Result:** Disabled media segment providers will no longer be run or included in results.


**Issues**
Fixes #16794
