### PR TITLE
Removed unused NowPlayingQueueFullItems in SessionManager

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -459,11 +459,6 @@ namespace Emby.Server.Implementations.Session
             if (nowPlayingQueue?.Length > 0 && !nowPlayingQueue.SequenceEqual(session.NowPlayingQueue))
             {
                 session.NowPlayingQueue = nowPlayingQueue;
-
-                var itemIds = Array.ConvertAll(nowPlayingQueue, queue => queue.Id);
-                session.NowPlayingQueueFullItems = _dtoService.GetBaseItemDtos(
-                    _libraryManager.GetItemList(new InternalItemsQuery { ItemIds = itemIds }),
-                    new DtoOptions(true));
             }
         }
 


### PR DESCRIPTION
**Changes**
Removed the hungry and unused NowPlayingQueueFullItems item from Sessions results. Performance and stability improvements in the admin dashboard, and for third-party tools using the Sessions API endpoint. 

**Issues**
Fixes #13377 
