### PR TITLE
Add playback rate support for audiobooks

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1264,6 +1264,7 @@ public class DynamicHlsController : BaseJellyfinApiController
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <response code="200">Video stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}")]
@@ -1324,7 +1325,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
         [FromQuery] Dictionary<string, string> streamOptions,
-        [FromQuery] bool enableAudioVbrEncoding = true)
+        [FromQuery] bool enableAudioVbrEncoding = true,
+        [FromQuery] double? audioPlaybackRate = null)
     {
         var streamingRequest = new StreamingRequestDto
         {
@@ -1378,7 +1380,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             Context = context ?? EncodingContext.Streaming,
             StreamOptions = streamOptions,
             EnableAudioVbrEncoding = enableAudioVbrEncoding,
-            AlwaysBurnInSubtitleWhenTranscoding = false
+            AlwaysBurnInSubtitleWhenTranscoding = false,
+            AudioPlaybackRate = audioPlaybackRate
         };
 
         return await GetDynamicSegment(streamingRequest, segmentId)
@@ -1427,11 +1430,6 @@ public class DynamicHlsController : BaseJellyfinApiController
 
     private async Task<ActionResult> GetDynamicSegment(StreamingRequestDto streamingRequest, int segmentId)
     {
-        if ((streamingRequest.StartTimeTicks ?? 0) > 0)
-        {
-            throw new ArgumentException("StartTimeTicks is not allowed.");
-        }
-
         // CTS lifecycle is managed internally.
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
@@ -1717,6 +1715,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             {
                 audioTranscodeParams += " -ar " + state.OutputAudioSampleRate.Value.ToString(CultureInfo.InvariantCulture);
             }
+
+            audioTranscodeParams += _encodingHelper.GetAudioFilterParam(state, _encodingOptions);
 
             return audioTranscodeParams;
         }

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1425,8 +1425,10 @@ public class DynamicHlsController : BaseJellyfinApiController
             state.Request.SegmentContainer ?? string.Empty,
             "hls1/main/",
             Request.QueryString.ToString(),
-            EncodingHelper.IsCopyCodec(state.OutputVideoCodec),
-            state.BaseRequest.AudioPlaybackRate ?? 1.0);
+            EncodingHelper.IsCopyCodec(state.OutputVideoCodec))
+        {
+            PlaybackRate = state.BaseRequest.AudioPlaybackRate ?? 1.0
+        };
         var playlist = _dynamicHlsPlaylistGenerator.CreateMainPlaylist(request);
 
         return new FileContentResult(Encoding.UTF8.GetBytes(playlist), MimeTypes.GetMimeType("playlist.m3u8"));
@@ -1634,10 +1636,7 @@ public class DynamicHlsController : BaseJellyfinApiController
                 Path.GetFileNameWithoutExtension(outputPath));
         }
 
-        // Atempo output is shorter than content by the rate, so segment duration = content length / rate.
-        var hlsTime = state.BaseRequest.AudioPlaybackRate is double playbackRate && Math.Abs(playbackRate - 1.0) > 0.001
-            ? (state.SegmentLength / playbackRate).ToString(CultureInfo.InvariantCulture)
-            : state.SegmentLength.ToString(CultureInfo.InvariantCulture);
+        var hlsTime = GetHlsTime(state);
 
         return string.Format(
             CultureInfo.InvariantCulture,
@@ -1656,6 +1655,14 @@ public class DynamicHlsController : BaseJellyfinApiController
             EncodingUtils.NormalizePath(outputTsArg),
             hlsArguments,
             EncodingUtils.NormalizePath(outputPath)).Trim();
