### PR TITLE
Safeguard against invalid GUIDs

### DIFF
--- a/Emby.Server.Implementations/Library/PathManager.cs
+++ b/Emby.Server.Implementations/Library/PathManager.cs
@@ -6,6 +6,7 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.IO;
+using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Library;
 
@@ -14,18 +15,22 @@ namespace Emby.Server.Implementations.Library;
 /// </summary>
 public class PathManager : IPathManager
 {
+    private readonly ILogger<PathManager> _logger;
     private readonly IServerConfigurationManager _config;
     private readonly IApplicationPaths _appPaths;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PathManager"/> class.
     /// </summary>
+    /// <param name="logger">The logger.</param>
     /// <param name="config">The server configuration manager.</param>
     /// <param name="appPaths">The application paths.</param>
     public PathManager(
+        ILogger<PathManager> logger,
         IServerConfigurationManager config,
         IApplicationPaths appPaths)
     {
+        _logger = logger;
         _config = config;
         _appPaths = appPaths;
     }
@@ -35,31 +40,43 @@ public class PathManager : IPathManager
     private string AttachmentCachePath => Path.Combine(_appPaths.DataPath, "attachments");
 
     /// <inheritdoc />
-    public string GetAttachmentPath(string mediaSourceId, string fileName)
+    public string? GetAttachmentPath(string mediaSourceId, string fileName)
     {
-        return Path.Combine(GetAttachmentFolderPath(mediaSourceId), fileName);
+        var folder = GetAttachmentFolderPath(mediaSourceId);
+        return folder is null ? null : Path.Combine(folder, fileName);
     }
 
     /// <inheritdoc />
-    public string GetAttachmentFolderPath(string mediaSourceId)
+    public string? GetAttachmentFolderPath(string mediaSourceId)
     {
-        var id = Guid.Parse(mediaSourceId).ToString("D", CultureInfo.InvariantCulture).AsSpan();
+        if (!Guid.TryParse(mediaSourceId, out var parsed))
+        {
+            _logger.LogWarning("Invalid MediaSource Id (not a GUID): '{MediaSourceId}'. Skipping attachment folder lookup.", mediaSourceId);
+            return null;
+        }
 
+        var id = parsed.ToString("D", CultureInfo.InvariantCulture).AsSpan();
         return Path.Join(AttachmentCachePath, id[..2], id);
     }
 
     /// <inheritdoc />
-    public string GetSubtitleFolderPath(string mediaSourceId)
+    public string? GetSubtitleFolderPath(string mediaSourceId)
     {
-        var id = Guid.Parse(mediaSourceId).ToString("D", CultureInfo.InvariantCulture).AsSpan();
+        if (!Guid.TryParse(mediaSourceId, out var parsed))
+        {
+            _logger.LogWarning("Invalid MediaSource Id (not a GUID): '{MediaSourceId}'. Skipping subtitle folder lookup.", mediaSourceId);
+            return null;
+        }
 
+        var id = parsed.ToString("D", CultureInfo.InvariantCulture).AsSpan();
         return Path.Join(SubtitleCachePath, id[..2], id);
     }
 
     /// <inheritdoc />
-    public string GetSubtitlePath(string mediaSourceId, int streamIndex, string extension)
+    public string? GetSubtitlePath(string mediaSourceId, int streamIndex, string extension)
     {
-        return Path.Combine(GetSubtitleFolderPath(mediaSourceId), streamIndex.ToString(CultureInfo.InvariantCulture) + extension);
+        var folder = GetSubtitleFolderPath(mediaSourceId);
+        return folder is null ? null : Path.Combine(folder, streamIndex.ToString(CultureInfo.InvariantCulture) + extension);
     }
 
     /// <inheritdoc />
@@ -90,12 +107,23 @@ public class PathManager : IPathManager
     public IReadOnlyList<string> GetExtractedDataPaths(BaseItem item)
     {
         var mediaSourceId = item.Id.ToString("N", CultureInfo.InvariantCulture);
-        return [
-            GetAttachmentFolderPath(mediaSourceId),
-            GetSubtitleFolderPath(mediaSourceId),
-            GetTrickplayDirectory(item, false),
-            GetTrickplayDirectory(item, true),
-            GetChapterImageFolderPath(item)
-        ];
+        List<string> paths = [];
+        var attachmentFolder = GetAttachmentFolderPath(mediaSourceId);
+        if (attachmentFolder is not null)
+        {
+            paths.Add(attachmentFolder);
+        }
+
+        var subtitleFolder = GetSubtitleFolderPath(mediaSourceId);
+        if (subtitleFolder is not null)
+        {
+            paths.Add(subtitleFolder);
+        }
+
+        paths.Add(GetTrickplayDirectory(item, false));
+        paths.Add(GetTrickplayDirectory(item, true));
+        paths.Add(GetChapterImageFolderPath(item));
+
+        return paths;
     }
 }

