### PR TITLE
Feat (fix) - Skip reprocessing program information when importing XMLTV EPG data

### DIFF
--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using Jellyfin.LiveTv.Configuration;
+using Jellyfin.LiveTv.Listings;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -496,6 +497,13 @@ public class GuideManager : IGuideManager
             };
 
             item.TrySetProviderId(EtagKey, info.Etag);
+        }
+        else if (XmlTvProgramEtag.MatchesStored(info.Etag, item.GetProviderId(EtagKey)))
+        {
+            // XMLTV ETags are generated from the final ProgramInfo fields Jellyfin consumes,
+            // so an exact match means nothing relevant changed. Other providers stay on the
+            // field-by-field update path.
+            return (item, false, false);
         }
 
         if (!string.Equals(info.ShowId, item.ShowId, StringComparison.OrdinalIgnoreCase))

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -495,8 +495,6 @@ public class GuideManager : IGuideManager
                 DateCreated = DateTime.UtcNow,
                 DateModified = DateTime.UtcNow
             };
-
-            item.TrySetProviderId(EtagKey, info.Etag);
         }
         else if (XmlTvProgramEtag.MatchesStored(info.Etag, item.GetProviderId(EtagKey)))
         {
@@ -629,13 +627,9 @@ public class GuideManager : IGuideManager
 
         forceUpdate |= UpdateImages(item, info);
 
-        if (isNew)
-        {
-            item.OnMetadataChanged();
-
-            return (item, true, false);
-        }
-
+        // Restore the etag wiped by `item.ProviderIds = info.ProviderIds` above and
+        // persist it on new items so they join the fast path on the next refresh
+        // instead of taking an extra full processing cycle.
         var isUpdated = forceUpdate;
         var etag = info.Etag;
         if (string.IsNullOrWhiteSpace(etag))
@@ -646,6 +640,13 @@ public class GuideManager : IGuideManager
         {
             item.SetProviderId(EtagKey, etag);
             isUpdated = true;
+        }
+
+        if (isNew)
+        {
+            item.OnMetadataChanged();
+
+            return (item, true, false);
         }
 
         if (isUpdated)

--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -172,7 +172,29 @@ namespace Jellyfin.LiveTv.Listings
             var reader = new XmlTvReader(path, GetLanguage(info));
 
             return reader.GetProgrammes(channelId, startDateUtc, endDateUtc, cancellationToken)
-                        .Select(p => GetProgramInfo(p, info));
+                        .Select(p => GetProgramInfoWithEtag(p, info));
+        }
+
+        private ProgramInfo GetProgramInfoWithEtag(XmlTvProgram program, ListingsProviderInfo info)
+        {
+            var programInfo = GetProgramInfo(program, info);
+
+            if (XmlTvProgramEtag.TryCreate(programInfo, out var etag, out var reason))
+            {
+                programInfo.Etag = etag;
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Unable to create XMLTV program ETag for program {ProgramId} on channel {ChannelId} from {StartDate} to {EndDate}: {Reason}. The program will be treated as updated on each guide refresh.",
+                    programInfo.Id,
+                    programInfo.ChannelId,
+                    programInfo.StartDate,
+                    programInfo.EndDate,
+                    reason);
+            }
+
+            return programInfo;
         }
 
         private static ProgramInfo GetProgramInfo(XmlTvProgram program, ListingsProviderInfo info)

