### PR TITLE
Use the container stream index when extracting internal subtitles

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -585,6 +585,28 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 || MediaStream.IsVobSubFormat(codec);
         }
 
+        /// <summary>
+        /// Gets the ffmpeg input stream index to use for <c>-map 0:N</c> when extracting a subtitle.
+        /// </summary>
+        /// <remarks>
+        /// For an internal stream the container index obtained from probing (<see cref="MediaStream.Index"/>)
+        /// is authoritative: it is immune to streams that the probe normalizer drops from
+        /// <see cref="MediaSourceInfo.MediaStreams"/> (codec-less subtitles, data streams, attachments).
+        /// Using the position within the (possibly incomplete) <c>MediaStreams</c> list instead can point
+        /// <c>-map</c> at the wrong stream — e.g. a PGS image stream while writing a text <c>.srt</c> — which
+        /// fails the whole extraction (see #15880). For an external stream the input is that single file, so
+        /// the index within it is needed instead.
+        /// </remarks>
+        /// <param name="mediaSource">The media source.</param>
+        /// <param name="subtitleStream">The subtitle stream to extract.</param>
+        /// <returns>The ffmpeg input stream index.</returns>
+        internal static int GetSubtitleStreamMapIndex(MediaSourceInfo mediaSource, MediaStream subtitleStream)
+        {
+            return subtitleStream.IsExternal
+                ? EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream)
+                : subtitleStream.Index;
+        }
+
         /// <inheritdoc />
         public async Task ExtractAllExtractableSubtitles(MediaSourceInfo mediaSource, CancellationToken cancellationToken)
         {
@@ -689,7 +711,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                     // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
                     var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
-                    var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
+                    var streamIndex = GetSubtitleStreamMapIndex(mediaSource, subtitleStream);
 
                     if (streamIndex == -1)
                     {
@@ -747,7 +769,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
                 // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
                 var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
-                var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
+                var streamIndex = GetSubtitleStreamMapIndex(mediaSource, subtitleStream);
 
                 if (streamIndex == -1)
                 {
@@ -910,7 +932,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 if (!File.Exists(outputPath) || _fileSystem.GetFileInfo(outputPath).Length == 0)
                 {
-                    var subtitleStreamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
+                    var subtitleStreamIndex = GetSubtitleStreamMapIndex(mediaSource, subtitleStream);
 
                     var args = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
@@ -103,5 +103,48 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
             Assert.Equal(subtitleInfo.Format, result.Format);
             Assert.Equal(subtitleInfo.IsExternal, result.IsExternal);
         }
+
+        [Fact]
+        public void GetSubtitleStreamMapIndex_InternalStream_UsesContainerIndex()
+        {
+            // The probe normalizer drops some container streams (codec-less subtitles, data,
+            // attachments) from MediaStreams, so a stream's position in the list can be lower than
+            // its real container index. The streams below have indices 0,1,2,6 (3-5 were dropped),
+            // so the target text subtitle is at list position 3 but container index 6. Using the
+            // position would point -map at the wrong stream (e.g. an interleaved PGS stream) and
+            // fail extraction (#15880); the container index must be used instead.
+            var target = new MediaStream { Index = 6, Type = MediaStreamType.Subtitle, Codec = "subrip" };
+            var mediaSource = new MediaSourceInfo
+            {
+                MediaStreams = new[]
+                {
+                    new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "hevc" },
+                    new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "eac3" },
+                    new MediaStream { Index = 2, Type = MediaStreamType.Subtitle, Codec = "subrip" },
+                    target
+                }
+            };
+
+            Assert.Equal(6, SubtitleEncoder.GetSubtitleStreamMapIndex(mediaSource, target));
+        }
+
+        [Fact]
+        public void GetSubtitleStreamMapIndex_ExternalStream_UsesIndexWithinItsOwnFile()
+        {
+            // An external subtitle is extracted from its own single-stream file, so the index within
+            // that file (0 here) is needed rather than the aggregated container index.
+            var target = new MediaStream { Index = 7, Type = MediaStreamType.Subtitle, Codec = "subrip", Path = "/media/movie.en.srt", IsExternal = true };
+            var mediaSource = new MediaSourceInfo
+            {
+                MediaStreams = new[]
+                {
+                    new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "hevc" },
+                    new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "eac3" },
+                    target
+                }
+            };
+
+            Assert.Equal(0, SubtitleEncoder.GetSubtitleStreamMapIndex(mediaSource, target));
+        }
     }
 }


### PR DESCRIPTION
## Problem

Subtitle extraction fails for some files, and when it does the whole batch fails so even valid text subtitles aren't extracted. Reported in #15880, where ffmpeg errors with:

```
[srt @ ...] Unsupported subtitles codec: hdmv_pgs_subtitle
[out#.../srt @ ...] Could not write header (incorrect codec parameters ?): Invalid argument
```

As @Skin80 noted in the thread, it happens with MKVs that contain both text (srt) and image (PGS) subtitles, particularly when text streams appear both before and after a PGS stream — Jellyfin maps the wrong streams.

## Root cause

The extraction commands build `-map 0:N` from `EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream)`, which returns the stream's **position** among same-path entries in `MediaStreams`.

But `ProbeResultNormalizer` deliberately drops some container streams from `MediaStreams` — codec-less subtitle streams, `Data` streams, and attachments. Those streams still occupy real ffmpeg stream indices, so the position-based value can be **lower** than the true container index. `-map 0:N` then points at the wrong stream: a text subtitle's output (`.srt`, `-c:s copy`) gets paired with an interleaved PGS image stream, which the srt muxer rejects, failing the entire extraction.

`MediaStream.Index` is set to the raw ffprobe stream index, so it is the true container index and is immune to those omissions.

## Fix

Use the container index (`MediaStream.Index`) for internal streams. External subtitles (`.mks` / standalone files) are extracted from their own single-file input, where the index *within that file* is needed, so those keep using `FindIndex`. A small helper centralizes the choice and all three extraction sites use it.

## Testing

Added unit tests for the helper: an internal stream whose container index is higher than its position in a normalizer-trimmed `MediaStreams` list resolves to the container index (and the test fails against the old position-based behavior), and an external stream resolves to its within-file index. Full `Jellyfin.MediaEncoding.Tests` suite passes.

Note: this is verified at the index-selection level; reproducing end-to-end needs a file where the normalizer drops a stream interleaved with the text subtitles.

Fixes #15880

🤖 Generated with [Claude Code](https://claude.com/claude-code)