### PR TITLE
Fall back to the default transcode path when it is unwritable

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -187,7 +187,14 @@ namespace Jellyfin.Server
                  * Initialize the transcode path marker so we avoid starting Jellyfin in a broken state.
                  * This should really be a part of IApplicationPaths but this path is configured differently.
                  */
-                _ = appHost.ConfigurationManager.GetTranscodePath();
+                var configuredTranscodePath = appHost.ConfigurationManager.GetEncodingOptions().TranscodingTempPath;
+                var transcodePath = appHost.ConfigurationManager.GetTranscodePath();
+                if (!string.IsNullOrEmpty(configuredTranscodePath) && !string.Equals(configuredTranscodePath, transcodePath, StringComparison.Ordinal))
+                {
+                    _logger.LogError(
+                        "Configured transcode path \"{Path}\" is not writable; using the default instead. Fix its permissions or set a writable path in the dashboard",
+                        configuredTranscodePath);
+                }
 
                 // Re-use the host service provider in the app host since ASP.NET doesn't allow a custom service collection.
                 appHost.ServiceProvider = _jellyfinHost.Services;

--- a/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
+++ b/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
@@ -18,24 +18,40 @@ namespace MediaBrowser.Common.Configuration
             => configurationManager.GetConfiguration<EncodingOptions>("encoding");
 
         /// <summary>
-        /// Retrieves the transcoding temp path from the encoding configuration, falling back to a default if no path
-        /// is specified in configuration. If the directory does not exist, it will be created.
+        /// Retrieves the transcoding temp path from the encoding configuration. Falls back to a default
+        /// when no path is configured, or when the configured path exists but cannot be used (for example
+        /// it is not writable), so a bad path does not stop the server or transcoding. The directory is
+        /// created if it does not exist.
         /// </summary>
         /// <param name="configurationManager">The configuration manager.</param>
         /// <returns>The transcoding temp path.</returns>
-        /// <exception cref="UnauthorizedAccessException">If the directory does not exist, and the caller does not have the required permission to create it.</exception>
-        /// <exception cref="NotSupportedException">If there is a custom path transcoding path specified, but it is invalid.</exception>
-        /// <exception cref="IOException">If the directory does not exist, and it also could not be created.</exception>
+        /// <exception cref="NotSupportedException">If a configured transcoding path is invalid.</exception>
+        /// <exception cref="UnauthorizedAccessException">If the default path cannot be created due to missing permissions.</exception>
+        /// <exception cref="IOException">If the default path could not be created.</exception>
         public static string GetTranscodePath(this IConfigurationManager configurationManager)
         {
             // Get the configured path and fall back to a default
+            var defaultPath = Path.Combine(configurationManager.CommonApplicationPaths.CachePath, "transcodes");
             var transcodingTempPath = configurationManager.GetEncodingOptions().TranscodingTempPath;
             if (string.IsNullOrEmpty(transcodingTempPath))
             {
-                transcodingTempPath = Path.Combine(configurationManager.CommonApplicationPaths.CachePath, "transcodes");
+                transcodingTempPath = defaultPath;
             }
 
-            configurationManager.CommonApplicationPaths.CreateAndCheckMarker(transcodingTempPath, "transcode", true);
+            try
+            {
+                configurationManager.CommonApplicationPaths.CreateAndCheckMarker(transcodingTempPath, "transcode", true);
+            }
+            catch (Exception ex) when (transcodingTempPath != defaultPath && ex is IOException or UnauthorizedAccessException)
+            {
+                // The configured path is not usable (e.g. it exists but is not writable). Fall back to the
+                // default so the server still starts and transcoding keeps working. The configured value is
+                // left untouched so a transient cause (such as a not-yet-mounted drive) self-heals on the
+                // next start.
+                configurationManager.CommonApplicationPaths.CreateAndCheckMarker(defaultPath, "transcode", true);
+                return defaultPath;
+            }
+
             return transcodingTempPath;
         }
     }

