### PR TITLE
Fix movie recommendations

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3389,6 +3389,12 @@ namespace Emby.Server.Implementations.Library
             return _peopleRepository.GetPeopleNames(query);
         }
 
+        /// <inheritdoc/>
+        public IReadOnlyList<string> GetPeopleNamesByItems(IReadOnlyList<Guid> itemIds, IReadOnlyList<string> personTypes, int limit)
+        {
+            return _peopleRepository.GetPeopleNamesByItems(itemIds, personTypes, limit);
+        }
+
         public void UpdatePeople(BaseItem item, List<PersonInfo> people)
         {
             UpdatePeopleAsync(item, people, CancellationToken.None).GetAwaiter().GetResult();

--- a/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
@@ -1,36 +1,65 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
-using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore;
+using BaseItemDto = MediaBrowser.Controller.Entities.BaseItem;
 
 namespace Emby.Server.Implementations.Library.SimilarItems;
 
 /// <summary>
-/// Provides similar items for movies and trailers.
+/// Provides similar items for movies and trailers using weighted scoring.
 /// </summary>
-public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie>, ILocalSimilarItemsProvider<Trailer>
+public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie>, ILocalSimilarItemsProvider<Trailer>, IBatchLocalSimilarItemsProvider
 {
-    private readonly ILibraryManager _libraryManager;
+    private const int GenreWeight = 10;
+    private const int TagWeight = 5;
+    private const int StudioWeight = 5;
+    private const int DirectorWeight = 50;
+    private const int ActorWeight = 15;
+
+    private static readonly (ItemValueType Type, int Weight)[] _itemValueDimensions =
+    [
+        (ItemValueType.Genre, GenreWeight),
+        (ItemValueType.Tags, TagWeight),
+        (ItemValueType.Studios, StudioWeight)
+    ];
+
+    private static readonly (string[] PersonTypes, int Weight)[] _peopleDimensions =
+    [
+        ([nameof(PersonKind.Director)], DirectorWeight),
+        ([nameof(PersonKind.Actor), nameof(PersonKind.GuestStar)], ActorWeight)
+    ];
+
+    private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
+    private readonly IItemQueryHelpers _queryHelpers;
     private readonly IServerConfigurationManager _serverConfigurationManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MovieSimilarItemsProvider"/> class.
     /// </summary>
-    /// <param name="libraryManager">The library manager.</param>
+    /// <param name="dbProvider">The database context factory.</param>
+    /// <param name="queryHelpers">The shared query helpers.</param>
     /// <param name="serverConfigurationManager">The server configuration manager.</param>
     public MovieSimilarItemsProvider(
-        ILibraryManager libraryManager,
+        IDbContextFactory<JellyfinDbContext> dbProvider,
+        IItemQueryHelpers queryHelpers,
         IServerConfigurationManager serverConfigurationManager)
     {
-        _libraryManager = libraryManager;
+        _dbProvider = dbProvider;
+        _queryHelpers = queryHelpers;
         _serverConfigurationManager = serverConfigurationManager;
     }
 
@@ -41,15 +70,17 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
     public MetadataPluginType Type => MetadataPluginType.LocalSimilarityProvider;
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(Movie item, SimilarItemsQuery query, CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<BaseItemDto>> GetSimilarItemsAsync(Movie item, SimilarItemsQuery query, CancellationToken cancellationToken)
     {
-        return Task.FromResult(GetSimilarMovieItems(item, query));
+        var results = await GetBatchSimilarItemsAsync([item], query).ConfigureAwait(false);
+        return results.TryGetValue(item.Id, out var items) ? items : [];
     }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<BaseItem>> GetSimilarItemsAsync(Trailer item, SimilarItemsQuery query, CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<BaseItemDto>> GetSimilarItemsAsync(Trailer item, SimilarItemsQuery query, CancellationToken cancellationToken)
     {
-        return Task.FromResult(GetSimilarMovieItems(item, query));
+        var results = await GetBatchSimilarItemsAsync([item], query).ConfigureAwait(false);
+        return results.TryGetValue(item.Id, out var items) ? items : [];
     }
 
     bool ILocalSimilarItemsProvider.Supports(Type itemType)
@@ -63,29 +94,230 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
             _ => throw new ArgumentException($"Unsupported item type {item.GetType()}", nameof(item))
         };
 
-    private IReadOnlyList<BaseItem> GetSimilarMovieItems(BaseItem item, SimilarItemsQuery query)
+    /// <inheritdoc/>
+    public Task<Dictionary<Guid, IReadOnlyList<BaseItemDto>>> GetBatchSimilarItemsAsync(
+        IReadOnlyList<BaseItemDto> sourceItems,
+        SimilarItemsQuery query)
     {
         var includeItemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-
         if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
         {
             includeItemTypes.Add(BaseItemKind.Trailer);
             includeItemTypes.Add(BaseItemKind.LiveTvProgram);
         }
 
-        var internalQuery = new InternalItemsQuery(query.User)
+        var limit = query.Limit ?? 50;
+        var dtoOptions = query.DtoOptions ?? new DtoOptions();
+
+        using var context = _dbProvider.CreateDbContext();
+
+        // Phase 1: Score all candidates per source item
+        var sourceIds = sourceItems.Select(i => i.Id).ToList();
+        var perSourceScores = ComputeBatchScores(sourceIds, context);
+
+        var allCandidateIds = new HashSet<Guid>();
+        foreach (var (_, scores) in perSourceScores)
         {
-            Genres = item.Genres,
-            Tags = item.Tags,
-            Limit = query.Limit,
-            DtoOptions = query.DtoOptions ?? new DtoOptions(),
-            ExcludeItemIds = [.. query.ExcludeItemIds],
+            allCandidateIds.UnionWith(
+                scores.OrderByDescending(kvp => kvp.Value)
+                    .Take(limit * 3)
+                    .Select(kvp => kvp.Key));
+        }
+
+        var result = new Dictionary<Guid, IReadOnlyList<BaseItemDto>>();
+        if (allCandidateIds.Count == 0)
+        {
+            return Task.FromResult(result);
+        }
+
+        // Phase 2: One access filter for all candidates
+        var filter = new InternalItemsQuery(query.User)
+        {
             IncludeItemTypes = [.. includeItemTypes],
+            ExcludeItemIds = [.. query.ExcludeItemIds],
+            DtoOptions = dtoOptions,
             EnableGroupByMetadataKey = true,
             EnableTotalRecordCount = false,
-            OrderBy = [(ItemSortBy.Random, SortOrder.Ascending)]
+            IsMovie = true,
+            IsPlayed = false
         };
 
-        return _libraryManager.GetItemList(internalQuery);
+        _queryHelpers.PrepareFilterQuery(filter);
+        var baseQuery = _queryHelpers.PrepareItemQuery(context, filter);
+        baseQuery = _queryHelpers.TranslateQuery(baseQuery, context, filter);
+
+        var allCandidateIdsList = allCandidateIds.ToList();
+        var accessibleItems = baseQuery
+            .Where(e => allCandidateIdsList.Contains(e.Id))
+            .Select(e => new { e.Id, e.PresentationUniqueKey })
+            .ToList();
+
+        // Phase 3: Pick top IDs per source, dedup by PresentationUniqueKey
+        var allOrderedIds = new HashSet<Guid>();
+        var perSourceOrderedIds = new Dictionary<Guid, List<Guid>>();
+
+        foreach (var item in sourceItems)
+        {
+            if (!perSourceScores.TryGetValue(item.Id, out var scores))
+            {
+                continue;
+            }
+
+            var orderedIds = accessibleItems
+                .Where(x => scores.ContainsKey(x.Id))
+                .OrderByDescending(x => scores.GetValueOrDefault(x.Id))
+                .DistinctBy(x => x.PresentationUniqueKey)
+                .Take(limit)
+                .Select(x => x.Id)
+                .ToList();
+
+            if (orderedIds.Count > 0)
+            {
+                perSourceOrderedIds[item.Id] = orderedIds;
+                allOrderedIds.UnionWith(orderedIds);
+            }
+        }
+
+        if (allOrderedIds.Count == 0)
+        {
+            return Task.FromResult(result);
+        }
+
+        // Phase 4: One entity load for all results
+        var allOrderedIdsList = allOrderedIds.ToList();
+        var entitiesById = _queryHelpers.ApplyNavigations(
+                context.BaseItems.AsNoTracking().Where(e => allOrderedIdsList.Contains(e.Id)),
+                filter)
+            .AsSplitQuery()
+            .AsEnumerable()
+            .Select(e => _queryHelpers.DeserializeBaseItem(e, filter.SkipDeserialization))
+            .Where(dto => dto is not null)
+            .ToDictionary(i => i!.Id);
+
+        // Phase 5: Split by source, preserving score order
+        foreach (var (sourceId, orderedIds) in perSourceOrderedIds)
+        {
+            var items = orderedIds
+                .Where(entitiesById.ContainsKey)
+                .Select(id => entitiesById[id]!)
+                .ToList();
+
+            if (items.Count > 0)
+            {
+                result[sourceId] = items;
+            }
+        }
+
+        return Task.FromResult(result);
+    }
+
+    private Dictionary<Guid, Dictionary<Guid, int>> ComputeBatchScores(List<Guid> sourceIds, JellyfinDbContext context)
+    {
+        var result = new Dictionary<Guid, Dictionary<Guid, int>>();
+        foreach (var id in sourceIds)
+        {
+            result[id] = [];
+        }
+
+        // Score item-value dimensions (genre, tags, studios)
+        foreach (var (valueType, weight) in _itemValueDimensions)
+        {
+            var sourceMap = context.ItemValuesMap.AsNoTracking()
+                .Where(m => sourceIds.Contains(m.ItemId) && m.ItemValue.Type == valueType)
+                .Select(m => new { m.ItemId, m.ItemValue.CleanValue })
+                .ToList()
+                .GroupBy(m => m.ItemId)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.CleanValue).ToHashSet());
+
+            var allValues = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
+            if (allValues.Count == 0)
+            {
+                continue;
+            }
+
+            var valueToCandidates = context.ItemValuesMap.AsNoTracking()
+                .Where(m => m.ItemValue.Type == valueType && allValues.Contains(m.ItemValue.CleanValue))
+                .Select(m => new { m.ItemId, m.ItemValue.CleanValue })
+                .ToList()
+                .GroupBy(m => m.CleanValue)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+
+            foreach (var sourceId in sourceIds)
+            {
+                if (!sourceMap.TryGetValue(sourceId, out var sourceValues))
+                {
+                    continue;
+                }
+
+                var scoreMap = result[sourceId];
+                foreach (var value in sourceValues)
+                {
+                    if (valueToCandidates.TryGetValue(value, out var candidates))
+                    {
+                        foreach (var candidateId in candidates)
+                        {
+                            scoreMap[candidateId] = scoreMap.GetValueOrDefault(candidateId) + weight;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Score people dimensions (directors, actors)
+        foreach (var (personTypes, weight) in _peopleDimensions)
+        {
+            var sourceMap = context.PeopleBaseItemMap.AsNoTracking()
+                .Where(m => sourceIds.Contains(m.ItemId) && personTypes.Contains(m.People.PersonType))
+                .Select(m => new { m.ItemId, m.PeopleId })
+                .ToList()
+                .GroupBy(m => m.ItemId)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.PeopleId).ToHashSet());
+
+            var allPeopleIds = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
+            if (allPeopleIds.Count == 0)
+            {
+                continue;
+            }
+
+            var personToCandidates = context.PeopleBaseItemMap.AsNoTracking()
+                .Where(m => allPeopleIds.Contains(m.PeopleId))
+                .Select(m => new { m.ItemId, m.PeopleId })
+                .ToList()
+                .GroupBy(m => m.PeopleId)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+
+            foreach (var sourceId in sourceIds)
+            {
+                if (!sourceMap.TryGetValue(sourceId, out var sourcePeopleIds))
+                {
+                    continue;
+                }
+
+                var scoreMap = result[sourceId];
+                foreach (var peopleId in sourcePeopleIds)
+                {
+                    if (personToCandidates.TryGetValue(peopleId, out var candidates))
+                    {
+                        foreach (var candidateId in candidates)
+                        {
+                            scoreMap[candidateId] = scoreMap.GetValueOrDefault(candidateId) + weight;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove self-references and empty entries
+        foreach (var sourceId in sourceIds)
+        {
+            var scoreMap = result[sourceId];
+            scoreMap.Remove(sourceId);
+            if (scoreMap.Count == 0)
+            {
+                result.Remove(sourceId);
+            }
+        }
+
+        return result;
     }
 }

--- a/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
@@ -188,7 +188,6 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
         var entitiesById = _queryHelpers.ApplyNavigations(
                 context.BaseItems.AsNoTracking().Where(e => allOrderedIdsList.Contains(e.Id)),
                 filter)
-            .AsSplitQuery()
             .AsEnumerable()
             .Select(e => _queryHelpers.DeserializeBaseItem(e, filter.SkipDeserialization))
             .Where(dto => dto is not null)

--- a/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
@@ -41,11 +41,14 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
         (ItemValueType.Studios, StudioWeight)
     ];
 
-    private static readonly (string[] PersonTypes, int Weight)[] _peopleDimensions =
-    [
-        ([nameof(PersonKind.Director)], DirectorWeight),
-        ([nameof(PersonKind.Actor), nameof(PersonKind.GuestStar)], ActorWeight)
-    ];
+    private static readonly Dictionary<string, int> _personTypeWeights = new(StringComparer.Ordinal)
+    {
+        [nameof(PersonKind.Director)] = DirectorWeight,
+        [nameof(PersonKind.Actor)] = ActorWeight,
+        [nameof(PersonKind.GuestStar)] = ActorWeight,
+    };
+
+    private static readonly string[] _scoredPersonTypes = [.. _personTypeWeights.Keys];
 
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
     private readonly IItemQueryHelpers _queryHelpers;
@@ -194,8 +197,7 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
                 return result;
             }
 
-            // Phase 4: One entity load for all results. AsSplitQuery avoids a SQL Cartesian
-            // product across the multiple collection Includes added by ApplyNavigations.
+            // Phase 4: One entity load for all results
             var allOrderedIdsList = allOrderedIds.ToList();
             var entities = await _queryHelpers.ApplyNavigations(
                     context.BaseItems.AsNoTracking().WhereOneOrMany(allOrderedIdsList, e => e.Id),
@@ -257,27 +259,31 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
             ApplyDimensionScores(sourceIds, sourceMap, keyToCandidates, weight, result);
         }
 
-        foreach (var (personTypes, weight) in _peopleDimensions)
+        var personSourceRows = await context.PeopleBaseItemMap.AsNoTracking()
+            .Where(m => sourceIds.Contains(m.ItemId) && _scoredPersonTypes.Contains(m.People.PersonType))
+            .Select(m => new { m.ItemId, m.PeopleId, m.People.PersonType })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        if (personSourceRows.Count > 0)
         {
-            var sourceRows = await context.PeopleBaseItemMap.AsNoTracking()
-                .Where(m => sourceIds.Contains(m.ItemId) && personTypes.Contains(m.People.PersonType))
-                .Select(m => new { m.ItemId, Key = m.PeopleId })
+            var allPersonIds = personSourceRows.Select(r => r.PeopleId).Distinct().ToList();
+
+            var personCandidateRows = await context.PeopleBaseItemMap.AsNoTracking()
+                .Where(m => allPersonIds.Contains(m.PeopleId))
+                .Select(m => new { m.ItemId, m.PeopleId })
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            var sourceMap = sourceRows.GroupBy(r => r.ItemId).ToDictionary(g => g.Key, g => g.Select(x => x.Key).ToHashSet());
-            var allKeys = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
-            if (allKeys.Count == 0)
+            var personToCandidates = personCandidateRows
+                .GroupBy(r => r.PeopleId)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+
+            foreach (var weightGroup in personSourceRows.GroupBy(r => _personTypeWeights[r.PersonType!]))
             {
-                continue;
+                var sourceMap = weightGroup
+                    .GroupBy(r => r.ItemId)
+                    .ToDictionary(g => g.Key, g => g.Select(x => x.PeopleId).ToHashSet());
+                ApplyDimensionScores(sourceIds, sourceMap, personToCandidates, weightGroup.Key, result);
             }
-
-            var candidateRows = await context.PeopleBaseItemMap.AsNoTracking()
-                .Where(m => allKeys.Contains(m.PeopleId))
-                .Select(m => new { m.ItemId, Key = m.PeopleId })
-                .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-            var keyToCandidates = candidateRows.GroupBy(r => r.Key).ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
-            ApplyDimensionScores(sourceIds, sourceMap, keyToCandidates, weight, result);
         }
 
         foreach (var sourceId in sourceIds)

--- a/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
@@ -30,6 +30,10 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
     private const int DirectorWeight = 50;
     private const int ActorWeight = 15;
 
+    // Caps the batch fan-out so downstream IN-list sizes (per-source scores, accessible-id
+    // load, navigation includes) stay bounded regardless of caller input.
+    private const int MaxBatchSourceItems = 64;
+
     private static readonly (ItemValueType Type, int Weight)[] _itemValueDimensions =
     [
         (ItemValueType.Genre, GenreWeight),
@@ -72,14 +76,14 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
     /// <inheritdoc/>
     public async Task<IReadOnlyList<BaseItemDto>> GetSimilarItemsAsync(Movie item, SimilarItemsQuery query, CancellationToken cancellationToken)
     {
-        var results = await GetBatchSimilarItemsAsync([item], query).ConfigureAwait(false);
+        var results = await GetBatchSimilarItemsAsync([item], query, cancellationToken).ConfigureAwait(false);
         return results.TryGetValue(item.Id, out var items) ? items : [];
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<BaseItemDto>> GetSimilarItemsAsync(Trailer item, SimilarItemsQuery query, CancellationToken cancellationToken)
     {
-        var results = await GetBatchSimilarItemsAsync([item], query).ConfigureAwait(false);
+        var results = await GetBatchSimilarItemsAsync([item], query, cancellationToken).ConfigureAwait(false);
         return results.TryGetValue(item.Id, out var items) ? items : [];
     }
 
@@ -95,9 +99,10 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
         };
 
     /// <inheritdoc/>
-    public Task<Dictionary<Guid, IReadOnlyList<BaseItemDto>>> GetBatchSimilarItemsAsync(
+    public async Task<Dictionary<Guid, IReadOnlyList<BaseItemDto>>> GetBatchSimilarItemsAsync(
         IReadOnlyList<BaseItemDto> sourceItems,
-        SimilarItemsQuery query)
+        SimilarItemsQuery query,
+        CancellationToken cancellationToken)
     {
         var includeItemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
         if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
@@ -109,108 +114,119 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
         var limit = query.Limit ?? 50;
         var dtoOptions = query.DtoOptions ?? new DtoOptions();
 
-        using var context = _dbProvider.CreateDbContext();
-
-        // Phase 1: Score all candidates per source item
-        var sourceIds = sourceItems.Select(i => i.Id).ToList();
-        var perSourceScores = ComputeBatchScores(sourceIds, context);
-
-        var allCandidateIds = new HashSet<Guid>();
-        foreach (var (_, scores) in perSourceScores)
+        if (sourceItems.Count > MaxBatchSourceItems)
         {
-            allCandidateIds.UnionWith(
-                scores.OrderByDescending(kvp => kvp.Value)
-                    .Take(limit * 3)
-                    .Select(kvp => kvp.Key));
+            sourceItems = sourceItems.Take(MaxBatchSourceItems).ToList();
         }
 
-        var result = new Dictionary<Guid, IReadOnlyList<BaseItemDto>>();
-        if (allCandidateIds.Count == 0)
+        var context = await _dbProvider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (context.ConfigureAwait(false))
         {
-            return Task.FromResult(result);
-        }
+            // Phase 1: Score all candidates per source item
+            var sourceIds = sourceItems.Select(i => i.Id).ToList();
+            var perSourceScores = await ComputeBatchScoresAsync(sourceIds, context, cancellationToken).ConfigureAwait(false);
 
-        // Phase 2: One access filter for all candidates
-        var filter = new InternalItemsQuery(query.User)
-        {
-            IncludeItemTypes = [.. includeItemTypes],
-            ExcludeItemIds = [.. query.ExcludeItemIds],
-            DtoOptions = dtoOptions,
-            EnableGroupByMetadataKey = true,
-            EnableTotalRecordCount = false,
-            IsMovie = true,
-            IsPlayed = false
-        };
-
-        _queryHelpers.PrepareFilterQuery(filter);
-        var baseQuery = _queryHelpers.PrepareItemQuery(context, filter);
-        baseQuery = _queryHelpers.TranslateQuery(baseQuery, context, filter);
-
-        var allCandidateIdsList = allCandidateIds.ToList();
-        var accessibleItems = baseQuery
-            .Where(e => allCandidateIdsList.Contains(e.Id))
-            .Select(e => new { e.Id, e.PresentationUniqueKey })
-            .ToList();
-
-        // Phase 3: Pick top IDs per source, dedup by PresentationUniqueKey
-        var allOrderedIds = new HashSet<Guid>();
-        var perSourceOrderedIds = new Dictionary<Guid, List<Guid>>();
-
-        foreach (var item in sourceItems)
-        {
-            if (!perSourceScores.TryGetValue(item.Id, out var scores))
+            var allCandidateIds = new HashSet<Guid>();
+            foreach (var (_, scores) in perSourceScores)
             {
-                continue;
+                allCandidateIds.UnionWith(
+                    scores.OrderByDescending(kvp => kvp.Value)
+                        .Take(limit * 3)
+                        .Select(kvp => kvp.Key));
             }
 
-            var orderedIds = accessibleItems
-                .Where(x => scores.ContainsKey(x.Id))
-                .OrderByDescending(x => scores.GetValueOrDefault(x.Id))
-                .DistinctBy(x => x.PresentationUniqueKey)
-                .Take(limit)
-                .Select(x => x.Id)
-                .ToList();
-
-            if (orderedIds.Count > 0)
+            var result = new Dictionary<Guid, IReadOnlyList<BaseItemDto>>();
+            if (allCandidateIds.Count == 0)
             {
-                perSourceOrderedIds[item.Id] = orderedIds;
-                allOrderedIds.UnionWith(orderedIds);
+                return result;
             }
-        }
 
-        if (allOrderedIds.Count == 0)
-        {
-            return Task.FromResult(result);
-        }
-
-        // Phase 4: One entity load for all results
-        var allOrderedIdsList = allOrderedIds.ToList();
-        var entitiesById = _queryHelpers.ApplyNavigations(
-                context.BaseItems.AsNoTracking().Where(e => allOrderedIdsList.Contains(e.Id)),
-                filter)
-            .AsEnumerable()
-            .Select(e => _queryHelpers.DeserializeBaseItem(e, filter.SkipDeserialization))
-            .Where(dto => dto is not null)
-            .ToDictionary(i => i!.Id);
-
-        // Phase 5: Split by source, preserving score order
-        foreach (var (sourceId, orderedIds) in perSourceOrderedIds)
-        {
-            var items = orderedIds
-                .Where(entitiesById.ContainsKey)
-                .Select(id => entitiesById[id]!)
-                .ToList();
-
-            if (items.Count > 0)
+            // Phase 2: One access filter for all candidates
+            var filter = new InternalItemsQuery(query.User)
             {
-                result[sourceId] = items;
-            }
-        }
+                IncludeItemTypes = [.. includeItemTypes],
+                ExcludeItemIds = [.. query.ExcludeItemIds],
+                DtoOptions = dtoOptions,
+                EnableGroupByMetadataKey = true,
+                EnableTotalRecordCount = false,
+                IsMovie = true,
+                IsPlayed = false
+            };
 
-        return Task.FromResult(result);
+            _queryHelpers.PrepareFilterQuery(filter);
+            var baseQuery = _queryHelpers.PrepareItemQuery(context, filter);
+            baseQuery = _queryHelpers.TranslateQuery(baseQuery, context, filter);
+
+            var allCandidateIdsList = allCandidateIds.ToList();
+            var accessibleItems = await baseQuery
+                .WhereOneOrMany(allCandidateIdsList, e => e.Id)
+                .Select(e => new { e.Id, e.PresentationUniqueKey })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            // Phase 3: Pick top IDs per source, dedup by PresentationUniqueKey
+            var allOrderedIds = new HashSet<Guid>();
+            var perSourceOrderedIds = new Dictionary<Guid, List<Guid>>();
+
+            foreach (var item in sourceItems)
+            {
+                if (!perSourceScores.TryGetValue(item.Id, out var scores))
+                {
+                    continue;
+                }
+
+                var orderedIds = accessibleItems
+                    .Where(x => scores.ContainsKey(x.Id))
+                    .OrderByDescending(x => scores.GetValueOrDefault(x.Id))
+                    .DistinctBy(x => x.PresentationUniqueKey)
+                    .Take(limit)
+                    .Select(x => x.Id)
+                    .ToList();
+
+                if (orderedIds.Count > 0)
+                {
+                    perSourceOrderedIds[item.Id] = orderedIds;
+                    allOrderedIds.UnionWith(orderedIds);
+                }
+            }
+
+            if (allOrderedIds.Count == 0)
+            {
+                return result;
+            }
+
+            // Phase 4: One entity load for all results. AsSplitQuery avoids a SQL Cartesian
+            // product across the multiple collection Includes added by ApplyNavigations.
+            var allOrderedIdsList = allOrderedIds.ToList();
+            var entities = await _queryHelpers.ApplyNavigations(
+                    context.BaseItems.AsNoTracking().WhereOneOrMany(allOrderedIdsList, e => e.Id),
+                    filter)
+                .AsSplitQuery()
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var entitiesById = entities
+                .Select(e => _queryHelpers.DeserializeBaseItem(e, filter.SkipDeserialization))
+                .Where(dto => dto is not null)
+                .ToDictionary(i => i!.Id);
+
+            // Phase 5: Split by source, preserving score order
+            foreach (var (sourceId, orderedIds) in perSourceOrderedIds)
+            {
+                var items = orderedIds
+                    .Where(entitiesById.ContainsKey)
+                    .Select(id => entitiesById[id]!)
+                    .ToList();
+
+                if (items.Count > 0)
+                {
+                    result[sourceId] = items;
+                }
+            }
+
+            return result;
+        }
     }
 
-    private Dictionary<Guid, Dictionary<Guid, int>> ComputeBatchScores(List<Guid> sourceIds, JellyfinDbContext context)
+    private static async Task<Dictionary<Guid, Dictionary<Guid, int>>> ComputeBatchScoresAsync(List<Guid> sourceIds, JellyfinDbContext context, CancellationToken cancellationToken)
     {
         var result = new Dictionary<Guid, Dictionary<Guid, int>>();
         foreach (var id in sourceIds)
@@ -218,95 +234,52 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
             result[id] = [];
         }
 
-        // Score item-value dimensions (genre, tags, studios)
         foreach (var (valueType, weight) in _itemValueDimensions)
         {
-            var sourceMap = context.ItemValuesMap.AsNoTracking()
+            var sourceRows = await context.ItemValuesMap.AsNoTracking()
                 .Where(m => sourceIds.Contains(m.ItemId) && m.ItemValue.Type == valueType)
-                .Select(m => new { m.ItemId, m.ItemValue.CleanValue })
-                .ToList()
-                .GroupBy(m => m.ItemId)
-                .ToDictionary(g => g.Key, g => g.Select(x => x.CleanValue).ToHashSet());
+                .Select(m => new { m.ItemId, Key = m.ItemValue.CleanValue })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            var allValues = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
-            if (allValues.Count == 0)
+            var sourceMap = sourceRows.GroupBy(r => r.ItemId).ToDictionary(g => g.Key, g => g.Select(x => x.Key).ToHashSet());
+            var allKeys = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
+            if (allKeys.Count == 0)
             {
                 continue;
             }
 
-            var valueToCandidates = context.ItemValuesMap.AsNoTracking()
-                .Where(m => m.ItemValue.Type == valueType && allValues.Contains(m.ItemValue.CleanValue))
-                .Select(m => new { m.ItemId, m.ItemValue.CleanValue })
-                .ToList()
-                .GroupBy(m => m.CleanValue)
-                .ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+            var candidateRows = await context.ItemValuesMap.AsNoTracking()
+                .Where(m => m.ItemValue.Type == valueType && allKeys.Contains(m.ItemValue.CleanValue))
+                .Select(m => new { m.ItemId, Key = m.ItemValue.CleanValue })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var sourceId in sourceIds)
-            {
-                if (!sourceMap.TryGetValue(sourceId, out var sourceValues))
-                {
-                    continue;
-                }
-
-                var scoreMap = result[sourceId];
-                foreach (var value in sourceValues)
-                {
-                    if (valueToCandidates.TryGetValue(value, out var candidates))
-                    {
-                        foreach (var candidateId in candidates)
-                        {
-                            scoreMap[candidateId] = scoreMap.GetValueOrDefault(candidateId) + weight;
-                        }
-                    }
-                }
-            }
+            var keyToCandidates = candidateRows.GroupBy(r => r.Key).ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+            ApplyDimensionScores(sourceIds, sourceMap, keyToCandidates, weight, result);
         }
 
-        // Score people dimensions (directors, actors)
         foreach (var (personTypes, weight) in _peopleDimensions)
         {
-            var sourceMap = context.PeopleBaseItemMap.AsNoTracking()
+            var sourceRows = await context.PeopleBaseItemMap.AsNoTracking()
                 .Where(m => sourceIds.Contains(m.ItemId) && personTypes.Contains(m.People.PersonType))
-                .Select(m => new { m.ItemId, m.PeopleId })
-                .ToList()
-                .GroupBy(m => m.ItemId)
-                .ToDictionary(g => g.Key, g => g.Select(x => x.PeopleId).ToHashSet());
+                .Select(m => new { m.ItemId, Key = m.PeopleId })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            var allPeopleIds = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
-            if (allPeopleIds.Count == 0)
+            var sourceMap = sourceRows.GroupBy(r => r.ItemId).ToDictionary(g => g.Key, g => g.Select(x => x.Key).ToHashSet());
+            var allKeys = sourceMap.Values.SelectMany(v => v).Distinct().ToList();
+            if (allKeys.Count == 0)
             {
                 continue;
             }
 
-            var personToCandidates = context.PeopleBaseItemMap.AsNoTracking()
-                .Where(m => allPeopleIds.Contains(m.PeopleId))
-                .Select(m => new { m.ItemId, m.PeopleId })
-                .ToList()
-                .GroupBy(m => m.PeopleId)
-                .ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+            var candidateRows = await context.PeopleBaseItemMap.AsNoTracking()
+                .Where(m => allKeys.Contains(m.PeopleId))
+                .Select(m => new { m.ItemId, Key = m.PeopleId })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var sourceId in sourceIds)
-            {
-                if (!sourceMap.TryGetValue(sourceId, out var sourcePeopleIds))
-                {
-                    continue;
-                }
-
-                var scoreMap = result[sourceId];
-                foreach (var peopleId in sourcePeopleIds)
-                {
-                    if (personToCandidates.TryGetValue(peopleId, out var candidates))
-                    {
-                        foreach (var candidateId in candidates)
-                        {
-                            scoreMap[candidateId] = scoreMap.GetValueOrDefault(candidateId) + weight;
-                        }
-                    }
-                }
-            }
+            var keyToCandidates = candidateRows.GroupBy(r => r.Key).ToDictionary(g => g.Key, g => g.Select(x => x.ItemId).ToList());
+            ApplyDimensionScores(sourceIds, sourceMap, keyToCandidates, weight, result);
         }
 
-        // Remove self-references and empty entries
         foreach (var sourceId in sourceIds)
         {
             var scoreMap = result[sourceId];
@@ -318,5 +291,36 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
         }
 
         return result;
+    }
+
+    private static void ApplyDimensionScores<TKey>(
+        List<Guid> sourceIds,
+        Dictionary<Guid, HashSet<TKey>> sourceMap,
+        Dictionary<TKey, List<Guid>> keyToCandidates,
+        int weight,
+        Dictionary<Guid, Dictionary<Guid, int>> result)
+        where TKey : notnull
+    {
+        foreach (var sourceId in sourceIds)
+        {
+            if (!sourceMap.TryGetValue(sourceId, out var sourceKeys))
+            {
+                continue;
+            }
+
+            var scoreMap = result[sourceId];
+            foreach (var key in sourceKeys)
+            {
+                if (!keyToCandidates.TryGetValue(key, out var candidates))
+                {
+                    continue;
+                }
+
+                foreach (var candidateId in candidates)
+                {
+                    scoreMap[candidateId] = scoreMap.GetValueOrDefault(candidateId) + weight;
+                }
+            }
+        }
     }
 }

--- a/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/MovieSimilarItemsProvider.cs
@@ -266,10 +266,11 @@ public sealed class MovieSimilarItemsProvider : ILocalSimilarItemsProvider<Movie
 
         if (personSourceRows.Count > 0)
         {
-            var allPersonIds = personSourceRows.Select(r => r.PeopleId).Distinct().ToList();
-
             var personCandidateRows = await context.PeopleBaseItemMap.AsNoTracking()
-                .Where(m => allPersonIds.Contains(m.PeopleId))
+                .Where(m => context.PeopleBaseItemMap
+                    .Where(s => sourceIds.Contains(s.ItemId) && _scoredPersonTypes.Contains(s.People.PersonType))
+                    .Select(s => s.PeopleId)
+                    .Contains(m.PeopleId))
                 .Select(m => new { m.ItemId, m.PeopleId })
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
@@ -8,12 +8,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions.Json;
+using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Querying;
@@ -30,6 +34,7 @@ public class SimilarItemsManager : ISimilarItemsManager
     private readonly IServerApplicationPaths _appPaths;
     private readonly ILibraryManager _libraryManager;
     private readonly IFileSystem _fileSystem;
+    private readonly IServerConfigurationManager _serverConfigurationManager;
     private ISimilarItemsProvider[] _similarItemsProviders = [];
 
     /// <summary>
@@ -39,16 +44,19 @@ public class SimilarItemsManager : ISimilarItemsManager
     /// <param name="appPaths">The server application paths.</param>
     /// <param name="libraryManager">The library manager.</param>
     /// <param name="fileSystem">The file system.</param>
+    /// <param name="serverConfigurationManager">The server configuration manager.</param>
     public SimilarItemsManager(
         ILogger<SimilarItemsManager> logger,
         IServerApplicationPaths appPaths,
         ILibraryManager libraryManager,
-        IFileSystem fileSystem)
+        IFileSystem fileSystem,
+        IServerConfigurationManager serverConfigurationManager)
     {
         _logger = logger;
         _appPaths = appPaths;
         _libraryManager = libraryManager;
         _fileSystem = fileSystem;
+        _serverConfigurationManager = serverConfigurationManager;
     }
 
     /// <inheritdoc/>
@@ -226,20 +234,205 @@ public class SimilarItemsManager : ISimilarItemsManager
     }
 
     /// <inheritdoc/>
