### PR TITLE
Version-aware playback tracking and multi-version fixes

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -369,7 +369,7 @@ namespace Emby.Server.Implementations.Dto
                 AttachStudios(dto, item);
             }
 
-            AttachBasicFields(dto, item, owner, options, artistsBatch);
+            AttachBasicFields(dto, item, owner, options, artistsBatch, user);
 
             if (options.ContainsField(ItemFields.CanDelete))
             {
@@ -943,7 +943,8 @@ namespace Emby.Server.Implementations.Dto
         /// <param name="owner">The owner.</param>
         /// <param name="options">The options.</param>
         /// <param name="artistsBatch">Optional pre-fetched artist lookup shared across a batch of items.</param>
-        private void AttachBasicFields(BaseItemDto dto, BaseItem item, BaseItem? owner, DtoOptions options, IReadOnlyDictionary<string, MusicArtist[]>? artistsBatch = null)
+        /// <param name="user">The user, for per-user values such as the accessible media source count.</param>
+        private void AttachBasicFields(BaseItemDto dto, BaseItem item, BaseItem? owner, DtoOptions options, IReadOnlyDictionary<string, MusicArtist[]>? artistsBatch = null, User? user = null)
         {
             if (options.ContainsField(ItemFields.DateCreated))
             {
@@ -1257,7 +1258,11 @@ namespace Emby.Server.Implementations.Dto
 
                 if (options.ContainsField(ItemFields.MediaSourceCount))
                 {
-                    var mediaSourceCount = video.MediaSourceCount;
+                    // Match the per-user filtering of the media sources: versions the user cannot
+                    // access are not selectable, so they must not count towards the badge either.
+                    var mediaSourceCount = user is null
+                        ? video.MediaSourceCount
+                        : video.GetAllVersions().Count(v => v.Id.Equals(video.Id) || v.IsVisibleStandalone(user));
                     if (mediaSourceCount != 1)
                     {
                         dto.MediaSourceCount = mediaSourceCount;

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -386,6 +386,12 @@ namespace Emby.Server.Implementations.Library
 
             if (user is not null)
             {
+                sources = sources
+                    .Where(source => !Guid.TryParse(source.Id, out var sourceId)
+                        || sourceId.Equals(item.Id)
+                        || _libraryManager.GetItemById<BaseItem>(sourceId, user) is not null)
+                    .ToArray();
+
                 foreach (var source in sources)
                 {
                     SetDefaultAudioAndSubtitleStreamIndices(item, source, user);

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -229,7 +229,7 @@ namespace Emby.Server.Implementations.Library
                 list.Add(source);
             }
 
-            return SortMediaSources(list).ToArray();
+            return SortMediaSources(list, item.Id).ToArray();
         }
 
         /// <inheritdoc />>
@@ -540,24 +540,32 @@ namespace Emby.Server.Implementations.Library
             }
         }
 
-        private static IEnumerable<MediaSourceInfo> SortMediaSources(IEnumerable<MediaSourceInfo> sources)
+        private static IEnumerable<MediaSourceInfo> SortMediaSources(IEnumerable<MediaSourceInfo> sources, Guid preferredItemId = default)
         {
-            return sources.OrderBy(i =>
-            {
-                if (i.VideoType.HasValue && i.VideoType.Value == VideoType.VideoFile)
+            // The source belonging to the queried item sorts first so it stays the default that gets played.
+            var preferredId = preferredItemId.IsEmpty()
+                ? null
+                : preferredItemId.ToString("N", CultureInfo.InvariantCulture);
+
+            return sources
+                .OrderByDescending(i => preferredId is not null && string.Equals(i.Id, preferredId, StringComparison.OrdinalIgnoreCase))
+                .ThenBy(i =>
                 {
-                    return 0;
-                }
+                    if (i.VideoType.HasValue && i.VideoType.Value == VideoType.VideoFile)
+                    {
+                        return 0;
+                    }
 
-                return 1;
-            }).ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
-            .ThenByDescending(i =>
-            {
-                var stream = i.VideoStream;
+                    return 1;
+                })
+                .ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
+                .ThenByDescending(i =>
+                {
+                    var stream = i.VideoStream;
 
-                return stream?.Width ?? 0;
-            })
-            .Where(i => i.Type != MediaSourceType.Placeholder);
+                    return stream?.Width ?? 0;
+                })
+                .Where(i => i.Type != MediaSourceType.Placeholder);
         }
 
         public async Task<Tuple<LiveStreamResponse, IDirectStreamProvider>> OpenLiveStreamInternal(LiveStreamRequest request, CancellationToken cancellationToken)

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -385,5 +385,41 @@ namespace Emby.Server.Implementations.Library
 
             return playedToCompletion;
         }
+
+        /// <inheritdoc />
+        public void ResetPlaybackStreamSelections(User user, BaseItem item)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(item);
+
+            using var dbContext = _repository.CreateDbContext();
+            var rows = dbContext.UserData
+                .Where(e => e.ItemId == item.Id && e.UserId == user.Id
+                            && (e.AudioStreamIndex != null || e.SubtitleStreamIndex != null))
+                .ToList();
+
+            if (rows.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var row in rows)
+            {
+                row.AudioStreamIndex = null;
+                row.SubtitleStreamIndex = null;
+            }
+
+            dbContext.SaveChanges();
+
+            var cacheKey = GetCacheKey(user.InternalId, item.Id);
+            if (_cache.TryGet(cacheKey, out var cached))
+            {
+                cached.AudioStreamIndex = null;
+                cached.SubtitleStreamIndex = null;
+                _cache.AddOrUpdate(cacheKey, cached);
+            }
+
+            item.UserData = dbContext.UserData.Where(e => e.ItemId == item.Id).AsNoTracking().ToArray();
+        }
     }
 }

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/ChapterImagesTask.cs
@@ -92,7 +92,8 @@ public class ChapterImagesTask : IScheduledTask
                 EnableImages = false
             },
             SourceTypes = [SourceType.Library],
-            IsVirtualItem = false
+            IsVirtualItem = false,
+            IncludeOwnedItems = true
         })
         .OfType<Video>()
         .ToList();

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/MediaSegmentExtractionTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/MediaSegmentExtractionTask.cs
@@ -68,6 +68,7 @@ public class MediaSegmentExtractionTask : IScheduledTask
             DtoOptions = new DtoOptions(true),
             SourceTypes = [SourceType.Library],
             Recursive = true,
+            IncludeOwnedItems = true,
             Limit = pagesize
         };
 

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -726,6 +726,31 @@ namespace Emby.Server.Implementations.Session
         }
 
         /// <summary>
+        /// Resolves the item whose user data (playback position, played status) should be updated
+        /// for a playback report. When an alternate version is played the client reports the displayed
+        /// item as <c>ItemId</c> and the played version as <c>MediaSourceId</c>.
+        /// </summary>
+        /// <param name="libraryItem">The now playing (displayed) item.</param>
+        /// <param name="mediaSourceId">The reported media source id.</param>
+        /// <returns>The item to track progress against.</returns>
+        private BaseItem GetProgressItem(BaseItem libraryItem, string mediaSourceId)
+        {
+            if (libraryItem is Video libraryVideo
+                && !string.IsNullOrEmpty(mediaSourceId)
+                && Guid.TryParse(mediaSourceId, out var mediaSourceItemId)
+                && !mediaSourceItemId.Equals(libraryVideo.Id))
+            {
+                var versionItem = libraryVideo.GetAlternateVersion(mediaSourceItemId);
+                if (versionItem is not null)
+                {
+                    return versionItem;
+                }
+            }
+
+            return libraryItem;
+        }
+
+        /// <summary>
         /// Used to report that playback has started for an item.
         /// </summary>
         /// <param name="info">The info.</param>
@@ -756,9 +781,10 @@ namespace Emby.Server.Implementations.Session
 
             if (libraryItem is not null)
             {
+                var progressItem = GetProgressItem(libraryItem, info.MediaSourceId);
                 foreach (var user in users)
                 {
-                    OnPlaybackStart(user, libraryItem);
+                    OnPlaybackStart(user, progressItem);
                 }
             }
 
@@ -890,9 +916,10 @@ namespace Emby.Server.Implementations.Session
             // only update saved user data on actual check-ins, not automated ones
             if (libraryItem is not null && !isAutomated)
             {
+                var progressItem = GetProgressItem(libraryItem, info.MediaSourceId);
                 foreach (var user in users)
                 {
-                    OnPlaybackProgress(user, libraryItem, info);
+                    OnPlaybackProgress(user, progressItem, info);
                 }
             }
 
@@ -952,6 +979,17 @@ namespace Emby.Server.Implementations.Session
             if (changed)
             {
                 _userDataManager.SaveUserData(user, item, data, UserDataSaveReason.PlaybackProgress, CancellationToken.None);
+
+                if (data.Played == true && item is Video playedVideo)
+                {
+                    playedVideo.PropagatePlayedState(user, true);
+                }
+            }
+
+            if ((!user.RememberAudioSelections && data.AudioStreamIndex.HasValue)
+                || (!user.RememberSubtitleSelections && data.SubtitleStreamIndex.HasValue))
+            {
+                _userDataManager.ResetPlaybackStreamSelections(user, item);
             }
         }
 
@@ -1083,9 +1121,10 @@ namespace Emby.Server.Implementations.Session
 
             if (libraryItem is not null)
             {
+                var progressItem = GetProgressItem(libraryItem, info.MediaSourceId);
                 foreach (var user in users)
                 {
-                    playedToCompletion = OnPlaybackStopped(user, libraryItem, info.PositionTicks, info.Failed);
+                    playedToCompletion = OnPlaybackStopped(user, progressItem, info.PositionTicks, info.Failed);
                 }
             }
 
@@ -1137,6 +1176,12 @@ namespace Emby.Server.Implementations.Session
             }
 
             _userDataManager.SaveUserData(user, item, data, UserDataSaveReason.PlaybackFinished, CancellationToken.None);