--- a/src/Jellyfin.LiveTv/Listings/XmlTvProgramEtag.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvProgramEtag.cs
@@ -1,0 +1,184 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MediaBrowser.Controller.LiveTv;
+
+namespace Jellyfin.LiveTv.Listings
+{
+    internal static class XmlTvProgramEtag
+    {
+        internal const string Prefix = "xmltv-sha256-v1:";
+
+        internal static bool IsXmlTvEtag(string? etag)
+            => !string.IsNullOrWhiteSpace(etag)
+                && etag.StartsWith(Prefix, StringComparison.Ordinal);
+
+        // Returns true only when the incoming etag is XMLTV-style AND equals the stored value.
+        // The IsXmlTvEtag gate keeps other providers (e.g. Schedules Direct) on the
+        // field-by-field update path even if their etag strings happen to match.
+        internal static bool MatchesStored(string? incomingEtag, string? storedEtag)
+            => IsXmlTvEtag(incomingEtag)
+                && string.Equals(incomingEtag, storedEtag, StringComparison.OrdinalIgnoreCase);
+
+        internal static bool TryCreate(ProgramInfo programInfo, out string? etag, out string? reason)
+        {
+            etag = null;
+
+            if (string.IsNullOrWhiteSpace(programInfo.Id))
+            {
+                reason = "program id is empty";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(programInfo.ChannelId))
+            {
+                reason = "channel id is empty";
+                return false;
+            }
+
+            if (programInfo.StartDate == default)
+            {
+                reason = "start date is empty";
+                return false;
+            }
+
+            if (programInfo.EndDate == default)
+            {
+                reason = "end date is empty";
+                return false;
+            }
+
+            if (programInfo.EndDate <= programInfo.StartDate)
+            {
+                reason = "end date is not after start date";
+                return false;
+            }
+
+            var builder = new StringBuilder(1024);
+
+            // Keep this list aligned with the ProgramInfo fields consumed by GuideManager.
+            AppendValue(builder, "schema", "xmltv-programinfo-v1");
+            AppendValue(builder, nameof(programInfo.Id), programInfo.Id);
+            AppendValue(builder, nameof(programInfo.ChannelId), programInfo.ChannelId);
+            AppendValue(builder, nameof(programInfo.Name), programInfo.Name);
+            AppendValue(builder, nameof(programInfo.OfficialRating), programInfo.OfficialRating);
+            AppendValue(builder, nameof(programInfo.Overview), programInfo.Overview);
+            AppendValue(builder, nameof(programInfo.StartDate), programInfo.StartDate);
+            AppendValue(builder, nameof(programInfo.EndDate), programInfo.EndDate);
+            AppendList(builder, nameof(programInfo.Genres), programInfo.Genres);
+            AppendValue(builder, nameof(programInfo.OriginalAirDate), programInfo.OriginalAirDate);
+            AppendValue(builder, nameof(programInfo.IsHD), programInfo.IsHD);
+            AppendValue(builder, nameof(programInfo.Audio), programInfo.Audio?.ToString());
+            AppendValue(builder, nameof(programInfo.CommunityRating), programInfo.CommunityRating);
+            AppendValue(builder, nameof(programInfo.IsRepeat), programInfo.IsRepeat);
+            AppendValue(builder, nameof(programInfo.EpisodeTitle), programInfo.EpisodeTitle);
+            AppendValue(builder, nameof(programInfo.ImagePath), programInfo.ImagePath);
+            AppendValue(builder, nameof(programInfo.ImageUrl), programInfo.ImageUrl);
+            AppendValue(builder, nameof(programInfo.ThumbImageUrl), programInfo.ThumbImageUrl);
+            AppendValue(builder, nameof(programInfo.LogoImageUrl), programInfo.LogoImageUrl);
+            AppendValue(builder, nameof(programInfo.BackdropImageUrl), programInfo.BackdropImageUrl);
+            AppendValue(builder, nameof(programInfo.IsMovie), programInfo.IsMovie);
+            AppendValue(builder, nameof(programInfo.IsSports), programInfo.IsSports);
+            AppendValue(builder, nameof(programInfo.IsSeries), programInfo.IsSeries);
+            AppendValue(builder, nameof(programInfo.IsLive), programInfo.IsLive);
+            AppendValue(builder, nameof(programInfo.IsNews), programInfo.IsNews);
+            AppendValue(builder, nameof(programInfo.IsKids), programInfo.IsKids);
+            AppendValue(builder, nameof(programInfo.IsPremiere), programInfo.IsPremiere);
+            AppendValue(builder, nameof(programInfo.ProductionYear), programInfo.ProductionYear);
+            AppendValue(builder, nameof(programInfo.SeriesId), programInfo.SeriesId);
+            AppendValue(builder, nameof(programInfo.ShowId), programInfo.ShowId);
+            AppendValue(builder, nameof(programInfo.SeasonNumber), programInfo.SeasonNumber);
+            AppendValue(builder, nameof(programInfo.EpisodeNumber), programInfo.EpisodeNumber);
+            AppendDictionary(builder, nameof(programInfo.ProviderIds), programInfo.ProviderIds);
+            AppendDictionary(builder, nameof(programInfo.SeriesProviderIds), programInfo.SeriesProviderIds);
+
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+            etag = Prefix + Convert.ToHexString(hash);
+            reason = null;
+            return true;
+        }
+
+        private static void AppendValue(StringBuilder builder, string name, string? value)
+        {
+            builder.Append(name).Append('|');
+            if (value is null)
+            {
+                builder.Append('N').Append("|0|");
+            }
+            else
+            {
+                builder.Append('S')
+                    .Append('|')
+                    .Append(value.Length.ToString(CultureInfo.InvariantCulture))
+                    .Append('|')
+                    .Append(value);
+            }
+
+            builder.Append('\n');
+        }
+
+        private static void AppendValue(StringBuilder builder, string name, DateTime value)
+            => AppendValue(builder, name, FormatDateTime(value));
+
+        private static void AppendValue(StringBuilder builder, string name, DateTime? value)
+            => AppendValue(builder, name, value.HasValue ? FormatDateTime(value.Value) : null);
+
+        // Treat Unspecified as UTC so the etag does not vary with the server's local timezone.
+        private static string FormatDateTime(DateTime value)
+        {
+            var utc = value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+                _ => value.ToUniversalTime(),
+            };
+
+            return utc.ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        private static void AppendValue(StringBuilder builder, string name, bool value)
+            => AppendValue(builder, name, value ? "true" : "false");
+
+        private static void AppendValue(StringBuilder builder, string name, bool? value)
+            => AppendValue(builder, name, value switch { true => "true", false => "false", null => null });
+
+        private static void AppendValue(StringBuilder builder, string name, int? value)
+            => AppendValue(builder, name, value?.ToString(CultureInfo.InvariantCulture));
+
+        private static void AppendValue(StringBuilder builder, string name, float? value)
+            => AppendValue(builder, name, value?.ToString("R", CultureInfo.InvariantCulture));
+
+        private static void AppendList(StringBuilder builder, string name, IReadOnlyList<string> values)
+        {
+            AppendValue(builder, name + ".Count", values.Count.ToString(CultureInfo.InvariantCulture));
+            for (var i = 0; i < values.Count; i++)
+            {
+                AppendValue(builder, $"{name}[{i}]", values[i]);
+            }
+        }
+
+        private static void AppendDictionary(StringBuilder builder, string name, IReadOnlyDictionary<string, string?> values)
+        {
+            AppendValue(builder, name + ".Count", values.Count.ToString(CultureInfo.InvariantCulture));
+            if (values.Count == 0)
+            {
+                return;
+            }
+
+            var index = 0;
+            foreach (var (key, value) in values
+                .OrderBy(i => i.Key, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(i => i.Key, StringComparer.Ordinal))
+            {
+                AppendValue(builder, $"{name}[{index}].Key", key);
+                AppendValue(builder, $"{name}[{index}].Value", value);
+                index++;
+            }
+        }
+    }
+}

--- a/src/Jellyfin.LiveTv/Listings/XmlTvProgramEtag.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvProgramEtag.cs
@@ -128,6 +128,18 @@ namespace Jellyfin.LiveTv.Listings
         private static void AppendValue(StringBuilder builder, string name, DateTime? value)
             => AppendValue(builder, name, value.HasValue ? FormatDateTime(value.Value) : null);
 
+        private static void AppendValue(StringBuilder builder, string name, bool value)
+            => AppendValue(builder, name, value ? "true" : "false");
+
+        private static void AppendValue(StringBuilder builder, string name, bool? value)
+            => AppendValue(builder, name, value switch { true => "true", false => "false", null => null });
+
+        private static void AppendValue(StringBuilder builder, string name, int? value)
+            => AppendValue(builder, name, value?.ToString(CultureInfo.InvariantCulture));
+
+        private static void AppendValue(StringBuilder builder, string name, float? value)
+            => AppendValue(builder, name, value?.ToString("R", CultureInfo.InvariantCulture));
+
         // Treat Unspecified as UTC so the etag does not vary with the server's local timezone.
         private static string FormatDateTime(DateTime value)
         {
@@ -140,18 +152,6 @@ namespace Jellyfin.LiveTv.Listings
 
             return utc.ToString("O", CultureInfo.InvariantCulture);
         }
-
-        private static void AppendValue(StringBuilder builder, string name, bool value)
-            => AppendValue(builder, name, value ? "true" : "false");
-
-        private static void AppendValue(StringBuilder builder, string name, bool? value)
-            => AppendValue(builder, name, value switch { true => "true", false => "false", null => null });
-
-        private static void AppendValue(StringBuilder builder, string name, int? value)
-            => AppendValue(builder, name, value?.ToString(CultureInfo.InvariantCulture));
-
-        private static void AppendValue(StringBuilder builder, string name, float? value)
-            => AppendValue(builder, name, value?.ToString("R", CultureInfo.InvariantCulture));
 
         private static void AppendList(StringBuilder builder, string name, IReadOnlyList<string> values)
         {

--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using Jellyfin.LiveTv.Listings;
+using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.LiveTv;
 using Moq;
 using Moq.Protected;
@@ -66,6 +67,7 @@ public class XmlTvListingsProviderTests
         Assert.True(program.HasImage);
         Assert.Equal("https://domain.tld/image.png", program.ImageUrl);
         Assert.Equal("3297", program.ChannelId);
+        AssertXmlTvEtag(program.Etag);
     }
 
     [Theory]
@@ -85,5 +87,60 @@ public class XmlTvListingsProviderTests
         var program = programsList[0];
         Assert.DoesNotContain(program.Genres, g => string.IsNullOrEmpty(g));
         Assert.Equal("3297", program.ChannelId);
+        AssertXmlTvEtag(program.Etag);
+    }
+
+    [Fact]
+    public async Task GetProgramsAsync_Etag_SameContentIsStable()
+    {
+        var first = await GetSingleProgramAsync("Test Data/LiveTv/Listings/XmlTv/etag-base.xml");
+        var second = await GetSingleProgramAsync("Test Data/LiveTv/Listings/XmlTv/etag-base.xml");
+
+        Assert.Equal(first.Etag, second.Etag);
+    }
+
+    [Theory]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-title-change.xml")]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-description-change.xml")]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-icon-change.xml")]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-category-change.xml")]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-progid-change.xml")]
+    public async Task GetProgramsAsync_Etag_ChangesWhenMappedContentChanges(string changedPath)
+    {
+        var original = await GetSingleProgramAsync("Test Data/LiveTv/Listings/XmlTv/etag-base.xml");
+        var changed = await GetSingleProgramAsync(changedPath);
+
+        Assert.NotEqual(original.Etag, changed.Etag);
+    }
+
+    [Theory]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-reordered.xml")]
+    [InlineData("Test Data/LiveTv/Listings/XmlTv/etag-unknown-field.xml")]
+    public async Task GetProgramsAsync_Etag_DoesNotChangeWhenMappedContentIsEquivalent(string equivalentPath)
+    {
+        var original = await GetSingleProgramAsync("Test Data/LiveTv/Listings/XmlTv/etag-base.xml");
+        var equivalent = await GetSingleProgramAsync(equivalentPath);
+
+        Assert.Equal(original.Etag, equivalent.Etag);
+    }
+
+    private async Task<ProgramInfo> GetSingleProgramAsync(string path)
+    {
+        var info = new ListingsProviderInfo()
+        {
+            Id = Path.GetFileNameWithoutExtension(path),
+            Path = path
+        };
+
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
+        var programs = await _xmlTvListingsProvider.GetProgramsAsync(info, "3297", startDate, startDate.AddDays(1), CancellationToken.None);
+
+        return Assert.Single(programs.ToList());
+    }
+
+    private static void AssertXmlTvEtag(string? etag)
+    {
+        Assert.NotNull(etag);
+        Assert.StartsWith("xmltv-sha256-v1:", etag!, StringComparison.Ordinal);
     }
 }

