### PR TITLE
fix: write livetv recording NFO dateadded as UTC

### DIFF
--- a/src/Jellyfin.LiveTv/Recordings/RecordingsMetadataManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsMetadataManager.cs
@@ -288,7 +288,7 @@ public class RecordingsMetadataManager
                     null,
                     "dateadded",
                     null,
-                    DateTime.Now.ToString(DateAddedFormat, CultureInfo.InvariantCulture)).ConfigureAwait(false);
+                    DateTime.UtcNow.ToString(DateAddedFormat, CultureInfo.InvariantCulture)).ConfigureAwait(false);
 
                 if (item.ProductionYear.HasValue)
                 {

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsMetadataManagerTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsMetadataManagerTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
+using Jellyfin.Extensions;
 using Jellyfin.LiveTv.Recordings;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -26,7 +27,7 @@ public sealed class RecordingsMetadataManagerTests
     {
         Directory.CreateDirectory(_tempDir);
         var recordingPath = Path.Combine(_tempDir, "test-recording.ts");
-        await File.WriteAllTextAsync(recordingPath, string.Empty, TestContext.Current.CancellationToken);
+        FileHelper.CreateEmpty(recordingPath);
 
         var config = new Mock<IConfigurationManager>();
         config.Setup(c => c.GetConfiguration("livetv"))

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsMetadataManagerTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsMetadataManagerTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml;
+using Jellyfin.LiveTv.Recordings;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.LiveTv;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings;
+
+public sealed class RecordingsMetadataManagerTests
+{
+    private readonly string _tempDir =
+        Path.Combine(Path.GetTempPath(), "jellyfin-test-" + Guid.NewGuid());
+
+    [Fact]
+    public async Task SaveRecordingMetadata_DateAddedIsUtc()
+    {
+        Directory.CreateDirectory(_tempDir);
+        var recordingPath = Path.Combine(_tempDir, "test-recording.ts");
+        await File.WriteAllTextAsync(recordingPath, string.Empty, TestContext.Current.CancellationToken);
+
+        var config = new Mock<IConfigurationManager>();
+        config.Setup(c => c.GetConfiguration("livetv"))
+            .Returns(new LiveTvOptions { SaveRecordingNFO = true, SaveRecordingImages = false });
+        config.Setup(c => c.GetConfiguration("xbmcmetadata"))
+            .Returns(new XbmcMetadataOptions());
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager
+            .Setup(l => l.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(Array.Empty<BaseItem>());
+
+        var manager = new RecordingsMetadataManager(
+            NullLogger<RecordingsMetadataManager>.Instance,
+            config.Object,
+            libraryManager.Object);
+
+        var timer = new TimerInfo { Name = "Test Recording", ProgramId = null };
+
+        var beforeUtc = DateTime.UtcNow.AddSeconds(-2);
+        await manager.SaveRecordingMetadata(timer, recordingPath, null);
+        var afterUtc = DateTime.UtcNow.AddSeconds(2);
+
+        var doc = new XmlDocument();
+        doc.Load(Path.ChangeExtension(recordingPath, ".nfo"));
+        var dateAddedText = doc.SelectSingleNode("//dateadded")?.InnerText ?? string.Empty;
+        var parsed = DateTime.ParseExact(
+            dateAddedText,
+            "yyyy-MM-dd HH:mm:ss",
+            CultureInfo.InvariantCulture);
+
+        Assert.InRange(parsed, beforeUtc, afterUtc);
+    }
+}


### PR DESCRIPTION
**Changes**
`RecordingsMetadataManager` was writing `<dateadded>` with `DateTime.Now`
Switched to `DateTime.UtcNow` to match the parser  

**Issues**
Fixes #16795