-    public Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
-        IReadOnlyList<BaseItem> sourceItems,
+    public async Task<IReadOnlyList<SimilarItemsRecommendation>> GetMovieRecommendationsAsync(
+        User? user,
+        Guid parentId,
+        int categoryLimit,
+        int itemLimit,
+        DtoOptions dtoOptions,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dtoOptions);
+
+        var recentlyPlayedMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = [BaseItemKind.Movie],
+            OrderBy = [(ItemSortBy.DatePlayed, SortOrder.Descending), (ItemSortBy.Random, SortOrder.Descending)],
+            Limit = 7,
+            ParentId = parentId,
+            Recursive = true,
+            IsPlayed = true,
+            EnableGroupByMetadataKey = true,
+            DtoOptions = dtoOptions
+        });
+
+        var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
+        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
+        {
+            itemTypes.Add(BaseItemKind.Trailer);
+            itemTypes.Add(BaseItemKind.LiveTvProgram);
+        }
+
+        var likedMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = itemTypes.ToArray(),
+            IsMovie = true,
+            OrderBy = [(ItemSortBy.Random, SortOrder.Descending)],
+            Limit = 10,
+            IsFavoriteOrLiked = true,
+            ExcludeItemIds = recentlyPlayedMovies.Select(i => i.Id).ToArray(),
+            EnableGroupByMetadataKey = true,
+            ParentId = parentId,
+            Recursive = true,
+            DtoOptions = dtoOptions
+        });
+
+        var mostRecentMovies = recentlyPlayedMovies.Take(Math.Min(recentlyPlayedMovies.Count, 6)).ToList();
+        var recentDirectors = GetPeopleNames(mostRecentMovies, [PersonType.Director]);
+        var recentActors = GetPeopleNames(mostRecentMovies, [PersonType.Actor, PersonType.GuestStar]);
+
+        // Cap baseline items to categoryLimit - the round-robin can't use more categories than that.
+        var recentlyPlayedBaseline = recentlyPlayedMovies.Count > categoryLimit
+            ? recentlyPlayedMovies.Take(categoryLimit).ToList()
+            : recentlyPlayedMovies;
+        var likedBaseline = likedMovies.Count > categoryLimit
+            ? likedMovies.Take(categoryLimit).ToList()
+            : likedMovies;
+
+        var batchQuery = new SimilarItemsQuery
+        {
+            User = user,
+            Limit = itemLimit,
+            DtoOptions = dtoOptions
+        };
+
+        var similarToRecentlyPlayed = await GetSimilarItemsRecommendationsAsync(
+            recentlyPlayedBaseline,
+            RecommendationType.SimilarToRecentlyPlayed,
+            batchQuery).ConfigureAwait(false);
+
+        var similarToLiked = await GetSimilarItemsRecommendationsAsync(
+            likedBaseline,
+            RecommendationType.SimilarToLikedItem,
+            batchQuery).ConfigureAwait(false);
+
+        var hasDirectorFromRecentlyPlayed = GetPersonRecommendations(user, recentDirectors, itemLimit, dtoOptions, RecommendationType.HasDirectorFromRecentlyPlayed, itemTypes);
+        var hasActorFromRecentlyPlayed = GetPersonRecommendations(user, recentActors, itemLimit, dtoOptions, RecommendationType.HasActorFromRecentlyPlayed, itemTypes);
+
+        // Use a single enumerator per list, listed twice so MoveNext advances it
+        // twice per round-robin pass (giving these categories double weight).
+        // IMPORTANT: Declare as IEnumerator<T> to box the List<T>.Enumerator struct once;
+        // using var would box separately per list insertion, creating independent copies.
+        IEnumerator<SimilarItemsRecommendation> similarToRecentlyPlayedEnum = similarToRecentlyPlayed.GetEnumerator();
+        IEnumerator<SimilarItemsRecommendation> similarToLikedEnum = similarToLiked.GetEnumerator();
+
+        var categoryTypes = new List<IEnumerator<SimilarItemsRecommendation>>
+        {
+            similarToRecentlyPlayedEnum,
+            similarToRecentlyPlayedEnum,
+            similarToLikedEnum,
+            similarToLikedEnum,
+            hasDirectorFromRecentlyPlayed.GetEnumerator(),
+            hasActorFromRecentlyPlayed.GetEnumerator()
+        };
+
+        var categories = new List<SimilarItemsRecommendation>();
+        while (categories.Count < categoryLimit)
+        {
+            var allEmpty = true;
+            foreach (var category in categoryTypes)
+            {
+                if (category.MoveNext())
+                {
+                    categories.Add(category.Current);
+                    allEmpty = false;
+
+                    if (categories.Count >= categoryLimit)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (allEmpty)
+            {
+                break;
+            }
+        }
+
+        return [.. categories.OrderBy(i => i.RecommendationType)];
+    }
+
+    private async Task<IReadOnlyList<SimilarItemsRecommendation>> GetSimilarItemsRecommendationsAsync(
+        IReadOnlyList<BaseItem> baselineItems,
+        RecommendationType recommendationType,
         SimilarItemsQuery query)
     {
         var batchProvider = _similarItemsProviders
             .OfType<IBatchLocalSimilarItemsProvider>()
             .FirstOrDefault();
 
-        if (batchProvider is null)
+        if (batchProvider is null || baselineItems.Count == 0)
         {
-            return Task.FromResult(new Dictionary<Guid, IReadOnlyList<BaseItem>>());
+            return [];
         }
 
-        return batchProvider.GetBatchSimilarItemsAsync(sourceItems, query);
+        var batchResults = await batchProvider.GetBatchSimilarItemsAsync(baselineItems, query).ConfigureAwait(false);
+
+        var recommendations = new List<SimilarItemsRecommendation>(baselineItems.Count);
+        foreach (var baseline in baselineItems)
+        {
+            if (batchResults.TryGetValue(baseline.Id, out var similar) && similar.Count > 0)
+            {
+                recommendations.Add(new SimilarItemsRecommendation
+                {
+                    BaselineItemName = baseline.Name,
+                    CategoryId = baseline.Id,
+                    RecommendationType = recommendationType,
+                    Items = similar
+                });
+            }
+        }
+
+        return recommendations;
+    }
+
+    private IEnumerable<SimilarItemsRecommendation> GetPersonRecommendations(
+        User? user,
+        IReadOnlyList<string> names,
+        int itemLimit,
+        DtoOptions dtoOptions,
+        RecommendationType type,
+        IReadOnlyList<BaseItemKind> itemTypes)
+    {
+        var personTypes = type == RecommendationType.HasDirectorFromRecentlyPlayed
+            ? [PersonType.Director]
+            : Array.Empty<string>();
+
+        foreach (var name in names)
+        {
+            var items = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                Person = name,
+                Limit = itemLimit + 2,
+                PersonTypes = personTypes,
+                IncludeItemTypes = itemTypes.ToArray(),
+                IsMovie = true,
+                IsPlayed = false,
+                EnableGroupByMetadataKey = true,
+                DtoOptions = dtoOptions
+            })
+                .DistinctBy(i => i.GetProviderId(MetadataProvider.Imdb) ?? Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture))
+                .Take(itemLimit)
+                .ToList();
+
+            if (items.Count > 0)
+            {
+                yield return new SimilarItemsRecommendation
+                {
+                    BaselineItemName = name,
+                    CategoryId = name.GetMD5(),
+                    RecommendationType = type,
+                    Items = items
+                };
+            }
+        }
+    }
+
+    private IReadOnlyList<string> GetPeopleNames(IReadOnlyList<BaseItem> items, IReadOnlyList<string> personTypes)
+    {
+        var itemIds = items.Select(i => i.Id).ToArray();
+        return _libraryManager.GetPeopleNamesByItems(itemIds, personTypes, limit: 0);
     }
 
     private List<(BaseItem Item, float Score)> ResolveRemoteReferences(

--- a/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
@@ -299,12 +299,14 @@ public class SimilarItemsManager : ISimilarItemsManager
         var similarToRecentlyPlayed = await GetSimilarItemsRecommendationsAsync(
             recentlyPlayedBaseline,
             RecommendationType.SimilarToRecentlyPlayed,
-            batchQuery).ConfigureAwait(false);
+            batchQuery,
+            cancellationToken).ConfigureAwait(false);
 
         var similarToLiked = await GetSimilarItemsRecommendationsAsync(
             likedBaseline,
             RecommendationType.SimilarToLikedItem,
-            batchQuery).ConfigureAwait(false);
+            batchQuery,
+            cancellationToken).ConfigureAwait(false);
 
         var hasDirectorFromRecentlyPlayed = GetPersonRecommendations(user, recentDirectors, itemLimit, dtoOptions, RecommendationType.HasDirectorFromRecentlyPlayed, itemTypes);
         var hasActorFromRecentlyPlayed = GetPersonRecommendations(user, recentActors, itemLimit, dtoOptions, RecommendationType.HasActorFromRecentlyPlayed, itemTypes);
