### PR TITLE
Close sessions for lost WebSockets to prevent zombie SyncPlay groups

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -127,8 +127,12 @@ namespace Emby.Server.Implementations.HttpServer
                 {
                     receiveResult = await _socket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
                 }
-                catch (WebSocketException ex)
+                catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
                 {
+                    // ObjectDisposedException/OperationCanceledException: the socket was torn
+                    // down underneath us (e.g. by the keep-alive watchdog after the connection
+                    // was declared lost). Fall through so Closed is still raised and the
+                    // session can release this connection.
                     _logger.LogWarning("WS {IP} error receiving data: {Message}", RemoteEndPoint, ex.Message);
                     break;
                 }

--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -246,8 +246,21 @@ namespace Emby.Server.Implementations.Session
                     _logger.LogInformation("Lost {0} WebSockets.", lost.Count);
                     foreach (var webSocket in lost)
                     {
-                        // TODO: handle session relative to the lost webSocket
                         RemoveWebSocket(webSocket);
+
+                        // The connection stopped answering keep-alives, so a close frame will
+                        // never arrive and the pending receive loop would hang forever, keeping
+                        // the session (and e.g. its SyncPlay group membership) alive. Disposing
+                        // the connection aborts the receive loop, which raises Closed and lets
+                        // the session end normally.
+                        try
+                        {
+                            webSocket.Dispose();
+                        }
+                        catch (Exception exception)
+                        {
+                            _logger.LogWarning(exception, "Error disposing lost WebSocket {0}.", webSocket);
+                        }
                     }
                 }
             }

--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -259,7 +259,7 @@ namespace Emby.Server.Implementations.Session
                         }
                         catch (Exception exception)
                         {
-                            _logger.LogWarning(exception, "Error disposing lost WebSocket {0}.", webSocket);
+                            _logger.LogWarning(exception, "Error disposing lost WebSocket from {RemoteEndPoint}.", webSocket.RemoteEndPoint);
                         }
                     }
                 }

