### PR TITLE
Add AudioPlaybackRate parameter for server-side atempo filter

### DIFF
--- a/Jellyfin.Api/Controllers/AudioController.cs
+++ b/Jellyfin.Api/Controllers/AudioController.cs
@@ -84,6 +84,7 @@ public class AudioController : BaseJellyfinApiController
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <response code="200">Audio stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream", Name = "GetAudioStream")]
@@ -140,6 +141,7 @@ public class AudioController : BaseJellyfinApiController
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
         [FromQuery] Dictionary<string, string>? streamOptions,
+        [FromQuery] double? audioPlaybackRate,
         [FromQuery] bool enableAudioVbrEncoding = true)
     {
         StreamingRequestDto streamingRequest = new StreamingRequestDto
@@ -192,6 +194,7 @@ public class AudioController : BaseJellyfinApiController
             VideoStreamIndex = videoStreamIndex,
             Context = context ?? EncodingContext.Static,
             StreamOptions = streamOptions,
+            AudioPlaybackRate = audioPlaybackRate,
             EnableAudioVbrEncoding = enableAudioVbrEncoding
         };
 
@@ -251,6 +254,7 @@ public class AudioController : BaseJellyfinApiController
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <response code="200">Audio stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("{itemId}/stream.{container}", Name = "GetAudioStreamByContainer")]
@@ -307,6 +311,7 @@ public class AudioController : BaseJellyfinApiController
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
         [FromQuery] Dictionary<string, string>? streamOptions,
+        [FromQuery] double? audioPlaybackRate,
         [FromQuery] bool enableAudioVbrEncoding = true)
     {
         StreamingRequestDto streamingRequest = new StreamingRequestDto
@@ -359,6 +364,7 @@ public class AudioController : BaseJellyfinApiController
             VideoStreamIndex = videoStreamIndex,
             Context = context ?? EncodingContext.Static,
             StreamOptions = streamOptions,
+            AudioPlaybackRate = audioPlaybackRate,
             EnableAudioVbrEncoding = enableAudioVbrEncoding
         };
 

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1282,6 +1282,7 @@ public class DynamicHlsController : BaseJellyfinApiController
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <response code="200">Video stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}")]
@@ -1343,7 +1344,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
         [FromQuery] Dictionary<string, string> streamOptions,