+    }
+
+    private static string GetHlsTime(StreamState state)
+    {
+        // Atempo output is shorter than content by the rate, so segment duration = content length / rate.
+        return state.BaseRequest.AudioPlaybackRate is double playbackRate && Math.Abs(playbackRate - 1.0) > 0.001
+            ? (state.SegmentLength / playbackRate).ToString(CultureInfo.InvariantCulture)
+            : state.SegmentLength.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -910,6 +910,7 @@ public class DynamicHlsController : BaseJellyfinApiController
     /// <param name="context">Optional. The <see cref="EncodingContext"/>.</param>
     /// <param name="streamOptions">Optional. The streaming options.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <response code="200">Audio stream returned.</response>
     /// <returns>A <see cref="FileResult"/> containing the audio file.</returns>
     [HttpGet("Audio/{itemId}/main.m3u8")]
@@ -964,7 +965,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         [FromQuery] int? videoStreamIndex,
         [FromQuery] EncodingContext? context,
         [FromQuery] Dictionary<string, string> streamOptions,
-        [FromQuery] bool enableAudioVbrEncoding = true)
+        [FromQuery] bool enableAudioVbrEncoding = true,
+        [FromQuery] double? audioPlaybackRate = null)
     {
         using var cancellationTokenSource = new CancellationTokenSource();
         var streamingRequest = new StreamingRequestDto
@@ -1016,7 +1018,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             Context = context ?? EncodingContext.Streaming,
             StreamOptions = streamOptions,
             EnableAudioVbrEncoding = enableAudioVbrEncoding,
-            AlwaysBurnInSubtitleWhenTranscoding = false
+            AlwaysBurnInSubtitleWhenTranscoding = false,
+            AudioPlaybackRate = audioPlaybackRate
         };
 
         return await GetVariantPlaylistInternal(streamingRequest, cancellationTokenSource)
@@ -1422,7 +1425,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             state.Request.SegmentContainer ?? string.Empty,
             "hls1/main/",
             Request.QueryString.ToString(),
-            EncodingHelper.IsCopyCodec(state.OutputVideoCodec));
+            EncodingHelper.IsCopyCodec(state.OutputVideoCodec),
+            state.BaseRequest.AudioPlaybackRate ?? 1.0);
         var playlist = _dynamicHlsPlaylistGenerator.CreateMainPlaylist(request);
 
         return new FileContentResult(Encoding.UTF8.GetBytes(playlist), MimeTypes.GetMimeType("playlist.m3u8"));
@@ -1630,6 +1634,11 @@ public class DynamicHlsController : BaseJellyfinApiController
                 Path.GetFileNameWithoutExtension(outputPath));
         }
 
+        // Atempo output is shorter than content by the rate, so segment duration = content length / rate.
+        var hlsTime = state.BaseRequest.AudioPlaybackRate is double playbackRate && Math.Abs(playbackRate - 1.0) > 0.001
+            ? (state.SegmentLength / playbackRate).ToString(CultureInfo.InvariantCulture)
+            : state.SegmentLength.ToString(CultureInfo.InvariantCulture);
+
         return string.Format(
             CultureInfo.InvariantCulture,
             "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
@@ -1640,7 +1649,7 @@ public class DynamicHlsController : BaseJellyfinApiController
             GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer),
             GetAudioArguments(state),
             maxMuxingQueueSize,
-            state.SegmentLength.ToString(CultureInfo.InvariantCulture),
+            hlsTime,
             segmentFormat,
             startNumber.ToString(CultureInfo.InvariantCulture),
             baseUrlParam,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -84,6 +84,7 @@ public class UniversalAudioController : BaseJellyfinApiController
     /// <param name="maxAudioBitDepth">Optional. The maximum audio bit depth.</param>
     /// <param name="enableRemoteMedia">Optional. Whether to enable remote media.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
+    /// <param name="audioPlaybackRate">Optional. The audio playback rate for server-side atempo adjustment.</param>
     /// <param name="enableRedirection">Whether to enable redirection. Defaults to true.</param>
     /// <response code="200">Audio stream returned.</response>
     /// <response code="302">Redirected to remote audio stream.</response>
@@ -114,6 +115,7 @@ public class UniversalAudioController : BaseJellyfinApiController
         [FromQuery] int? maxAudioBitDepth,
         [FromQuery] bool? enableRemoteMedia,
         [FromQuery] bool enableAudioVbrEncoding = true,
+        [FromQuery] double? audioPlaybackRate = null,
         [FromQuery] bool enableRedirection = true)
     {
         userId = RequestHelpers.GetUserId(User, userId);
@@ -179,6 +181,13 @@ public class UniversalAudioController : BaseJellyfinApiController
         // This one is currently very misleading as the SupportsDirectStream actually means "can direct play"
         // The definition of DirectStream also seems changed during development
         var isStatic = mediaSource.SupportsDirectStream;
+
+        // Force transcoding when a playback rate is requested so the atempo filter can be applied
+        if (audioPlaybackRate.HasValue && Math.Abs(audioPlaybackRate.Value - 1.0) > 0.001)
+        {
+            isStatic = false;
+        }
+
         if (!isStatic && mediaSource.TranscodingSubProtocol == MediaStreamProtocol.hls)
         {
             // hls segment container can only be mpegts or fmp4 per ffmpeg documentation
@@ -221,7 +230,8 @@ public class UniversalAudioController : BaseJellyfinApiController
                 Context = EncodingContext.Static,
                 StreamOptions = new Dictionary<string, string>(),
                 EnableAdaptiveBitrateStreaming = false,
-                EnableAudioVbrEncoding = enableAudioVbrEncoding
+                EnableAudioVbrEncoding = enableAudioVbrEncoding,
+                AudioPlaybackRate = audioPlaybackRate
             };
 
             return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType.Hls, dynamicHlsRequestDto, true)
