### PR TITLE
Add PlaybackRate sync to session state

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -452,6 +452,7 @@ namespace Emby.Server.Implementations.Session
             session.PlayState.PlayMethod = info.PlayMethod;
             session.PlayState.RepeatMode = info.RepeatMode;
             session.PlayState.PlaybackOrder = info.PlaybackOrder;
+            session.PlayState.PlaybackRate = info.PlaybackRate;
             session.PlaylistItemId = info.PlaylistItemId;
 
             var nowPlayingQueue = info.NowPlayingQueue;

--- a/MediaBrowser.Model/Session/GeneralCommandType.cs
+++ b/MediaBrowser.Model/Session/GeneralCommandType.cs
@@ -49,6 +49,7 @@ namespace MediaBrowser.Model.Session
         ToggleOsdMenu = 39,
         Play = 40,
         SetMaxStreamingBitrate = 41,
-        SetPlaybackOrder = 42
+        SetPlaybackOrder = 42,
+        SetPlaybackRate = 43
     }
 }

--- a/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
+++ b/MediaBrowser.Model/Session/PlaybackProgressInfo.cs
@@ -113,6 +113,12 @@ namespace MediaBrowser.Model.Session
         /// <value>The playback order.</value>
         public PlaybackOrder PlaybackOrder { get; set; }
 
+        /// <summary>
+        /// Gets or sets the playback rate.
+        /// </summary>
+        /// <value>The playback rate. 1.0 is normal speed.</value>
+        public float? PlaybackRate { get; set; }
+
         public QueueItem[] NowPlayingQueue { get; set; }
 
         public string PlaylistItemId { get; set; }

--- a/MediaBrowser.Model/Session/PlayerStateInfo.cs
+++ b/MediaBrowser.Model/Session/PlayerStateInfo.cs
@@ -72,6 +72,12 @@ namespace MediaBrowser.Model.Session
         public PlaybackOrder PlaybackOrder { get; set; }
 
         /// <summary>
+        /// Gets or sets the playback rate.
+        /// </summary>
+        /// <value>The playback rate. 1.0 is normal speed.</value>
+        public float? PlaybackRate { get; set; }
+
+        /// <summary>
         /// Gets or sets the now playing live stream identifier.
         /// </summary>
         /// <value>The live stream identifier.</value>


### PR DESCRIPTION
### Changes
- `PlaybackRate` is saved to the session (The client already sends out a PlaybackRate- it was just never saved)
- `SetPlaybackRate` command added to change the PlaybackRate on the client

### Related branches/PRs
- https://github.com/AirplanegoBrr/jellyfin-web/tree/feat/playback-speed-sync
- https://github.com/jellyfin/jellyfin-web/pull/7938