### PR TITLE
Allow plugins to customize “Similar” recommendations via composable providers

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -692,7 +692,8 @@ namespace Emby.Server.Implementations
                 GetExports<IMetadataProvider>(),
                 GetExports<IMetadataSaver>(),
                 GetExports<IExternalId>(),
-                GetExports<IExternalUrlProvider>());
+                GetExports<IExternalUrlProvider>(),
+                GetExports<IItemSimilarityProvider>());
 
             Resolve<IMediaSourceManager>().AddParts(GetExports<IMediaSourceProvider>());
         }

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -708,6 +708,7 @@ public class LibraryController : BaseJellyfinApiController
     /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
     /// <param name="limit">Optional. The maximum number of records to return.</param>
     /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">Similar items returned.</response>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> containing the similar items.</returns>
     [HttpGet("Artists/{itemId}/Similar", Name = "GetSimilarArtists")]
@@ -723,7 +724,8 @@ public class LibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] excludeArtistIds,
         [FromQuery] Guid? userId,
         [FromQuery] int? limit,
-        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields)
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
+        CancellationToken cancellationToken)
     {
         userId = RequestHelpers.GetUserId(User, userId);
         var user = userId.IsNullOrEmpty()
@@ -758,7 +760,7 @@ public class LibraryController : BaseJellyfinApiController
             {
                 try
                 {
-                    var providerResults = await provider.GetSimilarItems(item, limitValue, CancellationToken.None).ConfigureAwait(false);
+                    var providerResults = await provider.GetSimilarItems(item, limitValue, cancellationToken).ConfigureAwait(false);
                     var resultsList = providerResults?.ToList();
                     if (resultsList?.Count > 0)
                     {
@@ -923,6 +925,16 @@ public class LibraryController : BaseJellyfinApiController
 
         result.MediaSegmentProviders = plugins
             .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.MediaSegmentProvider))
+            .Select(i => new LibraryOptionInfoDto
+            {
+                Name = i.Name,
+                DefaultEnabled = true
+            })
+            .DistinctBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        result.SimilarityProviders = plugins
+            .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.SimilarityProvider))
             .Select(i => new LibraryOptionInfoDto
             {
                 Name = i.Name,

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -746,8 +746,8 @@ public class LibraryController : BaseJellyfinApiController
         }
 
         var dtoOptions = new DtoOptions { Fields = fields };
-        IEnumerable<Guid>? similarItemIds = null;
-        var limitValue = limit ?? 20;
+        IReadOnlyList<Guid>? similarItemIds = null;
+        int limitValue = limit ?? 20;
 
         // Try similarity providers first
         try
@@ -759,13 +759,14 @@ public class LibraryController : BaseJellyfinApiController
                 try
                 {
                     var providerResults = await provider.GetSimilarItems(item, limitValue, CancellationToken.None).ConfigureAwait(false);
-                    if (providerResults?.Any() == true)
+                    var resultsList = providerResults?.ToList();
+                    if (resultsList?.Count > 0)
                     {
-                        similarItemIds = providerResults;
+                        similarItemIds = resultsList;
                         _logger.LogDebug(
                             "Similarity provider {ProviderName} returned {Count} similar items for {ItemName}",
                             provider.Name,
-                            similarItemIds.Count(),
+                            similarItemIds.Count,
                             item.Name);
                         break;
                     }
@@ -784,8 +785,11 @@ public class LibraryController : BaseJellyfinApiController
             _logger.LogWarning(ex, "Error querying similarity providers, falling back to default algorithm");
         }
 
+        var startIndex = 0;
+        var totalRecordCount = 0;
+
         // Fallback to default metadata-based algorithm
-        if (similarItemIds == null || !similarItemIds.Any())
+        if (similarItemIds == null || similarItemIds.Count == 0)
         {
             var program = item as IHasProgramAttributes;
             bool? isMovie = item is Movie || (program is not null && program.IsMovie) || item is Trailer;
@@ -830,7 +834,13 @@ public class LibraryController : BaseJellyfinApiController
             }
 
             var itemsResult = _libraryManager.GetItemList(query);
-            similarItemIds = itemsResult.Select(i => i.Id);
+            similarItemIds = itemsResult.Select(i => i.Id).ToList();
+            startIndex = query.StartIndex ?? 0;
+            totalRecordCount = itemsResult.Count;
+        }
+        else
+        {
+            totalRecordCount = similarItemIds.Count;
         }
 
         // Convert IDs to DTOs
@@ -844,7 +854,7 @@ public class LibraryController : BaseJellyfinApiController
             }
         }
 
-        return new QueryResult<BaseItemDto>(0, items.Count, items);
+        return new QueryResult<BaseItemDto>(startIndex, totalRecordCount, items);
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -707,7 +707,7 @@ public class LibraryController : BaseJellyfinApiController
     /// <param name="excludeArtistIds">Exclude artist ids.</param>
     /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
     /// <param name="limit">Optional. The maximum number of records to return.</param>
-    /// <param name="fields">Optional. Specify additional fields of information to return in the output. This allows multiple, comma delimited. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines, TrailerUrls.</param>
+    /// <param name="fields">Optional. Specify additional fields of information to return in the output.</param>
     /// <response code="200">Similar items returned.</response>
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> containing the similar items.</returns>
     [HttpGet("Artists/{itemId}/Similar", Name = "GetSimilarArtists")]
