### PR TITLE
Refactor RemoveVirtualFolder not found handling

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -115,15 +115,15 @@ public class LibraryStructureController : BaseJellyfinApiController
             throw new ArgumentNullException(nameof(name));
         }
 
-        var virtualFolders = _libraryManager.GetVirtualFolders(true);
+        var virtualFolder = _libraryManager.GetVirtualFolders(true)
+            .FirstOrDefault(folder => string.Equals(folder.Name, name, StringComparison.Ordinal));
 
-        if (!virtualFolders.Any(folder =>
-                    string.Equals(folder.Name, name, StringComparison.OrdinalIgnoreCase)))
+        if (virtualFolder is null)
         {
             return NotFound("The media library does not exist.");
         }
 
-        await _libraryManager.RemoveVirtualFolder(name, refreshLibrary).ConfigureAwait(false);
+        await _libraryManager.RemoveVirtualFolder(virtualFolder.Name, refreshLibrary).ConfigureAwait(false);
 
         return NoContent();
     }

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -105,11 +105,24 @@ public class LibraryStructureController : BaseJellyfinApiController
     /// <returns>A <see cref="NoContentResult"/>.</returns>
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> RemoveVirtualFolder(
         [FromQuery] string name,
         [FromQuery] bool refreshLibrary = false)
     {
-        // TODO: refactor! this relies on an FileNotFound exception to return NotFound when attempting to remove a library that does not exist.
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        var rootFolderPath = _appPaths.DefaultUserViewsPath;
+        var currentPath = Path.Combine(rootFolderPath, name);
+
+        if (!Directory.Exists(currentPath))
+        {
+            return NotFound("The media library does not exist.");
+        }
+
         await _libraryManager.RemoveVirtualFolder(name, refreshLibrary).ConfigureAwait(false);
 
         return NoContent();

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -115,10 +115,10 @@ public class LibraryStructureController : BaseJellyfinApiController
             throw new ArgumentNullException(nameof(name));
         }
 
-        var rootFolderPath = _appPaths.DefaultUserViewsPath;
-        var currentPath = Path.Combine(rootFolderPath, name);
+        var virtualFolders = _libraryManager.GetVirtualFolders(true);
 
-        if (!Directory.Exists(currentPath))
+        if (!virtualFolders.Any(folder =>
+                    string.Equals(folder.Name, name, StringComparison.OrdinalIgnoreCase)))
         {
             return NotFound("The media library does not exist.");
         }


### PR DESCRIPTION
Refactors RemoveVirtualFolder to use an explicit check for the target folder's existence instead of relying on a FileNotFoundException to return a 404.

This addresses the existing TODO in LibraryStructureController.cs and keeps the 404 handling at the controller level instead of relying on manager-level exception handling.

Testing

dotnet build -p:AllowMissingPrunePackageData=true
dotnet test -p:AllowMissingPrunePackageData=true
Verified deleting an existing virtual folder returns 204
Verified deleting a nonexistent virtual folder returns 404
Verified /Library/VirtualFolders still returns valid data