### PR TITLE
Honor VideoStreamIndex in media playback negotiation

### DIFF
--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -98,6 +98,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="maxStreamingBitrate">The maximum streaming bitrate.</param>
     /// <param name="startTimeTicks">The start time in ticks.</param>
+    /// <param name="videoStreamIndex">The video stream index.</param>
     /// <param name="audioStreamIndex">The audio stream index.</param>
     /// <param name="subtitleStreamIndex">The subtitle stream index.</param>
     /// <param name="maxAudioChannels">The maximum number of audio channels.</param>
@@ -121,6 +122,7 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery, ParameterObsolete] Guid? userId,
         [FromQuery, ParameterObsolete] int? maxStreamingBitrate,
         [FromQuery, ParameterObsolete] long? startTimeTicks,
+        [FromQuery, ParameterObsolete] int? videoStreamIndex,
         [FromQuery, ParameterObsolete] int? audioStreamIndex,
         [FromQuery, ParameterObsolete] int? subtitleStreamIndex,
         [FromQuery, ParameterObsolete] int? maxAudioChannels,
@@ -152,6 +154,7 @@ public class MediaInfoController : BaseJellyfinApiController
         userId = RequestHelpers.GetUserId(User, userId);
         maxStreamingBitrate ??= playbackInfoDto?.MaxStreamingBitrate;
         startTimeTicks ??= playbackInfoDto?.StartTimeTicks;
+        videoStreamIndex ??= playbackInfoDto?.VideoStreamIndex;
         audioStreamIndex ??= playbackInfoDto?.AudioStreamIndex;
         subtitleStreamIndex ??= playbackInfoDto?.SubtitleStreamIndex;
         maxAudioChannels ??= playbackInfoDto?.MaxAudioChannels;
@@ -199,6 +202,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     maxStreamingBitrate ?? profile.MaxStreamingBitrate,
                     startTimeTicks ?? 0,
                     mediaSourceId ?? string.Empty,
+                    videoStreamIndex,
                     audioStreamIndex,
                     subtitleStreamIndex,
                     maxAudioChannels,
@@ -226,6 +230,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     HttpContext,
                     new LiveStreamRequest
                     {
+                        VideoStreamIndex = videoStreamIndex,
                         AudioStreamIndex = audioStreamIndex,
                         DeviceProfile = playbackInfoDto?.DeviceProfile,
                         EnableDirectPlay = enableDirectPlay.Value,
@@ -256,6 +261,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="playSessionId">The play session id.</param>
     /// <param name="maxStreamingBitrate">The maximum streaming bitrate.</param>
     /// <param name="startTimeTicks">The start time in ticks.</param>
+    /// <param name="videoStreamIndex">The video stream index.</param>
     /// <param name="audioStreamIndex">The audio stream index.</param>
     /// <param name="subtitleStreamIndex">The subtitle stream index.</param>
     /// <param name="maxAudioChannels">The maximum number of audio channels.</param>
@@ -274,6 +280,7 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery] string? playSessionId,
         [FromQuery] int? maxStreamingBitrate,
         [FromQuery] long? startTimeTicks,
+        [FromQuery] int? videoStreamIndex,
         [FromQuery] int? audioStreamIndex,
         [FromQuery] int? subtitleStreamIndex,
         [FromQuery] int? maxAudioChannels,
@@ -292,6 +299,7 @@ public class MediaInfoController : BaseJellyfinApiController
             PlaySessionId = playSessionId ?? openLiveStreamDto?.PlaySessionId,
             MaxStreamingBitrate = maxStreamingBitrate ?? openLiveStreamDto?.MaxStreamingBitrate,
             StartTimeTicks = startTimeTicks ?? openLiveStreamDto?.StartTimeTicks,
+            VideoStreamIndex = videoStreamIndex ?? openLiveStreamDto?.VideoStreamIndex,
             AudioStreamIndex = audioStreamIndex ?? openLiveStreamDto?.AudioStreamIndex,
             SubtitleStreamIndex = subtitleStreamIndex ?? openLiveStreamDto?.SubtitleStreamIndex,
             MaxAudioChannels = maxAudioChannels ?? openLiveStreamDto?.MaxAudioChannels,