+
+            // A completed version marks all of its alternate versions played; positions stay per-version.
+            if (data.Played == true && item is Video playedVideo)
+            {
+                playedVideo.PropagatePlayedState(user, true);
+            }
 
             return playedToCompletion;
         }

--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Jellyfin.Data;
 using Jellyfin.Data.Enums;
@@ -136,11 +137,15 @@ namespace Emby.Server.Implementations.TV
 
                 if (nextEpisode is not null)
                 {
+                    // The last played date and the version that was actually played live on the version item's user data
+                    // The played state propagated to the sibling versions carries no date
+                    var (playedVersion, lastPlayedDate) = GetMostRecentlyPlayedVersion(result.LastWatched, user);
+                    nextEpisode = GetPreferredVersion(nextEpisode, result.LastWatched, playedVersion);
+
                     DateTime lastWatchedDate = DateTime.MinValue;
                     if (result.LastWatched is not null)
                     {
-                        var userData = _userDataManager.GetUserData(user, result.LastWatched);
-                        lastWatchedDate = userData?.LastPlayedDate ?? DateTime.MinValue.AddDays(1);
+                        lastWatchedDate = lastPlayedDate ?? DateTime.MinValue.AddDays(1);
                     }
 
                     nextUpList.Add((lastWatchedDate, nextEpisode));
@@ -152,11 +157,13 @@ namespace Emby.Server.Implementations.TV
 
                     if (nextPlayedEpisode is not null)
                     {
+                        var (playedVersion, lastPlayedDate) = GetMostRecentlyPlayedVersion(result.LastWatchedForRewatching, user);
+                        nextPlayedEpisode = GetPreferredVersion(nextPlayedEpisode, result.LastWatchedForRewatching, playedVersion);
+
                         DateTime rewatchLastWatchedDate = DateTime.MinValue;
                         if (result.LastWatchedForRewatching is not null)
                         {
-                            var userData = _userDataManager.GetUserData(user, result.LastWatchedForRewatching);
-                            rewatchLastWatchedDate = userData?.LastPlayedDate ?? DateTime.MinValue.AddDays(1);
+                            rewatchLastWatchedDate = lastPlayedDate ?? DateTime.MinValue.AddDays(1);
                         }
 
                         nextUpList.Add((rewatchLastWatchedDate, nextPlayedEpisode));
@@ -219,10 +226,13 @@ namespace Emby.Server.Implementations.TV
 
             if (nextEpisode is not null && !includeResumable)
             {
-                var userData = _userDataManager.GetUserData(user, nextEpisode);
-                if (userData?.PlaybackPositionTicks > 0)
+                // The resume progress may live on an alternate version
+                foreach (var version in nextEpisode.GetAllVersions())
                 {
-                    return null;
+                    if (_userDataManager.GetUserData(user, version)?.PlaybackPositionTicks > 0)
+                    {
+                        return null;
+                    }
                 }
             }
 
@@ -235,6 +245,78 @@ namespace Emby.Server.Implementations.TV
             bool includeSpecials)
         {
             return DetermineNextEpisode(result, user, includeSpecials, includeResumable: false, includePlayed: true);
+        }
+
+        /// <summary>
+        /// Gets the version of the last watched episode that was actually played, together with its last played date.
+        /// The version that was played carries the most recent LastPlayedDate.
+        /// dates.
+        /// </summary>
+        /// <param name="lastWatched">The last watched episode (any version).</param>
+        /// <param name="user">The user.</param>
+        /// <returns>The played version and its last played date.</returns>
+        private (Video? PlayedVersion, DateTime? LastPlayedDate) GetMostRecentlyPlayedVersion(BaseItem? lastWatched, User user)
+        {
+            if (lastWatched is not Video lastWatchedVideo)
+            {
+                return (null, null);
+            }
+
+            Video? playedVersion = null;
+            DateTime? lastPlayedDate = null;
+            foreach (var version in lastWatchedVideo.GetAllVersions())
+            {
+                var data = _userDataManager.GetUserData(user, version);
+                if (data?.LastPlayedDate is { } date && (lastPlayedDate is null || date > lastPlayedDate))
+                {
+                    lastPlayedDate = date;
+                    playedVersion = version;
+                }
+            }
+
+            return (playedVersion, lastPlayedDate);
+        }
+
+        /// <summary>
+        /// When the last watched episode was played as an alternate version, prefer the next episode's version with the matching name,
+        /// so Next Up continues in the version the user has been watching instead of falling back to the primary.
+        /// </summary>
+        /// <param name="nextEpisode">The determined next episode (a primary).</param>
+        /// <param name="lastWatched">The last watched episode.</param>
+        /// <param name="playedVersion">The version of the last watched episode that was played.</param>
+        /// <returns>The matching version of the next episode, or the episode itself.</returns>
+        private Episode GetPreferredVersion(Episode nextEpisode, BaseItem? lastWatched, Video? playedVersion)
+        {
+            // No version preference, or the primary was played
+            if (lastWatched is not Video lastWatchedVideo
+                || playedVersion is null
+                || !playedVersion.PrimaryVersionId.HasValue)
+            {
+                return nextEpisode;
+            }
+
+            // Match by version name
+            var playedVersionId = playedVersion.Id.ToString("N", CultureInfo.InvariantCulture);
+            var playedVersionName = lastWatchedVideo.GetMediaSources(false)
+                .FirstOrDefault(source => string.Equals(source.Id, playedVersionId, StringComparison.OrdinalIgnoreCase))?.Name;
+
+            if (string.IsNullOrEmpty(playedVersionName))
+            {
+                return nextEpisode;
+            }
+
+            var matchingSource = nextEpisode.GetMediaSources(false)
+                .FirstOrDefault(source => string.Equals(source.Name, playedVersionName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchingSource is not null
+                && Guid.TryParse(matchingSource.Id, out var matchingId)
+                && !matchingId.Equals(nextEpisode.Id)
+                && _libraryManager.GetItemById<Episode>(matchingId) is { } matchingVersion)
+            {
+                return matchingVersion;
+            }
+
+            return nextEpisode;
         }
 
         private static string GetUniqueSeriesKey(Series series)

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -919,6 +919,7 @@ public class ItemsController : BaseJellyfinApiController
             MediaTypes = mediaTypes,
             IsVirtualItem = false,
             CollapseBoxSetItems = false,
+            IncludeOwnedItems = true,
             EnableTotalRecordCount = enableTotalRecordCount,
             AncestorIds = ancestorIds,
             IncludeItemTypes = includeItemTypes,

--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -213,7 +213,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     Request.HttpContext.GetNormalizedRemoteIP());
             }
 
-            _mediaInfoHelper.SortMediaSources(info, maxStreamingBitrate);
+            _mediaInfoHelper.SortMediaSources(info, maxStreamingBitrate, item.Id);
         }
 
         if (autoOpenLiveStream.Value)

--- a/Jellyfin.Api/Controllers/TvShowsController.cs
+++ b/Jellyfin.Api/Controllers/TvShowsController.cs
@@ -277,8 +277,15 @@ public class TvShowsController : BaseJellyfinApiController
 
         if (startItemId.HasValue)
         {
+            // The start item may be an alternate version, which is not part of the episode listing; start from its primary episode instead.
+            var startId = startItemId.Value;
+            if (_libraryManager.GetItemById<Video>(startId)?.PrimaryVersionId is { } primaryVersionId)
+            {
+                startId = primaryVersionId;
+            }
+
             episodes = episodes
-                .SkipWhile(i => !startItemId.Value.Equals(i.Id))
+                .SkipWhile(i => !startId.Equals(i.Id))
                 .ToList();
         }
 

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -163,7 +163,7 @@ public class UniversalAudioController : BaseJellyfinApiController
                 Request.HttpContext.GetNormalizedRemoteIP());
         }
 
-        _mediaInfoHelper.SortMediaSources(info, maxStreamingBitrate);
+        _mediaInfoHelper.SortMediaSources(info, maxStreamingBitrate, item.Id);
 
         foreach (var source in info.MediaSources)
         {

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -216,9 +216,17 @@ public class VideosController : BaseJellyfinApiController
         }
 
         var alternateVersionsOfPrimary = primaryVersion.LinkedAlternateVersions.ToList();
+        var localAlternateIds = _libraryManager.GetLocalAlternateVersionIds(primaryVersion).ToHashSet();
 
         foreach (var item in items.Where(i => !i.Id.Equals(primaryVersion.Id)))
         {
+            if (localAlternateIds.Contains(item.Id))
+            {
+                // Already a local (file-based) alternate of the primary; linking it would
+                // wrongly mark the group as user-merged (splittable).
+                continue;
+            }
+
             item.SetPrimaryVersionId(primaryVersion.Id);
 
             await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None).ConfigureAwait(false);

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -351,11 +351,20 @@ public class MediaInfoHelper
     /// </summary>
     /// <param name="result">Playback info response.</param>
     /// <param name="maxBitrate">Max bitrate.</param>