@@ -718,7 +718,7 @@ public class LibraryController : BaseJellyfinApiController
     [HttpGet("Trailers/{itemId}/Similar", Name = "GetSimilarTrailers")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<QueryResult<BaseItemDto>> GetSimilarItems(
+    public async Task<ActionResult<QueryResult<BaseItemDto>>> GetSimilarItems(
         [FromRoute, Required] Guid itemId,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] excludeArtistIds,
         [FromQuery] Guid? userId,
@@ -734,6 +734,7 @@ public class LibraryController : BaseJellyfinApiController
                 ? _libraryManager.RootFolder
                 : _libraryManager.GetUserRootFolder())
             : _libraryManager.GetItemById<BaseItem>(itemId, user);
+
         if (item is null)
         {
             return NotFound();
@@ -745,60 +746,105 @@ public class LibraryController : BaseJellyfinApiController
         }
 
         var dtoOptions = new DtoOptions { Fields = fields };
+        IEnumerable<Guid>? similarItemIds = null;
+        var limitValue = limit ?? 20;
 
-        var program = item as IHasProgramAttributes;
-        bool? isMovie = item is Movie || (program is not null && program.IsMovie) || item is Trailer;
-        bool? isSeries = item is Series || (program is not null && program.IsSeries);
-
-        var includeItemTypes = new List<BaseItemKind>();
-        if (isMovie.Value)
+        // Try similarity providers first
+        try
         {
-            includeItemTypes.Add(BaseItemKind.Movie);
-            if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+            var providers = _providerManager.GetSimilarityProviders(item);
+
+            foreach (var provider in providers)
             {
-                includeItemTypes.Add(BaseItemKind.Trailer);
-                includeItemTypes.Add(BaseItemKind.LiveTvProgram);
+                try
+                {
+                    var providerResults = await provider.GetSimilarItems(item, limitValue, CancellationToken.None).ConfigureAwait(false);
+                    if (providerResults?.Any() == true)
+                    {
+                        similarItemIds = providerResults;
+                        _logger.LogDebug(
+                            "Similarity provider {ProviderName} returned {Count} similar items for {ItemName}",
+                            provider.Name,
+                            similarItemIds.Count(),
+                            item.Name);
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Error getting similar items from provider {ProviderName}",
+                        provider.Name);
+                }
             }
         }
-        else if (isSeries.Value)
+        catch (Exception ex)
         {
-            includeItemTypes.Add(BaseItemKind.Series);
-        }
-        else
-        {
-            // For non series and movie types these columns are typically null
-            // isSeries = null;
-            isMovie = null;
-            includeItemTypes.Add(item.GetBaseItemKind());
+            _logger.LogWarning(ex, "Error querying similarity providers, falling back to default algorithm");
         }
 
-        var query = new InternalItemsQuery(user)
+        // Fallback to default metadata-based algorithm
+        if (similarItemIds == null || !similarItemIds.Any())
         {
-            Genres = item.Genres,
-            Tags = item.Tags,
-            Limit = limit,
-            IncludeItemTypes = includeItemTypes.ToArray(),
-            DtoOptions = dtoOptions,
-            EnableTotalRecordCount = !isMovie ?? true,
-            EnableGroupByMetadataKey = isMovie ?? false,
-            ExcludeItemIds = [itemId],
-            OrderBy = [(ItemSortBy.Random, SortOrder.Ascending)]
-        };
+            var program = item as IHasProgramAttributes;
+            bool? isMovie = item is Movie || (program is not null && program.IsMovie) || item is Trailer;
+            bool? isSeries = item is Series || (program is not null && program.IsSeries);
 
-        // ExcludeArtistIds
-        if (excludeArtistIds.Length != 0)
-        {
-            query.ExcludeArtistIds = excludeArtistIds;
+            var includeItemTypes = new List<BaseItemKind>();
+            if (isMovie.Value)
+            {
+                includeItemTypes.Add(BaseItemKind.Movie);
+                if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+                {
+                    includeItemTypes.Add(BaseItemKind.Trailer);
+                    includeItemTypes.Add(BaseItemKind.LiveTvProgram);
+                }
+            }
+            else if (isSeries.Value)
+            {
+                includeItemTypes.Add(BaseItemKind.Series);
+            }
+            else
+            {
+                isMovie = null;
+                includeItemTypes.Add(item.GetBaseItemKind());
+            }
+
+            var query = new InternalItemsQuery(user)
+            {
+                Genres = item.Genres,
+                Tags = item.Tags,
+                Limit = limitValue,
+                IncludeItemTypes = includeItemTypes.ToArray(),
+                DtoOptions = dtoOptions,
+                EnableTotalRecordCount = !isMovie ?? true,
+                EnableGroupByMetadataKey = isMovie ?? false,
+                ExcludeItemIds = [itemId],
+                OrderBy = [(ItemSortBy.Random, SortOrder.Ascending)]
+            };
+
+            if (excludeArtistIds.Length != 0)
+            {
+                query.ExcludeArtistIds = excludeArtistIds;
+            }
+
+            var itemsResult = _libraryManager.GetItemList(query);
+            similarItemIds = itemsResult.Select(i => i.Id);
         }
 
-        var itemsResult = _libraryManager.GetItemList(query);
+        // Convert IDs to DTOs
+        var items = new List<BaseItemDto>();
+        foreach (var id in similarItemIds)
+        {
+            var similarItem = _libraryManager.GetItemById<BaseItem>(id, user);
+            if (similarItem is not null)
+            {
+                items.Add(_dtoService.GetBaseItemDto(similarItem, dtoOptions, user));
+            }
+        }
 
-        var returnList = _dtoService.GetBaseItemDtos(itemsResult, dtoOptions, user);
-
-        return new QueryResult<BaseItemDto>(
-            query.StartIndex,
-            itemsResult.Count,
-            returnList);
+        return new QueryResult<BaseItemDto>(0, items.Count, items);
     }
 
     /// <summary>

