### PR TITLE
Allow all URLs in .strm files except file://

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -273,11 +273,10 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             // Only allow remote URLs in .strm files to prevent local file access
+            //   - check for a valid URI
+            //   - the URI scheme must not be 'file'
             if (Uri.TryCreate(shortcutPath, UriKind.Absolute, out var uri)
-                && (string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(uri.Scheme, "rtsp", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(uri.Scheme, "rtp", StringComparison.OrdinalIgnoreCase)))
+                && !string.Equals(uri.Scheme, "file", StringComparison.OrdinalIgnoreCase))
             {
                 item.ShortcutPath = shortcutPath;
             }


### PR DESCRIPTION
Hello,

with commit 8cecf53057b112a5b169d04e3994d1fb233e22f3 local file access with .strm files was disabled. Only

- http
- https
- rtsp
- rtp

are allowed now. But there are more remote file locations, e.g. `ftp://`, `s3://`, etc. Or custom URI schemes like `custom-app://`.

This PR addresses this issue and only `file://` URI schemes get blocked.

If the strm file contains an absolute file path `/path/to/file`, the `Uri.TryCreate` method automatically transforms it to `file:///path/to/file`, which will be blocked. Relative paths will also be blocked, because the  `Uri.TryCreate` will return false in that case.