-    public void SortMediaSources(PlaybackInfoResponse result, long? maxBitrate)
+    /// <param name="preferredItemId">The id of the queried item, whose own media source must stay the default.</param>
+    public void SortMediaSources(PlaybackInfoResponse result, long? maxBitrate, Guid preferredItemId = default)
     {
         var originalList = result.MediaSources.ToList();
 
-        result.MediaSources = result.MediaSources.OrderBy(i =>
+        // The queried item's source carries the user's resume state for that version, so it must stay the
+        // default the client plays. An unfavorable bitrate means transcoding it, not switching to a sibling version.
+        var preferredId = preferredItemId.IsEmpty()
+            ? null
+            : preferredItemId.ToString("N", CultureInfo.InvariantCulture);
+
+        result.MediaSources = result.MediaSources
+            .OrderByDescending(i => preferredId is not null && string.Equals(i.Id, preferredId, StringComparison.OrdinalIgnoreCase))
+            .ThenBy(i =>
             {
                 // Nothing beats direct playing a file
                 if (i.SupportsDirectPlay && i.Protocol == MediaProtocol.File)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -62,18 +62,21 @@ public sealed partial class BaseItemRepository
 
     private IQueryable<BaseItemEntity> ApplyGroupingFilter(JellyfinDbContext context, IQueryable<BaseItemEntity> dbQuery, InternalItemsQuery filter)
     {
-        // Collapse duplicates sharing a presentation key (e.g. alternate versions) by picking
-        // the min Id per group. Keep the grouped ids as an IQueryable sub-select; materializing
+        // Collapse duplicates sharing a presentation key (e.g. alternate versions), preferring the
+        // primary version (PrimaryVersionId is null) so detail pages and actions target it instead
+        // of an arbitrary alternate. Keep the grouped ids as an IQueryable sub-select; materializing
         // to a List would inline one bound parameter per id and hit SQLite's variable cap.
         var enableGroupByPresentationUniqueKey = EnableGroupByPresentationUniqueKey(filter);
         if (enableGroupByPresentationUniqueKey && filter.GroupBySeriesPresentationUniqueKey)
         {
-            var groupedIds = dbQuery.GroupBy(e => new { e.PresentationUniqueKey, e.SeriesPresentationUniqueKey }).Select(e => e.Min(x => x.Id));
+            var groupedIds = dbQuery.GroupBy(e => new { e.PresentationUniqueKey, e.SeriesPresentationUniqueKey })
+                .Select(g => g.Where(e => e.PrimaryVersionId == null).Min(e => (Guid?)e.Id) ?? g.Min(e => (Guid?)e.Id));
             dbQuery = context.BaseItems.AsNoTracking().Where(e => groupedIds.Contains(e.Id));
         }
         else if (enableGroupByPresentationUniqueKey)
         {
-            var groupedIds = dbQuery.GroupBy(e => e.PresentationUniqueKey).Select(e => e.Min(x => x.Id));
+            var groupedIds = dbQuery.GroupBy(e => e.PresentationUniqueKey)
+                .Select(g => g.Where(e => e.PrimaryVersionId == null).Min(e => (Guid?)e.Id) ?? g.Min(e => (Guid?)e.Id));
             dbQuery = context.BaseItems.AsNoTracking().Where(e => groupedIds.Contains(e.Id));
         }
         else if (filter.GroupBySeriesPresentationUniqueKey)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -513,12 +513,17 @@ public sealed partial class BaseItemRepository
         if (filter.IsResumable.HasValue)
         {
             var hasSeries = filter.IncludeItemTypes.Contains(BaseItemKind.Series);
+            var userId = filter.User!.Id;
+            var isResumable = filter.IsResumable.Value;
+
+            // In-progress user data rows; alternate versions track their own progress.
+            var inProgress = context.UserData
+                .Where(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0);
+            var resumableItemIds = inProgress.Select(ud => ud.ItemId);
 
             if (hasSeries)
             {
-                var userId = filter.User!.Id;
                 var seriesTypeName = _itemTypeLookup.BaseItemKindNames[BaseItemKind.Series];
-                var isResumable = filter.IsResumable.Value;
 
                 // Aggregate per series in a single GROUP BY pass, instead of three full scans.
                 var seriesEpisodeStats = context.BaseItems
@@ -539,22 +544,23 @@ public sealed partial class BaseItemRepository
                     .Where(s => s.HasInProgress || (s.HasPlayed && s.HasUnplayed))
                     .Select(s => s.SeriesId);
 
-                // Non-series items: resumable if PlaybackPositionTicks > 0
-                var resumableItemIds = context.UserData
-                    .Where(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0)
-                    .Select(ud => ud.ItemId);
-
                 baseQuery = baseQuery.Where(e =>
                     (e.Type == seriesTypeName && resumableSeriesIds.Contains(e.Id) == isResumable)
                     || (e.Type != seriesTypeName && resumableItemIds.Contains(e.Id) == isResumable));
             }
             else
             {
-                var resumableItemIds = context.UserData
-                    .Where(ud => ud.UserId == filter.User!.Id && ud.PlaybackPositionTicks > 0)
-                    .Select(ud => ud.ItemId);
-                var isResumable = filter.IsResumable.Value;
                 baseQuery = baseQuery.Where(e => resumableItemIds.Contains(e.Id) == isResumable);
+            }
+
+            if (isResumable)
+            {
+                // Multi-version items surface as the version that was actually played.
+                // When several versions of the same item are in progress, keep only the most recently played one.
+                baseQuery = baseQuery.Where(e => !context.BaseItems
+                    .Where(s => s.Id != e.Id && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
+                    .Any(s => inProgress.Where(su => su.ItemId == s.Id).Max(su => su.LastPlayedDate)
+                        > inProgress.Where(eu => eu.ItemId == e.Id).Max(eu => eu.LastPlayedDate)));
             }
         }
 

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -557,9 +557,11 @@ public class ItemPersistenceService : IItemPersistenceService
                     }
                 }
 
+                // Deduplicate; local (file-based) relationships take priority over linked (user-merged)
+                // ones, matching the LinkedChildren migration.
                 newLinkedChildren = newLinkedChildren
                     .GroupBy(c => c.ChildId)
-                    .Select(g => g.Last())
+                    .Select(g => g.OrderBy(c => c.Type == LinkedChildType.LocalAlternateVersion ? 0 : 1).First())
                     .ToList();
 
                 var childIdsToCheck = newLinkedChildren.Select(c => c.ChildId).ToList();

--- a/Jellyfin.Server.Implementations/Item/OrderMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/OrderMapper.cs
@@ -34,7 +34,10 @@ public static class OrderMapper
             (ItemSortBy.AirTime, _) => e => e.SortName,
             (ItemSortBy.Runtime, _) => e => e.RunTimeTicks,
             (ItemSortBy.Random, _) => e => EF.Functions.Random(),
-            (ItemSortBy.DatePlayed, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.LastPlayedDate,
+            (ItemSortBy.DatePlayed, not null) => e =>
+                jellyfinDbContext.UserData
+                    .Where(w => w.UserId == query.User.Id && (w.ItemId == e.Id || w.Item!.PrimaryVersionId == e.Id))
+                    .Max(f => f.LastPlayedDate),
             (ItemSortBy.PlayCount, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.PlayCount,
             (ItemSortBy.IsFavoriteOrLiked, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).Select(f => (bool?)f.IsFavorite).FirstOrDefault() ?? false,
             (ItemSortBy.IsFolder, _) => e => e.IsFolder,

--- a/Jellyfin.Server/Migrations/Routines/20260113120000_MigrateLinkedChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260113120000_MigrateLinkedChildren.cs
@@ -223,6 +223,35 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
 
                 toInsert = toInsert.Where(lc => existingChildIds.Contains(lc.ChildId)).ToList();
 
+                // Drop linked (user-merged) entries that point at items the parent owns (local
+                // file-based alternates or extras). These stem from legacy data that merged an
+                // owned item onto its own primary and would wrongly mark server-merged groups
+                // as user-merged (splittable).
+                var linkedChildIds = toInsert
+                    .Where(lc => lc.ChildType == LinkedChildType.LinkedAlternateVersion)
+                    .Select(lc => lc.ChildId)
+                    .Distinct()
+                    .ToList();
+
+                if (linkedChildIds.Count > 0)
+                {
+                    var ownerIdByChildId = context.BaseItems
+                        .WhereOneOrMany(linkedChildIds, b => b.Id)
+                        .Where(b => b.OwnerId.HasValue)
+                        .Select(b => new { b.Id, b.OwnerId })
+                        .ToDictionary(b => b.Id, b => b.OwnerId!.Value);
+
+                    var removedCount = toInsert.RemoveAll(lc =>
+                        lc.ChildType == LinkedChildType.LinkedAlternateVersion
+                        && ownerIdByChildId.TryGetValue(lc.ChildId, out var ownerId)
+                        && ownerId.Equals(lc.ParentId));
+
+                    if (removedCount > 0)
+                    {
+                        _logger.LogInformation("Skipped {Count} LinkedAlternateVersion records pointing at items owned by their parent.", removedCount);
+                    }
+                }
+
                 context.LinkedChildren.AddRange(toInsert);
                 context.SaveChanges();
 

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2112,12 +2112,23 @@ namespace MediaBrowser.Controller.Entities
             // I think it is okay to do this here.
             // if this is only called when a user is manually forcing something to un-played
             // then it probably is what we want to do...
+            ResetPlayedState(data);
+
+            UserDataManager.SaveUserData(user, this, data, UserDataSaveReason.TogglePlayed, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Clears the played state on the supplied user data.
+        /// </summary>
+        /// <param name="data">The user data to reset.</param>
+        protected static void ResetPlayedState(UserItemData data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
             data.PlayCount = 0;
             data.PlaybackPositionTicks = 0;
             data.LastPlayedDate = null;
             data.Played = false;
-
-            UserDataManager.SaveUserData(user, this, data, UserDataSaveReason.TogglePlayed, CancellationToken.None);
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -87,6 +87,10 @@ namespace MediaBrowser.Controller.Entities
             Model.Entities.ExtraType.Short
         };
 
+        // Separators the naming layer treats as version delimiters (Emby.Naming VideoFlagDelimiters),
+        // used when stripping the shared prefix from an alternate version's media source name.
+        private static readonly char[] VersionSeparators = [' ', '-', '_', '.'];
+
         private string _sortName;
 
         private string _forcedSortName;
@@ -1099,8 +1103,9 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
-            var list = GetAllItemsForMediaSources();
-            var result = list.Select(i => GetVersionInfo(enablePathSubstitution, i.Item, i.MediaSourceType)).ToList();
+            var list = GetAllItemsForMediaSources().ToList();
+            var commonPrefix = GetCommonNamePrefix(list);
+            var result = list.Select(i => GetVersionInfo(enablePathSubstitution, i.Item, i.MediaSourceType, commonPrefix)).ToList();
 
             if (IsActiveRecording())
             {
@@ -1128,7 +1133,7 @@ namespace MediaBrowser.Controller.Entities
             return Enumerable.Empty<(BaseItem, MediaSourceType)>();
         }
 
-        private MediaSourceInfo GetVersionInfo(bool enablePathSubstitution, BaseItem item, MediaSourceType type)
+        private MediaSourceInfo GetVersionInfo(bool enablePathSubstitution, BaseItem item, MediaSourceType type, string commonPrefix = null)
         {
             ArgumentNullException.ThrowIfNull(item);
 
@@ -1141,7 +1146,7 @@ namespace MediaBrowser.Controller.Entities
                 Protocol = protocol ?? MediaProtocol.File,
                 MediaStreams = MediaSourceManager.GetMediaStreams(item.Id),
                 MediaAttachments = MediaSourceManager.GetMediaAttachments(item.Id),
-                Name = GetMediaSourceName(item),
+                Name = GetMediaSourceName(item, commonPrefix),
                 Path = enablePathSubstitution ? GetMappedPath(item, itemPath, protocol) : itemPath,
                 RunTimeTicks = item.RunTimeTicks,
                 Container = item.Container,
@@ -1220,7 +1225,7 @@ namespace MediaBrowser.Controller.Entities
             return info;
         }
 
-        internal string GetMediaSourceName(BaseItem item)
+        internal string GetMediaSourceName(BaseItem item, string commonPrefix = null)
         {
             var terms = new List<string>();
 
@@ -1228,12 +1233,31 @@ namespace MediaBrowser.Controller.Entities
             if (item.IsFileProtocol && !string.IsNullOrEmpty(path))
             {
                 var displayName = System.IO.Path.GetFileNameWithoutExtension(path);
-                if (HasLocalAlternateVersions)
+
+                // Prefer the suffix that differs from the other versions: strip the prefix shared by
+                // all sibling files. This works regardless of folder layout, so it also labels episode
+                // versions that share a season folder (e.g. "Greyscale" instead of the full
+                // "Show - S01E02 - Title - Greyscale"). The prefix is already retreated to a separator
+                // boundary (see GetCommonVersionPrefix).
+                if (!string.IsNullOrEmpty(commonPrefix)
+                    && displayName.Length > commonPrefix.Length
+                    && displayName.StartsWith(commonPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var name = displayName.AsSpan(commonPrefix.Length).TrimStart(VersionSeparators);
+                    if (!name.IsWhiteSpace())
+                    {
+                        terms.Add(name.ToString());
+                    }
+                }
+
+                // Fall back to the containing folder name (the common layout for movie versions, and
+                // the path taken when no common prefix could be derived).
+                if (terms.Count == 0 && HasLocalAlternateVersions)
                 {
                     var containingFolderName = System.IO.Path.GetFileName(ContainingFolderPath);
                     if (displayName.Length > containingFolderName.Length && displayName.StartsWith(containingFolderName, StringComparison.OrdinalIgnoreCase))
                     {
-                        var name = displayName.AsSpan(containingFolderName.Length).TrimStart([' ', '-']);
+                        var name = displayName.AsSpan(containingFolderName.Length).TrimStart(VersionSeparators);
                         if (!name.IsWhiteSpace())
                         {
                             terms.Add(name.ToString());
@@ -1288,6 +1312,85 @@ namespace MediaBrowser.Controller.Entities
             }
 
             return string.Join('/', terms);
+        }
+
+        /// <summary>
+        /// Derives the prefix shared by the supplied media source items' file names, used to strip the
+        /// common part and surface a short version label per source. Returns null when there are fewer
+        /// than two file-based sources, since there is nothing to differentiate.
+        /// </summary>
+        /// <param name="items">The media source items.</param>
+        /// <returns>The shared prefix, or null when no useful prefix exists.</returns>
+        private static string GetCommonNamePrefix(IReadOnlyList<(BaseItem Item, MediaSourceType MediaSourceType)> items)
+        {
+            var fileNames = new List<string>();
+            foreach (var (item, _) in items)
+            {
+                if (item.IsFileProtocol && !string.IsNullOrEmpty(item.Path))
+                {
+                    fileNames.Add(System.IO.Path.GetFileNameWithoutExtension(item.Path));
+                }
+            }
+
+            if (fileNames.Count < 2)
+            {
+                return null;
+            }
+
+            var prefix = GetCommonVersionPrefix(fileNames);
+            return string.IsNullOrEmpty(prefix) ? null : prefix;
+        }
+
+        /// <summary>
+        /// Computes the case-insensitive longest common prefix of the supplied version file names,
+        /// retreated to the last separator boundary. Retreating keeps the differing suffix intact:
+        /// it avoids slicing through a word every version shares (e.g. "Grey" in "Greyscale" and
+        /// "Greyish") while still trimming the common part when every version is suffixed (e.g.
+        /// "- Greyscale" / "- Colorized"). The separators mirror the version delimiters recognised by
+        /// the naming layer (Emby.Naming VideoFlagDelimiters).
+        /// </summary>
+        /// <param name="fileNames">The version file names without extension; must contain at least one entry.</param>
+        /// <returns>The shared prefix retreated to a separator boundary, or an empty string when none is shared.</returns>
+        internal static string GetCommonVersionPrefix(IReadOnlyList<string> fileNames)
+        {
+            var prefix = fileNames[0];
+            for (var i = 1; i < fileNames.Count && prefix.Length > 0; i++)
+            {
+                var name = fileNames[i];
+                var length = Math.Min(prefix.Length, name.Length);
+                var common = 0;
+                while (common < length && char.ToUpperInvariant(prefix[common]) == char.ToUpperInvariant(name[common]))
+                {
+                    common++;
+                }
+
+                prefix = prefix[..common];
+            }
+
+            // If the common prefix is itself a whole file name then one version is unlabelled (the
+            // base name); the boundary already sits at the end of that name, so don't retreat into it.
+            var prefixIsWholeName = false;
+            for (var i = 0; i < fileNames.Count; i++)
+            {
+                if (fileNames[i].Length == prefix.Length)
+                {
+                    prefixIsWholeName = true;
+                    break;
+                }
+            }
+
+            if (!prefixIsWholeName)
+            {
+                var cut = prefix.Length;
+                while (cut > 0 && Array.IndexOf(VersionSeparators, prefix[cut - 1]) < 0)
+                {
+                    cut--;
+                }
+
+                prefix = prefix[..cut];
+            }
+
+            return prefix;
         }
 
         public Task RefreshMetadata(CancellationToken cancellationToken)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2855,6 +2855,15 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
+        /// Gets the ids of the items whose owned extras belong to this item.
+        /// </summary>
+        /// <returns>An array containing the owner ids.</returns>
+        protected virtual Guid[] GetExtraOwnerIds()
+        {
+            return [Id];
+        }
+
+        /// <summary>
         /// Get all extras associated with this item, sorted by <see cref="SortName"/>.
         /// </summary>
         /// <returns>An enumerable containing the items.</returns>
@@ -2862,7 +2871,7 @@ namespace MediaBrowser.Controller.Entities
         {
             return LibraryManager.GetItemList(new InternalItemsQuery()
             {
-                OwnerIds = [Id],
+                OwnerIds = GetExtraOwnerIds(),
                 OrderBy = [(ItemSortBy.SortName, SortOrder.Ascending)]
             });
         }
@@ -2876,7 +2885,7 @@ namespace MediaBrowser.Controller.Entities
         {
             return LibraryManager.GetItemList(new InternalItemsQuery()
             {
-                OwnerIds = [Id],
+                OwnerIds = GetExtraOwnerIds(),
                 ExtraTypes = extraTypes.ToArray(),
                 OrderBy = [(ItemSortBy.SortName, SortOrder.Ascending)]
             });

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1115,17 +1115,15 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
-            return result.OrderBy(i =>
-            {
-                if (i.VideoType == VideoType.VideoFile)
-                {
-                    return 0;
-                }
+            // The source belonging to the item being queried sorts first so it is the default the client plays.
+            var selfId = Id.ToString("N", CultureInfo.InvariantCulture);
 
-                return 1;
-            }).ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
-            .ThenByDescending(i => i, new MediaSourceWidthComparator())
-            .ToArray();
+            return result
+                .OrderByDescending(i => string.Equals(i.Id, selfId, StringComparison.OrdinalIgnoreCase))
+                .ThenBy(i => i.VideoType == VideoType.VideoFile ? 0 : 1)
+                .ThenBy(i => i.Video3DFormat.HasValue ? 1 : 0)
+                .ThenByDescending(i => i, new MediaSourceWidthComparator())
+                .ToArray();
         }
 
         protected virtual IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -87,9 +87,7 @@ namespace MediaBrowser.Controller.Entities
             Model.Entities.ExtraType.Short
         };
 
-        // Separators the naming layer treats as version delimiters (Emby.Naming VideoFlagDelimiters),
-        // used when stripping the shared prefix from an alternate version's media source name.
-        private static readonly char[] VersionSeparators = [' ', '-', '_', '.'];
+        private static readonly char[] VersionDelimiters = ['-', '_', '.'];
 
         private string _sortName;
 
@@ -1235,13 +1233,13 @@ namespace MediaBrowser.Controller.Entities
                 // Prefer the suffix that differs from the other versions: strip the prefix shared by
                 // all sibling files. This works regardless of folder layout, so it also labels episode
                 // versions that share a season folder (e.g. "Greyscale" instead of the full
-                // "Show - S01E02 - Title - Greyscale"). The prefix is already retreated to a separator
+                // "Show - S01E02 - Title - Greyscale"). The prefix is already retreated to a delimiter
                 // boundary (see GetCommonVersionPrefix).
                 if (!string.IsNullOrEmpty(commonPrefix)
                     && displayName.Length > commonPrefix.Length
                     && displayName.StartsWith(commonPrefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    var name = displayName.AsSpan(commonPrefix.Length).TrimStart(VersionSeparators);
+                    var name = displayName.AsSpan(commonPrefix.Length).TrimStart([' ', .. VersionDelimiters]);
                     if (!name.IsWhiteSpace())
                     {
                         terms.Add(name.ToString());
@@ -1255,7 +1253,7 @@ namespace MediaBrowser.Controller.Entities
                     var containingFolderName = System.IO.Path.GetFileName(ContainingFolderPath);
                     if (displayName.Length > containingFolderName.Length && displayName.StartsWith(containingFolderName, StringComparison.OrdinalIgnoreCase))
                     {
-                        var name = displayName.AsSpan(containingFolderName.Length).TrimStart(VersionSeparators);
+                        var name = displayName.AsSpan(containingFolderName.Length).TrimStart([' ', .. VersionDelimiters]);
                         if (!name.IsWhiteSpace())
                         {
                             terms.Add(name.ToString());
@@ -1341,11 +1339,14 @@ namespace MediaBrowser.Controller.Entities
 
         /// <summary>
         /// Computes the case-insensitive longest common prefix of the supplied version file names,
-        /// retreated to the last separator boundary. Retreating keeps the differing suffix intact:
+        /// retreated to the last delimiter boundary. Retreating keeps the differing suffix intact:
         /// it avoids slicing through a word every version shares (e.g. "Grey" in "Greyscale" and
         /// "Greyish") while still trimming the common part when every version is suffixed (e.g.
-        /// "- Greyscale" / "- Colorized"). The separators mirror the version delimiters recognised by
-        /// the naming layer (Emby.Naming VideoFlagDelimiters).
+        /// "- Greyscale" / "- Colorized"). It prefers a structural delimiter ('-', '_', '.') so a
+        /// token shared by the descriptors but separated only by spaces (e.g. a common "2160p ") is
+        /// kept in the label, falling back to a space only when no structural delimiter is shared. The
+        /// separators mirror the version delimiters recognised by the naming layer (Emby.Naming
+        /// VideoFlagDelimiters).
         /// </summary>
         /// <param name="fileNames">The version file names without extension; must contain at least one entry.</param>
         /// <returns>The shared prefix retreated to a separator boundary, or an empty string when none is shared.</returns>
@@ -1379,10 +1380,20 @@ namespace MediaBrowser.Controller.Entities
 
             if (!prefixIsWholeName)
             {
+                // Retreat to the last structural delimiter ('-', '_', '.').
                 var cut = prefix.Length;
-                while (cut > 0 && Array.IndexOf(VersionSeparators, prefix[cut - 1]) < 0)
+                while (cut > 0 && Array.IndexOf(VersionDelimiters, prefix[cut - 1]) < 0)
                 {
                     cut--;
+                }
+
+                if (cut == 0)
+                {
+                    cut = prefix.Length;
+                    while (cut > 0 && prefix[cut - 1] != ' ')
+                    {
+                        cut--;
+                    }
                 }
 
                 prefix = prefix[..cut];

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -738,6 +738,19 @@ namespace MediaBrowser.Controller.Entities
             }).FirstOrDefault();
         }
 
+        /// <summary>
+        /// Gets the ids of the items whose owned extras belong to this item.
+        /// Extras are linked to a single version but need tp be surfaced for all versions.
+        /// </summary>
+        /// <returns>An array containing the owner ids.</returns>
+        protected override Guid[] GetExtraOwnerIds()
+        {
+            return GetAllItemsForMediaSources()
+                .Select(i => i.Item.Id)
+                .Distinct()
+                .ToArray();
+        }
+
         protected override IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()
         {
             var primary = PrimaryVersionId.HasValue

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -254,7 +254,7 @@ namespace MediaBrowser.Controller.Entities
 
         private int GetMediaSourceCount(HashSet<Guid> callstack = null)
         {
-            callstack ??= new();
+            callstack ??= [];
             if (PrimaryVersionId.HasValue)
             {
                 var item = LibraryManager.GetItemById(PrimaryVersionId.Value);
@@ -757,12 +757,23 @@ namespace MediaBrowser.Controller.Entities
                 ? LibraryManager.GetItemById(PrimaryVersionId.Value) as Video
                 : null;
 
+            var primaryLinked = primary is null
+                ? []
+                : LibraryManager.GetLinkedAlternateVersions(primary).ToList();
+
+            // Grouping marks user-merged (splittable) sources. The primary is only such a source when
+            // this video is linked onto it; for local (file-based) alternates the primary is just
+            // another default source.
+            var primaryType = primaryLinked.Any(i => i.Id.Equals(Id))
+                ? MediaSourceType.Grouping
+                : MediaSourceType.Default;
+
             // This video and its linked alternates, when this is itself an alternate, the primary and the primary's linked alternates.
             var grouped = new[] { ((BaseItem)this, MediaSourceType.Default) }
                 .Concat(LibraryManager.GetLinkedAlternateVersions(this).Select(i => ((BaseItem)i, MediaSourceType.Grouping)))
                 .Concat(primary is null
                     ? []
-                    : LibraryManager.GetLinkedAlternateVersions(primary).Prepend(primary).Select(i => ((BaseItem)i, MediaSourceType.Grouping)))
+                    : primaryLinked.Select(i => ((BaseItem)i, MediaSourceType.Grouping)).Prepend(((BaseItem)primary, primaryType)))
                 .ToList();
 
             // The local (file-based) alternate versions of every grouped item.

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
@@ -33,11 +34,11 @@ namespace MediaBrowser.Controller.Entities
     {
         public Video()
         {
-            AdditionalParts = Array.Empty<string>();
-            LocalAlternateVersions = Array.Empty<string>();
-            SubtitleFiles = Array.Empty<string>();
-            AudioFiles = Array.Empty<string>();
-            LinkedAlternateVersions = Array.Empty<LinkedChild>();
+            AdditionalParts = [];
+            LocalAlternateVersions = [];
+            SubtitleFiles = [];
+            AudioFiles = [];
+            LinkedAlternateVersions = [];
         }
 
         [JsonIgnore]
@@ -332,6 +333,78 @@ namespace MediaBrowser.Controller.Entities
         {
             PrimaryVersionId = id;
             PresentationUniqueKey = CreatePresentationUniqueKey();
+        }
+
+        /// <summary>
+        /// Marks the played status of this video and propagates it to its alternate versions.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <param name="datePlayed">The date played.</param>
+        /// <param name="resetPosition">if set to <c>true</c> [reset position].</param>
+        public override void MarkPlayed(User user, DateTime? datePlayed, bool resetPosition)
+        {
+            base.MarkPlayed(user, datePlayed, resetPosition);
+            PropagatePlayedState(user, true, resetPosition);
+        }
+
+        /// <summary>
+        /// Marks this video unplayed and propagates the change to its alternate versions.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        public override void MarkUnplayed(User user)
+        {
+            base.MarkUnplayed(user);
+
+            // MarkUnplayed always clears the position on this video, so reset the versions too.
+            PropagatePlayedState(user, false, true);
+        }
+
+        /// <summary>
+        /// Propagates the played status to every alternate version of this video.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <param name="played">The played status to apply to the alternate versions.</param>
+        /// <param name="resetPosition">When <c>true</c>, the playback position of each version is also
+        /// reset, keeping the versions consistent with a deliberate played/unplayed toggle. When
+        /// <c>false</c>, only the played flag changes and each version keeps its own resume point.</param>
+        public void PropagatePlayedState(User user, bool played, bool resetPosition = true)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+
+            if (!PrimaryVersionId.HasValue && LinkedAlternateVersions.Length == 0 && !HasLocalAlternateVersions)
+            {
+                return;
+            }
+
+            foreach (var (item, _) in GetAllItemsForMediaSources())
+            {
+                if (item.Id.Equals(Id) || item is not Video)
+                {
+                    continue;
+                }
+
+                var dto = new UpdateUserItemDataDto { Played = played };
+                if (resetPosition)
+                {
+                    dto.PlaybackPositionTicks = 0;
+                }
+
+                // SaveUserData only writes the fields set on the DTO, so play count and other state are preserved.
+                UserDataManager.SaveUserData(user, item, dto, UserDataSaveReason.TogglePlayed);
+            }
+        }
+
+        /// <summary>
+        /// Gets the alternate version of this video that matches the supplied item id.
+        /// </summary>
+        /// <param name="itemId">The version item id (the playback media source id).</param>
+        /// <returns>The matching version, or <c>null</c> when the id is not a version of this video.</returns>
+        public Video GetAlternateVersion(Guid itemId)
+        {
+            return GetAllItemsForMediaSources()
+                .Select(i => i.Item)
+                .OfType<Video>()
+                .FirstOrDefault(i => i.Id.Equals(itemId));
         }
 
         public override string CreatePresentationUniqueKey()
@@ -643,37 +716,32 @@ namespace MediaBrowser.Controller.Entities
 
         protected override IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)> GetAllItemsForMediaSources()
         {
-            var list = new List<(BaseItem, MediaSourceType)>
-            {
-                (this, MediaSourceType.Default)
-            };
+            var primary = PrimaryVersionId.HasValue
+                ? LibraryManager.GetItemById(PrimaryVersionId.Value) as Video
+                : null;
 
-            list.AddRange(
-                LibraryManager.GetLinkedAlternateVersions(this)
-                    .Select(i => ((BaseItem)i, MediaSourceType.Grouping)));
-
-            if (PrimaryVersionId.HasValue)
-            {
-                if (LibraryManager.GetItemById(PrimaryVersionId.Value) is Video primary)
-                {
-                    var existingIds = list.Select(i => i.Item1.Id).ToList();
-                    list.Add((primary, MediaSourceType.Grouping));
-                    list.AddRange(LibraryManager.GetLinkedAlternateVersions(primary).Where(i => !existingIds.Contains(i.Id)).Select(i => ((BaseItem)i, MediaSourceType.Grouping)));
-                }
-            }
-
-            var localAlternates = list
-                .SelectMany(i =>
-                {
-                    return i.Item1 is Video video ? LibraryManager.GetLocalAlternateVersionIds(video) : Enumerable.Empty<Guid>();
-                })
-                .Select(LibraryManager.GetItemById)
-                .Where(i => i is not null)
+            // This video and its linked alternates, when this is itself an alternate, the primary and the primary's linked alternates.
+            var grouped = new[] { ((BaseItem)this, MediaSourceType.Default) }
+                .Concat(LibraryManager.GetLinkedAlternateVersions(this).Select(i => ((BaseItem)i, MediaSourceType.Grouping)))
+                .Concat(primary is null
+                    ? []
+                    : LibraryManager.GetLinkedAlternateVersions(primary).Prepend(primary).Select(i => ((BaseItem)i, MediaSourceType.Grouping)))
                 .ToList();
 
-            list.AddRange(localAlternates.Select(i => (i, MediaSourceType.Default)));
+            // The local (file-based) alternate versions of every grouped item.
+            var localAlternates = grouped
+                .Select(i => i.Item1)
+                .OfType<Video>()
+                .SelectMany(LibraryManager.GetLocalAlternateVersionIds)
+                .Select(LibraryManager.GetItemById)
+                .Where(i => i is not null)
+                .Select(i => (i, MediaSourceType.Default));
 
-            return list;
+            // Deduplicate
+            return grouped
+                .Concat(localAlternates)
+                .DistinctBy(i => i.Item1.Id)
+                .ToList();
         }
     }
 }

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -364,9 +364,9 @@ namespace MediaBrowser.Controller.Entities
         /// </summary>
         /// <param name="user">The user.</param>
         /// <param name="played">The played status to apply to the alternate versions.</param>
-        /// <param name="resetPosition">When <c>true</c>, the playback position of each version is also
-        /// reset, keeping the versions consistent with a deliberate played/unplayed toggle. When
-        /// <c>false</c>, only the played flag changes and each version keeps its own resume point.</param>
+        /// <param name="resetPosition">When marking played, controls whether each version's resume point
+        /// is also reset (<c>true</c>) or left untouched (<c>false</c>). Ignored when marking unplayed,
+        /// which always fully resets every version.</param>
         public void PropagatePlayedState(User user, bool played, bool resetPosition = true)
         {
             ArgumentNullException.ThrowIfNull(user);
@@ -383,14 +383,28 @@ namespace MediaBrowser.Controller.Entities
                     continue;
                 }
 
-                var dto = new UpdateUserItemDataDto { Played = played };
-                if (resetPosition)
+                if (played)
                 {
-                    dto.PlaybackPositionTicks = 0;
-                }
+                    var dto = new UpdateUserItemDataDto { Played = true };
+                    if (resetPosition)
+                    {
+                        dto.PlaybackPositionTicks = 0;
+                    }
 
-                // SaveUserData only writes the fields set on the DTO, so play count and other state are preserved.
-                UserDataManager.SaveUserData(user, item, dto, UserDataSaveReason.TogglePlayed);
+                    // SaveUserData only writes the fields set on the DTO, so play count and other state are preserved.
+                    UserDataManager.SaveUserData(user, item, dto, UserDataSaveReason.TogglePlayed);
+                }
+                else
+                {
+                    var data = UserDataManager.GetUserData(user, item);
+                    if (data is null)
+                    {
+                        continue;
+                    }
+
+                    ResetPlayedState(data);
+                    UserDataManager.SaveUserData(user, item, data, UserDataSaveReason.TogglePlayed, CancellationToken.None);
+                }
             }
         }
 

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -409,16 +409,26 @@ namespace MediaBrowser.Controller.Entities
         }
 
         /// <summary>
+        /// Gets this video together with all of its alternate versions (local and linked and, when this
+        /// is itself an alternate, the primary and the primary's other versions), deduplicated.
+        /// </summary>
+        /// <returns>This video and every alternate version of it.</returns>
+        public IReadOnlyList<Video> GetAllVersions()
+        {
+            return GetAllItemsForMediaSources()
+                .Select(i => i.Item)
+                .OfType<Video>()
+                .ToList();
+        }
+
+        /// <summary>
         /// Gets the alternate version of this video that matches the supplied item id.
         /// </summary>
         /// <param name="itemId">The version item id (the playback media source id).</param>
         /// <returns>The matching version, or <c>null</c> when the id is not a version of this video.</returns>
         public Video GetAlternateVersion(Guid itemId)
         {
-            return GetAllItemsForMediaSources()
-                .Select(i => i.Item)
-                .OfType<Video>()
-                .FirstOrDefault(i => i.Id.Equals(itemId));
+            return GetAllVersions().FirstOrDefault(i => i.Id.Equals(itemId));
         }
 
         public override string CreatePresentationUniqueKey()

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -80,5 +80,13 @@ namespace MediaBrowser.Controller.Library
         /// <param name="reportedPositionTicks">New playstate.</param>
         /// <returns>True if playstate was updated.</returns>
         bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks);
+
+        /// <summary>
+        /// Clears any stored audio and subtitle stream selections for the given user/item pair.
+        /// Used when the user has opted out of remembering selections.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <param name="item">The item.</param>
+        void ResetPlaybackStreamSelections(User user, BaseItem item);
     }
 }

--- a/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
@@ -102,7 +102,8 @@ namespace MediaBrowser.Providers.MediaInfo
                         DtoOptions = new DtoOptions(true),
                         SourceTypes = new[] { SourceType.Library },
                         Parent = library,
-                        Recursive = true
+                        Recursive = true,
+                        IncludeOwnedItems = true
                     };
 
                     if (skipIfAudioTrackMatches)

--- a/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
@@ -60,6 +60,7 @@ public class KeyframeExtractionScheduledTask : IScheduledTask
             DtoOptions = new DtoOptions(true),
             SourceTypes = [SourceType.Library],
             Recursive = true,
+            IncludeOwnedItems = true,
             Limit = Pagesize
         };
 

--- a/tests/Jellyfin.Api.Tests/Helpers/MediaInfoHelperTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/MediaInfoHelperTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Globalization;
+using Jellyfin.Api.Helpers;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Devices;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Helpers
+{
+    public class MediaInfoHelperTests
+    {
+        private static MediaInfoHelper CreateHelper()
+        {
+            return new MediaInfoHelper(
+                Mock.Of<IUserManager>(),
+                Mock.Of<ILibraryManager>(),
+                Mock.Of<IMediaSourceManager>(),
+                Mock.Of<IMediaEncoder>(),
+                Mock.Of<IServerConfigurationManager>(),
+                Mock.Of<ILogger<MediaInfoHelper>>(),
+                Mock.Of<INetworkManager>(),
+                Mock.Of<IDeviceManager>());
+        }
+
+        private static MediaSourceInfo CreateSource(Guid itemId, int bitrate, bool supportsDirectPlay = true)
+        {
+            return new MediaSourceInfo
+            {
+                Id = itemId.ToString("N", CultureInfo.InvariantCulture),
+                Protocol = MediaProtocol.File,
+                Bitrate = bitrate,
+                SupportsDirectPlay = supportsDirectPlay,
+                SupportsDirectStream = true,
+                SupportsTranscoding = true
+            };
+        }
+
+        [Fact]
+        public void SortMediaSources_PreferredItemExceedsBitrate_StaysDefault()
+        {
+            // The version the user was watching (the queried item) must stay the default
+            // even when a sibling version fits the bitrate limit better, since the resume
+            // position belongs to that exact version.
+            var preferredItemId = Guid.NewGuid();
+            var preferredSource = CreateSource(preferredItemId, bitrate: 80_000_000, supportsDirectPlay: false);
+            var siblingSource = CreateSource(Guid.NewGuid(), bitrate: 8_000_000);
+
+            var result = new PlaybackInfoResponse
+            {
+                MediaSources = [siblingSource, preferredSource]
+            };
+
+            CreateHelper().SortMediaSources(result, maxBitrate: 20_000_000, preferredItemId);
+
+            Assert.Equal(preferredSource.Id, result.MediaSources[0].Id);
+        }
+
+        [Fact]
+        public void SortMediaSources_NoPreferredItem_OrdersByPlayability()
+        {
+            var directPlay = CreateSource(Guid.NewGuid(), bitrate: 8_000_000);
+            var transcodeOnly = CreateSource(Guid.NewGuid(), bitrate: 8_000_000, supportsDirectPlay: false);
+            transcodeOnly.SupportsDirectStream = false;
+
+            var result = new PlaybackInfoResponse
+            {
+                MediaSources = [transcodeOnly, directPlay]
+            };
+
+            CreateHelper().SortMediaSources(result, maxBitrate: 20_000_000);
+
+            Assert.Equal(directPlay.Id, result.MediaSources[0].Id);
+        }
+
+        [Fact]
+        public void SortMediaSources_PreferredIdNotInSources_KeepsPlayabilityOrder()
+        {
+            var directPlay = CreateSource(Guid.NewGuid(), bitrate: 8_000_000);
+            var transcodeOnly = CreateSource(Guid.NewGuid(), bitrate: 8_000_000, supportsDirectPlay: false);
+            transcodeOnly.SupportsDirectStream = false;
+
+            var result = new PlaybackInfoResponse
+            {
+                MediaSources = [transcodeOnly, directPlay]
+            };
+
+            CreateHelper().SortMediaSources(result, maxBitrate: 20_000_000, Guid.NewGuid());
+
+            Assert.Equal(directPlay.Id, result.MediaSources[0].Id);
+        }
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -46,4 +46,66 @@ public class BaseItemTests
         Assert.Equal(name, video.GetMediaSourceName(video));
         Assert.Equal(altName, video.GetMediaSourceName(videoAlt));
     }
+
+    [Theory]
+    // Episode versions share a season folder; the common prefix (not the folder name) yields the label.
+    // Both files carry a suffix (no bare base name), so the shared "- " must be stripped too.
+    [InlineData(
+        "Spider-Noir - S01E02 - Wo ist Flint - Greyscale",
+        "Spider-Noir - S01E02 - Wo ist Flint - Colorized",
+        "Greyscale",
+        "Colorized")]
+    // One version is the bare base name; the other is suffixed.
+    [InlineData(
+        "Spider-Noir - S01E02 - Wo ist Flint",
+        "Spider-Noir - S01E02 - Wo ist Flint - Greyscale",
+        "Spider-Noir - S01E02 - Wo ist Flint",
+        "Greyscale")]
+    // Suffixes share a leading word ("Grey"); the prefix must retreat to the separator, not split it.
+    [InlineData(
+        "Demo - S01E01 - Greyscale",
+        "Demo - S01E01 - Greyish",
+        "Greyscale",
+        "Greyish")]
+    // Underscore separator.
+    [InlineData("Movie (2020)_4K", "Movie (2020)_1080p", "4K", "1080p")]
+    // Dot separator.
+    [InlineData("Movie (2020).UHD", "Movie (2020).1080p", "UHD", "1080p")]
+    // Resolution variants that share leading digits must retreat to the separator, not yield "p"/"i".
+    [InlineData("Movie - 1080p", "Movie - 1080i", "1080p", "1080i")]
+    // Bracketed version labels: the opening bracket is kept in the label.
+    [InlineData(
+        "Blade Runner (1982) [Final Cut] [1080p HEVC AAC]",
+        "Blade Runner (1982) [EE by ADM] [480p HEVC AAC]",
+        "[Final Cut] [1080p HEVC AAC]",
+        "[EE by ADM] [480p HEVC AAC]")]
+    public void GetMediaSourceName_CommonPrefix_Valid(string primaryName, string altName, string expectedPrimary, string expectedAlt)
+    {
+        var primaryPath = "/Shows/Demo/Season 01/" + primaryName + ".mkv";
+        var altPath = "/Shows/Demo/Season 01/" + altName + ".mkv";
+        var commonPrefix = BaseItem.GetCommonVersionPrefix([primaryName, altName]);
+
+        var video = new Video()
+        {
+            Path = primaryPath
+        };
+
+        var videoAlt = new Video()
+        {
+            Path = altPath,
+        };
+
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>()))
+                .Returns((string x) => MediaProtocol.File);
+        var libraryManager = new Mock<ILibraryManager>();
+        // No local alternate versions: these are linked (separate items), so the folder fallback is unavailable.
+        libraryManager.Setup(x => x.GetLocalAlternateVersionIds(It.IsAny<Video>()))
+                .Returns(Array.Empty<Guid>());
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        BaseItem.LibraryManager = libraryManager.Object;
+
+        Assert.Equal(expectedPrimary, video.GetMediaSourceName(video, commonPrefix));
+        Assert.Equal(expectedAlt, videoAlt.GetMediaSourceName(videoAlt, commonPrefix));
+    }
 }

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
 using Moq;
 using Xunit;
@@ -107,5 +115,165 @@ public class BaseItemTests
 
         Assert.Equal(expectedPrimary, video.GetMediaSourceName(video, commonPrefix));
         Assert.Equal(expectedAlt, videoAlt.GetMediaSourceName(videoAlt, commonPrefix));
+    }
+
+    [Fact]
+    public void GetAlternateVersion_ReturnsMatchingLocalVersion()
+    {
+        var (primary, alt1, alt2) = SetupVersionGroup();
+
+        Assert.Same(alt1, primary.GetAlternateVersion(alt1.Id));
+        Assert.Same(alt2, primary.GetAlternateVersion(alt2.Id));
+        Assert.Same(primary, primary.GetAlternateVersion(primary.Id));
+        Assert.Null(primary.GetAlternateVersion(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void PropagatePlayedState_MarksAlternateVersions_AndResetsPositionByDefault()
+    {
+        var (primary, alt1, alt2) = SetupVersionGroup();
+
+        var saved = CaptureSaves();
+
+        var user = new User("test", "default", "default");
+        primary.PropagatePlayedState(user, true);
+
+        // Both alternate versions are marked played, the primary (self) is not, and the position is
+        // reset so a watched version does not linger in "Continue Watching".
+        Assert.Equal(2, saved.Count);
+        Assert.DoesNotContain(saved, e => e.ItemId.Equals(primary.Id));
+        Assert.Contains(saved, e => e.ItemId.Equals(alt1.Id));
+        Assert.Contains(saved, e => e.ItemId.Equals(alt2.Id));
+        Assert.All(saved, e =>
+        {
+            Assert.True(e.Dto.Played.GetValueOrDefault());
+            Assert.Equal(0, e.Dto.PlaybackPositionTicks);
+        });
+    }
+
+    [Fact]
+    public void PropagatePlayedState_WithoutReset_LeavesPositionUntouched()
+    {
+        var (primary, _, _) = SetupVersionGroup();
+
+        var saved = CaptureSaves();
+
+        primary.PropagatePlayedState(new User("test", "default", "default"), true, resetPosition: false);
+
+        Assert.Equal(2, saved.Count);
+        Assert.All(saved, e =>
+        {
+            Assert.True(e.Dto.Played.GetValueOrDefault());
+            Assert.Null(e.Dto.PlaybackPositionTicks);
+        });
+    }
+
+    private static List<(Guid ItemId, UpdateUserItemDataDto Dto)> CaptureSaves()
+    {
+        var saved = new List<(Guid ItemId, UpdateUserItemDataDto Dto)>();
+        var userDataManager = new Mock<IUserDataManager>();
+        userDataManager
+            .Setup(x => x.SaveUserData(It.IsAny<User>(), It.IsAny<BaseItem>(), It.IsAny<UpdateUserItemDataDto>(), It.IsAny<UserDataSaveReason>()))
+            .Callback<User, BaseItem, UpdateUserItemDataDto, UserDataSaveReason>((_, item, dto, _) => saved.Add((item.Id, dto)));
+        BaseItem.UserDataManager = userDataManager.Object;
+        return saved;
+    }
+
+    [Fact]
+    public void PropagatePlayedState_SingleVersion_DoesNothing()
+    {
+        var solo = new Video { Id = Guid.NewGuid(), Path = "/Movies/Solo/Solo.mkv" };
+
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>())).Returns(MediaProtocol.File);
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(x => x.GetLocalAlternateVersionIds(It.IsAny<Video>())).Returns(Array.Empty<Guid>());
+        libraryManager.Setup(x => x.GetLinkedAlternateVersions(It.IsAny<Video>())).Returns(Array.Empty<Video>());
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        BaseItem.LibraryManager = libraryManager.Object;
+
+        var userDataManager = new Mock<IUserDataManager>();
+        BaseItem.UserDataManager = userDataManager.Object;
+
+        solo.PropagatePlayedState(new User("test", "default", "default"), true);
+
+        userDataManager.Verify(
+            x => x.SaveUserData(It.IsAny<User>(), It.IsAny<BaseItem>(), It.IsAny<UpdateUserItemDataDto>(), It.IsAny<UserDataSaveReason>()),
+            Times.Never);
+    }
+
+    private static (Video Primary, Video Alt1, Video Alt2) SetupVersionGroup()
+    {
+        var primary = new Video { Id = Guid.NewGuid(), Path = "/Movies/Movie/Movie.mkv" };
+        var alt1 = new Video { Id = Guid.NewGuid(), Path = "/Movies/Movie/Movie - 1080p.mkv", PrimaryVersionId = primary.Id };
+        var alt2 = new Video { Id = Guid.NewGuid(), Path = "/Movies/Movie/Movie - 4K.mkv", PrimaryVersionId = primary.Id };
+
+        // 2160p primary, 1080p alternates: width is only the ordering tiebreaker, set so it would place
+        // the primary first — letting the tests confirm the queried version's own source still wins.
+        var widths = new Dictionary<Guid, int> { [primary.Id] = 3840, [alt1.Id] = 1920, [alt2.Id] = 1920 };
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>())).Returns(MediaProtocol.File);
+        mediaSourceManager.Setup(x => x.GetMediaStreams(It.IsAny<Guid>()))
+            .Returns((Guid id) => new List<MediaStream> { new MediaStream { Type = MediaStreamType.Video, Width = widths.GetValueOrDefault(id) } });
+        mediaSourceManager.Setup(x => x.GetMediaAttachments(It.IsAny<Guid>())).Returns(new List<MediaAttachment>());
+
+        var segmentManager = new Mock<IMediaSegmentManager>();
+        segmentManager.Setup(x => x.IsTypeSupported(It.IsAny<BaseItem>())).Returns(false);
+        BaseItem.MediaSegmentManager = segmentManager.Object;
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(x => x.GetLinkedAlternateVersions(It.IsAny<Video>())).Returns(Array.Empty<Video>());
+        libraryManager.Setup(x => x.GetLocalAlternateVersionIds(primary)).Returns(new[] { alt1.Id, alt2.Id });
+        libraryManager.Setup(x => x.GetLocalAlternateVersionIds(alt1)).Returns(Array.Empty<Guid>());
+        libraryManager.Setup(x => x.GetLocalAlternateVersionIds(alt2)).Returns(Array.Empty<Guid>());
+        libraryManager.Setup(x => x.GetItemById(alt1.Id)).Returns(alt1);
+        libraryManager.Setup(x => x.GetItemById(alt2.Id)).Returns(alt2);
+        libraryManager.Setup(x => x.GetItemById(primary.Id)).Returns(primary);
+
+        var recordingsManager = new Mock<IRecordingsManager>();
+        recordingsManager.Setup(x => x.GetActiveRecordingInfo(It.IsAny<string>())).Returns((ActiveRecordingInfo?)null);
+        Video.RecordingsManager = recordingsManager.Object;
+
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        BaseItem.LibraryManager = libraryManager.Object;
+
+        return (primary, alt1, alt2);
+    }
+
+    [Fact]
+    public void GetMediaSources_DefaultsToTheQueriedVersionsOwnSource()
+    {
+        var (primary, alt1, _) = SetupVersionGroup();
+
+        // Resuming the 1080p alternate must default to the 1080p source, not the higher-resolution
+        // 2160p primary that the width ordering would otherwise place first.
+        Assert.Equal(alt1.Id.ToString("N"), alt1.GetMediaSources(false)[0].Id);
+
+        // Opening the primary still defaults to the primary's own (here highest-resolution) source.
+        Assert.Equal(primary.Id.ToString("N"), primary.GetMediaSources(false)[0].Id);
+    }
+
+    [Fact]
+    public void GetAllItemsForMediaSources_FromAnyVersion_HasNoDuplicates()
+    {
+        var (primary, alt1, alt2) = SetupVersionGroup();
+
+        var method = typeof(Video).GetMethod("GetAllItemsForMediaSources", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        // Each version must surface exactly once, regardless of which member the list is built from.
+        // Building from an alternate previously re-added that alternate as a "local alternate" of the
+        // primary, producing a duplicate entry in the version dropdown.
+        foreach (var source in new[] { primary, alt1, alt2 })
+        {
+            var items = (IEnumerable<(BaseItem Item, MediaSourceType MediaSourceType)>)method!.Invoke(source, null)!;
+            var ids = items.Select(i => i.Item.Id).ToList();
+
+            Assert.Equal(3, ids.Count);
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+            Assert.Contains(primary.Id, ids);
+            Assert.Contains(alt1.Id, ids);
+            Assert.Contains(alt2.Id, ids);
+        }
     }
 }

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -82,6 +82,13 @@ public class BaseItemTests
     [InlineData("Movie (2020).UHD", "Movie (2020).1080p", "UHD", "1080p")]
     // Resolution variants that share leading digits must retreat to the separator, not yield "p"/"i".
     [InlineData("Movie - 1080p", "Movie - 1080i", "1080p", "1080i")]