--- a/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
@@ -34,6 +34,11 @@ public class LibraryOptionsResultDto
     public IReadOnlyList<LibraryOptionInfoDto> MediaSegmentProviders { get; set; } = Array.Empty<LibraryOptionInfoDto>();
 
     /// <summary>
+    /// Gets or sets the similarity providers exposed to the Similar row.
+    /// </summary>
+    public IReadOnlyList<LibraryOptionInfoDto> SimilarityProviders { get; set; } = Array.Empty<LibraryOptionInfoDto>();
+
+    /// <summary>
     /// Gets or sets the type options.
     /// </summary>
     public IReadOnlyList<LibraryTypeOptionsDto> TypeOptions { get; set; } = Array.Empty<LibraryTypeOptionsDto>();

--- a/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
+++ b/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
@@ -9,11 +9,11 @@ using MediaBrowser.Controller.Entities;
 namespace MediaBrowser.Controller.Providers;
 
 // Example plugin implementation:
-// 
+//
 // public class AudioMuseAISimilarityProvider : IItemSimilarityProvider<Audio>, IItemSimilarityProvider<MusicAlbum>
 // {
 //     public string Name => "AudioMuse-AI";
-//     
+//
 //     public async Task<IEnumerable<Guid>> GetSimilarItems(
 //         Audio item,
 //         int limit,
@@ -22,7 +22,7 @@ namespace MediaBrowser.Controller.Providers;
 //         var response = await _httpClient.GetAsync(
 //             $"http://audiomuse:8000/similar_tracks?item_id={item.Id}&n={limit}",
 //             cancellationToken);
-//         
+//
 //         var json = await response.Content.ReadAsAsync<AudioMuseResponse>(cancellationToken);
 //         return json.SimilarItems.Select(i => i.JellyfinId).Take(limit);
 //     }

