### PR TITLE
Fix episode air date offset after initial scan

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -181,7 +181,9 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 ParentIndexNumber = seasonNumber,
                 IndexNumberEnd = info.IndexNumberEnd,
                 Name = episodeResult.Name,
-                PremiereDate = episodeResult.AirDate,
+                PremiereDate = episodeResult.AirDate.HasValue
+                    ? DateTime.SpecifyKind(episodeResult.AirDate.Value, DateTimeKind.Local).ToUniversalTime()
+                    : null,
                 ProductionYear = episodeResult.AirDate?.Year,
                 Overview = episodeResult.Overview,
                 CommunityRating = Convert.ToSingle(episodeResult.VoteAverage)


### PR DESCRIPTION
On initial scan, the premiere date was being stored in the database without the correct UTC offset. Upon restart the library manager would apply the correct offset. This caused the air date to be displayed incorrectly on clients using the /Items endpoint when viewing episode details before restarting the server.

**Changes**
Treat the air date as local time before converting to UTC.

**Code assistance**
N/A

**Issues**
Fixes #16452
