### PR TITLE
Improve language filters to only fetch language codes that match the requested items/libraries (follow up to #9787)

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3862,5 +3862,17 @@ namespace Emby.Server.Implementations.Library
         {
             return _mediaStreamRepository.GetMediaStreamLanguages(mediaStreamType);
         }
+
+        /// <inheritdoc />
+        public IReadOnlyList<string> GetMediaStreamLanguages(MediaStreamType mediaStreamType, InternalItemsQuery query)
+        {
+            if (query.User is not null)
+            {
+                AddUserToQuery(query, query.User);
+            }
+
+            SetTopParentOrAncestorIds(query);
+            return _itemRepository.GetMediaStreamLanguages(query, mediaStreamType);
+        }
     }
 }

--- a/Jellyfin.Api/Controllers/FilterController.cs
+++ b/Jellyfin.Api/Controllers/FilterController.cs
@@ -161,7 +161,7 @@ public class FilterController : BaseJellyfinApiController
         var streamLanguageQuery = new InternalItemsQuery(user)
         {
             // It's possible that different langauges are only available on alternative versions.
-            // To fetch them all, owned items are inlcluded.
+            // To fetch them all, owned items are included.
             IncludeOwnedItems = true,
             IncludeItemTypes = includeItemTypes,
             DtoOptions = new DtoOptions
@@ -194,7 +194,7 @@ public class FilterController : BaseJellyfinApiController
             && !includeItemTypes.Contains(BaseItemKind.Episode))
         {
             // streams are joined on epsiodes not shows or seasons
-            streamLanguageQuery.IncludeItemTypes = [..includeItemTypes, BaseItemKind.Episode];
+            streamLanguageQuery.IncludeItemTypes = [.. includeItemTypes, BaseItemKind.Episode];
         }
 
         if (includeItemTypes.Length == 1

--- a/Jellyfin.Api/Controllers/FilterController.cs
+++ b/Jellyfin.Api/Controllers/FilterController.cs
@@ -158,13 +158,42 @@ public class FilterController : BaseJellyfinApiController
             IsSeries = isSeries
         };
 
+        var streamLanguageQuery = new InternalItemsQuery(user)
+        {
+            // It's possible that different langauges are only available on alternative versions.
+            // To fetch them all, owned items are inlcluded.
+            IncludeOwnedItems = true,
+            IncludeItemTypes = includeItemTypes,
+            DtoOptions = new DtoOptions
+            {
+                Fields = Array.Empty<ItemFields>(),
+                EnableImages = false,
+                EnableUserData = false
+            },
+            IsAiring = isAiring,
+            IsMovie = isMovie,
+            IsSports = isSports,
+            IsKids = isKids,
+            IsNews = isNews,
+            IsSeries = isSeries
+        };
+
         if ((recursive ?? true) || parentItem is UserView || parentItem is ICollectionFolder)
         {
             genreQuery.AncestorIds = parentItem is null ? Array.Empty<Guid>() : new[] { parentItem.Id };
+            streamLanguageQuery.AncestorIds = parentItem is null ? Array.Empty<Guid>() : new[] { parentItem.Id };
         }
         else
         {
             genreQuery.Parent = parentItem;
+            streamLanguageQuery.Parent = parentItem;
+        }
+
+        if ((includeItemTypes.Contains(BaseItemKind.Series) || includeItemTypes.Contains(BaseItemKind.Season))
+            && !includeItemTypes.Contains(BaseItemKind.Episode))
+        {
+            // streams are joined on epsiodes not shows or seasons
+            streamLanguageQuery.IncludeItemTypes = [..includeItemTypes, BaseItemKind.Episode];
         }
 
         if (includeItemTypes.Length == 1
@@ -188,10 +217,13 @@ public class FilterController : BaseJellyfinApiController
             }).ToArray();
         }
 
