### PR TITLE
Update log for user session related concurrency update fails

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -271,9 +271,9 @@ namespace Emby.Server.Implementations.Session
                         user.LastActivityDate = activityDate;
                         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
                     }
-                    catch (DbUpdateConcurrencyException e)
+                    catch (DbUpdateConcurrencyException)
                     {
-                        _logger.LogDebug(e, "Error updating user's last activity date.");
+                        _logger.LogDebug("Error updating user's last activity date due to concurrency conflict. This is an expected event.");
                     }
                 }
             }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
@@ -273,6 +273,11 @@ public class JellyfinDbContext(DbContextOptions<JellyfinDbContext> options, ILog
             }).ConfigureAwait(false);
             return result;
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            // a concurrency exception is supposed to be always handled by the invoker of the method, logging it here is only causing log bloat.
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Error trying to save changes.");


### PR DESCRIPTION
Adapts the logging for that particular event to be less verbose as its an expected event and should not be as verbose as it is
