### PR TITLE
Fix exit code for --help and --version CLI options

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -72,14 +71,30 @@ namespace Jellyfin.Server
         {
             static Task ErrorParsingArguments(IEnumerable<Error> errors)
             {
-                Environment.ExitCode = 1;
+                Environment.ExitCode = errors.Any(IsBuiltInOptionRequest) ? 0 : 1;
                 return Task.CompletedTask;
+            }
+
+            var builtInOption = args.FirstOrDefault(IsBuiltInOption);
+            if (builtInOption is not null)
+            {
+                return new Parser(static settings => settings.HelpWriter = Console.Out)
+                    .ParseArguments<StartupOptions>(new[] { builtInOption })
+                    .MapResult(static _ => Task.CompletedTask, ErrorParsingArguments);
             }
 
             // Parse the command line arguments and either start the app or exit indicating error
             return Parser.Default.ParseArguments<StartupOptions>(args)
                 .MapResult(StartApp, ErrorParsingArguments);
         }
+
+        private static bool IsBuiltInOption(string arg)
+            => string.Equals(arg, "--help", StringComparison.Ordinal)
+                || string.Equals(arg, "--version", StringComparison.Ordinal);
+
+        private static bool IsBuiltInOptionRequest(Error error)
+            => error.Tag is ErrorType.HelpRequestedError
+                or ErrorType.VersionRequestedError;
 
         private static async Task StartApp(StartupOptions options)
         {

--- a/tests/Jellyfin.Server.Tests/ProgramTests.cs
+++ b/tests/Jellyfin.Server.Tests/ProgramTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Server.Tests
+{
+    public class ProgramTests
+    {
+        private static readonly SemaphoreSlim _consoleLock = new(1, 1);
+
+        [Theory]
+        [InlineData("--help")]
+        [InlineData("--version")]
+        public async Task Main_WhenBuiltInOptionFollowsParsedOption_DisplaysOutput(string builtInOption)
+        {
+            await _consoleLock.WaitAsync(TestContext.Current.CancellationToken);
+            try
+            {
+                TextWriter originalOut = Console.Out;
+                TextWriter originalError = Console.Error;
+                int originalExitCode = Environment.ExitCode;
+
+                using var outputWriter = new StringWriter(CultureInfo.InvariantCulture);
+                using var errorWriter = new StringWriter(CultureInfo.InvariantCulture);
+                string output;
+                string error;
+                int exitCode;
+
+                try
+                {
+                    Environment.ExitCode = 1;
+                    Console.SetOut(outputWriter);
+                    Console.SetError(errorWriter);
+
+                    await Program.Main(new[] { "--ffmpeg", Path.Combine(Path.GetTempPath(), "ffmpeg"), builtInOption });
+
+                    output = outputWriter.ToString();
+                    error = errorWriter.ToString();
+                    exitCode = Environment.ExitCode;
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                    Console.SetError(originalError);
+                    Environment.ExitCode = originalExitCode;
+                }
+
+                Assert.Equal(0, exitCode);
+                Assert.NotEmpty(output);
+                Assert.Empty(error);
+            }
+            finally
+            {
+                _consoleLock.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Before the patch, both returned 1 despite accepted CLI conventions.

Also, --version printed:

```
ERROR(S):
  Option 'version' is unknown.
```

After the patch, the error is no longer shown and the exit code for both
options is 0.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
