### PR TITLE
Don't delete media files still referenced by other library items

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -572,13 +572,30 @@ namespace Emby.Server.Implementations.Library
 
             if ((options.DeleteFileLocation && item.IsFileProtocol) || IsInternalItem(item))
             {
+                // Don't delete files that are still referenced by another library item
+                // (e.g. duplicate entries pointing at the same path, see #15754).
+                // Removing them would cause data loss for those items.
+                var deletingItemIds = children.Select(c => c.Id).Append(item.Id).ToHashSet();
+
                 // Assume only the first is required
                 // Add this flag to GetDeletePaths if required in the future
                 var isRequiredForDelete = true;
 
                 foreach (var fileSystemInfo in item.GetDeletePaths())
                 {
-                    DeleteItemPath(item, isRequiredForDelete, fileSystemInfo);
+                    if (IsPathReferencedByOtherItems(fileSystemInfo.FullName, deletingItemIds))
+                    {
+                        _logger.LogInformation(
+                            "Not deleting path because it is referenced by another item, Type: {Type}, Name: {Name}, Path: {Path}, Id: {Id}",
+                            item.GetType().Name,
+                            item.Name ?? "Unknown name",
+                            fileSystemInfo.FullName,
+                            item.Id);
+                    }
+                    else
+                    {
+                        DeleteItemPath(item, isRequiredForDelete, fileSystemInfo);
+                    }
 
                     isRequiredForDelete = false;
                 }
@@ -664,6 +681,31 @@ namespace Emby.Server.Implementations.Library
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines whether a file system path is still referenced by a library item other than the
+        /// ones currently being deleted. Used to avoid deleting files shared by multiple items (see #15754).
+        /// </summary>
+        /// <param name="path">The path being considered for deletion.</param>
+        /// <param name="deletingItemIds">The ids of the items being deleted, which should be ignored.</param>
+        /// <returns><c>true</c> if another item references the path; otherwise <c>false</c>.</returns>
+        internal bool IsPathReferencedByOtherItems(string path, IReadOnlySet<Guid> deletingItemIds)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            var query = new InternalItemsQuery
+            {
+                Path = path,
+                // A virtual/missing item has no real file behind it and must never keep a real file alive.
+                IsVirtualItem = false,
+                DtoOptions = new DtoOptions(false)
+            };
+
+            return GetItemList(query).Any(i => !deletingItemIds.Contains(i.Id));
         }
 
         private bool IsInternalItem(BaseItem item)

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/IsPathReferencedByOtherItemsTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManager/IsPathReferencedByOtherItemsTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Emby.Naming.Common;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Resolvers;
+using MediaBrowser.Controller.Sorting;
+using MediaBrowser.Model.IO;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library.LibraryManager;
+
+public class IsPathReferencedByOtherItemsTests
+{
+    private readonly Emby.Server.Implementations.Library.LibraryManager _libraryManager;
+    private readonly Mock<IItemRepository> _itemRepositoryMock;
+
+    public IsPathReferencedByOtherItemsTests()
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        fixture.Register(() => new NamingOptions());
+        var configMock = fixture.Freeze<Mock<IServerConfigurationManager>>();
+        configMock.Setup(c => c.ApplicationPaths.ProgramDataPath).Returns("/data");
+        _itemRepositoryMock = fixture.Freeze<Mock<IItemRepository>>();
+        _libraryManager = fixture.Build<Emby.Server.Implementations.Library.LibraryManager>().Do(s => s.AddParts(
+                fixture.Create<IEnumerable<IResolverIgnoreRule>>(),
+                fixture.Create<IEnumerable<IItemResolver>>(),
+                fixture.Create<IEnumerable<IIntroProvider>>(),
+                fixture.Create<IEnumerable<IBaseItemComparer>>(),
+                fixture.Create<IEnumerable<ILibraryPostScanTask>>()))
+            .Create();
+
+        BaseItem.FileSystem ??= fixture.Create<IFileSystem>();
+        BaseItem.MediaSourceManager ??= fixture.Create<IMediaSourceManager>();
+    }
+
+    [Fact]
+    public void IsPathReferencedByOtherItems_OtherItemSharesPath_ReturnsTrue()
+    {
+        var deletingId = Guid.NewGuid();
+        var otherItem = new Movie { Id = Guid.NewGuid(), Path = "/movies/Shared/movie.mkv" };
+        _itemRepositoryMock.Setup(i => i.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new List<BaseItem> { otherItem });
+
+        var result = _libraryManager.IsPathReferencedByOtherItems("/movies/Shared/movie.mkv", new HashSet<Guid> { deletingId });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPathReferencedByOtherItems_OnlyDeletingItemsSharePath_ReturnsFalse()
+    {
+        var deletingId = Guid.NewGuid();
+        var deletingItem = new Movie { Id = deletingId, Path = "/movies/Shared/movie.mkv" };
+        _itemRepositoryMock.Setup(i => i.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new List<BaseItem> { deletingItem });
+
+        var result = _libraryManager.IsPathReferencedByOtherItems("/movies/Shared/movie.mkv", new HashSet<Guid> { deletingId });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPathReferencedByOtherItems_NoItemReferencesPath_ReturnsFalse()
+    {
+        _itemRepositoryMock.Setup(i => i.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new List<BaseItem>());
+
+        var result = _libraryManager.IsPathReferencedByOtherItems("/movies/Shared/movie.mkv", new HashSet<Guid> { Guid.NewGuid() });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPathReferencedByOtherItems_EmptyPath_ReturnsFalse()
+    {
+        var result = _libraryManager.IsPathReferencedByOtherItems(string.Empty, new HashSet<Guid> { Guid.NewGuid() });
+
+        Assert.False(result);
+        _itemRepositoryMock.Verify(i => i.GetItemList(It.IsAny<InternalItemsQuery>()), Times.Never);
+    }
+
+    [Fact]
+    public void IsPathReferencedByOtherItems_QueriesByPathExcludingVirtualItems()
+    {
+        InternalItemsQuery? captured = null;
+        _itemRepositoryMock.Setup(i => i.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Callback<InternalItemsQuery>(q => captured = q)
+            .Returns(new List<BaseItem>());
+
+        _libraryManager.IsPathReferencedByOtherItems("/movies/Shared/movie.mkv", new HashSet<Guid> { Guid.NewGuid() });
+
+        Assert.NotNull(captured);
+        Assert.Equal("/movies/Shared/movie.mkv", captured!.Path);
+        // Virtual/missing items must never keep a real file alive.
+        Assert.False(captured.IsVirtualItem);
+    }
+}


### PR DESCRIPTION
## Problem

When two library items point at the same file (for example the duplicate-entry situation described in #3361), deleting one item physically deletes the underlying file, even though it is still required by the other item. The result is permanent data loss (#15754, reproducible and re-confirmed by the reporter).

## Root cause

`LibraryManager.DeleteItem` loops over `item.GetDeletePaths()` and deletes each path from disk via `DeleteItemPath` (`File.Delete`/`Directory.Delete`) without checking whether any other library item references the same path.

## Fix

Before physically deleting a path, check whether any **other** library item (i.e. not the item being deleted nor its recursive children) references that exact path. If so, keep the file on disk and only remove the database entry, logging the reason.

The lookup excludes virtual/missing items (`IsVirtualItem = false`): such an item has no real file behind it and must never keep a real file alive.

This deliberately trades an irreversible data-loss risk for a recoverable, logged leftover-file case: if a *stale* duplicate entry happens to share the path, the file is kept rather than deleted. The user can re-delete after the stale entry is cleaned up. Preserving data is the safe direction here.

### Scope

Exact-path matching, which covers the reported duplicate-item scenario. An item that references a file *inside* a directory being deleted is a broader (and riskier) case left out of this change.

## Testing

Added `IsPathReferencedByOtherItemsTests` (5 cases): another item shares the path → keep; only the items being deleted share it → delete; nothing references it → delete; empty path → delete without querying; and the lookup is built with the path and `IsVirtualItem == false`.

Full `Jellyfin.Server.Implementations.Tests` suite passes (552 passed, 4 skipped Windows-only).

Fixes #15754

🤖 Generated with [Claude Code](https://claude.com/claude-code)