### PR TITLE
Fix CA2007 warnings in InstallationManager

### DIFF
--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -527,42 +527,44 @@ namespace Emby.Server.Implementations.Updates
             using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
                 .GetAsync(new Uri(package.SourceUrl), cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-
-            // CA5351: Do Not Use Broken Cryptographic Algorithms
+            Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                // CA5351: Do Not Use Broken Cryptographic Algorithms
 #pragma warning disable CA5351
-            cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-            var hash = Convert.ToHexString(await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false));
-            if (!string.Equals(package.Checksum, hash, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogError(
-                    "The checksums didn't match while installing {Package}, expected: {Expected}, got: {Received}",
-                    package.Name,
-                    package.Checksum,
-                    hash);
-                throw new InvalidDataException("The checksum of the received data doesn't match.");
-            }
-
-            // Version folder as they cannot be overwritten in Windows.
-            targetDir += "_" + package.Version;
-
-            if (Directory.Exists(targetDir))
-            {
-                try
+                var hash = Convert.ToHexString(await MD5.HashDataAsync(stream, cancellationToken).ConfigureAwait(false));
+                if (!string.Equals(package.Checksum, hash, StringComparison.OrdinalIgnoreCase))
                 {
-                    Directory.Delete(targetDir, true);
+                    _logger.LogError(
+                        "The checksums didn't match while installing {Package}, expected: {Expected}, got: {Received}",
+                        package.Name,
+                        package.Checksum,
+                        hash);
+                    throw new InvalidDataException("The checksum of the received data doesn't match.");
                 }
+
+                // Version folder as they cannot be overwritten in Windows.
+                targetDir += "_" + package.Version;
+
+                if (Directory.Exists(targetDir))
+                {
+                    try
+                    {
+                        Directory.Delete(targetDir, true);
+                    }
 #pragma warning disable CA1031 // Do not catch general exception types
-                catch
+                    catch
 #pragma warning restore CA1031 // Do not catch general exception types
-                {
-                    // Ignore any exceptions.
+                    {
+                        // Ignore any exceptions.
+                    }
                 }
-            }
 
-            stream.Position = 0;
-            await ZipFile.ExtractToDirectoryAsync(stream, targetDir, true, cancellationToken);
+                stream.Position = 0;
+                await ZipFile.ExtractToDirectoryAsync(stream, targetDir, true, cancellationToken).ConfigureAwait(false);
+            }
 
             // Ensure we create one or populate existing ones with missing data.
             await _pluginManager.PopulateManifest(package.PackageInfo, package.Version, targetDir, status).ConfigureAwait(false);


### PR DESCRIPTION
Wraps the downloaded plugin stream in an explicit `await using` block with `ConfigureAwait(false)`, matching the pattern already used elsewhere (e.g. `LiveStreamHelper`). Also adds `ConfigureAwait(false)` to the `ZipFile.ExtractToDirectoryAsync` call.

No behavioural change — the stream is still disposed after extraction, just with the configured awaiter on the implicit `DisposeAsync`.

Verified locally: warning count for the file drops from 4 to 0, full solution builds clean, all tests pass, and `dotnet format --verify-no-changes` is clean. Smoke-tested by installing two plugins (TVHeadend, LDAP Authentication) from the live repo against a freshly-built server — both extracted to `plugins/` with no errors in the log.

Part of #2149