-        [FromQuery] bool enableAudioVbrEncoding = true)
+        [FromQuery] bool enableAudioVbrEncoding = true,
+        [FromQuery] double? audioPlaybackRate = null)
     {
         var streamingRequest = new StreamingRequestDto
         {
@@ -1398,7 +1400,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             Context = context ?? EncodingContext.Streaming,
             StreamOptions = streamOptions,
             EnableAudioVbrEncoding = enableAudioVbrEncoding,
-            AlwaysBurnInSubtitleWhenTranscoding = false
+            AlwaysBurnInSubtitleWhenTranscoding = false,
+            AudioPlaybackRate = audioPlaybackRate
         };
 
         return await GetDynamicSegment(streamingRequest, segmentId)
@@ -1447,11 +1450,6 @@ public class DynamicHlsController : BaseJellyfinApiController
 
     private async Task<ActionResult> GetDynamicSegment(StreamingRequestDto streamingRequest, int segmentId)
     {
-        if ((streamingRequest.StartTimeTicks ?? 0) > 0)
-        {
-            throw new ArgumentException("StartTimeTicks is not allowed.");
-        }
-
         // CTS lifecycle is managed internally.
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
@@ -1747,6 +1745,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             {
                 audioTranscodeParams += " -ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture);
             }
+
+            audioTranscodeParams += _encodingHelper.GetAudioFilterParam(state, _encodingOptions);
 
             return audioTranscodeParams;
         }

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -84,6 +84,7 @@ public class UniversalAudioController : BaseJellyfinApiController
     /// <param name="enableRemoteMedia">Optional. Whether to enable remote media.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
     /// <param name="breakOnNonKeyFrames">Optional. Whether to break on non key frames.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <param name="enableRedirection">Whether to enable redirection. Defaults to true.</param>
     /// <response code="200">Audio stream returned.</response>
     /// <response code="302">Redirected to remote audio stream.</response>
@@ -115,6 +116,7 @@ public class UniversalAudioController : BaseJellyfinApiController
         [FromQuery] bool? enableRemoteMedia,
         [FromQuery] bool enableAudioVbrEncoding = true,
         [FromQuery] bool breakOnNonKeyFrames = false,
+        [FromQuery] double? audioPlaybackRate = null,
         [FromQuery] bool enableRedirection = true)
     {
         userId = RequestHelpers.GetUserId(User, userId);
@@ -180,6 +182,12 @@ public class UniversalAudioController : BaseJellyfinApiController
         // This one is currently very misleading as the SupportsDirectStream actually means "can direct play"
         // The definition of DirectStream also seems changed during development
         var isStatic = mediaSource.SupportsDirectStream;
+
+        // Force transcoding when a playback rate is requested so the atempo filter can be applied
+        if (audioPlaybackRate.HasValue && Math.Abs(audioPlaybackRate.Value - 1.0) > 0.001)
+        {
+            isStatic = false;
+        }
         if (!isStatic && mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
         {
             // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
@@ -223,7 +231,8 @@ public class UniversalAudioController : BaseJellyfinApiController
                 Context = EncodingContext.Static,
                 StreamOptions = new Dictionary<string, string>(),
                 EnableAdaptiveBitrateStreaming = false,
-                EnableAudioVbrEncoding = enableAudioVbrEncoding
+                EnableAudioVbrEncoding = enableAudioVbrEncoding,
+                AudioPlaybackRate = audioPlaybackRate
             };
 
             return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType.Hls, dynamicHlsRequestDto, true)
@@ -252,7 +261,8 @@ public class UniversalAudioController : BaseJellyfinApiController
             StartTimeTicks = startTimeTicks,
             SubtitleMethod = SubtitleDeliveryMethod.Embed,
             TranscodeReasons = mediaSource.TranscodeReasons == 0 ? null : mediaSource.TranscodeReasons.ToString(),
-            Context = EncodingContext.Static
+            Context = EncodingContext.Static,
+            AudioPlaybackRate = audioPlaybackRate
         };
 
         return await _audioHelper.GetAudioStream(TranscodingJobType.Progressive, audioStreamingDto).ConfigureAwait(false);

--- a/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
+++ b/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
@@ -193,6 +193,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public bool EnableAudioVbrEncoding { get; set; }
 
+        /// <summary>
+        /// Gets or sets the audio playback speed multiplier applied via the atempo filter.
+        /// </summary>
+        /// <value>The playback rate (1.0 = normal speed).</value>
+        public double? AudioPlaybackRate { get; set; }
+
         public bool AlwaysBurnInSubtitleWhenTranscoding { get; set; }
 
         public string GetOption(string qualifier, string name)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2847,6 +2847,24 @@ namespace MediaBrowser.Controller.MediaEncoding
                         Math.Round(seconds)));
             }
 
+            if (state.BaseRequest.AudioPlaybackRate is double audioRate && Math.Abs(audioRate - 1.0) > 0.001)
+            {
+                var tempRate = audioRate;
+                while (tempRate > 2.0)
+                {
+                    filters.Add("atempo=2.0");
+                    tempRate /= 2.0;
+                }
+
+                while (tempRate < 0.5)
+                {
+                    filters.Add("atempo=0.5");
+                    tempRate *= 2.0;
+                }
+
+                filters.Add($"atempo={tempRate.ToString(CultureInfo.InvariantCulture)}");
+            }
+
             if (filters.Count > 0)
             {
                 return " -af \"" + string.Join(',', filters) + "\"";


### PR DESCRIPTION
**Changes**
Accept an optional AudioPlaybackRate query parameter on the universal audio and HLS audio segment endpoints. When the rate differs from 1.0, force transcoding (bypassing direct play) and apply ffmpeg's atempo filter chain so the speed is baked into the encoded stream. Fixes audio-only HLS transcoding which was missing the audio filter step, and removes a StartTimeTicks guard that incorrectly rejected segment requests generated by Jellyfin's own HLS playlist when resuming from a non-zero position.

**Issues**
https://github.com/jellyfin/jellyfin/issues/148 (This is already closed, but only because feature requests were moved elsewhere. Also they consensus was a frontend only fix, which unfortunately does not work for iOS.

**Notes**
I originally was targeting master until I realized that was 12.x so I switched to 10.11.z. If I should be targeting 12.x, please let me know and I will update this.
