### PR TITLE
Include resumable additional video parts

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -455,14 +455,29 @@ public sealed partial class BaseItemRepository
                 || (e.TopParentId.HasValue && allowedTagItemIds.Contains(e.TopParentId.Value)));
         }
 
-        // Exclude alternate versions (have PrimaryVersionId set) and owned non-extra items.
-        // Extras (trailers, etc.) have OwnerId set but also have ExtraType set — keep those.
-        if (!filter.IncludeOwnedItems)
+        return ApplyOwnedItemVisibilityFilter(baseQuery, filter);
+    }
+
+    private static IQueryable<BaseItemEntity> ApplyOwnedItemVisibilityFilter(
+        IQueryable<BaseItemEntity> baseQuery,
+        InternalItemsQuery filter)
+    {
+        if (filter.IncludeOwnedItems)
         {
-            baseQuery = baseQuery.Where(e => e.PrimaryVersionId == null && (e.OwnerId == null || e.ExtraType != null));
+            return baseQuery;
         }
 
-        return baseQuery;
+        // Additional parts are owned videos without a PrimaryVersionId. Keep them in
+        // resume queries while still excluding alternate versions.
+        if (filter.IsResumable == true)
+        {
+            return baseQuery.Where(e => e.PrimaryVersionId == null);
+        }
+
+        // Exclude alternate versions and owned non-extra items from general queries.
+        // Alternate versions have PrimaryVersionId set (pointing to their primary).
+        // Extras (trailers, etc.) have OwnerId set but also have ExtraType set - keep those.
+        return baseQuery.Where(e => e.PrimaryVersionId == null && (e.OwnerId == null || e.ExtraType != null));
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -740,12 +740,9 @@ public sealed partial class BaseItemRepository
                     .Where(e => e.OwnerId == null);
             }
         }
-        else if (filter.OwnerIds.Length == 0 && filter.ExtraTypes.Length == 0 && !filter.IncludeOwnedItems)
+        else if (filter.OwnerIds.Length == 0 && filter.ExtraTypes.Length == 0)
         {
-            // Exclude alternate versions and owned non-extra items from general queries.
-            // Alternate versions have PrimaryVersionId set (pointing to their primary).
-            // Extras (trailers, etc.) have OwnerId set but also have ExtraType set - keep those.
-            baseQuery = baseQuery.Where(e => e.PrimaryVersionId == null && (e.OwnerId == null || e.ExtraType != null));
+            baseQuery = ApplyOwnedItemVisibilityFilter(baseQuery, filter);
         }
 
         if (filter.OwnerIds.Length > 0)

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryTests.cs
@@ -1,7 +1,18 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
 using Jellyfin.Server.Implementations.Item;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Persistence;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -11,6 +22,8 @@ namespace Jellyfin.Server.Implementations.Tests.Item;
 
 public class BaseItemRepositoryTests
 {
+    private static readonly string VideoTypeName = typeof(Video).FullName!;
+
     [Fact]
     public void DeserializeBaseItem_WithUnknownType_ReturnsNull()
     {
@@ -68,5 +81,106 @@ public class BaseItemRepositoryTests
 
         // Assert
         Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void TranslateQuery_ResumableOwnedAdditionalPart_IncludesOwnedVideoWithoutPrimaryVersion()
+    {
+        // Arrange
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var context = CreateDbContext(dbOptions);
+        context.Database.EnsureCreated();
+
+        var user = new User("test", "Default", "Default");
+        var owner = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = VideoTypeName,
+            PresentationUniqueKey = "movie"
+        };
+        var additionalPart = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = VideoTypeName,
+            OwnerId = owner.Id,
+            PresentationUniqueKey = "movie-part-2"
+        };
+        var alternateVersion = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = VideoTypeName,
+            OwnerId = owner.Id,
+            PrimaryVersionId = owner.Id,
+            PresentationUniqueKey = "movie-alt"
+        };
+
+        context.Users.Add(user);
+        context.BaseItems.AddRange(owner, additionalPart, alternateVersion);
+        context.UserData.AddRange(
+            CreateUserData(user, additionalPart),
+            CreateUserData(user, alternateVersion));
+        context.SaveChanges();
+
+        var query = new InternalItemsQuery(user)
+        {
+            IsResumable = true
+        };
+        var repository = CreateRepository(context);
+        repository.PrepareFilterQuery(query);
+
+        // Act
+        var itemIds = repository
+            .TranslateQuery(context.BaseItems.AsNoTracking(), context, query)
+            .Select(e => e.Id)
+            .ToArray();
+
+        // Assert
+        Assert.Contains(additionalPart.Id, itemIds);
+        Assert.DoesNotContain(alternateVersion.Id, itemIds);
+    }
+
+    private static JellyfinDbContext CreateDbContext(DbContextOptions<JellyfinDbContext> dbOptions)
+    {
+        return new JellyfinDbContext(
+            dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+    }
+
+    private static BaseItemRepository CreateRepository(JellyfinDbContext context)
+    {
+        var dbProvider = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        dbProvider.Setup(f => f.CreateDbContext()).Returns(context);
+
+        var itemTypeLookup = new Mock<IItemTypeLookup>();
+        itemTypeLookup.SetupGet(i => i.BaseItemKindNames).Returns(new Dictionary<BaseItemKind, string>());
+        itemTypeLookup.SetupGet(i => i.MusicGenreTypes).Returns(Array.Empty<string>());
+
+        return new BaseItemRepository(
+            dbProvider.Object,
+            Mock.Of<IServerApplicationHost>(),
+            itemTypeLookup.Object,
+            Mock.Of<IServerConfigurationManager>(),
+            NullLogger<BaseItemRepository>.Instance);
+    }
+
+    private static UserData CreateUserData(User user, BaseItemEntity item)
+    {
+        return new UserData
+        {
+            CustomDataKey = item.Id.ToString("N"),
+            Item = item,
+            ItemId = item.Id,
+            PlaybackPositionTicks = 1,
+            User = user,
+            UserId = user.Id
+        };
     }
 }


### PR DESCRIPTION
**Changes**
- Allow resumable item queries to include owned video items that are not alternate versions, so stacked additional parts with saved playback progress can appear in Continue Watching.
- Keep alternate versions filtered out by requiring `PrimaryVersionId == null`.
- Add a repository query test covering owned additional parts versus alternate versions.

**Issues**
Fixes #16112

**Testing**
- `git diff --check`
- Not run: `dotnet test tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj --filter FullyQualifiedName~BaseItemRepositoryTests --no-restore` (`dotnet` is not installed in this environment)