--- a/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
+++ b/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
@@ -1,0 +1,56 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+
+namespace MediaBrowser.Controller.Providers;
+
+// Example plugin implementation:
+// 
+// public class AudioMuseAISimilarityProvider : IItemSimilarityProvider<Audio>, IItemSimilarityProvider<MusicAlbum>
+// {
+//     public string Name => "AudioMuse-AI";
+//     
+//     public async Task<IEnumerable<Guid>> GetSimilarItems(
+//         Audio item,
+//         int limit,
+//         CancellationToken cancellationToken)
+//     {
+//         var response = await _httpClient.GetAsync(
+//             $"http://audiomuse:8000/similar_tracks?item_id={item.Id}&n={limit}",
+//             cancellationToken);
+//         
+//         var json = await response.Content.ReadAsAsync<AudioMuseResponse>(cancellationToken);
+//         return json.SimilarItems.Select(i => i.JellyfinId).Take(limit);
+//     }
+// }
+
+/// <summary>
+/// Marker interface for item similarity providers.
+/// </summary>
+public interface IItemSimilarityProvider : IMetadataProvider
+{
+}
+
+/// <summary>
+/// Interface for providing similar items to a given item.
+/// </summary>
+/// <typeparam name="TItemType">The type of item this provider handles.</typeparam>
+public interface IItemSimilarityProvider<TItemType> : IMetadataProvider<TItemType>, IItemSimilarityProvider
+    where TItemType : BaseItem
+{
+    /// <summary>
+    /// Gets a collection of similar items for the given item.
+    /// </summary>
+    /// <param name="item">The item to find similar items for.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing an enumerable of similar item IDs.</returns>
+    Task<IEnumerable<Guid>> GetSimilarItems(
+        TItemType item,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
+++ b/MediaBrowser.Controller/Providers/IItemSimilarityProvider.cs
@@ -1,38 +1,32 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 
 namespace MediaBrowser.Controller.Providers;
 
-// Example plugin implementation:
-//
-// public class AudioMuseAISimilarityProvider : IItemSimilarityProvider<Audio>, IItemSimilarityProvider<MusicAlbum>
-// {
-//     public string Name => "AudioMuse-AI";
-//
-//     public async Task<IEnumerable<Guid>> GetSimilarItems(
-//         Audio item,
-//         int limit,
-//         CancellationToken cancellationToken)
-//     {
-//         var response = await _httpClient.GetAsync(
-//             $"http://audiomuse:8000/similar_tracks?item_id={item.Id}&n={limit}",
-//             cancellationToken);
-//
-//         var json = await response.Content.ReadAsAsync<AudioMuseResponse>(cancellationToken);
-//         return json.SimilarItems.Select(i => i.JellyfinId).Take(limit);
-//     }
-// }
-
 /// <summary>
 /// Marker interface for item similarity providers.
 /// </summary>
 public interface IItemSimilarityProvider : IMetadataProvider
 {
+    /// <summary>
+    /// Returns whether this provider can compute similar items for the specified item.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns><c>true</c> if this provider handles the item.</returns>
+    bool Supports(BaseItem item);
+
+    /// <summary>
+    /// Gets similar item ids for an item handled by this provider.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <param name="limit">The maximum count of ids to consider returning.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Similar item ids.</returns>
+    Task<IEnumerable<Guid>> GetSimilarItems(BaseItem item, int limit, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -53,4 +47,18 @@ public interface IItemSimilarityProvider<TItemType> : IMetadataProvider<TItemTyp
         TItemType item,
         int limit,
         CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    bool IItemSimilarityProvider.Supports(BaseItem item) => item is TItemType;
+
+    /// <inheritdoc />
+    async Task<IEnumerable<Guid>> IItemSimilarityProvider.GetSimilarItems(BaseItem item, int limit, CancellationToken cancellationToken)
+    {
+        if (item is not TItemType typed)
+        {
+            return Enumerable.Empty<Guid>();
+        }
+
+        return await GetSimilarItems(typed, limit, cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -101,13 +101,15 @@ namespace MediaBrowser.Controller.Providers
         /// <param name="metadataSavers">Metadata savers to use.</param>
         /// <param name="externalIds">External IDs to use.</param>
         /// <param name="externalUrlProviders">The list of external url providers.</param>
+        /// <param name="similarityProviders">The list of item similarity providers.</param>
         void AddParts(
             IEnumerable<IImageProvider> imageProviders,
             IEnumerable<IMetadataService> metadataServices,
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders);
+            IEnumerable<IExternalUrlProvider> externalUrlProviders,
+            IEnumerable<IItemSimilarityProvider> similarityProviders = null);
 
         /// <summary>
         /// Gets the available remote images.

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -107,7 +107,8 @@ namespace MediaBrowser.Controller.Providers
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders);
+            IEnumerable<IExternalUrlProvider> externalUrlProviders,
+            IEnumerable<IItemSimilarityProvider> similarityProviders = null);
 
         /// <summary>
         /// Gets the available remote images.
@@ -150,6 +151,21 @@ namespace MediaBrowser.Controller.Providers
         /// <param name="libraryOptions">The library options.</param>
         /// <returns>The metadata savers.</returns>
         IEnumerable<IMetadataSaver> GetMetadataSavers(BaseItem item, LibraryOptions libraryOptions);
+
+        /// <summary>
+        /// Gets the similarity providers for the provided item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <typeparam name="T">The type of item.</typeparam>
+        /// <returns>The similarity providers for the item.</returns>
+        IEnumerable<IItemSimilarityProvider<T>> GetSimilarityProviders<T>(T item)
+            where T : BaseItem;
+
+        /// <summary>
+        /// Adds similarity providers.
+        /// </summary>
+        /// <param name="providers">The providers to add.</param>
+        void AddSimilarityProviders(IEnumerable<IItemSimilarityProvider> providers);
 
         /// <summary>
         /// Gets all metadata plugins.

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -101,6 +101,7 @@ namespace MediaBrowser.Controller.Providers
         /// <param name="metadataSavers">Metadata savers to use.</param>
         /// <param name="externalIds">External IDs to use.</param>
         /// <param name="externalUrlProviders">The list of external url providers.</param>
+        /// <param name="similarityProviders">The similarity providers to use.</param>
         void AddParts(
             IEnumerable<IImageProvider> imageProviders,
             IEnumerable<IMetadataService> metadataServices,

--- a/MediaBrowser.Controller/Providers/IProviderManager.cs
+++ b/MediaBrowser.Controller/Providers/IProviderManager.cs
@@ -101,15 +101,13 @@ namespace MediaBrowser.Controller.Providers
         /// <param name="metadataSavers">Metadata savers to use.</param>
         /// <param name="externalIds">External IDs to use.</param>
         /// <param name="externalUrlProviders">The list of external url providers.</param>
-        /// <param name="similarityProviders">The similarity providers to use.</param>
         void AddParts(
             IEnumerable<IImageProvider> imageProviders,
             IEnumerable<IMetadataService> metadataServices,
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders,
-            IEnumerable<IItemSimilarityProvider> similarityProviders = null);
+            IEnumerable<IExternalUrlProvider> externalUrlProviders);
 
         /// <summary>
         /// Gets the available remote images.
@@ -157,16 +155,8 @@ namespace MediaBrowser.Controller.Providers
         /// Gets the similarity providers for the provided item.
         /// </summary>
         /// <param name="item">The item.</param>
-        /// <typeparam name="T">The type of item.</typeparam>
         /// <returns>The similarity providers for the item.</returns>
-        IEnumerable<IItemSimilarityProvider<T>> GetSimilarityProviders<T>(T item)
-            where T : BaseItem;
-
-        /// <summary>
-        /// Adds similarity providers.
-        /// </summary>
-        /// <param name="providers">The providers to add.</param>
-        void AddSimilarityProviders(IEnumerable<IItemSimilarityProvider> providers);
+        IEnumerable<IItemSimilarityProvider> GetSimilarityProviders(BaseItem item);
 
         /// <summary>
         /// Gets all metadata plugins.

--- a/MediaBrowser.Model/Configuration/MetadataPluginType.cs
+++ b/MediaBrowser.Model/Configuration/MetadataPluginType.cs
@@ -15,6 +15,7 @@ namespace MediaBrowser.Model.Configuration
         MetadataSaver,
         SubtitleFetcher,
         LyricFetcher,
-        MediaSegmentProvider
+        MediaSegmentProvider,
+        SimilarityProvider
     }
 }

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -102,6 +102,7 @@ namespace MediaBrowser.Providers.Manager
         /// <param name="lyricManager">The lyric manager.</param>
         /// <param name="memoryCache">The memory cache.</param>
         /// <param name="mediaSegmentManager">The media segment manager.</param>
+        /// <param name="similarityProviders">The similarity providers.</param>
         public ProviderManager(
             IHttpClientFactory httpClientFactory,
             ISubtitleManager subtitleManager,
@@ -114,7 +115,8 @@ namespace MediaBrowser.Providers.Manager
             IBaseItemManager baseItemManager,
             ILyricManager lyricManager,
             IMemoryCache memoryCache,
-            IMediaSegmentManager mediaSegmentManager)
+            IMediaSegmentManager mediaSegmentManager,
+            IEnumerable<IItemSimilarityProvider> similarityProviders)
         {
             _logger = logger;
             _httpClientFactory = httpClientFactory;
@@ -128,6 +130,7 @@ namespace MediaBrowser.Providers.Manager
             _lyricManager = lyricManager;
             _memoryCache = memoryCache;
             _mediaSegmentManager = mediaSegmentManager;
+            _similarityProviders = similarityProviders.ToArray();
 
             CollectionFolder.LibraryOptionsUpdated += OnLibraryOptionsUpdated;
         }
