### PR TITLE
Fix Swagger UI auth docs (#12990)

### DIFF
--- a/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiApplicationBuilderExtensions.cs
@@ -48,6 +48,7 @@ namespace Jellyfin.Server.Extensions
                     c.SwaggerEndpoint($"/{baseUrl}api-docs/openapi.json", "Jellyfin API");
                     c.InjectStylesheet($"/{baseUrl}api-docs/swagger/custom.css");
                     c.RoutePrefix = "api-docs/swagger";
+                    c.UseRequestInterceptor("""(req) => { req.headers['Authorization'] = `MediaBrowser Token=\"${req.headers['Authorization']}\"`; return req; }""");
                 })
                 .UseReDoc(c =>
                 {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

# Changes
Adds a `RequestInterceptor` to SwaggerUI [as described here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v10.0.0/docs/configure-and-customize-swaggerui.md#use-client-side-request-and-response-interceptors) to ensure the `Authorization` header generated by SwaggerUI matches [the Jellyfin authorization scheme](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f#the-jellyfin-authorization-scheme).

# Issues
- Fixes #12990
