### PR TITLE
Skip charset detection for WebVTT subtitles

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -1000,14 +1000,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             var subtitleCodec = subtitleStream.Codec;
             var path = subtitleStream.Path;
-            // WebVTT is always UTF-8 per spec (https://www.w3.org/TR/webvtt1/#file-structure),
-            // charset detection is unnecessary and may produce incorrect results on short files
-            // or files without BOM, causing ffmpeg to fail with an invalid iconv encoding.
-            if (string.Equals(subtitleCodec, "webvtt", StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".vtt", StringComparison.OrdinalIgnoreCase))
-            {
-                return string.Empty;
-            }
 
             if (path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
             {
@@ -1023,6 +1015,17 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             var result = await DetectCharset(path, mediaSource.Protocol, cancellationToken).ConfigureAwait(false);
             var charset = result.Detected?.EncodingName ?? string.Empty;
 
+            // WebVTT must be UTF-8 per spec (https://www.w3.org/TR/webvtt1/#file-structure).
+            // However, users may save the file with a different encoding using a text editor.
+            // Only pass charenc when the detector is confident enough; low confidence likely
+            // means the file is valid UTF-8/ASCII and detection produced a false positive.
+            if (string.Equals(subtitleCodec, "webvtt", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".vtt", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug("charset {0} detected for {Path}", charset, path);
+                return result.Detected?.Confidence >= 0.5f ? charset : string.Empty;
+            }
+
             // UTF16 is automatically converted to UTF8 by FFmpeg, do not specify a character encoding
             if ((path.EndsWith(".ass", StringComparison.Ordinal) || path.EndsWith(".ssa", StringComparison.Ordinal) || path.EndsWith(".srt", StringComparison.Ordinal))
                 && (string.Equals(charset, "utf-16le", StringComparison.OrdinalIgnoreCase)
@@ -1032,7 +1035,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
 
             _logger.LogDebug("charset {0} detected for {Path}", charset, path);
-
             return charset;
         }
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -1000,6 +1000,14 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             var subtitleCodec = subtitleStream.Codec;
             var path = subtitleStream.Path;
+            // WebVTT is always UTF-8 per spec (https://www.w3.org/TR/webvtt1/#file-structure),
+            // charset detection is unnecessary and may produce incorrect results on short files
+            // or files without BOM, causing ffmpeg to fail with an invalid iconv encoding.
+            if (string.Equals(subtitleCodec, "webvtt", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".vtt", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
 
             if (path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
## Summary
WebVTT is always UTF-8 per the W3C spec (https://www.w3.org/TR/webvtt1/#file-structure). Running charset detection on VTT files is unnecessary and can produce incorrect results, particularly on short files or files without a UTF-8 BOM.

## Problem
When transcoding video with an external WebVTT subtitle, `GetSubtitleFileCharacterSet` calls `CharsetDetector` on the VTT file. On short files (e.g. forced subtitles with few cues) without a BOM, the detector lacks sufficient byte patterns to identify UTF-8 correctly and returns an incorrect encoding such as `x-mac-ce`. This value is passed to ffmpeg as `charenc=x-mac-ce`, which fails because `iconv` on Linux does not recognize this encoding alias, causing the entire `filter_complex` to fail and breaking playback completely.

## Root cause
The VTT file in question was a valid UTF-8 file confirmed by `file -i`, but short (3 cues, no BOM). `CharsetDetector` had insufficient byte patterns to identify the encoding correctly and guessed `x-mac-ce`.

## Fix
Return empty string immediately for WebVTT files, bypassing charset detection entirely. This follows the same pattern already used in the method for ASS/SSA/SRT files with UTF-16 encoding.

## Reproduction
- External `.vtt` subtitle file, short content (few cues), no UTF-8 BOM
- Video requiring transcoding (e.g. H264 High Profile Level 5.0 on a client with Level 4.2 limit)
- Playback fails completely

## ffmpeg command and error log
<details>
<summary>Click to expand</summary>

**ffmpeg command generated by Jellyfin** (note `charenc=x-mac-ce` in the `subtitles=` filter):

```
/usr/lib/jellyfin-ffmpeg/ffmpeg -analyzeduration 200M -probesize 1G -ss 00:00:06.006 -f matroska -init_hw_device vaapi=va:,vendor_id=0x8086,driver=iHD -init_hw_device qsv=qs@va -filter_hw_device qs -hwaccel vaapi -hwaccel_output_format vaapi -noautorotate -i file:"/media/Toshiba_2TB/Anime/ReZERO Starting Life in Another World/s04/s04e01.mkv" -noautoscale -map_metadata -1 -map_chapters -1 -threads 0 -map 0:0 -map 0:1 -map -0:0 -codec:v:0 h264_qsv -preset veryfast -mbbrc 1 -b:v 3980009 -maxrate 3980010 -rc_init_occupancy 3980009 -bufsize 7960018 -profile:v:0 high -level 42 -g:v:0 144 -keyint_min:v:0 144 -filter_complex "alphasrc=s=1280x720:r=10:start='00\:00\:06\.006',format=bgra,subtitles=f='/media/Toshiba_2TB/Anime/ReZERO Starting Life in Another World/s04/s04e01.es.forced.vtt':charenc=x-mac-ce:alpha=1:sub2video=1:fontsdir='...'" ...
```

**ffmpeg error:**

```
[webvtt @ 0x7fdf9cb01a80] Unable to open iconv context with input character encoding "x-mac-ce"
[AVFilterGraph @ 0x7fdf9caf8180] Error initializing filters
Failed to set value '...' for option 'filter_complex': Invalid argument
Error parsing global options: Invalid argument
```

</details>