### PR TITLE
Fix crash when favoriting items with duplicate user data keys

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -55,7 +55,10 @@ namespace Emby.Server.Implementations.Library
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var keys = item.GetUserDataKeys();
+            // De-duplicate the keys: an item can produce the same user-data key more than
+            // once (e.g. a video whose IMDb and TMDB provider ids are identical), which would
+            // otherwise make EF Core track two UserData entities with the same primary key.
+            var keys = item.GetUserDataKeys().Distinct().ToList();
 
             using var dbContext = _repository.CreateDbContext();
             using var transaction = dbContext.Database.BeginTransaction();

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library
+{
+    public sealed class UserDataManagerTests : IDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+        private readonly UserDataManager _userDataManager;
+
+        public UserDataManagerTests()
+        {
+            Video.RecordingsManager = Mock.Of<IRecordingsManager>();
+
+            _connection = new SqliteConnection("Data Source=:memory:");
+            _connection.Open();
+
+            _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            using var ctx = CreateDbContext();
+            ctx.Database.EnsureCreated();
+
+            var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+            factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+            var configManager = new Mock<IServerConfigurationManager>();
+            configManager.Setup(x => x.Configuration).Returns(new ServerConfiguration());
+
+            _userDataManager = new UserDataManager(configManager.Object, factory.Object);
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+        }
+
+        // Regression test for #15140: favoriting a video whose IMDb and TMDB provider ids are
+        // identical (e.g. a malformed NFO) makes Video.GetUserDataKeys() return the same key
+        // twice. SaveUserData used to add one UserData entity per key without de-duplicating,
+        // so EF Core threw "The instance of entity type 'UserData' cannot be tracked because
+        // another instance with the same key value ... is already being tracked".
+        [Fact]
+        public void SaveUserData_WithDuplicateUserDataKeys_PersistsWithoutThrowing()
+        {
+            var itemId = Guid.NewGuid();
+            var user = new User("testuser", "Test", "Test");
+
+            using (var seed = CreateDbContext())
+            {
+                seed.BaseItems.Add(new BaseItemEntity { Id = itemId, Type = "Movie" });
+                seed.Users.Add(user);
+                seed.SaveChanges();
+            }
+
+            var item = new Movie
+            {
+                Id = itemId,
+                ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Imdb"] = "tt1234567",
+                    ["Tmdb"] = "tt1234567",
+                },
+            };
+
+            // Sanity check: the keys really do contain a duplicate.
+            var keys = item.GetUserDataKeys();
+            Assert.NotEqual(keys.Count, keys.Distinct().Count());
+
+            var userData = new UserItemData { Key = string.Empty, IsFavorite = true };
+
+            var exception = Record.Exception(
+                () => _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserData, CancellationToken.None));
+
+            Assert.Null(exception);
+
+            using var verify = CreateDbContext();
+            var rows = verify.UserData.AsNoTracking().Where(u => u.ItemId.Equals(itemId)).ToList();
+            Assert.NotEmpty(rows);
+            Assert.All(rows, r => Assert.True(r.IsFavorite));
+        }
+
+        private JellyfinDbContext CreateDbContext()
+        {
+            return new JellyfinDbContext(
+                _dbOptions,
+                NullLogger<JellyfinDbContext>.Instance,
+                new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+                new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
`UserDataManager.SaveUserData` saved one `UserData` row per key returned by `BaseItem.GetUserDataKeys()`. If an item produced the same key twice (for example a video whose IMDb and TMDB ids are identical, which happens with hand-written NFO files), two rows ended up with the same primary key `{ItemId, UserId, CustomDataKey}` and EF Core threw "another instance with the same key value is already being tracked", so the item could not be favorited. I de-duplicate the keys before saving, the same way the read path in `GetUserDataBatch` already does.

**Code assistance**
Used Claude Code for the diagnosis, fix and test. I confirmed the root cause by reproducing the exact error from the issue against a real EF Core SQLite context; the full Jellyfin.Server.Implementations test suite passes.

**Issues**
Fixes #15140
