### PR TITLE
Preserve external subtitles after strm probing

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -171,6 +171,7 @@ namespace Emby.Server.Implementations.Library
         public async Task<IReadOnlyList<MediaSourceInfo>> GetPlaybackMediaSources(BaseItem item, User user, bool allowMediaProbe, bool enablePathSubstitution, CancellationToken cancellationToken)
         {
             var mediaSources = GetStaticMediaSources(item, enablePathSubstitution, user);
+            var preservedExternalSubtitles = GetExternalSubtitleStreamsBySource(mediaSources);
 
             // If file is strm or main media stream is missing, force a metadata refresh with remote probing
             if (allowMediaProbe && mediaSources[0].Type != MediaSourceType.Placeholder
@@ -187,6 +188,7 @@ namespace Emby.Server.Implementations.Library
                     cancellationToken).ConfigureAwait(false);
 
                 mediaSources = GetStaticMediaSources(item, enablePathSubstitution, user);
+                RestoreExternalSubtitleStreams(mediaSources, preservedExternalSubtitles);
             }
 
             var dynamicMediaSources = await GetDynamicMediaSources(item, cancellationToken).ConfigureAwait(false);
@@ -222,6 +224,64 @@ namespace Emby.Server.Implementations.Library
             }
 
             return SortMediaSources(list).ToArray();
+        }
+
+        private IReadOnlyDictionary<string, IReadOnlyList<MediaStream>> GetExternalSubtitleStreamsBySource(IReadOnlyList<MediaSourceInfo> mediaSources)
+        {
+            return mediaSources
+                .Select(i => new
+                {
+                    i.Id,
+                    Streams = i.MediaStreams
+                        .Where(s => s.Type == MediaStreamType.Subtitle && s.IsExternal && !string.IsNullOrEmpty(s.Path))
+                        .Select(CloneMediaStream)
+                        .ToArray()
+                })
+                .Where(i => i.Streams.Length > 0)
+                .ToDictionary(i => i.Id, i => (IReadOnlyList<MediaStream>)i.Streams, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private MediaStream CloneMediaStream(MediaStream stream)
+        {
+            return JsonSerializer.Deserialize<MediaStream>(JsonSerializer.SerializeToUtf8Bytes(stream, _jsonOptions), _jsonOptions);
+        }
+
+        private void RestoreExternalSubtitleStreams(IReadOnlyList<MediaSourceInfo> mediaSources, IReadOnlyDictionary<string, IReadOnlyList<MediaStream>> preservedExternalSubtitles)
+        {
+            if (preservedExternalSubtitles.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var source in mediaSources)
+            {
+                if (!preservedExternalSubtitles.TryGetValue(source.Id, out var subtitles))
+                {
+                    continue;
+                }
+
+                var streams = source.MediaStreams.ToList();
+                var existingSubtitlePaths = streams
+                    .Where(i => i.Type == MediaStreamType.Subtitle && i.IsExternal && !string.IsNullOrEmpty(i.Path))
+                    .Select(i => i.Path)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var subtitle in subtitles)
+                {
+                    if (existingSubtitlePaths.Contains(subtitle.Path))
+                    {
+                        continue;
+                    }
+
+                    subtitle.DeliveryMethod = null;
+                    subtitle.DeliveryUrl = null;
+                    subtitle.IsExternalUrl = null;
+                    streams.Add(subtitle);
+                    existingSubtitlePaths.Add(subtitle.Path);
+                }
+
+                source.MediaStreams = streams;
+            }
         }
 
         /// <inheritdoc />>


### PR DESCRIPTION
## What changed

- Preserve external subtitle streams before the forced remote probe used for `.strm` playback sources.
- Restore those preserved external subtitles after the media sources are rebuilt from the probed stream metadata.
- Avoid duplicate restored subtitle paths and reindex restored streams after the existing probed stream indexes.

## Why

Remote `.strm` items, especially HLS URLs, are probed again during `PlaybackInfo` generation. That probe rebuilds media streams from the remote source and can drop already-discovered local sidecar subtitles. The result is that clients receive audio/video streams but no subtitle streams, so the subtitle selector disappears even though the library item has an external subtitle.

This keeps the probed audio/video streams while preserving local external subtitles that were attached to the original media source.

## Validation

- `dotnet build Emby.Server.Implementations/Emby.Server.Implementations.csproj -c Release -p:TreatWarningsAsErrors=false`
- `dotnet test tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj -c Release --no-restore`
- Manual verification on a Jellyfin 10.11.8 host with a remote HLS `.strm`: before the equivalent patch, `PlaybackInfo` returned only audio/video streams; after the patch it returned the external subtitle stream and the subtitle `Stream.vtt` endpoint returned `200 OK`.