@@ -356,7 +358,8 @@ public class SimilarItemsManager : ISimilarItemsManager
     private async Task<IReadOnlyList<SimilarItemsRecommendation>> GetSimilarItemsRecommendationsAsync(
         IReadOnlyList<BaseItem> baselineItems,
         RecommendationType recommendationType,
-        SimilarItemsQuery query)
+        SimilarItemsQuery query,
+        CancellationToken cancellationToken)
     {
         var batchProvider = _similarItemsProviders
             .OfType<IBatchLocalSimilarItemsProvider>()
@@ -367,7 +370,7 @@ public class SimilarItemsManager : ISimilarItemsManager
             return [];
         }
 
-        var batchResults = await batchProvider.GetBatchSimilarItemsAsync(baselineItems, query).ConfigureAwait(false);
+        var batchResults = await batchProvider.GetBatchSimilarItemsAsync(baselineItems, query, cancellationToken).ConfigureAwait(false);
 
         var recommendations = new List<SimilarItemsRecommendation>(baselineItems.Count);
         foreach (var baseline in baselineItems)

--- a/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
@@ -225,6 +225,23 @@ public class SimilarItemsManager : ISimilarItemsManager
             .ToList();
     }
 
+    /// <inheritdoc/>
+    public Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
+        IReadOnlyList<BaseItem> sourceItems,
+        SimilarItemsQuery query)
+    {
+        var batchProvider = _similarItemsProviders
+            .OfType<IBatchLocalSimilarItemsProvider>()
+            .FirstOrDefault();
+
+        if (batchProvider is null)
+        {
+            return Task.FromResult(new Dictionary<Guid, IReadOnlyList<BaseItem>>());
+        }
+
+        return batchProvider.GetBatchSimilarItemsAsync(sourceItems, query);
+    }
+
     private List<(BaseItem Item, float Score)> ResolveRemoteReferences(
         IReadOnlyList<SimilarItemReference> references,
         int providerOrder,

--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
 using Jellyfin.Data.Enums;
@@ -33,6 +36,7 @@ public class MoviesController : BaseJellyfinApiController
     private readonly ILibraryManager _libraryManager;
     private readonly IDtoService _dtoService;
     private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly ISimilarItemsManager _similarItemsManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MoviesController"/> class.
@@ -41,16 +45,19 @@ public class MoviesController : BaseJellyfinApiController
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="similarItemsManager">Instance of the <see cref="ISimilarItemsManager"/> interface.</param>
     public MoviesController(
         IUserManager userManager,
         ILibraryManager libraryManager,
         IDtoService dtoService,
-        IServerConfigurationManager serverConfigurationManager)
+        IServerConfigurationManager serverConfigurationManager,
+        ISimilarItemsManager similarItemsManager)
     {
         _userManager = userManager;
         _libraryManager = libraryManager;
         _dtoService = dtoService;
         _serverConfigurationManager = serverConfigurationManager;
+        _similarItemsManager = similarItemsManager;
     }
 
     /// <summary>
