### PR TITLE
Reject unsafe plugin package names in installer

### DIFF
--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -521,8 +521,26 @@ namespace Emby.Server.Implementations.Updates
                 return;
             }
 
+            if (!IsValidPackageDirectoryName(package.Name))
+            {
+                _logger.LogError("Refusing to install package with invalid name {PackageName}.", package.Name);
+                throw new InvalidDataException($"Plugin package name '{package.Name}' is not a valid directory name.");
+            }
+
             // Always override the passed-in target (which is a file) and figure it out again
             string targetDir = Path.Combine(_appPaths.PluginsPath, package.Name);
+
+            var pluginsRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_appPaths.PluginsPath));
+            var resolvedTarget = Path.GetFullPath(targetDir);
+            if (!resolvedTarget.StartsWith(pluginsRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogError(
+                    "Refusing to install package {PackageName}: resolved target {Resolved} is outside plugins directory {Root}.",
+                    package.Name,
+                    resolvedTarget,
+                    pluginsRoot);
+                throw new InvalidDataException($"Plugin package name '{package.Name}' resolves outside the plugins directory.");
+            }
 
             using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
                 .GetAsync(new Uri(package.SourceUrl), cancellationToken).ConfigureAwait(false);
@@ -570,6 +588,31 @@ namespace Emby.Server.Implementations.Updates
             await _pluginManager.PopulateManifest(package.PackageInfo, package.Version, targetDir, status).ConfigureAwait(false);
 
             _pluginManager.ImportPluginFrom(targetDir);
+        }
+
+        private static bool IsValidPackageDirectoryName(string? name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            if (name.Equals(".", StringComparison.Ordinal) || name.Equals("..", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (name.Contains('/', StringComparison.Ordinal) || name.Contains('\\', StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (name.AsSpan().IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private async Task<bool> InstallPackageInternal(InstallationInfo package, CancellationToken cancellationToken)

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -32,6 +32,8 @@ namespace Emby.Server.Implementations.Updates
     /// </summary>
     public class InstallationManager : IInstallationManager
     {
+        private static readonly char[] InvlidPackageNameChars = [.. Path.GetInvalidFileNameChars(), '/', '\\'];
+
         /// <summary>
         /// The logger.
         /// </summary>
@@ -602,12 +604,7 @@ namespace Emby.Server.Implementations.Updates
                 return false;
             }
 
-            if (name.Contains('/', StringComparison.Ordinal) || name.Contains('\\', StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            if (name.AsSpan().IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            if (name.AsSpan().IndexOfAny(InvlidPackageNameChars) >= 0)
             {
                 return false;
             }

--- a/Emby.Server.Implementations/Updates/InstallationManager.cs
+++ b/Emby.Server.Implementations/Updates/InstallationManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -32,7 +33,7 @@ namespace Emby.Server.Implementations.Updates
     /// </summary>
     public class InstallationManager : IInstallationManager
     {
-        private static readonly char[] InvlidPackageNameChars = [.. Path.GetInvalidFileNameChars(), '/', '\\'];
+        private static readonly SearchValues<char> InvalidPackageNameChars = SearchValues.Create([.. Path.GetInvalidFileNameChars(), '/', '\\']);
 
         /// <summary>
         /// The logger.
@@ -604,7 +605,7 @@ namespace Emby.Server.Implementations.Updates
                 return false;
             }
 
-            if (name.AsSpan().IndexOfAny(InvlidPackageNameChars) >= 0)
+            if (name.IndexOfAny(InvalidPackageNameChars) >= 0)
             {
                 return false;
             }

--- a/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Updates/InstallationManagerTests.cs
@@ -109,5 +109,29 @@ namespace Jellyfin.Server.Implementations.Tests.Updates
             var ex = await Record.ExceptionAsync(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
             Assert.Null(ex);
         }
+
+        [Theory]
+        [InlineData("../evil")]
+        [InlineData("..\\evil")]
+        [InlineData("../../escape_attempt")]
+        [InlineData("..")]
+        [InlineData(".")]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("foo/bar")]
+        [InlineData("foo\\bar")]
+        [InlineData("/absolute")]
+        [InlineData("foo\0bar")]
+        public async Task InstallPackage_InvalidName_ThrowsInvalidDataException(string name)
+        {
+            var packageInfo = new InstallationInfo()
+            {
+                Name = name,
+                SourceUrl = "https://repo.jellyfin.org/releases/plugin/empty/empty.zip",
+                Checksum = "11b5b2f1a9ebc4f66d6ef19018543361"
+            };
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => _installationManager.InstallPackage(packageInfo, CancellationToken.None));
+        }
     }
 }


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

`InstallationManager.PerformPackageInstallation` builds the install directory with `package.Name` straight from a repository manifest, so a name like `../../evil` resolves outside the plugins root and is then passed to `Directory.Delete`, `ZipFile.ExtractToDirectoryAsync`, and `PluginManager.SaveManifest`. Admin-only so not exactly a security issue, but the installer should still validate inputs appropriately.
 
The change validates `package.Name` against null/whitespace, `.`, `..`, path separators, and `Path.GetInvalidFileNameChars`, and verifies the fully resolved target stays under the plugins path.

**Issues**
Fixes #16899