### PR TITLE
Clean live TV HLS transcode segments

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -231,7 +231,7 @@
  - [MSalman5230](https://github.com/MSalman5230)
  - [dwandw](https://github.com/dwandw)
  - [Lampan-git](https://github.com/Lampan-git)
-
+ - [Lollinoo](https://github.com/lollinoo)
 # Emby Contributors
 
  - [LukePulverenti](https://github.com/LukePulverenti)

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -541,7 +541,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
 
     private void StartThrottler(StreamState state, TranscodingJob transcodingJob)
     {
-        if (EnableThrottling(state)
+        if (ShouldStartThrottler(state)
             && (_mediaEncoder.IsPkeyPauseSupported
                 || _mediaEncoder.EncoderVersion <= _maxFFmpegCkeyPauseSupported))
         {
@@ -550,28 +550,33 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         }
     }
 
-    private static bool EnableThrottling(StreamState state)
-        => state.InputProtocol == MediaProtocol.File
-           && state.RunTimeTicks.HasValue
-           && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks
-           && state.IsInputVideo
-           && state.VideoType == VideoType.VideoFile;
+    internal static bool ShouldStartThrottler(StreamState state)
+        => (state.InputProtocol == MediaProtocol.File
+            && state.RunTimeTicks.HasValue
+            && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks
+            && state.IsInputVideo
+            && state.VideoType == VideoType.VideoFile)
+           || (state.InputProtocol is MediaProtocol.File or MediaProtocol.Http
+               && state.IsInputVideo
+               && state.TranscodingType == TranscodingJobType.Hls
+               && state.MediaSource.IsInfiniteStream);
 
     private void StartSegmentCleaner(StreamState state, TranscodingJob transcodingJob)
     {
-        if (EnableSegmentCleaning(state))
+        if (ShouldStartSegmentCleaner(state))
         {
             transcodingJob.TranscodingSegmentCleaner = new TranscodingSegmentCleaner(transcodingJob, _loggerFactory.CreateLogger<TranscodingSegmentCleaner>(), _serverConfigurationManager, _fileSystem, _mediaEncoder, state.SegmentLength);
             transcodingJob.TranscodingSegmentCleaner.Start();
         }
     }
 
-    private static bool EnableSegmentCleaning(StreamState state)
+    internal static bool ShouldStartSegmentCleaner(StreamState state)
         => state.InputProtocol is MediaProtocol.File or MediaProtocol.Http
            && state.IsInputVideo
            && state.TranscodingType == TranscodingJobType.Hls
-           && state.RunTimeTicks.HasValue
-           && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks;
+           && (state.MediaSource.IsInfiniteStream
+               || (state.RunTimeTicks.HasValue
+                   && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks));
 
     private TranscodingJob OnTranscodeBeginning(
         string path,


### PR DESCRIPTION
## Summary

- Start the HLS segment cleaner for infinite Live TV streams.
- Start the transcoding throttler for infinite HLS video streams from file or HTTP inputs.
- Keep the existing behavior for long finite video files and long finite HLS streams.

## What happens

Live TV media sources are normalized as infinite streams, and media probing clears `RunTimeTicks` when the source has no fixed duration. That means many Live TV HLS transcodes reach `TranscodeManager` with `MediaSource.IsInfiniteStream == true` and `RunTimeTicks == null`.

On current `upstream/master`, the HLS segment cleaner is only enabled when all of these are true:

- input protocol is file or HTTP
- input is video
- transcoding type is HLS
- `RunTimeTicks` exists and is at least five minutes

Infinite Live TV streams fail the final condition because they intentionally do not have a runtime. As a result, no `TranscodingSegmentCleaner` is started for those sessions.

HLS transcoding writes segment files continuously while FFmpeg is running. Without the segment cleaner, those files remain in the transcode directory for the lifetime of the transcode. If the transcode path is backed by RAM, or if several clients start independent HLS transcodes for the same Live TV channel, segment files can accumulate until the transcode storage fills up.

The throttler has a similar finite-duration guard on `upstream/master`: it only starts for file-based video with a runtime of at least five minutes. Infinite HLS Live TV transcodes therefore also miss the normal throttling path.

## Change details

This updates the transcode cleanup and throttling predicates to treat infinite HLS video streams as eligible even when `RunTimeTicks` is not available. The existing finite-stream checks remain in place, so short finite streams are still excluded.

## Impact

Live TV HLS sessions without a fixed timestamp/runtime now get the same ongoing segment cleanup behavior as long finite HLS sessions. This limits transcode directory growth during long-running Live TV playback and reduces the risk of exhausting RAM-backed transcode storage.