--- a/Jellyfin.Api/Controllers/MediaInfoController.cs
+++ b/Jellyfin.Api/Controllers/MediaInfoController.cs
@@ -98,6 +98,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="userId">The user id.</param>
     /// <param name="maxStreamingBitrate">The maximum streaming bitrate.</param>
     /// <param name="startTimeTicks">The start time in ticks.</param>
+    /// <param name="videoStreamIndex">The video stream index.</param>
     /// <param name="audioStreamIndex">The audio stream index.</param>
     /// <param name="subtitleStreamIndex">The subtitle stream index.</param>
     /// <param name="maxAudioChannels">The maximum number of audio channels.</param>
@@ -121,6 +122,7 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery, ParameterObsolete] Guid? userId,
         [FromQuery, ParameterObsolete] int? maxStreamingBitrate,
         [FromQuery, ParameterObsolete] long? startTimeTicks,
+        [FromQuery, ParameterObsolete] int? videoStreamIndex,
         [FromQuery, ParameterObsolete] int? audioStreamIndex,
         [FromQuery, ParameterObsolete] int? subtitleStreamIndex,
         [FromQuery, ParameterObsolete] int? maxAudioChannels,
@@ -152,6 +154,7 @@ public class MediaInfoController : BaseJellyfinApiController
         userId = RequestHelpers.GetUserId(User, userId);
         maxStreamingBitrate ??= playbackInfoDto?.MaxStreamingBitrate;
         startTimeTicks ??= playbackInfoDto?.StartTimeTicks;
+        videoStreamIndex ??= playbackInfoDto?.VideoStreamIndex;
         audioStreamIndex ??= playbackInfoDto?.AudioStreamIndex;
         subtitleStreamIndex ??= playbackInfoDto?.SubtitleStreamIndex;
         maxAudioChannels ??= playbackInfoDto?.MaxAudioChannels;
@@ -200,6 +203,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     maxStreamingBitrate ?? profile.MaxStreamingBitrate,
                     startTimeTicks ?? 0,
                     mediaSourceId ?? string.Empty,
+                    videoStreamIndex,
                     audioStreamIndex,
                     subtitleStreamIndex,
                     maxAudioChannels,