@@ -61,15 +68,17 @@ public class MoviesController : BaseJellyfinApiController
     /// <param name="fields">Optional. The fields to return.</param>
     /// <param name="categoryLimit">The max number of categories to return.</param>
     /// <param name="itemLimit">The max number of items to return per category.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">Movie recommendations returned.</response>
     /// <returns>The list of movie recommendations.</returns>
     [HttpGet("Recommendations")]
-    public ActionResult<IEnumerable<RecommendationDto>> GetMovieRecommendations(
+    public Task<ActionResult<IEnumerable<RecommendationDto>>> GetMovieRecommendations(
         [FromQuery] Guid? userId,
         [FromQuery] Guid? parentId,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
         [FromQuery] int categoryLimit = 5,
-        [FromQuery] int itemLimit = 8)
+        [FromQuery] int itemLimit = 8,
+        CancellationToken cancellationToken = default)
     {
         userId = RequestHelpers.GetUserId(User, userId);
         var user = userId.IsNullOrEmpty()
@@ -86,15 +95,13 @@ public class MoviesController : BaseJellyfinApiController
             IncludeItemTypes = new[]
             {
                 BaseItemKind.Movie,
-                // nameof(Trailer),
-                // nameof(LiveTvProgram)
             },
-            // IsMovie = true
             OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending), (ItemSortBy.Random, SortOrder.Descending) },
             Limit = 7,
             ParentId = parentIdGuid,
             Recursive = true,
             IsPlayed = true,