@@ -148,8 +151,7 @@ namespace MediaBrowser.Providers.Manager
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders,
-            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
+            IEnumerable<IExternalUrlProvider> externalUrlProviders)
         {
             _imageProviders = imageProviders.ToArray();
             _metadataServices = metadataServices.OrderBy(i => i.Order).ToArray();
@@ -158,10 +160,38 @@ namespace MediaBrowser.Providers.Manager
             _externalUrlProviders = externalUrlProviders.OrderBy(i => i.Name).ToArray();
 
             _savers = metadataSavers.ToArray();
+        }
 
-            if (similarityProviders != null)
+        /// <inheritdoc/>
+        public IEnumerable<IItemSimilarityProvider> GetSimilarityProviders(BaseItem item)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+
+            foreach (var provider in _similarityProviders)
             {
-                AddSimilarityProviders(similarityProviders);
+                if (TrySupportsSimilarityProvider(provider, item, out var supports) && supports)
+                {
+                    yield return provider;
+                }
+            }
+        }
+
+        private bool TrySupportsSimilarityProvider(IItemSimilarityProvider provider, BaseItem item, out bool supports)
+        {
+            try
+            {
+                supports = provider.Supports(item);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Error in {ProviderName} Supports while resolving similarity providers for {ItemType}",
+                    provider.Name,
+                    item.GetType().Name);
+                supports = false;
+                return false;
             }
         }
 
@@ -1290,19 +1320,6 @@ namespace MediaBrowser.Providers.Manager
             }
 
             _logger.LogDebug("Invalidated metadata provider cache for library: {LibraryPath}", e.LibraryPath);
-        }
-
-        /// <inheritdoc />
-        public IEnumerable<IItemSimilarityProvider<T>> GetSimilarityProviders<T>(T item)
-            where T : BaseItem
-        {
-            return _similarityProviders.OfType<IItemSimilarityProvider<T>>();
-        }
-
-        /// <inheritdoc />
-        public void AddSimilarityProviders(IEnumerable<IItemSimilarityProvider> providers)
-        {
-            _similarityProviders = providers.ToArray();
         }
 
         internal void ClearMetadataProviderCache()

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -102,7 +102,6 @@ namespace MediaBrowser.Providers.Manager
         /// <param name="lyricManager">The lyric manager.</param>
         /// <param name="memoryCache">The memory cache.</param>
         /// <param name="mediaSegmentManager">The media segment manager.</param>
-        /// <param name="similarityProviders">The similarity providers.</param>
         public ProviderManager(
             IHttpClientFactory httpClientFactory,
             ISubtitleManager subtitleManager,
@@ -115,8 +114,7 @@ namespace MediaBrowser.Providers.Manager
             IBaseItemManager baseItemManager,
             ILyricManager lyricManager,
             IMemoryCache memoryCache,
-            IMediaSegmentManager mediaSegmentManager,
-            IEnumerable<IItemSimilarityProvider> similarityProviders)
+            IMediaSegmentManager mediaSegmentManager)
         {
             _logger = logger;
             _httpClientFactory = httpClientFactory;
@@ -130,7 +128,6 @@ namespace MediaBrowser.Providers.Manager
             _lyricManager = lyricManager;
             _memoryCache = memoryCache;
             _mediaSegmentManager = mediaSegmentManager;
-            _similarityProviders = similarityProviders.ToArray();
 
             CollectionFolder.LibraryOptionsUpdated += OnLibraryOptionsUpdated;
         }
