### PR TITLE
Fix VAAPI transcoding failure when only CQP rate control is supported

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1576,8 +1576,55 @@ namespace MediaBrowser.Controller.MediaEncoding
             return ".ts";
         }
 
-        private string GetVideoBitrateParam(EncodingJobInfo state, string videoCodec)
+        private static bool IsVaapiVideoEncoder(string videoCodec)
         {
+            return string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(videoCodec, "hevc_vaapi", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(videoCodec, "av1_vaapi", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int GetVaapiQp(EncodingOptions encodingOptions, string videoCodec)
+        {
+            var defaultQp = string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase) ? 23 : 28;
+            var configuredQp = string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase)
+                ? encodingOptions.H264Crf
+                : encodingOptions.H265Crf;
+
+            return configuredQp is >= 0 and <= 51 ? configuredQp : defaultQp;
+        }
+
+        private string GetVaapiVideoBitrateParam(EncodingJobInfo state, string videoCodec, EncodingOptions encodingOptions)
+        {
+            if (state.OutputVideoBitrate is null)
+            {
+                return string.Empty;
+            }
+
+            var bitrate = state.OutputVideoBitrate.Value;
+            var bufsize = (int)Math.Min((long)bitrate * 2, int.MaxValue);
+
+            // VBR in i965 driver may result in pixelated output.
+            if (_mediaEncoder.IsVaapiDeviceInteli965)
+            {
+                return FormattableString.Invariant($" -rc_mode CBR -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
+            }
+
+            if (!_mediaEncoder.SupportsVaapiRateControlMode(videoCodec, "VBR")
+                && _mediaEncoder.SupportsVaapiRateControlMode(videoCodec, "CQP"))
+            {
+                return FormattableString.Invariant($" -rc_mode CQP -qp {GetVaapiQp(encodingOptions, videoCodec)}");
+            }
+
+            return FormattableString.Invariant($" -rc_mode VBR -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
+        }
+
+        private string GetVideoBitrateParam(EncodingJobInfo state, string videoCodec, EncodingOptions encodingOptions)
+        {
+            if (IsVaapiVideoEncoder(videoCodec))
+            {
+                return GetVaapiVideoBitrateParam(state, videoCodec, encodingOptions);
+            }
+
             if (state.OutputVideoBitrate is null)
             {
                 return string.Empty;
@@ -1649,19 +1696,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 // Override the too high default qmin 18 in transcoding preset in legacy h26x_amf
                 return FormattableString.Invariant($" -rc cbr -qmin 0 -qmax 32 -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
-            }
-
-            if (string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(videoCodec, "hevc_vaapi", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(videoCodec, "av1_vaapi", StringComparison.OrdinalIgnoreCase))
-            {
-                // VBR in i965 driver may result in pixelated output.
-                if (_mediaEncoder.IsVaapiDeviceInteli965)
-                {
-                    return FormattableString.Invariant($" -rc_mode CBR -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
-                }
-
-                return FormattableString.Invariant($" -rc_mode VBR -b:v {bitrate} -maxrate {bitrate} -bufsize {bufsize}");
             }
 
             if (string.Equals(videoCodec, "h264_videotoolbox", StringComparison.OrdinalIgnoreCase)
@@ -2116,7 +2150,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var encodingPreset = encodingOptions.EncoderPreset;
 
             param += GetEncoderParam(encodingPreset, defaultPreset, encodingOptions, videoEncoder, isLibX265);
-            param += GetVideoBitrateParam(state, videoEncoder);
+            param += GetVideoBitrateParam(state, videoEncoder, encodingOptions);
 
             var framerate = GetFramerateParam(state);
             if (framerate.HasValue)

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -89,6 +89,14 @@ namespace MediaBrowser.Controller.MediaEncoding
         bool SupportsEncoder(string encoder);
 
         /// <summary>
+        /// Whether the configured VAAPI device supports a rate control mode for the given encoder.
+        /// </summary>
+        /// <param name="encoder">The VAAPI encoder.</param>
+        /// <param name="rateControlMode">The rate control mode.</param>
+        /// <returns><c>true</c> if the mode is supported, <c>false</c> otherwise.</returns>
+        bool SupportsVaapiRateControlMode(string encoder, string rateControlMode);
+
+        /// <summary>
         /// Whether given decoder codec is supported.
         /// </summary>
         /// <param name="decoder">The decoder.</param>

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -456,6 +456,33 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
         }
 
+        public bool CheckVaapiEncoderRateControlMode(string encoder, string rateControlMode, string renderNodePath)
+        {
+            if (!OperatingSystem.IsLinux())
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(encoder)
+                || string.IsNullOrEmpty(rateControlMode)
+                || string.IsNullOrEmpty(renderNodePath))
+            {
+                return false;
+            }
+
+            var rateControlArgs = string.Equals(rateControlMode, "CQP", StringComparison.OrdinalIgnoreCase)
+                ? "-rc_mode CQP -qp 28"
+                : FormattableString.Invariant($"-rc_mode {rateControlMode} -b:v 1000000 -maxrate 1000000 -bufsize 2000000");
+            var command = string.Format(
+                CultureInfo.InvariantCulture,
+                "-loglevel quiet -hide_banner -init_hw_device vaapi=va:{0} -filter_hw_device va -f lavfi -i testsrc2=s=128x128:r=1:d=1 -vf format=nv12,hwupload -frames:v 1 -an -c:v {1} {2} -f null -",
+                renderNodePath,
+                encoder,
+                rateControlArgs);
+
+            return GetProcessExitCode(_encoderPath, command);
+        }
+
         [SupportedOSPlatform("macos")]
         public bool CheckIsVideoToolboxAv1DecodeAvailable()
         {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -72,6 +72,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private List<string> _decoders = new List<string>();
         private List<string> _hwaccels = new List<string>();
         private List<string> _filters = new List<string>();
+        private Dictionary<string, HashSet<string>> _vaapiRateControlModes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         private IDictionary<FilterOptionType, bool> _filtersWithOption = new Dictionary<FilterOptionType, bool>();
         private IDictionary<BitStreamFilterOptionType, bool> _bitStreamFiltersWithOption = new Dictionary<BitStreamFilterOptionType, bool>();
 
@@ -98,6 +99,19 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "VK_EXT_external_memory_dma_buf",
             "VK_KHR_external_semaphore_fd",
             "VK_EXT_external_memory_host"
+        };
+
+        private static string[] _vaapiVideoEncoders =
+        {
+            "h264_vaapi",
+            "hevc_vaapi",
+            "av1_vaapi"
+        };
+
+        private static string[] _vaapiRateControlModesToProbe =
+        {
+            "VBR",
+            "CQP"
         };
 
         private Version _ffmpegVersion = null;
@@ -233,6 +247,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _isPkeyPauseSupported = validator.CheckSupportedRuntimeKey("p      pause transcoding", _ffmpegVersion);
                 _isLowPriorityHwDecodeSupported = validator.CheckSupportedHwaccelFlag("low_priority");
                 _proberSupportsFirstVideoFrame = validator.CheckSupportedProberOption("only_first_vframe", _ffprobePath);
+                _vaapiRateControlModes.Clear();
 
                 // Check the Vaapi device vendor
                 if (OperatingSystem.IsLinux()
@@ -245,6 +260,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     _isVaapiDeviceInteli965 = validator.CheckVaapiDeviceByDriverName("Intel i965 driver", options.VaapiDevice);
                     _isVaapiDeviceSupportVulkanDrmModifier = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanImageDrmFmtModifierExts);
                     _isVaapiDeviceSupportVulkanDrmInterop = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanExternalMemoryDmaBufExts);
+                    SetAvailableVaapiRateControlModes(validator, options.VaapiDevice);
 
                     if (_isVaapiDeviceAmd)
                     {
@@ -363,6 +379,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         /// <inheritdoc />
+        public bool SupportsVaapiRateControlMode(string encoder, string rateControlMode)
+        {
+            return _vaapiRateControlModes.TryGetValue(encoder, out var rateControlModes)
+                   && rateControlModes.Contains(rateControlMode);
+        }
+
+        /// <inheritdoc />
         public bool SupportsDecoder(string decoder)
         {
             return _decoders.Contains(decoder, StringComparer.OrdinalIgnoreCase);
@@ -389,6 +412,32 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public bool SupportsBitStreamFilterWithOption(BitStreamFilterOptionType option)
         {
             return _bitStreamFiltersWithOption.TryGetValue(option, out var val) && val;
+        }
+
+        private void SetAvailableVaapiRateControlModes(EncoderValidator validator, string renderNodePath)
+        {
+            foreach (var encoder in _vaapiVideoEncoders)
+            {
+                if (!SupportsEncoder(encoder))
+                {
+                    continue;
+                }
+
+                var rateControlModes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var rateControlMode in _vaapiRateControlModesToProbe)
+                {
+                    if (validator.CheckVaapiEncoderRateControlMode(encoder, rateControlMode, renderNodePath))
+                    {
+                        rateControlModes.Add(rateControlMode);
+                    }
+                }
+
+                if (rateControlModes.Count > 0)
+                {
+                    _vaapiRateControlModes[encoder] = rateControlModes;
+                    _logger.LogInformation("VAAPI encoder {Encoder} supports rate control modes: {RateControlModes}", encoder, rateControlModes);
+                }
+            }
         }
 
         public bool CanEncodeToAudioCodec(string codec)

--- a/tests/Jellyfin.Controller.Tests/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/EncodingHelperTests.cs
@@ -1,0 +1,139 @@
+using System;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+using IConfigurationManager = MediaBrowser.Common.Configuration.IConfigurationManager;
+
+namespace Jellyfin.Controller.Tests;
+
+public class EncodingHelperTests
+{
+    [Fact]
+    public void GetVideoQualityParam_VaapiEncoder_WithVbrSupport_KeepsVbrRateControl()
+    {
+        var encodingHelper = CreateEncodingHelper(mediaEncoder =>
+        {
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode("hevc_vaapi", "VBR")).Returns(true);
+        });
+        var state = CreateState("hevc");
+
+        var result = encodingHelper.GetVideoQualityParam(state, "hevc_vaapi", new EncodingOptions(), EncoderPreset.superfast);
+
+        Assert.Contains(" -rc_mode VBR -b:v 5616000 -maxrate 5616000 -bufsize 11232000", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("CQP", result, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("h264_vaapi", "h264", 23)]
+    [InlineData("hevc_vaapi", "hevc", 28)]
+    [InlineData("av1_vaapi", "av1", 28)]
+    public void GetVideoQualityParam_VaapiEncoder_WithCqpOnlySupport_UsesCqpRateControl(string videoEncoder, string outputCodec, int expectedQp)
+    {
+        var encodingHelper = CreateEncodingHelper(mediaEncoder =>
+        {
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode(videoEncoder, "VBR")).Returns(false);
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode(videoEncoder, "CQP")).Returns(true);
+        });
+        var state = CreateState(outputCodec);
+
+        var result = encodingHelper.GetVideoQualityParam(state, videoEncoder, new EncodingOptions(), EncoderPreset.superfast);
+
+        Assert.Contains($" -rc_mode CQP -qp {expectedQp}", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("CBR", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("VBR", result, StringComparison.Ordinal);
+        Assert.DoesNotContain(" -b:v ", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("maxrate", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("bufsize", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetVideoQualityParam_VaapiEncoder_WithInteli965_KeepsCbrRateControl()
+    {
+        var encodingHelper = CreateEncodingHelper(mediaEncoder =>
+        {
+            mediaEncoder.Setup(encoder => encoder.IsVaapiDeviceInteli965).Returns(true);
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode("h264_vaapi", "VBR")).Returns(false);
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode("h264_vaapi", "CQP")).Returns(true);
+        });
+        var state = CreateState("h264");
+
+        var result = encodingHelper.GetVideoQualityParam(state, "h264_vaapi", new EncodingOptions(), EncoderPreset.superfast);
+
+        Assert.Contains(" -rc_mode CBR -b:v 5616000 -maxrate 5616000 -bufsize 11232000", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("CQP", result, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("h264_vaapi", "h264", 99, 28, 23)]
+    [InlineData("hevc_vaapi", "hevc", 23, -1, 28)]
+    [InlineData("av1_vaapi", "av1", 23, 52, 28)]
+    public void GetVideoQualityParam_VaapiEncoder_InvalidConfiguredQp_UsesDefault(
+        string videoEncoder,
+        string outputCodec,
+        int h264Crf,
+        int h265Crf,
+        int expectedQp)
+    {
+        var encodingHelper = CreateEncodingHelper(mediaEncoder =>
+        {
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode(videoEncoder, "VBR")).Returns(false);
+            mediaEncoder.Setup(encoder => encoder.SupportsVaapiRateControlMode(videoEncoder, "CQP")).Returns(true);
+        });
+        var state = CreateState(outputCodec);
+        var encodingOptions = new EncodingOptions
+        {
+            H264Crf = h264Crf,
+            H265Crf = h265Crf
+        };
+
+        var result = encodingHelper.GetVideoQualityParam(state, videoEncoder, encodingOptions, EncoderPreset.superfast);
+
+        Assert.Contains($" -rc_mode CQP -qp {expectedQp}", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetVideoQualityParam_NonVaapiEncoder_KeepsBitrateControl()
+    {
+        var encodingHelper = CreateEncodingHelper();
+        var state = CreateState("h264");
+
+        var result = encodingHelper.GetVideoQualityParam(state, "libx264", new EncodingOptions(), EncoderPreset.superfast);
+
+        Assert.Contains(" -maxrate 5616000 -bufsize 11232000", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("rc_mode", result, StringComparison.Ordinal);
+    }
+
+    private static EncodingHelper CreateEncodingHelper(Action<Mock<IMediaEncoder>>? configureMediaEncoder = null)
+    {
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder.Setup(encoder => encoder.EncoderVersion).Returns(new Version(5, 0));
+        configureMediaEncoder?.Invoke(mediaEncoder);
+
+        return new EncodingHelper(
+            Mock.Of<IApplicationPaths>(),
+            mediaEncoder.Object,
+            Mock.Of<ISubtitleEncoder>(),
+            Mock.Of<IConfiguration>(),
+            Mock.Of<IConfigurationManager>(),
+            Mock.Of<IPathManager>());
+    }
+
+    private static EncodingJobInfo CreateState(string outputVideoCodec)
+    {
+        return new EncodingJobInfo(TranscodingJobType.Progressive)
+        {
+            BaseRequest = new BaseEncodingJobOptions(),
+            OutputVideoBitrate = 5616000,
+            OutputVideoCodec = outputVideoCodec,
+            VideoStream = new MediaStream
+            {
+                Codec = outputVideoCodec
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Changes**

This fixes a VAAPI hardware transcoding failure when the selected VAAPI encoder cannot use Jellyfin's default VBR rate control.

Some VAAPI drivers report only CQP support. Before this change, Jellyfin could still generate commands like `-rc_mode VBR`, which makes FFmpeg fail before writing any video frames:

```text
Driver does not support VBR RC mode (supported modes: CQP).
Error while opening encoder
Conversion failed!
```

The fix keeps the existing VAAPI VBR path when VBR is supported. When probing shows that VBR is unavailable but CQP works, Jellyfin now falls back to CQP and omits the bitrate-control arguments that do not belong with CQP (`-b:v`, `-maxrate`, and `-bufsize`).

This is intentionally limited to VAAPI rate-control selection. It does not change QSV, NVENC, AMF, decoding behavior, or add a new user-facing setting.

**Issues**

Relates to #11282.

**Testing**

- `dotnet test tests/Jellyfin.Controller.Tests/Jellyfin.Controller.Tests.csproj --configuration Release`
- `dotnet test tests/Jellyfin.MediaEncoding.Tests/Jellyfin.MediaEncoding.Tests.csproj --configuration Release`

I could not complete a local full-solution build because this checkout currently fails earlier with `CS9057`: `Jellyfin.CodeAnalysis` references compiler `5.3.0.0`, while the local compiler is `5.0.0.0`.
