### PR TITLE
Clear resume position when importing a watched item from NFO

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -317,6 +317,14 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                             {
                                 userData.Played = played;
 
+                                // A fully watched item has no resume position. Clearing it keeps the
+                                // item out of "Continue Watching", whose resume query treats any
+                                // PlaybackPositionTicks > 0 as resumable regardless of the played state.
+                                if (played)
+                                {
+                                    userData.PlaybackPositionTicks = 0;
+                                }
+
                                 if (!item.Id.IsEmpty())
                                 {
                                     _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.Import, CancellationToken.None);

--- a/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
+++ b/tests/Jellyfin.XbmcMetadata.Tests/Parsers/MovieNfoParserTests.cs
@@ -194,6 +194,29 @@ namespace Jellyfin.XbmcMetadata.Tests.Parsers
             Assert.Equal(_localImageFileMetadata.Name, result.Images[0].FileInfo.Name);
         }
 
+        [Fact]
+        public void Fetch_WatchedItem_ResetsResumePosition()
+        {
+            // Simulate a leftover resume position in the database (e.g. the item was partially
+            // watched before). Importing a watched=true NFO must clear it, otherwise the item
+            // stays in "Continue Watching" because the resume query only checks for a non-zero
+            // PlaybackPositionTicks. See https://github.com/jellyfin/jellyfin/issues/12054.
+            var item = new Movie();
+            var userData = _userDataManager.GetUserData(_testUser, item)!;
+            userData.PlaybackPositionTicks = TimeSpan.FromMinutes(30).Ticks;
+
+            var result = new MetadataResult<Video>()
+            {
+                Item = item
+            };
+
+            // Justice League.nfo contains <watched>true</watched>.
+            _parser.Fetch(result, "Test Data/Justice League.nfo", CancellationToken.None);
+
+            Assert.True(userData.Played);
+            Assert.Equal(0, userData.PlaybackPositionTicks);
+        }
+
         [Theory]
         [InlineData("Test Data/Tmdb.nfo", "Tmdb", "30287")]
         [InlineData("Test Data/Imdb.nfo", "Imdb", "tt0944947")]


### PR DESCRIPTION
**Changes**
Fully watched movies and episodes can stay in Continue Watching forever; the common factor in #12054 is NFO watch-status tracking. Continue Watching is the resume query, and "resumable" is defined purely as `PlaybackPositionTicks > 0` (`BaseItemRepository.TranslateQuery`); the resume endpoints set `IsResumable = true` but never `IsPlayed = false`. So any item that is both `Played = true` and `PlaybackPositionTicks > 0` stays there. Normal playback cannot create that state (`UpdatePlayState` zeroes the position on completion, and mark-as-watched uses `MarkPlayed(resetPosition: true)`), but the NFO import path set `Played = true` while leaving any leftover position untouched. I reset `PlaybackPositionTicks` to 0 when an NFO marks an item watched, matching `MarkPlayed(resetPosition: true)` and `UpdatePlayState`.

I did not exclude played items at the query level on purpose: an in-progress rewatch is also `Played = true` with `position > 0` and would be wrongly dropped from Continue Watching. Third-party paths (Trakt/webhook plugins) that mark items played without resetting the position are out of scope here.

**Code assistance**
Used Claude Code for the diagnosis, fix and test. Added `MovieNfoParserTests.Fetch_WatchedItem_ResetsResumePosition` (seed a 30-minute position, import a watched NFO, assert `Played == true` and position == 0); it fails without the fix and passes with it, and the full Jellyfin.XbmcMetadata.Tests suite is green. The reset runs on the same `userData` object and `SaveUserData` call that already persists the played flag, so it takes effect wherever the NFO watch-status import is applied.

**Issues**
Fixes #12054