@@ -151,7 +148,8 @@ namespace MediaBrowser.Providers.Manager
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders)
+            IEnumerable<IExternalUrlProvider> externalUrlProviders,
+            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
         {
             _imageProviders = imageProviders.ToArray();
             _metadataServices = metadataServices.OrderBy(i => i.Order).ToArray();
@@ -160,6 +158,14 @@ namespace MediaBrowser.Providers.Manager
             _externalUrlProviders = externalUrlProviders.OrderBy(i => i.Name).ToArray();
 
             _savers = metadataSavers.ToArray();
+
+            if (similarityProviders is not null)
+            {
+                _similarityProviders = similarityProviders
+                    .OrderBy(GetDefaultOrder)
+                    .ThenBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
         }
 
         /// <inheritdoc/>
@@ -723,6 +729,20 @@ namespace MediaBrowser.Providers.Manager
                 Name = i.Name,
                 Type = MetadataPluginType.MediaSegmentProvider
             }));
+
+            foreach (var similarityProvider in _similarityProviders)
+            {
+                if (!TrySupportsSimilarityProvider(similarityProvider, dummy, out var supported) || !supported)
+                {
+                    continue;
+                }
+
+                pluginList.Add(new MetadataPlugin
+                {
+                    Name = similarityProvider.Name,
+                    Type = MetadataPluginType.SimilarityProvider
+                });
+            }
 
             summary.Plugins = pluginList.ToArray();
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -83,6 +83,7 @@ namespace MediaBrowser.Providers.Manager
         private IMetadataSaver[] _savers = [];
         private IExternalId[] _externalIds = [];
         private IExternalUrlProvider[] _externalUrlProviders = [];
+        private IItemSimilarityProvider[] _similarityProviders = [];
         private bool _isProcessingRefreshQueue;
         private bool _disposed;
 
@@ -147,7 +148,8 @@ namespace MediaBrowser.Providers.Manager
             IEnumerable<IMetadataProvider> metadataProviders,
             IEnumerable<IMetadataSaver> metadataSavers,
             IEnumerable<IExternalId> externalIds,
-            IEnumerable<IExternalUrlProvider> externalUrlProviders)
+            IEnumerable<IExternalUrlProvider> externalUrlProviders,
+            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
         {
             _imageProviders = imageProviders.ToArray();
             _metadataServices = metadataServices.OrderBy(i => i.Order).ToArray();
@@ -156,6 +158,11 @@ namespace MediaBrowser.Providers.Manager
             _externalUrlProviders = externalUrlProviders.OrderBy(i => i.Name).ToArray();
 
             _savers = metadataSavers.ToArray();
+
+            if (similarityProviders != null)
+            {
+                AddSimilarityProviders(similarityProviders);
+            }
         }
 
         /// <inheritdoc/>
@@ -1283,6 +1290,19 @@ namespace MediaBrowser.Providers.Manager
             }
 
             _logger.LogDebug("Invalidated metadata provider cache for library: {LibraryPath}", e.LibraryPath);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<IItemSimilarityProvider<T>> GetSimilarityProviders<T>(T item)
+            where T : BaseItem
+        {
+            return _similarityProviders.OfType<IItemSimilarityProvider<T>>();
+        }
+
+        /// <inheritdoc />
+        public void AddSimilarityProviders(IEnumerable<IItemSimilarityProvider> providers)
+        {
+            _similarityProviders = providers.ToArray();
         }
 
         internal void ClearMetadataProviderCache()