+    // A token shared by the descriptors but separated only by spaces (the resolution) must stay in the
+    // label: retreat to the '-' delimiter, not the interior space, so the resolution is kept.
+    [InlineData(
+        "movie (2020) - 2160p Extended",
+        "movie (2020) - 2160p Original",
+        "2160p Extended",
+        "2160p Original")]
     // Bracketed version labels: the opening bracket is kept in the label.
     [InlineData(
         "Blade Runner (1982) [Final Cut] [1080p HEVC AAC]",

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -165,6 +166,41 @@ public class BaseItemTests
         {
             Assert.True(e.Dto.Played.GetValueOrDefault());
             Assert.Null(e.Dto.PlaybackPositionTicks);
+        });
+    }
+
+    [Fact]
+    public void PropagatePlayedState_Unwatched_ClearsAllWatchedStateOnVersions()
+    {
+        var (primary, alt1, alt2) = SetupVersionGroup();
+
+        // Each alternate starts out watched, with a play count, resume point and last-played date.
+        var existing = new Dictionary<Guid, UserItemData>
+        {
+            [alt1.Id] = new UserItemData { Key = "alt1", Played = true, PlayCount = 3, PlaybackPositionTicks = 1000, LastPlayedDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+            [alt2.Id] = new UserItemData { Key = "alt2", Played = true, PlayCount = 1, PlaybackPositionTicks = 500, LastPlayedDate = new DateTime(2021, 2, 2, 0, 0, 0, DateTimeKind.Utc) },
+        };
+
+        var saved = new List<UserItemData>();
+        var userDataManager = new Mock<IUserDataManager>();
+        userDataManager.Setup(x => x.GetUserData(It.IsAny<User>(), It.IsAny<BaseItem>()))
+            .Returns((User _, BaseItem item) => existing.GetValueOrDefault(item.Id));
+        userDataManager
+            .Setup(x => x.SaveUserData(It.IsAny<User>(), It.IsAny<BaseItem>(), It.IsAny<UserItemData>(), It.IsAny<UserDataSaveReason>(), It.IsAny<CancellationToken>()))
+            .Callback<User, BaseItem, UserItemData, UserDataSaveReason, CancellationToken>((_, _, data, _, _) => saved.Add(data));
+        BaseItem.UserDataManager = userDataManager.Object;
+
+        primary.PropagatePlayedState(new User("test", "default", "default"), false);
+
+        // Every alternate is fully reset to an unwatched state, mirroring MarkUnplayed: the played flag,
+        // play count, resume point and last-played date are all cleared so no watched state lingers.
+        Assert.Equal(2, saved.Count);
+        Assert.All(saved, d =>
+        {
+            Assert.False(d.Played);
+            Assert.Equal(0, d.PlayCount);
+            Assert.Equal(0, d.PlaybackPositionTicks);
+            Assert.Null(d.LastPlayedDate);
         });
     }
 

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -137,6 +137,22 @@ public class BaseItemTests
     }
 
     [Fact]
