### PR TITLE
Assign correct season info to new episodes

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -236,6 +236,7 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
     {
         var seriesChildren = series.GetRecursiveChildren(i => i is Episode || i is Season);
         var seasons = seriesChildren.OfType<Season>().ToList();
+        var episodes = seriesChildren.OfType<Episode>().ToList();
 
         var physicalSeasonIds = seasons
             .Where(e => e.LocationType != LocationType.Virtual)
@@ -261,17 +262,33 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
             if (existingSeason is null)
             {
                 var seasonName = GetValidSeasonNameForSeries(series, null, seasonNumber);
-                await CreateSeasonAsync(series, seasonName, seasonNumber, cancellationToken).ConfigureAwait(false);
+                var season = await CreateSeasonAsync(series, seasonName, seasonNumber, cancellationToken).ConfigureAwait(false);
+                seasons.Add(season);
             }
             else if (existingSeason.IsVirtualItem)
             {
-                var episodeCount = seriesChildren.OfType<Episode>().Count(e => e.ParentIndexNumber == seasonNumber && !e.IsMissingEpisode);
+                var episodeCount = episodes.Count(e => e.ParentIndexNumber == seasonNumber && !e.IsMissingEpisode);
                 if (episodeCount > 0)
                 {
                     existingSeason.IsVirtualItem = false;
                     await existingSeason.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                 }
             }
+        }
+
+        // Loop through episodes
+        foreach (var episode in episodes)
+        {
+            var season = seasons.FirstOrDefault(i => i.IndexNumber == episode.ParentIndexNumber);
+            if (season is null || episode.SeasonId.Equals(season.Id))
+            {
+                continue;
+            }
+
+            // Assign the correct season id and name to episode.
+            episode.SeasonId = season.Id;
+            episode.SeasonName = season.Name;
+            await episode.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -283,7 +300,7 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
     /// <param name="seasonNumber">The season number.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The newly created season.</returns>
-    private async Task CreateSeasonAsync(
+    private async Task<Season> CreateSeasonAsync(
         Series series,
         string? seasonName,
         int? seasonNumber,
@@ -306,6 +323,8 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
 
         series.AddChild(season);
         await season.RefreshMetadata(new MetadataRefreshOptions(new DirectoryService(FileSystem)), cancellationToken).ConfigureAwait(false);
+
+        return season;
     }
 
     private string GetValidSeasonNameForSeries(Series series, string? seasonName, int? seasonNumber)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
in `AfterMetadataRefresh`, which is called by the folder watcher from `ChangedExternally`, i made sure that season information is assigned to the episodes to avoid getting "Season Unknown". manual/scheduled library scan is not affected by this bug.

folder structure:
```
.
├── Bocchi the Rock
│   ├── Bocchi The Rock! - 01.mkv
│   ├── Bocchi The Rock! - 02.mkv
│   ├── Bocchi The Rock! - 03.mkv
│   ├── Bocchi The Rock! - 04.mkv
│   └── Bocchi The Rock! - 05.mkv
└── Frieren
    ├── Season 1
    │   ├── [xxxxx] Frieren - S01E01.mkv
    │   └── [xxxxx] Frieren - S01E02.mkv
    └── Season 2
        ├── [xxxxx] Sousou no Frieren 2nd Season - S02E01 [WEB.1080p.AV1].mkv
        ├── [xxxxx] Sousou no Frieren 2nd Season - S02E02 [WEB.1080p.AV1].mkv
        └── [xxxxx] Sousou no Frieren 2nd Season - S02E03 [WEB.1080p.AV1].mkv
```

plugins used: TMDb, OMDb

disclaimer: i used gpt 5.5 in the process of fixing this bug.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #16215