### PR TITLE
Fix HLS segment cleanup silently failing for live TV streams

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/TranscodingSegmentCleaner.cs
+++ b/MediaBrowser.Controller/MediaEncoding/TranscodingSegmentCleaner.cs
@@ -102,6 +102,19 @@ public class TranscodingSegmentCleaner : IDisposable
             var downloadPositionTicks = _job.DownloadPositionTicks ?? 0;
             var downloadPositionSeconds = Convert.ToInt64(TimeSpan.FromTicks(downloadPositionTicks).TotalSeconds);
 
+            // For live streams the client never reports a ticks-based position.
+            // Derive the current position from the highest segment index on disk instead.
+            if (downloadPositionSeconds == 0 && _segmentLength > 0)
+            {
+                downloadPositionSeconds = GetLiveSegmentPositionSeconds(_job);
+            }
+
+            _logger.LogDebug(
+                "Segment cleaner tick: downloadPositionSeconds={DownloadPositionSeconds}, segmentKeepSeconds={SegmentKeepSeconds}, segmentLength={SegmentLength}",
+                downloadPositionSeconds,
+                segmentKeepSeconds,
+                _segmentLength);
+
             if (downloadPositionSeconds > 0 && segmentKeepSeconds > 0 && downloadPositionSeconds > segmentKeepSeconds)
             {
                 var idxMaxToDelete = (downloadPositionSeconds - segmentKeepSeconds) / _segmentLength;
@@ -112,6 +125,39 @@ public class TranscodingSegmentCleaner : IDisposable
                 }
             }
         }
+        else
+        {
+            _logger.LogDebug("Segment cleaner tick: EnableSegmentDeletion=false, skipping");
+        }
+    }
+
+    private long GetLiveSegmentPositionSeconds(TranscodingJob job)
+    {
+        var path = job.Path;
+        if (string.IsNullOrEmpty(path))
+        {
+            return 0;
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return 0;
+        }
+
+        var name = Path.GetFileNameWithoutExtension(path);
+        long maxIdx = -1;
+
+        foreach (var file in _fileSystem.GetFilePaths(directory))
+        {
+            var stem = Path.GetFileNameWithoutExtension(file);
+            if (long.TryParse(stem.Replace(name, string.Empty, StringComparison.Ordinal), out var idx) && idx > maxIdx)
+            {
+                maxIdx = idx;
+            }
+        }
+
+        return maxIdx < 0 ? 0 : (maxIdx + 1) * _segmentLength;
     }
 
     private async Task DeleteSegmentFiles(TranscodingJob job, long idxMin, long idxMax, int delayMs)

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -566,7 +566,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         }
     }
 
-    private static bool EnableSegmentCleaning(StreamState state)
+    internal static bool EnableSegmentCleaning(StreamState state)
         => state.IsInputVideo
            && state.TranscodingType == TranscodingJobType.Hls
            && (state.IsSegmentedLiveStream

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -567,11 +567,12 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
     }
 
     private static bool EnableSegmentCleaning(StreamState state)
-        => state.InputProtocol is MediaProtocol.File or MediaProtocol.Http
-           && state.IsInputVideo
+        => state.IsInputVideo
            && state.TranscodingType == TranscodingJobType.Hls
