### PR TITLE
ImageProcessor: lock per source image instead of globally on encode

### DIFF
--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -42,6 +42,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
     private readonly IImageEncoder _imageEncoder;
 
     private readonly AsyncNonKeyedLocker _parallelEncodingLimit;
+    private readonly AsyncKeyedLocker<string> _perSourceEncodingLock;
 
     private bool _disposed;
 
@@ -72,6 +73,11 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
         }
 
         _parallelEncodingLimit = new(semaphoreCount);
+        _perSourceEncodingLock = new(o =>
+        {
+            o.PoolSize = 20;
+            o.PoolInitialFill = 1;
+        });
     }
 
     private string ResizedImageCachePath => Path.Combine(_appPaths.ImageCachePath, "resized-images");
@@ -196,17 +202,28 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
         {
             if (!File.Exists(cacheFilePath))
             {
-                string resultPath;
-
-                // Limit number of parallel (more precisely: concurrent) image encodings to prevent a high memory usage
-                using (await _parallelEncodingLimit.LockAsync().ConfigureAwait(false))
+                // Per-source lock lets independent source images encode concurrently
+                // while serializing identical-source work. The outer global semaphore
+                // still caps total parallelism to bound memory.
+                using (await _perSourceEncodingLock.LockAsync(originalImagePath).ConfigureAwait(false))
                 {
-                    resultPath = _imageEncoder.EncodeImage(originalImagePath, dateModified, cacheFilePath, autoOrient, orientation, quality, options, outputFormat);
-                }
+                    // Another waiter on the same source may have produced the same
+                    // cache file while we waited — recheck before encoding.
+                    if (File.Exists(cacheFilePath))
+                    {
+                        return (cacheFilePath, outputFormat.GetMimeType(), _fileSystem.GetLastWriteTimeUtc(cacheFilePath));
+                    }
 
-                if (string.Equals(resultPath, originalImagePath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
+                    string resultPath;
+                    using (await _parallelEncodingLimit.LockAsync().ConfigureAwait(false))
+                    {
+                        resultPath = _imageEncoder.EncodeImage(originalImagePath, dateModified, cacheFilePath, autoOrient, orientation, quality, options, outputFormat);
+                    }
+
+                    if (string.Equals(resultPath, originalImagePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
+                    }
                 }
             }
 
@@ -544,6 +561,7 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
         }
 
         _parallelEncodingLimit?.Dispose();
+        _perSourceEncodingLock?.Dispose();
 
         _disposed = true;
     }


### PR DESCRIPTION
## Changes

`ImageProcessor.ProcessImage` previously guarded the encoder call with
a single process-wide `AsyncNonKeyedLocker` capped at
`Environment.ProcessorCount`. Encoding two completely unrelated source
images was therefore serialized against the same set of slots, even
though the work is fully independent.

This PR introduces a two-layer locking strategy:

1. **Outer `AsyncKeyedLocker<string>`** keyed by `originalImagePath`.
   Two resize requests for _different_ source images can now run in
   parallel without contending; two requests for the _same_ source are
   still serialized. After acquiring the per-source lock, the cache
   file existence is rechecked so that a request that lost the race
   reuses the just-produced output instead of redoing identical work.
2. **Inner `AsyncNonKeyedLocker`** retained with the existing
   semantics — it acts as a global memory-pressure cap on
   simultaneous encoder invocations (the original intent of the
   `ParallelImageEncodingLimit` configuration).

The `AsyncKeyedLock` package is already a dependency (the namespace
is in `ImageProcessor`'s `using` directives and is used across the
codebase, e.g. `ProviderManager._imageSaveLock`,
`TranscodeManager._transcodingLocks`). The pool-size constants
(`PoolSize = 20`, `PoolInitialFill = 1`) match the pattern used
elsewhere.

## Issues

Closes _no specific open issue_, but is a small correctness/contention
improvement to the image-encoding pipeline.

## Type of change

- [x] Refactor (non-breaking change that improves contention behavior)

## How Has This Been Tested?

Builds locally against `master` (net10.0) with zero warnings. Same
codepath was deployed and exercised manually against a running
10.11.6 Docker container; image responses behave identically and no
regressions were observed. The user-visible effect is a contention-
only one — it does not change any cache layout, request handling, or
output bytes.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.