### PR TITLE
Update log for user session related concurrency update fails

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -271,9 +271,9 @@ namespace Emby.Server.Implementations.Session
                         user.LastActivityDate = activityDate;
                         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
                     }
-                    catch (DbUpdateConcurrencyException e)
+                    catch (DbUpdateConcurrencyException)
                     {
-                        _logger.LogDebug(e, "Error updating user's last activity date.");
+                        _logger.LogDebug("Error updating user's last activity date due to concurrency conflict. This is an expected event.");
                     }
                 }
             }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
@@ -268,6 +268,11 @@ public class JellyfinDbContext(DbContextOptions<JellyfinDbContext> options, ILog
             }).ConfigureAwait(false);
             return result;
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            // a concurrency exception is supposed to be always handled by the invoker of the method, logging it here is only causing log bloat.
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Error trying to save changes.");
@@ -288,6 +293,11 @@ public class JellyfinDbContext(DbContextOptions<JellyfinDbContext> options, ILog
                 result = base.SaveChanges(acceptAllChangesOnSuccess);
             });
             return result;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // a concurrency exception is supposed to be always handled by the invoker of the method, logging it here is only causing log bloat.
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
@@ -294,6 +294,11 @@ public class JellyfinDbContext(DbContextOptions<JellyfinDbContext> options, ILog
             });
             return result;
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            // a concurrency exception is supposed to be always handled by the invoker of the method, logging it here is only causing log bloat.
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Error trying to save changes.");

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinDbContext.cs
@@ -294,11 +294,6 @@ public class JellyfinDbContext(DbContextOptions<JellyfinDbContext> options, ILog
             });
             return result;
         }
-        catch (DbUpdateConcurrencyException)
-        {
-            // a concurrency exception is supposed to be always handled by the invoker of the method, logging it here is only causing log bloat.
-            throw;
-        }
         catch (Exception e)
         {
             logger.LogError(e, "Error trying to save changes.");


### PR DESCRIPTION
backport of: https://github.com/jellyfin/jellyfin/pull/16835

Added additional change missed by the o.g fix.


Only backport https://github.com/jellyfin/jellyfin/pull/16845/changes/5f3189af41f951c530c99a8e59249850add3f693