--- a/tests/Jellyfin.Server.Integration.Tests/SyncPlayLostWebSocketTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/SyncPlayLostWebSocketTests.cs
@@ -17,138 +17,124 @@ using MediaBrowser.Controller.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Jellyfin.Server.Integration.Tests
+namespace Jellyfin.Server.Integration.Tests;
+
+public sealed class SyncPlayLostWebSocketTests : IClassFixture<JellyfinApplicationFactory>
 {
-    /// <summary>
-    /// Reproduces the SyncPlay "zombie group" scenario: a client joins a group over
-    /// a WebSocket and then silently stops responding (mobile network drop, killed
-    /// WebView, NAT timeout) without ever sending a close frame. The keep-alive
-    /// watchdog detects the lost socket; the session it belongs to must then be
-    /// closed so that SyncPlay drops the dead participant and removes the empty
-    /// group. If that does not happen, the group keeps waiting on the dead
-    /// participant forever and every other member is stuck on an infinite load.
-    /// </summary>
-    public sealed class SyncPlayLostWebSocketTests : IClassFixture<JellyfinApplicationFactory>
+    private readonly JellyfinApplicationFactory _factory;
+
+    public SyncPlayLostWebSocketTests(JellyfinApplicationFactory factory)
     {
-        private readonly JellyfinApplicationFactory _factory;
+        _factory = factory;
+    }
 
-        public SyncPlayLostWebSocketTests(JellyfinApplicationFactory factory)
+    [Fact]
+    public async Task LostWebSocket_EndsSession_And_RemovesEmptySyncPlayGroup()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var client = _factory.CreateClient();
+        var accessToken = await AuthHelper.CompleteStartupAsync(client);
+        client.DefaultRequestHeaders.AddAuthHeader(accessToken);
+
+        var wsClient = _factory.Server.CreateWebSocketClient();
+        wsClient.ConfigureRequest = request =>
+            request.Headers.Authorization = AuthHelper.DummyAuthHeader + $", Token={accessToken}";
+
+        var webSocket = await wsClient.ConnectAsync(
+            new UriBuilder(_factory.Server.BaseAddress)
+            {
+                Scheme = "ws",
+                Path = "websocket"
+            }.Uri,
+            cancellationToken);
+
+        _ = DrainAsync(webSocket, cancellationToken);
+
+        var watched = await WaitForWatchedWebSocketsAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        var connection = Assert.Single(watched);
+
+        using var createResponse = await client.PostAsync(
+            "SyncPlay/New",
+            JsonContent.Create(new NewGroupRequestDto { GroupName = "ZombieGroupRepro" }, options: JsonDefaults.Options),
+            cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+        Assert.Equal(1, await WaitForGroupCountAsync(client, 1, TimeSpan.FromSeconds(10), cancellationToken));
+
+        connection.LastKeepAliveDate = DateTime.UtcNow - TimeSpan.FromSeconds(180);
+
+        var groupCount = await WaitForGroupCountAsync(client, 0, TimeSpan.FromSeconds(45), cancellationToken);
+        Assert.True(
+            groupCount == 0,
+            $"SyncPlay group still listed {groupCount} group(s) after the WebSocket was lost: "
+            + "the keep-alive watchdog removed the socket from its watchlist without closing "
+            + "the session, leaving a zombie participant in the group (SessionWebSocketListener).");
+    }
+
+    private static async Task DrainAsync(WebSocket webSocket, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[4096];
+        try
         {
-            _factory = factory;
+            while (webSocket.State == WebSocketState.Open)
+            {
+                await webSocket.ReceiveAsync(buffer, cancellationToken);
+            }
         }
-
-        [Fact]
-        public async Task LostWebSocket_EndsSession_And_RemovesEmptySyncPlayGroup()
+        catch
         {
-            var client = _factory.CreateClient();
-            var accessToken = await AuthHelper.CompleteStartupAsync(client);
-            client.DefaultRequestHeaders.AddAuthHeader(accessToken);
-
-            var wsClient = _factory.Server.CreateWebSocketClient();
-            wsClient.ConfigureRequest = request =>
-                request.Headers.Authorization = AuthHelper.DummyAuthHeader + $", Token={accessToken}";
-
-            var webSocket = await wsClient.ConnectAsync(
-                new UriBuilder(_factory.Server.BaseAddress)
-                {
-                    Scheme = "ws",
-                    Path = "websocket"
-                }.Uri,
-                TestContext.Current.CancellationToken);
-
-            // Drain server messages (ForceKeepAlive etc.) but never answer them,
-            // like a client whose connection went dark.
-            _ = DrainAsync(webSocket, TestContext.Current.CancellationToken);
-
-            var watched = await WaitForWatchedWebSocketsAsync(TimeSpan.FromSeconds(10));
-            var connection = Assert.Single(watched);
-
-            using var createResponse = await client.PostAsync(
-                "SyncPlay/New",
-                JsonContent.Create(new NewGroupRequestDto { GroupName = "ZombieGroupRepro" }, options: JsonDefaults.Options),
-                TestContext.Current.CancellationToken);
-            Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
-            Assert.Equal(1, await WaitForGroupCountAsync(client, 1, TimeSpan.FromSeconds(10)));
-
-            // Simulate the silent drop without waiting WebSocketLostTimeout (60s) in
-            // real time: backdating LastKeepAliveDate is equivalent to the client not
-            // having answered a keep-alive for that long. The next watchdog tick
-            // (every 12s) will classify the socket as lost.
-            connection.LastKeepAliveDate = DateTime.UtcNow - TimeSpan.FromSeconds(180);
-
-            var groupCount = await WaitForGroupCountAsync(client, 0, TimeSpan.FromSeconds(45));
-            Assert.True(
-                groupCount == 0,
-                $"SyncPlay group still listed {groupCount} group(s) after the WebSocket was lost: "
-                + "the keep-alive watchdog removed the socket from its watchlist without closing "
-                + "the session, leaving a zombie participant in the group (SessionWebSocketListener).");
+            // The server tears the connection down once the watchdog gives up on it.
         }
+    }
 
-        private static async Task DrainAsync(WebSocket webSocket, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<IWebSocketConnection>> WaitForWatchedWebSocketsAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var listener = _factory.Services.GetRequiredService<IEnumerable<IWebSocketListener>>()
+            .OfType<SessionWebSocketListener>()
+            .Single();
+        var watchlistField = typeof(SessionWebSocketListener)
+            .GetField("_webSockets", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(watchlistField);
+        var watchlist = (IEnumerable<IWebSocketConnection>)watchlistField.GetValue(listener)!;
+
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
         {
-            var buffer = new byte[4096];
             try
             {
-                while (webSocket.State == WebSocketState.Open)
+                var snapshot = watchlist.ToArray();
+                if (snapshot.Length > 0 || stopwatch.Elapsed >= timeout)
                 {
-                    await webSocket.ReceiveAsync(buffer, cancellationToken);
+                    return snapshot;
                 }
             }
-            catch
+            catch (InvalidOperationException)
             {
-                // The server tears the connection down once the watchdog gives up on it.
+                // The watchdog mutated the set during enumeration; retry.
             }
-        }
 
-        private async Task<IReadOnlyList<IWebSocketConnection>> WaitForWatchedWebSocketsAsync(TimeSpan timeout)
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+
+    private static async Task<int> WaitForGroupCountAsync(HttpClient client, int expected, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var count = -1;
+        while (stopwatch.Elapsed < timeout)
         {
-            var listener = _factory.Services.GetRequiredService<IEnumerable<IWebSocketListener>>()
-                .OfType<SessionWebSocketListener>()
-                .Single();
-            var watchlistField = typeof(SessionWebSocketListener)
-                .GetField("_webSockets", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(watchlistField);
-            var watchlist = (IEnumerable<IWebSocketConnection>)watchlistField.GetValue(listener)!;
-
-            var stopwatch = Stopwatch.StartNew();
-            while (true)
+            using var response = await client.GetAsync("SyncPlay/List", cancellationToken);
+            response.EnsureSuccessStatusCode();
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            count = document.RootElement.GetArrayLength();
+            if (count == expected)
             {
-                try
-                {
-                    var snapshot = watchlist.ToArray();
-                    if (snapshot.Length > 0 || stopwatch.Elapsed >= timeout)
-                    {
-                        return snapshot;
-                    }
-                }
-                catch (InvalidOperationException)
-                {
-                    // The watchdog mutated the set during enumeration; retry.
-                }
-
-                await Task.Delay(100);
-            }
-        }
-
-        private static async Task<int> WaitForGroupCountAsync(HttpClient client, int expected, TimeSpan timeout)
-        {
-            var stopwatch = Stopwatch.StartNew();
-            var count = -1;
-            while (stopwatch.Elapsed < timeout)
-            {
-                using var response = await client.GetAsync("SyncPlay/List");
-                response.EnsureSuccessStatusCode();
-                using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-                count = document.RootElement.GetArrayLength();
-                if (count == expected)
-                {
-                    return count;
-                }
-
-                await Task.Delay(500);
+                return count;
             }
 
-            return count;
+            await Task.Delay(500, cancellationToken);
         }
+
+        return count;
     }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/SyncPlayLostWebSocketTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/SyncPlayLostWebSocketTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Session;
+using Jellyfin.Api.Models.SyncPlayDtos;
+using Jellyfin.Extensions.Json;
+using MediaBrowser.Controller.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests
+{
+    /// <summary>
+    /// Reproduces the SyncPlay "zombie group" scenario: a client joins a group over
+    /// a WebSocket and then silently stops responding (mobile network drop, killed
+    /// WebView, NAT timeout) without ever sending a close frame. The keep-alive
+    /// watchdog detects the lost socket; the session it belongs to must then be
+    /// closed so that SyncPlay drops the dead participant and removes the empty
+    /// group. If that does not happen, the group keeps waiting on the dead
+    /// participant forever and every other member is stuck on an infinite load.
+    /// </summary>
+    public sealed class SyncPlayLostWebSocketTests : IClassFixture<JellyfinApplicationFactory>
+    {
+        private readonly JellyfinApplicationFactory _factory;
+
+        public SyncPlayLostWebSocketTests(JellyfinApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task LostWebSocket_EndsSession_And_RemovesEmptySyncPlayGroup()
+        {
+            var client = _factory.CreateClient();
+            var accessToken = await AuthHelper.CompleteStartupAsync(client);
+            client.DefaultRequestHeaders.AddAuthHeader(accessToken);
+
+            var wsClient = _factory.Server.CreateWebSocketClient();
+            wsClient.ConfigureRequest = request =>
+                request.Headers.Authorization = AuthHelper.DummyAuthHeader + $", Token={accessToken}";
+
+            var webSocket = await wsClient.ConnectAsync(
+                new UriBuilder(_factory.Server.BaseAddress)
+                {
+                    Scheme = "ws",
+                    Path = "websocket"
+                }.Uri,
+                TestContext.Current.CancellationToken);
+
+            // Drain server messages (ForceKeepAlive etc.) but never answer them,
+            // like a client whose connection went dark.
+            _ = DrainAsync(webSocket, TestContext.Current.CancellationToken);
+
+            var watched = await WaitForWatchedWebSocketsAsync(TimeSpan.FromSeconds(10));
+            var connection = Assert.Single(watched);
+
+            using var createResponse = await client.PostAsync(
+                "SyncPlay/New",
+                JsonContent.Create(new NewGroupRequestDto { GroupName = "ZombieGroupRepro" }, options: JsonDefaults.Options),
+                TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+            Assert.Equal(1, await WaitForGroupCountAsync(client, 1, TimeSpan.FromSeconds(10)));
+
+            // Simulate the silent drop without waiting WebSocketLostTimeout (60s) in
+            // real time: backdating LastKeepAliveDate is equivalent to the client not
+            // having answered a keep-alive for that long. The next watchdog tick
+            // (every 12s) will classify the socket as lost.
+            connection.LastKeepAliveDate = DateTime.UtcNow - TimeSpan.FromSeconds(180);
+
+            var groupCount = await WaitForGroupCountAsync(client, 0, TimeSpan.FromSeconds(45));
+            Assert.True(
+                groupCount == 0,
+                $"SyncPlay group still listed {groupCount} group(s) after the WebSocket was lost: "
+                + "the keep-alive watchdog removed the socket from its watchlist without closing "
+                + "the session, leaving a zombie participant in the group (SessionWebSocketListener).");
+        }
+
+        private static async Task DrainAsync(WebSocket webSocket, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[4096];
+            try
+            {
+                while (webSocket.State == WebSocketState.Open)
+                {
+                    await webSocket.ReceiveAsync(buffer, cancellationToken);
+                }
+            }
+            catch
+            {
+                // The server tears the connection down once the watchdog gives up on it.
+            }
+        }
+
+        private async Task<IReadOnlyList<IWebSocketConnection>> WaitForWatchedWebSocketsAsync(TimeSpan timeout)
+        {
+            var listener = _factory.Services.GetRequiredService<IEnumerable<IWebSocketListener>>()
+                .OfType<SessionWebSocketListener>()
+                .Single();
+            var watchlistField = typeof(SessionWebSocketListener)
+                .GetField("_webSockets", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(watchlistField);
+            var watchlist = (IEnumerable<IWebSocketConnection>)watchlistField.GetValue(listener)!;
+
+            var stopwatch = Stopwatch.StartNew();
+            while (true)
+            {
+                try
+                {
+                    var snapshot = watchlist.ToArray();
+                    if (snapshot.Length > 0 || stopwatch.Elapsed >= timeout)
+                    {
+                        return snapshot;
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                    // The watchdog mutated the set during enumeration; retry.
+                }
+
+                await Task.Delay(100);
+            }
+        }
+
+        private static async Task<int> WaitForGroupCountAsync(HttpClient client, int expected, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var count = -1;
+            while (stopwatch.Elapsed < timeout)
+            {
+                using var response = await client.GetAsync("SyncPlay/List");
+                response.EnsureSuccessStatusCode();
+                using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                count = document.RootElement.GetArrayLength();
+                if (count == expected)
+                {
+                    return count;
+                }
+
+                await Task.Delay(500);
+            }
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

The keep-alive watchdog in `SessionWebSocketListener` detected lost WebSockets but only removed them from its watchlist (the long-standing `// TODO: handle session relative to the lost webSocket`), so on a silent connection drop the receive loop hung forever, `Closed` never fired and the session never ended. The dead session then stayed in its SyncPlay group forever: `WaitingGroupState` has no timeout, so playback waited indefinitely on the zombie participant and the never-empty group kept being rejoined.

- `SessionWebSocketListener`: dispose lost connections so the pending receive loop aborts and `Closed` is raised; `WebSocketController` then releases the connection and `CloseIfNeededAsync` ends the session, letting the existing `SessionEnded` handler in `SyncPlayManager` drop the dead participant and delete the empty group. Sessions with other live connections are unaffected.
- `WebSocketConnection`: widen the receive-loop catch so `Closed` is also raised when the teardown surfaces as `ObjectDisposedException`/`OperationCanceledException` instead of `WebSocketException`.
- New integration test that opens a real WebSocket, creates a SyncPlay group, simulates the silent drop (backdated `LastKeepAliveDate`, no close frame), and asserts the group is removed. The test fails without this fix.

Also verified on real hardware: phone on Wi-Fi switched to airplane mode while in a SyncPlay group; within ~75s the server logs `Lost 1 WebSockets.` → session left group → `Group is empty, removing it.` A clean tab close still removes the group immediately, and a session with two sockets survives losing one of them.

**Code assistance**

The root-cause analysis, the fix and the integration test were developed with the assistance of an LLM coding agent (Claude Fable 5). All changes were reviewed by me, and verified locally with the full test suite plus manual end-to-end testing on a real device.

**Issues**

Fixes #17078
