### PR TITLE
Fix series year lost during name parsing

### DIFF
--- a/Emby.Naming/TV/SeriesInfo.cs
+++ b/Emby.Naming/TV/SeriesInfo.cs
@@ -25,5 +25,11 @@ namespace Emby.Naming.TV
         /// </summary>
         /// <value>The name of the series.</value>
         public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the year of the series.
+        /// </summary>
+        /// <value>The year of the series.</value>
+        public int? Year { get; set; }
     }
 }

--- a/Emby.Naming/TV/SeriesResolver.cs
+++ b/Emby.Naming/TV/SeriesResolver.cs
@@ -21,7 +21,7 @@ namespace Emby.Naming.TV
         /// Regex that matches titles with year in parentheses. Captures the title (which may be
         /// numeric) before the year, i.e. turns "1923 (2022)" into "1923".
         /// </summary>
-        [GeneratedRegex(@"(?<title>.+?)\s*\(\d{4}\)")]
+        [GeneratedRegex(@"(?<title>.+?)\s*\((?<year>\d{4})\)")]
         private static partial Regex TitleWithYearRegex();
 
         /// <summary>
@@ -43,7 +43,8 @@ namespace Emby.Naming.TV
                     seriesName = titleWithYearMatch.Groups["title"].Value.Trim();
                     return new SeriesInfo(path)
                     {
-                        Name = seriesName
+                        Name = seriesName,
+                        Year = int.TryParse(titleWithYearMatch.Groups["year"].Value, out var year) ? year : null
                     };
                 }
             }

--- a/Emby.Naming/TV/SeriesResolver.cs
+++ b/Emby.Naming/TV/SeriesResolver.cs
@@ -21,7 +21,7 @@ namespace Emby.Naming.TV
         /// Regex that matches titles with year in parentheses. Captures the title (which may be
         /// numeric) before the year, i.e. turns "1923 (2022)" into "1923".
         /// </summary>
-        [GeneratedRegex(@"(?<title>.+?)\s*\((?<year>\d{4})\)")]
+        [GeneratedRegex(@"(?<title>.+?)\s*\((?<year>[0-9]{4})\)")]
         private static partial Regex TitleWithYearRegex();
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Emby.Naming.TV
                     return new SeriesInfo(path)
                     {
                         Name = seriesName,
-                        Year = int.TryParse(titleWithYearMatch.Groups["year"].Value, out var year) ? year : null
+                        Year = int.TryParse(titleWithYearMatch.Groups["year"].ValueSpan, out var year) ? year : null
                     };
                 }
             }

--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
@@ -69,7 +69,8 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                         return new Series
                         {
                             Path = args.Path,
-                            Name = seriesInfo.Name
+                            Name = seriesInfo.Name,
+                            ProductionYear = seriesInfo.Year
                         };
                     }
                 }


### PR DESCRIPTION
In #14824 we stripped the year from the returned series name so titles like `1923 (2022)` would match correctly. That solved that issue, but created another since downstream uses the returned name to parse the year. An issue for series that share a name but have different years, e.g., `Doctor Who (2005)` and `Doctor Who (2024)`. 

For example, a folder named `Doctor Who (2024)` would resolve to `Doctor Who` with no year, causing providers to match it to `Doctor Who (2005)`, the first result.


**Changes**
Instead of discarding the year after stripping it, we now capture it from the same regex match and carry it through `SeriesInfo.Year` to the server resolver, which sets it as `ProductionYear` on the `Series` entity.


**Code assistance**
N/A

**Issues**
A lot of angry Doctor Who fans. 