### PR TITLE
Improve OriginalLanguage normalization and inheritance

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -440,10 +440,6 @@ namespace Emby.Server.Implementations.Library
 
             if (string.Equals(user.AudioLanguagePreference, "OriginalLanguage", StringComparison.OrdinalIgnoreCase))
             {
-                originalLanguage = !string.IsNullOrWhiteSpace(originalLanguage)
-                    ? originalLanguage.Split(',').FirstOrDefault()
-                    : null;
-
                 if (user.PlayDefaultAudioTrack)
                 {
                     source.DefaultAudioStreamIndex = MediaStreamSelector.GetDefaultAudioStreamIndex(
@@ -498,17 +494,7 @@ namespace Emby.Server.Implementations.Library
 
                 var allowRememberingSelection = item is null || item.EnableRememberingTrackSelections;
 
-                var originalLanguage = item?.OriginalLanguage ?? item switch
-                {
-                    Episode episode => episode.Series.OriginalLanguage,
-                    Video video => video.GetOwner() switch
-                    {
-                        Episode ownerEpisode => ownerEpisode.OriginalLanguage ?? ownerEpisode.Series.OriginalLanguage,
-                        BaseItem owner => owner.OriginalLanguage,
-                        null => null
-                    },
-                    _ => null
-                };
+                var originalLanguage = item?.GetInheritedOriginalLanguage();
 
                 SetDefaultAudioStreamIndex(source, userData, user, allowRememberingSelection, originalLanguage);
                 SetDefaultSubtitleStreamIndex(source, userData, user, allowRememberingSelection);

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -94,6 +94,8 @@ namespace MediaBrowser.Controller.Entities
 
         private string _name;
 
+        private string _originalLanguage;
+
         public const char SlugChar = '-';
 
         protected BaseItem()
@@ -217,7 +219,23 @@ namespace MediaBrowser.Controller.Entities
         public string OriginalTitle { get; set; }
 
         [JsonIgnore]
-        public string OriginalLanguage { get; set; }
+        public string OriginalLanguage
+        {
+            get => _originalLanguage;
+            set
+            {
+                var culture = LocalizationManager?.FindLanguageInfo(value);
+                if (culture is not null)
+                {
+                    _originalLanguage = culture.Name.Contains('-', StringComparison.OrdinalIgnoreCase)
+                        ? culture.Name
+                        : culture.ThreeLetterISOLanguageName;
+                    return;
+                }
+
+                _originalLanguage = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the id.
@@ -1564,7 +1582,7 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
-        /// Gets the preferred metadata language.
+        /// Gets the preferred metadata country code.
         /// </summary>
         /// <returns>System.String.</returns>
         public string GetPreferredMetadataCountryCode()
@@ -1596,6 +1614,15 @@ namespace MediaBrowser.Controller.Entities
             }
 
             return lang;
+        }
+
+        /// <summary>
+        /// Gets the original language of the item, inheriting from parent items if necessary.
+        /// </summary>
+        /// <returns>System.String.</returns>
+        public virtual string GetInheritedOriginalLanguage()
+        {
+            return OriginalLanguage;
         }
 
         public virtual bool IsSaveLocalMetadataEnabled()

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -222,19 +222,7 @@ namespace MediaBrowser.Controller.Entities
         public string OriginalLanguage
         {
             get => _originalLanguage;
-            set
-            {
-                var culture = LocalizationManager?.FindLanguageInfo(value);
-                if (culture is not null)
-                {
-                    _originalLanguage = culture.Name.Contains('-', StringComparison.OrdinalIgnoreCase)
-                        ? culture.Name
-                        : culture.ThreeLetterISOLanguageName;
-                    return;
-                }
-
-                _originalLanguage = value;
-            }
+            set => _originalLanguage = LocalizationManager?.FindLanguageInfo(value)?.TwoLetterISOLanguageName ?? value;
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -153,6 +153,12 @@ namespace MediaBrowser.Controller.Entities.TV
             return 16.0 / 9;
         }
 
+        /// <inheritdoc />
+        public override string GetInheritedOriginalLanguage()
+        {
+            return OriginalLanguage ?? Series?.GetInheritedOriginalLanguage();
+        }
+
         public override List<string> GetUserDataKeys()
         {
             var list = base.GetUserDataKeys();

--- a/MediaBrowser.Controller/Entities/TV/Season.cs
+++ b/MediaBrowser.Controller/Entities/TV/Season.cs
@@ -128,6 +128,12 @@ namespace MediaBrowser.Controller.Entities.TV
             return result;
         }
 
+        /// <inheritdoc />
+        public override string GetInheritedOriginalLanguage()
+        {
+            return OriginalLanguage ?? Series?.GetInheritedOriginalLanguage();
+        }
+
         public override string CreatePresentationUniqueKey()
         {
             if (IndexNumber.HasValue)

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -278,6 +278,12 @@ namespace MediaBrowser.Controller.Entities
             return linkedVersionCount + localVersionCount + 1;
         }
 
+        /// <inheritdoc />
+        public override string GetInheritedOriginalLanguage()
+        {
+            return OriginalLanguage ?? GetOwner()?.GetInheritedOriginalLanguage();
+        }
+
         public override List<string> GetUserDataKeys()
         {
             var list = base.GetUserDataKeys();

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -281,6 +281,11 @@ namespace MediaBrowser.Controller.Entities
         /// <inheritdoc />
         public override string GetInheritedOriginalLanguage()
         {
+            if (ExtraType.GetValueOrDefault() == Model.Entities.ExtraType.Trailer)
+            {
+                return GetOwner()?.GetInheritedOriginalLanguage();
+            }
+
             return OriginalLanguage ?? GetOwner()?.GetInheritedOriginalLanguage();
         }
 

--- a/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.cs
@@ -413,7 +413,7 @@ namespace MediaBrowser.Providers.Plugins.Omdb
             }
 
             item.Overview = result.Plot;
-            item.OriginalLanguage = result.Language;
+            item.OriginalLanguage = result.Language?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
 
             if (!Plugin.Instance.Configuration.CastAndCrew)
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Followup to https://github.com/jellyfin/jellyfin/pull/12579. This cleans stuff up so it's easier to use elsewhere in the repo. As @MarcoCoreDuo pointed out in https://github.com/jellyfin/jellyfin/pull/16001, it wasn't really ideal before. 

- Fix the commas in OMDb provider itself.
- Move the parent fallback to GetInheritedOriginalLanguage()
- Normalize OriginalLanguage in the setter.