--- a/Emby.Server.Implementations/Library/PathManager.cs
+++ b/Emby.Server.Implementations/Library/PathManager.cs
@@ -51,7 +51,7 @@ public class PathManager : IPathManager
     {
         if (!Guid.TryParse(mediaSourceId, out var parsed))
         {
-            _logger.LogWarning("Invalid MediaSource Id (not a GUID): '{MediaSourceId}'. Skipping attachment folder lookup.", mediaSourceId);
+            _logger.LogDebug("MediaSource Id '{MediaSourceId}' is not a GUID; no on-disk attachment folder.", mediaSourceId);
             return null;
         }
 
@@ -64,7 +64,7 @@ public class PathManager : IPathManager
     {
         if (!Guid.TryParse(mediaSourceId, out var parsed))
         {
-            _logger.LogWarning("Invalid MediaSource Id (not a GUID): '{MediaSourceId}'. Skipping subtitle folder lookup.", mediaSourceId);
+            _logger.LogDebug("MediaSource Id '{MediaSourceId}' is not a GUID; no on-disk subtitle folder.", mediaSourceId);
             return null;
         }
 

--- a/Jellyfin.Server/Migrations/Routines/MigrateLinkedChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLinkedChildren.cs
@@ -283,9 +283,9 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+        var deleted = SafeDeleteItems(itemsToDelete!);
 
-        _logger.LogInformation("Removed {Count} wrong-type alternate version items. They will be recreated with the correct type on next library scan.", itemsToDelete.Count);
+        _logger.LogInformation("Removed {Count} wrong-type alternate version items. They will be recreated with the correct type on next library scan.", deleted);
     }
 
     private void CleanupOrphanedAlternateVersionBaseItems(JellyfinDbContext context)
@@ -314,9 +314,9 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+        var deleted = SafeDeleteItems(itemsToDelete!);
 
-        _logger.LogInformation("Removed {Count} orphaned alternate version BaseItems.", itemsToDelete.Count);
+        _logger.LogInformation("Removed {Count} orphaned alternate version BaseItems.", deleted);
     }
 
     private void CleanupItemsFromDeletedLibraries(JellyfinDbContext context)
@@ -343,9 +343,9 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+        var deleted = SafeDeleteItems(itemsToDelete!);
 
-        _logger.LogInformation("Removed {Count} items from deleted libraries.", itemsToDelete.Count);
+        _logger.LogInformation("Removed {Count} items from deleted libraries.", deleted);
     }
 
     private void CleanupStaleFileEntries(JellyfinDbContext context)
@@ -431,9 +431,43 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+        var deleted = SafeDeleteItems(itemsToDelete!);
 
-        _logger.LogInformation("Removed {Count} stale items.", itemsToDelete.Count);
+        _logger.LogInformation("Removed {Count} stale items.", deleted);
+    }
+
+    private int SafeDeleteItems(IReadOnlyCollection<MediaBrowser.Controller.Entities.BaseItem> items)
+    {
+        if (items.Count == 0)
+        {
+            return 0;
+        }
+
+        try
+        {
+            _libraryManager.DeleteItemsUnsafeFast(items);
+            return items.Count;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Bulk delete of {Count} items failed; falling back to per-item delete.", items.Count);
+        }
+
+        var deleted = 0;
+        foreach (var item in items)
+        {
+            try
+            {
+                _libraryManager.DeleteItemsUnsafeFast([item]);
+                deleted++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Skipping item {ItemId} ({ItemName}): delete failed.", item.Id, item.Name ?? "Unknown");
+            }
+        }
+
+        return deleted;
     }
 
     private void CleanupOrphanedLinkedChildren(JellyfinDbContext context)

