### PR TITLE
Split RetrieveItem collection includes to avoid a cartesian explosion

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -463,7 +463,11 @@ public sealed partial class BaseItemRepository
             .Include(e => e.UserData)
             .Include(e => e.Images)
             .Include(e => e.LinkedChildEntities)
-            .AsSingleQuery();
+            // Split into one query per collection. Joining all of these in a single
+            // query multiplies the rows by their cartesian product and repeats the
+            // BaseItem row (including its Data blob) in each, which can exhaust memory
+            // on items with large collections (e.g. many UserData rows across users).
+            .AsSplitQuery();
 
         var item = dbQuery.FirstOrDefault(e => e.Id == id);
         if (item is null)


### PR DESCRIPTION
`RetrieveItem` includes six collections under a forced `AsSingleQuery`, so one item fetch returns the cartesian product of the collection sizes with the `BaseItem.Data` blob repeated in every row. On items with large collections (e.g. many `UserData` rows on a multi-user server) this can exhaust memory during a scan. `AsSplitQuery` is the documented remedy and is safe for a single-item-by-id fetch.

| | rows | `Data` bytes streamed |
|---|---|---|
| Single query (current) | 43,200 | ~160 MB |
| `AsSplitQuery` (this PR) | 65 | 3.9 KB |

`RetrieveItem` only runs on a `GetItemById` cache miss, so the extra round-trips of a split query stay off the steady-state path (they fall on cold cache and scans, which is where the blow-up happens anyway).

<details>
<summary>How this was measured</summary>

Against a Postgres instance with a real Jellyfin schema and a scanned library:

1. Captured the generated SQL for a `RetrieveItem` call and confirmed it `LEFT JOIN`s the six collection tables (`BaseItemTrailerTypes`, `BaseItemProviders`, `BaseItemMetadataFields`, `UserData`, `BaseItemImageInfos`, `LinkedChildren`) in one query.
2. Modelled the resulting cartesian product against the real item with the largest `Data` blob (3.9 KB). A `CROSS JOIN` reproduces what the all-matching `LEFT JOIN`s do, with `generate_series` standing in for the collection sizes of a heavy multi-user item:

```sql
WITH heaviest AS (
  SELECT "Data" FROM "BaseItems" ORDER BY octet_length("Data") DESC LIMIT 1
)
SELECT count(*) AS rows, pg_size_pretty(sum(octet_length("Data"))) AS data_streamed
FROM heaviest
CROSS JOIN generate_series(1,20)  -- images
CROSS JOIN generate_series(1,8)   -- providers
CROSS JOIN generate_series(1,30)  -- UserData (~one row per user)
CROSS JOIN generate_series(1,3)   -- trailer types
CROSS JOIN generate_series(1,3);  -- locked fields
-- result: 43200 rows, 161 MB
```

The split-query equivalent fetches the `Data` blob once plus each collection separately: 1 + 20 + 8 + 30 + 3 + 3 = 65 rows.
</details>

**Issues**
Reported downstream (PostgreSQL plugin) as JPVenson/Jellyfin.Pgsql#36.


Same item persistence/retrieval area as #17119. cc @JPVenson, who maintains the Jellyfin.Pgsql plugin these were reported against.