--- a/tests/Jellyfin.Api.Tests/Controllers/FailingSimilarityProvider.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/FailingSimilarityProvider.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class FailingSimilarityProvider : IItemSimilarityProvider<Audio>
+{
+    public string Name => "FailingProvider";
+
+    public Task<IEnumerable<Guid>> GetSimilarItems(Audio item, int limit, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Provider failed");
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/MockSimilarityProvider.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/MockSimilarityProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class MockSimilarityProvider : IItemSimilarityProvider<Audio>
+{
+    private readonly IEnumerable<Guid> _results;
+
+    public MockSimilarityProvider(IEnumerable<Guid> results)
+    {
+        _results = results;
+    }
+
+    public string Name => "MockProvider";
+
+    public Task<IEnumerable<Guid>> GetSimilarItems(
+        Audio item,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_results.Take(limit));
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Providers;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class SimilarityProvidersTests
+{
+    [Fact]
+    public async Task GetSimilarItems_WithValidProvider_ReturnsProviderResults()
+    {
+        // Arrange
+        var item = new Audio { Id = Guid.NewGuid(), Name = "Test Song" };
+        var expectedIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var provider = new MockSimilarityProvider(expectedIds);
+
+        // Act
+        var result = await provider.GetSimilarItems(item, 10, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedIds, result);
+    }
+
+    [Fact]
+    public async Task GetSimilarItems_WithProviderReturningEmpty_ReturnsEmpty()
+    {
+        // Arrange
+        var item = new Audio { Id = Guid.NewGuid(), Name = "Test Song" };
+        var provider = new MockSimilarityProvider(Array.Empty<Guid>());
+
+        // Act
+        var result = await provider.GetSimilarItems(item, 10, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}
+
+public class MockSimilarityProvider : IItemSimilarityProvider<Audio>
+{
+    private readonly IEnumerable<Guid> _results;
+
+    public MockSimilarityProvider(IEnumerable<Guid> results)
+    {
+        _results = results;
+    }
+
+    public string Name => "MockProvider";
+
+    public Task<IEnumerable<Guid>> GetSimilarItems(
+        Audio item,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_results.Take(limit));
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
-using MediaBrowser.Controller.Providers;
 using Xunit;
 
 namespace Jellyfin.Api.Tests.Controllers;
@@ -41,25 +38,5 @@ public class SimilarityProvidersTests
         // Assert
         Assert.NotNull(result);
         Assert.Empty(result);
-    }
-}
-
-public class MockSimilarityProvider : IItemSimilarityProvider<Audio>
-{
-    private readonly IEnumerable<Guid> _results;
-
-    public MockSimilarityProvider(IEnumerable<Guid> results)
-    {
-        _results = results;
-    }
-
-    public string Name => "MockProvider";
-
-    public Task<IEnumerable<Guid>> GetSimilarItems(
-        Audio item,
-        int limit,
-        CancellationToken cancellationToken)
-    {
-        return Task.FromResult(_results.Take(limit));
     }
 }

--- a/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/SimilarityProvidersTests.cs
@@ -39,4 +39,15 @@ public class SimilarityProvidersTests
         Assert.NotNull(result);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetSimilarItems_WithProviderThrowing_Throws()
+    {
+        // Arrange
+        var item = new Audio { Id = Guid.NewGuid(), Name = "Test Song" };
+        var provider = new FailingSimilarityProvider();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetSimilarItems(item, 10, CancellationToken.None));
+    }
 }

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -555,8 +556,7 @@ namespace Jellyfin.Providers.Tests.Manager
         private static ProviderManager GetProviderManager(
             ServerConfiguration? serverConfiguration = null,
             LibraryOptions? libraryOptions = null,
-            IBaseItemManager? baseItemManager = null,
-            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
+            IBaseItemManager? baseItemManager = null)
         {
             var serverConfigurationManager = new Mock<IServerConfigurationManager>(MockBehavior.Strict);
             serverConfigurationManager.Setup(i => i.Configuration)
@@ -566,6 +566,10 @@ namespace Jellyfin.Providers.Tests.Manager
             libraryManager.Setup(i => i.GetLibraryOptions(It.IsAny<BaseItem>()))
                 .Returns(libraryOptions ?? new LibraryOptions());
 
+            var appPaths = new Mock<IServerApplicationPaths>();
+            appPaths.Setup(p => p.InternalMetadataPath)
+                .Returns(Path.Combine(Path.GetTempPath(), "ProviderManagerTests-metadata"));
+
             var providerManager = new ProviderManager(
                 Mock.Of<IHttpClientFactory>(),
                 Mock.Of<ISubtitleManager>(),
@@ -573,13 +577,12 @@ namespace Jellyfin.Providers.Tests.Manager
                 Mock.Of<ILibraryMonitor>(),
                 _logger,
                 Mock.Of<IFileSystem>(),
-                Mock.Of<IServerApplicationPaths>(),
+                appPaths.Object,
                 libraryManager.Object,
                 baseItemManager!,
                 Mock.Of<ILyricManager>(),
                 Mock.Of<IMemoryCache>(),
-                Mock.Of<IMediaSegmentManager>(),
-                similarityProviders ?? Array.Empty<IItemSimilarityProvider>());
+                Mock.Of<IMediaSegmentManager>());
 
             return providerManager;
         }
@@ -591,7 +594,8 @@ namespace Jellyfin.Providers.Tests.Manager
             IEnumerable<IMetadataProvider>? metadataProviders = null,
             IEnumerable<IMetadataSaver>? metadataSavers = null,
             IEnumerable<IExternalId>? externalIds = null,
-            IEnumerable<IExternalUrlProvider>? externalUrlProviders = null)
+            IEnumerable<IExternalUrlProvider>? externalUrlProviders = null,
+            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
         {
             imageProviders ??= Array.Empty<IImageProvider>();
             metadataServices ??= Array.Empty<IMetadataService>();
@@ -600,7 +604,7 @@ namespace Jellyfin.Providers.Tests.Manager
             externalIds ??= Array.Empty<IExternalId>();
             externalUrlProviders ??= Array.Empty<IExternalUrlProvider>();
 
-            providerManager.AddParts(imageProviders, metadataServices, metadataProviders, metadataSavers, externalIds, externalUrlProviders);
+            providerManager.AddParts(imageProviders, metadataServices, metadataProviders, metadataSavers, externalIds, externalUrlProviders, similarityProviders);
         }
 
         [Fact]
@@ -614,7 +618,8 @@ namespace Jellyfin.Providers.Tests.Manager
                 new SimilarityProviderForMovie()
             };
 
-            using var providerManager = GetProviderManager(similarityProviders: providers);
+            using var providerManager = GetProviderManager();
+            AddParts(providerManager, similarityProviders: providers);
 
             var result = providerManager.GetSimilarityProviders(audio).ToArray();
 

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller;
 using MediaBrowser.Controller.BaseItemManager;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Lyrics;