+    public void GetAllVersions_FromAnyVersion_ReturnsEveryVersionOnce()
+    {
+        var (primary, alt1, alt2) = SetupVersionGroup();
+
+        foreach (var source in new[] { primary, alt1, alt2 })
+        {
+            var versions = source.GetAllVersions();
+
+            Assert.Equal(3, versions.Count);
+            Assert.Contains(versions, v => v.Id.Equals(primary.Id));
+            Assert.Contains(versions, v => v.Id.Equals(alt1.Id));
+            Assert.Contains(versions, v => v.Id.Equals(alt2.Id));
+        }
+    }
+
+    [Fact]
     public void PropagatePlayedState_MarksAlternateVersions_AndResetsPositionByDefault()
     {
         var (primary, alt1, alt2) = SetupVersionGroup();

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryGroupingTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryGroupingTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class BaseItemRepositoryGroupingTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly BaseItemRepository _repository;
+    private readonly string _movieTypeName;
+
+    public BaseItemRepositoryGroupingTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+        var itemTypeLookup = new ItemTypeLookup();
+        _movieTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Movie];
+
+        var serverConfigurationManager = new Mock<IServerConfigurationManager>();
+        serverConfigurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+
+        _repository = new BaseItemRepository(
+            factory.Object,
+            new Mock<IServerApplicationHost>().Object,
+            itemTypeLookup,
+            serverConfigurationManager.Object,
+            NullLogger<BaseItemRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public void GetItemList_VersionGroup_ReturnsPrimaryVersion()
+    {
+        // The alternate version sorts before the primary by id, so a plain Min(Id) per
+        // presentation key would wrongly pick the alternate as the group representative.
+        var primaryId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        var alternateId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var presentationKey = primaryId.ToString("N");
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.BaseItems.Add(CreateMovieEntity(primaryId, "Movie", presentationKey, null));
+            ctx.BaseItems.Add(CreateMovieEntity(alternateId, "Movie - 1080p", presentationKey, primaryId));
+            ctx.SaveChanges();
+        }
+
+        var result = _repository.GetItemList(CreateQuery());
+
+        var item = Assert.Single(result);
+        Assert.Equal(primaryId, item.Id);
+    }
+
+    [Fact]
+    public void GetItemList_GroupWithoutPrimary_FallsBackToMinId()
+    {
+        var firstId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var secondId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var otherPrimaryId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var presentationKey = otherPrimaryId.ToString("N");
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.BaseItems.Add(CreateMovieEntity(firstId, "Movie", presentationKey, otherPrimaryId));
+            ctx.BaseItems.Add(CreateMovieEntity(secondId, "Movie - 4K", presentationKey, otherPrimaryId));
+            ctx.SaveChanges();
+        }
+
+        var result = _repository.GetItemList(CreateQuery());
+
+        var item = Assert.Single(result);
+        Assert.Equal(firstId, item.Id);
+    }
+
+    private static InternalItemsQuery CreateQuery()
+    {
+        // IncludeOwnedItems keeps the alternate version rows in the query so the
+        // grouping collapse is what picks the group representative.
+        return new InternalItemsQuery(new Database.Implementations.Entities.User("test", "auth", "reset"))
+        {
+            IncludeItemTypes = [BaseItemKind.Movie],
+            IncludeOwnedItems = true
+        };
+    }
+
+    private BaseItemEntity CreateMovieEntity(Guid id, string name, string presentationKey, Guid? primaryVersionId)
+    {
+        return new BaseItemEntity
+        {
+            Id = id,
+            Type = _movieTypeName,
+            Name = name,
+            PresentationUniqueKey = presentationKey,
+            PrimaryVersionId = primaryVersionId,
+            MediaType = "Video",
+            IsMovie = true,
+            IsFolder = false,
+            IsVirtualItem = false
+        };
+    }
+
+    private JellyfinDbContext CreateDbContext()
+    {
+        return new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+    }
+}


### PR DESCRIPTION
When playing version B of  a movie/episode right now when resuming, we are playing version A from that progress which is incorrect.

This leads to a sideffect though:  The version that has playback data will appear first in the version dropdown

**Changes**
* Fix episode version naming stripping the common string
* Track playback progress on a per version basis
* Track played state for all versions of an item
* Don't exclude versions from data extraction
* Exlcude versions a user does not have access to
* Surface extras for all versions

**Issues**
Fixes #11118
Fixes #11967

**AI Code Assistance**
Claude Opus 4.6 was used for debugging issues and cleaning up the implementation.