### PR TITLE
Preserve playlist items that are momentarily unresolvable during a scan

### DIFF
--- a/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BaseXmlSaver.cs
@@ -513,18 +513,55 @@ namespace MediaBrowser.LocalMetadata.Savers
 
             foreach (var link in linkedChildren)
             {
-                string? path = null;
-                if (pathById is not null && link.ItemId.HasValue && pathById.TryGetValue(link.ItemId.Value, out var resolvedPath))
-                {
-                    path = resolvedPath;
-                }
+                await WriteLinkedChild(writer, link, pathById, singularNodeName).ConfigureAwait(false);
+            }
 
-                if (!string.IsNullOrWhiteSpace(path))
-                {
-                    await writer.WriteStartElementAsync(null, singularNodeName, null).ConfigureAwait(false);
-                    await writer.WriteElementStringAsync(null, "Path", null, path).ConfigureAwait(false);
-                    await writer.WriteEndElementAsync().ConfigureAwait(false);
-                }
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Writes a single linked child, preserving the entry by its ItemId when the path cannot be resolved.
+        /// </summary>
+        /// <param name="writer">The xml writer.</param>
+        /// <param name="link">The linked child to write.</param>
+        /// <param name="pathById">The resolved item id to path lookup, or <c>null</c> if none were resolved.</param>
+        /// <param name="singularNodeName">The singular node name.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        private static async Task WriteLinkedChild(XmlWriter writer, LinkedChild link, IReadOnlyDictionary<Guid, string?>? pathById, string singularNodeName)
+        {
+            var hasItemId = !link.ItemId.GetValueOrDefault().Equals(Guid.Empty);
+
+            string? path = null;
+            if (pathById is not null && link.ItemId.HasValue && pathById.TryGetValue(link.ItemId.Value, out var resolvedPath))
+            {
+                path = resolvedPath;
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+#pragma warning disable CS0618 // Type or member is obsolete - legacy LinkedChild fallback
+                path = link.Path;
+#pragma warning restore CS0618
+            }
+
+            // When the path can't be resolved right now (e.g. the item is temporarily removed during a
+            // library scan), keep the entry by writing its ItemId so the scan doesn't silently empty the
+            // playlist/collection (#12008). Skip only when there is nothing left to reference.
+            if (string.IsNullOrWhiteSpace(path) && !hasItemId)
+            {
+                return;
+            }
+
+            await writer.WriteStartElementAsync(null, singularNodeName, null).ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                await writer.WriteElementStringAsync(null, "Path", null, path).ConfigureAwait(false);
+            }
+
+            if (hasItemId)
+            {
+                await writer.WriteElementStringAsync(null, "ItemId", null, link.ItemId.GetValueOrDefault().ToString("N", CultureInfo.InvariantCulture)).ConfigureAwait(false);
             }
 
             await writer.WriteEndElementAsync().ConfigureAwait(false);

--- a/tests/Jellyfin.Server.Implementations.Tests/Savers/PlaylistXmlSaverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Savers/PlaylistXmlSaverTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.LocalMetadata.Savers;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Savers
+{
+    public sealed class PlaylistXmlSaverTests
+    {
+        // Regression test for #12008: a library scan briefly removes and re-adds items, so a
+        // playlist item's ItemId can momentarily fail to resolve to a path. The saver used to
+        // drop such entries from playlist.xml, permanently emptying playlists after a scan.
+        // The entry must instead be preserved via its ItemId.
+        [Fact]
+        public async Task SaveAsync_WhenLinkedChildIsTemporarilyUnresolvable_PreservesEntryByItemId()
+        {
+            Video.RecordingsManager = Mock.Of<IRecordingsManager>();
+
+            var resolvableId = Guid.NewGuid();
+            var unresolvableId = Guid.NewGuid(); // simulates an item removed during a scan
+
+            var libraryManager = new Mock<ILibraryManager> { DefaultValue = DefaultValue.Empty };
+            libraryManager
+                .Setup(l => l.GetPeople(It.IsAny<BaseItem>()))
+                .Returns(new List<PersonInfo>());
+            libraryManager
+                .Setup(l => l.GetItemList(It.IsAny<InternalItemsQuery>()))
+                .Returns(new List<BaseItem> { new Movie { Id = resolvableId, Path = "/media/Movie/movie.mkv" } });
+
+            var configManager = new Mock<IServerConfigurationManager>();
+            configManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+
+            var saver = new PlaylistXmlSaver(
+                Mock.Of<IFileSystem>(),
+                configManager.Object,
+                libraryManager.Object,
+                NullLogger<PlaylistXmlSaver>.Instance);
+
+            var tempDir = Directory.CreateTempSubdirectory("jf-playlist-test-");
+            try
+            {
+                var playlist = new Playlist
+                {
+                    Path = tempDir.FullName,
+                    PlaylistMediaType = MediaType.Video,
+                    LinkedChildren =
+                    [
+                        new LinkedChild { ItemId = resolvableId, Type = LinkedChildType.Manual },
+                        new LinkedChild { ItemId = unresolvableId, Type = LinkedChildType.Manual },
+                    ],
+                };
+
+                await saver.SaveAsync(playlist, TestContext.Current.CancellationToken);
+
+                var xml = await File.ReadAllTextAsync(
+                    PlaylistXmlSaver.GetSavePath(tempDir.FullName),
+                    TestContext.Current.CancellationToken);
+
+                // Both linked children must survive the save, even the one that could not be
+                // resolved to a path at save time.
+                Assert.Equal(2, CountOccurrences(xml, "<PlaylistItem>"));
+                Assert.Contains(resolvableId.ToString("N"), xml, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains(unresolvableId.ToString("N"), xml, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                tempDir.Delete(true);
+            }
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
`BaseXmlSaver.AddLinkedChildren` resolved each linked child's `ItemId` to a current library path and only wrote the entry when that resolution succeeded. During a library scan items are briefly removed and re-added, so a referenced item can momentarily fail to resolve; the entry was then dropped from `playlist.xml` (and from collections), and the next parse persisted the shorter list, permanently emptying playlists after a scan. 10.10.7 did not do this — it wrote the stored `Path`/`ItemId` directly without dropping unresolved entries. I changed the saver to always persist the `ItemId` so an entry is never dropped just because it could not be resolved at save time, while still writing the resolved `Path` when it is available.

**Code assistance**
Used Claude Code for the diagnosis (including confirming the regression against 10.10.7), fix and test. I reproduced the data loss with a test that writes and re-reads a real playlist.xml; the full Jellyfin.Server.Implementations test suite passes.

**Issues**
Fixes #12008