--- a/Jellyfin.Server/Migrations/Routines/MigrateLinkedChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/MigrateLinkedChildren.cs
@@ -7,6 +7,7 @@ using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -283,7 +284,7 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        var deleted = SafeDeleteItems(itemsToDelete!);
+        var deleted = DeleteItems(itemsToDelete!);
 
         _logger.LogInformation("Removed {Count} wrong-type alternate version items. They will be recreated with the correct type on next library scan.", deleted);
     }
@@ -314,7 +315,7 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        var deleted = SafeDeleteItems(itemsToDelete!);
+        var deleted = DeleteItems(itemsToDelete!);
 
         _logger.LogInformation("Removed {Count} orphaned alternate version BaseItems.", deleted);
     }
@@ -343,7 +344,7 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        var deleted = SafeDeleteItems(itemsToDelete!);
+        var deleted = DeleteItems(itemsToDelete!);
 
         _logger.LogInformation("Removed {Count} items from deleted libraries.", deleted);
     }
@@ -431,34 +432,25 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             .Select(id => _libraryManager.GetItemById(id))
             .Where(item => item is not null)
             .ToList();
-        var deleted = SafeDeleteItems(itemsToDelete!);
+        var deleted = DeleteItems(itemsToDelete!);
 
         _logger.LogInformation("Removed {Count} stale items.", deleted);
     }
 
