### PR TITLE
Remove NowPlayingQueueFullItems from session DTOs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -114,6 +114,7 @@
  - [oddstr13](https://github.com/oddstr13)
  - [olsh](https://github.com/olsh)
  - [orryverducci](https://github.com/orryverducci)
+ - [PCEWLKR](https://github.com/PCEWLKR)
  - [petermcneil](https://github.com/petermcneil)
  - [Phlogi](https://github.com/Phlogi)
  - [pjeanjean](https://github.com/pjeanjean)

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -453,18 +453,6 @@ namespace Emby.Server.Implementations.Session
             session.PlayState.RepeatMode = info.RepeatMode;
             session.PlayState.PlaybackOrder = info.PlaybackOrder;
             session.PlaylistItemId = info.PlaylistItemId;
-
-            var nowPlayingQueue = info.NowPlayingQueue;
-
-            if (nowPlayingQueue?.Length > 0 && !nowPlayingQueue.SequenceEqual(session.NowPlayingQueue))
-            {
-                session.NowPlayingQueue = nowPlayingQueue;
-
-                var itemIds = Array.ConvertAll(nowPlayingQueue, queue => queue.Id);
-                session.NowPlayingQueueFullItems = _dtoService.GetBaseItemDtos(
-                    _libraryManager.GetItemList(new InternalItemsQuery { ItemIds = itemIds }),
-                    new DtoOptions(true));
-            }
         }
 
         /// <summary>
@@ -1217,7 +1205,6 @@ namespace Emby.Server.Implementations.Session
                 SupportsMediaControl = sessionInfo.SupportsMediaControl,
                 SupportsRemoteControl = sessionInfo.SupportsRemoteControl,
                 NowPlayingQueue = sessionInfo.NowPlayingQueue,
-                NowPlayingQueueFullItems = sessionInfo.NowPlayingQueueFullItems,
                 HasCustomDeviceName = sessionInfo.HasCustomDeviceName,
                 PlaylistItemId = sessionInfo.PlaylistItemId,
                 ServerId = sessionInfo.ServerId,

--- a/MediaBrowser.Controller/Session/SessionInfo.cs
+++ b/MediaBrowser.Controller/Session/SessionInfo.cs
@@ -45,7 +45,6 @@ namespace MediaBrowser.Controller.Session
             PlayState = new PlayerStateInfo();
             SessionControllers = [];
             NowPlayingQueue = [];
-            NowPlayingQueueFullItems = [];
         }
 
         /// <summary>
@@ -272,15 +271,9 @@ namespace MediaBrowser.Controller.Session
         public IReadOnlyList<QueueItem> NowPlayingQueue { get; set; }
 
         /// <summary>
-        /// Gets or sets the now playing queue full items.
-        /// </summary>
-        /// <value>The now playing queue full items.</value>
-        public IReadOnlyList<BaseItemDto> NowPlayingQueueFullItems { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether the session has a custom device name.
         /// </summary>
-        /// <value><c>true</c> if this session has a custom device name; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if the session has a custom device name; otherwise, <c>false</c>.</value>
         public bool HasCustomDeviceName { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Dto/SessionInfoDto.cs
+++ b/MediaBrowser.Model/Dto/SessionInfoDto.cs
@@ -149,13 +149,7 @@ public class SessionInfoDto
     public IReadOnlyList<QueueItem>? NowPlayingQueue { get; set; }
 
     /// <summary>
-    /// Gets or sets the now playing queue full items.
-    /// </summary>
-    /// <value>The now playing queue full items.</value>
-    public IReadOnlyList<BaseItemDto>? NowPlayingQueueFullItems { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the session has a custom device name.
+    /// Gets or sets a value indicating whether this session has a custom device name.
     /// </summary>
     /// <value><c>true</c> if this session has a custom device name; otherwise, <c>false</c>.</value>
     public bool HasCustomDeviceName { get; set; }


### PR DESCRIPTION
## Summary

Removes the `NowPlayingQueueFullItems` property from session DTOs along with the associated population logic in `SessionManager`.

From what I could find, `NowPlayingQueueFullItems` no longer appears to be referenced outside of session population/copying. The removed logic was also rebuilding full DTOs for the queue whenever queue contents changed.

## Testing

- `dotnet build -p:AllowMissingPrunePackageData=true`
- `dotnet test -p:AllowMissingPrunePackageData=true`
- Local playback test
- Verified `/Sessions` still returns valid session data via Bruno