### PR TITLE
Fix identify on locked items and BoxSet ID references

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -483,14 +483,14 @@ namespace MediaBrowser.Providers.Manager
             return _savers.Where(i => IsSaverEnabledForItem(i, item, libraryOptions, ItemUpdateType.MetadataEdit, false));
         }
 
-        private IEnumerable<IMetadataProvider<T>> GetMetadataProvidersInternal<T>(BaseItem item, LibraryOptions libraryOptions, MetadataOptions globalMetadataOptions, bool includeDisabled, bool forceEnableInternetMetadata, string libraryPath)
+        private IEnumerable<IMetadataProvider<T>> GetMetadataProvidersInternal<T>(BaseItem item, LibraryOptions libraryOptions, MetadataOptions globalMetadataOptions, bool includeDisabled, bool forceEnableInternetMetadata, string libraryPath, bool ignoreItemLock = false)
             where T : BaseItem
         {
             var typeOptions = libraryOptions.GetTypeOptions(item.GetType().Name);
 
             var orderedProviders = GetOrCreateOrderedProviders<T>(item.GetType().Name, libraryOptions, globalMetadataOptions, includeDisabled, forceEnableInternetMetadata, libraryPath);
 
-            return orderedProviders.Where(i => CanRefreshMetadata(i, item, typeOptions, includeDisabled, forceEnableInternetMetadata));
+            return orderedProviders.Where(i => CanRefreshMetadata(i, item, typeOptions, includeDisabled, forceEnableInternetMetadata, ignoreItemLock));
         }
 
         private IMetadataProvider<T>[] GetOrCreateOrderedProviders<T>(
@@ -561,7 +561,8 @@ namespace MediaBrowser.Providers.Manager
             BaseItem item,
             TypeOptions? libraryTypeOptions,
             bool includeDisabled,
-            bool forceEnableInternetMetadata)
+            bool forceEnableInternetMetadata,
+            bool ignoreItemLock = false)
         {
             if (!item.SupportsLocalMetadata && provider is ILocalMetadataProvider)
             {
@@ -573,8 +574,8 @@ namespace MediaBrowser.Providers.Manager
                 return true;
             }
 
-            // If locked only allow local providers
-            if (item.IsLocked && provider is not ILocalMetadataProvider && provider is not IForcedProvider)
+            // If locked only allow local providers, unless the lock is being ignored (e.g. for an explicit, manual remote search/identify).
+            if (item.IsLocked && !ignoreItemLock && provider is not ILocalMetadataProvider && provider is not IForcedProvider)
             {
                 return false;
             }
@@ -938,7 +939,8 @@ namespace MediaBrowser.Providers.Manager
 
             var options = GetMetadataOptions(referenceItem);
             var libraryPath = GetLibraryPathForItem(referenceItem);
-            var providers = GetMetadataProvidersInternal<TItemType>(referenceItem, libraryOptions, options, searchInfo.IncludeDisabledProviders, false, libraryPath)
+            // A remote search is an explicit, manual user action, so the item being locked must not hide the available remote providers.
+            var providers = GetMetadataProvidersInternal<TItemType>(referenceItem, libraryOptions, options, searchInfo.IncludeDisabledProviders, false, libraryPath, ignoreItemLock: true)
                 .OfType<IRemoteSearchProvider<TLookupType>>();
 
             if (!string.IsNullOrEmpty(searchInfo.SearchProviderName))

--- a/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbCollectionExternalId.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/BoxSets/TmdbCollectionExternalId.cs
@@ -1,3 +1,4 @@
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
@@ -6,15 +7,15 @@ using MediaBrowser.Model.Providers;
 namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
 {
     /// <summary>
-    /// External id for a TMDb box set.
+    /// External id linking a movie, music video or trailer to the TMDb collection it belongs to.
     /// </summary>
-    public class TmdbBoxSetExternalId : IExternalId
+    public class TmdbCollectionExternalId : IExternalId
     {
         /// <inheritdoc />
         public string ProviderName => TmdbUtils.ProviderName;
 
         /// <inheritdoc />
-        public string Key => MetadataProvider.Tmdb.ToString();
+        public string Key => MetadataProvider.TmdbCollection.ToString();
 
         /// <inheritdoc />
         public ExternalIdMediaType? Type => ExternalIdMediaType.BoxSet;
@@ -22,7 +23,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.BoxSets
         /// <inheritdoc />
         public bool Supports(IHasProviderIds item)
         {
-            return item is BoxSet;
+            return item is Movie || item is MusicVideo || item is Trailer;
         }
     }
 }


### PR DESCRIPTION
While debugging why manually created BoxSets don't return anything when identifying I encountered two issues:
* By default they are marked as Locked, which prevents identify from returning anything.
* BoxSets can have Tmdb IDs but right now we don't allow it due to it only being not assignable

**Changes**
* Allow remote searches to run and return data, even on locked items
* Use the existing `TmdbBoxSetExternalId` to handle the BoxSet's own Tmdb Id
* Create new `TmdbCollectionExternalId` that handles the Item -> BoxSet relation

**Code assistance**
None