### PR TITLE
Fix subtitle currentFormat to always use file extention

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -223,8 +223,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 };
             }
 
-            var currentFormat = subtitleStream.Codec ?? Path.GetExtension(subtitleStream.Path)
-                .TrimStart('.');
+            var currentFormat = Path.GetExtension(subtitleStream.Path).TrimStart('.');
 
             // Handle PGS subtitles as raw streams for the client to render
             if (MediaStream.IsPgsFormat(currentFormat))


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**

The original line was this:

https://github.com/jellyfin/jellyfin/blob/c169184e019d224a60fcbb9125b05de607f42799/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L226-L227

The codec and the file extension are often different (like "subrip" vs "srt", and "webvtt" vs "vtt"). That makes `_subtitleParser.SupportsFileExtension` return false here:

https://github.com/jellyfin/jellyfin/blob/c169184e019d224a60fcbb9125b05de607f42799/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs#L242

because it's looking up the codec name (e.g. "webvtt") in a list of file extensions. Then it falls back to using ffmpeg to convert it to SRT before converting to the desired format (which could have been the same format the file was already in). That also makes it lose position data from VTT and ASS files.

I removed `subtitleStream.Codec ??` so it only uses the file extension. At this point in the code, we're only dealing with external subtitles, so `subtitleStream.Path` will always have a value.

#16805 may make this moot, but I have a feeling that may not be ready for the next release. This is a quick and easy fix.