### PR TITLE
Fix duplicate key collision

### DIFF
--- a/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
+++ b/MediaBrowser.MediaEncoding/Probing/FFProbeHelpers.cs
@@ -76,7 +76,13 @@ namespace MediaBrowser.MediaEncoding.Probing
         /// <returns>Dictionary{System.StringSystem.String}.</returns>
         private static Dictionary<string, string?> ConvertDictionaryToCaseInsensitive(IReadOnlyDictionary<string, string?> dict)
         {
-            return new Dictionary<string, string?>(dict, StringComparer.OrdinalIgnoreCase);
+            var result = new Dictionary<string, string?>(dict.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var (key, value) in dict)
+            {
+                result.TryAdd(key, value);
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
If a file has metadata tags with the same key but different cases (e.g., DATE & date), a collision would occur when converting to a case-insensitive dictionary.

**Changes**
Use a `TryAdd` loop  to skip duplicate keys

**Code assistance**
N/A

**Issues**
<details>
  <summary>Log Error</summary>

```
System.ArgumentException: An item with the same key has already been added. Key: DATE
   at System.Collections.Generic.Dictionary`2.AddRange(IEnumerable`1 enumerable)
   at MediaBrowser.MediaEncoding.Probing.FFProbeHelpers.ConvertDictionaryToCaseInsensitive(IReadOnlyDictionary`2 dict) in C:\Gits\jellyfin\MediaBrowser.MediaEncoding\Probing\FFProbeHelpers.cs:line 79
   at MediaBrowser.MediaEncoding.Probing.FFProbeHelpers.NormalizeFFProbeResult(InternalMediaInfoResult result) in C:\Gits\jellyfin\MediaBrowser.MediaEncoding\Probing\FFProbeHelpers.cs:line 22
   at MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer.GetMediaInfo(InternalMediaInfoResult data, Nullable`1 videoType, Boolean isAudio, String path, MediaProtocol protocol) in C:\Gits\jellyfin\MediaBrowser.MediaEncoding\Probing\ProbeResultNormalizer.cs:line 107
   at MediaBrowser.MediaEncoding.Encoder.MediaEncoder.GetMediaInfoInternal(String inputPath, String primaryPath, MediaProtocol protocol, Boolean extractChapters, String probeSizeArgument, Boolean isAudio, Nullable`1 videoType, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.MediaEncoding\Encoder\MediaEncoder.cs:line 589
   at MediaBrowser.MediaEncoding.Encoder.MediaEncoder.GetMediaInfoInternal(String inputPath, String primaryPath, MediaProtocol protocol, Boolean extractChapters, String probeSizeArgument, Boolean isAudio, Nullable`1 videoType, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.MediaEncoding\Encoder\MediaEncoder.cs:line 589
   at MediaBrowser.Providers.MediaInfo.AudioFileProber.Probe[T](T item, MetadataRefreshOptions options, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.Providers\MediaInfo\AudioFileProber.cs:line 103
   at MediaBrowser.Providers.Manager.MetadataService`2.RunCustomProvider(ICustomMetadataProvider`1 provider, TItemType item, String logName, MetadataRefreshOptions options, RefreshResult refreshResult, CancellationToken cancellationToken) in C:\Gits\jellyfin\MediaBrowser.Providers\Manager\MetadataService.cs:line 880
```

</details>