### PR TITLE
Fix AlbumIds filtering by Name instead of by Id

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@
  - [mark-monteiro](https://github.com/mark-monteiro)
  - [MarkCiliaVincenti](https://github.com/MarkCiliaVincenti)
  - [Martin Reuter](https://github.com/reuterma24)
+ - [Matt Teahan](https://github.com/matt-teahan)
  - [Matt07211](https://github.com/Matt07211)
  - [Matthew Jones](https://github.com/matthew-jones-uk)
  - [Maxr1998](https://github.com/Maxr1998)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -586,8 +586,7 @@ public sealed partial class BaseItemRepository
 
         if (filter.AlbumIds.Length > 0)
         {
-            var subQuery = context.BaseItems.WhereOneOrMany(filter.AlbumIds, f => f.Id);
-            baseQuery = baseQuery.Where(e => subQuery.Any(f => f.Name == e.Album));
+            baseQuery = baseQuery.Where(e => filter.AlbumIds.Contains((Guid)e.ParentId!));
         }
 
         if (filter.ExcludeArtistIds.Length > 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -586,7 +586,7 @@ public sealed partial class BaseItemRepository
 
         if (filter.AlbumIds.Length > 0)
         {
-            baseQuery = baseQuery.Where(e => filter.AlbumIds.Contains((Guid)e.ParentId!));
+            baseQuery = baseQuery.Where(e => e.ParentId.HasValue && filter.AlbumIds.Contains(e.ParentId.Value));
         }
 
         if (filter.ExcludeArtistIds.Length > 0)


### PR DESCRIPTION
**Changes**
Replaces query that compares a song's Album metadata string to the Album's name (which was fetched via the id) to instead fetch songs that have a parent album which has an id of a queried id

**Code assistance**
AI not used

**Issues**
#17084 