@@ -227,6 +231,7 @@ public class MediaInfoController : BaseJellyfinApiController
                     HttpContext,
                     new LiveStreamRequest
                     {
+                        VideoStreamIndex = videoStreamIndex,
                         AudioStreamIndex = audioStreamIndex,
                         DeviceProfile = playbackInfoDto?.DeviceProfile,
                         EnableDirectPlay = enableDirectPlay.Value,
@@ -257,6 +262,7 @@ public class MediaInfoController : BaseJellyfinApiController
     /// <param name="playSessionId">The play session id.</param>
     /// <param name="maxStreamingBitrate">The maximum streaming bitrate.</param>
     /// <param name="startTimeTicks">The start time in ticks.</param>
+    /// <param name="videoStreamIndex">The video stream index.</param>
     /// <param name="audioStreamIndex">The audio stream index.</param>
     /// <param name="subtitleStreamIndex">The subtitle stream index.</param>
     /// <param name="maxAudioChannels">The maximum number of audio channels.</param>
@@ -275,6 +281,7 @@ public class MediaInfoController : BaseJellyfinApiController
         [FromQuery] string? playSessionId,
         [FromQuery] int? maxStreamingBitrate,
         [FromQuery] long? startTimeTicks,
+        [FromQuery] int? videoStreamIndex,
         [FromQuery] int? audioStreamIndex,
         [FromQuery] int? subtitleStreamIndex,
         [FromQuery] int? maxAudioChannels,
@@ -293,6 +300,7 @@ public class MediaInfoController : BaseJellyfinApiController
             PlaySessionId = playSessionId ?? openLiveStreamDto?.PlaySessionId,
             MaxStreamingBitrate = maxStreamingBitrate ?? openLiveStreamDto?.MaxStreamingBitrate,
             StartTimeTicks = startTimeTicks ?? openLiveStreamDto?.StartTimeTicks,
+            VideoStreamIndex = videoStreamIndex ?? openLiveStreamDto?.VideoStreamIndex,
             AudioStreamIndex = audioStreamIndex ?? openLiveStreamDto?.AudioStreamIndex,
             SubtitleStreamIndex = subtitleStreamIndex ?? openLiveStreamDto?.SubtitleStreamIndex,
             MaxAudioChannels = maxAudioChannels ?? openLiveStreamDto?.MaxAudioChannels,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -151,6 +151,7 @@ public class UniversalAudioController : BaseJellyfinApiController
                 mediaSourceId ?? string.Empty,
                 null,
                 null,
+                null,
                 maxAudioChannels,
                 info.PlaySessionId!,
                 userId ?? Guid.Empty,

--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -152,6 +152,7 @@ public class UniversalAudioController : BaseJellyfinApiController
                 mediaSourceId ?? string.Empty,
                 null,
                 null,
+                null,
                 maxAudioChannels,
                 info.PlaySessionId!,
                 userId ?? Guid.Empty,

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -155,6 +155,7 @@ public class MediaInfoHelper
     /// <param name="maxBitrate">Max bitrate.</param>
     /// <param name="startTimeTicks">Start time ticks.</param>
     /// <param name="mediaSourceId">Media source id.</param>
+    /// <param name="videoStreamIndex">Video stream index.</param>
     /// <param name="audioStreamIndex">Audio stream index.</param>
     /// <param name="subtitleStreamIndex">Subtitle stream index.</param>
     /// <param name="maxAudioChannels">Max audio channels.</param>
@@ -175,6 +176,7 @@ public class MediaInfoHelper
         int? maxBitrate,
         long startTimeTicks,
         string mediaSourceId,
+        int? videoStreamIndex,
         int? audioStreamIndex,
         int? subtitleStreamIndex,
         int? maxAudioChannels,
@@ -206,6 +208,7 @@ public class MediaInfoHelper
         if (string.Equals(mediaSourceId, mediaSource.Id, StringComparison.OrdinalIgnoreCase))
         {
             options.MediaSourceId = mediaSourceId;
+            options.VideoStreamIndex = videoStreamIndex;
             options.AudioStreamIndex = audioStreamIndex;
             options.SubtitleStreamIndex = subtitleStreamIndex;
         }
@@ -438,6 +441,7 @@ public class MediaInfoHelper
                 request.MaxStreamingBitrate,
                 request.StartTimeTicks ?? 0,
                 result.MediaSource.Id,
+                request.VideoStreamIndex,
                 request.AudioStreamIndex,
                 request.SubtitleStreamIndex,
                 request.MaxAudioChannels,

--- a/Jellyfin.Api/Helpers/MediaInfoHelper.cs
+++ b/Jellyfin.Api/Helpers/MediaInfoHelper.cs
@@ -167,6 +167,7 @@ public class MediaInfoHelper
     /// <param name="maxBitrate">Max bitrate.</param>
     /// <param name="startTimeTicks">Start time ticks.</param>
     /// <param name="mediaSourceId">Media source id.</param>
+    /// <param name="videoStreamIndex">Video stream index.</param>
     /// <param name="audioStreamIndex">Audio stream index.</param>
     /// <param name="subtitleStreamIndex">Subtitle stream index.</param>
     /// <param name="maxAudioChannels">Max audio channels.</param>
@@ -187,6 +188,7 @@ public class MediaInfoHelper
         int? maxBitrate,
         long startTimeTicks,
         string mediaSourceId,
+        int? videoStreamIndex,
         int? audioStreamIndex,
         int? subtitleStreamIndex,
         int? maxAudioChannels,
@@ -218,6 +220,7 @@ public class MediaInfoHelper
         if (string.Equals(mediaSourceId, mediaSource.Id, StringComparison.OrdinalIgnoreCase))
         {
             options.MediaSourceId = mediaSourceId;
+            options.VideoStreamIndex = videoStreamIndex;
             options.AudioStreamIndex = audioStreamIndex;
             options.SubtitleStreamIndex = subtitleStreamIndex;
         }
@@ -452,6 +455,7 @@ public class MediaInfoHelper
                 request.MaxStreamingBitrate,
                 request.StartTimeTicks ?? 0,
                 result.MediaSource.Id,
+                request.VideoStreamIndex,
                 request.AudioStreamIndex,
                 request.SubtitleStreamIndex,
                 request.MaxAudioChannels,

--- a/Jellyfin.Api/Models/MediaInfoDtos/OpenLiveStreamDto.cs
+++ b/Jellyfin.Api/Models/MediaInfoDtos/OpenLiveStreamDto.cs
@@ -36,6 +36,11 @@ public class OpenLiveStreamDto
     public long? StartTimeTicks { get; set; }
 
     /// <summary>
+    /// Gets or sets the video stream index.
+    /// </summary>
+    public int? VideoStreamIndex { get; set; }
+
+    /// <summary>
     /// Gets or sets the audio stream index.
     /// </summary>
     public int? AudioStreamIndex { get; set; }

--- a/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
+++ b/Jellyfin.Api/Models/MediaInfoDtos/PlaybackInfoDto.cs
@@ -24,6 +24,11 @@ public class PlaybackInfoDto
     public long? StartTimeTicks { get; set; }
 
     /// <summary>
+    /// Gets or sets the video stream index.
+    /// </summary>
+    public int? VideoStreamIndex { get; set; }
+
+    /// <summary>
     /// Gets or sets the audio stream index.
     /// </summary>
     public int? AudioStreamIndex { get; set; }

--- a/MediaBrowser.Model/Dlna/MediaOptions.cs
+++ b/MediaBrowser.Model/Dlna/MediaOptions.cs
@@ -103,6 +103,11 @@ namespace MediaBrowser.Model.Dlna
         public int? AudioTranscodingBitrate { get; set; }
 
         /// <summary>
+        /// Gets or sets an override for the video stream index.
+        /// </summary>
+        public int? VideoStreamIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets an override for the audio stream index.
         /// </summary>
         public int? AudioStreamIndex { get; set; }

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -709,6 +709,14 @@ namespace MediaBrowser.Model.Dlna
             }
 
             var videoStream = item.VideoStream;