@@ -249,7 +259,8 @@ public class UniversalAudioController : BaseJellyfinApiController
             StartTimeTicks = startTimeTicks,
             SubtitleMethod = SubtitleDeliveryMethod.Embed,
             TranscodeReasons = mediaSource.TranscodeReasons == 0 ? null : mediaSource.TranscodeReasons.ToString(),
-            Context = EncodingContext.Static
+            Context = EncodingContext.Static,
+            AudioPlaybackRate = audioPlaybackRate
         };
 
         return await _audioHelper.GetAudioStream(TranscodingJobType.Progressive, audioStreamingDto).ConfigureAwait(false);

--- a/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
+++ b/MediaBrowser.Controller/MediaEncoding/BaseEncodingJobOptions.cs
@@ -197,6 +197,12 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         public bool EnableAudioVbrEncoding { get; set; }
 
+        /// <summary>
+        /// Gets or sets the audio playback speed multiplier applied via the atempo filter.
+        /// </summary>
+        /// <value>The playback rate (1.0 = normal speed).</value>
+        public double? AudioPlaybackRate { get; set; }
+
         public bool AlwaysBurnInSubtitleWhenTranscoding { get; set; }
 
         public string GetOption(string qualifier, string name)

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2922,6 +2922,24 @@ namespace MediaBrowser.Controller.MediaEncoding
                         Math.Round(seconds)));
             }
 
+            if (state.BaseRequest.AudioPlaybackRate is double audioRate && Math.Abs(audioRate - 1.0) > 0.001)
+            {
+                var tempRate = audioRate;
+                while (tempRate > 2.0)
+                {
+                    filters.Add("atempo=2.0");
+                    tempRate /= 2.0;
+                }
+
+                while (tempRate < 0.5)
+                {
+                    filters.Add("atempo=0.5");
+                    tempRate *= 2.0;
+                }
+
+                filters.Add($"atempo={tempRate.ToString(CultureInfo.InvariantCulture)}");
+            }
+
             if (filters.Count > 0)
             {
                 return " -af \"" + string.Join(',', filters) + "\"";

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2924,20 +2924,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (state.BaseRequest.AudioPlaybackRate is double audioRate && Math.Abs(audioRate - 1.0) > 0.001)
             {
-                var tempRate = audioRate;
-                while (tempRate > 2.0)
-                {
-                    filters.Add("atempo=2.0");
-                    tempRate /= 2.0;
-                }
-
-                while (tempRate < 0.5)
-                {
-                    filters.Add("atempo=0.5");
-                    tempRate *= 2.0;
-                }
-
-                filters.Add($"atempo={tempRate.ToString(CultureInfo.InvariantCulture)}");
+                filters.AddRange(GetAtempoFilters(audioRate));
             }
 
             if (filters.Count > 0)
@@ -2946,6 +2933,24 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             return string.Empty;
+        }
+
+        private static IEnumerable<string> GetAtempoFilters(double audioRate)
+        {
+            var tempRate = audioRate;
+            while (tempRate > 2.0)
+            {
+                yield return "atempo=2.0";
+                tempRate /= 2.0;
+            }
+
+            while (tempRate < 0.5)
+            {
+                yield return "atempo=0.5";
+                tempRate *= 2.0;
+            }
+
+            yield return $"atempo={tempRate.ToString(CultureInfo.InvariantCulture)}";
         }
 
         /// <summary>

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
@@ -18,8 +18,7 @@ public class CreateMainPlaylistRequest
     /// <param name="endpointPrefix">The URI prefix for the relative URL in the playlist.</param>
     /// <param name="queryString">The desired query string to append (must start with ?).</param>
     /// <param name="isRemuxingVideo">Whether the video is being remuxed.</param>