-    private int SafeDeleteItems(IReadOnlyCollection<MediaBrowser.Controller.Entities.BaseItem> items)
+    private int DeleteItems(IReadOnlyCollection<BaseItem> items)
     {
         if (items.Count == 0)
         {
             return 0;
         }
 
-        try
-        {
-            _libraryManager.DeleteItemsUnsafeFast(items);
-            return items.Count;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Bulk delete of {Count} items failed; falling back to per-item delete.", items.Count);
-        }
-
+        var options = new DeleteOptions { DeleteFileLocation = false, DeleteFromExternalProvider = false };
         var deleted = 0;
         foreach (var item in items)
         {
             try
             {
-                _libraryManager.DeleteItemsUnsafeFast([item]);
+                _libraryManager.DeleteItem(item, options);
                 deleted++;
             }
             catch (Exception ex)

--- a/Jellyfin.Server/Migrations/Routines/MoveExtractedFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/MoveExtractedFiles.cs
@@ -144,6 +144,11 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
                 }
 
                 var newSubtitleCachePath = _pathManager.GetSubtitlePath(itemIdString, mediaStreamIndex, extension);
+                if (newSubtitleCachePath is null)
+                {
+                    continue;
+                }
+
                 if (File.Exists(newSubtitleCachePath))
                 {
                     File.Delete(oldSubtitleCachePath);
@@ -182,6 +187,11 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
             }
 
             var newAttachmentPath = _pathManager.GetAttachmentPath(itemIdString, attachment.Filename ?? attachmentIndex.ToString(CultureInfo.InvariantCulture));
+            if (newAttachmentPath is null)
+            {
+                continue;
+            }
+
             if (File.Exists(newAttachmentPath))
             {
                 File.Delete(oldAttachmentPath);

--- a/MediaBrowser.Controller/IO/IPathManager.cs
+++ b/MediaBrowser.Controller/IO/IPathManager.cs
@@ -22,30 +22,30 @@ public interface IPathManager
     /// <param name="mediaSourceId">The media source id.</param>
     /// <param name="streamIndex">The stream index.</param>
     /// <param name="extension">The subtitle file extension.</param>
-    /// <returns>The absolute path.</returns>
-    public string GetSubtitlePath(string mediaSourceId, int streamIndex, string extension);
+    /// <returns>The absolute path, or <c>null</c> if <paramref name="mediaSourceId"/> is not a valid GUID.</returns>
+    public string? GetSubtitlePath(string mediaSourceId, int streamIndex, string extension);
 
     /// <summary>
     /// Gets the path to the subtitle file.
     /// </summary>
     /// <param name="mediaSourceId">The media source id.</param>
-    /// <returns>The absolute path.</returns>
-    public string GetSubtitleFolderPath(string mediaSourceId);
+    /// <returns>The absolute path, or <c>null</c> if <paramref name="mediaSourceId"/> is not a valid GUID.</returns>
+    public string? GetSubtitleFolderPath(string mediaSourceId);
 
     /// <summary>
     /// Gets the path to the attachment file.
     /// </summary>
     /// <param name="mediaSourceId">The media source id.</param>
     /// <param name="fileName">The attachmentFileName index.</param>
-    /// <returns>The absolute path.</returns>
-    public string GetAttachmentPath(string mediaSourceId, string fileName);
+    /// <returns>The absolute path, or <c>null</c> if <paramref name="mediaSourceId"/> is not a valid GUID.</returns>
+    public string? GetAttachmentPath(string mediaSourceId, string fileName);
 
     /// <summary>
     /// Gets the path to the attachment folder.
     /// </summary>
     /// <param name="mediaSourceId">The media source id.</param>
-    /// <returns>The absolute path.</returns>
-    public string GetAttachmentFolderPath(string mediaSourceId);
+    /// <returns>The absolute path, or <c>null</c> if <paramref name="mediaSourceId"/> is not a valid GUID.</returns>
+    public string? GetAttachmentFolderPath(string mediaSourceId);
 
     /// <summary>
     /// Gets the chapter images data path.

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1880,10 +1880,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             var sub2videoParam = enableSub2video ? ":sub2video=1" : string.Empty;
 
             var fontPath = _pathManager.GetAttachmentFolderPath(state.MediaSource.Id);
-            var fontParam = string.Format(
-                CultureInfo.InvariantCulture,
-                ":fontsdir='{0}'",
-                _mediaEncoder.EscapeSubtitleFilterPath(fontPath));
+            var fontParam = fontPath is null
+                ? string.Empty
+                : string.Format(
+                    CultureInfo.InvariantCulture,
+                    ":fontsdir='{0}'",
+                    _mediaEncoder.EscapeSubtitleFilterPath(fontPath));
 
             if (state.SubtitleStream.IsExternal)
             {

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -129,6 +129,12 @@ namespace MediaBrowser.MediaEncoding.Attachments
             ArgumentException.ThrowIfNullOrEmpty(inputPath);
 
             var outputFolder = _pathManager.GetAttachmentFolderPath(mediaSource.Id);
+            if (outputFolder is null)
+            {
+                _logger.LogWarning("Skipping attachment extraction for input {InputFile}: MediaSource Id is not a valid GUID.", inputFile);
+                return;
+            }
+
             using (await _semaphoreLocks.LockAsync(outputFolder, cancellationToken).ConfigureAwait(false))
             {
                 var directory = Directory.CreateDirectory(outputFolder);
@@ -241,9 +247,15 @@ namespace MediaBrowser.MediaEncoding.Attachments
             CancellationToken cancellationToken)
         {
             var attachmentFolderPath = _pathManager.GetAttachmentFolderPath(mediaSource.Id);
+            if (attachmentFolderPath is null)
+            {
+                _logger.LogWarning("Cannot extract attachment for MediaSource {MediaSourceId}: Id is not a valid GUID.", mediaSource.Id);
+                throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id, attachment cannot be extracted.");
+            }
+
             using (await _semaphoreLocks.LockAsync(attachmentFolderPath, cancellationToken).ConfigureAwait(false))
             {
-                var attachmentPath = _pathManager.GetAttachmentPath(mediaSource.Id, mediaAttachment.FileName ?? mediaAttachment.Index.ToString(CultureInfo.InvariantCulture));
+                var attachmentPath = _pathManager.GetAttachmentPath(mediaSource.Id, mediaAttachment.FileName ?? mediaAttachment.Index.ToString(CultureInfo.InvariantCulture))!;
                 if (!File.Exists(attachmentPath))
                 {
                     await ExtractAttachmentInternal(

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -131,7 +131,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
             var outputFolder = _pathManager.GetAttachmentFolderPath(mediaSource.Id);
             if (outputFolder is null)
             {
-                _logger.LogWarning("Skipping attachment extraction for input {InputFile}: MediaSource Id is not a valid GUID.", inputFile);
+                _logger.LogDebug("Skipping attachment extraction for input {InputFile}: MediaSource Id is not a GUID.", inputFile);
                 return;
             }
 
@@ -249,8 +249,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
             var attachmentFolderPath = _pathManager.GetAttachmentFolderPath(mediaSource.Id);
             if (attachmentFolderPath is null)
             {
-                _logger.LogWarning("Cannot extract attachment for MediaSource {MediaSourceId}: Id is not a valid GUID.", mediaSource.Id);
-                throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id, attachment cannot be extracted.");
+                throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has no attachment cache (non-GUID Id, e.g. Live TV stream).");
             }
 
             using (await _semaphoreLocks.LockAsync(attachmentFolderPath, cancellationToken).ConfigureAwait(false))

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -213,7 +213,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
                 var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
                 var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension)
-                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id; subtitle cache path cannot be resolved.");
+                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has no subtitle cache (non-GUID Id, e.g. Live TV stream).");
 
                 return new SubtitleInfo()
                 {
@@ -244,7 +244,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 // Convert
                 var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, ".srt")
-                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id; subtitle cache path cannot be resolved.");
+                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has no subtitle cache (non-GUID Id, e.g. Live TV stream).");
 
                 await ConvertTextSubtitleToSrt(subtitleStream, mediaSource, outputPath, cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -212,7 +212,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
                 var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
                 var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
-                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension);
+                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension)
+                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id; subtitle cache path cannot be resolved.");
 
                 return new SubtitleInfo()
                 {
@@ -242,7 +243,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             if (!_subtitleParser.SupportsFileExtension(currentFormat))
             {
                 // Convert
-                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, ".srt");
+                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, ".srt")
+                    ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has an invalid Id; subtitle cache path cannot be resolved.");
 
                 await ConvertTextSubtitleToSrt(subtitleStream, mediaSource, outputPath, cancellationToken).ConfigureAwait(false);
 
@@ -520,6 +522,10 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
 
                     var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                    if (outputPath is null)
+                    {
+                        continue;
+                    }
 
                     var releaser = await _semaphoreLocks.LockAsync(outputPath, cancellationToken).ConfigureAwait(false);
 
@@ -591,6 +597,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
 
                     var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                    if (outputPath is null)
+                    {
+                        continue;
+                    }
+
                     var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                     var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
@@ -636,6 +647,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
 
                 var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                if (outputPath is null)
+                {
+                    continue;
+                }
+
                 var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
@@ -968,7 +984,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
-        private string GetSubtitleCachePath(MediaSourceInfo mediaSource, int subtitleStreamIndex, string outputSubtitleExtension)
+        private string? GetSubtitleCachePath(MediaSourceInfo mediaSource, int subtitleStreamIndex, string outputSubtitleExtension)
         {
             return _pathManager.GetSubtitlePath(mediaSource.Id, subtitleStreamIndex, outputSubtitleExtension);
         }
@@ -981,9 +997,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             if (path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
             {
-                path = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + subtitleCodec);
-                await ExtractTextSubtitle(mediaSource, subtitleStream, subtitleCodec, path, cancellationToken)
-                    .ConfigureAwait(false);
+                var cachePath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + subtitleCodec);
+                if (cachePath is not null)
+                {
+                    path = cachePath;
+                    await ExtractTextSubtitle(mediaSource, subtitleStream, subtitleCodec, path, cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             var result = await DetectCharset(path, mediaSource.Protocol, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Apparently people have invalid mediaSourceIds in their database which breaks deletion and migrations that use it.

**Changes**
* Add safeguard against invalid GUIDs