+            EnableGroupByMetadataKey = true,
             DtoOptions = dtoOptions
         };
 
@@ -122,31 +129,52 @@ public class MoviesController : BaseJellyfinApiController
         });
 
         var mostRecentMovies = recentlyPlayedMovies.Take(Math.Min(recentlyPlayedMovies.Count, 6)).ToList();
-        // Get recently played directors
-        var recentDirectors = GetDirectors(mostRecentMovies)
-            .ToList();
+        var recentDirectors = GetDirectors(mostRecentMovies).ToList();
+        var recentActors = GetActors(mostRecentMovies).ToList();
 
-        // Get recently played actors
-        var recentActors = GetActors(mostRecentMovies)
-            .ToList();
+        // Cap baseline items to categoryLimit - the round-robin can't use more categories than that.
+        var recentlyPlayedBaseline = recentlyPlayedMovies.Count > categoryLimit
+            ? recentlyPlayedMovies.Take(categoryLimit).ToList()
+            : recentlyPlayedMovies;
+        var likedBaseline = likedMovies.Count > categoryLimit
+            ? likedMovies.Take(categoryLimit).ToList()
+            : likedMovies;
 
-        var similarToRecentlyPlayed = GetSimilarTo(user, recentlyPlayedMovies, itemLimit, dtoOptions, RecommendationType.SimilarToRecentlyPlayed).GetEnumerator();
-        var similarToLiked = GetSimilarTo(user, likedMovies, itemLimit, dtoOptions, RecommendationType.SimilarToLikedItem).GetEnumerator();
+        var batchQuery = new SimilarItemsQuery
+        {
+            User = user,
+            Limit = itemLimit,
+            DtoOptions = dtoOptions
+        };
 