+            if (options.VideoStreamIndex.HasValue)
+            {
+                var requestedVideoStream = item.GetMediaStream(MediaStreamType.Video, options.VideoStreamIndex.Value);
+                if (requestedVideoStream is not null)
+                {
+                    videoStream = requestedVideoStream;
+                }
+            }
 
             var bitrateLimitExceeded = IsBitrateLimitExceeded(item, options.GetMaxBitrate(false) ?? 0);
             var isEligibleForDirectPlay = options.EnableDirectPlay && (options.ForceDirectPlay || !bitrateLimitExceeded);
@@ -718,6 +726,14 @@ namespace MediaBrowser.Model.Dlna
             // Force transcode or remux for BD/DVD folders
             if (item.VideoType == VideoType.Dvd || item.VideoType == VideoType.BluRay)
             {
+                isEligibleForDirectPlay = false;
+            }
+
+            // A video stream other than the default one can only be honored by remuxing or transcoding,
+            // since direct play would deliver the original file containing every video stream.
+            if (videoStream is not null && videoStream.Index != item.VideoStream?.Index)
+            {
+                playlistItem.VideoStreamIndex = videoStream.Index;
                 isEligibleForDirectPlay = false;
             }
 

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -708,6 +708,14 @@ namespace MediaBrowser.Model.Dlna
             }
 
             var videoStream = item.VideoStream;
+            if (options.VideoStreamIndex.HasValue)
+            {
+                var requestedVideoStream = item.GetMediaStream(MediaStreamType.Video, options.VideoStreamIndex.Value);
+                if (requestedVideoStream is not null)
+                {
+                    videoStream = requestedVideoStream;
+                }
+            }
 
             var bitrateLimitExceeded = IsBitrateLimitExceeded(item, options.GetMaxBitrate(false) ?? 0);
             var isEligibleForDirectPlay = options.EnableDirectPlay && (options.ForceDirectPlay || !bitrateLimitExceeded);
