### PR TITLE
feat: Add DVD/Blu-Ray playback title selection

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1244,6 +1244,7 @@ namespace Emby.Server.Implementations.Dto
                 dto.VideoType = video.VideoType;
                 dto.Video3DFormat = video.Video3DFormat;
                 dto.IsoType = video.IsoType;
+                dto.IsoPlaybackTitle = video.IsoPlaybackTitle;
 
                 if (video.HasSubtitles)
                 {

--- a/Emby.Server.Implementations/Localization/Core/en-US.json
+++ b/Emby.Server.Implementations/Localization/Core/en-US.json
@@ -20,6 +20,7 @@
     "HearingImpaired": "Hearing Impaired",
     "HomeVideos": "Home Videos",
     "Inherit": "Inherit",
+    "ItemNotDvdBluray": "Item is not a DVD or Blu-ray.",
     "LabelIpAddressValue": "IP address: {0}",
     "LabelRunningTimeValue": "Running time: {0}",
     "Latest": "Latest",

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -244,7 +244,7 @@ public class ItemUpdateController : BaseJellyfinApiController
 
         if (item is not Video video)
         {
-            return BadRequest("Item is not a DVD/Blu-ray ISO or unpacked disc.");
+            return BadRequest(_localizationManager.GetLocalizedString("ItemNotDvdBluray"));
         }
 
         IsoType? effectiveIsoType = video.VideoType switch
@@ -278,7 +278,7 @@ public class ItemUpdateController : BaseJellyfinApiController
                 }
             }
 
-            return BadRequest("Item is not a DVD/Blu-ray ISO or unpacked disc.");
+            return BadRequest(_localizationManager.GetLocalizedString("ItemNotDvdBluray"));
         }
 
         var titles = _mediaEncoder.GetIsoTitles(video.Path, effectiveIsoType.Value);

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -15,11 +15,13 @@ using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -38,6 +40,7 @@ public class ItemUpdateController : BaseJellyfinApiController
     private readonly ILocalizationManager _localizationManager;
     private readonly IFileSystem _fileSystem;
     private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly IMediaEncoder _mediaEncoder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemUpdateController"/> class.
@@ -47,18 +50,21 @@ public class ItemUpdateController : BaseJellyfinApiController
     /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
     /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
     public ItemUpdateController(
         IFileSystem fileSystem,
         ILibraryManager libraryManager,
         IProviderManager providerManager,
         ILocalizationManager localizationManager,
-        IServerConfigurationManager serverConfigurationManager)
+        IServerConfigurationManager serverConfigurationManager,
+        IMediaEncoder mediaEncoder)
     {
         _libraryManager = libraryManager;
         _providerManager = providerManager;
         _localizationManager = localizationManager;
         _fileSystem = fileSystem;
         _serverConfigurationManager = serverConfigurationManager;
+        _mediaEncoder = mediaEncoder;
     }
 
     /// <summary>
@@ -88,6 +94,10 @@ public class ItemUpdateController : BaseJellyfinApiController
             series.DisplayOrder ?? string.Empty,
             request.DisplayOrder ?? string.Empty,
             StringComparison.OrdinalIgnoreCase);
+        // Queue a re-probe only when a supported disc item's stored title differs from the requested title.
+        var shouldReprobeForTitleChange = item is Video existingVideo
+            && IsIsoPlaybackTitleSupported(existingVideo)
+            && existingVideo.IsoPlaybackTitle != request.IsoPlaybackTitle;
 
         // Do this first so that metadata savers can pull the updates from the database.
         if (request.People is not null)
@@ -132,6 +142,19 @@ public class ItemUpdateController : BaseJellyfinApiController
                 RefreshPriority.High);
         }
 
+        if (shouldReprobeForTitleChange)
+        {
+            // Re-probe using the selected title so tracks/codecs/chapters reflect that title.
+            _providerManager.QueueRefresh(
+                item.Id,
+                new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                {
+                    MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
+                    ImageRefreshMode = MetadataRefreshMode.None
+                },
+                RefreshPriority.High);
+        }
+
         return NoContent();
     }
 
@@ -161,7 +184,9 @@ public class ItemUpdateController : BaseJellyfinApiController
             Cultures = _localizationManager.GetCultures()
                 .DistinctBy(c => c.DisplayName, StringComparer.OrdinalIgnoreCase)
                 .OrderBy(c => c.DisplayName)
-                .ToArray()
+                .ToArray(),
+            SupportsDvdVideo = _mediaEncoder.SupportsDvdVideo,
+            SupportsLibBluray = _mediaEncoder.SupportsLibBluray
         };
 
         if (!item.IsVirtualItem
@@ -194,6 +219,70 @@ public class ItemUpdateController : BaseJellyfinApiController
         }
 
         return info;
+    }
+
+    /// <summary>
+    /// Gets the available playback titles for a DVD or Blu-ray (ISO or unpacked directory).
+    /// Returns a list of title numbers and their durations so the user can select the desired title.
+    /// </summary>
+    /// <param name="itemId">The item id.</param>
+    /// <response code="200">Titles returned.</response>
+    /// <response code="404">Item not found.</response>
+    /// <response code="400">Item is not a DVD/Blu-ray ISO or unpacked disc.</response>
+    /// <returns>A list of <see cref="IsoTitleInfo"/> on success.</returns>
+    [HttpGet("Items/{itemId}/IsoTitles")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<IReadOnlyList<IsoTitleInfo>> GetIsoTitles([FromRoute, Required] Guid itemId)
+    {
+        var item = _libraryManager.GetItemById<BaseItem>(itemId, User.GetUserId());
+        if (item is null)
+        {
+            return NotFound();
+        }
+
+        if (item is not Video video)
+        {
+            return BadRequest("Item is not a DVD/Blu-ray ISO or unpacked disc.");
+        }
+
+        IsoType? effectiveIsoType = video.VideoType switch
+        {
+            VideoType.Iso when video.IsoType.HasValue => video.IsoType.Value,
+            VideoType.BluRay => IsoType.BluRay,
+            VideoType.Dvd => IsoType.Dvd,
+            _ => null
+        };
+
+        if (effectiveIsoType is null)
+        {
+            if (video.VideoType == VideoType.Iso)
+            {
+                if (_mediaEncoder.SupportsDvdVideo)
+                {
+                    var dvdTitles = _mediaEncoder.GetIsoTitles(video.Path, IsoType.Dvd);
+                    if (dvdTitles.Count > 0)
+                    {
+                        return Ok(dvdTitles);
+                    }
+                }
+
+                if (_mediaEncoder.SupportsLibBluray)
+                {
+                    var blurayTitles = _mediaEncoder.GetIsoTitles(video.Path, IsoType.BluRay);
+                    if (blurayTitles.Count > 0)
+                    {
+                        return Ok(blurayTitles);
+                    }
+                }
+            }
+
+            return BadRequest("Item is not a DVD/Blu-ray ISO or unpacked disc.");
+        }
+
+        var titles = _mediaEncoder.GetIsoTitles(video.Path, effectiveIsoType.Value);
+        return Ok(titles);
     }
 
     /// <summary>
@@ -416,6 +505,12 @@ public class ItemUpdateController : BaseJellyfinApiController
         if (item is Video video)
         {
             video.Video3DFormat = request.Video3DFormat;
+
+            // Allow setting the ISO/disc playback title for DVD/Blu-ray ISO files or unpacked directories.
+            if (IsIsoPlaybackTitleSupported(video))
+            {
+                video.IsoPlaybackTitle = request.IsoPlaybackTitle;
+            }
         }
 
         if (request.AlbumArtists is not null)
@@ -456,6 +551,14 @@ public class ItemUpdateController : BaseJellyfinApiController
                 }
         }
     }
+
+    /// <summary>
+    /// Determines whether ISO/disc playback title selection applies to the given video item.
+    /// Supported for unpacked DVD/Blu-ray directories and ISO items with a known <see cref="IsoType"/>.
+    /// </summary>
+    private static bool IsIsoPlaybackTitleSupported(Video video)
+        => video.VideoType is MediaBrowser.Model.Entities.VideoType.Dvd or MediaBrowser.Model.Entities.VideoType.BluRay
+            || (video.VideoType == MediaBrowser.Model.Entities.VideoType.Iso && video.IsoType.HasValue);
 
     private SeriesStatus? GetSeriesStatus(BaseItemDto item)
     {

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -465,10 +465,11 @@ public class VideosController : BaseJellyfinApiController
         }
 
         var isIso = state.MediaSource.VideoType == VideoType.Iso;
-        var isIsoDvdOrBluRay = (isIso && (state.MediaSource.IsoType == IsoType.Dvd || state.MediaSource.IsoType == IsoType.BluRay)) || (state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd);
+        var isUnpackedDvdBluray = state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd;
+        var isIsoDvdOrBluRay = isIso && (state.MediaSource.IsoType == IsoType.Dvd || state.MediaSource.IsoType == IsoType.BluRay);
 
         // Static stream
-        if (@static.HasValue && @static.Value && isIso && isIsoDvdOrBluRay)
+        if (@static.HasValue && @static.Value && !isUnpackedDvdBluray)
         {
             var contentType = state.GetMimeType("." + state.OutputContainer, false) ?? state.GetMimeType(state.MediaPath);
 

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -464,10 +464,11 @@ public class VideosController : BaseJellyfinApiController
             return BadRequest($"Input protocol {state.InputProtocol} cannot be streamed statically");
         }
 
-        var isIsoDvdOrBluRay = (state.MediaSource.VideoType == VideoType.Iso && (state.MediaSource.IsoType == IsoType.Dvd || state.MediaSource.IsoType == IsoType.BluRay)) || (state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd);
+        var isIso = state.MediaSource.VideoType == VideoType.Iso;
+        var isIsoDvdOrBluRay = (isIso && (state.MediaSource.IsoType == IsoType.Dvd || state.MediaSource.IsoType == IsoType.BluRay)) || (state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd);
 
         // Static stream
-        if (@static.HasValue && @static.Value && !isIsoDvdOrBluRay)
+        if (@static.HasValue && @static.Value && isIso && isIsoDvdOrBluRay)
         {
             var contentType = state.GetMimeType("." + state.OutputContainer, false) ?? state.GetMimeType(state.MediaPath);
 
@@ -480,17 +481,6 @@ public class VideosController : BaseJellyfinApiController
             return FileStreamResponseHelpers.GetStaticFileResult(
                 state.MediaPath,
                 contentType);
-        }
-
-        if (@static.HasValue && @static.Value && isIsoDvdOrBluRay)
-        {
-            state.OutputAudioCodec = "copy";
-            state.OutputVideoCodec = "copy";
-            state.OutputAudioBitrate = null;
-            state.OutputAudioChannels = null;
-            state.OutputVideoBitrate = null;
-            state.OutputFilePath += ".mkv";
-            state.MapAll = true;
         }
 
         // Need to start ffmpeg (because media can't be returned directly)

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -464,8 +464,10 @@ public class VideosController : BaseJellyfinApiController
             return BadRequest($"Input protocol {state.InputProtocol} cannot be streamed statically");
         }
 
+        var isIsoDvdOrBluRay = (state.MediaSource.VideoType == VideoType.Iso && (state.MediaSource.IsoType == IsoType.Dvd || state.MediaSource.IsoType == IsoType.BluRay)) || (state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd);
+
         // Static stream
-        if (@static.HasValue && @static.Value && !(state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd))
+        if (@static.HasValue && @static.Value && !isIsoDvdOrBluRay)
         {
             var contentType = state.GetMimeType("." + state.OutputContainer, false) ?? state.GetMimeType(state.MediaPath);
 
@@ -478,6 +480,17 @@ public class VideosController : BaseJellyfinApiController
             return FileStreamResponseHelpers.GetStaticFileResult(
                 state.MediaPath,
                 contentType);
+        }
+
+        if (@static.HasValue && @static.Value && isIsoDvdOrBluRay)
+        {
+            state.OutputAudioCodec = "copy";
+            state.OutputVideoCodec = "copy";
+            state.OutputAudioBitrate = null;
+            state.OutputAudioChannels = null;
+            state.OutputVideoBitrate = null;
+            state.OutputFilePath += ".mkv";
+            state.MapAll = true;
         }
 
         // Need to start ffmpeg (because media can't be returned directly)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1169,6 +1169,7 @@ namespace MediaBrowser.Controller.Entities
                 info.VideoType = video.VideoType;
                 info.Video3DFormat = video.Video3DFormat;
                 info.Timestamp = video.Timestamp;
+                info.IsoPlaybackTitle = video.IsoPlaybackTitle;
 
                 if (video.IsShortcut && !string.IsNullOrEmpty(video.ShortcutPath))
                 {

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -135,6 +135,13 @@ namespace MediaBrowser.Controller.Entities
         public IsoType? IsoType { get; set; }
 
         /// <summary>
+        /// Gets or sets the 1-based playback title number to use when playing a DVD/Blu-ray ISO or directory.
+        /// When null, the default (longest) title is used.
+        /// </summary>
+        /// <value>The playback title number, or null for the default title.</value>
+        public int? IsoPlaybackTitle { get; set; }
+
+        /// <summary>
         /// Gets or sets the video3 D format.
         /// </summary>
         /// <value>The video3 D format.</value>

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1280,10 +1280,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                 && _mediaEncoder.SupportsLibBluray)
             {
                 // Unpacked Blu-ray directory with an explicit title selection: use libbluray title selection.
-                // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
+                // IsoPlaybackTitle is 1-based for display; libbluray expects the specific number of the .mpls file.
                 var titleNumber = state.MediaSource.IsoPlaybackTitle.Value;
-                arg.Append(" -bluray_video_title ")
-                    .Append(titleNumber - 1)
+                arg.Append(" -playlist ")
+                    .Append(titleNumber.ToString(CultureInfo.InvariantCulture).PadLeft(5, '0'))
                     .Append(" -i ")
                     .Append(_mediaEncoder.GetInputPathArgument(state));
             }
@@ -1313,13 +1313,13 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 if (_mediaEncoder.SupportsLibBluray)
                 {
-                    // Blu-ray ISO: pass -bluray_video_title N (0-based) before the input.
-                    // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
+                    // Blu-ray ISO: pass -playlist N (BDMV/PLAYLIST/?????.mpls) before the input.
+                    // IsoPlaybackTitle is 1-based for display; libbluray expects the exact .mpls number.
                     // If no title is stored, resolve the longest title on demand.
                     var titleNumber = state.MediaSource.IsoPlaybackTitle
                         ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.BluRay);
-                    arg.Append(" -bluray_video_title ")
-                        .Append(titleNumber - 1)
+                    arg.Append(" -playlist ")
+                        .Append(titleNumber.ToString(CultureInfo.InvariantCulture).PadLeft(5, '0'))
                         .Append(" -i ")
                         .Append(_mediaEncoder.GetInputPathArgument(state));
                 }
@@ -7987,6 +7987,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             for (var i = 0; i < length; i++)
             {
                 var currentMediaStream = mediaStreams[i];
+
+                if (currentMediaStream.Codec == "dvd_nav_packet")
+                {
+                    continue;
+                }
+
                 if (currentMediaStream == streamToFind)
                 {
                     return index;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1295,7 +1295,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     // DVD ISO: use the dvdvideo demuxer which requires libdvdnav + libdvdread.
                     // Use the stored playback title; if none is set, resolve the longest title on demand.
                     var titleNumber = state.MediaSource.IsoPlaybackTitle
-                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.Dvd);
+                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.Dvd, _mediaEncoder);
                     arg.Append(" -f dvdvideo -title ")
                         .Append(titleNumber)
                         .Append(" -i ")
@@ -1317,7 +1317,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     // IsoPlaybackTitle is 1-based for display; libbluray expects the exact .mpls number.
                     // If no title is stored, resolve the longest title on demand.
                     var titleNumber = state.MediaSource.IsoPlaybackTitle
-                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.BluRay);
+                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.BluRay, _mediaEncoder);
                     arg.Append(" -playlist ")
                         .Append(titleNumber.ToString(CultureInfo.InvariantCulture).PadLeft(5, '0'))
                         .Append(" -i ")
@@ -8059,11 +8059,15 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// Used as a fallback at encode time when <see cref="MediaSourceInfo.IsoPlaybackTitle"/> is not set.
         /// Falls back to title 1 if the title list is empty or enumeration fails.
         /// </summary>
-        private int GetLongestIsoTitleNumber(string path, IsoType isoType)
+        /// <param name="path">The path to the media.</param>
+        /// <param name="isoType">The type of iso if applicable.</param>
+        /// <param name="mediaEncoder">The media encoder instance.</param>
+        /// <returns>The number for the longest title.</returns>
+        public static int GetLongestIsoTitleNumber(string path, IsoType isoType, IMediaEncoder mediaEncoder)
         {
             try
             {
-                var titles = _mediaEncoder.GetIsoTitles(path, isoType);
+                var titles = mediaEncoder.GetIsoTitles(path, isoType);
                 if (titles.Count == 0)
                 {
                     return 1;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1250,7 +1250,8 @@ namespace MediaBrowser.Controller.MediaEncoding
                 arg.Append(canvasArgs);
             }
 
-            if (state.MediaSource.VideoType == VideoType.Dvd || state.MediaSource.VideoType == VideoType.BluRay)
+            if ((state.MediaSource.VideoType == VideoType.Dvd && (!state.MediaSource.IsoPlaybackTitle.HasValue || !_mediaEncoder.SupportsDvdVideo))
+                || (state.MediaSource.VideoType == VideoType.BluRay && (!state.MediaSource.IsoPlaybackTitle.HasValue || !_mediaEncoder.SupportsLibBluray)))
             {
                 var concatFilePath = Path.Join(_configurationManager.CommonApplicationPaths.CachePath, "concat", state.MediaSource.Id + ".concat");
                 if (!File.Exists(concatFilePath))
@@ -1262,8 +1263,76 @@ namespace MediaBrowser.Controller.MediaEncoding
                     .Append(concatFilePath)
                     .Append("\" ");
             }
+            else if (state.MediaSource.VideoType == VideoType.Dvd
+                && state.MediaSource.IsoPlaybackTitle.HasValue
+                && _mediaEncoder.SupportsDvdVideo)
+            {
+                // Unpacked DVD directory with an explicit title selection: use dvdvideo demuxer.
+                // IsoPlaybackTitle is 1-based.
+                var titleNumber = state.MediaSource.IsoPlaybackTitle.Value;
+                arg.Append(" -f dvdvideo -title ")
+                    .Append(titleNumber)
+                    .Append(" -i ")
+                    .Append(_mediaEncoder.GetInputPathArgument(state));
+            }
+            else if (state.MediaSource.VideoType == VideoType.BluRay
+                && state.MediaSource.IsoPlaybackTitle.HasValue
+                && _mediaEncoder.SupportsLibBluray)
+            {
+                // Unpacked Blu-ray directory with an explicit title selection: use libbluray title selection.
+                // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
+                var titleNumber = state.MediaSource.IsoPlaybackTitle.Value;
+                arg.Append(" -bluray_video_title ")
+                    .Append(titleNumber - 1)
+                    .Append(" -i ")
+                    .Append(_mediaEncoder.GetInputPathArgument(state));
+            }
+            else if (state.MediaSource.VideoType == VideoType.Iso
+                && state.MediaSource.IsoType == IsoType.Dvd)
+            {
+                if (_mediaEncoder.SupportsDvdVideo)
+                {
+                    // DVD ISO: use the dvdvideo demuxer which requires libdvdnav + libdvdread.
+                    // Use the stored playback title; if none is set, resolve the longest title on demand.
+                    var titleNumber = state.MediaSource.IsoPlaybackTitle
+                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.Dvd);
+                    arg.Append(" -f dvdvideo -title ")
+                        .Append(titleNumber)
+                        .Append(" -i ")
+                        .Append(_mediaEncoder.GetInputPathArgument(state));
+                }
+                else
+                {
+                    // dvdvideo demuxer unavailable: fall back to passing the ISO path directly.
+                    arg.Append(" -i ")
+                        .Append(_mediaEncoder.GetInputPathArgument(state));
+                }
+            }
+            else if (state.MediaSource.VideoType == VideoType.Iso
+                && state.MediaSource.IsoType == IsoType.BluRay)
+            {
+                if (_mediaEncoder.SupportsLibBluray)
+                {
+                    // Blu-ray ISO: pass -bluray_video_title N (0-based) before the input.
+                    // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
+                    // If no title is stored, resolve the longest title on demand.
+                    var titleNumber = state.MediaSource.IsoPlaybackTitle
+                        ?? GetLongestIsoTitleNumber(state.MediaPath, IsoType.BluRay);
+                    arg.Append(" -bluray_video_title ")
+                        .Append(titleNumber - 1)
+                        .Append(" -i ")
+                        .Append(_mediaEncoder.GetInputPathArgument(state));
+                }
+                else
+                {
+                    // libbluray unavailable: fall back to passing the ISO path directly.
+                    arg.Append(" -i ")
+                        .Append(_mediaEncoder.GetInputPathArgument(state));
+                }
+            }
             else
             {
+                // Covers generic ISOs (IsoType = null), plain video files, and anything not handled above.
                 arg.Append(" -i ")
                     .Append(_mediaEncoder.GetInputPathArgument(state));
             }
@@ -3060,6 +3129,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <returns>System.String.</returns>
         public string GetMapArgs(EncodingJobInfo state)
         {
+            var mapAll = state.MapAll.HasValue && state.MapAll.Value;
+
             // If we don't have known media info
             // If input is video, use -sn to drop subtitles
             // Otherwise just return empty
@@ -3097,7 +3168,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 args += "-vn";
             }
 
-            if (state.AudioStream is not null)
+            if (!mapAll && state.AudioStream is not null)
             {
                 int audioStreamIndex = FindIndex(state.MediaSource.MediaStreams, state.AudioStream);
                 if (state.AudioStream.IsExternal)
@@ -3118,6 +3189,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                         " -map 0:{0}",
                         audioStreamIndex);
                 }
+            }
+            else if (mapAll)
+            {
+                args += " -map 0:a";
             }
             else
             {
@@ -7777,6 +7852,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Get the output codec name
             var codec = GetAudioEncoder(state);
 
+            if (state.MapAll.HasValue && state.MapAll.Value)
+            {
+                return "-codec:a " + codec;
+            }
+
             var args = "-codec:a:0 " + codec;
 
             if (IsCopyCodec(codec))
@@ -7966,6 +8046,33 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // -vsync is deprecated in FFmpeg 5.1 and will be removed in the future.
             return $" -vsync {videoSync}";
+        }
+
+        /// <summary>
+        /// Resolves the 1-based title number of the longest title in a DVD or Blu-ray ISO.
+        /// Used as a fallback at encode time when <see cref="MediaSourceInfo.IsoPlaybackTitle"/> is not set.
+        /// Falls back to title 1 if the title list is empty or enumeration fails.
+        /// </summary>
+        private int GetLongestIsoTitleNumber(string path, IsoType isoType)
+        {
+            try
+            {
+                var titles = _mediaEncoder.GetIsoTitles(path, isoType);
+                if (titles.Count == 0)
+                {
+                    return 1;
+                }
+
+                return titles
+                    .OrderByDescending(t => t.DurationTicks ?? 0)
+                    .ThenByDescending(t => t.TitleNumber)
+                    .First()
+                    .TitleNumber;
+            }
+            catch
+            {
+                return 1;
+            }
         }
     }
 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingJobInfo.cs