-        var hasDirectorFromRecentlyPlayed = GetWithDirector(user, recentDirectors, itemLimit, dtoOptions, RecommendationType.HasDirectorFromRecentlyPlayed).GetEnumerator();
-        var hasActorFromRecentlyPlayed = GetWithActor(user, recentActors, itemLimit, dtoOptions, RecommendationType.HasActorFromRecentlyPlayed).GetEnumerator();
+        var similarToRecentlyPlayed = BuildPendingFromBatch(
+            _similarItemsManager.GetBatchSimilarItemsAsync(recentlyPlayedBaseline, batchQuery),
+            recentlyPlayedBaseline,
+            RecommendationType.SimilarToRecentlyPlayed);
 
-        var categoryTypes = new List<IEnumerator<RecommendationDto>>
+        var similarToLiked = BuildPendingFromBatch(
+            _similarItemsManager.GetBatchSimilarItemsAsync(likedBaseline, batchQuery),
+            likedBaseline,
+            RecommendationType.SimilarToLikedItem);
+
+        var hasDirectorFromRecentlyPlayed = GetWithPerson(user, recentDirectors, itemLimit, dtoOptions, RecommendationType.HasDirectorFromRecentlyPlayed);
+        var hasActorFromRecentlyPlayed = GetWithPerson(user, recentActors, itemLimit, dtoOptions, RecommendationType.HasActorFromRecentlyPlayed);
+
+        // Use a single enumerator per list, listed twice so MoveNext advances it
+        // twice per round-robin pass (giving these categories double weight).
+        // IMPORTANT: Declare as IEnumerator<T> to box the List<T>.Enumerator struct once;
+        // using var would box separately per list insertion, creating independent copies.
+        IEnumerator<PendingRecommendation> similarToRecentlyPlayedEnum = similarToRecentlyPlayed.GetEnumerator();
+        IEnumerator<PendingRecommendation> similarToLikedEnum = similarToLiked.GetEnumerator();
+
+        var categoryTypes = new List<IEnumerator<PendingRecommendation>>
             {
-                // Give this extra weight
-                similarToRecentlyPlayed,
-                similarToRecentlyPlayed,
-
-                // Give this extra weight
-                similarToLiked,
-                similarToLiked,
-                hasDirectorFromRecentlyPlayed,
-                hasActorFromRecentlyPlayed
+                similarToRecentlyPlayedEnum,
+                similarToRecentlyPlayedEnum,
+                similarToLikedEnum,
+                similarToLikedEnum,
+                hasDirectorFromRecentlyPlayed.GetEnumerator(),
+                hasActorFromRecentlyPlayed.GetEnumerator()
             };
 
         while (categories.Count < categoryLimit)
@@ -157,7 +185,17 @@ public class MoviesController : BaseJellyfinApiController
             {
                 if (category.MoveNext())
                 {
-                    categories.Add(category.Current);
+                    var pending = category.Current;
+                    var returnItems = _dtoService.GetBaseItemDtos(pending.Items, dtoOptions, user);
+
+                    categories.Add(new RecommendationDto
+                    {
+                        BaselineItemName = pending.BaselineItemName,
+                        CategoryId = pending.CategoryId,
+                        RecommendationType = pending.RecommendationType,
+                        Items = returnItems
+                    });
+
                     allEmpty = false;
 
                     if (categories.Count >= categoryLimit)
@@ -173,10 +211,36 @@ public class MoviesController : BaseJellyfinApiController
             }
         }
 
-        return Ok(categories.OrderBy(i => i.RecommendationType).AsEnumerable());
+        return Task.FromResult<ActionResult<IEnumerable<RecommendationDto>>>(
+            Ok(categories.OrderBy(i => i.RecommendationType).AsEnumerable()));
     }
 
-    private IEnumerable<RecommendationDto> GetWithDirector(
+    private static List<PendingRecommendation> BuildPendingFromBatch(
+        Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> batchTask,
+        IReadOnlyList<BaseItem> baselineItems,
+        RecommendationType type)
+    {
+        var batchResults = batchTask.GetAwaiter().GetResult();
+        var results = new List<PendingRecommendation>();
+
+        foreach (var item in baselineItems)
+        {
+            if (batchResults.TryGetValue(item.Id, out var similar) && similar.Count > 0)
+            {
+                results.Add(new PendingRecommendation
+                {
+                    BaselineItemName = item.Name,
+                    CategoryId = item.Id,
+                    RecommendationType = type,
+                    Items = similar
+                });
+            }
+        }
+
+        return results;
+    }
+
+    private IEnumerable<PendingRecommendation> GetWithPerson(
         User? user,
         IEnumerable<string> names,
         int itemLimit,
@@ -190,17 +254,21 @@ public class MoviesController : BaseJellyfinApiController
             itemTypes.Add(BaseItemKind.LiveTvProgram);
         }
 
+        var personTypes = type == RecommendationType.HasDirectorFromRecentlyPlayed
+            ? [PersonType.Director]
+            : Array.Empty<string>();
+
         foreach (var name in names)
         {
             var items = _libraryManager.GetItemList(
                 new InternalItemsQuery(user)
                 {
                     Person = name,
-                    // Account for duplicates by IMDb id, since the database doesn't support this yet
                     Limit = itemLimit + 2,
-                    PersonTypes = new[] { PersonType.Director },
+                    PersonTypes = personTypes,
                     IncludeItemTypes = itemTypes.ToArray(),
                     IsMovie = true,
+                    IsPlayed = false,
                     EnableGroupByMetadataKey = true,
                     DtoOptions = dtoOptions
                 }).DistinctBy(i => i.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb) ?? Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture))
@@ -209,119 +277,47 @@ public class MoviesController : BaseJellyfinApiController
 
             if (items.Count > 0)
             {
-                var returnItems = _dtoService.GetBaseItemDtos(items, dtoOptions, user);
-
-                yield return new RecommendationDto
+                yield return new PendingRecommendation
                 {
                     BaselineItemName = name,
                     CategoryId = name.GetMD5(),
                     RecommendationType = type,
-                    Items = returnItems
+                    Items = items
                 };
             }
         }
     }
 
-    private IEnumerable<RecommendationDto> GetWithActor(User? user, IEnumerable<string> names, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
+    private IReadOnlyList<string> GetActors(IReadOnlyList<BaseItem> items)
     {
-        var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
-        {
-            itemTypes.Add(BaseItemKind.Trailer);
-            itemTypes.Add(BaseItemKind.LiveTvProgram);
-        }
-
-        foreach (var name in names)
-        {
-            var items = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                Person = name,
-                // Account for duplicates by IMDb id, since the database doesn't support this yet
-                Limit = itemLimit + 2,
-                IncludeItemTypes = itemTypes.ToArray(),
-                IsMovie = true,
-                EnableGroupByMetadataKey = true,
-                DtoOptions = dtoOptions
-            }).DistinctBy(i => i.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb) ?? Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture))
-                .Take(itemLimit)
-                .ToList();
-
-            if (items.Count > 0)
-            {
-                var returnItems = _dtoService.GetBaseItemDtos(items, dtoOptions, user);
-
-                yield return new RecommendationDto
-                {
-                    BaselineItemName = name,
-                    CategoryId = name.GetMD5(),
-                    RecommendationType = type,
-                    Items = returnItems
-                };
-            }
-        }
+        var itemIds = items.Select(i => i.Id).ToArray();
+        return _libraryManager.GetPeopleNamesByItems(
+            itemIds,
+            new[] { PersonType.Actor, PersonType.GuestStar },
+            limit: 0);
     }
 
-    private IEnumerable<RecommendationDto> GetSimilarTo(User? user, IEnumerable<BaseItem> baselineItems, int itemLimit, DtoOptions dtoOptions, RecommendationType type)
+    private IReadOnlyList<string> GetDirectors(IReadOnlyList<BaseItem> items)
     {
-        var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
-        {
-            itemTypes.Add(BaseItemKind.Trailer);
-            itemTypes.Add(BaseItemKind.LiveTvProgram);
-        }
-
-        foreach (var item in baselineItems)
-        {
-            var similar = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                Limit = itemLimit,
-                IncludeItemTypes = itemTypes.ToArray(),
-                IsMovie = true,
-                EnableGroupByMetadataKey = true,
-                DtoOptions = dtoOptions
-            });
-
-            if (similar.Count > 0)
-            {
-                var returnItems = _dtoService.GetBaseItemDtos(similar, dtoOptions, user);
-
-                yield return new RecommendationDto
-                {
-                    BaselineItemName = item.Name,
-                    CategoryId = item.Id,
-                    RecommendationType = type,
-                    Items = returnItems
-                };
-            }
-        }
+        var itemIds = items.Select(i => i.Id).ToArray();
+        return _libraryManager.GetPeopleNamesByItems(
+            itemIds,
+            [PersonType.Director],
+            limit: 0);
     }
 
-    private IEnumerable<string> GetActors(IEnumerable<BaseItem> items)
+    /// <summary>
+    /// Holds a recommendation category's BaseItems before DTO conversion.
+    /// DTO conversion is deferred until the round-robin actually selects the category.
+    /// </summary>
+    private sealed class PendingRecommendation
     {
-        var people = _libraryManager.GetPeople(new InternalPeopleQuery(Array.Empty<string>(), new[] { PersonType.Director })
-        {
-            MaxListOrder = 3
-        });
+        public required string BaselineItemName { get; init; }
 
-        var itemIds = items.Select(i => i.Id).ToList();
+        public required Guid CategoryId { get; init; }
 
-        return people
-            .Where(i => itemIds.Contains(i.ItemId))
-            .Select(i => i.Name)
-            .DistinctNames();
-    }
+        public required RecommendationType RecommendationType { get; init; }
 
