### PR TITLE
Fix pessimistic SQLite locking deadlock

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.CommandLockingInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.CommandLockingInterceptor.cs
@@ -1,0 +1,86 @@
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+public partial class PessimisticLockBehavior
+{
+    private sealed class CommandLockingInterceptor : DbCommandInterceptor
+    {
+        private readonly ILogger _logger;
+
+        public CommandLockingInterceptor(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            using (DbLock.EnterWrite(_logger, command.Transaction, command))
+            {
+                return InterceptionResult<int>.SuppressWithResult(command.ExecuteNonQuery());
+            }
+        }
+
+        public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            await using (await DbLock.EnterWriteAsync(_logger, command.Transaction, command, cancellationToken).ConfigureAwait(false))
+            {
+                return InterceptionResult<int>.SuppressWithResult(await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false));
+            }
+        }
+
+        public override InterceptionResult<object> ScalarExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            using (EnterReadOrWrite(command, eventData))
+            {
+                return InterceptionResult<object>.SuppressWithResult(command.ExecuteScalar()!);
+            }
+        }
+
+        public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+        {
+            await using (await EnterReadOrWriteAsync(command, eventData, cancellationToken).ConfigureAwait(false))
+            {
+                return InterceptionResult<object>.SuppressWithResult((await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false))!);
+            }
+        }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            using (EnterReadOrWrite(command, eventData))
+            {
+                return InterceptionResult<DbDataReader>.SuppressWithResult(command.ExecuteReader());
+            }
+        }
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            await using (await EnterReadOrWriteAsync(command, eventData, cancellationToken).ConfigureAwait(false))
+            {
+                return InterceptionResult<DbDataReader>.SuppressWithResult(await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false));
+            }
+        }
+
+#pragma warning disable IDISP015 // Member should not return created and cached instance
+        private DbLock EnterReadOrWrite(DbCommand command, CommandEventData eventData)
+#pragma warning restore IDISP015 // Member should not return created and cached instance
+        {
+            // SQLite SaveChanges can use reader/scalar commands for generated values. Those commands
+            // are still part of the write pipeline, so they must wait behind an earlier writer request.
+            return eventData.CommandSource == CommandSource.SaveChanges
+                ? DbLock.EnterWrite(_logger, command.Transaction, command)
+                : DbLock.EnterRead(_logger, command.Transaction);
+        }
+
+        private ValueTask<DbLock> EnterReadOrWriteAsync(DbCommand command, CommandEventData eventData, CancellationToken cancellationToken)
+        {
+            return eventData.CommandSource == CommandSource.SaveChanges
+                ? DbLock.EnterWriteAsync(_logger, command.Transaction, command, cancellationToken)
+                : DbLock.EnterReadAsync(_logger, command.Transaction, cancellationToken);
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.DbLock.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.DbLock.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Concurrent;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+public partial class PessimisticLockBehavior
+{
+    private sealed partial class DbLock : IDisposable, IAsyncDisposable
+    {
+        private const string WriteHeldMessage = "Write Held {Caller}:{Line}";
+
+        // This must not use a thread-affine reader/writer lock: async EF work may resume and
+        // dispose on a different thread than the one that acquired the lock.
+        private static readonly ReaderWriterSemaphore _databaseLock = new();
+        // A DbTransaction owns the global write lock until the transaction ends. Commands inside
+        // that transaction check this map to avoid reacquiring the same global lock and deadlocking.
+        private static readonly ConcurrentDictionary<DbTransaction, DbLock> _transactionLocks = new();
+        private static readonly DbLock _noLock = new(null) { _disposed = true };
+        private static readonly TransactionDisposedDiagnosticObserver _transactionDisposedDiagnosticObserver = new();
+        private static readonly object _diagnosticListenerLock = new();
+        private static (string Command, Guid Id, DateTimeOffset QueryDate, bool Printed) _blockQuery;
+        private static IDisposable? _diagnosticListenerSubscription;
+
+        private readonly Action? _action;
+        private bool _disposed;
+
+        private DbLock(Action? action)
+        {
+            _action = action;
+        }
+
+        public static void EnsureTransactionDisposedListener()
+        {
+            lock (_diagnosticListenerLock)
+            {
+                if (_diagnosticListenerSubscription is not null)
+                {
+                    return;
+                }
+
+                _diagnosticListenerSubscription = DiagnosticListener.AllListeners.Subscribe(_transactionDisposedDiagnosticObserver);
+            }
+        }
+
+#pragma warning disable IDISP015 // Member should not return created and cached instance
+        public static DbLock EnterWrite(ILogger logger, DbTransaction? transaction = null, IDbCommand? command = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+#pragma warning restore IDISP015 // Member should not return created and cached instance
+        {
+            logger.LogTrace("Enter Write for {Caller}:{Line}", callerMemberName, callerNo);
+            if (IsLockHeld(transaction))
+            {
+                logger.LogTrace(WriteHeldMessage, callerMemberName, callerNo);
+                return _noLock;
+            }
+
+            return EnterWriteCore(logger, command, callerMemberName, callerNo);
+        }
+
+        public static ValueTask<DbLock> EnterWriteAsync(ILogger logger, DbTransaction? transaction = null, IDbCommand? command = null, CancellationToken cancellationToken = default, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Enter Write for {Caller}:{Line}", callerMemberName, callerNo);
+            if (IsLockHeld(transaction))
+            {
+                logger.LogTrace(WriteHeldMessage, callerMemberName, callerNo);
+                return new ValueTask<DbLock>(_noLock);
+            }
+
+            return EnterWriteCoreAsync(logger, command, cancellationToken, callerMemberName, callerNo);
+        }
+
+#pragma warning disable IDISP015 // Member should not return created and cached instance
+        public static DbLock EnterRead(ILogger logger, DbTransaction? transaction = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+#pragma warning restore IDISP015 // Member should not return created and cached instance
+        {
+            logger.LogTrace("Enter Read {Caller}:{Line}", callerMemberName, callerNo);
+            if (IsLockHeld(transaction))
+            {
+                logger.LogTrace(WriteHeldMessage, callerMemberName, callerNo);
+                return _noLock;
+            }
+
+            return EnterReadCore(logger, callerMemberName, callerNo);
+        }
+
+        public static ValueTask<DbLock> EnterReadAsync(ILogger logger, DbTransaction? transaction = null, CancellationToken cancellationToken = default, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Enter Read {Caller}:{Line}", callerMemberName, callerNo);
+            if (IsLockHeld(transaction))
+            {
+                logger.LogTrace(WriteHeldMessage, callerMemberName, callerNo);
+                return new ValueTask<DbLock>(_noLock);
+            }
+
+            return EnterReadCoreAsync(logger, cancellationToken, callerMemberName, callerNo);
+        }
+
+        public static InterceptionResult<DbTransaction> BeginTransaction(ILogger logger, DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            var transactionLock = EnterWriteCore(logger, command: null, callerMemberName, callerNo);
+            try
+            {
+                // Create the transaction while the write lock is held so the transaction object and
+                // its lock enter _transactionLocks as one atomic ownership handoff.
+                var transaction = result.HasResult
+                    ? result.Result
+                    : connection.BeginTransaction(eventData.IsolationLevel);
+                TrackTransactionLock(transaction, transactionLock);
+
+                return InterceptionResult<DbTransaction>.SuppressWithResult(transaction);
+            }
+            catch
+            {
+                transactionLock.Dispose();
+                throw;
+            }
+        }
+
+        public static async ValueTask<InterceptionResult<DbTransaction>> BeginTransactionAsync(ILogger logger, DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result, CancellationToken cancellationToken = default, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            var transactionLock = await EnterWriteCoreAsync(logger, command: null, cancellationToken, callerMemberName, callerNo).ConfigureAwait(false);
+            try
+            {
+                var transaction = result.HasResult
+                    ? result.Result
+                    : await connection.BeginTransactionAsync(eventData.IsolationLevel, cancellationToken).ConfigureAwait(false);
+                TrackTransactionLock(transaction, transactionLock);
+
+                return InterceptionResult<DbTransaction>.SuppressWithResult(transaction);
+            }
+            catch
+            {
+                await transactionLock.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        public static void EndTransactionLock(DbTransaction transaction)
+        {
+            if (_transactionLocks.TryRemove(transaction, out var transactionLock))
+            {
+                transactionLock.Dispose();
+            }
+        }
+
+        public static async ValueTask EndTransactionLockAsync(DbTransaction transaction)
+        {
+            if (_transactionLocks.TryRemove(transaction, out var transactionLock))
+            {
+                await transactionLock.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        private static bool IsLockHeld(DbTransaction? transaction)
+        {
+            return transaction is not null && _transactionLocks.ContainsKey(transaction);
+        }
+
+        private static void TrackTransactionLock(DbTransaction transaction, DbLock transactionLock)
+        {
+            if (!_transactionLocks.TryAdd(transaction, transactionLock))
+            {
+                transactionLock.Dispose();
+            }
+        }
+
+        private static DbLock EnterWriteCore(ILogger logger, IDbCommand? command, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Acquire Write {Caller}:{Line}", callerMemberName, callerNo);
+            if (!_databaseLock.AcquireWrite(TimeSpan.FromMilliseconds(1000), () => LogQueryCongestionDetected(logger)))
+            {
+                var blockingQuery = _blockQuery;
+                logger.LogInformation("Query congestion cleared: '{Id}' for '{Date}'", blockingQuery.Id, DateTimeOffset.Now - blockingQuery.QueryDate);
+            }
+
+            _blockQuery = (command?.CommandText ?? "Transaction", Guid.NewGuid(), DateTimeOffset.Now, false);
+
+            logger.LogTrace("Write Acquired {Caller}:{Line}", callerMemberName, callerNo);
+            return new DbLock(
+                static () =>
+                {
+                    _databaseLock.ExitWrite();
+                });
+        }
+
+        private static async ValueTask<DbLock> EnterWriteCoreAsync(ILogger logger, IDbCommand? command, CancellationToken cancellationToken, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Acquire Write {Caller}:{Line}", callerMemberName, callerNo);
+            if (!await _databaseLock.AcquireWriteAsync(TimeSpan.FromMilliseconds(1000), () => LogQueryCongestionDetected(logger), cancellationToken).ConfigureAwait(false))
+            {
+                var blockingQuery = _blockQuery;
+                logger.LogInformation("Query congestion cleared: '{Id}' for '{Date}'", blockingQuery.Id, DateTimeOffset.Now - blockingQuery.QueryDate);
+            }
+
+            _blockQuery = (command?.CommandText ?? "Transaction", Guid.NewGuid(), DateTimeOffset.Now, false);
+
+            logger.LogTrace("Write Acquired {Caller}:{Line}", callerMemberName, callerNo);
+            return new DbLock(
+                static () =>
+                {
+                    _databaseLock.ExitWrite();
+                });
+        }
+
+        private static void LogQueryCongestionDetected(ILogger logger)
+        {
+            var blockingQuery = _blockQuery;
+            if (!blockingQuery.Printed)
+            {
+                _blockQuery = (blockingQuery.Command, blockingQuery.Id, blockingQuery.QueryDate, true);
+                logger.LogInformation("QueryLock: {Id} --- {Query}", blockingQuery.Id, blockingQuery.Command);
+            }
+
+            logger.LogInformation("Query congestion detected: '{Id}' since '{Date}'", blockingQuery.Id, blockingQuery.QueryDate);
+        }
+
+        private static DbLock EnterReadCore(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Acquire Read {Caller}:{Line}", callerMemberName, callerNo);
+            _databaseLock.AcquireRead();
+            logger.LogTrace("Read Acquired {Caller}:{Line}", callerMemberName, callerNo);
+            return new DbLock(
+                static () =>
+                {
+                    _databaseLock.ExitRead();
+                });
+        }
+
+        private static async ValueTask<DbLock> EnterReadCoreAsync(ILogger logger, CancellationToken cancellationToken, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
+        {
+            logger.LogTrace("Acquire Read {Caller}:{Line}", callerMemberName, callerNo);
+            await _databaseLock.AcquireReadAsync(cancellationToken).ConfigureAwait(false);
+            logger.LogTrace("Read Acquired {Caller}:{Line}", callerMemberName, callerNo);
+            return new DbLock(
+                static () =>
+                {
+                    _databaseLock.ExitRead();
+                });
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            if (_action is not null)
+            {
+                _action();
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return default;
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.ReaderWriterSemaphore.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.ReaderWriterSemaphore.cs
@@ -1,0 +1,145 @@
+#pragma warning disable S2222 // Resource semaphore ownership is returned to callers and released by DbLock disposal.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+public partial class PessimisticLockBehavior
+{
+    private sealed partial class DbLock
+    {
+        // Writer-priority reader/writer lock built from semaphores. SemaphoreSlim has no thread
+        // affinity, so async continuations can release the lock on whichever thread resumes them.
+        private sealed class ReaderWriterSemaphore : IDisposable
+        {
+            // A waiting writer holds the turnstile so later readers cannot jump ahead of it.
+            private readonly SemaphoreSlim _turnstileLock = new(1, 1);
+            // The shared resource gate is held by one writer or by the first active reader.
+            private readonly SemaphoreSlim _resourceLock = new(1, 1);
+            // Protects the reader count and first-reader/last-reader transitions.
+            private readonly SemaphoreSlim _readerLock = new(1, 1);
+            private int _readers;
+
+            public bool AcquireWrite(TimeSpan timeout, Action onTimeout)
+            {
+                _turnstileLock.Wait();
+                try
+                {
+                    if (_resourceLock.Wait(timeout))
+                    {
+                        return true;
+                    }
+
+                    onTimeout();
+                    _resourceLock.Wait();
+                    return false;
+                }
+                finally
+                {
+                    _turnstileLock.Release();
+                }
+            }
+
+            public async ValueTask<bool> AcquireWriteAsync(TimeSpan timeout, Action onTimeout, CancellationToken cancellationToken)
+            {
+                await _turnstileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    if (await _resourceLock.WaitAsync(timeout, cancellationToken).ConfigureAwait(false))
+                    {
+                        return true;
+                    }
+
+                    onTimeout();
+                    await _resourceLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return false;
+                }
+                finally
+                {
+                    _turnstileLock.Release();
+                }
+            }
+
+            public void ExitWrite()
+            {
+                _resourceLock.Release();
+            }
+
+            public void AcquireRead()
+            {
+                _turnstileLock.Wait();
+                _turnstileLock.Release();
+                _readerLock.Wait();
+                try
+                {
+                    _readers++;
+                    if (_readers == 1)
+                    {
+                        _resourceLock.Wait();
+                    }
+                }
+                catch
+                {
+                    _readers--;
+                    throw;
+                }
+                finally
+                {
+                    _readerLock.Release();
+                }
+            }
+
+            public async ValueTask AcquireReadAsync(CancellationToken cancellationToken)
+            {
+                await _turnstileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                _turnstileLock.Release();
+                await _readerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    _readers++;
+                    if (_readers == 1)
+                    {
+                        await _resourceLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                catch
+                {
+                    _readers--;
+                    throw;
+                }
+                finally
+                {
+                    _readerLock.Release();
+                }
+            }
+
+            public void ExitRead()
+            {
+                _readerLock.Wait();
+                try
+                {
+                    _readers--;
+                    if (_readers == 0)
+                    {
+                        _resourceLock.Release();
+                    }
+                }
+                finally
+                {
+                    _readerLock.Release();
+                }
+            }
+
+            public void Dispose()
+            {
+                _turnstileLock.Dispose();
+                _resourceLock.Dispose();
+                _readerLock.Dispose();
+            }
+        }
+    }
+}
+
+#pragma warning restore S2222

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.TransactionDisposedDiagnosticObserver.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.TransactionDisposedDiagnosticObserver.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+public partial class PessimisticLockBehavior
+{
+    private sealed partial class DbLock
+    {
+        private sealed class TransactionDisposedDiagnosticObserver : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>
+        {
+            private readonly object _syncLock = new();
+            // The behavior is process-lifetime, so diagnostic subscriptions are intentionally kept
+            // for the process lifetime too. Dropping them would make dispose-only transactions
+            // invisible and could leave their write lock held.
+            private readonly List<IDisposable> _subscriptions = [];
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(DiagnosticListener value)
+            {
+                if (!value.Name.Equals("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                lock (_syncLock)
+                {
+                    _subscriptions.Add(value.Subscribe(this));
+                }
+            }
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                // EF emits this event when a transaction object is disposed without an explicit
+                // commit, rollback, or failure callback.
+                if (value.Key.EndsWith(".TransactionDisposed", StringComparison.Ordinal)
+                    && value.Value is TransactionEventData eventData)
+                {
+                    EndTransactionLock(eventData.Transaction);
+                }
+            }
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.TransactionLockingInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.TransactionLockingInterceptor.cs
@@ -1,0 +1,74 @@
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+public partial class PessimisticLockBehavior
+{
+    private sealed class TransactionLockingInterceptor : DbTransactionInterceptor
+    {
+        private readonly ILogger _logger;
+
+        public TransactionLockingInterceptor(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public override InterceptionResult<DbTransaction> TransactionStarting(DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result)
+        {
+            // Transactions span multiple commands, so the transaction lifetime, not each command,
+            // owns the write lock once the transaction starts.
+            return DbLock.BeginTransaction(_logger, connection, eventData, result);
+        }
+
+        public override async ValueTask<InterceptionResult<DbTransaction>> TransactionStartingAsync(DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result, CancellationToken cancellationToken = default)
+        {
+            return await DbLock.BeginTransactionAsync(_logger, connection, eventData, result, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void TransactionCommitted(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            DbLock.EndTransactionLock(transaction);
+
+            base.TransactionCommitted(transaction, eventData);
+        }
+
+        public override async Task TransactionCommittedAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            await DbLock.EndTransactionLockAsync(transaction).ConfigureAwait(false);
+
+            await base.TransactionCommittedAsync(transaction, eventData, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void TransactionFailed(DbTransaction transaction, TransactionErrorEventData eventData)
+        {
+            DbLock.EndTransactionLock(transaction);
+
+            base.TransactionFailed(transaction, eventData);
+        }
+
+        public override async Task TransactionFailedAsync(DbTransaction transaction, TransactionErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            await DbLock.EndTransactionLockAsync(transaction).ConfigureAwait(false);
+
+            await base.TransactionFailedAsync(transaction, eventData, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void TransactionRolledBack(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            DbLock.EndTransactionLock(transaction);
+
+            base.TransactionRolledBack(transaction, eventData);
+        }
+
+        public override async Task TransactionRolledBackAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            await DbLock.EndTransactionLockAsync(transaction).ConfigureAwait(false);
+
+            await base.TransactionRolledBackAsync(transaction, eventData, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
@@ -1,23 +1,14 @@
-#pragma warning disable MT1013 // Releasing lock without guarantee of execution
-#pragma warning disable MT1012 // Acquiring lock without guarantee of releasing
-#pragma warning disable CA1873
-
 using System;
-using System.Data;
-using System.Data.Common;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Database.Implementations.Locking;
 
 /// <summary>
-/// A locking behavior that will always block any operation while a write is requested. Mimicks the old SqliteRepository behavior.
+/// A locking behavior that will always block any operation while a write is requested. Mimics the old SqliteRepository behavior.
 /// </summary>
-public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
+public partial class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
 {
     private readonly ILogger<PessimisticLockBehavior> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -33,21 +24,21 @@ public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
         _loggerFactory = loggerFactory;
     }
 
-    private static ReaderWriterLockSlim DatabaseLock { get; } = new(LockRecursionPolicy.SupportsRecursion);
-
     /// <inheritdoc/>
     public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
     {
-        using (DbLock.EnterWrite(_logger))
-        {
-            saveChanges();
-        }
+        // The EF command and transaction interceptors own the lock. Wrapping SaveChanges here would
+        // hold one outer lock across EF's command pipeline and would miss provider-specific commands.
+        saveChanges();
     }
 
     /// <inheritdoc/>
     public void Initialise(DbContextOptionsBuilder optionsBuilder)
     {
         _logger.LogInformation("The database locking mode has been set to: Pessimistic.");
+        // Commit, rollback, and failure are covered by transaction interceptors; dispose-only
+        // transactions are only visible through EF's diagnostic listener.
+        DbLock.EnsureTransactionDisposedListener();
         optionsBuilder.AddInterceptors(new CommandLockingInterceptor(_loggerFactory.CreateLogger<CommandLockingInterceptor>()));
         optionsBuilder.AddInterceptors(new TransactionLockingInterceptor(_loggerFactory.CreateLogger<TransactionLockingInterceptor>()));
     }
@@ -55,243 +46,8 @@ public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
     /// <inheritdoc/>
     public async Task OnSaveChangesAsync(JellyfinDbContext context, Func<Task> saveChanges)
     {
-        using (DbLock.EnterWrite(_logger))
-        {
-            await saveChanges().ConfigureAwait(false);
-        }
-    }
-
-    private sealed class TransactionLockingInterceptor : DbTransactionInterceptor
-    {
-        private readonly ILogger _logger;
-
-        public TransactionLockingInterceptor(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public override InterceptionResult<DbTransaction> TransactionStarting(DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result)
-        {
-            DbLock.BeginWriteLock(_logger);
-
-            return base.TransactionStarting(connection, eventData, result);
-        }
-
-        public override ValueTask<InterceptionResult<DbTransaction>> TransactionStartingAsync(DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result, CancellationToken cancellationToken = default)
-        {
-            DbLock.BeginWriteLock(_logger);
-
-            return base.TransactionStartingAsync(connection, eventData, result, cancellationToken);
-        }
-
-        public override void TransactionCommitted(DbTransaction transaction, TransactionEndEventData eventData)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            base.TransactionCommitted(transaction, eventData);
-        }
-
-        public override Task TransactionCommittedAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            return base.TransactionCommittedAsync(transaction, eventData, cancellationToken);
-        }
-
-        public override void TransactionFailed(DbTransaction transaction, TransactionErrorEventData eventData)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            base.TransactionFailed(transaction, eventData);
-        }
-
-        public override Task TransactionFailedAsync(DbTransaction transaction, TransactionErrorEventData eventData, CancellationToken cancellationToken = default)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            return base.TransactionFailedAsync(transaction, eventData, cancellationToken);
-        }
-
-        public override void TransactionRolledBack(DbTransaction transaction, TransactionEndEventData eventData)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            base.TransactionRolledBack(transaction, eventData);
-        }
-
-        public override Task TransactionRolledBackAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
-        {
-            DbLock.EndWriteLock(_logger);
-
-            return base.TransactionRolledBackAsync(transaction, eventData, cancellationToken);
-        }
-    }
-
-    /// <summary>
-    /// Adds strict read/write locking.
-    /// </summary>
-    private sealed class CommandLockingInterceptor : DbCommandInterceptor
-    {
-        private readonly ILogger _logger;
-
-        public CommandLockingInterceptor(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
-        {
-            using (DbLock.EnterWrite(_logger, command))
-            {
-                return InterceptionResult<int>.SuppressWithResult(command.ExecuteNonQuery());
-            }
-        }
-
-        public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
-        {
-            using (DbLock.EnterWrite(_logger, command))
-            {
-                return InterceptionResult<int>.SuppressWithResult(await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false));
-            }
-        }
-
-        public override InterceptionResult<object> ScalarExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
-        {
-            using (DbLock.EnterRead(_logger))
-            {
-                return InterceptionResult<object>.SuppressWithResult(command.ExecuteScalar()!);
-            }
-        }
-
-        public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
-        {
-            using (DbLock.EnterRead(_logger))
-            {
-                return InterceptionResult<object>.SuppressWithResult((await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false))!);
-            }
-        }
-
-        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
-        {
-            using (DbLock.EnterRead(_logger))
-            {
-                return InterceptionResult<DbDataReader>.SuppressWithResult(command.ExecuteReader()!);
-            }
-        }
-
-        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
-        {
-            using (DbLock.EnterRead(_logger))
-            {
-                return InterceptionResult<DbDataReader>.SuppressWithResult(await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false));
-            }
-        }
-    }
-
-    private sealed class DbLock : IDisposable
-    {
-        private readonly Action? _action;
-        private bool _disposed;
-
-        private static readonly IDisposable _noLock = new DbLock(null) { _disposed = true };
-        private static (string Command, Guid Id, DateTimeOffset QueryDate, bool Printed) _blockQuery;
-
-        public DbLock(Action? action = null)
-        {
-            _action = action;
-        }
-
-#pragma warning disable IDISP015 // Member should not return created and cached instance
-        public static IDisposable EnterWrite(ILogger logger, IDbCommand? command = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-#pragma warning restore IDISP015 // Member should not return created and cached instance
-        {
-            logger.LogTrace("Enter Write for {Caller}:{Line}", callerMemberName, callerNo);
-            if (DatabaseLock.IsWriteLockHeld)
-            {
-                logger.LogTrace("Write Held {Caller}:{Line}", callerMemberName, callerNo);
-                return _noLock;
-            }
-
-            BeginWriteLock(logger, command, callerMemberName, callerNo);
-            return new DbLock(() =>
-            {
-                EndWriteLock(logger, callerMemberName, callerNo);
-            });
-        }
-
-#pragma warning disable IDISP015 // Member should not return created and cached instance
-        public static IDisposable EnterRead(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-#pragma warning restore IDISP015 // Member should not return created and cached instance
-        {
-            logger.LogTrace("Enter Read {Caller}:{Line}", callerMemberName, callerNo);
-            if (DatabaseLock.IsWriteLockHeld)
-            {
-                logger.LogTrace("Write Held {Caller}:{Line}", callerMemberName, callerNo);
-                return _noLock;
-            }
-
-            BeginReadLock(logger, callerMemberName, callerNo);
-            return new DbLock(() =>
-            {
-                ExitReadLock(logger, callerMemberName, callerNo);
-            });
-        }
-
-        public static void BeginWriteLock(ILogger logger, IDbCommand? command = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-        {
-            logger.LogTrace("Aquire Write {Caller}:{Line}", callerMemberName, callerNo);
-            if (!DatabaseLock.TryEnterWriteLock(TimeSpan.FromMilliseconds(1000)))
-            {
-                var blockingQuery = _blockQuery;
-                if (!blockingQuery.Printed)
-                {
-                    _blockQuery = (blockingQuery.Command, blockingQuery.Id, blockingQuery.QueryDate, true);
-                    logger.LogInformation("QueryLock: {Id} --- {Query}", blockingQuery.Id, blockingQuery.Command);
-                }
-
-                logger.LogInformation("Query congestion detected: '{Id}' since '{Date}'", blockingQuery.Id, blockingQuery.QueryDate);
-
-                DatabaseLock.EnterWriteLock();
-
-                logger.LogInformation("Query congestion cleared: '{Id}' for '{Date}'", blockingQuery.Id, DateTimeOffset.Now - blockingQuery.QueryDate);
-            }
-
-            _blockQuery = (command?.CommandText ?? "Transaction", Guid.NewGuid(), DateTimeOffset.Now, false);
-
-            logger.LogTrace("Write Aquired {Caller}:{Line}", callerMemberName, callerNo);
-        }
-
-        public static void BeginReadLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-        {
-            logger.LogTrace("Aquire Write {Caller}:{Line}", callerMemberName, callerNo);
-            DatabaseLock.EnterReadLock();
-            logger.LogTrace("Read Aquired {Caller}:{Line}", callerMemberName, callerNo);
-        }
-
-        public static void EndWriteLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-        {
-            logger.LogTrace("Release Write {Caller}:{Line}", callerMemberName, callerNo);
-            DatabaseLock.ExitWriteLock();
-        }
-
-        public static void ExitReadLock(ILogger logger, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int? callerNo = null)
-        {
-            logger.LogTrace("Release Read {Caller}:{Line}", callerMemberName, callerNo);
-            DatabaseLock.ExitReadLock();
-        }
-
-        public void Dispose()
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            _disposed = true;
-            if (_action is not null)
-            {
-                _action();
-            }
-        }
+        // Keep async continuations outside a thread-affine outer lock. Individual commands still
+        // acquire the global pessimistic lock below.
+        await saveChanges().ConfigureAwait(false);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorCommandTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorCommandTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Locking;
+
+public sealed partial class PessimisticLockBehaviorTests
+{
+    [Fact]
+    public async Task ReadCommands_WhenNoWriterIsHeld_RunConcurrently()
+    {
+        var behavior = CreateBehavior();
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        await using var firstContext = database.CreateContext(behavior, enableDelayFunction: true);
+        await using var secondContext = database.CreateContext(behavior, enableDelayFunction: true);
+        await firstContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await secondContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        var stopwatch = Stopwatch.StartNew();
+
+        var firstRead = Task.Run(async () => await firstContext.Database.SqlQueryRaw<int>("SELECT delay(1000) AS Value").SingleAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        var secondRead = Task.Run(async () => await secondContext.Database.SqlQueryRaw<int>("SELECT delay(1000) AS Value").SingleAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(firstRead, secondRead).WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(1700), $"Concurrent reads took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task ReadCommands_WhenWriterIsWaiting_BlockBehindWriter()
+    {
+        Task? secondReader = null;
+        LockingDbContext? secondReaderContext = null;
+        var congestionObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondReaderCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondReaderStarted = 0;
+        var behavior = CreateBehavior(() =>
+        {
+            congestionObserved.TrySetResult();
+            if (Interlocked.Exchange(ref secondReaderStarted, 1) != 0)
+            {
+                return;
+            }
+
+            secondReader = Task.Run(
+                async () =>
+                {
+                    await secondReaderContext!.Database.SqlQueryRaw<int>("SELECT delay(10) AS Value").SingleAsync(TestContext.Current.CancellationToken);
+                    secondReaderCompleted.SetResult();
+                },
+                TestContext.Current.CancellationToken);
+        });
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        var firstReaderStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var firstReaderContext = database.CreateContext(behavior, enableDelayFunction: true, delayStarted: firstReaderStarted);
+        await using var writerContext = database.CreateContext(behavior);
+        await using var lateReaderContext = database.CreateContext(behavior, enableDelayFunction: true);
+        secondReaderContext = lateReaderContext;
+        await firstReaderContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await lateReaderContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        var firstReader = Task.Run(async () => await firstReaderContext.Database.SqlQueryRaw<int>("SELECT delay(2000) AS Value").SingleAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        await firstReaderStarted.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        var writer = Task.Run(
+            async () =>
+            {
+                await writerContext.Database.ExecuteSqlRawAsync("INSERT INTO Rows (Name) VALUES ('writer')", TestContext.Current.CancellationToken);
+            },
+            TestContext.Current.CancellationToken);
+        await congestionObserved.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        Assert.False(await CompletesWithinAsync(secondReaderCompleted.Task, LockProbeDelay));
+
+        await firstReader.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        await writer.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        await secondReader!.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WhenWriterIsWaiting_BlocksReadersBehindWriter()
+    {
+        Task? secondReader = null;
+        LockingDbContext? secondReaderContext = null;
+        var congestionObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondReaderCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondReaderStarted = 0;
+        var behavior = CreateBehavior(() =>
+        {
+            congestionObserved.TrySetResult();
+            if (Interlocked.Exchange(ref secondReaderStarted, 1) != 0)
+            {
+                return;
+            }
+
+            secondReader = Task.Run(
+                async () =>
+                {
+                    await secondReaderContext!.Database.SqlQueryRaw<int>("SELECT delay(10) AS Value").SingleAsync(TestContext.Current.CancellationToken);
+                    secondReaderCompleted.SetResult();
+                },
+                TestContext.Current.CancellationToken);
+        });
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        var firstReaderStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var firstReaderContext = database.CreateContext(behavior, enableDelayFunction: true, delayStarted: firstReaderStarted);
+        await using var writerContext = database.CreateContext(behavior);
+        await using var lateReaderContext = database.CreateContext(behavior, enableDelayFunction: true);
+        secondReaderContext = lateReaderContext;
+        await firstReaderContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await lateReaderContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        var firstReader = Task.Run(async () => await firstReaderContext.Database.SqlQueryRaw<int>("SELECT delay(2000) AS Value").SingleAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        await firstReaderStarted.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        writerContext.Rows.Add(new Row { Name = "save changes writer" });
+        var writer = Task.Run(
+            async () =>
+            {
+                await writerContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+            },
+            TestContext.Current.CancellationToken);
+        await congestionObserved.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        Assert.False(await CompletesWithinAsync(secondReaderCompleted.Task, LockProbeDelay));
+
+        await firstReader.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        await writer.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        await secondReader!.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task WriteCommandAsync_WhenCanceledWhileWaitingForReader_ReleasesWriterTurnstile()
+    {
+        var behavior = CreateBehavior();
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        var firstReaderStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writerReachedCommandPipeline = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var firstReaderContext = database.CreateContext(behavior, enableDelayFunction: true, delayStarted: firstReaderStarted);
+        await using var writerContext = database.CreateContext(behavior, commandStarted: writerReachedCommandPipeline);
+        await using var probeReaderContext = database.CreateContext(behavior);
+        await firstReaderContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        using var writerCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        writerCancellation.CancelAfter(TestTimeout);
+        var firstReader = Task.Run(async () => await firstReaderContext.Database.SqlQueryRaw<int>("SELECT delay(2000) AS Value").SingleAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        await firstReaderStarted.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        var writer = writerContext.Database.ExecuteSqlRawAsync(
+            "INSERT INTO Rows (Name) VALUES ('canceled writer')",
+            [],
+            writerCancellation.Token);
+        await writerReachedCommandPipeline.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        await Task.Delay(LockProbeDelay, TestContext.Current.CancellationToken);
+        await writerCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await writer);
+
+        await firstReader.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        await probeReaderContext.Database.SqlQueryRaw<int>("SELECT 1 AS Value").SingleAsync(TestContext.Current.CancellationToken).WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorFixtures.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorFixtures.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Locking;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Locking;
+
+public sealed partial class PessimisticLockBehaviorTests
+{
+    private sealed class SqliteTestDatabase : IAsyncDisposable
+    {
+        private readonly SqliteConnection _keepAliveConnection;
+        private readonly string _connectionString;
+
+        private SqliteTestDatabase(SqliteConnection keepAliveConnection, string connectionString)
+        {
+            _keepAliveConnection = keepAliveConnection;
+            _connectionString = connectionString;
+        }
+
+        public static async Task<SqliteTestDatabase> CreateAsync(PessimisticLockBehavior behavior)
+        {
+            var connectionString = $"Data Source={Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+            var keepAliveConnection = new SqliteConnection(connectionString);
+            await keepAliveConnection.OpenAsync(TestContext.Current.CancellationToken);
+
+            var database = new SqliteTestDatabase(keepAliveConnection, connectionString);
+            await using var context = database.CreateContext(behavior);
+            await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+            return database;
+        }
+
+        public LockingDbContext CreateContext(
+            PessimisticLockBehavior behavior,
+            bool enableDelayFunction = false,
+            TaskCompletionSource? delayStarted = null,
+            TaskCompletionSource? commandStarted = null)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<LockingDbContext>()
+                .UseSqlite(_connectionString);
+            if (enableDelayFunction)
+            {
+                optionsBuilder.AddInterceptors(new DelayFunctionConnectionInterceptor(delayStarted));
+            }
+
+            if (commandStarted is not null)
+            {
+                optionsBuilder.AddInterceptors(new CommandStartedInterceptor(commandStarted));
+            }
+
+            behavior.Initialise(optionsBuilder);
+
+            return new LockingDbContext(optionsBuilder.Options);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _keepAliveConnection.DisposeAsync();
+        }
+    }
+
+    private sealed class LockingDbContext(DbContextOptions<LockingDbContext> options) : DbContext(options)
+    {
+        public DbSet<Row> Rows => Set<Row>();
+    }
+
+    private sealed class Row
+    {
+        public int Id { get; set; }
+
+        public required string Name { get; set; }
+    }
+
+    private sealed class DelayFunctionConnectionInterceptor : DbConnectionInterceptor
+    {
+        private readonly TaskCompletionSource? _delayStarted;
+
+        public DelayFunctionConnectionInterceptor(TaskCompletionSource? delayStarted)
+        {
+            _delayStarted = delayStarted;
+        }
+
+        public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            AddDelayFunction(connection);
+        }
+
+        public override Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            AddDelayFunction(connection);
+            return Task.CompletedTask;
+        }
+
+        private void AddDelayFunction(DbConnection connection)
+        {
+            if (connection is SqliteConnection sqliteConnection)
+            {
+                sqliteConnection.CreateFunction(
+                    "delay",
+                    (int milliseconds) =>
+                    {
+                        _delayStarted?.TrySetResult();
+                        Thread.Sleep(milliseconds);
+                        return milliseconds;
+                    });
+            }
+        }
+    }
+
+    private sealed class CommandStartedInterceptor(TaskCompletionSource commandStarted) : DbCommandInterceptor
+    {
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            commandStarted.TrySetResult();
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            commandStarted.TrySetResult();
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class CongestionLoggerFactory(Action onQueryCongestionDetected) : ILoggerFactory
+    {
+        private int _notified;
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new CongestionLogger(() =>
+            {
+                if (Interlocked.Exchange(ref _notified, 1) == 0)
+                {
+                    onQueryCongestionDetected();
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CongestionLogger(Action onQueryCongestionDetected) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (formatter(state, exception).Contains("Query congestion detected", StringComparison.Ordinal))
+            {
+                onQueryCongestionDetected();
+            }
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorSaveChangesTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorSaveChangesTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Locking;
+
+public sealed partial class PessimisticLockBehaviorTests
+{
+    [Fact]
+    public async Task OnSaveChangesAsync_WhenSaveChangesContinuationThreadHops_CompletesWithoutThreadAffineLockFailure()
+    {
+        var exception = await InvokeWithDedicatedThreadHopAsync(static (behavior, context, hopTask) =>
+            behavior.OnSaveChangesAsync(context, () => hopTask));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task OnSaveChangesAsync_WhenNestedSaveChangesContinuationThreadHops_CompletesWithoutThreadAffineLockFailure()
+    {
+        var exception = await InvokeWithDedicatedThreadHopAsync(static (behavior, context, hopTask) =>
+            behavior.OnSaveChangesAsync(context, () =>
+                behavior.OnSaveChangesAsync(context, () => hopTask)));
+
+        Assert.Null(exception);
+    }
+
+    private static JellyfinDbContext CreateJellyfinContext(PessimisticLockBehavior behavior)
+    {
+        var options = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+
+        return new JellyfinDbContext(
+            options,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            behavior);
+    }
+
+    private static async Task<Exception?> InvokeWithDedicatedThreadHopAsync(
+        Func<PessimisticLockBehavior, JellyfinDbContext, Task, Task> invokeSaveChanges)
+    {
+        var result = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ownerThread = new Thread(() =>
+        {
+            Exception? observedException = null;
+            var setupException = Record.Exception(() =>
+            {
+                observedException = InvokeOnLockOwnerThread(invokeSaveChanges);
+            });
+
+            result.SetResult(setupException ?? observedException);
+        })
+        {
+            IsBackground = true,
+            Name = "PessimisticLockBehaviorTests lock owner"
+        };
+
+        ownerThread.Start();
+        return await result.Task;
+    }
+
+    private static Exception? InvokeOnLockOwnerThread(
+        Func<PessimisticLockBehavior, JellyfinDbContext, Task, Task> invokeSaveChanges)
+    {
+        Thread? continuationThread = null;
+        Exception? completionException = null;
+
+        try
+        {
+            var behavior = CreateBehavior();
+            using var context = CreateJellyfinContext(behavior);
+            var threadHop = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var saveChangesTask = invokeSaveChanges(behavior, context, threadHop.Task);
+
+            if (saveChangesTask.IsCompleted)
+            {
+                return new InvalidOperationException("The save changes task completed before the test could force a thread hop.");
+            }
+
+            continuationThread = new Thread(() =>
+            {
+                completionException = Record.Exception(threadHop.SetResult);
+            })
+            {
+                IsBackground = true,
+                Name = "PessimisticLockBehaviorTests continuation"
+            };
+
+            continuationThread.Start();
+
+            var saveChangesException = Record.Exception(saveChangesTask.GetAwaiter().GetResult);
+            return saveChangesException ?? completionException;
+        }
+        finally
+        {
+            continuationThread?.Join();
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Locking;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Locking;
+
+public sealed partial class PessimisticLockBehaviorTests
+{
+    private static readonly TimeSpan LockProbeDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    private static PessimisticLockBehavior CreateBehavior(Action? onQueryCongestionDetected = null)
+    {
+        ILoggerFactory loggerFactory = onQueryCongestionDetected is null
+            ? NullLoggerFactory.Instance
+            : new CongestionLoggerFactory(onQueryCongestionDetected);
+
+        return new PessimisticLockBehavior(
+            NullLogger<PessimisticLockBehavior>.Instance,
+            loggerFactory);
+    }
+
+    private static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout)
+    {
+        var completedTask = await Task.WhenAny(task, Task.Delay(timeout, TestContext.Current.CancellationToken));
+        if (!ReferenceEquals(completedTask, task))
+        {
+            return false;
+        }
+
+        await task;
+        return true;
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorTransactionTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Locking/PessimisticLockBehaviorTransactionTests.cs
@@ -1,0 +1,95 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Locking;
+
+public sealed partial class PessimisticLockBehaviorTests
+{
+    [Fact]
+    public async Task TransactionCommands_WhenTransactionLockIsHeld_DoNotReenterGlobalLock()
+    {
+        var behavior = CreateBehavior();
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        await using var context = database.CreateContext(behavior);
+        await using var transaction = await context.Database.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        await context.Database
+            .ExecuteSqlRawAsync("INSERT INTO Rows (Name) VALUES ('inside transaction')", TestContext.Current.CancellationToken)
+            .WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        var rowCount = await context.Rows.CountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, rowCount);
+    }
+
+    [Fact]
+    public async Task BeginTransactionAsync_WhenAnotherTransactionIsOpen_BlocksUntilFirstTransactionDisposes()
+    {
+        var behavior = CreateBehavior();
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        await using var firstContext = database.CreateContext(behavior);
+        await using var secondContext = database.CreateContext(behavior);
+        var firstTransaction = await firstContext.Database.BeginTransactionAsync(TestContext.Current.CancellationToken);
+        IDbContextTransaction? secondTransaction = null;
+        using var secondTransactionCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        secondTransactionCancellation.CancelAfter(TestTimeout);
+        var secondTransactionTask = secondContext.Database.BeginTransactionAsync(secondTransactionCancellation.Token);
+
+        try
+        {
+            Assert.False(await CompletesWithinAsync(secondTransactionTask, LockProbeDelay));
+
+            await firstTransaction.DisposeAsync();
+            secondTransaction = await secondTransactionTask.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            if (secondTransaction is not null)
+            {
+                await secondTransaction.DisposeAsync();
+            }
+
+            await firstTransaction.DisposeAsync();
+            if (secondTransaction is null && !secondTransactionTask.IsCompleted)
+            {
+                await secondTransactionCancellation.CancelAsync();
+                await IgnoreCancellationAsync(secondTransactionTask);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DisposeOnlyTransaction_WhenNoExplicitRollbackOrCommit_ReleasesPessimisticLock()
+    {
+        var behavior = CreateBehavior();
+        await using var database = await SqliteTestDatabase.CreateAsync(behavior);
+        await using var transactionContext = database.CreateContext(behavior);
+        await using var commandContext = database.CreateContext(behavior);
+        var transaction = await transactionContext.Database.BeginTransactionAsync(TestContext.Current.CancellationToken);
+        using var commandCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        commandCancellation.CancelAfter(TestTimeout);
+
+        var blockedCommand = commandContext.Database.ExecuteSqlRawAsync(
+            "INSERT INTO Rows (Name) VALUES ('after dispose')",
+            [],
+            commandCancellation.Token);
+
+        try
+        {
+            Assert.False(await CompletesWithinAsync(blockedCommand, LockProbeDelay));
+
+            await transaction.DisposeAsync();
+            await blockedCommand.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            if (!blockedCommand.IsCompleted)
+            {
+                await commandCancellation.CancelAsync();
+                await IgnoreCancellationAsync(blockedCommand);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Problem**

Pessimistic SQLite locking currently wraps `SaveChanges` and `SaveChangesAsync` with a `ReaderWriterLockSlim`. That is unsafe for async EF work because the continuation that releases the lock is not guaranteed to run on the thread that acquired it. It also puts the lock above EF's command pipeline, while SQLite save operations can be split across non-query, reader, scalar, and transaction callbacks.

This targets `master`. If maintainers want the 10.11 fix released from the stable branch, it should be backported from this mainline change.

**Changes**

- Move locking to EF command and transaction interceptors so each provider operation is locked where it actually runs.
- Replace the thread-affine lock with a semaphore-based reader/writer lock that supports async release and gives priority to a queued writer.
- Keep concurrent reads when no writer is waiting, but block later readers once a writer is queued.
- Treat SQLite `SaveChanges` reader/scalar commands as writes, because generated-value commands are still part of the write path.
- Track write locks by `DbTransaction` so commands inside an open transaction do not deadlock by reacquiring the global lock.
- Release transaction locks from commit, rollback, failure, and dispose-only paths.
- Keep the Sonar lock-lifetime suppression scoped to the semaphore implementation, because the resource semaphore is intentionally released by the returned `DbLock` token rather than in the acquisition method.

**Tests**

The new SQLite-backed tests cover:

- async `SaveChanges` thread hops, including nested calls;
- concurrent reads;
- writer priority for direct SQL and `SaveChangesAsync`;
- cancellation while a writer waits;
- command execution inside a held transaction;
- transaction blocking; and
- dispose-only transaction cleanup.

**Verification**

- `dotnet restore tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj`
- `dotnet build src/Jellyfin.Database/Jellyfin.Database.Implementations/Jellyfin.Database.Implementations.csproj --no-restore`
- `dotnet test tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj --no-restore --filter FullyQualifiedName~PessimisticLockBehaviorTests`
- `git diff --check`