@@ -64,6 +64,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public VideoType VideoType { get; set; }
 
+        public bool? MapAll { get; set; }
+
         public Dictionary<string, string> RemoteHttpHeaders { get; set; }
 
         public string OutputVideoCodec { get; set; }

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -82,6 +82,18 @@ namespace MediaBrowser.Controller.MediaEncoding
         bool IsVideoToolboxAv1DecodeAvailable { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the <c>dvdvideo</c> demuxer is available in ffmpeg.
+        /// When <c>false</c>, DVD title selection and per-title probing are not available.
+        /// </summary>
+        bool SupportsDvdVideo { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <c>bluray</c> input protocol (libbluray) is available in ffmpeg.
+        /// When <c>false</c>, Blu-ray title selection and per-title probing are not available.
+        /// </summary>
+        bool SupportsLibBluray { get; }
+
+        /// <summary>
         /// Whether given encoder codec is supported.
         /// </summary>
         /// <param name="encoder">The encoder.</param>
@@ -259,6 +271,16 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="path">The to the .m2ts files.</param>
         /// <returns>A playlist.</returns>
         IReadOnlyList<string> GetPrimaryPlaylistM2tsFiles(string path);
+
+        /// <summary>
+        /// Gets all available playback titles from a DVD or Blu-ray ISO file or directory.
+        /// For DVD ISOs/directories the title count is read directly from the Video Manager IFO (VIDEO_TS.IFO);
+        /// for Blu-ray ISOs/directories they come from BDInfo playlist analysis.
+        /// </summary>
+        /// <param name="path">The path to the ISO file.</param>
+        /// <param name="isoType">The type of ISO (DVD or Blu-ray).</param>
+        /// <returns>A list of <see cref="IsoTitleInfo"/> ordered by title number.</returns>
+        IReadOnlyList<IsoTitleInfo> GetIsoTitles(string path, IsoType isoType);
 
         /// <summary>
         /// Gets the input path argument from <see cref="EncodingJobInfo"/>.

--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
@@ -105,20 +105,22 @@ public class BdInfoExaminer : IBlurayExaminer
         bdrom.Scan();
 
         // Enumerate all valid playlists sorted by filename (alphabetical playlist order).
-        // Title numbers are sequential 1-based integers across valid playlists for user display.
-        // At encode time, the -bluray_video_title option expects a 0-based index, so subtract 1.
+        // Title numbers are the integer value of the .mpls file name without the extension.
         var titles = new List<IsoTitleInfo>();
-        int titleNumber = 1;
         foreach (var playlist in bdrom.PlaylistFiles.Values.OrderBy(p => p.Name))
         {
             if (playlist.IsValid)
             {
-                titles.Add(new IsoTitleInfo
+                var playlistIdString = playlist.Name.Split(".").FirstOrDefault();
+
+                if (playlistIdString != null && playlistIdString.Length > 0 && int.TryParse(playlistIdString, out var playlistId))
                 {
-                    TitleNumber = titleNumber,
-                    DurationTicks = TimeSpan.FromSeconds(playlist.TotalLength).Ticks
-                });
-                titleNumber++;
+                    titles.Add(new IsoTitleInfo
+                    {
+                        TitleNumber = playlistId,
+                        DurationTicks = TimeSpan.FromSeconds(playlist.TotalLength).Ticks
+                    });
+                }
             }
         }
 

--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
@@ -93,6 +93,38 @@ public class BdInfoExaminer : IBlurayExaminer
         return outputStream;
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<IsoTitleInfo> GetTitles(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        var bdrom = new BDROM(BdInfoDirectoryInfo.FromFileSystemPath(_fileSystem, path));
+        bdrom.Scan();
+
+        // Enumerate all valid playlists sorted by filename (alphabetical playlist order).
+        // Title numbers are sequential 1-based integers across valid playlists for user display.
+        // At encode time, the -bluray_video_title option expects a 0-based index, so subtract 1.
+        var titles = new List<IsoTitleInfo>();
+        int titleNumber = 1;
+        foreach (var playlist in bdrom.PlaylistFiles.Values.OrderBy(p => p.Name))
+        {
+            if (playlist.IsValid)
+            {
+                titles.Add(new IsoTitleInfo
+                {
+                    TitleNumber = titleNumber,
+                    DurationTicks = TimeSpan.FromSeconds(playlist.TotalLength).Ticks
+                });
+                titleNumber++;
+            }
+        }
+
+        return titles;
+    }
+
     /// <summary>
     /// Adds the video stream.
     /// </summary>

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -574,6 +574,52 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return !string.IsNullOrEmpty(option) && GetProcessExitCode(proberPath, $"-loglevel quiet -f lavfi -i nullsrc=s=1x1:d=1 -{option}");
         }
 