--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvProgramEtagTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvProgramEtagTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Jellyfin.LiveTv.Listings;
+using MediaBrowser.Controller.LiveTv;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Listings;
+
+public class XmlTvProgramEtagTests
+{
+    [Fact]
+    public void TryCreate_GenreOrderIsSignificant()
+    {
+        // GuideManager assigns item.Genres = info.Genres.ToArray() preserving order,
+        // so the same genres in a different order is a real mapped-content change.
+        var first = NewProgram();
+        first.Genres = new() { "Drama", "Action" };
+
+        var second = NewProgram();
+        second.Genres = new() { "Action", "Drama" };
+
+        Assert.True(XmlTvProgramEtag.TryCreate(first, out var firstEtag, out _));
+        Assert.True(XmlTvProgramEtag.TryCreate(second, out var secondEtag, out _));
+        Assert.NotEqual(firstEtag, secondEtag);
+    }
+
+    [Fact]
+    public void MatchesStored_EqualXmlTvEtags_ReturnsTrue()
+    {
+        const string Etag = XmlTvProgramEtag.Prefix + "ABCDEF0123456789";
+        Assert.True(XmlTvProgramEtag.MatchesStored(Etag, Etag));
+    }
+
+    [Fact]
+    public void MatchesStored_DifferentXmlTvEtags_ReturnsFalse()
+    {
+        Assert.False(XmlTvProgramEtag.MatchesStored(
+            XmlTvProgramEtag.Prefix + "AAAA",
+            XmlTvProgramEtag.Prefix + "BBBB"));
+    }
+
+    [Fact]
+    public void MatchesStored_EqualNonXmlTvEtags_ReturnsFalse()
+    {
+        // Other providers (e.g. Schedules Direct) use their own etag schemes.
+        // The IsXmlTvEtag gate must keep them on the field-by-field update path
+        // even when their incoming and stored values happen to match exactly.
+        const string Etag = "sd-abc123";
+        Assert.False(XmlTvProgramEtag.MatchesStored(Etag, Etag));
+    }
+
+    private static ProgramInfo NewProgram() => new()
+    {
+        Id = "program-id",
+        ChannelId = "channel-id",
+        Name = "Program Name",
+        StartDate = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+        EndDate = new DateTime(2026, 1, 1, 13, 0, 0, DateTimeKind.Utc),
+    };
+}

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-base.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-base.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-category-change.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-category-change.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">sports</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-description-change.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-description-change.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Changed description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-icon-change.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-icon-change.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/changed.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-progid-change.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-progid-change.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789013</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-reordered.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-reordered.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" stop="20221104140000 +0000" start="20221104130000 +0000">
+    <icon src="https://domain.tld/base.png"/>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <category lang="en">series</category>
+    <desc lang="en">Base description.</desc>
+    <sub-title lang="en">Base Episode</sub-title>
+    <title lang="en">Base Program</title>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-title-change.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-title-change.xml
@@ -1,0 +1,17 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Changed Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-unknown-field.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/etag-unknown-field.xml
@@ -1,0 +1,18 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Base Program</title>
+    <sub-title lang="en">Base Episode</sub-title>
+    <desc lang="en">Base description.</desc>
+    <category lang="en">series</category>
+    <episode-num system="xmltv_ns">0 . 1 . </episode-num>
+    <episode-num system="dd_progid">EP123456789012</episode-num>
+    <rating system="VCHIP">
+      <value>TV-G</value>
+    </rating>
+    <star-rating>
+      <value>3/5</value>
+    </star-rating>
+    <previously-unknown-field>Ignored by Jellyfin XMLTV mapping.</previously-unknown-field>
+    <icon src="https://domain.tld/base.png"/>
+  </programme>
+</tv>


