### PR TITLE
Skip video copy-preference ranking when re-encoding is required

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -859,6 +859,10 @@ namespace MediaBrowser.Model.Dlna
             var videoCodec = videoStream?.Codec;
             var audioCodec = audioStream?.Codec;
 
+            // When the video stream must be re-encoded (not just remuxed), skip the copy-preference
+            // ranking so that client profile ordering determines the target codec.
+            var videoMustReencode = (playlistItem.TranscodeReasons & (VideoReasons | TranscodeReason.ContainerBitrateExceedsLimit)) != 0;
+
             var analyzedProfiles = transcodingProfiles
                 .Select(transcodingProfile =>
                 {
@@ -868,6 +872,7 @@ namespace MediaBrowser.Model.Dlna
 
                     if (videoStream is not null
                         && options.AllowVideoStreamCopy
+                        && !videoMustReencode
                         && ContainerHelper.ContainsContainer(transcodingProfile.VideoCodec, videoCodec))
                     {
                         var failures = GetCompatibilityVideoCodec(options, mediaSource, container, videoStream);


### PR DESCRIPTION
`GetVideoTranscodeProfile()` ranks transcoding profiles by whether the source video codec can be stream-copied. This makes sense when the source needs remuxing only. 

But when the video stream must be re-encoded (bitrate limit, etc.), the ranking still favours profiles containing the source codec. 

This prevents a more efficient video codec from being selected when it's in a different profile to the source codec.

The fix is to check the already-computed transcode reasons before applying copy-preference ranking. When `VideoReasons` or `ContainerBitrateExceedsLimit` are present, all profiles receive equal video rank and the client's profile ordering determines the target codec. When the video can actually be copied, the existing copy-preference ranking is preserved.

One scenario where this doesn't work is with SubtitleCodecNotSupported, don't see a way to drop the copy-preference ranking for burning in subtitles only.