### PR TITLE
Add Prometheus metrics for users, sessions, and library

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -154,6 +154,7 @@
  - [Terror-Gene](https://github.com/Terror-Gene)
  - [ThatNerdyPikachu](https://github.com/ThatNerdyPikachu)
  - [ThibaultNocchi](https://github.com/ThibaultNocchi)
+ - [Thomas05000005](https://github.com/Thomas05000005)
  - [thornbill](https://github.com/thornbill)
  - [ThreeFive-O](https://github.com/ThreeFive-O)
  - [tjwalkr3](https://github.com/tjwalkr3)

--- a/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
+++ b/Jellyfin.Server.Implementations/Jellyfin.Server.Implementations.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="prometheus-net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Server.Implementations/Metrics/IMetricsCollector.cs
+++ b/Jellyfin.Server.Implementations/Metrics/IMetricsCollector.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Defines a Prometheus metrics collector that refreshes its gauges or counters when invoked.
+/// </summary>
+public interface IMetricsCollector
+{
+    /// <summary>
+    /// Gets the human-readable name of the collector, used in log output.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Refreshes all metrics owned by the collector.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task CollectAsync(CancellationToken cancellationToken);
+}

--- a/Jellyfin.Server.Implementations/Metrics/LibraryMetrics.cs
+++ b/Jellyfin.Server.Implementations/Metrics/LibraryMetrics.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Prometheus;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Exposes Prometheus metrics describing the contents of the media library.
+/// </summary>
+public sealed class LibraryMetrics : IMetricsCollector
+{
+    private static readonly BaseItemKind[] _trackedKinds =
+    [
+        BaseItemKind.Movie,
+        BaseItemKind.Series,
+        BaseItemKind.Season,
+        BaseItemKind.Episode,
+        BaseItemKind.MusicArtist,
+        BaseItemKind.MusicAlbum,
+        BaseItemKind.Audio,
+        BaseItemKind.AudioBook,
+        BaseItemKind.Book,
+        BaseItemKind.Photo,
+        BaseItemKind.Video,
+    ];
+
+    private static readonly Gauge _items = Prometheus.Metrics
+        .CreateGauge("jellyfin_library_items", "Number of items in the media library grouped by item type.", "type");
+
+    private readonly ILibraryManager _libraryManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryMetrics"/> class.
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    public LibraryMetrics(ILibraryManager libraryManager)
+    {
+        _libraryManager = libraryManager;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(LibraryMetrics);
+
+    /// <inheritdoc />
+    public Task CollectAsync(CancellationToken cancellationToken)
+    {
+        foreach (var kind in _trackedKinds)
+        {
+            var count = _libraryManager.GetCount(new InternalItemsQuery
+            {
+                IncludeItemTypes = [kind],
+            });
+            _items.WithLabels(kind.ToString()).Set(count);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Server.Implementations/Metrics/MetricsHostedService.cs
+++ b/Jellyfin.Server.Implementations/Metrics/MetricsHostedService.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Periodically refreshes every registered <see cref="IMetricsCollector"/> when Prometheus metrics are enabled.
+/// </summary>
+public sealed class MetricsHostedService : BackgroundService
+{
+    private static readonly TimeSpan _interval = TimeSpan.FromSeconds(15);
+
+    private readonly IServerConfigurationManager _configurationManager;
+    private readonly IEnumerable<IMetricsCollector> _collectors;
+    private readonly ILogger<MetricsHostedService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetricsHostedService"/> class.
+    /// </summary>
+    /// <param name="configurationManager">The server configuration manager.</param>
+    /// <param name="collectors">All registered metrics collectors.</param>
+    /// <param name="logger">The logger.</param>
+    public MetricsHostedService(
+        IServerConfigurationManager configurationManager,
+        IEnumerable<IMetricsCollector> collectors,
+        ILogger<MetricsHostedService> logger)
+    {
+        _configurationManager = configurationManager;
+        _collectors = collectors;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(_interval);
+
+        do
+        {
+            if (_configurationManager.Configuration.EnableMetrics)
+            {
+                foreach (var collector in _collectors)
+                {
+                    try
+                    {
+                        await collector.CollectAsync(stoppingToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+#pragma warning disable CA1031 // Collectors must never bring down the host: log and keep going.
+                    catch (Exception ex)
+#pragma warning restore CA1031
+                    {
+                        _logger.LogWarning(ex, "Failed to refresh metrics from {Collector}", collector.Name);
+                    }
+                }
+            }
+        }
+        while (await SafeWaitAsync(timer, stoppingToken).ConfigureAwait(false));
+    }
+
+    private static async Task<bool> SafeWaitAsync(PeriodicTimer timer, CancellationToken stoppingToken)
+    {
+        try
+        {
+            return await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+}

--- a/Jellyfin.Server.Implementations/Metrics/SessionMetrics.cs
+++ b/Jellyfin.Server.Implementations/Metrics/SessionMetrics.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Prometheus;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Exposes Prometheus metrics describing the live sessions and streams handled by the server.
+/// </summary>
+public sealed class SessionMetrics : IMetricsCollector
+{
+    private static readonly Gauge _sessions = Prometheus.Metrics
+        .CreateGauge("jellyfin_sessions", "Number of Jellyfin sessions grouped by playback state.", "state");
+
+    private static readonly Gauge _sessionsByClient = Prometheus.Metrics
+        .CreateGauge("jellyfin_sessions_clients", "Number of Jellyfin sessions grouped by reported client name.", "client");
+
+    private static readonly Gauge _streams = Prometheus.Metrics
+        .CreateGauge("jellyfin_streams", "Number of currently active streams grouped by play method.", "play_method");
+
+    private readonly ISessionManager _sessionManager;
+
+    private readonly HashSet<string> _seenClients = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionMetrics"/> class.
+    /// </summary>
+    /// <param name="sessionManager">The session manager.</param>
+    public SessionMetrics(ISessionManager sessionManager)
+    {
+        _sessionManager = sessionManager;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(SessionMetrics);
+
+    /// <inheritdoc />
+    public Task CollectAsync(CancellationToken cancellationToken)
+    {
+        var sessions = _sessionManager.Sessions.ToList();
+
+        var playing = sessions.Count(s => s.NowPlayingItem is not null);
+        _sessions.WithLabels("playing").Set(playing);
+        _sessions.WithLabels("idle").Set(sessions.Count - playing);
+
+        var clientCounts = sessions
+            .GroupBy(s => string.IsNullOrEmpty(s.Client) ? "Unknown" : s.Client)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+        // Zero out clients seen previously but absent now so gauges do not stick at stale values.
+        foreach (var oldClient in _seenClients)
+        {
+            if (!clientCounts.ContainsKey(oldClient))
+            {
+                _sessionsByClient.WithLabels(oldClient).Set(0);
+            }
+        }
+
+        foreach (var (client, count) in clientCounts)
+        {
+            _sessionsByClient.WithLabels(client).Set(count);
+            _seenClients.Add(client);
+        }
+
+        var transcodes = sessions.Count(s => s.TranscodingInfo is not null);
+        var directPlays = sessions.Count(s => s.PlayState?.PlayMethod == PlayMethod.DirectPlay);
+        var directStreams = sessions.Count(s => s.PlayState?.PlayMethod == PlayMethod.DirectStream);
+
+        _streams.WithLabels(nameof(PlayMethod.DirectPlay)).Set(directPlays);
+        _streams.WithLabels(nameof(PlayMethod.DirectStream)).Set(directStreams);
+        _streams.WithLabels(nameof(PlayMethod.Transcode)).Set(transcodes);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Server.Implementations/Metrics/TranscodingMetrics.cs
+++ b/Jellyfin.Server.Implementations/Metrics/TranscodingMetrics.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Session;
+using Prometheus;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Exposes Prometheus metrics describing the active transcoding sessions.
+/// </summary>
+public sealed class TranscodingMetrics : IMetricsCollector
+{
+    private static readonly Gauge _transcodes = Prometheus.Metrics
+        .CreateGauge("jellyfin_transcoding_sessions", "Number of active transcoding sessions grouped by hardware acceleration usage.", "hardware");
+
+    private static readonly Gauge _transcodingBitrate = Prometheus.Metrics
+        .CreateGauge("jellyfin_transcoding_bitrate_bps", "Aggregated bitrate of all active transcoding sessions, in bits per second.");
+
+    private readonly ISessionManager _sessionManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TranscodingMetrics"/> class.
+    /// </summary>
+    /// <param name="sessionManager">The session manager.</param>
+    public TranscodingMetrics(ISessionManager sessionManager)
+    {
+        _sessionManager = sessionManager;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(TranscodingMetrics);
+
+    /// <inheritdoc />
+    public Task CollectAsync(CancellationToken cancellationToken)
+    {
+        var transcodes = _sessionManager.Sessions
+            .Where(s => s.TranscodingInfo is not null)
+            .Select(s => s.TranscodingInfo)
+            .ToList();
+
+        var hardwareAccelerated = transcodes.Count(t => t.HardwareAccelerationType is not null);
+        _transcodes.WithLabels("true").Set(hardwareAccelerated);
+        _transcodes.WithLabels("false").Set(transcodes.Count - hardwareAccelerated);
+
+        var totalBitrate = transcodes.Sum(t => t.Bitrate ?? 0);
+        _transcodingBitrate.Set(totalBitrate);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Server.Implementations/Metrics/UserMetrics.cs
+++ b/Jellyfin.Server.Implementations/Metrics/UserMetrics.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Library;
+using Prometheus;
+
+namespace Jellyfin.Server.Implementations.Metrics;
+
+/// <summary>
+/// Exposes Prometheus metrics describing the configured Jellyfin user accounts.
+/// </summary>
+public sealed class UserMetrics : IMetricsCollector
+{
+    private static readonly Gauge _users = Prometheus.Metrics
+        .CreateGauge("jellyfin_users", "Number of Jellyfin user accounts grouped by state.", "state");
+
+    private static readonly Gauge _usersByAuthProvider = Prometheus.Metrics
+        .CreateGauge("jellyfin_users_authentication_provider", "Number of users grouped by authentication provider id.", "provider");
+
+    private static readonly Gauge _recentlyActiveUsers = Prometheus.Metrics
+        .CreateGauge("jellyfin_users_active_recent", "Number of users that have been active within the last 30 days.");
+
+    private static readonly Gauge _usersWithFailedLogins = Prometheus.Metrics
+        .CreateGauge("jellyfin_users_failed_logins", "Number of users that currently have one or more failed login attempts on record.");
+
+    private readonly IUserManager _userManager;
+
+    private readonly HashSet<string> _seenAuthProviders = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserMetrics"/> class.
+    /// </summary>
+    /// <param name="userManager">The user manager.</param>
+    public UserMetrics(IUserManager userManager)
+    {
+        _userManager = userManager;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(UserMetrics);
+
+    /// <inheritdoc />
+    public Task CollectAsync(CancellationToken cancellationToken)
+    {
+        var users = _userManager.GetUsers().ToList();
+
+        var disabled = users.Count(u => u.HasPermission(PermissionKind.IsDisabled));
+        var admins = users.Count(u => u.HasPermission(PermissionKind.IsAdministrator));
+        _users.WithLabels("enabled").Set(users.Count - disabled);
+        _users.WithLabels("disabled").Set(disabled);
+        _users.WithLabels("admin").Set(admins);
+
+        var providerCounts = users
+            .GroupBy(u => string.IsNullOrEmpty(u.AuthenticationProviderId) ? "Unknown" : u.AuthenticationProviderId)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+        // Reset providers seen in earlier ticks but absent from this snapshot, so the gauge reflects reality.
+        foreach (var oldProvider in _seenAuthProviders)
+        {
+            if (!providerCounts.ContainsKey(oldProvider))
+            {
+                _usersByAuthProvider.WithLabels(oldProvider).Set(0);
+            }
+        }
+
+        foreach (var (provider, count) in providerCounts)
+        {
+            _usersByAuthProvider.WithLabels(provider).Set(count);
+            _seenAuthProviders.Add(provider);
+        }
+
+        var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+        _recentlyActiveUsers.Set(users.Count(u => u.LastActivityDate >= thirtyDaysAgo));
+
+        _usersWithFailedLogins.Set(users.Count(u => u.InvalidLoginAttemptCount > 0));
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -12,6 +12,7 @@ using Jellyfin.Server.Implementations.Activity;
 using Jellyfin.Server.Implementations.Devices;
 using Jellyfin.Server.Implementations.Events;
 using Jellyfin.Server.Implementations.Extensions;
+using Jellyfin.Server.Implementations.Metrics;
 using Jellyfin.Server.Implementations.Security;
 using Jellyfin.Server.Implementations.Trickplay;
 using Jellyfin.Server.Implementations.Users;
@@ -87,6 +88,11 @@ namespace Jellyfin.Server
             serviceCollection.AddSingleton<IDisplayPreferencesManager, DisplayPreferencesManager>();
             serviceCollection.AddSingleton<IDeviceManager, DeviceManager>();
             serviceCollection.AddSingleton<ITrickplayManager, TrickplayManager>();
+
+            serviceCollection.AddSingleton<IMetricsCollector, UserMetrics>();
+            serviceCollection.AddSingleton<IMetricsCollector, SessionMetrics>();
+            serviceCollection.AddSingleton<IMetricsCollector, LibraryMetrics>();
+            serviceCollection.AddHostedService<MetricsHostedService>();
 
             // TODO search the assemblies instead of adding them manually?
             serviceCollection.AddSingleton<IWebSocketListener, SessionWebSocketListener>();

--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -92,6 +92,7 @@ namespace Jellyfin.Server
             serviceCollection.AddSingleton<IMetricsCollector, UserMetrics>();
             serviceCollection.AddSingleton<IMetricsCollector, SessionMetrics>();
             serviceCollection.AddSingleton<IMetricsCollector, LibraryMetrics>();
+            serviceCollection.AddSingleton<IMetricsCollector, TranscodingMetrics>();
             serviceCollection.AddHostedService<MetricsHostedService>();
 
             // TODO search the assemblies instead of adding them manually?

--- a/tests/Jellyfin.Server.Implementations.Tests/Metrics/LibraryMetricsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Metrics/LibraryMetricsTests.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Server.Implementations.Metrics;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Metrics;
+
+public class LibraryMetricsTests
+{
+    [Fact]
+    public async Task CollectAsync_QueriesEveryTrackedKind()
+    {
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(m => m.GetCount(It.IsAny<InternalItemsQuery>())).Returns(7);
+
+        var collector = new LibraryMetrics(libraryManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        libraryManager.Verify(m => m.GetCount(It.IsAny<InternalItemsQuery>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task CollectAsync_WithEmptyLibrary_DoesNotThrow()
+    {
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(m => m.GetCount(It.IsAny<InternalItemsQuery>())).Returns(0);
+
+        var collector = new LibraryMetrics(libraryManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void Name_ReturnsExpectedValue()
+    {
+        var collector = new LibraryMetrics(Mock.Of<ILibraryManager>());
+
+        Assert.Equal(nameof(LibraryMetrics), collector.Name);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Metrics/MetricsHostedServiceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Metrics/MetricsHostedServiceTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Server.Implementations.Metrics;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Metrics;
+
+public class MetricsHostedServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenMetricsDisabled_DoesNotInvokeCollectors()
+    {
+        var collector = new Mock<IMetricsCollector>();
+        collector.SetupGet(c => c.Name).Returns("Mock");
+        var configManager = new Mock<IServerConfigurationManager>();
+        configManager.SetupGet(c => c.Configuration).Returns(new ServerConfiguration { EnableMetrics = false });
+
+        using var cts = new CancellationTokenSource();
+        var service = new MetricsHostedService(
+            configManager.Object,
+            new[] { collector.Object },
+            NullLogger<MetricsHostedService>.Instance);
+
+        // Cancel immediately so the loop exits before the first wait completes.
+        await cts.CancelAsync();
+        await service.StartAsync(cts.Token);
+        await service.StopAsync(CancellationToken.None);
+
+        collector.Verify(c => c.CollectAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCollectorThrows_DoesNotPropagate()
+    {
+        var failing = new Mock<IMetricsCollector>();
+        failing.SetupGet(c => c.Name).Returns("Failing");
+        failing.Setup(c => c.CollectAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("boom"));
+        var configManager = new Mock<IServerConfigurationManager>();
+        configManager.SetupGet(c => c.Configuration).Returns(new ServerConfiguration { EnableMetrics = true });
+
+        using var cts = new CancellationTokenSource();
+        var service = new MetricsHostedService(
+            configManager.Object,
+            new[] { failing.Object },
+            NullLogger<MetricsHostedService>.Instance);
+
+        await service.StartAsync(cts.Token);
+        // Give the BackgroundService one scheduling slice to enter the loop.
+        await Task.Yield();
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        // The host must still be alive — no unobserved exception escaped the catch block.
+        Assert.True(true);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Metrics/SessionMetricsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Metrics/SessionMetricsTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Server.Implementations.Metrics;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Metrics;
+
+public class SessionMetricsTests
+{
+    [Fact]
+    public async Task CollectAsync_WithMixedSessions_CompletesWithoutError()
+    {
+        var sessionManager = new Mock<ISessionManager>();
+        var playing = new SessionInfo(sessionManager.Object, NullLogger.Instance) { Client = "Web", NowPlayingItem = new BaseItemDto() };
+        playing.PlayState!.PlayMethod = PlayMethod.DirectPlay;
+        var idle = new SessionInfo(sessionManager.Object, NullLogger.Instance) { Client = "Android" };
+        var transcoding = new SessionInfo(sessionManager.Object, NullLogger.Instance) { Client = "AndroidTV", NowPlayingItem = new BaseItemDto(), TranscodingInfo = new TranscodingInfo() };
+        transcoding.PlayState!.PlayMethod = PlayMethod.Transcode;
+        sessionManager.SetupGet(m => m.Sessions).Returns(new[] { playing, idle, transcoding });
+
+        var collector = new SessionMetrics(sessionManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        sessionManager.VerifyGet(m => m.Sessions, Times.Once);
+    }
+
+    [Fact]
+    public async Task CollectAsync_WithNoSessions_DoesNotThrow()
+    {
+        var sessionManager = new Mock<ISessionManager>();
+        sessionManager.SetupGet(m => m.Sessions).Returns(new List<SessionInfo>());
+
+        var collector = new SessionMetrics(sessionManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        sessionManager.VerifyGet(m => m.Sessions, Times.Once);
+    }
+
+    [Fact]
+    public void Name_ReturnsExpectedValue()
+    {
+        var collector = new SessionMetrics(Mock.Of<ISessionManager>());
+
+        Assert.Equal(nameof(SessionMetrics), collector.Name);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Metrics/TranscodingMetricsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Metrics/TranscodingMetricsTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Server.Implementations.Metrics;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Metrics;
+
+public class TranscodingMetricsTests
+{
+    [Fact]
+    public async Task CollectAsync_WithHardwareAndSoftwareTranscodes_CompletesWithoutError()
+    {
+        var sessionManager = new Mock<ISessionManager>();
+        var hardware = new SessionInfo(sessionManager.Object, NullLogger.Instance)
+        {
+            TranscodingInfo = new TranscodingInfo
+            {
+                HardwareAccelerationType = HardwareAccelerationType.nvenc,
+                Bitrate = 4_000_000,
+            },
+        };
+        var software = new SessionInfo(sessionManager.Object, NullLogger.Instance)
+        {
+            TranscodingInfo = new TranscodingInfo
+            {
+                HardwareAccelerationType = null,
+                Bitrate = 2_000_000,
+            },
+        };
+        var notTranscoding = new SessionInfo(sessionManager.Object, NullLogger.Instance);
+        sessionManager.SetupGet(m => m.Sessions).Returns(new[] { hardware, software, notTranscoding });
+
+        var collector = new TranscodingMetrics(sessionManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        sessionManager.VerifyGet(m => m.Sessions, Times.Once);
+    }
+
+    [Fact]
+    public async Task CollectAsync_WithNoActiveTranscodes_DoesNotThrow()
+    {
+        var sessionManager = new Mock<ISessionManager>();
+        sessionManager.SetupGet(m => m.Sessions).Returns(new List<SessionInfo>());
+
+        var collector = new TranscodingMetrics(sessionManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void Name_ReturnsExpectedValue()
+    {
+        var collector = new TranscodingMetrics(Mock.Of<ISessionManager>());
+
+        Assert.Equal(nameof(TranscodingMetrics), collector.Name);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Metrics/UserMetricsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Metrics/UserMetricsTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Server.Implementations.Metrics;
+using MediaBrowser.Controller.Library;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Metrics;
+
+public class UserMetricsTests
+{
+    [Fact]
+    public async Task CollectAsync_WithMixedUsers_CompletesWithoutError()
+    {
+        var users = new[]
+        {
+            CreateUser("admin", isAdmin: true, isDisabled: false, lastActivityDaysAgo: 1, failedLogins: 0),
+            CreateUser("regular", isAdmin: false, isDisabled: false, lastActivityDaysAgo: 5, failedLogins: 2),
+            CreateUser("disabled", isAdmin: false, isDisabled: true, lastActivityDaysAgo: 90, failedLogins: 0),
+        };
+        var userManager = new Mock<IUserManager>();
+        userManager.Setup(m => m.GetUsers()).Returns(users);
+
+        var collector = new UserMetrics(userManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        userManager.Verify(m => m.GetUsers(), Times.Once);
+    }
+
+    [Fact]
+    public async Task CollectAsync_WithNoUsers_DoesNotThrow()
+    {
+        var userManager = new Mock<IUserManager>();
+        userManager.Setup(m => m.GetUsers()).Returns(Array.Empty<User>());
+
+        var collector = new UserMetrics(userManager.Object);
+        await collector.CollectAsync(CancellationToken.None);
+
+        userManager.Verify(m => m.GetUsers(), Times.Once);
+    }
+
+    [Fact]
+    public void Name_ReturnsExpectedValue()
+    {
+        var collector = new UserMetrics(Mock.Of<IUserManager>());
+
+        Assert.Equal(nameof(UserMetrics), collector.Name);
+    }
+
+    private static User CreateUser(string name, bool isAdmin, bool isDisabled, int lastActivityDaysAgo, int failedLogins)
+    {
+        var user = new User(name, "DefaultAuthenticationProvider", "DefaultPasswordResetProvider")
+        {
+            LastActivityDate = DateTime.UtcNow.AddDays(-lastActivityDaysAgo),
+            InvalidLoginAttemptCount = failedLogins,
+        };
+        user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
+        user.SetPermission(PermissionKind.IsDisabled, isDisabled);
+        return user;
+    }
+}


### PR DESCRIPTION
**Changes**

This PR adds Prometheus metrics on top of the existing `/metrics` endpoint (activated by `EnableMetrics`). It introduces an `IMetricsCollector` interface and a single `MetricsHostedService` that refreshes every registered collector every 15 seconds.

Four collectors ship with this change:

- **UserMetrics**
  - `jellyfin_users{state="enabled|disabled|admin"}`
  - `jellyfin_users_authentication_provider{provider="..."}`
  - `jellyfin_users_active_recent`
  - `jellyfin_users_failed_logins`
- **SessionMetrics**
  - `jellyfin_sessions{state="playing|idle"}`
  - `jellyfin_sessions_clients{client="..."}`
  - `jellyfin_streams{play_method="DirectPlay|DirectStream|Transcode"}`
- **LibraryMetrics**
  - `jellyfin_library_items{type="Movie|Series|Episode|Audio|..."}`
- **TranscodingMetrics**
  - `jellyfin_transcoding_sessions{hardware="true|false"}`
  - `jellyfin_transcoding_bitrate_bps`

Metric names are consolidated under labels (one `jellyfin_users` series with a `state` label, instead of separate `_total` / `_active` / `_admin` gauges) to match the Prometheus best-practice feedback that came up on #14920.

**Architecture**

- Collectors are pulled by the hosted service rather than pushed from inside `UserManager` / `SessionManager`, so the managers stay clean.
- Adding more metrics (scan duration, plugin counts...) is just a new `IMetricsCollector` file under `Jellyfin.Server.Implementations/Metrics`.
- File-scoped namespaces, sealed classes, no public mutable state.

**Design notes**

A few intentional choices that are worth flagging up-front for reviewers:

- **Pull model, 15s tick.** The default Prometheus scrape interval is 15 seconds, so refreshing the gauges at the same cadence keeps the metric values fresh at scrape time without doing redundant work between scrapes. The interval is a `private static readonly` constant for now; happy to expose it via configuration if there is appetite for it.
- **Background refresh vs. lazy callbacks.** `prometheus-net` supports lazy callbacks (`Gauge.AddCallback` / observable gauges) which would compute values on scrape only. I went with `BackgroundService` because it matches existing Jellyfin patterns (`RecordingsHost`, `DeviceAccessHost`, `LibraryChangedNotifier`), is easier to reason about, and stays consistent with the direction the previous PR (#14920) ended up taking after review feedback. The `IMetricsCollector` interface keeps a future switch to lazy callbacks isolated to `MetricsHostedService.cs` without touching the collectors themselves.
- **Performance under load.** With #15368 having removed the `UserManager` cache, every tick now hits the database for users / sessions / library counts. On a small home server this is invisible; on a large multi-user instance with concurrent activity it could add measurable DB pressure. If reviewers want to address this proactively, options are (a) raising the interval, (b) caching results inside `MetricsHostedService` between ticks, or (c) switching to lazy callbacks (see point above). I would prefer to wait for actual feedback before adding configuration surface here.
- **Web UI is intentionally out of scope.** Prometheus metrics are designed to be scraped by external tooling (Grafana, varken, jellyfin-exporter, etc.). Native widgets in the Jellyfin Dashboard would duplicate that tooling. If the project wants a "Server health" widget later, it can land as a separate PR on `jellyfin-web` consuming existing JSON endpoints (`/Sessions`, `/Users`, `/Library/Items/Counts`) rather than `/metrics`.

**Tests**

Unit tests added for all four collectors and the hosted service in `tests/Jellyfin.Server.Implementations.Tests/Metrics/` (xUnit + Moq, 14 tests total, all passing locally). They cover:

- `*MetricsTests`: smoke tests on `CollectAsync` for each collector with realistic and empty inputs, plus a `Name` sanity check.
- `MetricsHostedServiceTests`: confirms that `CollectAsync` is never invoked while `EnableMetrics=false`, and that an exception thrown by a collector is caught and logged without bringing down the hosted service.

**Runtime testing performed**

Built against master (.NET 10) and ran on Windows with `--nowebclient --datadir <tmp>`:

| Scenario | Result |
| --- | --- |
| `EnableMetrics=true` -> `GET /metrics` | All `jellyfin_*` series visible |
| Create a 2nd user via API | `state="enabled"` 1 -> 2 after the 15s tick |
| Disable the 2nd user via Policy API | `state="enabled"` 2 -> 1, `state="disabled"` 0 -> 1 |
| Authenticate as `Client="test"` | `jellyfin_sessions_clients{client="test"} 1` appears |
| Logged-in user activity | `jellyfin_users_active_recent` 0 -> 1 |
| `EnableMetrics=false` | `GET /metrics` -> 404 (collectors no-op) |

**Relation to #14920**

#14920 has been inactive since 2025-12-15. This PR picks up the same direction (#3016) but reorganises the code along the lines reviewers asked for there:

- single hosted service driving an `IMetricsCollector` interface (no manual `UpdateUserMetrics()` calls scattered through `UserManager`),
- consolidated metric names using labels (per @jpds' feedback on cardinality),
- file-scoped namespaces (per @Bond-009's feedback).

Happy to close this and rebase onto #14920 if @ysf3rdm comes back to finish it.

**Issues**

#3016

### Code assistance

Used Claude (LLM) to help with code drafting and to format this description.