@@ -725,6 +733,14 @@ namespace MediaBrowser.Model.Dlna
             // Jellyfin url the client would fetch it from.
             if (ContainerHelper.ContainsContainer(ManifestContainers, item.Container))
             {
+                isEligibleForDirectPlay = false;
+            }
+
+            // A video stream other than the default one can only be honored by remuxing or transcoding,
+            // since direct play would deliver the original file containing every video stream.
+            if (videoStream is not null && videoStream.Index != item.VideoStream?.Index)
+            {
+                playlistItem.VideoStreamIndex = videoStream.Index;
                 isEligibleForDirectPlay = false;
             }
 

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -124,13 +124,19 @@ public class StreamInfo
     public IReadOnlyList<string> VideoCodecs { get; set; }
 
     /// <summary>
+    /// Gets or sets the video stream index.
+    /// </summary>
+    /// <value>The video stream index.</value>
+    public int? VideoStreamIndex { get; set; }
+
+    /// <summary>
     /// Gets or sets the audio stream index.
     /// </summary>
     /// <value>The audio stream index.</value>
     public int? AudioStreamIndex { get; set; }
 
     /// <summary>
-    /// Gets or sets the video stream index.
+    /// Gets or sets the subtitle stream index.
     /// </summary>
     /// <value>The subtitle stream index.</value>
     public int? SubtitleStreamIndex { get; set; }
@@ -944,6 +950,12 @@ public class StreamInfo
         {
             sb.Append("&AudioCodec=");
             sb.AppendJoin(',', AudioCodecs);
+        }
+
+        if (VideoStreamIndex.HasValue)
+        {
+            sb.Append("&VideoStreamIndex=");
+            sb.Append(VideoStreamIndex.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (AudioStreamIndex.HasValue)

--- a/MediaBrowser.Model/MediaInfo/LiveStreamRequest.cs
+++ b/MediaBrowser.Model/MediaInfo/LiveStreamRequest.cs
@@ -27,6 +27,8 @@ namespace MediaBrowser.Model.MediaInfo
 
         public long? StartTimeTicks { get; set; }
 
+        public int? VideoStreamIndex { get; set; }
+
         public int? AudioStreamIndex { get; set; }
 
         public int? SubtitleStreamIndex { get; set; }


### PR DESCRIPTION
### Changes

The transcode path (`EncodingHelper`) already knows how to map a specific video stream, there was just no way to actually ask for one through PlaybackInfo. This adds `VideoStreamIndex` to the negotiation, right next to the `AudioStreamIndex` and `SubtitleStreamIndex` that are already there: `PlaybackInfoDto`/`OpenLiveStreamDto`/`LiveStreamRequest`, `MediaInfoController`, `MediaInfoHelper`, `MediaOptions`, and the stream URL built in `StreamInfo`.

In `StreamBuilder`, if you ask for a video stream that isn't the default one, it gets written into the stream URL and direct play is switched off, so the stream you picked actually gets mapped during remux/transcode. Asking for the default stream (or not asking at all) behaves exactly like before. And if the index doesn't match a video stream in that source, it just falls back to the default instead of doing anything weird.

Web side is here: https://github.com/jellyfin/jellyfin-web/pull/8051

### Issues

Related to jellyfin/jellyfin-web#1421, https://github.com/jellyfin/jellyfin/issues/10303 and https://features.jellyfin.org/posts/942/support-multi-track-video-quality

### Follow-up / known gap

Clients have to send `VideoStreamIndex` for any of this to do something. The web client is in the companion PR. The native apps (Android TV, Swiftfin, Roku, ...) each need their own picker and won't get it automatically. I looked at the Android TV one but didn't feel solid enough about threading the selected index through its playback launch path to do it here, so I'm leaving that as a follow-up.

### Testing

- `dotnet build` (net10.0), clean.
- `StreamBuilderTests`, 300/300 passing.
- Ran it against a local server with an MKV that has a couple of video tracks, plus a movie with two versions that have different stream layouts on purpose. Checked that the picked index shows up in the transcode URL for the right source, that a bogus index (one pointing at an audio stream, or out of range) falls back to the default instead of breaking, and that picking a stream in one version doesn't bleed into the other.