### PR TITLE
Compare old file byte-by-byte to new stream

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -208,7 +208,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
             Directory.CreateDirectory(directory);
 
             // Compare byte-for-byte before proceeding.
-            if (File.Exists(path) && await IsFileIdenticalAsync(stream, path, cancellationToken).ConfigureAwait(false))
+            if (File.Exists(path) && await stream.IsFileIdenticalAsync(path, cancellationToken).ConfigureAwait(false))
             {
                 return; // Don't save since .nfo is unchanged.
             }
@@ -236,68 +236,6 @@ namespace MediaBrowser.XbmcMetadata.Savers
             if (ConfigurationManager.Configuration.SaveMetadataHidden)
             {
                 SetHidden(path, true);
-            }
-        }
-
-        private static async Task<bool> IsFileIdenticalAsync(Stream stream, string path, CancellationToken cancellationToken)
-        {
-            ArgumentNullException.ThrowIfNull(stream);
-            ArgumentException.ThrowIfNullOrEmpty(path);
-
-            if (!stream.CanSeek)
-            {
-                return false;
-            }
-
-            const int BufferSize = 81920;
-            var originalPosition = stream.Position;
-
-            try
-            {
-                stream.Position = 0;
-
-                using var existingFileStream = new FileStream(
-                    path,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    bufferSize: BufferSize,
-                    FileOptions.Asynchronous);
-
-                if (existingFileStream.Length != stream.Length)
-                {
-                    return false;
-                }
-
-                var streamBuffer = new byte[BufferSize];
-                var existingBuffer = new byte[BufferSize];
-
-                while (true)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    var streamBytesRead = await stream.ReadAsync(streamBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-                    var existingBytesRead = await existingFileStream.ReadAsync(existingBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-                    if (streamBytesRead != existingBytesRead)
-                    {
-                        return false;
-                    }
-
-                    if (streamBytesRead == 0)
-                    {
-                        return true;
-                    }
-
-                    if (!streamBuffer.AsSpan(0, streamBytesRead).SequenceEqual(existingBuffer.AsSpan(0, existingBytesRead)))
-                    {
-                        return false;
-                    }
-                }
-            }
-            finally
-            {
-                stream.Position = originalPosition;
             }
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -198,14 +198,22 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await SaveToFileAsync(memoryStream, path).ConfigureAwait(false);
+                await SaveToFileAsync(memoryStream, path, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task SaveToFileAsync(Stream stream, string path)
+        private async Task SaveToFileAsync(Stream stream, string path, CancellationToken cancellationToken)
         {
             var directory = Path.GetDirectoryName(path) ?? throw new ArgumentException($"Provided path ({path}) is not valid.", nameof(path));
             Directory.CreateDirectory(directory);
+
+            // Compare byte-for-byte before proceeding.
+            if (File.Exists(path) && await IsFileIdenticalAsync(stream, path, cancellationToken).ConfigureAwait(false))
+            {
+                return; // Don't save since .nfo is unchanged.
+            }
+
+            stream.Position = 0;
 
             // On Windows, saving the file will fail if the file is hidden or readonly
             FileSystem.SetAttributes(path, false, false);
@@ -222,12 +230,74 @@ namespace MediaBrowser.XbmcMetadata.Savers
             var filestream = new FileStream(path, fileStreamOptions);
             await using (filestream.ConfigureAwait(false))
             {
-                await stream.CopyToAsync(filestream).ConfigureAwait(false);
+                await stream.CopyToAsync(filestream, cancellationToken).ConfigureAwait(false);
             }
 
             if (ConfigurationManager.Configuration.SaveMetadataHidden)
             {
                 SetHidden(path, true);
+            }
+        }
+
+        private static async Task<bool> IsFileIdenticalAsync(Stream stream, string path, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            if (!stream.CanSeek)
+            {
+                return false;
+            }
+
+            const int BufferSize = 81920;
+            var originalPosition = stream.Position;
+
+            try
+            {
+                stream.Position = 0;
+
+                using var existingFileStream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    bufferSize: BufferSize,
+                    FileOptions.Asynchronous);
+
+                if (existingFileStream.Length != stream.Length)
+                {
+                    return false;
+                }
+
+                var streamBuffer = new byte[BufferSize];
+                var existingBuffer = new byte[BufferSize];
+
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var streamBytesRead = await stream.ReadAsync(streamBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    var existingBytesRead = await existingFileStream.ReadAsync(existingBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+
+                    if (streamBytesRead != existingBytesRead)
+                    {
+                        return false;
+                    }
+
+                    if (streamBytesRead == 0)
+                    {
+                        return true;
+                    }
+
+                    if (!streamBuffer.AsSpan(0, streamBytesRead).SequenceEqual(existingBuffer.AsSpan(0, existingBytesRead)))
+                    {
+                        return false;
+                    }
+                }
+            }
+            finally
+            {
+                stream.Position = originalPosition;
             }
         }
 

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -73,6 +73,7 @@ namespace Jellyfin.Extensions
         /// <param name="path">The file path to compare against.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the stream and file are identical; otherwise false.</returns>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> does not support seeking.</exception>
         public static async Task<bool> IsFileIdenticalAsync(this Stream stream, string path, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(stream);
@@ -80,7 +81,7 @@ namespace Jellyfin.Extensions
 
             if (!stream.CanSeek)
             {
-                return false;
+                throw new ArgumentException("Stream must support seeking.", nameof(stream));
             }
 
             var originalPosition = stream.Position;
@@ -113,30 +114,39 @@ namespace Jellyfin.Extensions
         /// <param name="b">The second stream to compare.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the streams are identical; otherwise false.</returns>
+        /// <exception cref="ArgumentException"><paramref name="a"/> or <paramref name="b"/> does not support seeking.</exception>
         public static async Task<bool> IsStreamIdenticalAsync(this Stream a, Stream b, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(a);
             ArgumentNullException.ThrowIfNull(b);
+
+            if (!a.CanSeek)
+            {
+                throw new ArgumentException("Stream must support seeking.", nameof(a));
+            }
+
+            if (!b.CanSeek)
+            {
+                throw new ArgumentException("Stream must support seeking.", nameof(b));
+            }
 
             if (b.Length != a.Length)
             {
                 return false;
             }
 
-            // If b is MemoryStream but a is not, swap them to use fast path B
+            // If b is MemoryStream but a is not, swap them to enable fast path B
             if (b is MemoryStream && a is not MemoryStream)
             {
                 (a, b) = (b, a);
             }
 
-            if (a is MemoryStream ms_a)
+            if (a is MemoryStream streamA && streamA.TryGetBuffer(out var segmentA))
             {
-                var bufferA = ms_a.GetBuffer();
-
                 // Fast path A: if both streams are MemoryStreams, compare directly against each other
-                if (b is MemoryStream ms_b)
+                if (b is MemoryStream streamB && streamB.TryGetBuffer(out var segmentB))
                 {
-                    return bufferA.AsSpan(0, (int)ms_a.Length).SequenceEqual(ms_b.GetBuffer().AsSpan(0, (int)ms_b.Length));
+                    return segmentA.AsSpan().SequenceEqual(segmentB.AsSpan());
                 }
 
                 // Fast path B: only first stream is a MemoryStream, compare against second stream chunk-by-chunk
@@ -148,9 +158,7 @@ namespace Jellyfin.Extensions
                     int bytesRead;
                     while ((bytesRead = await b.ReadAsync(memoryB, cancellationToken).ConfigureAwait(false)) > 0)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        if (!bufferA.AsSpan(offset, bytesRead).SequenceEqual(bufferB.AsSpan(0, bytesRead)))
+                        if (!segmentA.AsSpan(offset, bytesRead).SequenceEqual(memoryB.Span[..bytesRead]))
                         {
                             return false;
                         }
@@ -158,7 +166,7 @@ namespace Jellyfin.Extensions
                         offset += bytesRead;
                     }
 
-                    return offset == ms_a.Length;
+                    return offset == segmentA.Count;
                 }
                 finally
                 {
@@ -190,7 +198,7 @@ namespace Jellyfin.Extensions
                             return true;
                         }
 
-                        if (!bufferA.AsSpan(0, bytesReadA).SequenceEqual(bufferB.AsSpan(0, bytesReadB)))
+                        if (!memoryA.Span[..bytesReadA].SequenceEqual(memoryB.Span[..bytesReadB]))
                         {
                             return false;
                         }

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -123,37 +123,84 @@ namespace Jellyfin.Extensions
                 return false;
             }
 
-            var bufferA = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
-            var bufferB = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
-            try
+            // If b is MemoryStream but a is not, swap them to use fast path B
+            if (b is MemoryStream && a is not MemoryStream)
             {
-                while (true)
+                (a, b) = (b, a);
+            }
+
+            if (a is MemoryStream ms_a)
+            {
+                var bufferA = ms_a.GetBuffer();
+
+                // Fast path A: if both streams are MemoryStreams, compare directly against each other
+                if (b is MemoryStream ms_b)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    return bufferA.AsSpan(0, (int)ms_a.Length).SequenceEqual(ms_b.GetBuffer().AsSpan(0, (int)ms_b.Length));
+                }
 
-                    var bytesReadA = await a.ReadAsync(bufferA.AsMemory(), cancellationToken).ConfigureAwait(false);
-                    var bytesReadB = await b.ReadAsync(bufferB.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-                    if (bytesReadA != bytesReadB)
+                // Fast path B: only first stream is a MemoryStream, compare against second stream chunk-by-chunk
+                var bufferB = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
+                try
+                {
+                    var memoryB = bufferB.AsMemory();
+                    int offset = 0;
+                    int bytesRead;
+                    while ((bytesRead = await b.ReadAsync(memoryB, cancellationToken).ConfigureAwait(false)) > 0)
                     {
-                        return false;
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        if (!bufferA.AsSpan(offset, bytesRead).SequenceEqual(bufferB.AsSpan(0, bytesRead)))
+                        {
+                            return false;
+                        }
+
+                        offset += bytesRead;
                     }
 
-                    if (bytesReadA == 0)
-                    {
-                        return true;
-                    }
-
-                    if (!bufferA.AsSpan(0, bytesReadA).SequenceEqual(bufferB.AsSpan(0, bytesReadB)))
-                    {
-                        return false;
-                    }
+                    return offset == ms_a.Length;
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(bufferB);
                 }
             }
-            finally
+            else
             {
-                ArrayPool<byte>.Shared.Return(bufferA);
-                ArrayPool<byte>.Shared.Return(bufferB);
+                var bufferA = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
+                var bufferB = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
+                try
+                {
+                    var memoryA = bufferA.AsMemory();
+                    var memoryB = bufferB.AsMemory();
+                    while (true)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var bytesReadA = await a.ReadAsync(memoryA, cancellationToken).ConfigureAwait(false);
+                        var bytesReadB = await b.ReadAsync(memoryB, cancellationToken).ConfigureAwait(false);
+
+                        if (bytesReadA != bytesReadB)
+                        {
+                            return false;
+                        }
+
+                        if (bytesReadA == 0)
+                        {
+                            return true;
+                        }
+
+                        if (!bufferA.AsSpan(0, bytesReadA).SequenceEqual(bufferB.AsSpan(0, bytesReadB)))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(bufferA);
+                    ArrayPool<byte>.Shared.Return(bufferB);
+                }
             }
         }
     }

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -133,36 +133,40 @@ namespace Jellyfin.Extensions
                 return true;
             }
 
