### PR TITLE
Make ItemValues get-or-create concurrency-safe under parallel item saves

### DIFF
--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -295,11 +295,13 @@ public class ItemPersistenceService : IItemPersistenceService
         var values = allListedItemValues.Select(e => e.Value).Distinct().ToArray();
         var allListedItemValuesSet = allListedItemValues.ToHashSet();
 
-        var existingValues = context.ItemValues
+        ItemValue[] StoredItemValues() => context.ItemValues
             .Where(e => types.Contains(e.Type) && values.Contains(e.Value))
             .AsEnumerable()
             .Where(e => allListedItemValuesSet.Contains((e.Type, e.Value)))
             .ToArray();
+
+        var existingValues = StoredItemValues();
         var missingItemValues = allListedItemValues.Except(existingValues.Select(f => (MagicNumber: f.Type, f.Value))).Select(f => new ItemValue()
         {
             CleanValue = f.Value.GetCleanValue(),
@@ -307,9 +309,30 @@ public class ItemPersistenceService : IItemPersistenceService
             Type = f.MagicNumber,
             Value = f.Value
         }).ToArray();
-        context.ItemValues.AddRange(missingItemValues);
 
-        var itemValuesStore = existingValues.Concat(missingItemValues).ToArray();
+        var itemValuesStore = existingValues;
+        if (missingItemValues.Length > 0)
+        {
+            // ItemValues is a shared de-duplication table with a unique (Type, Value)
+            // index. The library scanner saves items in parallel, so two items that
+            // introduce the same new value (a shared genre, studio, tag, ...) can race to
+            // create it; a plain INSERT lets the loser violate the constraint and abort
+            // the transaction. Insert through a conflict-tolerant upsert (get-or-create)
+            // rather than the change tracker so concurrent creators converge. Backends
+            // that serialise writes never race, but the upsert is correct there too
+            // (SQLite has supported ON CONFLICT since 3.24).
+            foreach (var itemValue in missingItemValues)
+            {
+                context.Database.ExecuteSql(
+                    $"""INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ({itemValue.ItemValueId}, {(int)itemValue.Type}, {itemValue.Value}, {itemValue.CleanValue}) ON CONFLICT ("Type", "Value") DO NOTHING""");
+            }
+
+            // Re-read to resolve the canonical ids: a value we just upserted may have been
+            // created concurrently under a different ItemValueId, so the map must point at
+            // the row that actually exists rather than the id generated above.
+            itemValuesStore = StoredItemValues();
+        }
+
         var valueMap = itemValueMaps
             .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore.First(g => g.Value == e.Value && g.Type == e.MagicNumber)).DistinctBy(e => e.ItemValueId).ToArray()))
             .ToArray();

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -26,6 +26,13 @@ namespace Jellyfin.Server.Implementations.Item;
 /// </summary>
 public class ItemPersistenceService : IItemPersistenceService
 {
+    /// <summary>
+    /// How many times a save is re-attempted after losing a race to create a shared ItemValue.
+    /// Each retry resolves at least one contested value, so a small bound is enough; it exists
+    /// to stop an unforeseen persistent conflict from spinning forever.
+    /// </summary>
+    private const int ItemValueConflictMaxAttempts = 3;
+
     private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
     private readonly IServerApplicationHost _appHost;
     private readonly ILogger<ItemPersistenceService> _logger;
@@ -247,6 +254,73 @@ public class ItemPersistenceService : IItemPersistenceService
     private void UpdateOrInsertItems(IReadOnlyList<BaseItemDto> items, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(items);
+
+        // ItemValues is a de-duplication table with a unique (Type, Value) index, and the
+        // library scanner saves items in parallel. Two items that introduce the same new
+        // value (a shared genre, studio, tag, ...) race to create it, and the loser's insert
+        // violates the index and aborts its whole transaction. Backends that serialise
+        // writes never reach it, which is why it only shows up on PostgreSQL and friends.
+        //
+        // Resolve it the way SaveImagesAsync does: let the write be the check, and on
+        // failure re-read to find out whether the assumption it was made under still holds.
+        // The alternative, an ON CONFLICT upsert, is not portable - MariaDB has no such
+        // clause - so the race is settled here rather than in dialect-specific SQL.
+        var attemptedNewItemValues = new List<(ItemValueType Type, string Value)>();
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                UpdateOrInsertItemsCore(items, attemptedNewItemValues, cancellationToken);
+                return;
+            }
+            catch (DbUpdateException) when (attempt < ItemValueConflictMaxAttempts)
+            {
+                // Deliberately checked here and not in the filter above: an exception filter runs
+                // before the failed attempt unwinds, so the transaction would still be open and
+                // still holding its write lock while this reads.
+                if (!LostItemValueRace(attemptedNewItemValues))
+                {
+                    throw;
+                }
+
+                // Whatever we were going to create exists now, so the next attempt reads it
+                // back instead of inserting it. Every write went through the transaction that
+                // has just rolled back, leaving nothing to undo before retrying.
+                _logger.LogDebug(
+                    "Retrying item save after losing a race to create a shared ItemValue (attempt {Attempt} of {MaxAttempts})",
+                    attempt,
+                    ItemValueConflictMaxAttempts);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reports whether any ItemValue the failed attempt meant to create exists now, which is
+    /// what losing the race looks like from here. A failure for any other reason leaves them
+    /// absent and is rethrown rather than retried.
+    /// </summary>
+    /// <param name="attemptedNewItemValues">The values the failed attempt tried to create.</param>
+    /// <returns><c>true</c> if a concurrent writer created one of them.</returns>
+    private bool LostItemValueRace(List<(ItemValueType Type, string Value)> attemptedNewItemValues)
+    {
+        if (attemptedNewItemValues.Count == 0)
+        {
+            return false;
+        }
+
+        var types = attemptedNewItemValues.Select(e => e.Type).Distinct().ToArray();
+        var values = attemptedNewItemValues.Select(e => e.Value).Distinct().ToArray();
+        var attempted = attemptedNewItemValues.ToHashSet();
+
+        using var context = _dbProvider.CreateDbContext();
+        return context.ItemValues
+            .Where(e => types.Contains(e.Type) && values.Contains(e.Value))
+            .AsEnumerable()
+            .Any(e => attempted.Contains((e.Type, e.Value)));
+    }
+
+    private void UpdateOrInsertItemsCore(IReadOnlyList<BaseItemDto> items, List<(ItemValueType Type, string Value)> attemptedNewItemValues, CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
 
         var tuples = new List<(BaseItemDto Item, List<Guid>? AncestorIds, BaseItemDto TopParent, IEnumerable<string> UserDataKey, List<string> InheritedTags)>();
@@ -320,6 +394,11 @@ public class ItemPersistenceService : IItemPersistenceService
             Value = f.Value
         }).ToArray();
         context.ItemValues.AddRange(missingItemValues);
+
+        // Recorded for the caller's retry check: these are the rows a concurrent writer can
+        // create between the read above and the save below.
+        attemptedNewItemValues.Clear();
+        attemptedNewItemValues.AddRange(missingItemValues.Select(e => (e.Type, e.Value)));
 
         var itemValuesStore = existingValues
             .Concat(missingItemValues)

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceItemValueRaceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceItemValueRaceTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+/// <summary>
+/// Covers the ItemValues get-or-create in <c>ItemPersistenceService.UpdateOrInsertItems</c>.
+/// ItemValues de-duplicates on a unique (Type, Value) index, and the scanner saves items in
+/// parallel, so two items introducing the same new value race to create it. These tests run on a
+/// file-backed SQLite database rather than the shared in-memory fixture, because the race needs a
+/// second connection that can commit while the save under test is still open.
+/// </summary>
+public sealed class ItemPersistenceServiceItemValueRaceTests : IDisposable
+{
+    private readonly string _databaseFile;
+    private readonly string _connectionString;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly IApplicationPaths _applicationPaths = new Mock<IApplicationPaths>().Object;
+    private readonly ILibraryManager? _previousLibraryManager;
+    private readonly IServerConfigurationManager? _previousConfigurationManager;
+    private CompetingItemValueWriter? _competingWriter;
+
+    public ItemPersistenceServiceItemValueRaceTests()
+    {
+        _databaseFile = Path.Combine(Path.GetTempPath(), $"jf-itemvalue-race-{Guid.NewGuid():N}.db");
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = _databaseFile }.ToString();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connectionString)
+            .AddInterceptors(new CompetingWriterInterceptor(() => _competingWriter))
+            .Options;
+
+        using var context = CreateDbContext();
+        context.Database.EnsureCreated();
+        context.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL");
+
+        // BaseItem resolves these through process-wide statics; restored in Dispose.
+        _previousLibraryManager = BaseItem.LibraryManager;
+        _previousConfigurationManager = BaseItem.ConfigurationManager;
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(l => l.GetCollectionFolders(It.IsAny<BaseItem>())).Returns([]);
+        BaseItem.LibraryManager = libraryManager.Object;
+
+        var configurationManager = new Mock<IServerConfigurationManager>();
+        configurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        BaseItem.ConfigurationManager = configurationManager.Object;
+    }
+
+    public void Dispose()
+    {
+        BaseItem.LibraryManager = _previousLibraryManager!;
+        BaseItem.ConfigurationManager = _previousConfigurationManager!;
+
+        SqliteConnection.ClearAllPools();
+        foreach (var path in new[] { _databaseFile, _databaseFile + "-wal", _databaseFile + "-shm" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void ItemValues_UniqueTypeValueIndex_IsEnforced()
+    {
+        // The premise of the race: the schema really does reject a duplicate (Type, Value), so a
+        // plain insert by the losing writer aborts its transaction rather than being ignored.
+        using var context = CreateDbContext();
+        InsertItemValue(context, Guid.NewGuid(), ItemValueType.Genre, "Drama");
+
+        Assert.ThrowsAny<DbException>(() => InsertItemValue(context, Guid.NewGuid(), ItemValueType.Genre, "Drama"));
+    }
+
+    [Fact]
+    public void SaveItems_TwoItemsSharingANewValue_CreateItOnce()
+    {
+        var first = CreateItem("Drama");
+        var second = CreateItem("Drama");
+
+        CreateService().SaveItems([first, second], CancellationToken.None);
+
+        Assert.Single(StoredValues("Drama"));
+        Assert.Equal(2, MappedItemCount("Drama"));
+    }
+
+    [Fact]
+    public void SaveItems_ValueAlreadyExists_ReusesItInsteadOfInserting()
+    {
+        // The state a retry converges to: once the winner's row is committed, the loser's next
+        // attempt must map onto it rather than try to create its own.
+        var service = CreateService();
+        service.SaveItems([CreateItem("Drama")], CancellationToken.None);
+        service.SaveItems([CreateItem("Drama")], CancellationToken.None);
+
+        Assert.Single(StoredValues("Drama"));
+        Assert.Equal(2, MappedItemCount("Drama"));
+    }
+
+    [Fact]
+    public void SaveItems_LosesRaceToCreateTheValue_RetriesOntoTheWinnersRow()
+    {
+        // Reproduces the reported failure. SQLite serialises writers, which is why the bug never
+        // shows up there and why a second thread cannot stage it: the save under test already holds
+        // the write lock by the time it inserts. The race is instead played out through the seams
+        // the service is constructed with, and both halves that matter stay real. The interceptor
+        // writes the contested value into the failing save's own transaction, so the exception comes
+        // from the actual unique index rather than a fabricated one, and the winning row is then
+        // committed for real, from its own connection, before the service re-reads.
+        _competingWriter = new CompetingItemValueWriter(_connectionString, ItemValueType.Genre, "Drama");
+
+        CreateService().SaveItems([CreateItem("Drama")], CancellationToken.None);
+
+        Assert.True(_competingWriter.ProvokedConflict, "the save never hit the unique index, so no race was staged");
+        Assert.True(_competingWriter.Committed, "the winning row was never committed, so there was nothing to retry onto");
+
+        // One row survives, it is the winner's, and the item is mapped onto it: the losing save must
+        // not keep the ItemValueId it generated before the race.
+        var stored = StoredValues("Drama");
+        Assert.Single(stored);
+        Assert.Equal(_competingWriter.ItemValueId, stored[0].ItemValueId);
+        Assert.Equal(1, MappedItemCount("Drama"));
+    }
+
+    private static BaseItem CreateItem(string genre)
+        => new Book
+        {
+            Id = Guid.NewGuid(),
+            Name = "Book",
+            Genres = [genre]
+        };
+
+    private static void InsertItemValue(JellyfinDbContext context, Guid id, ItemValueType type, string value)
+        => context.Database.ExecuteSql(
+            $"""INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ({id}, {(int)type}, {value}, {value})""");
+
+    private List<ItemValue> StoredValues(string value)
+    {
+        using var context = CreateDbContext();
+        return context.ItemValues.Where(e => e.Type == ItemValueType.Genre && e.Value == value).ToList();
+    }
+
+    private int MappedItemCount(string value)
+    {
+        using var context = CreateDbContext();
+        return context.ItemValuesMap.Count(e => e.ItemValue.Type == ItemValueType.Genre && e.ItemValue.Value == value);
+    }
+
+    private ItemPersistenceService CreateService()
+        => new(
+            CreateDbContextFactory(),
+            Mock.Of<IServerApplicationHost>(),
+            NullLogger<ItemPersistenceService>.Instance);
+
+    private JellyfinDbContext CreateDbContext() => new(
+        _dbOptions,
+        NullLogger<JellyfinDbContext>.Instance,
+        new SqliteDatabaseProvider(_applicationPaths, NullLogger<SqliteDatabaseProvider>.Instance),
+        new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+
+    private IDbContextFactory<JellyfinDbContext> CreateDbContextFactory()
+    {
+        // The first context the service asks for after its save failed is the one it checks the
+        // race with, and by then its transaction is gone and the write lock is free. That is the
+        // point the winning row can actually be committed.
+        JellyfinDbContext CreateDbContextForService()
+        {
+            _competingWriter?.CommitOnce();
+            return CreateDbContext();
+        }
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContextForService);
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(CreateDbContextForService);
+
+        return factory.Object;
+    }
+
+    /// <summary>
+    /// Stages the loss of a race for one (Type, Value), in the two steps it happens in: provoke the
+    /// unique-index violation inside the save that is about to fail, then commit the winning row
+    /// from a separate connection once that save has rolled back and released the write lock.
+    /// </summary>
+    private sealed class CompetingItemValueWriter
+    {
+        private readonly string _connectionString;
+        private readonly ItemValueType _type;
+        private readonly string _value;
+
+        public CompetingItemValueWriter(string connectionString, ItemValueType type, string value)
+        {
+            _connectionString = connectionString;
+            _type = type;
+            _value = value;
+            ItemValueId = Guid.NewGuid();
+        }
+
+        public Guid ItemValueId { get; }
+
+        public bool ProvokedConflict { get; private set; }
+
+        public bool Committed { get; private set; }
+
+        /// <summary>
+        /// Writes the contested value into the save's own transaction, so the insert it is about to
+        /// flush collides with the real index. Rolled back with that transaction, which is why the
+        /// row still has to be committed afterwards.
+        /// </summary>
+        /// <param name="context">The context whose save is about to run.</param>
+        public void ProvokeConflictOnce(DbContext context)
+        {
+            if (ProvokedConflict)
+            {
+                return;
+            }
+
+            ProvokedConflict = true;
+            context.Database.ExecuteSql(
+                $"""INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ({ItemValueId}, {(int)_type}, {_value}, {_value})""");
+        }
+
+        /// <summary>
+        /// Commits the winning row from its own connection, as the writer that won the race would
+        /// have. Only meaningful once the losing save has rolled back.
+        /// </summary>
+        public void CommitOnce()
+        {
+            if (Committed || !ProvokedConflict)
+            {
+                return;
+            }
+
+            Committed = true;
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = """INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ($id, $type, $value, $value)""";
+            command.Parameters.AddWithValue("$id", ItemValueId);
+            command.Parameters.AddWithValue("$type", (int)_type);
+            command.Parameters.AddWithValue("$value", _value);
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private sealed class CompetingWriterInterceptor : SaveChangesInterceptor
+    {
+        private readonly Func<CompetingItemValueWriter?> _writer;
+
+        public CompetingWriterInterceptor(Func<CompetingItemValueWriter?> writer)
+        {
+            _writer = writer;
+        }
+
+        public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+        {
+            if (eventData.Context is not null)
+            {
+                _writer()?.ProvokeConflictOnce(eventData.Context);
+            }
+
+            return base.SavingChanges(eventData, result);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemValueUpsertTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemValueUpsertTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Data.Common;
+using System.Linq;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+/// <summary>
+/// Covers the conflict-tolerant ItemValues get-or-create used by
+/// <c>ItemPersistenceService.UpdateOrInsertItems</c>. The concurrency race itself cannot be
+/// reproduced on the in-memory SQLite test harness (SQLite serialises writes, which is exactly
+/// why the bug does not occur there), but these tests verify the two facts the fix relies on
+/// against the real generated schema: the unique (Type, Value) index is enforced, and the
+/// ON CONFLICT upsert the fix emits is portable to SQLite and idempotent.
+/// </summary>
+public sealed class ItemValueUpsertTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+
+    public ItemValueUpsertTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using var context = CreateDbContext();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public void PlainInsert_DuplicateTypeValue_ViolatesUniqueConstraint()
+    {
+        using var context = CreateDbContext();
+
+        InsertPlain(context, Guid.NewGuid(), ItemValueType.Genre, "Drama");
+
+        // Without conflict handling, a second item introducing the same (Type, Value)
+        // violates IX_ItemValues_Type_Value. This is the failure reported in
+        // JPVenson/Jellyfin.Pgsql#19 when two items race to create a shared value.
+        Assert.ThrowsAny<DbException>(() => InsertPlain(context, Guid.NewGuid(), ItemValueType.Genre, "Drama"));
+    }
+
+    [Fact]
+    public void Upsert_DuplicateTypeValue_IsIdempotentAndDoesNotThrow()
+    {
+        using var context = CreateDbContext();
+
+        var inserted = Upsert(context, Guid.NewGuid(), ItemValueType.Genre, "Drama");
+        var conflicted = Upsert(context, Guid.NewGuid(), ItemValueType.Genre, "Drama");
+
+        Assert.Equal(1, inserted);   // first writer creates the row
+        Assert.Equal(0, conflicted); // second writer is a no-op, not a constraint violation
+
+        var rows = context.ItemValues
+            .Where(e => e.Type == ItemValueType.Genre && e.Value == "Drama")
+            .ToList();
+        Assert.Single(rows);
+    }
+
+    private static void InsertPlain(JellyfinDbContext context, Guid id, ItemValueType type, string value)
+        => context.Database.ExecuteSql(
+            $"""INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ({id}, {(int)type}, {value}, {value})""");
+
+    // Mirrors the upsert in ItemPersistenceService.UpdateOrInsertItems.
+    private static int Upsert(JellyfinDbContext context, Guid id, ItemValueType type, string value)
+        => context.Database.ExecuteSql(
+            $"""INSERT INTO "ItemValues" ("ItemValueId", "Type", "Value", "CleanValue") VALUES ({id}, {(int)type}, {value}, {value}) ON CONFLICT ("Type", "Value") DO NOTHING""");
+
+    private JellyfinDbContext CreateDbContext()
+        => new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+}


### PR DESCRIPTION
`ItemPersistenceService.UpdateOrInsertItems` reads the existing `ItemValues`, then inserts the missing ones through the change tracker with no concurrency guard. Two items saved in parallel that introduce the same new value (a shared genre, studio, tag, ...) both insert it, and the loser violates the unique `IX_ItemValues_Type_Value` index and aborts its transaction. SQLite serialises writes, so this only surfaces on backends with concurrent writers.

**Changes**

The race is settled in C# rather than in SQL. The save is retried, bounded, when a re-read shows the values it meant to create exist now, which is what losing the race looks like from here; any other failure is rethrown untouched. That is the same "let the write be the check, then re-read to see whether the assumption it was made under still holds" shape `SaveImagesAsync` already uses in this class for the item-deleted-underneath race.

Behaviour is unchanged on backends that serialise writes: with no concurrent writer there is never a conflict, so the retry never runs.

Two details worth pointing at during review:

- The retry check runs in the `catch` body, not in the exception filter. A filter runs before the failed attempt unwinds, so the transaction would still be open, and still holding its write lock, while the check reads.
- The whole save is retried rather than just the `ItemValues` insert, because the method runs as one transaction and the values must be resolved before the map rows that reference them are built.

**Previous revision**

The first version of this PR used `INSERT ... ON CONFLICT ("Type", "Value") DO NOTHING`. Per @Shadowghost's review that is not portable, MariaDB has no such clause, so it has been replaced. No dialect-specific SQL is emitted now.

**Tests**

`ItemPersistenceServiceItemValueRaceTests` covers the unique index being enforced, two items in one batch sharing a new value creating it once, an already-existing value being reused, and the retry converging onto the winner's row.

The last of those needs a note. SQLite cannot host a genuine two-connection version of this race, which is the same reason the bug does not occur there: the save under test already holds the write lock, so a competing writer is simply locked out. The test therefore stages the race through the seams the service is constructed with, and the two halves that matter stay real. The conflicting row is written into the failing save's own transaction, so the exception comes from the actual unique index rather than a fabricated one, and the winning row is then committed for real, from its own connection, before the service re-reads.

**Issues**

Reported downstream (PostgreSQL plugin) as JPVenson/Jellyfin.Pgsql#19; the bug is in core.