+        /// <summary>
+        /// Checks whether the <c>dvdvideo</c> demuxer is compiled into ffmpeg.
+        /// The demuxer requires libdvdnav and libdvdread at build time.
+        /// </summary>
+        /// <returns><c>true</c> if dvdvideo is listed in <c>ffmpeg -formats</c>.</returns>
+        public bool CheckDvdVideoSupport()
+        {
+            string output;
+            try
+            {
+                output = GetProcessOutput(_encoderPath, "-formats", false, null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking dvdvideo demuxer support");
+                return false;
+            }
+
+            return output.Contains("dvdvideo", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks whether the <c>bluray</c> input protocol is compiled into ffmpeg.
+        /// The protocol requires libbluray at build time.
+        /// </summary>
+        /// <returns><c>true</c> if bluray is listed in <c>ffmpeg -protocols</c>.</returns>
+        public bool CheckLibBluraySupport()
+        {
+            string output;
+            try
+            {
+                output = GetProcessOutput(_encoderPath, "-protocols", false, null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking libbluray protocol support");
+                return false;
+            }
+
+            // The output lists one protocol per line; match the token exactly to avoid false positives.
+            // Split on both \r\n and \n to handle different line-ending conventions.
+            return output
+                .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                .Any(line => string.Equals(line.Trim(), "bluray", StringComparison.OrdinalIgnoreCase));
+        }
+
         private IEnumerable<string> GetCodecs(Codec codec)
         {
             string codecstr = codec == Codec.Encoder ? "encoders" : "decoders";

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -452,7 +452,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     && _supportsLibBluray)
                 {
                     // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
-                    extraArgs += $" -bluray_video_title {mediaSource.IsoPlaybackTitle.Value - 1}";
+                    extraArgs += $" -playlist {mediaSource.IsoPlaybackTitle.Value.ToString(CultureInfo.InvariantCulture).PadLeft(5, '0')}";
                     inputPath = GetInputPathArgument(mediaSource.Path, mediaSource);
                 }
             }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -89,6 +89,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private bool _isVideoToolboxAv1DecodeAvailable = false;
 
+        private bool _supportsDvdVideo = false;
+        private bool _supportsLibBluray = false;
+
         private static string[] _vulkanImageDrmFmtModifierExts =
         {
             "VK_EXT_image_drm_format_modifier",
@@ -166,6 +169,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public bool IsVaapiDeviceSupportVulkanDrmInterop => _isVaapiDeviceSupportVulkanDrmInterop;
 
         public bool IsVideoToolboxAv1DecodeAvailable => _isVideoToolboxAv1DecodeAvailable;
+
+        /// <inheritdoc />
+        public bool SupportsDvdVideo => _supportsDvdVideo;
+
+        /// <inheritdoc />
+        public bool SupportsLibBluray => _supportsLibBluray;
 
         [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
         private static partial Regex FfprobePathRegex();
@@ -277,6 +286,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 {
                     _isVideoToolboxAv1DecodeAvailable = validator.CheckIsVideoToolboxAv1DecodeAvailable();
                 }
+
+                // Check DVD and Blu-ray disc feature availability.
+                _supportsDvdVideo = validator.CheckDvdVideoSupport();
+                _supportsLibBluray = validator.CheckLibBluraySupport();
+                _logger.LogInformation("FFmpeg disc features — dvdvideo: {DvdVideo}, libbluray: {LibBluray}", _supportsDvdVideo, _supportsLibBluray);
             }
 
             _logger.LogInformation("FFmpeg: {FfmpegPath}", _ffmpegPath ?? string.Empty);
@@ -418,15 +432,39 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             var extractChapters = request.ExtractChapters;
             var extraArgs = GetExtraArguments(request);
+            var inputPath = GetInputArgument(request.MediaSource.Path, request.MediaSource);
+            var mediaSource = request.MediaSource;
+
+            // Title-based probing applies to disc video sources; audio probe requests do not use disc title selection.
+            if (mediaSource.IsoPlaybackTitle.HasValue && request.MediaType != DlnaProfileType.Audio)
+            {
+                // Probe using the selected title when available so stream/chapter metadata reflects
+                // the user-selected title rather than the default playlist/file sequence.
+                if (((mediaSource.VideoType == VideoType.Dvd)
+                    || (mediaSource.VideoType == VideoType.Iso && mediaSource.IsoType == IsoType.Dvd))
+                    && _supportsDvdVideo)
+                {
+                    extraArgs += $" -f dvdvideo -title {mediaSource.IsoPlaybackTitle.Value}";
+                    inputPath = GetDvdVideoInputArgument(mediaSource.Path, mediaSource.Protocol);
+                }
+                else if (((mediaSource.VideoType == VideoType.BluRay)
+                    || (mediaSource.VideoType == VideoType.Iso && mediaSource.IsoType == IsoType.BluRay))
+                    && _supportsLibBluray)
+                {
+                    // IsoPlaybackTitle is 1-based for display; libbluray expects 0-based.
+                    extraArgs += $" -bluray_video_title {mediaSource.IsoPlaybackTitle.Value - 1}";
+                    inputPath = GetInputPathArgument(mediaSource.Path, mediaSource);
+                }
+            }
 
             return GetMediaInfoInternal(
-                GetInputArgument(request.MediaSource.Path, request.MediaSource),
-                request.MediaSource.Path,
-                request.MediaSource.Protocol,
+                inputPath,
+                mediaSource.Path,
+                mediaSource.Protocol,
                 extractChapters,
                 extraArgs,
                 request.MediaType == DlnaProfileType.Audio,
-                request.MediaSource.VideoType,
+                mediaSource.VideoType,
                 cancellationToken);
         }
 
@@ -1274,6 +1312,74 @@ namespace MediaBrowser.MediaEncoding.Encoder
             => _blurayExaminer.GetDiscInfo(path).Files;
 
         /// <inheritdoc />
+        public IReadOnlyList<IsoTitleInfo> GetIsoTitles(string path, IsoType isoType)
+        {
+            if (isoType == IsoType.BluRay)
+            {
+                // Title enumeration for Blu-ray uses BDInfo (no ffmpeg dependency), but playback
+                // of a specific title requires libbluray in ffmpeg.  Return an empty list when
+                // libbluray is absent so the UI doesn't offer a selection that cannot be honoured.
+                if (!_supportsLibBluray)
+                {
+                    _logger.LogDebug("Skipping Blu-ray title enumeration: libbluray not available in ffmpeg");
+                    return Array.Empty<IsoTitleInfo>();
+                }
+
+                try
+                {
+                    return _blurayExaminer.GetTitles(path);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error enumerating Blu-ray titles for {Path}", path);
+                    return Array.Empty<IsoTitleInfo>();
+                }
+            }
+
+            // DVD title enumeration uses pure IFO binary parsing — no ffmpeg/dvdvideo demuxer required.
+            // Note: per-title playback still requires the dvdvideo demuxer at transcode time.
+            return GetDvdTitles(path);
+        }
+
+        /// <summary>
+        /// Enumerates DVD titles and their durations by parsing the IFO files directly.
+        /// Works for both ISO files and unpacked DVD directories without requiring ffprobe.
+        /// </summary>
+        private IReadOnlyList<IsoTitleInfo> GetDvdTitles(string path)
+        {
+            bool isFile = File.Exists(path);
+
+            DvdDiscInfo disc;
+            try
+            {
+                disc = isFile
+                    ? DvdVideoProber.ParseVideoTsIso(path, _logger)
+                    : DvdVideoProber.ParseVideoTsDirectory(path, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error parsing DVD IFO for {Path}", path);
+                return Array.Empty<IsoTitleInfo>();
+            }
+
+            if (disc.Titles.Count == 0)
+            {
+                return Array.Empty<IsoTitleInfo>();
+            }
+
+            return disc.Titles
+                .OrderBy(t => t.TitleNumber)
+                .Select(t => new IsoTitleInfo
+                {
+                    TitleNumber = t.TitleNumber,
+                    DurationTicks = t.Duration?.Ticks,
+                    ChapterCount = t.ChapterCount,
+                    AngleCount = t.AngleCount
+                })
+                .ToList();
+        }
+
+        /// <inheritdoc />
         public string GetInputPathArgument(EncodingJobInfo state)
             => GetInputPathArgument(state.MediaPath, state.MediaSource);
 
@@ -1282,10 +1388,29 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             return mediaSource.VideoType switch
             {
+                // When a specific title has been selected for an unpacked DVD directory, use a raw
+                // filesystem path with dvdvideo. ffmpeg has no "dvd" protocol.
+                // Without a title selection (or when dvdvideo is unavailable), fall back to concat.
+                VideoType.Dvd when mediaSource.IsoPlaybackTitle.HasValue && _supportsDvdVideo
+                    => GetDvdVideoInputArgument(path, mediaSource.Protocol),
                 VideoType.Dvd => GetInputArgument(GetPrimaryPlaylistVobFiles(path, null), mediaSource),
+                // When a specific title has been selected for an unpacked Blu-ray directory, use the
+                // bluray: URI scheme so FFmpeg's libbluray can apply -bluray_video_title selection.
+                // Without a title selection (or when libbluray is unavailable), fall back to concat.
+                VideoType.BluRay when mediaSource.IsoPlaybackTitle.HasValue && _supportsLibBluray
+                    => EncodingUtils.GetInputArgument("bluray", path, mediaSource.Protocol),
                 VideoType.BluRay => GetInputArgument(GetPrimaryPlaylistM2tsFiles(path), mediaSource),
+                // dvdvideo demuxer with ISO input requires a raw filesystem path, not file:"path".
+                VideoType.Iso when mediaSource.IsoType == IsoType.Dvd && _supportsDvdVideo
+                    => GetDvdVideoInputArgument(path, mediaSource.Protocol),
                 _ => GetInputArgument(path, mediaSource)
             };
+        }
+
+        private static string GetDvdVideoInputArgument(string inputPath, MediaProtocol protocol)
+        {
+            var normalizedPath = protocol == MediaProtocol.File ? EncodingUtils.NormalizePath(inputPath) : inputPath;
+            return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", normalizedPath);
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -1395,7 +1395,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     => GetDvdVideoInputArgument(path, mediaSource.Protocol),
                 VideoType.Dvd => GetInputArgument(GetPrimaryPlaylistVobFiles(path, null), mediaSource),
                 // When a specific title has been selected for an unpacked Blu-ray directory, use the
-                // bluray: URI scheme so FFmpeg's libbluray can apply -bluray_video_title selection.
+                // bluray: URI scheme so FFmpeg's libbluray can apply -playlist selection.
                 // Without a title selection (or when libbluray is unavailable), fall back to concat.
                 VideoType.BluRay when mediaSource.IsoPlaybackTitle.HasValue && _supportsLibBluray
                     => EncodingUtils.GetInputArgument("bluray", path, mediaSource.Protocol),

--- a/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
+++ b/MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="BDInfo" />
+    <PackageReference Include="DiscUtils.Udf" />
     <PackageReference Include="libse" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="UTF.Unknown" />

--- a/MediaBrowser.MediaEncoding/Probing/DvdDiscInfo.cs
+++ b/MediaBrowser.MediaEncoding/Probing/DvdDiscInfo.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace MediaBrowser.MediaEncoding.Probing;
+
+/// <summary>
+/// Holds parsed information about all titles on a DVD disc,
+/// derived from VIDEO_TS.IFO and the per-title-set VTS_xx_0.IFO files.
+/// </summary>
+internal sealed class DvdDiscInfo
+{
+    /// <summary>Gets the ordered list of titles found on the disc.</summary>
+    public List<DvdTitleInfo> Titles { get; } = new();
+}

--- a/MediaBrowser.MediaEncoding/Probing/DvdTitleInfo.cs
+++ b/MediaBrowser.MediaEncoding/Probing/DvdTitleInfo.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace MediaBrowser.MediaEncoding.Probing;
+
+/// <summary>
+/// Holds parsed information about a single DVD title, combining data from
+/// VIDEO_TS.IFO (TT_SRPT entry) and the corresponding VTS_xx_0.IFO
+/// (VTS_PTT_SRPT + VTS_PGCITI tables).
+/// </summary>
+internal sealed class DvdTitleInfo
+{
+    /// <summary>Gets the DVD title number (1-based, as seen by the user).</summary>
+    public int TitleNumber { get; init; }
+
+    /// <summary>Gets the title-set number (VTS number) that owns this title.</summary>
+    public int TitleSetNumber { get; init; }
+
+    /// <summary>Gets the title number within its title set (VTS-local, 1-based).</summary>
+    public int VtsTitleNumber { get; init; }
+
+    /// <summary>Gets the number of chapters (PTT entries) in this title.</summary>
+    public int ChapterCount { get; init; }
+
+    /// <summary>Gets the number of angles available for this title.</summary>
+    public int AngleCount { get; init; }
+
+    /// <summary>Gets or sets the Program Chain number resolved from VTS_PTT_SRPT.</summary>
+    public int ProgramChainNumber { get; set; }
+
+    /// <summary>Gets or sets the program number within the PGC.</summary>
+    public int ProgramNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the playback duration parsed from the PGC in VTS_PGCITI.
+    /// <c>null</c> if the VTS IFO was missing or the PGC data could not be parsed.
+    /// </summary>
+    public TimeSpan? Duration { get; set; }
+
+    /// <summary>Gets the start sector of the VTS within the disc image.</summary>
+    public uint VtsStartSector { get; init; }
+}

--- a/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
+++ b/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
@@ -23,7 +23,7 @@ namespace MediaBrowser.MediaEncoding.Probing;
 /// Sector pointers in header fields are relative to the start of the IFO file.
 /// Table-internal offsets are relative to the start of the table (not the file).
 /// </remarks>
-internal static class DvdVideoProber
+internal class DvdVideoProber
 {
     private const string VmgIfoDirectoryName = "VIDEO_TS";
     private const string VmgIfoFileName = "VIDEO_TS.IFO";
@@ -38,10 +38,11 @@ internal static class DvdVideoProber
     /// by reading the Video Manager IFO embedded in the UDF image.
     /// </summary>
     /// <param name="isoPath">Path to the ISO image file.</param>
+    /// <param name="logger">The logger; warnings are emitted for missing/corrupt IFOs.</param>
     /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
-    internal static IReadOnlyList<int> GetIsoTitleNumbers(string isoPath)
+    internal static IReadOnlyList<int> GetIsoTitleNumbers(string isoPath, ILogger logger)
     {
-        var disc = ParseVideoTsIso(isoPath);
+        var disc = ParseVideoTsIso(isoPath, logger);
         return disc.Titles.Count > 0
             ? disc.Titles.Select(t => t.TitleNumber).ToList()
             : Array.Empty<int>();
@@ -55,10 +56,11 @@ internal static class DvdVideoProber
     /// Path to either the root directory (containing a VIDEO_TS sub-directory)
     /// or directly to the VIDEO_TS directory itself.
     /// </param>
+    /// <param name="logger">The logger; warnings are emitted for missing/corrupt IFOs.</param>
     /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
-    internal static IReadOnlyList<int> GetDirectoryTitleNumbers(string dvdPath)
+    internal static IReadOnlyList<int> GetDirectoryTitleNumbers(string dvdPath, ILogger logger)
     {
-        var disc = ParseVideoTsDirectory(dvdPath);
+        var disc = ParseVideoTsDirectory(dvdPath, logger);
         return disc.Titles.Count > 0
             ? disc.Titles.Select(t => t.TitleNumber).ToList()
             : Array.Empty<int>();
@@ -74,9 +76,9 @@ internal static class DvdVideoProber
     /// Root DVD directory (may contain a VIDEO_TS sub-directory) or the VIDEO_TS
     /// directory itself.
     /// </param>
-    /// <param name="logger">Optional logger; warnings are emitted for missing/corrupt IFOs.</param>
+    /// <param name="logger">The logger; warnings are emitted for missing/corrupt IFOs.</param>
     /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
-    internal static DvdDiscInfo ParseVideoTsDirectory(string dvdPath, ILogger? logger = null)
+    internal static DvdDiscInfo ParseVideoTsDirectory(string dvdPath, ILogger logger)
     {
         var videoTsPath = ResolveVideoTsPath(dvdPath);
         if (videoTsPath is null)
@@ -87,7 +89,7 @@ internal static class DvdVideoProber
         var ifoPath = FindFileInsensitive(videoTsPath, VmgIfoFileName);
         if (ifoPath is null)
         {
-            logger?.LogWarning("VIDEO_TS.IFO not found in {VideoTsPath}", videoTsPath);
+            logger.LogWarning("VIDEO_TS.IFO not found in {VideoTsPath}", videoTsPath);
             return new DvdDiscInfo();
         }
 
@@ -98,7 +100,7 @@ internal static class DvdVideoProber
         }
         catch (Exception ex)
         {
-            logger?.LogError(ex, "Failed to read VIDEO_TS.IFO at {Path}", ifoPath);
+            logger.LogError(ex, "Failed to read VIDEO_TS.IFO at {Path}", ifoPath);
             return new DvdDiscInfo();
         }
 
@@ -120,7 +122,7 @@ internal static class DvdVideoProber
             var vtsIfoPath = FindFileInsensitive(videoTsPath, vtsIfoName);
             if (vtsIfoPath is null)
             {
-                logger?.LogWarning("VTS IFO {FileName} not found in {VideoTsPath}", vtsIfoName, videoTsPath);
+                logger.LogWarning("VTS IFO {FileName} not found in {VideoTsPath}", vtsIfoName, videoTsPath);
                 continue;
             }
 
@@ -131,7 +133,7 @@ internal static class DvdVideoProber
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Failed to read VTS IFO at {Path}", vtsIfoPath);
+                logger.LogError(ex, "Failed to read VTS IFO at {Path}", vtsIfoPath);
                 continue;
             }
 
@@ -145,9 +147,9 @@ internal static class DvdVideoProber
     /// Parses a DVD ISO image and returns full disc information including per-title durations.
     /// </summary>
     /// <param name="isoPath">Path to the ISO image file.</param>
-    /// <param name="logger">Optional logger.</param>
+    /// <param name="logger">The logger.</param>
     /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
-    internal static DvdDiscInfo ParseVideoTsIso(string isoPath, ILogger? logger = null)
+    internal static DvdDiscInfo ParseVideoTsIso(string isoPath, ILogger logger)
     {
         try
         {
@@ -157,7 +159,7 @@ internal static class DvdVideoProber
             var vtsDirectory = udfReader.GetDirectoryInfo(VmgIfoDirectoryName);
             if (!vtsDirectory.Exists)
             {
-                logger?.LogWarning("VIDEO_TS directory not found in ISO {Path}", isoPath);
+                logger.LogWarning("VIDEO_TS directory not found in ISO {Path}", isoPath);
                 return new DvdDiscInfo();
             }
 
@@ -167,7 +169,7 @@ internal static class DvdVideoProber
                 f => string.Equals(f.Name, VmgIfoFileName, StringComparison.OrdinalIgnoreCase));
             if (vmgIfoFile is null)
             {
-                logger?.LogWarning("VIDEO_TS.IFO not found in ISO {Path}", isoPath);
+                logger.LogWarning("VIDEO_TS.IFO not found in ISO {Path}", isoPath);
                 return new DvdDiscInfo();
             }
 
@@ -196,7 +198,7 @@ internal static class DvdVideoProber
                     f => string.Equals(f.Name, vtsIfoName, StringComparison.OrdinalIgnoreCase));
                 if (vtsIfoFile is null)
                 {
-                    logger?.LogWarning("VTS IFO {FileName} not found in ISO {Path}", vtsIfoName, isoPath);
+                    logger.LogWarning("VTS IFO {FileName} not found in ISO {Path}", vtsIfoName, isoPath);
                     continue;
                 }
 
@@ -208,7 +210,7 @@ internal static class DvdVideoProber
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogError(ex, "Failed to read VTS IFO {FileName} from ISO", vtsIfoName);
+                    logger.LogError(ex, "Failed to read VTS IFO {FileName} from ISO", vtsIfoName);
                     continue;
                 }
 
@@ -219,7 +221,7 @@ internal static class DvdVideoProber
         }
         catch (Exception ex)
         {
-            logger?.LogError(ex, "Failed to parse DVD ISO at {Path}", isoPath);
+            logger.LogError(ex, "Failed to parse DVD ISO at {Path}", isoPath);
             return new DvdDiscInfo();
         }
     }
@@ -431,18 +433,18 @@ internal static class DvdVideoProber
     /// Mutates <paramref name="titles"/> in-place, setting <see cref="DvdTitleInfo.ProgramChainNumber"/>,
     /// <see cref="DvdTitleInfo.ProgramNumber"/>, and <see cref="DvdTitleInfo.Duration"/> on each entry.
     /// </remarks>
-    private static void ParseVtsIfo(byte[] data, int vtsNumber, IEnumerable<DvdTitleInfo> titles, ILogger? logger)
+    private static void ParseVtsIfo(byte[] data, int vtsNumber, IEnumerable<DvdTitleInfo> titles, ILogger logger)
     {
         if (!HasMagic(data, MagicVts))
         {
-            logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO has wrong magic bytes — skipping", vtsNumber);
+            logger.LogWarning("VTS_{VtsNum:D2}_0.IFO has wrong magic bytes — skipping", vtsNumber);
             return;
         }
 
         // vtsi_mat_t: vts_ptt_srpt at 0xC8, vts_pgcit at 0xCC
         if (data.Length < 0xD0)
         {
-            logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO is too short to contain VTSI_MAT pointers", vtsNumber);
+            logger.LogWarning("VTS_{VtsNum:D2}_0.IFO is too short to contain VTSI_MAT pointers", vtsNumber);
             return;
         }
 
@@ -460,7 +462,7 @@ internal static class DvdVideoProber
             }
             else
             {
-                logger?.LogWarning(
+                logger.LogWarning(
                     "VTS_{VtsNum:D2}_0.IFO: VTS_PTT_SRPT sector {Sector} points outside file",
                     vtsNumber,
                     pttSrptSector);
@@ -478,7 +480,7 @@ internal static class DvdVideoProber
             }
             else
             {
-                logger?.LogWarning(
+                logger.LogWarning(
                     "VTS_{VtsNum:D2}_0.IFO: VTS_PGCITI sector {Sector} points outside file",
                     vtsNumber,
                     pgcitiSector);

--- a/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
+++ b/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
@@ -4,100 +4,177 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 
-namespace MediaBrowser.MediaEncoding.Probing
+namespace MediaBrowser.MediaEncoding.Probing;
+
+/// <summary>
+/// Parses DVD-Video IFO files (VIDEO_TS.IFO and VTS_xx_0.IFO) to enumerate disc titles
+/// and resolve per-title durations.
+/// </summary>
+/// <remarks>
+/// Binary layout follows the DVD specification as implemented in libdvdread / libdvdnav.
+/// Key references:
+/// <list type="bullet">
+///   <item><description>libdvdread <c>ifo_types.h</c> — structure definitions.</description></item>
+///   <item><description>libdvdread <c>ifo_read.c</c> — parsing functions (ifoRead_TT_SRPT, ifoRead_VTS_PTT_SRPT, ifoRead_VTS_PGCIT).</description></item>
+///   <item><description>libdvdnav <c>read_cache.c</c> / <c>dvdnav.c</c> — sector navigation.</description></item>
+/// </list>
+/// All multi-byte integers in IFO files are big-endian.
+/// DVD sectors are 2 048 bytes.
+/// Sector pointers in header fields are relative to the start of the IFO file.
+/// Table-internal offsets are relative to the start of the table (not the file).
+/// </remarks>
+internal static class DvdVideoProber
 {
+    private const string VmgIfoDirectoryName = "VIDEO_TS";
+    private const string VmgIfoFileName = "VIDEO_TS.IFO";
+    private const int DvdSectorSize = 2048;
+    private static readonly byte[] MagicVmg = System.Text.Encoding.ASCII.GetBytes("DVDVIDEO-VMG");
+    private static readonly byte[] MagicVts = System.Text.Encoding.ASCII.GetBytes("DVDVIDEO-VTS");
+
+    // ── Public convenience wrappers (title-number lists only) ──────────────
+
     /// <summary>
-    /// Parses DVD-Video IFO files (VIDEO_TS.IFO and VTS_xx_0.IFO) to enumerate disc titles
-    /// and resolve per-title durations.
+    /// Returns the list of title numbers (1-based) present in a DVD ISO file,
+    /// by reading the Video Manager IFO embedded in the UDF image.
     /// </summary>
-    /// <remarks>
-    /// Binary layout follows the DVD specification as implemented in libdvdread / libdvdnav.
-    /// Key references:
-    /// <list type="bullet">
-    ///   <item><description>libdvdread <c>ifo_types.h</c> — structure definitions.</description></item>
-    ///   <item><description>libdvdread <c>ifo_read.c</c> — parsing functions (ifoRead_TT_SRPT, ifoRead_VTS_PTT_SRPT, ifoRead_VTS_PGCIT).</description></item>
-    ///   <item><description>libdvdnav <c>read_cache.c</c> / <c>dvdnav.c</c> — sector navigation.</description></item>
-    /// </list>
-    /// All multi-byte integers in IFO files are big-endian.
-    /// DVD sectors are 2 048 bytes.
-    /// Sector pointers in header fields are relative to the start of the IFO file.
-    /// Table-internal offsets are relative to the start of the table (not the file).
-    /// </remarks>
-    internal static class DvdVideoProber
+    /// <param name="isoPath">Path to the ISO image file.</param>
+    /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
+    internal static IReadOnlyList<int> GetIsoTitleNumbers(string isoPath)
     {
-        private const string VmgIfoDirectoryName = "VIDEO_TS";
-        private const string VmgIfoFileName = "VIDEO_TS.IFO";
-        private const int DvdSectorSize = 2048;
+        var disc = ParseVideoTsIso(isoPath);
+        return disc.Titles.Count > 0
+            ? disc.Titles.Select(t => t.TitleNumber).ToList()
+            : Array.Empty<int>();
+    }
 
-        // ── Public convenience wrappers (title-number lists only) ──────────────
+    /// <summary>
+    /// Returns the list of title numbers (1-based) present in an unpacked DVD directory,
+    /// by reading the Video Manager IFO from the filesystem.
+    /// </summary>
+    /// <param name="dvdPath">
+    /// Path to either the root directory (containing a VIDEO_TS sub-directory)
+    /// or directly to the VIDEO_TS directory itself.
+    /// </param>
+    /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
+    internal static IReadOnlyList<int> GetDirectoryTitleNumbers(string dvdPath)
+    {
+        var disc = ParseVideoTsDirectory(dvdPath);
+        return disc.Titles.Count > 0
+            ? disc.Titles.Select(t => t.TitleNumber).ToList()
+            : Array.Empty<int>();
+    }
 
-        /// <summary>
-        /// Returns the list of title numbers (1-based) present in a DVD ISO file,
-        /// by reading the Video Manager IFO embedded in the UDF image.
-        /// </summary>
-        /// <param name="isoPath">Path to the ISO image file.</param>
-        /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
-        internal static IReadOnlyList<int> GetIsoTitleNumbers(string isoPath)
+    // ── Full disc parsers ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Parses a DVD VIDEO_TS directory (on disk) and returns full disc information
+    /// including per-title durations resolved from the VTS IFO files.
+    /// </summary>
+    /// <param name="dvdPath">
+    /// Root DVD directory (may contain a VIDEO_TS sub-directory) or the VIDEO_TS
+    /// directory itself.
+    /// </param>
+    /// <param name="logger">Optional logger; warnings are emitted for missing/corrupt IFOs.</param>
+    /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
+    internal static DvdDiscInfo ParseVideoTsDirectory(string dvdPath, ILogger? logger = null)
+    {
+        var videoTsPath = ResolveVideoTsPath(dvdPath);
+        if (videoTsPath is null)
         {
-            var disc = ParseVideoTsIso(isoPath);
-            return disc.Titles.Count > 0
-                ? disc.Titles.Select(t => t.TitleNumber).ToList()
-                : Array.Empty<int>();
+            return new DvdDiscInfo();
         }
 
-        /// <summary>
-        /// Returns the list of title numbers (1-based) present in an unpacked DVD directory,
-        /// by reading the Video Manager IFO from the filesystem.
-        /// </summary>
-        /// <param name="dvdPath">
-        /// Path to either the root directory (containing a VIDEO_TS sub-directory)
-        /// or directly to the VIDEO_TS directory itself.
-        /// </param>
-        /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
-        internal static IReadOnlyList<int> GetDirectoryTitleNumbers(string dvdPath)
+        var ifoPath = FindFileInsensitive(videoTsPath, VmgIfoFileName);
+        if (ifoPath is null)
         {
-            var disc = ParseVideoTsDirectory(dvdPath);
-            return disc.Titles.Count > 0
-                ? disc.Titles.Select(t => t.TitleNumber).ToList()
-                : Array.Empty<int>();
+            logger?.LogWarning("VIDEO_TS.IFO not found in {VideoTsPath}", videoTsPath);
+            return new DvdDiscInfo();
         }
 
-        // ── Full disc parsers ──────────────────────────────────────────────────
-
-        /// <summary>
-        /// Parses a DVD VIDEO_TS directory (on disk) and returns full disc information
-        /// including per-title durations resolved from the VTS IFO files.
-        /// </summary>
-        /// <param name="dvdPath">
-        /// Root DVD directory (may contain a VIDEO_TS sub-directory) or the VIDEO_TS
-        /// directory itself.
-        /// </param>
-        /// <param name="logger">Optional logger; warnings are emitted for missing/corrupt IFOs.</param>
-        /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
-        internal static DvdDiscInfo ParseVideoTsDirectory(string dvdPath, ILogger? logger = null)
+        byte[] vmgData;
+        try
         {
-            var videoTsPath = ResolveVideoTsPath(dvdPath);
-            if (videoTsPath is null)
+            vmgData = File.ReadAllBytes(ifoPath);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Failed to read VIDEO_TS.IFO at {Path}", ifoPath);
+            return new DvdDiscInfo();
+        }
+
+        var disc = ParseVmgIfo(vmgData);
+        if (disc.Titles.Count == 0)
+        {
+            return disc;
+        }
+
+        foreach (var vtsGroup in disc.Titles.GroupBy(t => t.TitleSetNumber))
+        {
+            var vtsNum = vtsGroup.Key;
+            if (vtsNum == 0)
             {
+                continue;
+            }
+
+            var vtsIfoName = FormattableString.Invariant($"VTS_{vtsNum:D2}_0.IFO");
+            var vtsIfoPath = FindFileInsensitive(videoTsPath, vtsIfoName);
+            if (vtsIfoPath is null)
+            {
+                logger?.LogWarning("VTS IFO {FileName} not found in {VideoTsPath}", vtsIfoName, videoTsPath);
+                continue;
+            }
+
+            byte[] vtsData;
+            try
+            {
+                vtsData = File.ReadAllBytes(vtsIfoPath);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to read VTS IFO at {Path}", vtsIfoPath);
+                continue;
+            }
+
+            ParseVtsIfo(vtsData, vtsNum, vtsGroup, logger);
+        }
+
+        return disc;
+    }
+
+    /// <summary>
+    /// Parses a DVD ISO image and returns full disc information including per-title durations.
+    /// </summary>
+    /// <param name="isoPath">Path to the ISO image file.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
+    internal static DvdDiscInfo ParseVideoTsIso(string isoPath, ILogger? logger = null)
+    {
+        try
+        {
+            using var fileStream = File.Open(isoPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var udfReader = new DiscUtils.Udf.UdfReader(fileStream);
+
+            var vtsDirectory = udfReader.GetDirectoryInfo(VmgIfoDirectoryName);
+            if (!vtsDirectory.Exists)
+            {
+                logger?.LogWarning("VIDEO_TS directory not found in ISO {Path}", isoPath);
                 return new DvdDiscInfo();
             }
 
-            var ifoPath = FindFileInsensitive(videoTsPath, VmgIfoFileName);
-            if (ifoPath is null)
+            var allFiles = vtsDirectory.GetFiles();
+
+            var vmgIfoFile = allFiles.FirstOrDefault(
+                f => string.Equals(f.Name, VmgIfoFileName, StringComparison.OrdinalIgnoreCase));
+            if (vmgIfoFile is null)
             {
-                logger?.LogWarning("VIDEO_TS.IFO not found in {VideoTsPath}", videoTsPath);
+                logger?.LogWarning("VIDEO_TS.IFO not found in ISO {Path}", isoPath);
                 return new DvdDiscInfo();
             }
 
             byte[] vmgData;
-            try
+            using (var stream = udfReader.OpenFile(vmgIfoFile.FullName, FileMode.Open, FileAccess.Read))
             {
-                vmgData = File.ReadAllBytes(ifoPath);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "Failed to read VIDEO_TS.IFO at {Path}", ifoPath);
-                return new DvdDiscInfo();
+                vmgData = ReadStreamFully(stream);
             }
 
             var disc = ParseVmgIfo(vmgData);
@@ -115,21 +192,23 @@ namespace MediaBrowser.MediaEncoding.Probing
                 }
 
                 var vtsIfoName = FormattableString.Invariant($"VTS_{vtsNum:D2}_0.IFO");
-                var vtsIfoPath = FindFileInsensitive(videoTsPath, vtsIfoName);
-                if (vtsIfoPath is null)
+                var vtsIfoFile = allFiles.FirstOrDefault(
+                    f => string.Equals(f.Name, vtsIfoName, StringComparison.OrdinalIgnoreCase));
+                if (vtsIfoFile is null)
                 {
-                    logger?.LogWarning("VTS IFO {FileName} not found in {VideoTsPath}", vtsIfoName, videoTsPath);
+                    logger?.LogWarning("VTS IFO {FileName} not found in ISO {Path}", vtsIfoName, isoPath);
                     continue;
                 }
 
                 byte[] vtsData;
                 try
                 {
-                    vtsData = File.ReadAllBytes(vtsIfoPath);
+                    using var stream = udfReader.OpenFile(vtsIfoFile.FullName, FileMode.Open, FileAccess.Read);
+                    vtsData = ReadStreamFully(stream);
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogError(ex, "Failed to read VTS IFO at {Path}", vtsIfoPath);
+                    logger?.LogError(ex, "Failed to read VTS IFO {FileName} from ISO", vtsIfoName);
                     continue;
                 }
 
@@ -138,652 +217,602 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             return disc;
         }
-
-        /// <summary>
-        /// Parses a DVD ISO image and returns full disc information including per-title durations.
-        /// </summary>
-        /// <param name="isoPath">Path to the ISO image file.</param>
-        /// <param name="logger">Optional logger.</param>
-        /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
-        internal static DvdDiscInfo ParseVideoTsIso(string isoPath, ILogger? logger = null)
+        catch (Exception ex)
         {
-            try
-            {
-                using var fileStream = File.Open(isoPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using var udfReader = new DiscUtils.Udf.UdfReader(fileStream);
+            logger?.LogError(ex, "Failed to parse DVD ISO at {Path}", isoPath);
+            return new DvdDiscInfo();
+        }
+    }
 
-                var vtsDirectory = udfReader.GetDirectoryInfo(VmgIfoDirectoryName);
-                if (!vtsDirectory.Exists)
-                {
-                    logger?.LogWarning("VIDEO_TS directory not found in ISO {Path}", isoPath);
-                    return new DvdDiscInfo();
-                }
-
-                var allFiles = vtsDirectory.GetFiles();
-
-                var vmgIfoFile = allFiles.FirstOrDefault(
-                    f => string.Equals(f.Name, VmgIfoFileName, StringComparison.OrdinalIgnoreCase));
-                if (vmgIfoFile is null)
-                {
-                    logger?.LogWarning("VIDEO_TS.IFO not found in ISO {Path}", isoPath);
-                    return new DvdDiscInfo();
-                }
-
-                byte[] vmgData;
-                using (var stream = udfReader.OpenFile(vmgIfoFile.FullName, FileMode.Open, FileAccess.Read))
-                {
-                    vmgData = ReadStreamFully(stream);
-                }
-
-                var disc = ParseVmgIfo(vmgData);
-                if (disc.Titles.Count == 0)
-                {
-                    return disc;
-                }
-
-                foreach (var vtsGroup in disc.Titles.GroupBy(t => t.TitleSetNumber))
-                {
-                    var vtsNum = vtsGroup.Key;
-                    if (vtsNum == 0)
-                    {
-                        continue;
-                    }
-
-                    var vtsIfoName = FormattableString.Invariant($"VTS_{vtsNum:D2}_0.IFO");
-                    var vtsIfoFile = allFiles.FirstOrDefault(
-                        f => string.Equals(f.Name, vtsIfoName, StringComparison.OrdinalIgnoreCase));
-                    if (vtsIfoFile is null)
-                    {
-                        logger?.LogWarning("VTS IFO {FileName} not found in ISO {Path}", vtsIfoName, isoPath);
-                        continue;
-                    }
-
-                    byte[] vtsData;
-                    try
-                    {
-                        using var stream = udfReader.OpenFile(vtsIfoFile.FullName, FileMode.Open, FileAccess.Read);
-                        vtsData = ReadStreamFully(stream);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger?.LogError(ex, "Failed to read VTS IFO {FileName} from ISO", vtsIfoName);
-                        continue;
-                    }
-
-                    ParseVtsIfo(vtsData, vtsNum, vtsGroup, logger);
-                }
-
-                return disc;
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "Failed to parse DVD ISO at {Path}", isoPath);
-                return new DvdDiscInfo();
-            }
+    /// <summary>
+    /// Returns the title most likely to be the main feature: the longest title whose
+    /// duration is at or above <paramref name="minDuration"/> (default: no minimum).
+    /// </summary>
+    /// <param name="disc">Parsed disc info.</param>
+    /// <param name="minDuration">Optional minimum duration threshold.</param>
+    /// <returns>The best-candidate <see cref="DvdTitleInfo"/>, or <c>null</c> if none qualifies.</returns>
+    internal static DvdTitleInfo? FindMainFeature(DvdDiscInfo disc, TimeSpan? minDuration = null)
+    {
+        IEnumerable<DvdTitleInfo> candidates = disc.Titles.Where(t => t.Duration.HasValue);
+        if (minDuration.HasValue)
+        {
+            candidates = candidates.Where(t => t.Duration >= minDuration);
         }
 
-        /// <summary>
-        /// Returns the title most likely to be the main feature: the longest title whose
-        /// duration is at or above <paramref name="minDuration"/> (default: no minimum).
-        /// </summary>
-        /// <param name="disc">Parsed disc info.</param>
-        /// <param name="minDuration">Optional minimum duration threshold.</param>
-        /// <returns>The best-candidate <see cref="DvdTitleInfo"/>, or <c>null</c> if none qualifies.</returns>
-        internal static DvdTitleInfo? FindMainFeature(DvdDiscInfo disc, TimeSpan? minDuration = null)
-        {
-            IEnumerable<DvdTitleInfo> candidates = disc.Titles.Where(t => t.Duration.HasValue);
-            if (minDuration.HasValue)
-            {
-                candidates = candidates.Where(t => t.Duration >= minDuration);
-            }
+        return candidates.OrderByDescending(t => t.Duration).FirstOrDefault();
+    }
 
-            return candidates.OrderByDescending(t => t.Duration).FirstOrDefault();
+    // ── VMG IFO (VIDEO_TS.IFO) parser ────────────────────────────────────
+
+    /// <summary>
+    /// Reads the number of titles from a DVD Video Manager IFO (VIDEO_TS.IFO) stream.
+    /// Kept for callers that only need the count without full disc parsing.
+    /// </summary>
+    /// <remarks>
+    /// Implements the same logic as <c>ifoRead_TT_SRPT</c> in libdvdread.
+    /// vmgi_mat_t layout (big-endian multi-byte fields):
+    ///   0x00–0x0B  vmg_identifier   "DVDVIDEO-VMG"
+    ///   0xC0–0xC3  vmgm_vobs        sector address of menu VOBs (skipped)
+    ///   0xC4–0xC7  tt_srpt          sector address of the TT_SRPT table
+    /// tt_srpt_t starts at tt_srpt×2048 within the file:
+    ///   +0x00–0x01 nr_of_srpts      number of titles (big-endian uint16).
+    /// </remarks>
+    /// <param name="ifoStream">Seekable stream positioned at the start of VIDEO_TS.IFO.</param>
+    /// <returns>The number of titles, or 0 if the stream is not a valid VMG IFO.</returns>
+    internal static int ReadVmgTitleCount(Stream ifoStream)
+    {
+        Span<byte> magic = stackalloc byte[12];
+        if (ifoStream.Read(magic) < 12)
+        {
+            return 0;
         }
 
-        // ── VMG IFO (VIDEO_TS.IFO) parser ────────────────────────────────────
-
-        /// <summary>
-        /// Reads the number of titles from a DVD Video Manager IFO (VIDEO_TS.IFO) stream.
-        /// Kept for callers that only need the count without full disc parsing.
-        /// </summary>
-        /// <remarks>
-        /// Implements the same logic as <c>ifoRead_TT_SRPT</c> in libdvdread.
-        /// vmgi_mat_t layout (big-endian multi-byte fields):
-        ///   0x00–0x0B  vmg_identifier   "DVDVIDEO-VMG"
-        ///   0xC0–0xC3  vmgm_vobs        sector address of menu VOBs (skipped)
-        ///   0xC4–0xC7  tt_srpt          sector address of the TT_SRPT table
-        /// tt_srpt_t starts at tt_srpt×2048 within the file:
-        ///   +0x00–0x01 nr_of_srpts      number of titles (big-endian uint16).
-        /// </remarks>
-        /// <param name="ifoStream">Seekable stream positioned at the start of VIDEO_TS.IFO.</param>
-        /// <returns>The number of titles, or 0 if the stream is not a valid VMG IFO.</returns>
-        internal static int ReadVmgTitleCount(Stream ifoStream)
+        if (!magic.SequenceEqual(MagicVmg))
         {
-            Span<byte> magic = stackalloc byte[12];
-            if (ifoStream.Read(magic) < 12)
-            {
-                return 0;
-            }
-
-            if (!magic.SequenceEqual("DVDVIDEO-VMG"u8))
-            {
-                return 0;
-            }
-
-            ifoStream.Seek(0xC4, SeekOrigin.Begin);
-            Span<byte> sectorBytes = stackalloc byte[4];
-            if (ifoStream.Read(sectorBytes) < 4)
-            {
-                return 0;
-            }
-
-            if (BitConverter.IsLittleEndian)
-            {
-                sectorBytes.Reverse();
-            }
-
-            var srptSector = BitConverter.ToUInt32(sectorBytes);
-            if (srptSector == 0)
-            {
-                return 0;
-            }
-
-            var srptOffset = (long)srptSector * DvdSectorSize;
-            if (srptOffset + 2 > ifoStream.Length)
-            {
-                return 0;
-            }
-
-            ifoStream.Seek(srptOffset, SeekOrigin.Begin);
-            Span<byte> countBytes = stackalloc byte[2];
-            if (ifoStream.Read(countBytes) < 2)
-            {
-                return 0;
-            }
-
-            if (BitConverter.IsLittleEndian)
-            {
-                countBytes.Reverse();
-            }
-
-            return BitConverter.ToUInt16(countBytes);
+            return 0;
         }
 
-        // ── Core IFO parsers ──────────────────────────────────────────────────
-
-        /// <summary>
-        /// Parses the VMG IFO byte array and builds a <see cref="DvdDiscInfo"/> from the
-        /// TT_SRPT (Title Search Pointer Table).
-        /// </summary>
-        /// <remarks>
-        /// vmgi_mat_t (VIDEO_TS.IFO header, all multi-byte values big-endian):
-        ///   0x00  vmg_identifier[12]   "DVDVIDEO-VMG"
-        ///   0xC4  tt_srpt              sector pointer to TT_SRPT table
-        ///
-        /// tt_srpt_t at tt_srpt×2048:
-        ///   +0x00 nr_of_srpts          UInt16BE — title count
-        ///   +0x04 last_byte            UInt32BE — byte offset of last byte of table
-        ///   +0x08 title entries        12 bytes each (title_info_t)
-        ///
-        /// title_info_t (12 bytes, per libdvdread ifo_types.h):
-        ///   +0x00 pb_ty                1 byte — playback type flags
-        ///   +0x01 nr_of_angles         1 byte
-        ///   +0x02 nr_of_ptts           UInt16BE — chapter count
-        ///   +0x04 parental_id          UInt16BE (ignored)
-        ///   +0x06 title_set_nr         1 byte — VTS number
-        ///   +0x07 vts_ttn              1 byte — title number within VTS
-        ///   +0x08 title_set_sector     UInt32BE — VTS start sector on disc.
-        /// </remarks>
-        private static DvdDiscInfo ParseVmgIfo(byte[] data)
+        ifoStream.Seek(0xC4, SeekOrigin.Begin);
+        Span<byte> sectorBytes = stackalloc byte[4];
+        if (ifoStream.Read(sectorBytes) < 4)
         {
-            var disc = new DvdDiscInfo();
+            return 0;
+        }
 
-            if (!HasMagic(data, "DVDVIDEO-VMG"))
-            {
-                return disc;
-            }
+        if (BitConverter.IsLittleEndian)
+        {
+            sectorBytes.Reverse();
+        }
 
-            // tt_srpt sector pointer at 0xC4
-            if (data.Length < 0xC8)
-            {
-                return disc;
-            }
+        var srptSector = BitConverter.ToUInt32(sectorBytes);
+        if (srptSector == 0)
+        {
+            return 0;
+        }
 
-            uint srptSector = ReadUInt32BE(data, 0xC4);
-            if (srptSector == 0)
-            {
-                return disc;
-            }
+        var srptOffset = (long)srptSector * DvdSectorSize;
+        if (srptOffset + 2 > ifoStream.Length)
+        {
+            return 0;
+        }
 
-            long srptByteOffset = (long)srptSector * DvdSectorSize;
+        ifoStream.Seek(srptOffset, SeekOrigin.Begin);
+        Span<byte> countBytes = stackalloc byte[2];
+        if (ifoStream.Read(countBytes) < 2)
+        {
+            return 0;
+        }
 
-            // Need at least the 8-byte TT_SRPT header
-            if (srptByteOffset + 8 > data.Length)
-            {
-                return disc;
-            }
+        if (BitConverter.IsLittleEndian)
+        {
+            countBytes.Reverse();
+        }
 
-            int srptBase = (int)srptByteOffset;
-            int titleCount = ReadUInt16BE(data, srptBase + 0);
-            // srptBase+2: reserved (skipped)
-            // srptBase+4: last_byte (used for an additional bounds check)
-            uint lastByte = ReadUInt32BE(data, srptBase + 4);
+        return BitConverter.ToUInt16(countBytes);
+    }
 
-            if (titleCount <= 0)
-            {
-                return disc;
-            }
+    // ── Core IFO parsers ──────────────────────────────────────────────────
 
-            // Each title_info_t entry is 12 bytes; verify all entries fit.
-            long entriesEnd = srptByteOffset + 8 + ((long)titleCount * 12);
-            if (entriesEnd > data.Length)
-            {
-                return disc;
-            }
+    /// <summary>
+    /// Parses the VMG IFO byte array and builds a <see cref="DvdDiscInfo"/> from the
+    /// TT_SRPT (Title Search Pointer Table).
+    /// </summary>
+    /// <remarks>
+    /// vmgi_mat_t (VIDEO_TS.IFO header, all multi-byte values big-endian):
+    ///   0x00  vmg_identifier[12]   "DVDVIDEO-VMG"
+    ///   0xC4  tt_srpt              sector pointer to TT_SRPT table
+    ///
+    /// tt_srpt_t at tt_srpt×2048:
+    ///   +0x00 nr_of_srpts          UInt16BE — title count
+    ///   +0x04 last_byte            UInt32BE — byte offset of last byte of table
+    ///   +0x08 title entries        12 bytes each (title_info_t)
+    ///
+    /// title_info_t (12 bytes, per libdvdread ifo_types.h):
+    ///   +0x00 pb_ty                1 byte — playback type flags
+    ///   +0x01 nr_of_angles         1 byte
+    ///   +0x02 nr_of_ptts           UInt16BE — chapter count
+    ///   +0x04 parental_id          UInt16BE (ignored)
+    ///   +0x06 title_set_nr         1 byte — VTS number
+    ///   +0x07 vts_ttn              1 byte — title number within VTS
+    ///   +0x08 title_set_sector     UInt32BE — VTS start sector on disc.
+    /// </remarks>
+    private static DvdDiscInfo ParseVmgIfo(byte[] data)
+    {
+        var disc = new DvdDiscInfo();
 
-            for (int i = 0; i < titleCount; i++)
-            {
-                int o = srptBase + 8 + (i * 12);
-
-                // title_info_t layout (12 bytes):
-                // o+0  pb_ty          — playback type (unused here)
-                // o+1  nr_of_angles   — angle count
-                // o+2  nr_of_ptts     — chapter count (UInt16BE)
-                // o+4  parental_id    — parental mask (UInt16BE, unused)
-                // o+6  title_set_nr   — VTS number
-                // o+7  vts_ttn        — VTS-local title number
-                // o+8  title_set_sector — VTS start sector (UInt32BE)
-                byte angleCount = data[o + 1];
-                int chapterCount = ReadUInt16BE(data, o + 2);
-                byte vtsNumber = data[o + 6];
-                byte vtsTitleNum = data[o + 7];
-                uint vtsStartSec = ReadUInt32BE(data, o + 8);
-
-                disc.Titles.Add(new DvdTitleInfo
-                {
-                    TitleNumber = i + 1,
-                    TitleSetNumber = vtsNumber,
-                    VtsTitleNumber = vtsTitleNum,
-                    ChapterCount = chapterCount,
-                    AngleCount = angleCount,
-                    VtsStartSector = vtsStartSec
-                });
-            }
-
+        if (!HasMagic(data, MagicVmg))
+        {
             return disc;
         }
 
-        /// <summary>
-        /// Parses a VTS IFO byte array and fills in <see cref="DvdTitleInfo.Duration"/>,
-        /// <see cref="DvdTitleInfo.ProgramChainNumber"/>, and <see cref="DvdTitleInfo.ProgramNumber"/>
-        /// for each of the supplied titles belonging to this title set.
-        /// </summary>
-        /// <remarks>
-        /// vtsi_mat_t sector pointers used (big-endian UInt32, relative to VTS IFO start):
-        ///   0xC8  vts_ptt_srpt    → VTS_PTT_SRPT table
-        ///   0xCC  vts_pgcit       → VTS_PGCITI table
-        ///
-        /// VTS_PTT_SRPT maps VTS-local title number → first PGC + program number.
-        /// VTS_PGCITI maps PGC number → PGC playback time.
-        ///
-        /// Mutates <paramref name="titles"/> in-place, setting <see cref="DvdTitleInfo.ProgramChainNumber"/>,
-        /// <see cref="DvdTitleInfo.ProgramNumber"/>, and <see cref="DvdTitleInfo.Duration"/> on each entry.
-        /// </remarks>
-        private static void ParseVtsIfo(byte[] data, int vtsNumber, IEnumerable<DvdTitleInfo> titles, ILogger? logger)
+        // tt_srpt sector pointer at 0xC4
+        if (data.Length < 0xC8)
         {
-            if (!HasMagic(data, "DVDVIDEO-VTS"))
+            return disc;
+        }
+
+        uint srptSector = ReadUInt32BE(data, 0xC4);
+        if (srptSector == 0)
+        {
+            return disc;
+        }
+
+        long srptByteOffset = (long)srptSector * DvdSectorSize;
+
+        // Need at least the 8-byte TT_SRPT header
+        if (srptByteOffset + 8 > data.Length)
+        {
+            return disc;
+        }
+
+        int srptBase = (int)srptByteOffset;
+        int titleCount = ReadUInt16BE(data, srptBase + 0);
+        // srptBase+2: reserved (skipped)
+        // srptBase+4: last_byte (used for an additional bounds check)
+        uint lastByte = ReadUInt32BE(data, srptBase + 4);
+
+        if (titleCount <= 0)
+        {
+            return disc;
+        }
+
+        // Each title_info_t entry is 12 bytes; verify all entries fit.
+        long entriesEnd = srptByteOffset + 8 + ((long)titleCount * 12);
+        if (entriesEnd > data.Length)
+        {
+            return disc;
+        }
+
+        for (int i = 0; i < titleCount; i++)
+        {
+            int o = srptBase + 8 + (i * 12);
+
+            // title_info_t layout (12 bytes):
+            // o+0  pb_ty          — playback type (unused here)
+            // o+1  nr_of_angles   — angle count
+            // o+2  nr_of_ptts     — chapter count (UInt16BE)
+            // o+4  parental_id    — parental mask (UInt16BE, unused)
+            // o+6  title_set_nr   — VTS number
+            // o+7  vts_ttn        — VTS-local title number
+            // o+8  title_set_sector — VTS start sector (UInt32BE)
+            byte angleCount = data[o + 1];
+            int chapterCount = ReadUInt16BE(data, o + 2);
+            byte vtsNumber = data[o + 6];
+            byte vtsTitleNum = data[o + 7];
+            uint vtsStartSec = ReadUInt32BE(data, o + 8);
+
+            disc.Titles.Add(new DvdTitleInfo
             {
-                logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO has wrong magic bytes — skipping", vtsNumber);
-                return;
+                TitleNumber = i + 1,
+                TitleSetNumber = vtsNumber,
+                VtsTitleNumber = vtsTitleNum,
+                ChapterCount = chapterCount,
+                AngleCount = angleCount,
+                VtsStartSector = vtsStartSec
+            });
+        }
+
+        return disc;
+    }
+
+    /// <summary>
+    /// Parses a VTS IFO byte array and fills in <see cref="DvdTitleInfo.Duration"/>,
+    /// <see cref="DvdTitleInfo.ProgramChainNumber"/>, and <see cref="DvdTitleInfo.ProgramNumber"/>
+    /// for each of the supplied titles belonging to this title set.
+    /// </summary>
+    /// <remarks>
+    /// vtsi_mat_t sector pointers used (big-endian UInt32, relative to VTS IFO start):
+    ///   0xC8  vts_ptt_srpt    → VTS_PTT_SRPT table
+    ///   0xCC  vts_pgcit       → VTS_PGCITI table
+    ///
+    /// VTS_PTT_SRPT maps VTS-local title number → first PGC + program number.
+    /// VTS_PGCITI maps PGC number → PGC playback time.
+    ///
+    /// Mutates <paramref name="titles"/> in-place, setting <see cref="DvdTitleInfo.ProgramChainNumber"/>,
+    /// <see cref="DvdTitleInfo.ProgramNumber"/>, and <see cref="DvdTitleInfo.Duration"/> on each entry.
+    /// </remarks>
+    private static void ParseVtsIfo(byte[] data, int vtsNumber, IEnumerable<DvdTitleInfo> titles, ILogger? logger)
+    {
+        if (!HasMagic(data, MagicVts))
+        {
+            logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO has wrong magic bytes — skipping", vtsNumber);
+            return;
+        }
+
+        // vtsi_mat_t: vts_ptt_srpt at 0xC8, vts_pgcit at 0xCC
+        if (data.Length < 0xD0)
+        {
+            logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO is too short to contain VTSI_MAT pointers", vtsNumber);
+            return;
+        }
+
+        uint pttSrptSector = ReadUInt32BE(data, 0xC8);
+        uint pgcitiSector = ReadUInt32BE(data, 0xCC);
+
+        // Parse VTS_PTT_SRPT → VTS title → (PGC number, program number)
+        Dictionary<int, (int PgcNumber, int ProgramNumber)>? pttMap = null;
+        if (pttSrptSector > 0)
+        {
+            long pttBase = (long)pttSrptSector * DvdSectorSize;
+            if (pttBase + 8 <= data.Length)
+            {
+                pttMap = ParseVtsPttSrpt(data, (int)pttBase);
             }
-
-            // vtsi_mat_t: vts_ptt_srpt at 0xC8, vts_pgcit at 0xCC
-            if (data.Length < 0xD0)
+            else
             {
-                logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO is too short to contain VTSI_MAT pointers", vtsNumber);
-                return;
-            }
-
-            uint pttSrptSector = ReadUInt32BE(data, 0xC8);
-            uint pgcitiSector = ReadUInt32BE(data, 0xCC);
-
-            // Parse VTS_PTT_SRPT → VTS title → (PGC number, program number)
-            Dictionary<int, (int PgcNumber, int ProgramNumber)>? pttMap = null;
-            if (pttSrptSector > 0)
-            {
-                long pttBase = (long)pttSrptSector * DvdSectorSize;
-                if (pttBase + 8 <= data.Length)
-                {
-                    pttMap = ParseVtsPttSrpt(data, (int)pttBase);
-                }
-                else
-                {
-                    logger?.LogWarning(
-                        "VTS_{VtsNum:D2}_0.IFO: VTS_PTT_SRPT sector {Sector} points outside file",
-                        vtsNumber,
-                        pttSrptSector);
-                }
-            }
-
-            // Parse VTS_PGCITI → PGC number → duration
-            Dictionary<int, TimeSpan?>? pgcDurations = null;
-            if (pgcitiSector > 0)
-            {
-                long pgcitiBase = (long)pgcitiSector * DvdSectorSize;
-                if (pgcitiBase + 8 <= data.Length)
-                {
-                    pgcDurations = ParseVtsPgciti(data, (int)pgcitiBase);
-                }
-                else
-                {
-                    logger?.LogWarning(
-                        "VTS_{VtsNum:D2}_0.IFO: VTS_PGCITI sector {Sector} points outside file",
-                        vtsNumber,
-                        pgcitiSector);
-                }
-            }
-
-            foreach (var title in titles)
-            {
-                if (pttMap is not null && pttMap.TryGetValue(title.VtsTitleNumber, out var pttEntry))
-                {
-                    title.ProgramChainNumber = pttEntry.PgcNumber;
-                    title.ProgramNumber = pttEntry.ProgramNumber;
-
-                    if (pgcDurations is not null && pgcDurations.TryGetValue(pttEntry.PgcNumber, out var duration))
-                    {
-                        title.Duration = duration;
-                    }
-                }
+                logger?.LogWarning(
+                    "VTS_{VtsNum:D2}_0.IFO: VTS_PTT_SRPT sector {Sector} points outside file",
+                    vtsNumber,
+                    pttSrptSector);
             }
         }
 
-        /// <summary>
-        /// Parses the VTS_PTT_SRPT (VTS Part-of-Title Search Pointer Table) and returns a
-        /// dictionary mapping VTS-local title number → (first PGC number, first program number).
-        /// </summary>
-        /// <remarks>
-        /// vts_ptt_srpt_t layout (per libdvdread ifo_types.h):
-        ///   +0x00 nr_of_srpts    UInt16BE — number of VTS titles
-        ///   +0x02 (reserved)
-        ///   +0x04 last_byte      UInt32BE — last byte of table, relative to table base
-        ///   +0x08 offset[]       UInt32BE per VTS title, relative to table base
-        ///         Each offset points to the first ttu_t (PTT) entry for that title.
-        ///
-        /// ttu_t (4 bytes per chapter/PTT):
-        ///   +0x00 pgcn           UInt16BE — PGC number (1-based)
-        ///   +0x02 pgn            UInt16BE — program number within PGC (1-based).
-        /// </remarks>
-        private static Dictionary<int, (int PgcNumber, int ProgramNumber)> ParseVtsPttSrpt(byte[] data, int pttBase)
+        // Parse VTS_PGCITI → PGC number → duration
+        Dictionary<int, TimeSpan?>? pgcDurations = null;
+        if (pgcitiSector > 0)
         {
-            var result = new Dictionary<int, (int PgcNumber, int ProgramNumber)>();
-
-            if (pttBase + 8 > data.Length)
+            long pgcitiBase = (long)pgcitiSector * DvdSectorSize;
+            if (pgcitiBase + 8 <= data.Length)
             {
-                return result;
+                pgcDurations = ParseVtsPgciti(data, (int)pgcitiBase);
             }
-
-            int vtsTitleCount = ReadUInt16BE(data, pttBase + 0);
-            uint lastByte = ReadUInt32BE(data, pttBase + 4);
-
-            if (vtsTitleCount <= 0)
+            else
             {
-                return result;
+                logger?.LogWarning(
+                    "VTS_{VtsNum:D2}_0.IFO: VTS_PGCITI sector {Sector} points outside file",
+                    vtsNumber,
+                    pgcitiSector);
             }
+        }
 
-            // Verify offset table fits
-            int offsetTableEnd = pttBase + 8 + (vtsTitleCount * 4);
-            if (offsetTableEnd > data.Length)
+        foreach (var title in titles)
+        {
+            if (pttMap is not null && pttMap.TryGetValue(title.VtsTitleNumber, out var pttEntry))
             {
-                return result;
-            }
+                title.ProgramChainNumber = pttEntry.PgcNumber;
+                title.ProgramNumber = pttEntry.ProgramNumber;
 
-            for (int n = 1; n <= vtsTitleCount; n++)
-            {
-                int offsetPos = pttBase + 8 + ((n - 1) * 4);
-                uint titleRelOffset = ReadUInt32BE(data, offsetPos);
-
-                // Determine how many PTT/chapter entries this VTS title has (for bounds safety).
-                uint nextRelOffset;
-                if (n < vtsTitleCount)
+                if (pgcDurations is not null && pgcDurations.TryGetValue(pttEntry.PgcNumber, out var duration))
                 {
-                    nextRelOffset = ReadUInt32BE(data, offsetPos + 4);
-                }
-                else
-                {
-                    // last_byte is the byte index of the last byte, so +1 gives exclusive end
-                    nextRelOffset = lastByte + 1;
-                }
-
-                if (nextRelOffset <= titleRelOffset)
-                {
-                    // Degenerate or corrupt entry — no chapters
-                    continue;
-                }
-
-                // Each ttu_t is 4 bytes; only the first (title's first chapter) is needed
-                long firstPttOffset = (long)pttBase + titleRelOffset;
-                if (firstPttOffset + 4 > data.Length)
-                {
-                    break;
-                }
-
-                int pgcNumber = ReadUInt16BE(data, (int)firstPttOffset + 0);
-                int programNumber = ReadUInt16BE(data, (int)firstPttOffset + 2);
-
-                if (pgcNumber > 0) // PGC 0 is invalid per spec
-                {
-                    result[n] = (pgcNumber, programNumber);
+                    title.Duration = duration;
                 }
             }
+        }
+    }
 
+    /// <summary>
+    /// Parses the VTS_PTT_SRPT (VTS Part-of-Title Search Pointer Table) and returns a
+    /// dictionary mapping VTS-local title number → (first PGC number, first program number).
+    /// </summary>
+    /// <remarks>
+    /// vts_ptt_srpt_t layout (per libdvdread ifo_types.h):
+    ///   +0x00 nr_of_srpts    UInt16BE — number of VTS titles
+    ///   +0x02 (reserved)
+    ///   +0x04 last_byte      UInt32BE — last byte of table, relative to table base
+    ///   +0x08 offset[]       UInt32BE per VTS title, relative to table base
+    ///         Each offset points to the first ttu_t (PTT) entry for that title.
+    ///
+    /// ttu_t (4 bytes per chapter/PTT):
+    ///   +0x00 pgcn           UInt16BE — PGC number (1-based)
+    ///   +0x02 pgn            UInt16BE — program number within PGC (1-based).
+    /// </remarks>
+    private static Dictionary<int, (int PgcNumber, int ProgramNumber)> ParseVtsPttSrpt(byte[] data, int pttBase)
+    {
+        var result = new Dictionary<int, (int PgcNumber, int ProgramNumber)>();
+
+        if (pttBase + 8 > data.Length)
+        {
             return result;
         }
 
-        /// <summary>
-        /// Parses the VTS_PGCITI (VTS PGC Information Table) and returns a dictionary
-        /// mapping PGC number (1-based) → playback duration.
-        /// </summary>
-        /// <remarks>
-        /// vts_pgcit_t layout (per libdvdread ifo_types.h):
-        ///   +0x00 nr_of_pgci_srp  UInt16BE — number of PGC search pointers
-        ///   +0x02 (reserved)
-        ///   +0x04 last_byte       UInt32BE
-        ///   +0x08 pgci_srp[]      8 bytes each (pgci_srp_t)
-        ///
-        /// pgci_srp_t (8 bytes):
-        ///   +0x00 entry_id        1 byte
-        ///   +0x01 flags           1 byte  (block_mode / block_type bits)
-        ///   +0x02 ptl_id_mask     UInt16BE
-        ///   +0x04 pgc_start_byte  UInt32BE — byte offset of PGC, relative to table base
-        ///
-        /// pgc_t at pgciti_base + pgc_start_byte:
-        ///   +0x00 (reserved)
-        ///   +0x01 nr_of_programs  1 byte
-        ///   +0x02 nr_of_cells     1 byte
-        ///   +0x03 (reserved)
-        ///   +0x04 playback_time   4 bytes  (dvd_time_t / BCD + frame-rate).
-        /// </remarks>
-        private static Dictionary<int, TimeSpan?> ParseVtsPgciti(byte[] data, int pgcitiBase)
+        int vtsTitleCount = ReadUInt16BE(data, pttBase + 0);
+        uint lastByte = ReadUInt32BE(data, pttBase + 4);
+
+        if (vtsTitleCount <= 0)
         {
-            var result = new Dictionary<int, TimeSpan?>();
-
-            if (pgcitiBase + 8 > data.Length)
-            {
-                return result;
-            }
-
-            int pgcCount = ReadUInt16BE(data, pgcitiBase + 0);
-            if (pgcCount <= 0)
-            {
-                return result;
-            }
-
-            for (int n = 1; n <= pgcCount; n++)
-            {
-                // pgci_srp_t is 8 bytes; search pointer for PGC n is at index n-1
-                int srpOffset = pgcitiBase + 8 + ((n - 1) * 8);
-                if (srpOffset + 8 > data.Length)
-                {
-                    result[n] = null;
-                    continue;
-                }
-
-                // pgc_start_byte at srp+4, relative to pgcitiBase
-                uint pgcRelOffset = ReadUInt32BE(data, srpOffset + 4);
-                long pgcAddress = (long)pgcitiBase + pgcRelOffset;
-
-                // Need at least 8 bytes of PGC header to read playback_time at +4
-                if (pgcAddress + 8 > data.Length)
-                {
-                    result[n] = null;
-                    continue;
-                }
-
-                result[n] = TryReadDvdTime(data, (int)pgcAddress + 4);
-            }
-
             return result;
         }
 
-        // ── DVD time decoding ─────────────────────────────────────────────────
-
-        /// <summary>
-        /// Decodes a 4-byte DVD time field (dvd_time_t) into a <see cref="TimeSpan"/>.
-        /// Returns <c>null</c> if the field contains invalid BCD values or is out of bounds.
-        /// </summary>
-        /// <remarks>
-        /// dvd_time_t layout (per libdvdread ifo_types.h):
-        ///   +0  hour      BCD
-        ///   +1  minute    BCD
-        ///   +2  second    BCD
-        ///   +3  frame_u   bits 7-6 = frame-rate code (0x40=25fps, 0xC0≈29.97fps),
-        ///                 bits 5-0 = frame count.
-        /// </remarks>
-        private static TimeSpan? TryReadDvdTime(byte[] data, int offset)
+        // Verify offset table fits
+        int offsetTableEnd = pttBase + 8 + (vtsTitleCount * 4);
+        if (offsetTableEnd > data.Length)
         {
-            if (offset + 4 > data.Length)
+            return result;
+        }
+
+        for (int n = 1; n <= vtsTitleCount; n++)
+        {
+            int offsetPos = pttBase + 8 + ((n - 1) * 4);
+            uint titleRelOffset = ReadUInt32BE(data, offsetPos);
+
+            // Determine how many PTT/chapter entries this VTS title has (for bounds safety).
+            uint nextRelOffset;
+            if (n < vtsTitleCount)
             {
-                return null;
+                nextRelOffset = ReadUInt32BE(data, offsetPos + 4);
+            }
+            else
+            {
+                // last_byte is the byte index of the last byte, so +1 gives exclusive end
+                nextRelOffset = lastByte + 1;
             }
 
-            int hours = FromBcd(data[offset + 0]);
-            int minutes = FromBcd(data[offset + 1]);
-            int seconds = FromBcd(data[offset + 2]);
-
-            // Validate decoded BCD values before constructing TimeSpan
-            if (minutes >= 60 || seconds >= 60)
+            if (nextRelOffset <= titleRelOffset)
             {
-                return null;
+                // Degenerate or corrupt entry — no chapters
+                continue;
             }
 
-            byte frameAndRate = data[offset + 3];
-            int frames = frameAndRate & 0x3F;
-            int rateCode = frameAndRate & 0xC0;
-
-            double fps = rateCode switch
+            // Each ttu_t is 4 bytes; only the first (title's first chapter) is needed
+            long firstPttOffset = (long)pttBase + titleRelOffset;
+            if (firstPttOffset + 4 > data.Length)
             {
-                0x40 => 25.0,
-                0xC0 => 29.97,
-                _ => 0.0
-            };
-
-            double frameSeconds = fps > 0 ? frames / fps : 0.0;
-
-            try
-            {
-                return new TimeSpan(hours, minutes, seconds) + TimeSpan.FromSeconds(frameSeconds);
+                break;
             }
-            catch (OverflowException)
+
+            int pgcNumber = ReadUInt16BE(data, (int)firstPttOffset + 0);
+            int programNumber = ReadUInt16BE(data, (int)firstPttOffset + 2);
+
+            if (pgcNumber > 0) // PGC 0 is invalid per spec
             {
-                return null;
+                result[n] = (pgcNumber, programNumber);
             }
         }
 
-        /// <summary>
-        /// Decodes a BCD (Binary-Coded Decimal) byte into its integer value.
-        /// E.g. 0x59 → 59, 0x23 → 23.
-        /// </summary>
-        private static int FromBcd(byte value)
-            => ((value >> 4) * 10) + (value & 0x0F);
+        return result;
+    }
 
-        // ── Big-endian binary helpers ─────────────────────────────────────────
+    /// <summary>
+    /// Parses the VTS_PGCITI (VTS PGC Information Table) and returns a dictionary
+    /// mapping PGC number (1-based) → playback duration.
+    /// </summary>
+    /// <remarks>
+    /// vts_pgcit_t layout (per libdvdread ifo_types.h):
+    ///   +0x00 nr_of_pgci_srp  UInt16BE — number of PGC search pointers
+    ///   +0x02 (reserved)
+    ///   +0x04 last_byte       UInt32BE
+    ///   +0x08 pgci_srp[]      8 bytes each (pgci_srp_t)
+    ///
+    /// pgci_srp_t (8 bytes):
+    ///   +0x00 entry_id        1 byte
+    ///   +0x01 flags           1 byte  (block_mode / block_type bits)
+    ///   +0x02 ptl_id_mask     UInt16BE
+    ///   +0x04 pgc_start_byte  UInt32BE — byte offset of PGC, relative to table base
+    ///
+    /// pgc_t at pgciti_base + pgc_start_byte:
+    ///   +0x00 (reserved)
+    ///   +0x01 nr_of_programs  1 byte
+    ///   +0x02 nr_of_cells     1 byte
+    ///   +0x03 (reserved)
+    ///   +0x04 playback_time   4 bytes  (dvd_time_t / BCD + frame-rate).
+    /// </remarks>
+    private static Dictionary<int, TimeSpan?> ParseVtsPgciti(byte[] data, int pgcitiBase)
+    {
+        var result = new Dictionary<int, TimeSpan?>();
 
-        /// <summary>Reads a big-endian unsigned 16-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
-        /// <param name="data">Source byte array.</param>
-        /// <param name="offset">Zero-based byte offset to read from.</param>
-        /// <returns>The decoded <see cref="ushort"/> value.</returns>
-        internal static ushort ReadUInt16BE(byte[] data, int offset)
-            => (ushort)((data[offset] << 8) | data[offset + 1]);
-
-        /// <summary>Reads a big-endian unsigned 32-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
-        /// <param name="data">Source byte array.</param>
-        /// <param name="offset">Zero-based byte offset to read from.</param>
-        /// <returns>The decoded <see cref="uint"/> value.</returns>
-        internal static uint ReadUInt32BE(byte[] data, int offset)
-            => ((uint)data[offset] << 24)
-             | ((uint)data[offset + 1] << 16)
-             | ((uint)data[offset + 2] << 8)
-             | (uint)data[offset + 3];
-
-        // ── Utility helpers ───────────────────────────────────────────────────
-
-        /// <summary>
-        /// Returns <c>true</c> if <paramref name="data"/> begins with the ASCII bytes of <paramref name="magic"/>.
-        /// </summary>
-        private static bool HasMagic(byte[] data, string magic)
+        if (pgcitiBase + 8 > data.Length)
         {
-            if (data.Length < magic.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < magic.Length; i++)
-            {
-                if (data[i] != (byte)magic[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return result;
         }
 
-        /// <summary>
-        /// Resolves the VIDEO_TS directory from a DVD root or VIDEO_TS path.
-        /// Returns <c>null</c> if neither path exists.
-        /// </summary>
-        private static string? ResolveVideoTsPath(string dvdPath)
+        int pgcCount = ReadUInt16BE(data, pgcitiBase + 0);
+        if (pgcCount <= 0)
         {
-            var candidate = Path.Combine(dvdPath, VmgIfoDirectoryName);
-            if (Directory.Exists(candidate))
+            return result;
+        }
+
+        for (int n = 1; n <= pgcCount; n++)
+        {
+            // pgci_srp_t is 8 bytes; search pointer for PGC n is at index n-1
+            int srpOffset = pgcitiBase + 8 + ((n - 1) * 8);
+            if (srpOffset + 8 > data.Length)
             {
-                return candidate;
+                result[n] = null;
+                continue;
             }
 
-            if (Directory.Exists(dvdPath))
+            // pgc_start_byte at srp+4, relative to pgcitiBase
+            uint pgcRelOffset = ReadUInt32BE(data, srpOffset + 4);
+            long pgcAddress = (long)pgcitiBase + pgcRelOffset;
+
+            // Need at least 8 bytes of PGC header to read playback_time at +4
+            if (pgcAddress + 8 > data.Length)
             {
-                return dvdPath;
+                result[n] = null;
+                continue;
             }
 
+            result[n] = TryReadDvdTime(data, (int)pgcAddress + 4);
+        }
+
+        return result;
+    }
+
+    // ── DVD time decoding ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Decodes a 4-byte DVD time field (dvd_time_t) into a <see cref="TimeSpan"/>.
+    /// Returns <c>null</c> if the field contains invalid BCD values or is out of bounds.
+    /// </summary>
+    /// <remarks>
+    /// dvd_time_t layout (per libdvdread ifo_types.h):
+    ///   +0  hour      BCD
+    ///   +1  minute    BCD
+    ///   +2  second    BCD
+    ///   +3  frame_u   bits 7-6 = frame-rate code (0x40=25fps, 0xC0≈29.97fps),
+    ///                 bits 5-0 = frame count.
+    /// </remarks>
+    private static TimeSpan? TryReadDvdTime(byte[] data, int offset)
+    {
+        if (offset + 4 > data.Length)
+        {
             return null;
         }
 
-        /// <summary>
-        /// Case-insensitive file lookup inside a directory.
-        /// Returns the full path of the first match, or <c>null</c> if not found.
-        /// </summary>
-        private static string? FindFileInsensitive(string directory, string fileName)
-            => Directory.GetFiles(directory)
-                .FirstOrDefault(f => string.Equals(
-                    Path.GetFileName(f), fileName, StringComparison.OrdinalIgnoreCase));
-
-        /// <summary>Reads all bytes from <paramref name="stream"/> regardless of its initial position.</summary>
-        private static byte[] ReadStreamFully(Stream stream)
+        // Validate BCD digits and decode
+        if (!TryFromBcd(data[offset + 0], out int hours)
+            || !TryFromBcd(data[offset + 1], out int minutes)
+            || !TryFromBcd(data[offset + 2], out int seconds))
         {
-            using var ms = new MemoryStream();
-            stream.CopyTo(ms);
-            return ms.ToArray();
+            return null;
         }
+
+        // Validate ranges
+        if (minutes >= 60 || seconds >= 60 || hours < 0 || hours > 99)
+        {
+            return null;
+        }
+
+        byte frameAndRate = data[offset + 3];
+        int frames = frameAndRate & 0x3F;
+        int rateCode = frameAndRate & 0xC0;
+
+        double fps = rateCode switch
+        {
+            0x40 => 25.0,
+            0xC0 => 29.97,
+            _ => -1.0 // unknown/invalid rate code
+        };
+
+        if (fps <= 0.0)
+        {
+            return null;
+        }
+
+        if (frames < 0 || frames > 0x3F)
+        {
+            return null;
+        }
+
+        double frameSeconds = frames / fps;
+
+        try
+        {
+            return new TimeSpan(hours, minutes, seconds) + TimeSpan.FromSeconds(frameSeconds);
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Decodes a BCD (Binary-Coded Decimal) byte into its integer value.
+    /// E.g. 0x59 → 59, 0x23 → 23.
+    /// </summary>
+    private static int FromBcd(byte value)
+        => ((value >> 4) * 10) + (value & 0x0F);
+
+    private static bool TryFromBcd(byte value, out int result)
+    {
+        int hi = (value >> 4) & 0x0F;
+        int lo = value & 0x0F;
+        if (hi > 9 || lo > 9)
+        {
+            result = 0;
+            return false;
+        }
+
+        result = (hi * 10) + lo;
+        return true;
+    }
+
+    // ── Big-endian binary helpers ─────────────────────────────────────────
+
+    /// <summary>Reads a big-endian unsigned 16-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
+    /// <param name="data">Source byte array.</param>
+    /// <param name="offset">Zero-based byte offset to read from.</param>
+    /// <returns>The decoded <see cref="ushort"/> value.</returns>
+    internal static ushort ReadUInt16BE(byte[] data, int offset)
+        => (ushort)((data[offset] << 8) | data[offset + 1]);
+
+    /// <summary>Reads a big-endian unsigned 32-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
+    /// <param name="data">Source byte array.</param>
+    /// <param name="offset">Zero-based byte offset to read from.</param>
+    /// <returns>The decoded <see cref="uint"/> value.</returns>
+    internal static uint ReadUInt32BE(byte[] data, int offset)
+        => ((uint)data[offset] << 24)
+            | ((uint)data[offset + 1] << 16)
+            | ((uint)data[offset + 2] << 8)
+            | (uint)data[offset + 3];
+
+    // ── Utility helpers ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="data"/> begins with the ASCII bytes of <paramref name="magic"/>.
+    /// </summary>
+    private static bool HasMagic(byte[] data, ReadOnlySpan<byte> magic)
+    {
+        if (data.Length < magic.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < magic.Length; i++)
+        {
+            if (data[i] != magic[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the VIDEO_TS directory from a DVD root or VIDEO_TS path.
+    /// Returns <c>null</c> if neither path exists.
+    /// </summary>
+    private static string? ResolveVideoTsPath(string dvdPath)
+    {
+        var candidate = Path.Combine(dvdPath, VmgIfoDirectoryName);
+        if (Directory.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        if (Directory.Exists(dvdPath))
+        {
+            return dvdPath;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Case-insensitive file lookup inside a directory.
+    /// Returns the full path of the first match, or <c>null</c> if not found.
+    /// </summary>
+    private static string? FindFileInsensitive(string directory, string fileName)
+        => Directory.GetFiles(directory)
+            .FirstOrDefault(f => string.Equals(
+                Path.GetFileName(f), fileName, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Reads all bytes from <paramref name="stream"/> regardless of its initial position.</summary>
+    private static byte[] ReadStreamFully(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
     }
 }

--- a/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
+++ b/MediaBrowser.MediaEncoding/Probing/DvdVideoProber.cs
@@ -1,0 +1,789 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.MediaEncoding.Probing
+{
+    /// <summary>
+    /// Parses DVD-Video IFO files (VIDEO_TS.IFO and VTS_xx_0.IFO) to enumerate disc titles
+    /// and resolve per-title durations.
+    /// </summary>
+    /// <remarks>
+    /// Binary layout follows the DVD specification as implemented in libdvdread / libdvdnav.
+    /// Key references:
+    /// <list type="bullet">
+    ///   <item><description>libdvdread <c>ifo_types.h</c> — structure definitions.</description></item>
+    ///   <item><description>libdvdread <c>ifo_read.c</c> — parsing functions (ifoRead_TT_SRPT, ifoRead_VTS_PTT_SRPT, ifoRead_VTS_PGCIT).</description></item>
+    ///   <item><description>libdvdnav <c>read_cache.c</c> / <c>dvdnav.c</c> — sector navigation.</description></item>
+    /// </list>
+    /// All multi-byte integers in IFO files are big-endian.
+    /// DVD sectors are 2 048 bytes.
+    /// Sector pointers in header fields are relative to the start of the IFO file.
+    /// Table-internal offsets are relative to the start of the table (not the file).
+    /// </remarks>
+    internal static class DvdVideoProber
+    {
+        private const string VmgIfoDirectoryName = "VIDEO_TS";
+        private const string VmgIfoFileName = "VIDEO_TS.IFO";
+        private const int DvdSectorSize = 2048;
+
+        // ── Public convenience wrappers (title-number lists only) ──────────────
+
+        /// <summary>
+        /// Returns the list of title numbers (1-based) present in a DVD ISO file,
+        /// by reading the Video Manager IFO embedded in the UDF image.
+        /// </summary>
+        /// <param name="isoPath">Path to the ISO image file.</param>
+        /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
+        internal static IReadOnlyList<int> GetIsoTitleNumbers(string isoPath)
+        {
+            var disc = ParseVideoTsIso(isoPath);
+            return disc.Titles.Count > 0
+                ? disc.Titles.Select(t => t.TitleNumber).ToList()
+                : Array.Empty<int>();
+        }
+
+        /// <summary>
+        /// Returns the list of title numbers (1-based) present in an unpacked DVD directory,
+        /// by reading the Video Manager IFO from the filesystem.
+        /// </summary>
+        /// <param name="dvdPath">
+        /// Path to either the root directory (containing a VIDEO_TS sub-directory)
+        /// or directly to the VIDEO_TS directory itself.
+        /// </param>
+        /// <returns>An ordered list of title numbers, or an empty list on failure.</returns>
+        internal static IReadOnlyList<int> GetDirectoryTitleNumbers(string dvdPath)
+        {
+            var disc = ParseVideoTsDirectory(dvdPath);
+            return disc.Titles.Count > 0
+                ? disc.Titles.Select(t => t.TitleNumber).ToList()
+                : Array.Empty<int>();
+        }
+
+        // ── Full disc parsers ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Parses a DVD VIDEO_TS directory (on disk) and returns full disc information
+        /// including per-title durations resolved from the VTS IFO files.
+        /// </summary>
+        /// <param name="dvdPath">
+        /// Root DVD directory (may contain a VIDEO_TS sub-directory) or the VIDEO_TS
+        /// directory itself.
+        /// </param>
+        /// <param name="logger">Optional logger; warnings are emitted for missing/corrupt IFOs.</param>
+        /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
+        internal static DvdDiscInfo ParseVideoTsDirectory(string dvdPath, ILogger? logger = null)
+        {
+            var videoTsPath = ResolveVideoTsPath(dvdPath);
+            if (videoTsPath is null)
+            {
+                return new DvdDiscInfo();
+            }
+
+            var ifoPath = FindFileInsensitive(videoTsPath, VmgIfoFileName);
+            if (ifoPath is null)
+            {
+                logger?.LogWarning("VIDEO_TS.IFO not found in {VideoTsPath}", videoTsPath);
+                return new DvdDiscInfo();
+            }
+
+            byte[] vmgData;
+            try
+            {
+                vmgData = File.ReadAllBytes(ifoPath);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to read VIDEO_TS.IFO at {Path}", ifoPath);
+                return new DvdDiscInfo();
+            }
+
+            var disc = ParseVmgIfo(vmgData);
+            if (disc.Titles.Count == 0)
+            {
+                return disc;
+            }
+
+            foreach (var vtsGroup in disc.Titles.GroupBy(t => t.TitleSetNumber))
+            {
+                var vtsNum = vtsGroup.Key;
+                if (vtsNum == 0)
+                {
+                    continue;
+                }
+
+                var vtsIfoName = FormattableString.Invariant($"VTS_{vtsNum:D2}_0.IFO");
+                var vtsIfoPath = FindFileInsensitive(videoTsPath, vtsIfoName);
+                if (vtsIfoPath is null)
+                {
+                    logger?.LogWarning("VTS IFO {FileName} not found in {VideoTsPath}", vtsIfoName, videoTsPath);
+                    continue;
+                }
+
+                byte[] vtsData;
+                try
+                {
+                    vtsData = File.ReadAllBytes(vtsIfoPath);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "Failed to read VTS IFO at {Path}", vtsIfoPath);
+                    continue;
+                }
+
+                ParseVtsIfo(vtsData, vtsNum, vtsGroup, logger);
+            }
+
+            return disc;
+        }
+
+        /// <summary>
+        /// Parses a DVD ISO image and returns full disc information including per-title durations.
+        /// </summary>
+        /// <param name="isoPath">Path to the ISO image file.</param>
+        /// <param name="logger">Optional logger.</param>
+        /// <returns>Parsed disc info; titles list may be empty on failure.</returns>
+        internal static DvdDiscInfo ParseVideoTsIso(string isoPath, ILogger? logger = null)
+        {
+            try
+            {
+                using var fileStream = File.Open(isoPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var udfReader = new DiscUtils.Udf.UdfReader(fileStream);
+
+                var vtsDirectory = udfReader.GetDirectoryInfo(VmgIfoDirectoryName);
+                if (!vtsDirectory.Exists)
+                {
+                    logger?.LogWarning("VIDEO_TS directory not found in ISO {Path}", isoPath);
+                    return new DvdDiscInfo();
+                }
+
+                var allFiles = vtsDirectory.GetFiles();
+
+                var vmgIfoFile = allFiles.FirstOrDefault(
+                    f => string.Equals(f.Name, VmgIfoFileName, StringComparison.OrdinalIgnoreCase));
+                if (vmgIfoFile is null)
+                {
+                    logger?.LogWarning("VIDEO_TS.IFO not found in ISO {Path}", isoPath);
+                    return new DvdDiscInfo();
+                }
+
+                byte[] vmgData;
+                using (var stream = udfReader.OpenFile(vmgIfoFile.FullName, FileMode.Open, FileAccess.Read))
+                {
+                    vmgData = ReadStreamFully(stream);
+                }
+
+                var disc = ParseVmgIfo(vmgData);
+                if (disc.Titles.Count == 0)
+                {
+                    return disc;
+                }
+
+                foreach (var vtsGroup in disc.Titles.GroupBy(t => t.TitleSetNumber))
+                {
+                    var vtsNum = vtsGroup.Key;
+                    if (vtsNum == 0)
+                    {
+                        continue;
+                    }
+
+                    var vtsIfoName = FormattableString.Invariant($"VTS_{vtsNum:D2}_0.IFO");
+                    var vtsIfoFile = allFiles.FirstOrDefault(
+                        f => string.Equals(f.Name, vtsIfoName, StringComparison.OrdinalIgnoreCase));
+                    if (vtsIfoFile is null)
+                    {
+                        logger?.LogWarning("VTS IFO {FileName} not found in ISO {Path}", vtsIfoName, isoPath);
+                        continue;
+                    }
+
+                    byte[] vtsData;
+                    try
+                    {
+                        using var stream = udfReader.OpenFile(vtsIfoFile.FullName, FileMode.Open, FileAccess.Read);
+                        vtsData = ReadStreamFully(stream);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogError(ex, "Failed to read VTS IFO {FileName} from ISO", vtsIfoName);
+                        continue;
+                    }
+
+                    ParseVtsIfo(vtsData, vtsNum, vtsGroup, logger);
+                }
+
+                return disc;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to parse DVD ISO at {Path}", isoPath);
+                return new DvdDiscInfo();
+            }
+        }
+
+        /// <summary>
+        /// Returns the title most likely to be the main feature: the longest title whose
+        /// duration is at or above <paramref name="minDuration"/> (default: no minimum).
+        /// </summary>
+        /// <param name="disc">Parsed disc info.</param>
+        /// <param name="minDuration">Optional minimum duration threshold.</param>
+        /// <returns>The best-candidate <see cref="DvdTitleInfo"/>, or <c>null</c> if none qualifies.</returns>
+        internal static DvdTitleInfo? FindMainFeature(DvdDiscInfo disc, TimeSpan? minDuration = null)
+        {
+            IEnumerable<DvdTitleInfo> candidates = disc.Titles.Where(t => t.Duration.HasValue);
+            if (minDuration.HasValue)
+            {
+                candidates = candidates.Where(t => t.Duration >= minDuration);
+            }
+
+            return candidates.OrderByDescending(t => t.Duration).FirstOrDefault();
+        }
+
+        // ── VMG IFO (VIDEO_TS.IFO) parser ────────────────────────────────────
+
+        /// <summary>
+        /// Reads the number of titles from a DVD Video Manager IFO (VIDEO_TS.IFO) stream.
+        /// Kept for callers that only need the count without full disc parsing.
+        /// </summary>
+        /// <remarks>
+        /// Implements the same logic as <c>ifoRead_TT_SRPT</c> in libdvdread.
+        /// vmgi_mat_t layout (big-endian multi-byte fields):
+        ///   0x00–0x0B  vmg_identifier   "DVDVIDEO-VMG"
+        ///   0xC0–0xC3  vmgm_vobs        sector address of menu VOBs (skipped)
+        ///   0xC4–0xC7  tt_srpt          sector address of the TT_SRPT table
+        /// tt_srpt_t starts at tt_srpt×2048 within the file:
+        ///   +0x00–0x01 nr_of_srpts      number of titles (big-endian uint16).
+        /// </remarks>
+        /// <param name="ifoStream">Seekable stream positioned at the start of VIDEO_TS.IFO.</param>
+        /// <returns>The number of titles, or 0 if the stream is not a valid VMG IFO.</returns>
+        internal static int ReadVmgTitleCount(Stream ifoStream)
+        {
+            Span<byte> magic = stackalloc byte[12];
+            if (ifoStream.Read(magic) < 12)
+            {
+                return 0;
+            }
+
+            if (!magic.SequenceEqual("DVDVIDEO-VMG"u8))
+            {
+                return 0;
+            }
+
+            ifoStream.Seek(0xC4, SeekOrigin.Begin);
+            Span<byte> sectorBytes = stackalloc byte[4];
+            if (ifoStream.Read(sectorBytes) < 4)
+            {
+                return 0;
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                sectorBytes.Reverse();
+            }
+
+            var srptSector = BitConverter.ToUInt32(sectorBytes);
+            if (srptSector == 0)
+            {
+                return 0;
+            }
+
+            var srptOffset = (long)srptSector * DvdSectorSize;
+            if (srptOffset + 2 > ifoStream.Length)
+            {
+                return 0;
+            }
+
+            ifoStream.Seek(srptOffset, SeekOrigin.Begin);
+            Span<byte> countBytes = stackalloc byte[2];
+            if (ifoStream.Read(countBytes) < 2)
+            {
+                return 0;
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                countBytes.Reverse();
+            }
+
+            return BitConverter.ToUInt16(countBytes);
+        }
+
+        // ── Core IFO parsers ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Parses the VMG IFO byte array and builds a <see cref="DvdDiscInfo"/> from the
+        /// TT_SRPT (Title Search Pointer Table).
+        /// </summary>
+        /// <remarks>
+        /// vmgi_mat_t (VIDEO_TS.IFO header, all multi-byte values big-endian):
+        ///   0x00  vmg_identifier[12]   "DVDVIDEO-VMG"
+        ///   0xC4  tt_srpt              sector pointer to TT_SRPT table
+        ///
+        /// tt_srpt_t at tt_srpt×2048:
+        ///   +0x00 nr_of_srpts          UInt16BE — title count
+        ///   +0x04 last_byte            UInt32BE — byte offset of last byte of table
+        ///   +0x08 title entries        12 bytes each (title_info_t)
+        ///
+        /// title_info_t (12 bytes, per libdvdread ifo_types.h):
+        ///   +0x00 pb_ty                1 byte — playback type flags
+        ///   +0x01 nr_of_angles         1 byte
+        ///   +0x02 nr_of_ptts           UInt16BE — chapter count
+        ///   +0x04 parental_id          UInt16BE (ignored)
+        ///   +0x06 title_set_nr         1 byte — VTS number
+        ///   +0x07 vts_ttn              1 byte — title number within VTS
+        ///   +0x08 title_set_sector     UInt32BE — VTS start sector on disc.
+        /// </remarks>
+        private static DvdDiscInfo ParseVmgIfo(byte[] data)
+        {
+            var disc = new DvdDiscInfo();
+
+            if (!HasMagic(data, "DVDVIDEO-VMG"))
+            {
+                return disc;
+            }
+
+            // tt_srpt sector pointer at 0xC4
+            if (data.Length < 0xC8)
+            {
+                return disc;
+            }
+
+            uint srptSector = ReadUInt32BE(data, 0xC4);
+            if (srptSector == 0)
+            {
+                return disc;
+            }
+
+            long srptByteOffset = (long)srptSector * DvdSectorSize;
+
+            // Need at least the 8-byte TT_SRPT header
+            if (srptByteOffset + 8 > data.Length)
+            {
+                return disc;
+            }
+
+            int srptBase = (int)srptByteOffset;
+            int titleCount = ReadUInt16BE(data, srptBase + 0);
+            // srptBase+2: reserved (skipped)
+            // srptBase+4: last_byte (used for an additional bounds check)
+            uint lastByte = ReadUInt32BE(data, srptBase + 4);
+
+            if (titleCount <= 0)
+            {
+                return disc;
+            }
+
+            // Each title_info_t entry is 12 bytes; verify all entries fit.
+            long entriesEnd = srptByteOffset + 8 + ((long)titleCount * 12);
+            if (entriesEnd > data.Length)
+            {
+                return disc;
+            }
+
+            for (int i = 0; i < titleCount; i++)
+            {
+                int o = srptBase + 8 + (i * 12);
+
+                // title_info_t layout (12 bytes):
+                // o+0  pb_ty          — playback type (unused here)
+                // o+1  nr_of_angles   — angle count
+                // o+2  nr_of_ptts     — chapter count (UInt16BE)
+                // o+4  parental_id    — parental mask (UInt16BE, unused)
+                // o+6  title_set_nr   — VTS number
+                // o+7  vts_ttn        — VTS-local title number
+                // o+8  title_set_sector — VTS start sector (UInt32BE)
+                byte angleCount = data[o + 1];
+                int chapterCount = ReadUInt16BE(data, o + 2);
+                byte vtsNumber = data[o + 6];
+                byte vtsTitleNum = data[o + 7];
+                uint vtsStartSec = ReadUInt32BE(data, o + 8);
+
+                disc.Titles.Add(new DvdTitleInfo
+                {
+                    TitleNumber = i + 1,
+                    TitleSetNumber = vtsNumber,
+                    VtsTitleNumber = vtsTitleNum,
+                    ChapterCount = chapterCount,
+                    AngleCount = angleCount,
+                    VtsStartSector = vtsStartSec
+                });
+            }
+
+            return disc;
+        }
+
+        /// <summary>
+        /// Parses a VTS IFO byte array and fills in <see cref="DvdTitleInfo.Duration"/>,
+        /// <see cref="DvdTitleInfo.ProgramChainNumber"/>, and <see cref="DvdTitleInfo.ProgramNumber"/>
+        /// for each of the supplied titles belonging to this title set.
+        /// </summary>
+        /// <remarks>
+        /// vtsi_mat_t sector pointers used (big-endian UInt32, relative to VTS IFO start):
+        ///   0xC8  vts_ptt_srpt    → VTS_PTT_SRPT table
+        ///   0xCC  vts_pgcit       → VTS_PGCITI table
+        ///
+        /// VTS_PTT_SRPT maps VTS-local title number → first PGC + program number.
+        /// VTS_PGCITI maps PGC number → PGC playback time.
+        ///
+        /// Mutates <paramref name="titles"/> in-place, setting <see cref="DvdTitleInfo.ProgramChainNumber"/>,
+        /// <see cref="DvdTitleInfo.ProgramNumber"/>, and <see cref="DvdTitleInfo.Duration"/> on each entry.
+        /// </remarks>
+        private static void ParseVtsIfo(byte[] data, int vtsNumber, IEnumerable<DvdTitleInfo> titles, ILogger? logger)
+        {
+            if (!HasMagic(data, "DVDVIDEO-VTS"))
+            {
+                logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO has wrong magic bytes — skipping", vtsNumber);
+                return;
+            }
+
+            // vtsi_mat_t: vts_ptt_srpt at 0xC8, vts_pgcit at 0xCC
+            if (data.Length < 0xD0)
+            {
+                logger?.LogWarning("VTS_{VtsNum:D2}_0.IFO is too short to contain VTSI_MAT pointers", vtsNumber);
+                return;
+            }
+
+            uint pttSrptSector = ReadUInt32BE(data, 0xC8);
+            uint pgcitiSector = ReadUInt32BE(data, 0xCC);
+
+            // Parse VTS_PTT_SRPT → VTS title → (PGC number, program number)
+            Dictionary<int, (int PgcNumber, int ProgramNumber)>? pttMap = null;
+            if (pttSrptSector > 0)
+            {
+                long pttBase = (long)pttSrptSector * DvdSectorSize;
+                if (pttBase + 8 <= data.Length)
+                {
+                    pttMap = ParseVtsPttSrpt(data, (int)pttBase);
+                }
+                else
+                {
+                    logger?.LogWarning(
+                        "VTS_{VtsNum:D2}_0.IFO: VTS_PTT_SRPT sector {Sector} points outside file",
+                        vtsNumber,
+                        pttSrptSector);
+                }
+            }
+
+            // Parse VTS_PGCITI → PGC number → duration
+            Dictionary<int, TimeSpan?>? pgcDurations = null;
+            if (pgcitiSector > 0)
+            {
+                long pgcitiBase = (long)pgcitiSector * DvdSectorSize;
+                if (pgcitiBase + 8 <= data.Length)
+                {
+                    pgcDurations = ParseVtsPgciti(data, (int)pgcitiBase);
+                }
+                else
+                {
+                    logger?.LogWarning(
+                        "VTS_{VtsNum:D2}_0.IFO: VTS_PGCITI sector {Sector} points outside file",
+                        vtsNumber,
+                        pgcitiSector);
+                }
+            }
+
+            foreach (var title in titles)
+            {
+                if (pttMap is not null && pttMap.TryGetValue(title.VtsTitleNumber, out var pttEntry))
+                {
+                    title.ProgramChainNumber = pttEntry.PgcNumber;
+                    title.ProgramNumber = pttEntry.ProgramNumber;
+
+                    if (pgcDurations is not null && pgcDurations.TryGetValue(pttEntry.PgcNumber, out var duration))
+                    {
+                        title.Duration = duration;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses the VTS_PTT_SRPT (VTS Part-of-Title Search Pointer Table) and returns a
+        /// dictionary mapping VTS-local title number → (first PGC number, first program number).
+        /// </summary>
+        /// <remarks>
+        /// vts_ptt_srpt_t layout (per libdvdread ifo_types.h):
+        ///   +0x00 nr_of_srpts    UInt16BE — number of VTS titles
+        ///   +0x02 (reserved)
+        ///   +0x04 last_byte      UInt32BE — last byte of table, relative to table base
+        ///   +0x08 offset[]       UInt32BE per VTS title, relative to table base
+        ///         Each offset points to the first ttu_t (PTT) entry for that title.
+        ///
+        /// ttu_t (4 bytes per chapter/PTT):
+        ///   +0x00 pgcn           UInt16BE — PGC number (1-based)
+        ///   +0x02 pgn            UInt16BE — program number within PGC (1-based).
+        /// </remarks>
+        private static Dictionary<int, (int PgcNumber, int ProgramNumber)> ParseVtsPttSrpt(byte[] data, int pttBase)
+        {
+            var result = new Dictionary<int, (int PgcNumber, int ProgramNumber)>();
+
+            if (pttBase + 8 > data.Length)
+            {
+                return result;
+            }
+
+            int vtsTitleCount = ReadUInt16BE(data, pttBase + 0);
+            uint lastByte = ReadUInt32BE(data, pttBase + 4);
+
+            if (vtsTitleCount <= 0)
+            {
+                return result;
+            }
+
+            // Verify offset table fits
+            int offsetTableEnd = pttBase + 8 + (vtsTitleCount * 4);
+            if (offsetTableEnd > data.Length)
+            {
+                return result;
+            }
+
+            for (int n = 1; n <= vtsTitleCount; n++)
+            {
+                int offsetPos = pttBase + 8 + ((n - 1) * 4);
+                uint titleRelOffset = ReadUInt32BE(data, offsetPos);
+
+                // Determine how many PTT/chapter entries this VTS title has (for bounds safety).
+                uint nextRelOffset;
+                if (n < vtsTitleCount)
+                {
+                    nextRelOffset = ReadUInt32BE(data, offsetPos + 4);
+                }
+                else
+                {
+                    // last_byte is the byte index of the last byte, so +1 gives exclusive end
+                    nextRelOffset = lastByte + 1;
+                }
+
+                if (nextRelOffset <= titleRelOffset)
+                {
+                    // Degenerate or corrupt entry — no chapters
+                    continue;
+                }
+
+                // Each ttu_t is 4 bytes; only the first (title's first chapter) is needed
+                long firstPttOffset = (long)pttBase + titleRelOffset;
+                if (firstPttOffset + 4 > data.Length)
+                {
+                    break;
+                }
+
+                int pgcNumber = ReadUInt16BE(data, (int)firstPttOffset + 0);
+                int programNumber = ReadUInt16BE(data, (int)firstPttOffset + 2);
+
+                if (pgcNumber > 0) // PGC 0 is invalid per spec
+                {
+                    result[n] = (pgcNumber, programNumber);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Parses the VTS_PGCITI (VTS PGC Information Table) and returns a dictionary
+        /// mapping PGC number (1-based) → playback duration.
+        /// </summary>
+        /// <remarks>
+        /// vts_pgcit_t layout (per libdvdread ifo_types.h):
+        ///   +0x00 nr_of_pgci_srp  UInt16BE — number of PGC search pointers
+        ///   +0x02 (reserved)
+        ///   +0x04 last_byte       UInt32BE
+        ///   +0x08 pgci_srp[]      8 bytes each (pgci_srp_t)
+        ///
+        /// pgci_srp_t (8 bytes):
+        ///   +0x00 entry_id        1 byte
+        ///   +0x01 flags           1 byte  (block_mode / block_type bits)
+        ///   +0x02 ptl_id_mask     UInt16BE
+        ///   +0x04 pgc_start_byte  UInt32BE — byte offset of PGC, relative to table base
+        ///
+        /// pgc_t at pgciti_base + pgc_start_byte:
+        ///   +0x00 (reserved)
+        ///   +0x01 nr_of_programs  1 byte
+        ///   +0x02 nr_of_cells     1 byte
+        ///   +0x03 (reserved)
+        ///   +0x04 playback_time   4 bytes  (dvd_time_t / BCD + frame-rate).
+        /// </remarks>
+        private static Dictionary<int, TimeSpan?> ParseVtsPgciti(byte[] data, int pgcitiBase)
+        {
+            var result = new Dictionary<int, TimeSpan?>();
+
+            if (pgcitiBase + 8 > data.Length)
+            {
+                return result;
+            }
+
+            int pgcCount = ReadUInt16BE(data, pgcitiBase + 0);
+            if (pgcCount <= 0)
+            {
+                return result;
+            }
+
+            for (int n = 1; n <= pgcCount; n++)
+            {
+                // pgci_srp_t is 8 bytes; search pointer for PGC n is at index n-1
+                int srpOffset = pgcitiBase + 8 + ((n - 1) * 8);
+                if (srpOffset + 8 > data.Length)
+                {
+                    result[n] = null;
+                    continue;
+                }
+
+                // pgc_start_byte at srp+4, relative to pgcitiBase
+                uint pgcRelOffset = ReadUInt32BE(data, srpOffset + 4);
+                long pgcAddress = (long)pgcitiBase + pgcRelOffset;
+
+                // Need at least 8 bytes of PGC header to read playback_time at +4
+                if (pgcAddress + 8 > data.Length)
+                {
+                    result[n] = null;
+                    continue;
+                }
+
+                result[n] = TryReadDvdTime(data, (int)pgcAddress + 4);
+            }
+
+            return result;
+        }
+
+        // ── DVD time decoding ─────────────────────────────────────────────────
+
+        /// <summary>
+        /// Decodes a 4-byte DVD time field (dvd_time_t) into a <see cref="TimeSpan"/>.
+        /// Returns <c>null</c> if the field contains invalid BCD values or is out of bounds.
+        /// </summary>
+        /// <remarks>
+        /// dvd_time_t layout (per libdvdread ifo_types.h):
+        ///   +0  hour      BCD
+        ///   +1  minute    BCD
+        ///   +2  second    BCD
+        ///   +3  frame_u   bits 7-6 = frame-rate code (0x40=25fps, 0xC0≈29.97fps),
+        ///                 bits 5-0 = frame count.
+        /// </remarks>
+        private static TimeSpan? TryReadDvdTime(byte[] data, int offset)
+        {
+            if (offset + 4 > data.Length)
+            {
+                return null;
+            }
+
+            int hours = FromBcd(data[offset + 0]);
+            int minutes = FromBcd(data[offset + 1]);
+            int seconds = FromBcd(data[offset + 2]);
+
+            // Validate decoded BCD values before constructing TimeSpan
+            if (minutes >= 60 || seconds >= 60)
+            {
+                return null;
+            }
+
+            byte frameAndRate = data[offset + 3];
+            int frames = frameAndRate & 0x3F;
+            int rateCode = frameAndRate & 0xC0;
+
+            double fps = rateCode switch
+            {
+                0x40 => 25.0,
+                0xC0 => 29.97,
+                _ => 0.0
+            };
+
+            double frameSeconds = fps > 0 ? frames / fps : 0.0;
+
+            try
+            {
+                return new TimeSpan(hours, minutes, seconds) + TimeSpan.FromSeconds(frameSeconds);
+            }
+            catch (OverflowException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Decodes a BCD (Binary-Coded Decimal) byte into its integer value.
+        /// E.g. 0x59 → 59, 0x23 → 23.
+        /// </summary>
+        private static int FromBcd(byte value)
+            => ((value >> 4) * 10) + (value & 0x0F);
+
+        // ── Big-endian binary helpers ─────────────────────────────────────────
+
+        /// <summary>Reads a big-endian unsigned 16-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
+        /// <param name="data">Source byte array.</param>
+        /// <param name="offset">Zero-based byte offset to read from.</param>
+        /// <returns>The decoded <see cref="ushort"/> value.</returns>
+        internal static ushort ReadUInt16BE(byte[] data, int offset)
+            => (ushort)((data[offset] << 8) | data[offset + 1]);
+
+        /// <summary>Reads a big-endian unsigned 32-bit integer from <paramref name="data"/> at <paramref name="offset"/>.</summary>
+        /// <param name="data">Source byte array.</param>
+        /// <param name="offset">Zero-based byte offset to read from.</param>
+        /// <returns>The decoded <see cref="uint"/> value.</returns>
+        internal static uint ReadUInt32BE(byte[] data, int offset)
+            => ((uint)data[offset] << 24)
+             | ((uint)data[offset + 1] << 16)
+             | ((uint)data[offset + 2] << 8)
+             | (uint)data[offset + 3];
+
+        // ── Utility helpers ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="data"/> begins with the ASCII bytes of <paramref name="magic"/>.
+        /// </summary>
+        private static bool HasMagic(byte[] data, string magic)
+        {
+            if (data.Length < magic.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < magic.Length; i++)
+            {
+                if (data[i] != (byte)magic[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Resolves the VIDEO_TS directory from a DVD root or VIDEO_TS path.
+        /// Returns <c>null</c> if neither path exists.
+        /// </summary>
+        private static string? ResolveVideoTsPath(string dvdPath)
+        {
+            var candidate = Path.Combine(dvdPath, VmgIfoDirectoryName);
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            if (Directory.Exists(dvdPath))
+            {
+                return dvdPath;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Case-insensitive file lookup inside a directory.
+        /// Returns the full path of the first match, or <c>null</c> if not found.
+        /// </summary>
+        private static string? FindFileInsensitive(string directory, string fileName)
+            => Directory.GetFiles(directory)
+                .FirstOrDefault(f => string.Equals(
+                    Path.GetFileName(f), fileName, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>Reads all bytes from <paramref name="stream"/> regardless of its initial position.</summary>
+        private static byte[] ReadStreamFully(Stream stream)
+        {
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+    }
+}

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -636,12 +636,64 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             List<MediaStream> subtitleStreams,
             CancellationToken cancellationToken)
         {
-            var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
+            var inputPath = _mediaEncoder.GetInputPathArgument(mediaSource.Path, mediaSource);
+
             var outputPaths = new List<string>();
-            var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-i {0}",
-                inputPath);
+            var args = string.Empty;
+
+            if (mediaSource.VideoType == VideoType.Dvd
+                && mediaSource.IsoPlaybackTitle.HasValue
+                && _mediaEncoder.SupportsDvdVideo)
+            {
+                // Unpacked DVD directory with an explicit title selection: use dvdvideo demuxer.
+                // IsoPlaybackTitle is 1-based.
+                var titleNumber = mediaSource.IsoPlaybackTitle.Value;
+                args += " -f dvdvideo -title ";
+                args += titleNumber;
+                args += " -i ";
+                args += inputPath;
+            }
+            else if (mediaSource.VideoType == VideoType.BluRay
+                && mediaSource.IsoPlaybackTitle.HasValue
+                && _mediaEncoder.SupportsLibBluray)
+            {
+                // Unpacked Blu-ray directory with an explicit title selection: use libbluray title selection.
+                // IsoPlaybackTitle is 1-based for display; libbluray expects the specific number of the .mpls file.
+                var titleNumber = mediaSource.IsoPlaybackTitle.Value;
+                args += " -playlist ";
+                args += titleNumber.ToString(CultureInfo.InvariantCulture).PadLeft(5, '0');
+                args += " -i ";
+                args += inputPath;
+            }
+            else if (mediaSource.VideoType == VideoType.Iso
+                && mediaSource.IsoType == IsoType.Dvd)
+            {
+                if (_mediaEncoder.SupportsDvdVideo)
+                {
+                    // DVD ISO: use the dvdvideo demuxer which requires libdvdnav + libdvdread.
+                    // Use the stored playback title; if none is set, resolve the longest title on demand.
+                    var titleNumber = mediaSource.IsoPlaybackTitle
+                        ?? EncodingHelper.GetLongestIsoTitleNumber(inputPath, IsoType.Dvd, _mediaEncoder);
+                    args += " -f dvdvideo -title ";
+                    args += titleNumber;
+                    args += " -i ";
+                    args += inputPath;
+                }
+                else
+                {
+                    // dvdvideo demuxer unavailable: fall back to passing the ISO path directly.
+                    args += " -i ";
+                    args += inputPath;
+                }
+            }
+            else
+            {
+                inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
+                args += string.Format(
+                    CultureInfo.InvariantCulture,
+                    "-i {0}",
+                    inputPath);
+            }
 
             foreach (var subtitleStream in subtitleStreams)
             {

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -584,6 +584,12 @@ namespace MediaBrowser.Model.Dto
         public IsoType? IsoType { get; set; }
 
         /// <summary>
+        /// Gets or sets the 1-based playback title number for DVD/Blu-ray ISO or directory.
+        /// </summary>
+        /// <value>The playback title number, or null for the default title.</value>
+        public int? IsoPlaybackTitle { get; set; }
+
+        /// <summary>
         /// Gets or sets the type of the media.
         /// </summary>
         /// <value>The type of the media.</value>

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -92,6 +92,11 @@ namespace MediaBrowser.Model.Dto
 
         public IsoType? IsoType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the 1-based playback title number for DVD/Blu-ray ISO or directory.
+        /// </summary>
+        public int? IsoPlaybackTitle { get; set; }
+
         public Video3DFormat? Video3DFormat { get; set; }
 
         public IReadOnlyList<MediaStream> MediaStreams { get; set; }

--- a/MediaBrowser.Model/Dto/MetadataEditorInfo.cs
+++ b/MediaBrowser.Model/Dto/MetadataEditorInfo.cs
@@ -52,4 +52,16 @@ public class MetadataEditorInfo
     /// Gets or sets the content type options.
     /// </summary>
     public IReadOnlyList<NameValuePair> ContentTypeOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the dvdvideo demuxer is available in ffmpeg.
+    /// When <c>false</c>, DVD title selection cannot be offered in the editor UI.
+    /// </summary>
+    public bool SupportsDvdVideo { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the libbluray input protocol is available in ffmpeg.
+    /// When <c>false</c>, Blu-ray title selection cannot be offered in the editor UI.
+    /// </summary>
+    public bool SupportsLibBluray { get; set; }
 }

--- a/MediaBrowser.Model/MediaInfo/IBlurayExaminer.cs
+++ b/MediaBrowser.Model/MediaInfo/IBlurayExaminer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace MediaBrowser.Model.MediaInfo;
 
 /// <summary>
@@ -11,4 +13,11 @@ public interface IBlurayExaminer
     /// <param name="path">The path.</param>
     /// <returns>BlurayDiscInfo.</returns>
     BlurayDiscInfo GetDiscInfo(string path);
+
+    /// <summary>
+    /// Gets all available playback titles from a Blu-ray disc or ISO, ordered by title number.
+    /// </summary>
+    /// <param name="path">The path to the disc directory or ISO file.</param>
+    /// <returns>A list of <see cref="IsoTitleInfo"/> with title numbers and durations.</returns>
+    IReadOnlyList<IsoTitleInfo> GetTitles(string path);
 }

--- a/MediaBrowser.Model/MediaInfo/IsoTitleInfo.cs
+++ b/MediaBrowser.Model/MediaInfo/IsoTitleInfo.cs
@@ -1,0 +1,29 @@
+namespace MediaBrowser.Model.MediaInfo;
+
+/// <summary>
+/// Represents a playback title available within an ISO disc image.
+/// </summary>
+public class IsoTitleInfo
+{
+    /// <summary>
+    /// Gets or sets the 1-based title number.
+    /// </summary>
+    public int TitleNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration of the title in ticks, if known.
+    /// </summary>
+    public long? DurationTicks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of chapters (PTT entries) in this title.
+    /// 0 if not known.
+    /// </summary>
+    public int ChapterCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of angles available for this title.
+    /// 0 if not known.
+    /// </summary>
+    public int AngleCount { get; set; }
+}

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -3,11 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
+using MediaBrowser.Common;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -84,11 +86,23 @@ namespace MediaBrowser.Providers.MediaInfo
 
             Model.MediaInfo.MediaInfo? mediaInfoResult = null;
 
+            if (item.VideoType == VideoType.Iso && !item.IsoType.HasValue)
+            {
+                item.IsoType = DetectIsoType(item);
+            }
+
             if (!item.IsShortcut || options.EnableRemoteContentProbe)
             {
                 if (item.VideoType == VideoType.Dvd)
                 {
-                    // Get list of playable .vob files
+                    // Enumerate titles and select the longest on first scan or full metadata replace,
+                    // but only when the dvdvideo demuxer is available to actually play the selection back.
+                    if (_mediaEncoder.SupportsDvdVideo && (!item.IsoPlaybackTitle.HasValue || options.ReplaceAllMetadata))
+                    {
+                        SetDefaultTitle(item, IsoType.Dvd);
+                    }
+
+                    // Get list of playable .vob files for metadata probing
                     var vobs = _mediaEncoder.GetPrimaryPlaylistVobFiles(item.Path, null);
 
                     // Return if no playable .vob files are found
@@ -131,6 +145,13 @@ namespace MediaBrowser.Providers.MediaInfo
                         return ItemUpdateType.MetadataImport;
                     }
 
+                    // Enumerate titles and select the longest one on first scan or full metadata replace,
+                    // but only when libbluray is available to actually play the selection back.
+                    if (_mediaEncoder.SupportsLibBluray && (!item.IsoPlaybackTitle.HasValue || options.ReplaceAllMetadata))
+                    {
+                        SetDefaultTitle(item, IsoType.BluRay);
+                    }
+
                     // Fetch metadata of first .m2ts file
                     mediaInfoResult = await GetMediaInfo(
                         new Video
@@ -138,6 +159,26 @@ namespace MediaBrowser.Providers.MediaInfo
                             Path = blurayDiscInfo.Files[0]
                         },
                         cancellationToken).ConfigureAwait(false);
+                }
+                else if (item.VideoType == VideoType.Iso
+                    && item.IsoType is IsoType.Dvd or IsoType.BluRay)
+                {
+                    // For DVD/Blu-ray ISO files, enumerate available titles and set the default (longest) one.
+                    // Only do this on first scan (IsoPlaybackTitle not yet set) or on a full metadata replace,
+                    // and only when the required ffmpeg feature is present.
+                    if (!item.IsoPlaybackTitle.HasValue || options.ReplaceAllMetadata)
+                    {
+                        bool featureAvailable = item.IsoType == IsoType.Dvd
+                            ? _mediaEncoder.SupportsDvdVideo
+                            : _mediaEncoder.SupportsLibBluray;
+
+                        if (featureAvailable)
+                        {
+                            SetDefaultTitle(item, item.IsoType.Value);
+                        }
+                    }
+
+                    mediaInfoResult = await GetMediaInfo(item, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -150,6 +191,78 @@ namespace MediaBrowser.Providers.MediaInfo
             await Fetch(item, cancellationToken, mediaInfoResult, blurayDiscInfo, options).ConfigureAwait(false);
 
             return ItemUpdateType.MetadataImport;
+        }
+
+        internal IsoType? DetectIsoType(Video item)
+        {
+            if (item.VideoType != VideoType.Iso || string.IsNullOrWhiteSpace(item.Path))
+            {
+                return null;
+            }
+
+            return TryDetectIsoType(item.Path, IsoType.Dvd, _mediaEncoder.SupportsDvdVideo)
+                ?? TryDetectIsoType(item.Path, IsoType.BluRay, _mediaEncoder.SupportsLibBluray);
+        }
+
+        private IsoType? TryDetectIsoType(string path, IsoType isoType, bool featureSupported)
+        {
+            if (!featureSupported)
+            {
+                return null;
+            }
+
+            try
+            {
+                if (_mediaEncoder.GetIsoTitles(path, isoType).Count > 0)
+                {
+                    return isoType;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or FfmpegException)
+            {
+                _logger.LogDebug(ex, "Failed to probe ISO as {IsoType}: {Path}", isoType, path);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Enumerates all available titles and sets <see cref="Video.IsoPlaybackTitle"/>
+        /// to the longest one. Called during probing when a title hasn't been selected yet.
+        /// Works for both ISO files (DVD/Blu-ray) and unpacked Blu-ray directories.
+        /// </summary>
+        private void SetDefaultTitle(Video item, IsoType isoType)
+        {
+            try
+            {
+                var titles = _mediaEncoder.GetIsoTitles(item.Path, isoType);
+                if (titles.Count == 0)
+                {
+                    return;
+                }
+
+                // Select the title with the longest duration. When durations are unavailable, fall back to
+                // the highest title number (typically the main feature on DVDs).
+                var longest = titles
+                    .OrderByDescending(t => t.DurationTicks ?? 0)
+                    .ThenByDescending(t => t.TitleNumber)
+                    .First();
+
+                _logger.LogInformation(
+                    "{Path}: found {Count} title(s); defaulting to title {TitleNumber} (duration {Duration})",
+                    item.Path,
+                    titles.Count,
+                    longest.TitleNumber,
+                    longest.DurationTicks.HasValue
+                        ? TimeSpan.FromTicks(longest.DurationTicks.Value).ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture)
+                        : "unknown");
+
+                item.IsoPlaybackTitle = longest.TitleNumber;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to enumerate titles for {Path}", item.Path);
+            }
         }
 
         private Task<Model.MediaInfo.MediaInfo> GetMediaInfo(
@@ -177,7 +290,8 @@ namespace MediaBrowser.Providers.MediaInfo
                         Path = path,
                         Protocol = protocol,
                         VideoType = item.VideoType,
-                        IsoType = item.IsoType
+                        IsoType = item.IsoType,
+                        IsoPlaybackTitle = item.IsoPlaybackTitle
                     }
                 },
                 cancellationToken);

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -859,6 +859,19 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     case "durationinseconds":
                         video.RunTimeTicks = new TimeSpan(0, 0, reader.ReadElementContentAsInt()).Ticks;
                         break;
+                    case "isoplaybacktitle":
+                        {
+                            var titleText = reader.ReadElementContentAsString();
+                            // Accept title numbers in the range 1–999 (covers DVD titles 1–99 and BD playlists).
+                            if (int.TryParse(titleText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var titleNum)
+                                && titleNum is > 0 and <= 999)
+                            {
+                                video.IsoPlaybackTitle = titleNum;
+                            }
+
+                            break;
+                        }
+
                     default:
                         reader.Skip();
                         break;

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -97,7 +97,9 @@ namespace MediaBrowser.XbmcMetadata.Savers
             "isuserfavorite",
             "userrating",
 
-            "countrycode"
+            "countrycode",
+
+            "isoplaybacktitle",
         };
 
         protected BaseNfoSaver(
@@ -429,6 +431,17 @@ namespace MediaBrowser.XbmcMetadata.Savers
                                     writer.WriteElementString("format3d", "MVC");
                                     break;
                             }
+                        }
+
+                        // Persist the selected disc playback title so it survives a library re-scan.
+                        // For ISO items only write when IsoType is known; Dvd and BluRay directories always qualify.
+                        if (video.IsoPlaybackTitle.HasValue
+                            && (video.VideoType is VideoType.Dvd or VideoType.BluRay
+                                || (video.VideoType == VideoType.Iso && video.IsoType.HasValue)))
+                        {
+                            writer.WriteElementString(
+                                "isoplaybacktitle",
+                                video.IsoPlaybackTitle.Value.ToString(CultureInfo.InvariantCulture));
                         }
                     }
                 }

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/DvdVideoProberTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/DvdVideoProberTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using MediaBrowser.MediaEncoding.Probing;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Jellyfin.MediaEncoding.Tests.Probing;
@@ -157,7 +159,7 @@ public class DvdVideoProberTests
         WriteBE16(data, 2048 + 0, 1);
 
         using var dir = new TempVideoTsDirectory(data);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
 
         Assert.Single(disc.Titles);
         var t = disc.Titles[0];
@@ -189,7 +191,7 @@ public class DvdVideoProberTests
         }
 
         using var dir = new TempVideoTsDirectory(data);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
 
         Assert.Equal(titleCount, disc.Titles.Count);
         for (int i = 0; i < titleCount; i++)
@@ -202,7 +204,7 @@ public class DvdVideoProberTests
     public void ParseVideoTsDirectory_MissingVmgIfo_ReturnsEmptyDisc()
     {
         using var emptyDir = new TempVideoTsDirectory(null);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(emptyDir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(emptyDir.Path, Mock.Of<ILogger<DvdVideoProber>>());
         Assert.Empty(disc.Titles);
     }
 
@@ -212,7 +214,7 @@ public class DvdVideoProberTests
         var data = new byte[4096];
         "NOT-A-DVD-IFO"u8.CopyTo(data.AsSpan(0));
         using var dir = new TempVideoTsDirectory(data);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
         Assert.Empty(disc.Titles);
     }
 
@@ -292,7 +294,7 @@ public class DvdVideoProberTests
         });
 
         using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
 
         Assert.Single(disc.Titles);
         var t = disc.Titles[0];
@@ -333,7 +335,7 @@ public class DvdVideoProberTests
         });
 
         using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
 
         Assert.Equal(7, disc.Titles.Count);
         Assert.Equal(1, disc.Titles[0].TitleNumber);
@@ -412,7 +414,7 @@ public class DvdVideoProberTests
         var vtsData = BuildFullVtsIfoWithRawTime(dvdTime);
 
         using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
-        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path, Mock.Of<ILogger<DvdVideoProber>>());
         return disc.Titles.Count == 1 ? disc.Titles[0].Duration : null;
     }
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/DvdVideoProberTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/DvdVideoProberTests.cs
@@ -1,0 +1,578 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MediaBrowser.MediaEncoding.Probing;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.Probing;
+
+public class DvdVideoProberTests
+{
+    // ── Synthetic IFO builders ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a minimal VMG IFO byte array.
+    /// Layout:
+    ///   0x00: "DVDVIDEO-VMG"
+    ///   0xC0: vmgm_vobs sector (big-endian uint32) — set to 0 unless overridden
+    ///   0xC4: tt_srpt sector (big-endian uint32)
+    ///   srptSector*2048 + 0: nr_of_srpts (big-endian uint16).
+    /// </summary>
+    private static byte[] BuildVmgIfoBytes(uint srptSector, ushort titleCount, uint vmgmVobsSector = 0)
+    {
+        var totalSize = (int)(((long)srptSector * 2048) + 2);
+        var data = new byte[totalSize];
+
+        "DVDVIDEO-VMG"u8.CopyTo(data.AsSpan(0));
+
+        WriteBE32(data, 0xC0, vmgmVobsSector);
+        WriteBE32(data, 0xC4, srptSector);
+        WriteBE16(data, (int)((long)srptSector * 2048), titleCount);
+
+        return data;
+    }
+
+    private static MemoryStream BuildVmgIfo(uint srptSector, ushort titleCount, uint vmgmVobsSector = 0)
+        => new MemoryStream(BuildVmgIfoBytes(srptSector, titleCount, vmgmVobsSector), writable: false);
+
+    // ── Binary helper tests ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(new byte[] { 0x00, 0x01 }, 0, 1)]
+    [InlineData(new byte[] { 0x01, 0x00 }, 0, 256)]
+    [InlineData(new byte[] { 0xFF, 0xFF }, 0, 65535)]
+    [InlineData(new byte[] { 0x00, 0x07 }, 0, 7)]
+    public void ReadUInt16BE_ReturnsCorrectValue(byte[] data, int offset, int expected)
+        => Assert.Equal((ushort)expected, DvdVideoProber.ReadUInt16BE(data, offset));
+
+    [Theory]
+    [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x01 }, 0, 1u)]
+    [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x11 }, 0, 17u)]
+    [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x08 }, 0, 8u)]
+    [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, 0, 0xFFFFFFFFu)]
+    [InlineData(new byte[] { 0x01, 0x02, 0x03, 0x04 }, 0, 0x01020304u)]
+    public void ReadUInt32BE_ReturnsCorrectValue(byte[] data, int offset, uint expected)
+        => Assert.Equal(expected, DvdVideoProber.ReadUInt32BE(data, offset));
+
+    // ── ReadVmgTitleCount tests (stream-based, kept for compat) ──────────────
+
+    [Theory]
+    [InlineData(1u, 1)]
+    [InlineData(1u, 5)]
+    [InlineData(2u, 3)]
+    [InlineData(1u, 99)]
+    public void ReadVmgTitleCount_ValidIfo_ReturnsCorrectCount(uint srptSector, int expectedCount)
+    {
+        using var stream = BuildVmgIfo(srptSector, (ushort)expectedCount);
+        Assert.Equal(expectedCount, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    [Fact]
+    public void ReadVmgTitleCount_WrongMagic_ReturnsZero()
+    {
+        using var stream = new MemoryStream(new byte[4096]);
+        Assert.Equal(0, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    [Fact]
+    public void ReadVmgTitleCount_EmptyStream_ReturnsZero()
+    {
+        using var stream = new MemoryStream(Array.Empty<byte>());
+        Assert.Equal(0, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    [Fact]
+    public void ReadVmgTitleCount_TruncatedAfterMagic_ReturnsZero()
+    {
+        var data = new byte[20];
+        "DVDVIDEO-VMG"u8.CopyTo(data.AsSpan(0));
+        using var stream = new MemoryStream(data, writable: false);
+        Assert.Equal(0, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    [Fact]
+    public void ReadVmgTitleCount_ZeroSectorPointer_ReturnsZero()
+    {
+        var data = new byte[2050];
+        "DVDVIDEO-VMG"u8.CopyTo(data.AsSpan(0));
+        using var stream = new MemoryStream(data, writable: false);
+        Assert.Equal(0, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    [Fact]
+    public void ReadVmgTitleCount_SectorAddressBeyondFileLength_ReturnsZero()
+    {
+        const uint hugeSector = 100u;
+        var data = new byte[512];
+        "DVDVIDEO-VMG"u8.CopyTo(data.AsSpan(0));
+        WriteBE32(data, 0xC4, hugeSector);
+        using var stream = new MemoryStream(data, writable: false);
+        Assert.Equal(0, DvdVideoProber.ReadVmgTitleCount(stream));
+    }
+
+    // ── Real-world layout regression tests ───────────────────────────────────
+
+    /// <summary>
+    /// Verifies the three real-world IFO layouts from the bug report:
+    ///   VIDEO_TS_1.IFO: vmgm_vobs=0x00, tt_srpt=1 → 7 titles
+    ///   VIDEO_TS_2.IFO: vmgm_vobs=0x11, tt_srpt=1 → 72 titles
+    ///   VIDEO_TS_3.IFO: vmgm_vobs=0x08, tt_srpt=1 → 11 titles
+    /// Confirms that vmgm_vobs at 0xC0 is not confused with tt_srpt at 0xC4.
+    /// </summary>
+    /// <param name="vmgmVobsSector">The sector value stored at the vmgm_vobs pointer (byte value placed at 0xC0).</param>
+    /// <param name="expectedCount">The expected number of titles parsed from the TT_SRPT table.</param>
+    [Theory]
+    [InlineData(0x00u, 7)]
+    [InlineData(0x11u, 72)]
+    [InlineData(0x08u, 11)]
+    public void ReadVmgTitleCount_NonZeroVmgmVobs_DoesNotConfuseWithTtSrpt(uint vmgmVobsSector, int expectedCount)
+    {
+        using var ms = BuildVmgIfo(1u, (ushort)expectedCount, vmgmVobsSector);
+        Assert.Equal(expectedCount, DvdVideoProber.ReadVmgTitleCount(ms));
+    }
+
+    // ── ParseVmgIfo tests (via ParseVideoTsDirectory helper) ─────────────────
+
+    /// <summary>
+    /// Verifies TT_SRPT entry parsing: TitleNumber, TitleSetNumber, VtsTitleNumber,
+    /// ChapterCount, AngleCount, VtsStartSector.
+    /// </summary>
+    [Fact]
+    public void ParseVmgIfo_SingleTitle_ParsesAllFields()
+    {
+        var data = BuildVmgIfoBytes(1u, 1);
+        Array.Resize(ref data, 2048 + 8 + 12);
+
+        WriteBE32(data, 2048 + 4, 19u);
+
+        int o = 2048 + 8;
+        data[o + 0] = 0x01;
+        data[o + 1] = 2;
+        WriteBE16(data, o + 2, 34);
+        WriteBE16(data, o + 4, 0);
+        data[o + 6] = 1;
+        data[o + 7] = 1;
+        WriteBE32(data, o + 8, 5u);
+
+        WriteBE16(data, 2048 + 0, 1);
+
+        using var dir = new TempVideoTsDirectory(data);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+
+        Assert.Single(disc.Titles);
+        var t = disc.Titles[0];
+        Assert.Equal(1, t.TitleNumber);
+        Assert.Equal(1, t.TitleSetNumber);
+        Assert.Equal(1, t.VtsTitleNumber);
+        Assert.Equal(34, t.ChapterCount);
+        Assert.Equal(2, t.AngleCount);
+        Assert.Equal(5u, t.VtsStartSector);
+    }
+
+    [Fact]
+    public void ParseVmgIfo_MultipleTitles_CountMatchesTitleCount()
+    {
+        const int titleCount = 7;
+        var data = BuildVmgIfoBytes(1u, (ushort)titleCount);
+        int entriesBase = 2048 + 8;
+        Array.Resize(ref data, entriesBase + (titleCount * 12));
+        WriteBE32(data, 2048 + 4, (uint)(8 + (titleCount * 12) - 1));
+        WriteBE16(data, 2048 + 0, (ushort)titleCount);
+
+        for (int i = 0; i < titleCount; i++)
+        {
+            int o = entriesBase + (i * 12);
+            data[o + 1] = 1;
+            WriteBE16(data, o + 2, 1);
+            data[o + 6] = 1;
+            data[o + 7] = (byte)(i + 1);
+        }
+
+        using var dir = new TempVideoTsDirectory(data);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+
+        Assert.Equal(titleCount, disc.Titles.Count);
+        for (int i = 0; i < titleCount; i++)
+        {
+            Assert.Equal(i + 1, disc.Titles[i].TitleNumber);
+        }
+    }
+
+    [Fact]
+    public void ParseVideoTsDirectory_MissingVmgIfo_ReturnsEmptyDisc()
+    {
+        using var emptyDir = new TempVideoTsDirectory(null);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(emptyDir.Path);
+        Assert.Empty(disc.Titles);
+    }
+
+    [Fact]
+    public void ParseVideoTsDirectory_WrongMagic_ReturnsEmptyDisc()
+    {
+        var data = new byte[4096];
+        "NOT-A-DVD-IFO"u8.CopyTo(data.AsSpan(0));
+        using var dir = new TempVideoTsDirectory(data);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        Assert.Empty(disc.Titles);
+    }
+
+    // ── DVD time decoding tests ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies BCD decoding against the FromBcd helper exposed via ReadDvdTime round-trips.
+    /// </summary>
+    /// <param name="bcd">The BCD-encoded minute value to decode.</param>
+    /// <param name="expected">The expected minute value after decoding the BCD byte.</param>
+    [Theory]
+    [InlineData(0x00, 0)] // 0x00 → 0
+    [InlineData(0x09, 9)] // 0x09 → 9
+    [InlineData(0x10, 10)] // 0x10 → 10
+    [InlineData(0x59, 59)] // 0x59 → 59
+    [InlineData(0x23, 23)] // 0x23 → 23
+    public void FromBcd_ViaDvdTime_CorrectlyDecodesMinutes(byte bcd, int expected)
+    {
+        // Build a 4-byte dvd_time_t: hour=0x00, minute=bcd, second=0x00, frame_u=0x00
+        var time = BuildDvdTime(0x00, bcd, 0x00, 0x00);
+        var result = ParseOnePgcDuration(time);
+        Assert.NotNull(result);
+        Assert.Equal(expected, result!.Value.Minutes);
+    }
+
+    [Theory]
+    [InlineData(0x01, 0x55, 0x34, 0x40 | 7, 1, 55, 34)] // 01:55:34 @ 25fps, 7 frames
+    [InlineData(0x00, 0x00, 0x12, 0x40 | 0, 0, 0, 12)] // 00:00:12 @ 25fps, 0 frames
+    [InlineData(0x00, 0x02, 0x34, 0xC0 | 5, 0, 2, 34)] // 00:02:34 @ 29.97fps, 5 frames
+    public void TryReadDvdTime_ValidBcd_ReturnsCorrectTimeSpan(
+        byte h, byte m, byte s, byte frameAndRate, int expHours, int expMinutes, int expSeconds)
+    {
+        var time = BuildDvdTime(h, m, s, frameAndRate);
+        var result = ParseOnePgcDuration(time);
+        Assert.NotNull(result);
+        Assert.Equal(expHours, result!.Value.Hours);
+        Assert.Equal(expMinutes, result!.Value.Minutes);
+        Assert.Equal(expSeconds, result!.Value.Seconds);
+    }
+
+    [Fact]
+    public void TryReadDvdTime_InvalidMinutes_ReturnsNull()
+    {
+        // minutes=0x99 → BCD decodes to 99, which is ≥ 60 → invalid
+        var time = BuildDvdTime(0x00, 0x99, 0x00, 0x40);
+        var result = ParseOnePgcDuration(time);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryReadDvdTime_InvalidSeconds_ReturnsNull()
+    {
+        var time = BuildDvdTime(0x00, 0x00, 0x99, 0x40);
+        var result = ParseOnePgcDuration(time);
+        Assert.Null(result);
+    }
+
+    // ── VTS parsing end-to-end tests ─────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a one-title, one-PGC VTS IFO is parsed correctly, yielding the
+    /// expected duration for the title.
+    /// </summary>
+    [Fact]
+    public void ParseVideoTsDirectory_WithVtsIfo_ReturnsCorrectDuration()
+    {
+        // VIDEO_TS.IFO: 1 title → VTS 1, VTS title 1, 34 chapters
+        var vmgData = BuildFullVmgIfo(new (int TitleSetNr, int VtsTtn, int Chapters, int Angles, uint Sector)[]
+        {
+            (TitleSetNr: 1, VtsTtn: 1, Chapters: 34, Angles: 1, Sector: 10u)
+        });
+
+        // VTS_01_0.IFO: VTS title 1 → PGC 1 → 1h 55m 34s
+        var vtsData = BuildFullVtsIfo(new (int PgcNumber, int ProgramNumber, byte DurationH, byte DurationM, byte DurationS, byte FrameAndRate)[]
+        {
+            (PgcNumber: 1, ProgramNumber: 1, DurationH: 0x01, DurationM: 0x55, DurationS: 0x34, FrameAndRate: (byte)(0x40 | 7))
+        });
+
+        using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+
+        Assert.Single(disc.Titles);
+        var t = disc.Titles[0];
+        Assert.Equal(1, t.TitleNumber);
+        Assert.Equal(1, t.ProgramChainNumber);
+        Assert.NotNull(t.Duration);
+        Assert.Equal(1, t.Duration!.Value.Hours);
+        Assert.Equal(55, t.Duration.Value.Minutes);
+        Assert.Equal(34, t.Duration.Value.Seconds);
+    }
+
+    /// <summary>
+    /// Verifies the 7-title layout from the bug-report IFO (all titles in VTS 1).
+    /// </summary>
+    [Fact]
+    public void ParseVideoTsDirectory_SevenTitlesOneTitleSet_AllTitlesPresent()
+    {
+        var vmgData = BuildFullVmgIfo(new (int TitleSetNr, int VtsTtn, int Chapters, int Angles, uint Sector)[]
+        {
+            (TitleSetNr: 1, VtsTtn: 1, Chapters: 34, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 2, Chapters: 1, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 3, Chapters: 1, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 4, Chapters: 1, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 5, Chapters: 1, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 6, Chapters: 1, Angles: 1, Sector: 10u),
+            (TitleSetNr: 1, VtsTtn: 7, Chapters: 1, Angles: 1, Sector: 10u),
+        });
+
+        var vtsData = BuildFullVtsIfo(new (int PgcNumber, int ProgramNumber, byte DurationH, byte DurationM, byte DurationS, byte FrameAndRate)[]
+        {
+            (PgcNumber: 1, ProgramNumber: 1, DurationH: 0x01, DurationM: 0x55, DurationS: 0x34, FrameAndRate: (byte)(0x40 | 7)),
+            (PgcNumber: 2, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x00, DurationS: 0x12, FrameAndRate: (byte)(0x40 | 0)),
+            (PgcNumber: 3, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x00, DurationS: 0x32, FrameAndRate: (byte)(0x40 | 0)),
+            (PgcNumber: 4, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x00, DurationS: 0x29, FrameAndRate: (byte)(0xC0 | 29)),
+            (PgcNumber: 5, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x01, DurationS: 0x05, FrameAndRate: (byte)(0x40 | 0)),
+            (PgcNumber: 6, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x00, DurationS: 0x07, FrameAndRate: (byte)(0x40 | 0)),
+            (PgcNumber: 7, ProgramNumber: 1, DurationH: 0x00, DurationM: 0x02, DurationS: 0x34, FrameAndRate: (byte)(0xC0 | 5)),
+        });
+
+        using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+
+        Assert.Equal(7, disc.Titles.Count);
+        Assert.Equal(1, disc.Titles[0].TitleNumber);
+        Assert.Equal(34, disc.Titles[0].ChapterCount);
+        Assert.NotNull(disc.Titles[0].Duration);
+        Assert.Equal(1, disc.Titles[0].Duration!.Value.Hours);
+        Assert.Equal(55, disc.Titles[0].Duration!.Value.Minutes);
+    }
+
+    [Fact]
+    public void FindMainFeature_ReturnsLongestTitle()
+    {
+        var disc = new DvdDiscInfo();
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 1, Duration = TimeSpan.FromMinutes(5) });
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 2, Duration = TimeSpan.FromMinutes(115) });
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 3, Duration = TimeSpan.FromMinutes(2) });
+
+        var main = DvdVideoProber.FindMainFeature(disc);
+        Assert.NotNull(main);
+        Assert.Equal(2, main!.TitleNumber);
+    }
+
+    [Fact]
+    public void FindMainFeature_WithMinDuration_ExcludesShortTitles()
+    {
+        var disc = new DvdDiscInfo();
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 1, Duration = TimeSpan.FromMinutes(115) });
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 2, Duration = TimeSpan.FromMinutes(5) });
+
+        var main = DvdVideoProber.FindMainFeature(disc, minDuration: TimeSpan.FromMinutes(10));
+        Assert.NotNull(main);
+        Assert.Equal(1, main!.TitleNumber);
+    }
+
+    [Fact]
+    public void FindMainFeature_AllShortTitles_ReturnsNull()
+    {
+        var disc = new DvdDiscInfo();
+        disc.Titles.Add(new DvdTitleInfo { TitleNumber = 1, Duration = TimeSpan.FromMinutes(2) });
+
+        Assert.Null(DvdVideoProber.FindMainFeature(disc, minDuration: TimeSpan.FromMinutes(10)));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void WriteBE16(byte[] data, int offset, int value)
+    {
+        data[offset] = (byte)(value >> 8);
+        data[offset + 1] = (byte)value;
+    }
+
+    private static void WriteBE32(byte[] data, int offset, uint value)
+    {
+        data[offset] = (byte)(value >> 24);
+        data[offset + 1] = (byte)(value >> 16);
+        data[offset + 2] = (byte)(value >> 8);
+        data[offset + 3] = (byte)value;
+    }
+
+    private static byte[] BuildDvdTime(byte h, byte m, byte s, byte frameAndRate)
+        => new[] { h, m, s, frameAndRate };
+
+    /// <summary>
+    /// Exercises TryReadDvdTime by embedding the 4-byte dvd_time_t inside a
+    /// minimal VTS_PGCITI table (one PGC) and parsing it via ParseVideoTsDirectory.
+    /// </summary>
+    private static TimeSpan? ParseOnePgcDuration(byte[] dvdTime)
+    {
+        // Build a VMG IFO pointing to VTS 1, VTS title 1
+        var vmgData = BuildFullVmgIfo(new (int TitleSetNr, int VtsTtn, int Chapters, int Angles, uint Sector)[]
+        {
+            (TitleSetNr: 1, VtsTtn: 1, Chapters: 1, Angles: 1, Sector: 10u)
+        });
+
+        // Build a VTS IFO with the given dvd_time_t bytes injected as the PGC playback time
+        var vtsData = BuildFullVtsIfoWithRawTime(dvdTime);
+
+        using var dir = new TempVideoTsDirectory(vmgData, vts01Data: vtsData);
+        var disc = DvdVideoProber.ParseVideoTsDirectory(dir.Path);
+        return disc.Titles.Count == 1 ? disc.Titles[0].Duration : null;
+    }
+
+    /// <summary>
+    /// Builds a complete VMG IFO with the given title entries.
+    /// Each title entry follows the title_info_t layout (12 bytes).
+    /// </summary>
+    private static byte[] BuildFullVmgIfo(
+        IReadOnlyList<(int TitleSetNr, int VtsTtn, int Chapters, int Angles, uint Sector)> entries)
+    {
+        const int srptSector = 1;
+        const int srptBase = srptSector * 2048;
+        int entryCount = entries.Count;
+        int tableSize = 8 + (entryCount * 12);
+        var data = new byte[srptBase + tableSize];
+
+        "DVDVIDEO-VMG"u8.CopyTo(data.AsSpan(0));
+        WriteBE32(data, 0xC4, srptSector);
+        WriteBE16(data, srptBase + 0, entryCount);
+        WriteBE32(data, srptBase + 4, (uint)(tableSize - 1));
+
+        for (int i = 0; i < entryCount; i++)
+        {
+            var (titleSetNr, vtsTtn, chapters, angles, sector) = entries[i];
+            int o = srptBase + 8 + (i * 12);
+            data[o + 1] = (byte)angles;
+            WriteBE16(data, o + 2, (ushort)chapters);
+            data[o + 6] = (byte)titleSetNr;
+            data[o + 7] = (byte)vtsTtn;
+            WriteBE32(data, o + 8, sector);
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Builds a VTS IFO where each entry maps (VTS title N → PGC N).
+    /// VTS_PTT_SRPT at sector 1, VTS_PGCITI at sector 2.
+    /// </summary>
+    private static byte[] BuildFullVtsIfo(
+        IReadOnlyList<(int PgcNumber, int ProgramNumber, byte DurationH, byte DurationM, byte DurationS, byte FrameAndRate)> pgcs)
+    {
+        int vtsTitleCount = pgcs.Count;
+
+        // Sector layout: 0=header, 1=VTS_PTT_SRPT, 2=VTS_PGCITI
+        const int pttSector = 1;
+        const int pgcitiSector = 2;
+
+        // --- VTS_PTT_SRPT ---
+        // header (8 bytes) + one UInt32 offset per title + one PTT entry (4 bytes) per title
+        int pttOffsetTableSize = vtsTitleCount * 4;
+        int pttDataSize = 8 + pttOffsetTableSize + (vtsTitleCount * 4);
+        int pttBase = pttSector * 2048;
+
+        // --- VTS_PGCITI ---
+        // header (8 bytes) + 8 bytes per pgci_srp_t + 8-byte PGC header per entry
+        const int pgcHeaderSize = 8; // only the bytes we write (+4=playback_time)
+        int pgcitiSrpSize = vtsTitleCount * 8;
+        int pgcitiDataSize = 8 + pgcitiSrpSize + (vtsTitleCount * pgcHeaderSize);
+        int pgcitiBase = pgcitiSector * 2048;
+
+        var data = new byte[Math.Max(pttBase + pttDataSize, pgcitiBase + pgcitiDataSize)];
+
+        // Magic
+        "DVDVIDEO-VTS"u8.CopyTo(data.AsSpan(0));
+
+        // vtsi_mat_t pointers
+        WriteBE32(data, 0xC8, pttSector);
+        WriteBE32(data, 0xCC, pgcitiSector);
+
+        // VTS_PTT_SRPT header
+        WriteBE16(data, pttBase + 0, (ushort)vtsTitleCount);
+        WriteBE32(data, pttBase + 4, (uint)(pttDataSize - 1));
+
+        // Offset table: one UInt32 per title, relative to pttBase.
+        // Each title occupies 4 bytes (one PTT entry) starting after the offset table.
+        for (int n = 0; n < vtsTitleCount; n++)
+        {
+            uint titleRelOffset = (uint)(8 + pttOffsetTableSize + (n * 4));
+            WriteBE32(data, pttBase + 8 + (n * 4), titleRelOffset);
+
+            // PTT entry: pgcn and pgn
+            var (pgcNumber, programNumber, _, _, _, _) = pgcs[n];
+            int pttEntryAddr = pttBase + (int)titleRelOffset;
+            WriteBE16(data, pttEntryAddr + 0, (ushort)pgcNumber);
+            WriteBE16(data, pttEntryAddr + 2, (ushort)programNumber);
+        }
+
+        // VTS_PGCITI header
+        WriteBE16(data, pgcitiBase + 0, (ushort)vtsTitleCount);
+        WriteBE32(data, pgcitiBase + 4, (uint)(pgcitiDataSize - 1));
+
+        // pgci_srp_t entries: each is 8 bytes, pgc_start_byte at srp+4 relative to pgcitiBase
+        for (int n = 0; n < vtsTitleCount; n++)
+        {
+            int srpOffset = pgcitiBase + 8 + (n * 8);
+            uint pgcRelOff = (uint)(8 + pgcitiSrpSize + (n * pgcHeaderSize));
+            WriteBE32(data, srpOffset + 4, pgcRelOff);
+
+            // PGC at pgcitiBase + pgcRelOff: playback_time at +4
+            var (_, _, durationH, durationM, durationS, frameAndRate) = pgcs[n];
+            int pgcAddr = pgcitiBase + (int)pgcRelOff;
+            data[pgcAddr + 4] = durationH;
+            data[pgcAddr + 5] = durationM;
+            data[pgcAddr + 6] = durationS;
+            data[pgcAddr + 7] = frameAndRate;
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Like <see cref="BuildFullVtsIfo"/> but injects raw dvd_time_t bytes for PGC 1.
+    /// </summary>
+    private static byte[] BuildFullVtsIfoWithRawTime(byte[] dvdTime)
+    {
+        var pgcs = new (int PgcNumber, int ProgramNumber, byte DurationH, byte DurationM, byte DurationS, byte FrameAndRate)[]
+        {
+            (PgcNumber: 1, ProgramNumber: 1, DurationH: dvdTime[0], DurationM: dvdTime[1],
+             DurationS: dvdTime[2], FrameAndRate: dvdTime[3])
+        };
+        return BuildFullVtsIfo(pgcs);
+    }
+
+    // ── TempVideoTsDirectory helper ────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a temporary VIDEO_TS directory structure for testing and deletes it on dispose.
+    /// </summary>
+    private sealed class TempVideoTsDirectory : IDisposable
+    {
+        public TempVideoTsDirectory(byte[]? vmgIfoData, byte[]? vts01Data = null)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            var videoTs = System.IO.Path.Combine(Path, "VIDEO_TS");
+            Directory.CreateDirectory(videoTs);
+
+            if (vmgIfoData is not null)
+            {
+                File.WriteAllBytes(System.IO.Path.Combine(videoTs, "VIDEO_TS.IFO"), vmgIfoData);
+            }
+
+            if (vts01Data is not null)
+            {
+                File.WriteAllBytes(System.IO.Path.Combine(videoTs, "VTS_01_0.IFO"), vts01Data);
+            }
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
@@ -1,9 +1,13 @@
 using System;
+using System.IO;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Providers.MediaInfo;
 using Moq;
 using Xunit;
@@ -13,6 +17,7 @@ namespace Jellyfin.Providers.Tests.MediaInfo;
 public class FFProbeVideoInfoTests
 {
     private readonly FFProbeVideoInfo _fFProbeVideoInfo;
+    private readonly Mock<IMediaEncoder> _mediaEncoderMock;
 
     public FFProbeVideoInfoTests()
     {
@@ -26,6 +31,7 @@ public class FFProbeVideoInfoTests
 
         IFixture fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
         fixture.Inject(serverConfig);
+        _mediaEncoderMock = fixture.Freeze<Mock<IMediaEncoder>>();
         _fFProbeVideoInfo = fixture.Create<FFProbeVideoInfo>();
     }
 
@@ -74,5 +80,67 @@ public class FFProbeVideoInfoTests
         });
 
         Assert.All(chapters, chapter => Assert.True(chapter.StartPositionTicks < runtime));
+    }
+
+    [Fact]
+    public void DetectIsoType_WhenDvdTitlesExist_ReturnsDvd()
+    {
+        _mediaEncoderMock.SetupGet(x => x.SupportsDvdVideo).Returns(true);
+        _mediaEncoderMock.SetupGet(x => x.SupportsLibBluray).Returns(true);
+        _mediaEncoderMock.Setup(x => x.GetIsoTitles("/media/movie.iso", IsoType.Dvd))
+            .Returns(
+            [
+                new IsoTitleInfo { TitleNumber = 1 }
+            ]);
+
+        var detected = _fFProbeVideoInfo.DetectIsoType(new Video
+        {
+            Path = "/media/movie.iso",
+            VideoType = VideoType.Iso
+        });
+
+        Assert.Equal(IsoType.Dvd, detected);
+        _mediaEncoderMock.Verify(x => x.GetIsoTitles("/media/movie.iso", IsoType.BluRay), Times.Never());
+    }
+
+    [Fact]
+    public void DetectIsoType_WhenDvdProbeFailsAndBlurayTitlesExist_ReturnsBluRay()
+    {
+        _mediaEncoderMock.SetupGet(x => x.SupportsDvdVideo).Returns(true);
+        _mediaEncoderMock.SetupGet(x => x.SupportsLibBluray).Returns(true);
+        _mediaEncoderMock.Setup(x => x.GetIsoTitles("/media/movie.iso", IsoType.Dvd))
+            .Throws(new IOException("in use"));
+        _mediaEncoderMock.Setup(x => x.GetIsoTitles("/media/movie.iso", IsoType.BluRay))
+            .Returns(
+            [
+                new IsoTitleInfo { TitleNumber = 1 }
+            ]);
+
+        var detected = _fFProbeVideoInfo.DetectIsoType(new Video
+        {
+            Path = "/media/movie.iso",
+            VideoType = VideoType.Iso
+        });
+
+        Assert.Equal(IsoType.BluRay, detected);
+    }
+
+    [Fact]
+    public void DetectIsoType_WhenNoSupportedProbeFindsTitles_ReturnsNull()
+    {
+        _mediaEncoderMock.SetupGet(x => x.SupportsDvdVideo).Returns(true);
+        _mediaEncoderMock.SetupGet(x => x.SupportsLibBluray).Returns(true);
+        _mediaEncoderMock.Setup(x => x.GetIsoTitles("/media/movie.iso", IsoType.Dvd))
+            .Returns(Array.Empty<IsoTitleInfo>());
+        _mediaEncoderMock.Setup(x => x.GetIsoTitles("/media/movie.iso", IsoType.BluRay))
+            .Throws(new IOException("still in use"));
+
+        var detected = _fFProbeVideoInfo.DetectIsoType(new Video
+        {
+            Path = "/media/movie.iso",
+            VideoType = VideoType.Iso
+        });
+
+        Assert.Null(detected);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
Adds the ability to select the title to play from a DVD or Blu-Ray image or unpacked directory structure.

This requires an ffmpeg binary with libdvdnav, and libbluray support.

**Known Issues**
Static streams of such media will be transcoded on the fly with codec copy to an .mkv file and sent.  This means no seeking of the media.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