-            if (a.CanSeek)
+            if (a.CanSeek is var aCanSeek && aCanSeek)
             {
                 a.Position = 0;
             }
 
-            if (b.CanSeek)
+            if (b.CanSeek is var bCanSeek && bCanSeek)
             {
                 b.Position = 0;
             }
 
-            if (a.CanSeek && b.CanSeek && b.Length != a.Length)
+            if (aCanSeek && bCanSeek && b.Length != a.Length)
             {
                 return false;
             }
 
-            // If b is MemoryStream but a is not, swap them to enable fast path B
-            if (b is MemoryStream && a is not MemoryStream)
+            // MemoryStreams only unlock a fast path if their underlying buffer is exposed via TryGetBuffer.
+            var segmentA = a is MemoryStream streamA && streamA.TryGetBuffer(out var bufA) ? bufA : default;
+            var segmentB = b is MemoryStream streamB && streamB.TryGetBuffer(out var bufB) ? bufB : default;
+
+            // Fast path A: both streams expose buffers, compare segments directly
+            if (segmentA.Array is not null && segmentB.Array is not null)
             {
-                (a, b) = (b, a);
+                return segmentA.AsSpan().SequenceEqual(segmentB.AsSpan());
             }
 
-            if (a is MemoryStream streamA && streamA.TryGetBuffer(out var segmentA))
+            if (segmentB.Array is not null) // && segmentA.Array is null guaranteed by previous check
             {
-                // Fast path A: if both streams are MemoryStreams, compare directly against each other
-                if (b is MemoryStream streamB && streamB.TryGetBuffer(out var segmentB))
-                {
-                    return segmentA.AsSpan().SequenceEqual(segmentB.AsSpan());
-                }
+                // swap so that segmentA is the non-null one, compared to b we need only one fast path B
+                (segmentA, b) = (segmentB, a);
+            }
 
