### PR TITLE
Don't let stale user-data keys shadow the current played state

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -192,7 +192,10 @@ namespace Emby.Server.Implementations.Library
                 }
                 else
                 {
-                    var userData = item.UserData?.Where(e => e.UserId.Equals(user.Id)).Select(Map).FirstOrDefault();
+                    var keys = item.GetUserDataKeys();
+                    var userData = item.UserData is null
+                        ? null
+                        : SelectCurrentUserData(item.UserData.Where(e => e.UserId.Equals(user.Id)), keys);
                     if (userData is not null)
                     {
                         result[item.Id] = userData;
@@ -200,7 +203,6 @@ namespace Emby.Server.Implementations.Library
                     }
                     else
                     {
-                        var keys = item.GetUserDataKeys();
                         itemsNeedingQuery.Add((item, keys));
                     }
                 }
@@ -230,8 +232,7 @@ namespace Emby.Server.Implementations.Library
                     UserItemData userData;
                     if (userDataByItem.TryGetValue(item.Id, out var itemUserData) && itemUserData.Length > 0)
                     {
-                        var directDataReference = itemUserData.FirstOrDefault(e => e.CustomDataKey == item.Id.ToString("N"));
-                        userData = directDataReference is not null ? Map(directDataReference) : Map(itemUserData.First());
+                        userData = SelectCurrentUserData(itemUserData, keys) ?? Map(itemUserData[0]);
                     }
                     else
                     {
@@ -259,10 +260,41 @@ namespace Emby.Server.Implementations.Library
         /// <inheritdoc />
         public UserItemData? GetUserData(User user, BaseItem item)
         {
-            return item.UserData?.Where(e => e.UserId.Equals(user.Id)).Select(Map).FirstOrDefault() ?? new UserItemData()
+            var keys = item.GetUserDataKeys();
+            var userData = item.UserData is null
+                ? null
+                : SelectCurrentUserData(item.UserData.Where(e => e.UserId.Equals(user.Id)), keys);
+
+            return userData ?? new UserItemData()
             {
-                Key = item.GetUserDataKeys()[0],
+                Key = keys[0],
             };
+        }
+
+        /// <summary>
+        /// Selects the user data row stored under one of the item's current keys, falling back to the
+        /// first available row. This prevents stale rows left over from a previous match (for example
+        /// after an item was re-identified, see #15795) from shadowing the current state.
+        /// </summary>
+        /// <param name="userRowsForUser">The user data rows for the relevant user.</param>
+        /// <param name="keys">The item's current user data keys.</param>
+        /// <returns>The mapped user data, or <c>null</c> if there are no rows.</returns>
+        private static UserItemData? SelectCurrentUserData(IEnumerable<UserData> userRowsForUser, IReadOnlyList<string> keys)
+        {
+            UserData? match = null;
+            UserData? first = null;
+            foreach (var row in userRowsForUser)
+            {
+                first ??= row;
+                if (keys.Contains(row.CustomDataKey))
+                {
+                    match = row;
+                    break;
+                }
+            }
+
+            var selected = match ?? first;
+            return selected is null ? null : Map(selected);
         }
 
         /// <inheritdoc />

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerKeySelectionTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerKeySelectionTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class UserDataManagerKeySelectionTests
+{
+    private readonly UserDataManager _userDataManager;
+    private readonly User _user;
+
+    public UserDataManagerKeySelectionTests()
+    {
+        var config = new Mock<IServerConfigurationManager>();
+        config.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        var dbProvider = new Mock<IDbContextFactory<JellyfinDbContext>>();
+
+        _userDataManager = new UserDataManager(config.Object, dbProvider.Object);
+        _user = new User("Test User", "Auth provider", "Reset provider");
+
+        // Video.SourceType -> IsActiveRecording() dereferences this static.
+        Video.RecordingsManager ??= Mock.Of<IRecordingsManager>(r => r.GetActiveRecordingInfo(It.IsAny<string>()) == null);
+    }
+
+    private UserData Row(Guid itemId, string key, bool played) => new UserData
+    {
+        CustomDataKey = key,
+        ItemId = itemId,
+        Item = null,
+        UserId = _user.Id,
+        User = null,
+        Played = played,
+    };
+
+    [Fact]
+    public void GetUserData_StaleRowFirst_PrefersCurrentKeyRow()
+    {
+        // A re-identified item keeps user data rows under old (stale) keys as well as its current
+        // keys. The current key here is the item id (no provider ids set). The stale row is first,
+        // so the previous FirstOrDefault logic would have returned it. See #15795.
+        var itemId = Guid.NewGuid();
+        var movie = new Movie { Id = itemId };
+        movie.UserData = new List<UserData>
+        {
+            Row(itemId, "tt0197013", played: false), // stale key from the wrong match
+            Row(itemId, itemId.ToString(), played: true) // current key
+        };
+
+        var result = _userDataManager.GetUserData(_user, movie);
+
+        Assert.NotNull(result);
+        Assert.True(result!.Played);
+    }
+
+    [Fact]
+    public void GetUserData_OnlyStaleRows_FallsBackToFirstRow()
+    {
+        var itemId = Guid.NewGuid();
+        var movie = new Movie { Id = itemId };
+        movie.UserData = new List<UserData>
+        {
+            Row(itemId, "tt0197013", played: true)
+        };
+
+        var result = _userDataManager.GetUserData(_user, movie);
+
+        Assert.NotNull(result);
+        Assert.True(result!.Played);
+    }
+
+    [Fact]
+    public void GetUserData_NoRows_ReturnsDefaultWithCurrentKey()
+    {
+        var itemId = Guid.NewGuid();
+        var movie = new Movie { Id = itemId };
+        movie.UserData = new List<UserData>();
+
+        var result = _userDataManager.GetUserData(_user, movie);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Played);
+        Assert.Equal(itemId.ToString(), result.Key);
+    }
+}


### PR DESCRIPTION
**Changes**
After an item is re-identified (for example fixing a wrong match), marking it watched returns 200 but immediately flips back to unwatched and the API returns `"Played": false` (#15795). Re-identifying leaves the old user-data rows under the previous keys alongside new rows under the current keys. `SaveUserData` writes the played state to all of the item's current keys, but the stale rows keep their old values, and the read paths picked an arbitrary row: `GetUserData` and the cached path in `GetUserDataBatch` did `item.UserData.Where(user).FirstOrDefault()` over every row, so a stale row could shadow the current state; the `GetUserDataBatch` query path compared `CustomDataKey == item.Id.ToString("N")`, which never matches the dashed `Id.ToString()` format actually stored, so it always fell back to `.First()`. When reading I now prefer the row stored under one of the item's current `GetUserDataKeys()`, falling back to the first available row. This is robust regardless of key format because it compares the stored `CustomDataKey` against the same key set `SaveUserData` writes to. The three read sites share a small helper.

**Code assistance**
Used Claude Code for the diagnosis, fix and tests. Added `UserDataManagerKeySelectionTests` (3 cases: a stale row ordered first no longer shadows the current-key row; only-stale rows still resolve; no rows yields the default with the primary key) and ran the full Jellyfin.Server.Implementations.Tests suite green.

**Issues**
Fixes #15795