### PR TITLE
Add library option to prefer original title over localized name

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1054,7 +1054,7 @@ namespace Emby.Server.Implementations.Dto
                 dto.RemoteTrailers = item.RemoteTrailers;
             }
 
-            dto.Name = item.Name;
+            dto.Name = GetDisplayName(item);
             dto.OfficialRating = item.OfficialRating;
 
             if (options.ContainsField(ItemFields.Overview))
@@ -1479,6 +1479,17 @@ namespace Emby.Server.Implementations.Dto
                     dto.ChannelName = channel.Name;
                 }
             }
+        }
+
+        private string GetDisplayName(BaseItem item)
+        {
+            var libraryOptions = _libraryManager.GetLibraryOptions(item);
+            if (libraryOptions.PreferOriginalTitle && !string.IsNullOrEmpty(item.OriginalTitle))
+            {
+                return item.OriginalTitle;
+            }
+
+            return item.Name;
         }
 
         private BaseItem? GetImageDisplayParent(BaseItem currentItem, BaseItem originalItem)

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -38,6 +38,7 @@ namespace MediaBrowser.Model.Configuration
             UseCustomTagDelimiters = false;
             CustomTagDelimiters = _defaultTagDelimiters;
             DelimiterWhitelist = Array.Empty<string>();
+            PreferOriginalTitle = false;
         }
 
         public bool Enabled { get; set; } = true;
@@ -134,6 +135,9 @@ namespace MediaBrowser.Model.Configuration
         public bool AutomaticallyAddToCollection { get; set; }
 
         public EmbeddedSubtitleOptions AllowEmbeddedSubtitles { get; set; }
+
+        [DefaultValue(false)]
+        public bool PreferOriginalTitle { get; set; }
 
         public TypeOptions[] TypeOptions { get; set; }
 


### PR DESCRIPTION
**Changes**
Adds a `PreferOriginalTitle` option to `LibraryOptions`. When enabled, item names returned by the API will use `OriginalTitle` instead of the localized `Name`. If `OriginalTitle` is absent, it will just use the regular `Name`.
This allows users who prefer seeing titles in their original language (e.g. Swedish titles instead of English translations) to configure this per library.

**Issues**
This addresses https://features.jellyfin.org/posts/32/keep-original-title-option
