### PR TITLE
Skip parsing root-level folders in SeriesResolver

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeriesResolver.cs
@@ -57,6 +57,11 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                     return null;
                 }
 
+                if (args.Parent is not null && args.Parent.IsRoot)
+                {
+                    return null;
+                }
+
                 var seriesInfo = Naming.TV.SeriesResolver.Resolve(_namingOptions, args.Path);
 
                 var collectionType = args.GetCollectionType();


### PR DESCRIPTION
While debugging another issue, I noticed that root-level folders were being passed into `SeriesResolver` and unnecessarily processed by `SeriesPathParser`

**Changes**
Add an early return for root-level folders to skip series parsing.

**Code assistance**
N/A

**Issues**
N/A