-    private IEnumerable<string> GetDirectors(IEnumerable<BaseItem> items)
-    {
-        var people = _libraryManager.GetPeople(new InternalPeopleQuery(
-            new[] { PersonType.Director },
-            Array.Empty<string>()));
-
-        var itemIds = items.Select(i => i.Id).ToList();
-
-        return people
-            .Where(i => itemIds.Contains(i.ItemId))
-            .Select(i => i.Name)
-            .DistinctNames();
+        public required IReadOnlyList<BaseItem> Items { get; init; }
     }
 }

--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -1,20 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
 using Jellyfin.Api.ModelBinders;
-using Jellyfin.Data.Enums;
-using Jellyfin.Database.Implementations.Entities;
-using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
-using MediaBrowser.Common.Extensions;
-using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Dto;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -33,30 +26,22 @@ namespace Jellyfin.Api.Controllers;
 public class MoviesController : BaseJellyfinApiController
 {
     private readonly IUserManager _userManager;
-    private readonly ILibraryManager _libraryManager;
     private readonly IDtoService _dtoService;
-    private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly ISimilarItemsManager _similarItemsManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MoviesController"/> class.
     /// </summary>
     /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
-    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
-    /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
     /// <param name="similarItemsManager">Instance of the <see cref="ISimilarItemsManager"/> interface.</param>
     public MoviesController(
         IUserManager userManager,
-        ILibraryManager libraryManager,
         IDtoService dtoService,
-        IServerConfigurationManager serverConfigurationManager,
         ISimilarItemsManager similarItemsManager)
     {
         _userManager = userManager;
-        _libraryManager = libraryManager;
         _dtoService = dtoService;
-        _serverConfigurationManager = serverConfigurationManager;
         _similarItemsManager = similarItemsManager;
     }
 
@@ -72,7 +57,7 @@ public class MoviesController : BaseJellyfinApiController
     /// <response code="200">Movie recommendations returned.</response>
     /// <returns>The list of movie recommendations.</returns>
     [HttpGet("Recommendations")]
-    public Task<ActionResult<IEnumerable<RecommendationDto>>> GetMovieRecommendations(
+    public async Task<ActionResult<IEnumerable<RecommendationDto>>> GetMovieRecommendations(
         [FromQuery] Guid? userId,
         [FromQuery] Guid? parentId,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
@@ -86,238 +71,16 @@ public class MoviesController : BaseJellyfinApiController
             : _userManager.GetUserById(userId.Value);
         var dtoOptions = new DtoOptions { Fields = fields };
 
-        var categories = new List<RecommendationDto>();
+        var recommendations = await _similarItemsManager
+            .GetMovieRecommendationsAsync(user, parentId ?? Guid.Empty, categoryLimit, itemLimit, dtoOptions, cancellationToken)
+            .ConfigureAwait(false);
 
-        var parentIdGuid = parentId ?? Guid.Empty;
-
-        var query = new InternalItemsQuery(user)
+        return Ok(recommendations.Select(r => new RecommendationDto
         {
-            IncludeItemTypes = new[]
-            {
-                BaseItemKind.Movie,
-            },
-            OrderBy = new[] { (ItemSortBy.DatePlayed, SortOrder.Descending), (ItemSortBy.Random, SortOrder.Descending) },
-            Limit = 7,
-            ParentId = parentIdGuid,
-            Recursive = true,
-            IsPlayed = true,
-            EnableGroupByMetadataKey = true,
-            DtoOptions = dtoOptions
-        };
-
-        var recentlyPlayedMovies = _libraryManager.GetItemList(query);
-
-        var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
-        {
-            itemTypes.Add(BaseItemKind.Trailer);
-            itemTypes.Add(BaseItemKind.LiveTvProgram);
-        }
-
-        var likedMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
-        {
-            IncludeItemTypes = itemTypes.ToArray(),
-            IsMovie = true,
-            OrderBy = new[] { (ItemSortBy.Random, SortOrder.Descending) },
-            Limit = 10,
-            IsFavoriteOrLiked = true,
-            ExcludeItemIds = recentlyPlayedMovies.Select(i => i.Id).ToArray(),
-            EnableGroupByMetadataKey = true,
-            ParentId = parentIdGuid,
-            Recursive = true,
-            DtoOptions = dtoOptions
-        });
-
-        var mostRecentMovies = recentlyPlayedMovies.Take(Math.Min(recentlyPlayedMovies.Count, 6)).ToList();
-        var recentDirectors = GetDirectors(mostRecentMovies).ToList();
-        var recentActors = GetActors(mostRecentMovies).ToList();
-
-        // Cap baseline items to categoryLimit - the round-robin can't use more categories than that.
-        var recentlyPlayedBaseline = recentlyPlayedMovies.Count > categoryLimit
-            ? recentlyPlayedMovies.Take(categoryLimit).ToList()
-            : recentlyPlayedMovies;
-        var likedBaseline = likedMovies.Count > categoryLimit
-            ? likedMovies.Take(categoryLimit).ToList()
-            : likedMovies;
-
-        var batchQuery = new SimilarItemsQuery
-        {
-            User = user,
-            Limit = itemLimit,
-            DtoOptions = dtoOptions
-        };
-
-        var similarToRecentlyPlayed = BuildPendingFromBatch(
-            _similarItemsManager.GetBatchSimilarItemsAsync(recentlyPlayedBaseline, batchQuery),
-            recentlyPlayedBaseline,
-            RecommendationType.SimilarToRecentlyPlayed);
-
-        var similarToLiked = BuildPendingFromBatch(
-            _similarItemsManager.GetBatchSimilarItemsAsync(likedBaseline, batchQuery),
-            likedBaseline,
-            RecommendationType.SimilarToLikedItem);
-
-        var hasDirectorFromRecentlyPlayed = GetWithPerson(user, recentDirectors, itemLimit, dtoOptions, RecommendationType.HasDirectorFromRecentlyPlayed);
-        var hasActorFromRecentlyPlayed = GetWithPerson(user, recentActors, itemLimit, dtoOptions, RecommendationType.HasActorFromRecentlyPlayed);
-
-        // Use a single enumerator per list, listed twice so MoveNext advances it
-        // twice per round-robin pass (giving these categories double weight).
-        // IMPORTANT: Declare as IEnumerator<T> to box the List<T>.Enumerator struct once;
-        // using var would box separately per list insertion, creating independent copies.
-        IEnumerator<PendingRecommendation> similarToRecentlyPlayedEnum = similarToRecentlyPlayed.GetEnumerator();
-        IEnumerator<PendingRecommendation> similarToLikedEnum = similarToLiked.GetEnumerator();
-
-        var categoryTypes = new List<IEnumerator<PendingRecommendation>>
-            {
-                similarToRecentlyPlayedEnum,
-                similarToRecentlyPlayedEnum,
-                similarToLikedEnum,
-                similarToLikedEnum,
-                hasDirectorFromRecentlyPlayed.GetEnumerator(),
-                hasActorFromRecentlyPlayed.GetEnumerator()
-            };
-
-        while (categories.Count < categoryLimit)
-        {
-            var allEmpty = true;
-
-            foreach (var category in categoryTypes)
-            {
-                if (category.MoveNext())
-                {
-                    var pending = category.Current;
-                    var returnItems = _dtoService.GetBaseItemDtos(pending.Items, dtoOptions, user);
-
-                    categories.Add(new RecommendationDto
-                    {
-                        BaselineItemName = pending.BaselineItemName,
-                        CategoryId = pending.CategoryId,
-                        RecommendationType = pending.RecommendationType,
-                        Items = returnItems
-                    });
-
-                    allEmpty = false;
-
-                    if (categories.Count >= categoryLimit)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            if (allEmpty)
-            {
-                break;
-            }
-        }
-
-        return Task.FromResult<ActionResult<IEnumerable<RecommendationDto>>>(
-            Ok(categories.OrderBy(i => i.RecommendationType).AsEnumerable()));
-    }
-
-    private static List<PendingRecommendation> BuildPendingFromBatch(
-        Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> batchTask,
-        IReadOnlyList<BaseItem> baselineItems,
-        RecommendationType type)
-    {
-        var batchResults = batchTask.GetAwaiter().GetResult();
-        var results = new List<PendingRecommendation>();
-
-        foreach (var item in baselineItems)
-        {
-            if (batchResults.TryGetValue(item.Id, out var similar) && similar.Count > 0)
-            {
-                results.Add(new PendingRecommendation
-                {
-                    BaselineItemName = item.Name,
-                    CategoryId = item.Id,
-                    RecommendationType = type,
-                    Items = similar
-                });
-            }
-        }
-
-        return results;
-    }
-
-    private IEnumerable<PendingRecommendation> GetWithPerson(
-        User? user,
-        IEnumerable<string> names,
-        int itemLimit,
-        DtoOptions dtoOptions,
-        RecommendationType type)
-    {
-        var itemTypes = new List<BaseItemKind> { BaseItemKind.Movie };
-        if (_serverConfigurationManager.Configuration.EnableExternalContentInSuggestions)
-        {
-            itemTypes.Add(BaseItemKind.Trailer);
-            itemTypes.Add(BaseItemKind.LiveTvProgram);
-        }
-
-        var personTypes = type == RecommendationType.HasDirectorFromRecentlyPlayed
-            ? [PersonType.Director]
-            : Array.Empty<string>();
-
-        foreach (var name in names)
-        {
-            var items = _libraryManager.GetItemList(
-                new InternalItemsQuery(user)
-                {
-                    Person = name,
-                    Limit = itemLimit + 2,
-                    PersonTypes = personTypes,
-                    IncludeItemTypes = itemTypes.ToArray(),
-                    IsMovie = true,
-                    IsPlayed = false,
-                    EnableGroupByMetadataKey = true,
-                    DtoOptions = dtoOptions
-                }).DistinctBy(i => i.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb) ?? Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture))
-                .Take(itemLimit)
-                .ToList();
-
-            if (items.Count > 0)
-            {
-                yield return new PendingRecommendation
-                {
-                    BaselineItemName = name,
-                    CategoryId = name.GetMD5(),
-                    RecommendationType = type,
-                    Items = items
-                };
-            }
-        }
-    }
-
-    private IReadOnlyList<string> GetActors(IReadOnlyList<BaseItem> items)
-    {
-        var itemIds = items.Select(i => i.Id).ToArray();
-        return _libraryManager.GetPeopleNamesByItems(
-            itemIds,
-            new[] { PersonType.Actor, PersonType.GuestStar },
-            limit: 0);
-    }
-
-    private IReadOnlyList<string> GetDirectors(IReadOnlyList<BaseItem> items)
-    {
-        var itemIds = items.Select(i => i.Id).ToArray();
-        return _libraryManager.GetPeopleNamesByItems(
-            itemIds,
-            [PersonType.Director],
-            limit: 0);
-    }
-
-    /// <summary>
-    /// Holds a recommendation category's BaseItems before DTO conversion.
-    /// DTO conversion is deferred until the round-robin actually selects the category.
-    /// </summary>
-    private sealed class PendingRecommendation
-    {
-        public required string BaselineItemName { get; init; }
-
-        public required Guid CategoryId { get; init; }
-
-        public required RecommendationType RecommendationType { get; init; }
-
-        public required IReadOnlyList<BaseItem> Items { get; init; }
+            BaselineItemName = r.BaselineItemName,
+            CategoryId = r.CategoryId,
+            RecommendationType = r.RecommendationType,
+            Items = _dtoService.GetBaseItemDtos(r.Items, dtoOptions, user)
+        }));
     }
 }

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -165,6 +165,31 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         transaction.Commit();
     }
 
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetPeopleNamesByItems(IReadOnlyList<Guid> itemIds, IReadOnlyList<string> personTypes, int limit)
+    {
+        using var context = _dbProvider.CreateDbContext();
+        var query = context.PeopleBaseItemMap
+            .AsNoTracking()
+            .Where(m => itemIds.Contains(m.ItemId));
+
+        if (personTypes.Count > 0)
+        {
+            query = query.Where(m => personTypes.Contains(m.People.PersonType));
+        }
+
+        var names = query
+            .Select(m => m.People.Name)
+            .Distinct();
+
+        if (limit > 0)
+        {
+            names = names.Take(limit);
+        }
+
+        return names.ToArray();
+    }
+
     private PersonInfo Map(People people)
     {
         var mapping = people.BaseItems?.FirstOrDefault();
@@ -239,7 +264,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (filter.MaxListOrder.HasValue && !filter.ItemId.IsEmpty())
         {
-            query = query.Where(e => e.BaseItems!.Where(w => w.ItemId == filter.ItemId).OrderBy(w => w.ListOrder).First().ListOrder <= filter.MaxListOrder.Value);
+            query = query.Where(e => e.BaseItems!.Any(w => w.ItemId == filter.ItemId && w.ListOrder <= filter.MaxListOrder.Value));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.NameContains))

