### PR TITLE
Episode list on season page should sort by part number to break ties

### DIFF
--- a/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
+++ b/Emby.Server.Implementations/Sorting/AiredEpisodeOrderComparer.cs
@@ -1,7 +1,10 @@
 #pragma warning disable CS1591
 
 using System;
+using System.IO;
+using System.Text.RegularExpressions;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Sorting;
@@ -11,6 +14,11 @@ namespace Emby.Server.Implementations.Sorting
 {
     public class AiredEpisodeOrderComparer : IBaseItemComparer
     {
+        private static readonly Regex EpisodePartRegex = new(
+            @"(?:^|[ _.-])(?:cd|dvd|part|pt|dis[ck])[ _.-]*(?<number>[0-9]+|[a-d])(?:$|[ _.-])",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            TimeSpan.FromMilliseconds(200));
+
         /// <summary>
         /// Gets the name.
         /// </summary>
@@ -148,6 +156,16 @@ namespace Emby.Server.Implementations.Sorting
             var xValue = ((x.ParentIndexNumber ?? -1) * 1000) + (x.IndexNumber ?? -1);
             var yValue = ((y.ParentIndexNumber ?? -1) * 1000) + (y.IndexNumber ?? -1);
             var comparisonResult = xValue.CompareTo(yValue);
+            if (comparisonResult == 0)
+            {
+                comparisonResult = GetAdditionalPartIndex(x, y).CompareTo(GetAdditionalPartIndex(y, x));
+            }
+
+            if (comparisonResult == 0)
+            {
+                comparisonResult = GetFilenamePartIndex(x).CompareTo(GetFilenamePartIndex(y));
+            }
+
             // If equal, compare premiere dates
             if (comparisonResult == 0 && x.PremiereDate.HasValue && y.PremiereDate.HasValue)
             {
@@ -155,6 +173,51 @@ namespace Emby.Server.Implementations.Sorting
             }
 
             return comparisonResult;
+        }
+
+        private static int GetAdditionalPartIndex(Episode item, Episode other)
+        {
+            if (item.OwnerId.IsEmpty())
+            {
+                return 0;
+            }
+
+            var owner = item.OwnerId.Equals(other.Id)
+                ? other as Video
+                : item.GetOwner() as Video;
+
+            if (owner is null)
+            {
+                return int.MaxValue;
+            }
+
+            var index = Array.FindIndex(
+                owner.AdditionalParts,
+                path => string.Equals(path, item.Path, StringComparison.Ordinal));
+
+            return index < 0 ? int.MaxValue : index + 1;
+        }
+
+        private static int GetFilenamePartIndex(Episode item)
+        {
+            if (string.IsNullOrEmpty(item.Path))
+            {
+                return int.MaxValue;
+            }
+
+            var match = EpisodePartRegex.Match(Path.GetFileNameWithoutExtension(item.Path));
+            if (!match.Success)
+            {
+                return int.MaxValue;
+            }
+
+            var number = match.Groups["number"].Value;
+            if (int.TryParse(number, out var partNumber))
+            {
+                return partNumber;
+            }
+
+            return char.ToUpperInvariant(number[0]) - 'A' + 1;
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Sorting/AiredEpisodeOrderComparerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Sorting/AiredEpisodeOrderComparerTests.cs
@@ -3,6 +3,8 @@ using Emby.Server.Implementations.Sorting;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using Moq;
 using Xunit;
 
 namespace Jellyfin.Server.Implementations.Tests.Sorting
@@ -24,6 +26,82 @@ namespace Jellyfin.Server.Implementations.Tests.Sorting
         {
             Assert.Equal(expected, _cmp.Compare(x, y));
             Assert.Equal(-expected, _cmp.Compare(y, x));
+        }
+
+        [Fact]
+        public void Compare_StackedEpisodeParts_SortsByAdditionalPartOrder()
+        {
+            var ownerId = Guid.NewGuid();
+            var owner = new Episode
+            {
+                Id = ownerId,
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = "/series/Season 01/Show - S01E01 - part1.mkv",
+                AdditionalParts =
+                [
+                    "/series/Season 01/Show - S01E01 - part2.mkv",
+                    "/series/Season 01/Show - S01E01 - part3.mkv"
+                ]
+            };
+            var part2 = new Episode
+            {
+                OwnerId = ownerId,
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = "/series/Season 01/Show - S01E01 - part2.mkv"
+            };
+            var part3 = new Episode
+            {
+                OwnerId = ownerId,
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = "/series/Season 01/Show - S01E01 - part3.mkv"
+            };
+
+            var libraryManager = new Mock<ILibraryManager>();
+            libraryManager.Setup(i => i.GetItemById(ownerId)).Returns(owner);
+            var previousLibraryManager = BaseItem.LibraryManager;
+            try
+            {
+                BaseItem.LibraryManager = libraryManager.Object;
+
+                Assert.True(_cmp.Compare(owner, part2) < 0);
+                Assert.True(_cmp.Compare(part2, part3) < 0);
+                Assert.True(_cmp.Compare(part3, owner) > 0);
+            }
+            finally
+            {
+                BaseItem.LibraryManager = previousLibraryManager;
+            }
+        }
+
+        [Theory]
+        [InlineData(
+            "/series/Season 01/Show S01E01-part-1 - Pilot.mkv",
+            "/series/Season 01/Show S01E01-part-2 - Pilot.mkv")]
+        [InlineData(
+            "/series/Season 01/Show S01E01 pt A - Pilot.mkv",
+            "/series/Season 01/Show S01E01 pt B - Pilot.mkv")]
+        public void Compare_DuplicateEpisodeFilenameParts_SortsByPartNumber(string firstPartPath, string secondPartPath)
+        {
+            var firstPart = new Episode
+            {
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = firstPartPath,
+                PremiereDate = new DateTime(2021, 09, 12, 0, 0, 0)
+            };
+            var secondPart = new Episode
+            {
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = secondPartPath,
+                PremiereDate = new DateTime(2021, 09, 11, 0, 0, 0)
+            };
+
+            Assert.True(_cmp.Compare(firstPart, secondPart) < 0);
+            Assert.True(_cmp.Compare(secondPart, firstPart) > 0);
         }
 
         private sealed class EpisodeBadData : TheoryData<BaseItem?, BaseItem?>


### PR DESCRIPTION
**Changes**

For a show, the default metadata provider identifies the pilot as a single episode. Other providers identify it as two separate parts. I have two files for this episode, and believe that to be common.

To appease the metadata, I have accepted the single episode demarcation, but provided two files: part-1 and part-2. This works, except in one place. The sort order of the season episode list page will put part-2 first. I believe it is doing so by chance. The part-X is missing from the sort key.

**Issues**

Fixes #16817
