### PR TITLE
Don't crash the server when a keep-alive target socket is disposed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -171,7 +171,7 @@ namespace Emby.Server.Implementations.Session
             {
                 await SendForceKeepAlive(webSocket).ConfigureAwait(false);
             }
-            catch (WebSocketException exception)
+            catch (Exception exception) when (exception is WebSocketException or ObjectDisposedException)
             {
                 _logger.LogWarning(exception, "Cannot send ForceKeepAlive message to WebSocket {0}.", webSocket);
             }
@@ -232,8 +232,10 @@ namespace Emby.Server.Implementations.Session
                 {
                     await SendForceKeepAlive(webSocket).ConfigureAwait(false);
                 }
-                catch (WebSocketException exception)
+                catch (Exception exception) when (exception is WebSocketException or ObjectDisposedException)
                 {
+                    // A disposed socket (e.g. an abruptly disconnected client) throws ObjectDisposedException.
+                    // This runs in an async void timer handler, so an unhandled exception would crash the server.
                     _logger.LogInformation(exception, "Error sending ForceKeepAlive message to WebSocket.");
                     lost.Add(webSocket);
                 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Session/SessionWebSocketListenerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Session/SessionWebSocketListenerTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Session;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Net;
+using MediaBrowser.Controller.Net.WebSocketMessages;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Session;
+
+public class SessionWebSocketListenerTests
+{
+    [Fact]
+    public async Task ProcessWebSocketConnectedAsync_KeepAliveSendThrowsObjectDisposed_DoesNotThrow()
+    {
+        // A disposed socket (abruptly disconnected client) makes SendAsync throw ObjectDisposedException.
+        // The keep-alive send runs in an async void timer handler, so an unhandled exception crashes the
+        // whole server (#15709, #14837). Sending the initial ForceKeepAlive must swallow it instead.
+        var sessionManager = new Mock<ISessionManager>();
+        var userManager = new Mock<IUserManager>();
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        var session = new SessionInfo(sessionManager.Object, NullLogger.Instance);
+        sessionManager
+            .Setup(s => s.LogSessionActivity(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Jellyfin.Database.Implementations.Entities.User>()))
+            .ReturnsAsync(session);
+
+        var connection = new Mock<IWebSocketConnection>();
+        connection
+            .Setup(c => c.SendAsync(It.IsAny<OutboundWebSocketMessage<int>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ObjectDisposedException("socket"));
+
+        using var listener = new SessionWebSocketListener(
+            new NullLogger<SessionWebSocketListener>(),
+            sessionManager.Object,
+            userManager.Object,
+            loggerFactory);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = IPAddress.Loopback;
+
+        var exception = await Record.ExceptionAsync(
+            () => listener.ProcessWebSocketConnectedAsync(connection.Object, httpContext));
+
+        Assert.Null(exception);
+        connection.Verify(
+            c => c.SendAsync(It.IsAny<OutboundWebSocketMessage<int>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Problem

Jellyfin crashes entirely when a connected WebSocket client disconnects abruptly (e.g. the machine sleeps, Wi-Fi drops, or the browser is killed). An unhandled `ObjectDisposedException` terminates the whole server process. Reported as 100% reproducible in #15709, and as intermittent "Cannot access a disposed object" crashes after days of uptime in #14837.

## Root cause

`SessionWebSocketListener` watches connections with a timer whose handler, `KeepAliveSockets`, is `async void`. When a client disconnects abruptly its `WebSocket` is disposed; the next keep-alive tick calls `SendAsync` on it, and the underlying socket throws **`ObjectDisposedException`** (not `WebSocketException`).

Both keep-alive send sites only caught `WebSocketException`, so the `ObjectDisposedException` escaped. Because it escapes an `async void` method, it becomes an unhandled exception and brings down the whole process. (The receive path is already guarded in `WebSocketManager`, so this timer path is the remaining crash route.)

## Fix

Broaden the two keep-alive catches to also handle `ObjectDisposedException`, using an exception filter. A dropped client connection should never crash the server; the affected socket is simply treated as lost.

## Testing

Added `SessionWebSocketListenerTests`: a connection whose `SendAsync` throws `ObjectDisposedException` no longer causes `ProcessWebSocketConnectedAsync` (which performs the initial keep-alive send) to throw. Verified the test fails without the fix and passes with it.

Full `Jellyfin.Server.Implementations.Tests` suite passes (548 passed, 4 skipped Windows-only).

Fixes #15709
Fixes #14837

🤖 Generated with [Claude Code](https://claude.com/claude-code)