### PR TITLE
Use --batch --yes for installing jellyfin keyring in devcontainer

### DIFF
--- a/.devcontainer/install-ffmpeg.sh
+++ b/.devcontainer/install-ffmpeg.sh
@@ -15,7 +15,7 @@ sudo apt-get install software-properties-common -y
 sudo add-apt-repository universe -y
 
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
+curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/jellyfin.gpg
 export VERSION_OS="$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )"
 export VERSION_CODENAME="$( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )"
 export DPKG_ARCHITECTURE="$( dpkg --print-architecture )"


### PR DESCRIPTION
**Changes**
Add `--batch --yes` to the _install-ffmpeg.sh_  GPG jellyfin keyring install. This will make GPG assume the answer is Yes and not pause for interactive response.

**Issues**
Fixes this halt while devcontainer is being built. `File '/etc/apt/keyrings/jellyfin.gpg' exists. Overwrite? (y/N)`