### PR TITLE
Set max rating for splashscreen to 13

### DIFF
--- a/Emby.Server.Implementations/Library/SplashscreenPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/SplashscreenPostScanTask.cs
@@ -80,7 +80,7 @@ public class SplashscreenPostScanTask : ILibraryPostScanTask
             ImageTypes = [imageType],
             Limit = 30,
             // TODO max parental rating configurable
-            MaxParentalRating = new(10, null),
+            MaxParentalRating = new(13, null),
             OrderBy =
             [
                 (ItemSortBy.Random, SortOrder.Ascending)


### PR DESCRIPTION
**Changes**
Set max rating for splashscreen to 13. This correlates to the PG-13 rating we use in webUI for backdrops: 
https://github.com/jellyfin/jellyfin-web/blob/a9f6c0aad91362f29263a55afb84cba09b4781da/src/scripts/autoBackdrops.js#L34


**Issues**
Fixes: #16469