@@ -554,7 +555,8 @@ namespace Jellyfin.Providers.Tests.Manager
         private static ProviderManager GetProviderManager(
             ServerConfiguration? serverConfiguration = null,
             LibraryOptions? libraryOptions = null,
-            IBaseItemManager? baseItemManager = null)
+            IBaseItemManager? baseItemManager = null,
+            IEnumerable<IItemSimilarityProvider>? similarityProviders = null)
         {
             var serverConfigurationManager = new Mock<IServerConfigurationManager>(MockBehavior.Strict);
             serverConfigurationManager.Setup(i => i.Configuration)
@@ -576,7 +578,8 @@ namespace Jellyfin.Providers.Tests.Manager
                 baseItemManager!,
                 Mock.Of<ILyricManager>(),
                 Mock.Of<IMemoryCache>(),
-                Mock.Of<IMediaSegmentManager>());
+                Mock.Of<IMediaSegmentManager>(),
+                similarityProviders ?? Array.Empty<IItemSimilarityProvider>());
 
             return providerManager;
         }
@@ -598,6 +601,51 @@ namespace Jellyfin.Providers.Tests.Manager
             externalUrlProviders ??= Array.Empty<IExternalUrlProvider>();
 
             providerManager.AddParts(imageProviders, metadataServices, metadataProviders, metadataSavers, externalIds, externalUrlProviders);
+        }
+
+        [Fact]
+        public void GetSimilarityProviders_FiltersBySupports()
+        {
+            var audio = new Audio();
+            var providers = new List<IItemSimilarityProvider>
+            {
+                new SimilarityProviderForBase(),
+                new SimilarityProviderForAudio(),
+                new SimilarityProviderForMovie()
+            };
+
+            using var providerManager = GetProviderManager(similarityProviders: providers);
+
+            var result = providerManager.GetSimilarityProviders(audio).ToArray();
+
+            Assert.Equal(2, result.Length);
+            Assert.Contains(result, p => p.Name == nameof(SimilarityProviderForBase));
+            Assert.Contains(result, p => p.Name == nameof(SimilarityProviderForAudio));
+            Assert.DoesNotContain(result, p => p.Name == nameof(SimilarityProviderForMovie));
+        }
+
+        private sealed class SimilarityProviderForBase : IItemSimilarityProvider<BaseItem>
+        {
+            public string Name => nameof(SimilarityProviderForBase);
+
+            public Task<IEnumerable<Guid>> GetSimilarItems(BaseItem item, int limit, CancellationToken cancellationToken)
+                => Task.FromResult<IEnumerable<Guid>>(Array.Empty<Guid>());
+        }
+
+        private sealed class SimilarityProviderForAudio : IItemSimilarityProvider<Audio>
+        {
+            public string Name => nameof(SimilarityProviderForAudio);
+
+            public Task<IEnumerable<Guid>> GetSimilarItems(Audio item, int limit, CancellationToken cancellationToken)
+                => Task.FromResult<IEnumerable<Guid>>(Array.Empty<Guid>());
+        }
+
+        private sealed class SimilarityProviderForMovie : IItemSimilarityProvider<Movie>
+        {
+            public string Name => nameof(SimilarityProviderForMovie);
+
+            public Task<IEnumerable<Guid>> GetSimilarItems(Movie item, int limit, CancellationToken cancellationToken)
+                => Task.FromResult<IEnumerable<Guid>>(Array.Empty<Guid>());
         }
 
         /// <summary>


### PR DESCRIPTION
This change lets third-party code supply the item IDs used for the Similar row on movies, shows, music, and other supported types, while keeping the existing server-side fallback when no plugin returns results.

## Behavior

- On each Similar request, the server asks registered `IItemSimilarityProvider` implementations, in order (`IHasOrder` when implemented, then name), for the first implementation whose `Supports` method accepts the item.
- If a provider returns one or more GUIDs, those are resolved to DTOs and returned. If every provider returns empty, errors, or declines the item, the previous metadata-based random query is unchanged.
- `GET Libraries/AvailableOptions` gains a `similarityProviders` list so admins and clients can see which similarity plugins are loaded, consistent with subtitle, lyric, and media-segment listings.
- Similar requests now honor the HTTP `CancellationToken` when calling into providers.

## Plugin authors

- Implement `IItemSimilarityProvider<T>` (or `IItemSimilarityProvider` for custom `Supports` / `GetSimilarItems` behavior) from `MediaBrowser.Controller.Providers`.
- Ship your types in a plugin assembly that Jellyfin already composes; `IItemSimilarityProvider` exports are collected in `FindParts` the same way as image and metadata providers (`GetExports<IItemSimilarityProvider>()`). No extra `IPluginServiceRegistrator` boilerplate is required for basic discovery.

## Tests

- `ProviderManager` tests cover similarity `Supports` filtering and full existing provider-ordering behavior.
- API tests cover the `IItemSimilarityProvider<Audio>` surface (success, empty, and exception from the typed `GetSimilarItems` path).

## Breaking / contract

- `LibraryOptionsResultDto` is extended with `similarityProviders`. OpenAPI generation should be run or left to the repo's usual workflow so consumers pick up the new field.