### PR TITLE
fix: suppress repeated PriorityClass warning in MediaEncoder

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -85,6 +85,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private bool _isVaapiDeviceSupportVulkanDrmModifier = false;
         private bool _isVaapiDeviceSupportVulkanDrmInterop = false;
 
+        private bool _canSetProcessPriority = true;
+
         private bool _isVideoToolboxAv1DecodeAvailable = false;
 
         private static string[] _vulkanImageDrmFmtModifierExts =
@@ -1123,13 +1125,17 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             process.Process.Start();
 
-            try
+            if (_canSetProcessPriority)
             {
-                process.Process.PriorityClass = ProcessPriorityClass.BelowNormal;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Unable to set process priority to BelowNormal for {ProcessFileName}", process.Process.StartInfo.FileName);
+                try
+                {
+                    process.Process.PriorityClass = ProcessPriorityClass.BelowNormal;
+                }
+                catch (Exception ex)
+                {
+                    _canSetProcessPriority = false;
+                    _logger.LogWarning(ex, "Unable to set process priority to BelowNormal for {ProcessFileName}. Further attempts will be skipped.", process.Process.StartInfo.FileName);
+                }
             }
 
             lock (_runningProcessesLock)


### PR DESCRIPTION
When Jellyfin runs without permission to set process priority (e.g. Docker), StartProcess() logged a warning for every file probed during a library scan. Add a _canSetProcessPriority flag: warn once on first failure, skip all subsequent attempts.

**Changes**
Add a _canSetProcessPriority flag to MediaEncoder. On first failure to set ProcessPriorityClass.BelowNormal, log a single warning and set the flag to false. All subsequent StartProcess() calls skip the attempt entirely, eliminating log spam during library scans in permission-restricted environments (e.g. Docker).

**Issues**
Fixes #15287
