### PR TITLE
Fix missing person thumbnails after initial library scan (issue #8103)

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3624,6 +3624,29 @@ namespace Emby.Server.Implementations.Library
                     personEntity.DateLastSaved = DateTime.UtcNow;
 
                     CreateItems([personEntity], null, CancellationToken.None);
+
+                    // Download person image stubs to ensure images are available during initial scan
+                    if (itemUpdateType == ItemUpdateType.ImageUpdate && personEntity.HasImage(ImageType.Primary))
+                    {
+                        var primaryImage = personEntity.GetImageInfo(ImageType.Primary, 0);
+                        if (primaryImage != null && !string.IsNullOrWhiteSpace(primaryImage.Path)
+                            && primaryImage.Path.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                        {
+                            try
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                await ConvertImageToLocal(personEntity, primaryImage, 0, removeOnFailure: false).ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogDebug(ex, "Failed to download person image for {Name}, will use lazy loading", personEntity.Name);
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Changes**

Convert remote primary images for person entities to local images during image updates.

When a library is initially scanned with metadata stored locally, person entities can be created with remote image URLs that are not downloaded until the person's page is opened. This results in missing actor thumbnails in movie views despite the image being available.

This change eagerly converts remote person images to local images during the image update process, making actor thumbnails available immediately after the initial scan.

**Code assistance**

GitHub Copilot was used to help identify the relevant code path and propose an initial implementation. The generated code was reviewed, adapted, built, and validated against the reported issue before submission.

**Issues**

Fixes #8103 