### PR TITLE
Fix AudioDb album description not displayed for English (mirror of #16606)

### DIFF
--- a/MediaBrowser.Providers/Plugins/AudioDb/AudioDbAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/AudioDb/AudioDbAlbumProvider.cs
@@ -142,7 +142,9 @@ namespace MediaBrowser.Providers.Plugins.AudioDb
 
             if (string.IsNullOrWhiteSpace(overview))
             {
-                overview = result.strDescriptionEN;
+                overview = string.IsNullOrWhiteSpace(result.strDescriptionEN)
+                    ? result.strDescription
+                    : result.strDescriptionEN;
             }
 
             item.Overview = (overview ?? string.Empty).StripHtml();
@@ -239,6 +241,8 @@ namespace MediaBrowser.Providers.Plugins.AudioDb
             public string strAlbumThumb { get; set; }
 
             public string strAlbumCDart { get; set; }
+
+            public string strDescription { get; set; }
 
             public string strDescriptionEN { get; set; }
 


### PR DESCRIPTION
## Changes

Mirrors the fix from #16606 (which addressed the same bug in `AudioDbArtistProvider`) over to `AudioDbAlbumProvider`.

- Add a `strDescription` fallback in `ProcessResult` so the base (unsuffixed) field is read when `strDescriptionEN` is absent.
- Add the missing `strDescription` property to the `Album` DTO so the deserializer can populate it.

## Issues

Fixes #17080

## Root cause (recap)

TheAudioDB stores the English album description in the field `strDescription` (no language suffix). Localized variants follow `strDescription<LANG>` (`strDescriptionDE`, `strDescriptionFR`, …). The previous code only ever read `strDescriptionEN` as the final fallback, which **does not exist** in the API response — so the album Overview stayed empty whenever no localized variant was available, which is the common case at TheAudioDB.

Identical pattern, identical fix as for the artist biography (`strBiography` vs `strBiographyEN`) merged in #16606.

## Verification

Tested against `https://www.theaudiodb.com/api/v1/json/2/searchalbum.php?s=Cream&a=Wheels+of+Fire`:
- `strDescription` contains the full English description.
- `strDescriptionEN` is absent from the JSON.
- All localized `strDescription<LANG>` fields are `null`.

With this patch, the album Overview is populated from `strDescription` after the fallback kicks in.