### PR TITLE
Use ConfigureAwait(false) in CollectionController

### DIFF
--- a/Jellyfin.Api/Controllers/CollectionController.cs
+++ b/Jellyfin.Api/Controllers/CollectionController.cs
@@ -88,7 +88,7 @@ public class CollectionController : BaseJellyfinApiController
         [FromRoute, Required] Guid collectionId,
         [FromQuery, Required, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] ids)
     {
-        await _collectionManager.AddToCollectionAsync(collectionId, ids).ConfigureAwait(true);
+        await _collectionManager.AddToCollectionAsync(collectionId, ids).ConfigureAwait(false);
         return NoContent();
     }
 


### PR DESCRIPTION



Update `AddToCollection` in `CollectionController` to use `ConfigureAwait(false)`, matching the async continuation pattern used throughout the controller and wider codebase.


Testing:

* `dotnet build` succeeds
* Verified collection operations still function correctly in local Docker development environment



**Changes**
No functional behavior change intended.

**Issues**
N/A