### PR TITLE
Add support for background images and episode thumbnails from XMLTV

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using Jellyfin.XmlTv;
 using Jellyfin.XmlTv.Entities;
+using Jellyfin.XmlTv.Enums;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Configuration;
@@ -180,6 +181,8 @@ namespace Jellyfin.LiveTv.Listings
             string? episodeTitle = program.Episode?.Title;
             var programCategories = program.Categories.Where(c => !string.IsNullOrWhiteSpace(c)).ToList();
             var imageUrl = program.Icons.FirstOrDefault()?.Source;
+            var episodeImageUrl = program.Images?.FirstOrDefault(m => m.Type == ImageType.Still)?.Path;
+            var backgroundImageUrl = program.Images?.FirstOrDefault(m => m.Type == ImageType.Backdrop)?.Path;
             var rating = program.Ratings.FirstOrDefault()?.Value;
             var starRating = program.StarRatings?.FirstOrDefault()?.StarRating;
 
@@ -205,6 +208,8 @@ namespace Jellyfin.LiveTv.Listings
                 IsSports = programCategories.Any(c => info.SportsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),
                 ImageUrl = string.IsNullOrEmpty(imageUrl) ? null : imageUrl,
                 HasImage = !string.IsNullOrEmpty(imageUrl),
+                BackdropImageUrl = string.IsNullOrEmpty(backgroundImageUrl) ? null : backgroundImageUrl,
+                ThumbImageUrl = string.IsNullOrEmpty(episodeImageUrl) ? null : episodeImageUrl,
                 OfficialRating = string.IsNullOrEmpty(rating) ? null : rating,
                 CommunityRating = starRating is null ? null : (float)starRating.Value,
                 SeriesId = program.Episode?.Episode is null ? null : program.Title?.GetMD5().ToString("N", CultureInfo.InvariantCulture)


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Jellyfin's XMLTV parser has had support for XMLTV background images and episode thumbnails since jellyfin/Jellyfin.XmlTv#21. Additionally, the internal Jellyfin `ProgramInfo` model has support for background images and episode thumbnails, however these two have never been linked up. This PR is very simple, it simply uses the pre-existing XMLTV support to supply that information.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
No code assistance was used.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
No specific issue (although happy to create one), I just figured it was a relatively small change.

Screenshots of it in action:
<img width="1658" height="977" alt="image" src="https://github.com/user-attachments/assets/14bd9e98-2ecd-406c-806d-2b9f5fed5385" />

<img width="1660" height="885" alt="image" src="https://github.com/user-attachments/assets/ecb06532-0ea5-4bff-8e11-9633d6ce1477" />


I'd be happy to provide XMLTV samples if that would assist with testing, as I don't think this is a particularly common feature.