-                // Fast path B: only first stream is a MemoryStream, compare against second stream chunk-by-chunk
+            if (segmentA.Array is not null) // either a was non-null, or b was non-null and was swapped there
+            {
+                // Fast path B: only one stream exposed a buffer, compare against the other chunk-by-chunk
                 var bufferB = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
                 try
                 {
@@ -198,8 +202,12 @@ namespace Jellyfin.Extensions
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var bytesReadA = await a.ReadAtLeastAsync(memoryA, memoryA.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
-                        var bytesReadB = await b.ReadAtLeastAsync(memoryB, memoryB.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                        var taskA = a.ReadAtLeastAsync(memoryA, memoryA.Length, throwOnEndOfStream: false, cancellationToken).AsTask();
+                        var taskB = b.ReadAtLeastAsync(memoryB, memoryB.Length, throwOnEndOfStream: false, cancellationToken).AsTask();
+                        await Task.WhenAll(taskA, taskB).ConfigureAwait(false);
+
+                        var bytesReadA = await taskA.ConfigureAwait(false);
+                        var bytesReadB = await taskB.ConfigureAwait(false);
 
                         if (bytesReadA != bytesReadB)
                         {

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Extensions
     /// </summary>
     public static class StreamExtensions
     {
-        private const int StreamComparisonBufferSize = 65536;
+        private const int StreamComparisonBufferSize = 81920;
 
         /// <summary>
         /// Reads all lines in the <see cref="Stream" />.
@@ -114,23 +114,12 @@ namespace Jellyfin.Extensions
         /// <param name="b">The second stream to compare.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the streams are identical; otherwise false.</returns>
-        /// <exception cref="ArgumentException"><paramref name="a"/> or <paramref name="b"/> does not support seeking.</exception>
         public static async Task<bool> IsStreamIdenticalAsync(this Stream a, Stream b, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(a);
             ArgumentNullException.ThrowIfNull(b);
 
-            if (!a.CanSeek)
-            {
-                throw new ArgumentException("Stream must support seeking.", nameof(a));
-            }
-
-            if (!b.CanSeek)
-            {
-                throw new ArgumentException("Stream must support seeking.", nameof(b));
-            }
-
-            if (b.Length != a.Length)
+            if (a.CanSeek && b.CanSeek && b.Length != a.Length)
             {
                 return false;
             }

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Jellyfin.Extensions
 {
@@ -12,6 +15,8 @@ namespace Jellyfin.Extensions
     /// </summary>
     public static class StreamExtensions
     {
+        private const int StreamComparisonBufferSize = 65536;
+
         /// <summary>
         /// Reads all lines in the <see cref="Stream" />.
         /// </summary>
@@ -58,6 +63,97 @@ namespace Jellyfin.Extensions
             while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
             {
                 yield return line;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a stream is identical to a file on disk.
+        /// </summary>
+        /// <param name="stream">The stream to compare.</param>
+        /// <param name="path">The file path to compare against.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>True if the stream and file are identical; otherwise false.</returns>
+        public static async Task<bool> IsFileIdenticalAsync(this Stream stream, string path, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            if (!stream.CanSeek)
+            {
+                return false;
+            }
+
+            var originalPosition = stream.Position;
+            try
+            {
+                stream.Position = 0;
+
+                var existingFileStream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    bufferSize: StreamComparisonBufferSize,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                await using (existingFileStream.ConfigureAwait(false))
+                {
+                    return await stream.IsStreamIdenticalAsync(existingFileStream, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                stream.Position = originalPosition;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether two streams are identical.
+        /// </summary>
+        /// <param name="a">The first stream to compare.</param>
+        /// <param name="b">The second stream to compare.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>True if the streams are identical; otherwise false.</returns>
+        public static async Task<bool> IsStreamIdenticalAsync(this Stream a, Stream b, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(a);
+            ArgumentNullException.ThrowIfNull(b);
+
+            if (b.Length != a.Length)
+            {
+                return false;
+            }
+
+            var bufferA = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
+            var bufferB = ArrayPool<byte>.Shared.Rent(StreamComparisonBufferSize);
+            try
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var bytesReadA = await a.ReadAsync(bufferA.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    var bytesReadB = await b.ReadAsync(bufferB.AsMemory(), cancellationToken).ConfigureAwait(false);
+
+                    if (bytesReadA != bytesReadB)
+                    {
+                        return false;
+                    }
+
+                    if (bytesReadA == 0)
+                    {
+                        return true;
+                    }
+
+                    if (!bufferA.AsSpan(0, bytesReadA).SequenceEqual(bufferB.AsSpan(0, bytesReadB)))
+                    {
+                        return false;
+                    }
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(bufferA);
+                ArrayPool<byte>.Shared.Return(bufferB);
             }
         }
     }

--- a/src/Jellyfin.Extensions/StreamExtensions.cs
+++ b/src/Jellyfin.Extensions/StreamExtensions.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace Jellyfin.Extensions
 {
     /// <summary>
-    /// Class BaseExtensions.
+    /// Extension methods for the <see cref="Stream"/> class.
     /// </summary>
     public static class StreamExtensions
     {
@@ -74,7 +74,11 @@ namespace Jellyfin.Extensions
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the stream and file are identical; otherwise false.</returns>
         /// <exception cref="ArgumentException"><paramref name="stream"/> does not support seeking.</exception>
-        public static async Task<bool> IsFileIdenticalAsync(this Stream stream, string path, CancellationToken cancellationToken)
+        /// <remarks>
+        /// The entire stream is compared against the file from the beginning (the position is reset to 0 on entry)
+        /// and restored to its original value after the call.
+        /// </remarks>
+        public static async Task<bool> IsFileIdenticalAsync(this Stream stream, string path, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(stream);
             ArgumentException.ThrowIfNullOrEmpty(path);
@@ -114,10 +118,30 @@ namespace Jellyfin.Extensions
         /// <param name="b">The second stream to compare.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the streams are identical; otherwise false.</returns>
-        public static async Task<bool> IsStreamIdenticalAsync(this Stream a, Stream b, CancellationToken cancellationToken)
+        /// <remarks>
+        /// Seekable streams are compared from the beginning (their position is reset to 0 on entry).
+        /// Non-seekable streams are compared from their current read position. Stream positions are not
+        /// restored after the call.
+        /// </remarks>
+        public static async Task<bool> IsStreamIdenticalAsync(this Stream a, Stream b, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(a);
             ArgumentNullException.ThrowIfNull(b);
+
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a.CanSeek)
+            {
+                a.Position = 0;
+            }
+
+            if (b.CanSeek)
+            {
+                b.Position = 0;
+            }
 
             if (a.CanSeek && b.CanSeek && b.Length != a.Length)
             {
@@ -145,9 +169,9 @@ namespace Jellyfin.Extensions
                     var memoryB = bufferB.AsMemory();
                     int offset = 0;
                     int bytesRead;
-                    while ((bytesRead = await b.ReadAsync(memoryB, cancellationToken).ConfigureAwait(false)) > 0)
+                    while ((bytesRead = await b.ReadAtLeastAsync(memoryB, memoryB.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false)) > 0)
                     {
-                        if (!segmentA.AsSpan(offset, bytesRead).SequenceEqual(memoryB.Span[..bytesRead]))
+                        if (offset + bytesRead > segmentA.Count || !segmentA.AsSpan(offset, bytesRead).SequenceEqual(memoryB.Span[..bytesRead]))
                         {
                             return false;
                         }
@@ -174,8 +198,8 @@ namespace Jellyfin.Extensions
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var bytesReadA = await a.ReadAsync(memoryA, cancellationToken).ConfigureAwait(false);
-                        var bytesReadB = await b.ReadAsync(memoryB, cancellationToken).ConfigureAwait(false);
+                        var bytesReadA = await a.ReadAtLeastAsync(memoryA, memoryA.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                        var bytesReadB = await b.ReadAtLeastAsync(memoryB, memoryB.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
 
                         if (bytesReadA != bytesReadB)
                         {

--- a/tests/Jellyfin.Extensions.Tests/StreamExtensionsTests.cs
+++ b/tests/Jellyfin.Extensions.Tests/StreamExtensionsTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Extensions;
 using Xunit;
 
 namespace Jellyfin.Extensions.Tests;
@@ -65,8 +64,12 @@ public class StreamExtensionsTests
         }
     }
 
-    [Fact]
-    public async Task IsFileIdenticalAsync_UsesStartOfStreamAndRestoresPosition_OnMatch()
+    // Both publiclyVisible values are exercised so the test runs once under the fast path
+    // (TryGetBuffer succeeds) and once under the slow path (TryGetBuffer returns false).
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task IsFileIdenticalAsync_UsesStartOfStreamAndRestoresPosition_OnMatch(bool publiclyVisible)
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
@@ -75,7 +78,7 @@ public class StreamExtensionsTests
 
         try
         {
-            await using var stream = new MemoryStream(bytes);
+            await using var stream = CreateMemoryStream(bytes, publiclyVisible);
             stream.Position = 3;
 
             var result = await stream.IsFileIdenticalAsync(path, cancellationToken);
@@ -89,8 +92,10 @@ public class StreamExtensionsTests
         }
     }
 
-    [Fact]
-    public async Task IsFileIdenticalAsync_RestoresPosition_OnMismatch()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task IsFileIdenticalAsync_RestoresPosition_OnMismatch(bool publiclyVisible)
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
@@ -98,7 +103,7 @@ public class StreamExtensionsTests
 
         try
         {
-            await using var stream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 });
+            await using var stream = CreateMemoryStream(new byte[] { 10, 20, 30, 40, 50 }, publiclyVisible);
             stream.Position = 2;
 
             var result = await stream.IsFileIdenticalAsync(path, cancellationToken);
@@ -111,6 +116,96 @@ public class StreamExtensionsTests
             File.Delete(path);
         }
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task IsStreamIdenticalAsync_BothMemoryStreams_NonZeroPositions_SeeksToStart(bool publiclyVisible)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = CreateMemoryStream(new byte[] { 1, 2, 3, 4, 5 }, publiclyVisible);
+        await using var b = CreateMemoryStream(new byte[] { 1, 2, 3, 4, 5 }, publiclyVisible);
+        a.Position = 3;
+        b.Position = 1;
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task IsStreamIdenticalAsync_MemoryStreamPairedWithSeekableNonMemoryStream_NonZeroPositions_SeeksToStart(bool publiclyVisible)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = CreateMemoryStream(new byte[] { 1, 2, 3, 4 }, publiclyVisible);
+        await using var b = new SeekableNonMemoryStream(new byte[] { 1, 2, 3, 4 });
+        a.Position = 2;
+        b.Position = 3;
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task IsStreamIdenticalAsync_NonMemoryStreamPairedWithMemoryStream_Swaps_ReturnsTrue(bool publiclyVisible)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new SeekableNonMemoryStream(new byte[] { 1, 2, 3, 4 });
+        await using var b = CreateMemoryStream(new byte[] { 1, 2, 3, 4 }, publiclyVisible);
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsStreamIdenticalAsync_BothSeekableNonMemoryStreams_NonZeroPositions_SeeksToStart()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new SeekableNonMemoryStream(new byte[] { 1, 2, 3, 4 });
+        await using var b = new SeekableNonMemoryStream(new byte[] { 1, 2, 3, 4 });
+        a.Position = 1;
+        b.Position = 2;
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsStreamIdenticalAsync_NonSeekableShortReads_Identical_ReturnsTrue()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        await using var a = new ShortReadingNonSeekableStream(data, maxReadSize: 3);
+        await using var b = new ShortReadingNonSeekableStream(data, maxReadSize: 5);
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsStreamIdenticalAsync_NonSeekableShortReads_DifferentLengths_ReturnsFalse()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new ShortReadingNonSeekableStream(new byte[] { 1, 2, 3, 4 }, maxReadSize: 3);
+        await using var b = new ShortReadingNonSeekableStream(new byte[] { 1, 2, 3, 4, 5 }, maxReadSize: 5);
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.False(result);
+    }
+
+    private static MemoryStream CreateMemoryStream(byte[] data, bool publiclyVisible)
+        => publiclyVisible
+            ? new MemoryStream(data, 0, data.Length, writable: false, publiclyVisible: true)
+            : new MemoryStream(data);
 
     private sealed class NonSeekableReadStream : Stream
     {
@@ -147,6 +242,132 @@ public class StreamExtensionsTests
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class SeekableNonMemoryStream : Stream
+    {
+        private readonly MemoryStream _inner;
+
+        public SeekableNonMemoryStream(byte[] data)
+        {
+            _inner = new MemoryStream(data, writable: false);
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => _inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _inner.ReadAsync(buffer, cancellationToken);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => _inner.Seek(offset, origin);
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class ShortReadingNonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly int _maxReadSize;
+
+        public ShortReadingNonSeekableStream(byte[] data, int maxReadSize)
+        {
+            _inner = new MemoryStream(data, writable: false);
+            _maxReadSize = maxReadSize;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => _inner.Read(buffer, offset, Math.Min(count, _maxReadSize));
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _inner.ReadAsync(buffer[..Math.Min(buffer.Length, _maxReadSize)], cancellationToken);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _inner.ReadAsync(buffer.AsMemory(offset, Math.Min(count, _maxReadSize)), cancellationToken).AsTask();
 
         public override long Seek(long offset, SeekOrigin origin)
             => throw new NotSupportedException();

--- a/tests/Jellyfin.Extensions.Tests/StreamExtensionsTests.cs
+++ b/tests/Jellyfin.Extensions.Tests/StreamExtensionsTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Extensions;
+using Xunit;
+
+namespace Jellyfin.Extensions.Tests;
+
+public class StreamExtensionsTests
+{
+    [Fact]
+    public async Task IsStreamIdenticalAsync_SeekableDifferentLengths_ReturnsFalse()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new MemoryStream(new byte[] { 1, 2, 3 });
+        await using var b = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsStreamIdenticalAsync_NonSeekableIdenticalStreams_ReturnsTrue()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4 });
+        await using var b = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4 });
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsStreamIdenticalAsync_NonSeekableDifferentStreams_ReturnsFalse()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var a = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4 });
+        await using var b = new NonSeekableReadStream(new byte[] { 1, 2, 9, 4 });
+
+        var result = await a.IsStreamIdenticalAsync(b, cancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsFileIdenticalAsync_NonSeekableStream_ThrowsArgumentException()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        await File.WriteAllBytesAsync(path, new byte[] { 1, 2, 3, 4 }, cancellationToken);
+
+        try
+        {
+            await using var stream = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4 });
+
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await stream.IsFileIdenticalAsync(path, cancellationToken));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task IsFileIdenticalAsync_UsesStartOfStreamAndRestoresPosition_OnMatch()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        var bytes = new byte[] { 10, 20, 30, 40, 50 };
+        await File.WriteAllBytesAsync(path, bytes, cancellationToken);
+
+        try
+        {
+            await using var stream = new MemoryStream(bytes);
+            stream.Position = 3;
+
+            var result = await stream.IsFileIdenticalAsync(path, cancellationToken);
+
+            Assert.True(result);
+            Assert.Equal(3, stream.Position);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task IsFileIdenticalAsync_RestoresPosition_OnMismatch()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        await File.WriteAllBytesAsync(path, new byte[] { 10, 20, 30, 40, 99 }, cancellationToken);
+
+        try
+        {
+            await using var stream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 });
+            stream.Position = 2;
+
+            var result = await stream.IsFileIdenticalAsync(path, cancellationToken);
+
+            Assert.False(result);
+            Assert.Equal(2, stream.Position);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private sealed class NonSeekableReadStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableReadStream(byte[] data)
+        {
+            _inner = new MemoryStream(data, writable: false);
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => _inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _inner.ReadAsync(buffer, cancellationToken);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
When computing the NFO contents, we will rewrite the file even if everything is unchanged. This causes the file updated time to change and increases load on the filesystem (and underlying drives), causing other consumers of the NFO files to force a rescan (e.g. ChannelsDVR).



Now does a byte-by-byte comparison and skips the write if the NFO is identitcal.

Also now passes the cancellationToken down to the stream copy so we abort faster if cancelled.

Fixes https://github.com/jellyfin/jellyfin/issues/12978