### PR DESCRIPTION

TL;DR version: When processing multiday XMLTV xml guides, Jellyfin reprocesses program information that hasn't changed on it's configured timer (say every 5 hours etc).  The worse consequences of this is a constant redownloading (precaching) of images assets. This not only makes guide processing slow but unnecessarily beats up EPG providers with constant downloading of image resources. 


**Changes**
Leveraged existing "etag" functionality. Creates a synthetic md5 "hash" like schedules direct provides, to identify the program from the information jellyfin parses/cares about.  Skips processing if nothing changed.


**TL;WR version (Too Long; Want to Read :-)):**

These changes address an issue I noticed while Jellyfin was processing XMLTV guide data. In my setup, an XMLTV guide file is imported into tvheadend through its EPG importers and then served to Jellyfin over HTTP. The guide contains multiple days of future program data, and Jellyfin may refresh that guide on a recurring schedule, for example every 5 hours. In my case, this covers roughly 50 OTA/IPTV channels.

With the current XMLTV processing path, unchanged programs are treated as updated on each guide refresh. That causes Jellyfin to re-run metadata update handling and, more importantly, re-run Live TV image precaching for programs whose guide data has not actually changed. The XML parsing itself is not the main concern; Jellyfin still needs to read the XMLTV data to know what programs exist. The expensive part is repeatedly downloading and localizing the same guide artwork.

