### PR TITLE
Resolve the Blu-ray/DVD playlist when extracting subtitles from disc folders

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -723,7 +723,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             List<MediaStream> subtitleStreams,
             CancellationToken cancellationToken)
         {
-            var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
+            var inputPath = _mediaEncoder.GetInputPathArgument(mediaSource.Path, mediaSource);
             var outputPaths = new List<string>();
             var args = string.Format(
                 CultureInfo.InvariantCulture,
@@ -912,7 +912,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 {
                     var subtitleStreamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
-                    var args = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
+                    var args = _mediaEncoder.GetInputPathArgument(mediaSource.Path, mediaSource);
 
                     if (subtitleStream.IsExternal)
                     {


### PR DESCRIPTION
**Changes**
On-the-fly subtitle extraction fails for media stored as a raw Blu-ray (`BDMV/`) or DVD (`VIDEO_TS/`) folder, so the `.sup`/`.srt` is never produced and clients that render image (PGS) subtitles externally get nothing (#16987). Extraction builds its ffmpeg input from `GetInputArgument(mediaSource.Path, mediaSource)`, which only special-cases `IsoType.BluRay` (ISO images) and not `VideoType.BluRay`/`VideoType.Dvd` (raw disc folders); for a disc-folder source `mediaSource.Path` is a directory, so ffmpeg cannot open it. The transcode/playback pipeline avoids this by using `GetInputPathArgument`, which resolves the disc playlist (`GetPrimaryPlaylistM2tsFiles`/`GetPrimaryPlaylistVobFiles`) and falls back to `GetInputArgument` for ordinary files (that is also why burn-in works). I switched the two main-file subtitle-extraction inputs (`ExtractAllExtractableSubtitlesInternal` and `ExtractTextSubtitle`) to `GetInputPathArgument`; it is identical to `GetInputArgument` for normal files. The external `.mks` input path is unchanged.

**Code assistance**
Used Claude Code for the diagnosis and fix. There is no behaviour change for ordinary files: `GetInputPathArgument` only resolves a playlist for `VideoType.Dvd`/`VideoType.BluRay` and otherwise returns `GetInputArgument(path, mediaSource)` unchanged, so the only difference is exactly the disc-folder case this fixes — and that uses the same resolver the transcode/burn-in pipeline already relies on. Build is clean and the full Jellyfin.MediaEncoding.Tests suite passes. I did not add a unit test: the extraction methods are private and spawn a real ffmpeg process, so this reuses the existing, already-exercised resolver rather than a brittle process-driven test. A full end-to-end check needs a real BDMV/VIDEO_TS folder source, which I don't have to test against.

**Issues**
Fixes #16987