--- a/tests/Jellyfin.Server.Tests/EncodingConfigurationExtensionsTests.cs
+++ b/tests/Jellyfin.Server.Tests/EncodingConfigurationExtensionsTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Configuration;
+using Moq;
+using Xunit;
+using IConfigurationManager = MediaBrowser.Common.Configuration.IConfigurationManager;
+
+namespace Jellyfin.Server.Tests
+{
+    public class EncodingConfigurationExtensionsTests
+    {
+        private static Mock<IConfigurationManager> CreateConfig(EncodingOptions options, Mock<IApplicationPaths> paths)
+        {
+            var config = new Mock<IConfigurationManager>();
+            config.Setup(c => c.GetConfiguration("encoding")).Returns(options);
+            config.SetupGet(c => c.CommonApplicationPaths).Returns(paths.Object);
+            return config;
+        }
+
+        [Fact]
+        public void GetTranscodePath_UnwritableConfiguredPath_FallsBackToDefaultWithoutChangingConfig()
+        {
+            const string CachePath = "/cache";
+            var defaultPath = Path.Combine(CachePath, "transcodes");
+            const string BadPath = "/var/empty/not-writable-transcode";
+            var options = new EncodingOptions { TranscodingTempPath = BadPath };
+
+            var paths = new Mock<IApplicationPaths>();
+            paths.SetupGet(p => p.CachePath).Returns(CachePath);
+            paths.Setup(p => p.CreateAndCheckMarker(BadPath, "transcode", true))
+                .Throws(new UnauthorizedAccessException("denied"));
+
+            var config = CreateConfig(options, paths);
+
+            var result = config.Object.GetTranscodePath();
+
+            // Falls back to the default, and leaves the configured value untouched so a transient cause
+            // (e.g. a not-yet-mounted drive) self-heals on a later call.
+            Assert.Equal(defaultPath, result);
+            Assert.Equal(BadPath, options.TranscodingTempPath);
+            paths.Verify(p => p.CreateAndCheckMarker(defaultPath, "transcode", true), Times.Once);
+        }
+
+        [Fact]
+        public void GetTranscodePath_WritableConfiguredPath_ReturnsConfiguredPath()
+        {
+            const string GoodPath = "/mnt/fast/transcode";
+            var options = new EncodingOptions { TranscodingTempPath = GoodPath };
+
+            var paths = new Mock<IApplicationPaths>();
+            paths.SetupGet(p => p.CachePath).Returns("/cache");
+
+            var config = CreateConfig(options, paths);
+
+            Assert.Equal(GoodPath, config.Object.GetTranscodePath());
+        }
+
+        [Fact]
+        public void GetTranscodePath_NoConfiguredPath_ReturnsDefault()
+        {
+            const string CachePath = "/cache";
+            var options = new EncodingOptions { TranscodingTempPath = null };
+
+            var paths = new Mock<IApplicationPaths>();
+            paths.SetupGet(p => p.CachePath).Returns(CachePath);
+
+            var config = CreateConfig(options, paths);
+
+            Assert.Equal(Path.Combine(CachePath, "transcodes"), config.Object.GetTranscodePath());
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
A transcoding temp path that exists but is not writable by the Jellyfin user bricks the server: `GetTranscodePath()` creates a `.jellyfin-transcode` marker in that directory, and the unhandled `UnauthorizedAccessException` it throws aborts startup, so the server never starts. Playback also breaks, since transcoding resolves its path the same way. The only recovery is to hand-edit `encoding.xml`. This is the issue in #16766. I make `GetTranscodePath` fall back to the default transcode path when the configured one can't be used, so the server starts and transcoding keeps working. The configured value is left untouched, so a transient cause (for example a drive that isn't mounted yet at boot) self-heals on the next start. Startup logs an error telling the admin the configured path is being ignored and how to fix it.

**Code assistance**
Used Claude Code for the diagnosis, fix and tests. Added `EncodingConfigurationExtensionsTests` covering the unwritable path (falls back to default, config untouched), a writable path (returned as-is), and no configured path (default). I also verified it end-to-end against a real server: I saved a transcode path, made the directory unwritable, and restarted. On master the server fails to start; with this change it starts, logs the warning, keeps the configured path in `encoding.xml`, and serves requests.

**Issues**
Fixes #16766