-        if (includeItemTypes.Contains(BaseItemKind.Movie) || includeItemTypes.Contains(BaseItemKind.Series))
+        if (includeItemTypes.Contains(BaseItemKind.Movie)
+            || includeItemTypes.Contains(BaseItemKind.Series)
+            || includeItemTypes.Contains(BaseItemKind.Season)
+            || includeItemTypes.Contains(BaseItemKind.Episode))
         {
             filters.AudioLanguages = _libraryManager
-                .GetMediaStreamLanguages(MediaStreamType.Audio)
+                .GetMediaStreamLanguages(MediaStreamType.Audio, streamLanguageQuery)
                 .Select(language =>
                 {
                     var culture = _localization.FindLanguageInfo(language);
@@ -204,7 +236,7 @@ public class FilterController : BaseJellyfinApiController
                 .OrderBy(l => l.Name)
                 .ToArray();
             filters.SubtitleLanguages = _libraryManager
-                .GetMediaStreamLanguages(MediaStreamType.Subtitle)
+                .GetMediaStreamLanguages(MediaStreamType.Subtitle, streamLanguageQuery)
                 .Select(language =>
                 {
                     var culture = _localization.FindLanguageInfo(language);

--- a/Jellyfin.Api/Controllers/FilterController.cs
+++ b/Jellyfin.Api/Controllers/FilterController.cs
@@ -180,8 +180,9 @@ public class FilterController : BaseJellyfinApiController
 
         if ((recursive ?? true) || parentItem is UserView || parentItem is ICollectionFolder)
         {
-            genreQuery.AncestorIds = parentItem is null ? Array.Empty<Guid>() : new[] { parentItem.Id };
-            streamLanguageQuery.AncestorIds = parentItem is null ? Array.Empty<Guid>() : new[] { parentItem.Id };
+            var ancestorIds = parentItem is null ? Array.Empty<Guid>() : new[] { parentItem.Id };
+            genreQuery.AncestorIds = ancestorIds;
+            streamLanguageQuery.AncestorIds = ancestorIds;
         }
         else
         {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -87,11 +87,6 @@ public sealed partial class BaseItemRepository
     {
         ArgumentNullException.ThrowIfNull(filter);
 
-        if (!filter.Limit.HasValue)
-        {
-            filter.EnableTotalRecordCount = false;
-        }
-
         using var context = _dbProvider.CreateDbContext();
 
         return TranslateQuery(

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -7,6 +7,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.EntityFrameworkCore;
 using BaseItemDto = MediaBrowser.Controller.Entities.BaseItem;
@@ -79,6 +80,46 @@ public sealed partial class BaseItemRepository
             _getGenreValueTypes,
             [],
             _itemTypeLookup.MusicGenreTypes);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetMediaStreamLanguages(InternalItemsQuery filter, MediaStreamType mediaStreamType)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        if (!filter.Limit.HasValue)
+        {
+            filter.EnableTotalRecordCount = false;
+        }
+
+        using var context = _dbProvider.CreateDbContext();
+
+        return TranslateQuery(
+            context.BaseItems.Include(e => e.MediaStreams).Where(e => e.Id != EF.Constant(PlaceholderId)),
+            context,
+            new InternalItemsQuery(filter.User)
+            {
+                IncludeOwnedItems = filter.IncludeOwnedItems,
+                ExcludeItemTypes = filter.ExcludeItemTypes,
+                IncludeItemTypes = filter.IncludeItemTypes,
+                MediaTypes = filter.MediaTypes,
+                AncestorIds = filter.AncestorIds,
+                ItemIds = filter.ItemIds,
+                TopParentIds = filter.TopParentIds,
+                ParentId = filter.ParentId,
+                IsAiring = filter.IsAiring,
+                IsMovie = filter.IsMovie,
+                IsSports = filter.IsSports,
+                IsKids = filter.IsKids,
+                IsNews = filter.IsNews,
+                IsSeries = filter.IsSeries
+            })
+            .Where(e => e.MediaStreams != null)
+            .SelectMany(e => e.MediaStreams!)
+            .Where(e => e.StreamType == (MediaStreamTypeEntity)mediaStreamType)
+            .Select(s => string.IsNullOrEmpty(s.Language) ? "und" : s.Language) // und = undetermined
+            .Distinct()
+            .ToArray();
     }
 
     private string[] GetItemValueNames(IReadOnlyList<ItemValueType> itemValueTypes, IReadOnlyList<string> withItemTypes, IReadOnlyList<string> excludeItemTypes)

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -800,5 +800,13 @@ namespace MediaBrowser.Controller.Library
         /// <param name="mediaStreamType">The stream type.</param>
         /// <returns>List of language codes.</returns>
         IReadOnlyList<string> GetMediaStreamLanguages(MediaStreamType mediaStreamType);
+
+        /// <summary>
+        /// Gets a list of all language codes for the matching items and the the provided stream type.
+        /// </summary>
+        /// <param name="mediaStreamType">The stream type.</param>
+        /// <param name="query">The query filter.</param>
+        /// <returns>List of language codes.</returns>
+        IReadOnlyList<string> GetMediaStreamLanguages(MediaStreamType mediaStreamType, InternalItemsQuery query);
     }
 }

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -7,6 +7,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 
 namespace MediaBrowser.Controller.Persistence;
@@ -118,6 +119,14 @@ public interface IItemRepository
     /// </summary>
     /// <returns>The list of genre names.</returns>
     IReadOnlyList<string> GetGenreNames();
+
+    /// <summary>
+    /// Gets all language codes of the matching base items and the provided stream type.
+    /// </summary>
+    /// <param name="filter">The query filter.</param>
+    /// <param name="mediaStreamType">The type of the media stream.</param>
+    /// <returns>List of language codes.</returns>
+    public IReadOnlyList<string> GetMediaStreamLanguages(InternalItemsQuery filter, MediaStreamType mediaStreamType);
 
     /// <summary>
     /// Gets all artist names.


### PR DESCRIPTION
#9787 introduced language filters for audio and subtitles. One downside of the original implementation is that all language codes are fetched from the database when building the filter values, regardless of the requested item type or library.
I adapted the code so that the language codes are pre filtered based on the requested library and item types, similar to the genre filter values.

**Changes**
- only return language codes for the requested library and item types
-  enable language filters for season and episode views