-    /// <param name="playbackRate">The audio playback rate (1.0 = normal speed).</param>
-    public CreateMainPlaylistRequest(Guid? mediaSourceId, string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString, bool isRemuxingVideo, double playbackRate = 1.0)
+    public CreateMainPlaylistRequest(Guid? mediaSourceId, string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString, bool isRemuxingVideo)
     {
         MediaSourceId = mediaSourceId;
         FilePath = filePath;
@@ -29,7 +28,6 @@ public class CreateMainPlaylistRequest
         EndpointPrefix = endpointPrefix;
         QueryString = queryString;
         IsRemuxingVideo = isRemuxingVideo;
-        PlaybackRate = playbackRate;
     }
 
     /// <summary>
@@ -75,5 +73,5 @@ public class CreateMainPlaylistRequest
     /// <summary>
     /// Gets the audio playback rate (1.0 = normal speed).
     /// </summary>
-    public double PlaybackRate { get; }
+    public double PlaybackRate { get; init; } = 1.0;
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
@@ -18,7 +18,8 @@ public class CreateMainPlaylistRequest
     /// <param name="endpointPrefix">The URI prefix for the relative URL in the playlist.</param>
     /// <param name="queryString">The desired query string to append (must start with ?).</param>
     /// <param name="isRemuxingVideo">Whether the video is being remuxed.</param>
-    public CreateMainPlaylistRequest(Guid? mediaSourceId, string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString, bool isRemuxingVideo)
+    /// <param name="playbackRate">The audio playback rate (1.0 = normal speed).</param>
+    public CreateMainPlaylistRequest(Guid? mediaSourceId, string filePath, int desiredSegmentLengthMs, long totalRuntimeTicks, string segmentContainer, string endpointPrefix, string queryString, bool isRemuxingVideo, double playbackRate = 1.0)
     {
         MediaSourceId = mediaSourceId;
         FilePath = filePath;
@@ -28,6 +29,7 @@ public class CreateMainPlaylistRequest
         EndpointPrefix = endpointPrefix;
         QueryString = queryString;
         IsRemuxingVideo = isRemuxingVideo;
+        PlaybackRate = playbackRate;
     }
 
     /// <summary>
@@ -69,4 +71,9 @@ public class CreateMainPlaylistRequest
     /// Gets a value indicating whether the video is being remuxed.
     /// </summary>
     public bool IsRemuxingVideo { get; }
+
+    /// <summary>
+    /// Gets the audio playback rate (1.0 = normal speed).
+    /// </summary>
+    public double PlaybackRate { get; }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
@@ -80,13 +80,14 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
                 .AppendLine();
         }
 
+        var playbackRate = request.PlaybackRate > 0 ? request.PlaybackRate : 1;
         long currentRuntimeInSeconds = 0;
         foreach (var length in segments)
         {
             // Manually convert to ticks to avoid precision loss when converting double
             var lengthTicks = Convert.ToInt64(length * TimeSpan.TicksPerSecond);
             builder.Append("#EXTINF:")
-                .Append(length.ToString("0.000000", CultureInfo.InvariantCulture))
+                .Append((length / playbackRate).ToString("0.000000", CultureInfo.InvariantCulture))
                 .AppendLine(", nodesc")
                 .Append(request.EndpointPrefix)
                 .Append(index++)


### PR DESCRIPTION
**Changes**
- Add an optional `AudioPlaybackRate` query parameter to the universal-audio and HLS audio-segment endpoints.
- A non-1.0 rate forces transcoding (bypassing direct play) and applies ffmpeg's `atempo` filter chain, baking the speed into the stream.
- Audio-only HLS transcoding never added the `-af` audio filter argument; call `GetAudioFilterParam` so atempo (and any existing audio filters like downmix/volume) are applied.
- Remove the `StartTimeTicks` guard in `GetDynamicSegment`. Each segment's start comes from its own `runtimeTicks`, so a `StartTimeTicks` on a segment request is overwritten or ignored rather than something to reject.

**Code assistance**
I used Opus to identify the issue and where I would need to make the changes. I used Opus to also look over the changes to make any suggestions. It suggested to fallback of >2 and < 0.5.

**Issues**
https://github.com/jellyfin/jellyfin/issues/148 (This is already closed, but only because feature requests were moved elsewhere. Also they consensus was a frontend only fix, which unfortunately does not work for iOS.

**Associated Changes**
- [Web Change](https://github.com/jellyfin/jellyfin-web/pull/8024)
