### PR TITLE
Add support for filtering boxsets by parentId

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -280,10 +280,17 @@ public class ItemsController : BaseJellyfinApiController
         var item = _libraryManager.GetParentItem(parentId, userId);
         QueryResult<BaseItem> result;
 
+        Guid[] boxSetLinkedChildAncestorIds = [];
         if (includeItemTypes.Length == 1
             && includeItemTypes[0] == BaseItemKind.BoxSet
             && item is not BoxSet)
         {
+            var isBoxSetsLibrary = item is IHasCollectionType hct && hct.CollectionType == CollectionType.boxsets;
+            if (parentId.HasValue && item is not UserRootFolder && !isBoxSetsLibrary)
+            {
+                boxSetLinkedChildAncestorIds = [parentId.Value];
+            }
+
             parentId = null;
             item = _libraryManager.GetUserRootFolder();
         }
@@ -405,6 +412,7 @@ public class ItemsController : BaseJellyfinApiController
                 MaxPremiereDate = maxPremiereDate?.ToUniversalTime(),
                 AudioLanguages = audioLanguages,
                 SubtitleLanguages = subtitleLanguages,
+                LinkedChildAncestorIds = boxSetLinkedChildAncestorIds,
             };
 
             if (ids.Length != 0 || !string.IsNullOrWhiteSpace(searchTerm))

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -1027,6 +1027,15 @@ public sealed partial class BaseItemRepository
             baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
         }
 
+        if (filter.LinkedChildAncestorIds.Length > 0)
+        {
+            // Keep folder-like items (BoxSets, Playlists) whose linked children descend from any of the requested ancestor ids.
+            var linkedChildAncestorIds = filter.LinkedChildAncestorIds;
+            baseQuery = baseQuery.Where(e => context.LinkedChildren.Any(lc =>
+                lc.ParentId == e.Id
+                && lc.Child!.Parents!.Any(a => linkedChildAncestorIds.Contains(a.ParentItemId))));
+        }
+
         if (!string.IsNullOrWhiteSpace(filter.AncestorWithPresentationUniqueKey))
         {
             baseQuery = baseQuery

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -21,6 +21,7 @@ namespace MediaBrowser.Controller.Entities
             AlbumArtistIds = [];
             AlbumIds = [];
             AncestorIds = [];
+            LinkedChildAncestorIds = [];
             ArtistIds = [];
             BlockUnratedItems = [];
             BoxSetLibraryFolders = [];
@@ -264,6 +265,12 @@ namespace MediaBrowser.Controller.Entities
         public BaseItemKind? ParentType { get; set; }
 
         public Guid[] AncestorIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of ancestor ids that the item's linked children must descend from.
+        /// Useful for filtering BoxSets/Playlists to only those that contain items from a specific library.
+        /// </summary>
+        public Guid[] LinkedChildAncestorIds { get; set; }
 
         public Guid[] TopParentIds { get; set; }
 


### PR DESCRIPTION
Since BoxSets are virtual, we querying them with a parentId filter did not work

**Changes**
If querying for boxsets and filtering by parent, only return entities that have children linked to that parentId.
This allows library-specific boxset filtering (aka which BoxSet has items form that library).