### PR TITLE
Deprecate the redundant /Trailers endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -122,6 +122,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <returns>A <see cref="QueryResult{BaseItemDto}"/> with the trailers.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [Obsolete("Use GetItems with includeItemTypes=Trailer instead.")]
     public async Task<ActionResult<QueryResult<BaseItemDto>>> GetTrailers(
         [FromQuery] Guid? userId,
         [FromQuery] string? maxOfficialRating,


### PR DESCRIPTION
**Changes**
`GET /Trailers` is a thin alias for `GET /Items` with `includeItemTypes=Trailer` — it just forwards to the injected `ItemsController`. Per the review on this PR, the agreed direction is to deprecate it rather than keep maintaining the delegation. I mark the action `[Obsolete]` so it is flagged as `deprecated` in the OpenAPI spec; clients should call the `GetItems` operation with `includeItemTypes=Trailer` instead. No behaviour change beyond the deprecation flag.

**Code assistance**
Used Claude Code. Verified against a running server that the generated OpenAPI spec now marks `GET /Trailers` as `deprecated: true` (operationId `GetTrailers`). No unit test is added: this is an API-surface (attribute) change, and the OpenAPI diff on the PR shows the deprecation.

**Issues**
Re #17065 — the endpoint is a redundant alias, so deprecating it steers clients to the working `GetItems` operation.