Schedules Direct already uses `ProgramInfo.Etag` for this purpose. It maps the Schedules Direct md5 value into Jellyfin’s Etag field, and `GuideManager` stores that value as `ProgramEtag` to detect whether a program has changed on later  refreshes. This was introduced in commit `de133cb8aa2b078ba653ee7c3e1cef4fd16996d6` “the listings provider has a token that changes when the program data changes, so Jellyfin can avoid treating unchanged guide entries as updated.” 

XMLTV does not provide a standard equivalent "change token" tag/attribute, so this change creates a synthetic token from the XMLTV data after it has been mapped into Jellyfin’s `ProgramInfo`. The token includes the program fields consumed by `GuideManager`, such as title, description, categories/genres, timing, flags, provider ids, episode data, and image URLs. This is encapsulated in a new xml etag class that creates this identifier. If the token matches the stored value for an existing XMLTV program, Jellyfin can skip per-program reconciliation and image update handling for that unchanged item.

Local testing showed a substantial reduction in guide refresh processing time, primarily by avoiding repeated image precaching. More importantly, it **reduces the number of calls to providers for images by a factor of thousands.**


_**One very important note: As part of this, I discovered an existing issue with the schedule direct etag feature. I put a comment in the code to explain restoring etags after getting "wiped out".  Naturally, I wanted to just fix that issue to eliminate the problem.... but this would "activate" the broken schedule direct implementation and goes beyond the scope of this PR and could have unintended consequences. Best to deal with that separately.**_


_There is still room for a broader image caching improvement needed that is not addressed here. Today, once a remote guide image is converted to a local cached file, later refreshes **compare the stored local file path against the incoming HTTP image URL**. Those values will always be different, even when the source image has not changed. This causes Jellyfin to treat the image as changed and thus redownloads the image(s) This almost certainly not intended behavior. A more general fix would likely require preserving the original source URL for cached images and comparing against that source identity. I am/have been working on some ideas/solutions to that but that would be a broader image metadata code changes probably involving new database field addition(s) etc that I'm not comfortable with yet - WIP._ 


LLM usage: Opus 4.7 and Codex 5.5 used for research, investigation of approaches, refactoring, code reviews and some authoring (unit tests etc). 
