### PR TITLE
Fix SysctlByName on macOS

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
@@ -46,7 +46,10 @@ public static class ApplePlatformHelper
 
     private static int SysctlByName(ReadOnlySpan<byte> name, IntPtr oldp, ref IntPtr oldlenp, IntPtr newp, uint newlen)
     {
-        return NativeMethods.SysctlByName(name.ToArray(), oldp, ref oldlenp, newp, newlen);
+        // sysctlbyname expects a null-terminated C string.
+        var nameBytes = new byte[name.Length + 1];
+        name.CopyTo(nameBytes);
+        return NativeMethods.SysctlByName(nameBytes, oldp, ref oldlenp, newp, newlen);
     }
 
     /// <summary>


### PR DESCRIPTION
On start current master logs `Error getting CPU brand string: Failed to get sysctl value for machdep.cpu.brand_string with error -1`
- caused by `sysctlbyname` expecting a null-terminated C string:

**Changes**
* Add the null-terminator before parsing

**Code assistance**
None