--- a/MediaBrowser.Controller/Library/IBatchLocalSimilarItemsProvider.cs
+++ b/MediaBrowser.Controller/Library/IBatchLocalSimilarItemsProvider.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+
+namespace MediaBrowser.Controller.Library;
+
+/// <summary>
+/// A local similar items provider that supports batch queries across multiple source items.
+/// Implementations share access filtering and entity loading across all sources for better performance.
+/// </summary>
+public interface IBatchLocalSimilarItemsProvider : ISimilarItemsProvider
+{
+    /// <summary>
+    /// Gets similar items for multiple source items in a single batch.
+    /// </summary>
+    /// <param name="sourceItems">The source items to find similar items for.</param>
+    /// <param name="query">The query options.</param>
+    /// <returns>Per-source-item results keyed by source item ID.</returns>
+    Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
+        IReadOnlyList<BaseItem> sourceItems,
+        SimilarItemsQuery query);
+}

--- a/MediaBrowser.Controller/Library/IBatchLocalSimilarItemsProvider.cs
+++ b/MediaBrowser.Controller/Library/IBatchLocalSimilarItemsProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 
@@ -16,8 +17,10 @@ public interface IBatchLocalSimilarItemsProvider : ISimilarItemsProvider
     /// </summary>
     /// <param name="sourceItems">The source items to find similar items for.</param>
     /// <param name="query">The query options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>Per-source-item results keyed by source item ID.</returns>
     Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
         IReadOnlyList<BaseItem> sourceItems,
-        SimilarItemsQuery query);
+        SimilarItemsQuery query,
+        CancellationToken cancellationToken);
 }

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -598,6 +598,15 @@ namespace MediaBrowser.Controller.Library
         IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery query);
 
         /// <summary>
+        /// Gets distinct people names for multiple items.
+        /// </summary>
+        /// <param name="itemIds">The item IDs.</param>
+        /// <param name="personTypes">The person types to include.</param>
+        /// <param name="limit">Maximum number of names.</param>
+        /// <returns>The distinct people names.</returns>
+        IReadOnlyList<string> GetPeopleNamesByItems(IReadOnlyList<Guid> itemIds, IReadOnlyList<string> personTypes, int limit);
+
+        /// <summary>
         /// Queries the items.
         /// </summary>
         /// <param name="query">The query.</param>

--- a/MediaBrowser.Controller/Library/ISimilarItemsManager.cs
+++ b/MediaBrowser.Controller/Library/ISimilarItemsManager.cs
@@ -47,4 +47,14 @@ public interface ISimilarItemsManager
         int? limit,
         LibraryOptions? libraryOptions,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets similar items for multiple source items in a single batch.
+    /// </summary>
+    /// <param name="sourceItems">The source items to find similar items for.</param>
+    /// <param name="query">The query options.</param>
+    /// <returns>Per-source-item results keyed by source item ID.</returns>
+    Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
+        IReadOnlyList<BaseItem> sourceItems,
+        SimilarItemsQuery query);
 }

--- a/MediaBrowser.Controller/Library/ISimilarItemsManager.cs
+++ b/MediaBrowser.Controller/Library/ISimilarItemsManager.cs
@@ -6,6 +6,7 @@ using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
 
 namespace MediaBrowser.Controller.Library;
 
@@ -49,12 +50,21 @@ public interface ISimilarItemsManager
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets similar items for multiple source items in a single batch.
+    /// Builds movie recommendations for a user: a mix of similar-items and person-based categories,
+    /// scheduled round-robin and capped to <paramref name="categoryLimit"/>.
     /// </summary>
-    /// <param name="sourceItems">The source items to find similar items for.</param>
-    /// <param name="query">The query options.</param>
-    /// <returns>Per-source-item results keyed by source item ID.</returns>
-    Task<Dictionary<Guid, IReadOnlyList<BaseItem>>> GetBatchSimilarItemsAsync(
-        IReadOnlyList<BaseItem> sourceItems,
-        SimilarItemsQuery query);
+    /// <param name="user">The user the recommendations are for. May be <see langword="null"/> for anonymous access.</param>
+    /// <param name="parentId">The library/folder to localize the search to. Pass <see cref="Guid.Empty"/> to use the root.</param>
+    /// <param name="categoryLimit">Maximum number of recommendation categories to return.</param>
+    /// <param name="itemLimit">Maximum number of items per category.</param>
+    /// <param name="dtoOptions">DTO options used when querying the library.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The list of recommendation categories, ordered by <see cref="RecommendationType"/>.</returns>
+    Task<IReadOnlyList<SimilarItemsRecommendation>> GetMovieRecommendationsAsync(
+        User? user,
+        Guid parentId,
+        int categoryLimit,
+        int itemLimit,
+        DtoOptions dtoOptions,
+        CancellationToken cancellationToken);
 }

--- a/MediaBrowser.Controller/Library/SimilarItemsRecommendation.cs
+++ b/MediaBrowser.Controller/Library/SimilarItemsRecommendation.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Dto;
+
+namespace MediaBrowser.Controller.Library;
+
+/// <summary>
+/// A recommendation category derived from a baseline item, holding similar items prior to DTO conversion.
+/// </summary>
+public sealed class SimilarItemsRecommendation
+{
+    /// <summary>
+    /// Gets the display name of the baseline item the recommendation is based on.
+    /// </summary>
+    public required string BaselineItemName { get; init; }
+
+    /// <summary>
+    /// Gets an identifier for the recommendation category.
+    /// </summary>
+    public required Guid CategoryId { get; init; }
+
+    /// <summary>
+    /// Gets the recommendation type.
+    /// </summary>
+    public required RecommendationType RecommendationType { get; init; }
+
+    /// <summary>
+    /// Gets the similar items for the baseline, ordered by relevance.
+    /// </summary>
+    public required IReadOnlyList<BaseItem> Items { get; init; }
+}

--- a/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IPeopleRepository.cs
@@ -32,4 +32,13 @@ public interface IPeopleRepository
     /// <param name="filter">The query.</param>
     /// <returns>The list of people names matching the filter.</returns>
     IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery filter);
+
+    /// <summary>
+    /// Gets distinct people names for multiple items efficiently by querying from the mapping table.
+    /// </summary>
+    /// <param name="itemIds">The item IDs to get people for.</param>
+    /// <param name="personTypes">The person types to include (e.g. "Actor", "Director").</param>
+    /// <param name="limit">Maximum number of names to return.</param>
+    /// <returns>The distinct people names.</returns>
+    IReadOnlyList<string> GetPeopleNamesByItems(IReadOnlyList<Guid> itemIds, IReadOnlyList<string> personTypes, int limit);
 }


### PR DESCRIPTION
Add a batch path to the local similar-items pipeline so movie recommendations can score and resolve candidates for several source items in one pass instead of N independent queries.

**Changes**
* Restore weighted recommendations for movies

**Issues**
Fixes: #14088