### PR TITLE
Bound-check playlist item move index to avoid HTTP 500

### DIFF
--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -335,26 +335,35 @@ namespace Emby.Server.Implementations.Playlists
             var children = playlist.GetManageableItems().ToList();
             var accessibleChildren = children.Where(c => c.Item2.IsVisible(user)).ToArray();
 
-            var oldIndexAll = children.FindIndex(i => string.Equals(entryId, i.Item1.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
-            var oldIndexAccessible = accessibleChildren.FindIndex(i => string.Equals(entryId, i.Item1.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
+            bool MatchesEntry(LinkedChild child)
+                => string.Equals(entryId, child.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase);
+
+            var oldIndexAccessible = accessibleChildren.FindIndex(i => MatchesEntry(i.Item1));
+
+            // The requested entry isn't among the user's accessible playlist items (this also
+            // covers an empty playlist), so there is nothing to move. Returning here also
+            // guarantees accessibleChildren is non-empty for the index access below.
+            if (oldIndexAccessible < 0)
+            {
+                _logger.LogWarning("Modified item not found in playlist. ItemId: {ItemId}, PlaylistId: {PlaylistId}", entryId, playlistId);
+
+                return;
+            }
 
             if (oldIndexAccessible == newIndex)
             {
                 return;
             }
 
-            var newPriorItemIndex = Math.Max(newIndex - 1, 0);
+            // Clamp the target index so an out-of-range value (e.g. beyond the playlist length)
+            // moves the item to the end instead of throwing an IndexOutOfRangeException. See #17066.
+            var newPriorItemIndex = Math.Clamp(newIndex - 1, 0, accessibleChildren.Length - 1);
             var newPriorItemId = accessibleChildren[newPriorItemIndex].Item1.ItemId;
             var newPriorItemIndexOnAllChildren = children.FindIndex(c => c.Item1.ItemId.Equals(newPriorItemId));
             var adjustedNewIndex = DetermineAdjustedIndex(newPriorItemIndexOnAllChildren, newIndex);
 
-            var item = playlist.LinkedChildren.FirstOrDefault(i => string.Equals(entryId, i.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
-            if (item is null)
-            {
-                _logger.LogWarning("Modified item not found in playlist. ItemId: {ItemId}, PlaylistId: {PlaylistId}", entryId, playlistId);
-
-                return;
-            }
+            // The entry was found in accessibleChildren above, so it is guaranteed to be present here.
+            var item = playlist.LinkedChildren.First(MatchesEntry);
 
             var newList = playlist.LinkedChildren.ToList();
             newList.Remove(item);

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/PlaylistsControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/PlaylistsControllerTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Jellyfin.Api.Models.PlaylistDtos;
+using Jellyfin.Data.Enums;
+using Jellyfin.Extensions.Json;
+using MediaBrowser.Model.Playlists;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public sealed class PlaylistsControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private readonly JellyfinApplicationFactory _factory;
+    private static string? _accessToken;
+
+    public PlaylistsControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task MoveItem_OutOfRangeIndex_DoesNotReturnServerError()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        // Create an empty playlist owned by the authenticated user (no media items required).
+        using var createResponse = await client.PostAsJsonAsync(
+            "Playlists",
+            new CreatePlaylistDto { Name = "MoveItemRepro", MediaType = MediaType.Audio },
+            JsonDefaults.Options,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+
+        var created = await createResponse.Content
+            .ReadFromJsonAsync<PlaylistCreationResult>(JsonDefaults.Options, TestContext.Current.CancellationToken);
+        Assert.NotNull(created);
+
+        // Regression test for #17066: moving an item to an out-of-range index used to throw an
+        // unhandled IndexOutOfRangeException in PlaylistManager.MoveItemAsync (HTTP 500) because
+        // newIndex was used to index the items array without bound-checking.
+        using var moveResponse = await client.PostAsync(
+            $"Playlists/{created.Id}/Items/{Guid.Empty:N}/Move/999",
+            content: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, moveResponse.StatusCode);
+    }
+}


### PR DESCRIPTION
**Changes**
`POST /Playlists/{playlistId}/Items/{itemId}/Move/{newIndex}` with an out-of-range `newIndex` threw an unhandled `IndexOutOfRangeException` (HTTP 500). `PlaylistManager.MoveItemAsync` indexed the accessible-items array with `Math.Max(newIndex - 1, 0)` before checking whether the entry existed, so a `newIndex` past the playlist length, or any move on an empty playlist, read past the end of the array. Any authenticated user could trigger this on a playlist they own. I moved the existing not-found guard ahead of the array access, so it now returns early when the entry is not among the user's accessible items (this also covers an empty playlist and guarantees the array is non-empty), and I clamp the prior-item index to the array bounds so an over-large index moves the item to the end, consistent with the existing `newIndex >= count` handling further down. With the guard moved up, the later null check it duplicated is now removed.

**Code assistance**
Used Claude Code for the diagnosis, fix and test. Added an integration test mirroring the report: it creates an empty playlist for the authenticated user and moves a non-existent item to index 999. It returns 500 on master and 204 with this change.

**Issues**
Fixes #17066