-           && state.RunTimeTicks.HasValue
-           && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks;
+           && (state.IsSegmentedLiveStream
+               || (state.InputProtocol is MediaProtocol.File or MediaProtocol.Http
+                   && state.RunTimeTicks.HasValue
+                   && state.RunTimeTicks.Value >= TimeSpan.FromMinutes(5).Ticks));
 
     private TranscodingJob OnTranscodeBeginning(
         string path,

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -561,8 +561,25 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
     {
         if (EnableSegmentCleaning(state))
         {
+            _logger.LogDebug(
+                "Starting segment cleaner for {Path} (IsInputVideo={IsInputVideo}, TranscodingType={TranscodingType}, IsSegmentedLiveStream={IsSegmentedLiveStream}, RunTimeTicks={RunTimeTicks})",
+                transcodingJob.Path,
+                state.IsInputVideo,
+                state.TranscodingType,
+                state.IsSegmentedLiveStream,
+                state.RunTimeTicks);
             transcodingJob.TranscodingSegmentCleaner = new TranscodingSegmentCleaner(transcodingJob, _loggerFactory.CreateLogger<TranscodingSegmentCleaner>(), _serverConfigurationManager, _fileSystem, _mediaEncoder, state.SegmentLength);
             transcodingJob.TranscodingSegmentCleaner.Start();
+        }
+        else
+        {
+            _logger.LogDebug(
+                "Segment cleaning disabled for {Path} (IsInputVideo={IsInputVideo}, TranscodingType={TranscodingType}, IsSegmentedLiveStream={IsSegmentedLiveStream}, RunTimeTicks={RunTimeTicks})",
+                transcodingJob.Path,
+                state.IsInputVideo,
+                state.TranscodingType,
+                state.IsSegmentedLiveStream,
+                state.RunTimeTicks);
         }
     }
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Jellyfin.MediaEncoding.Tests.csproj
+++ b/tests/Jellyfin.MediaEncoding.Tests/Jellyfin.MediaEncoding.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../MediaBrowser.Controller/MediaBrowser.Controller.csproj" />
     <ProjectReference Include="../../MediaBrowser.MediaEncoding/MediaBrowser.MediaEncoding.csproj" />
   </ItemGroup>
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Transcoding/EnableSegmentCleaningTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Transcoding/EnableSegmentCleaningTests.cs
@@ -1,0 +1,116 @@
+using System;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.MediaEncoding.Transcoding;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.Transcoding;
+
+public class EnableSegmentCleaningTests
+{
+    private static StreamState LiveHlsState() => new StreamState(
+        Mock.Of<IMediaSourceManager>(),
+        TranscodingJobType.Hls,
+        Mock.Of<ITranscodeManager>())
+    {
+        IsInputVideo = true,
+        InputProtocol = MediaProtocol.Http,
+        // RunTimeTicks = null → IsSegmentedLiveStream = true
+    };
+
+    private static StreamState VodFileState(long runTimeTicks) => new StreamState(
+        Mock.Of<IMediaSourceManager>(),
+        TranscodingJobType.Hls,
+        Mock.Of<ITranscodeManager>())
+    {
+        IsInputVideo = true,
+        InputProtocol = MediaProtocol.File,
+        RunTimeTicks = runTimeTicks,
+    };
+
+    [Fact]
+    public void EnableSegmentCleaning_LiveHlsStream_ReturnsTrue()
+    {
+        // IsSegmentedLiveStream = HLS + no RunTimeTicks → segment cleaning must activate.
+        var state = LiveHlsState();
+        Assert.True(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_LiveProgressiveStream_ReturnsFalse()
+    {
+        // Progressive type is not HLS — cleaning has no meaning here.
+        var state = new StreamState(
+            Mock.Of<IMediaSourceManager>(),
+            TranscodingJobType.Progressive,
+            Mock.Of<ITranscodeManager>())
+        {
+            IsInputVideo = true,
+            InputProtocol = MediaProtocol.Http,
+        };
+        Assert.False(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_LiveHlsNonVideo_ReturnsFalse()
+    {
+        // Audio-only live streams don't carry video; cleaning should be skipped.
+        var state = LiveHlsState();
+        state.IsInputVideo = false;
+        Assert.False(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_VodFileWithLongDuration_ReturnsTrue()
+    {
+        // File-protocol VOD with duration >= 5 minutes should trigger cleaning.
+        var fiveMinutes = TimeSpan.FromMinutes(5).Ticks;
+        var state = VodFileState(fiveMinutes);
+        Assert.True(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_VodFileShortDuration_ReturnsFalse()
+    {
+        // Content shorter than 5 minutes is too short to bother cleaning up.
+        var fourMinutes = TimeSpan.FromMinutes(4).Ticks;
+        var state = VodFileState(fourMinutes);
+        Assert.False(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_VodUdpProtocol_ReturnsFalse()
+    {
+        // UDP is neither File nor Http; cleaning has never applied.
+        var state = new StreamState(
+            Mock.Of<IMediaSourceManager>(),
+            TranscodingJobType.Hls,
+            Mock.Of<ITranscodeManager>())
+        {
+            IsInputVideo = true,
+            InputProtocol = MediaProtocol.Udp,
+            RunTimeTicks = TimeSpan.FromHours(1).Ticks,
+        };
+        Assert.False(TranscodeManager.EnableSegmentCleaning(state));
+    }
+
+    [Fact]
+    public void EnableSegmentCleaning_VodHttpWithLongDuration_ReturnsTrue()
+    {
+        // Http-protocol VOD (e.g. remote file) with duration >= 5 minutes should also work.
+        var state = new StreamState(
+            Mock.Of<IMediaSourceManager>(),
+            TranscodingJobType.Hls,
+            Mock.Of<ITranscodeManager>())
+        {
+            IsInputVideo = true,
+            InputProtocol = MediaProtocol.Http,
+            RunTimeTicks = TimeSpan.FromHours(2).Ticks,
+        };
+        Assert.True(TranscodeManager.EnableSegmentCleaning(state));
+    }
+}


### PR DESCRIPTION
Changes

HLS segment cleanup was silently disabled for live TV streams due to two independent bugs. First, the EnableSegmentCleaning predicate in TranscodeManager required RunTimeTicks.HasValue, which is always null for live TV — so the cleaner was never started. Second, even when the cleaner did run, it derived the client's playback position from DownloadPositionTicks, which live TV clients never report (they play at the live edge with no ticks-based position), so the position stayed at zero and no segments were ever deleted. This fix extends EnableSegmentCleaning to include live TV HLS streams via the existing IsSegmentedLiveStream flag, and adds a GetLiveSegmentPositionSeconds fallback that derives the current position from the highest segment index present on disk when the client reports no position.

Code assistance

Claude (claude-sonnet-4-6) was used for: identifying the two-bug root cause, generating the GetLiveSegmentPositionSeconds implementation, writing the unit tests for EnableSegmentCleaning, and debugging guidance during local testing against a live HDHomeRun tuner.

Issues

Fixes #13725
Partially fixes #17120