### PR TITLE
Fix movie recommendations returning alphabetical results instead of similar items

### DIFF
--- a/Jellyfin.Api/Controllers/MoviesController.cs
+++ b/Jellyfin.Api/Controllers/MoviesController.cs
@@ -274,11 +274,15 @@ public class MoviesController : BaseJellyfinApiController
         {
             var similar = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
+                Genres = item.Genres,
+                Tags = item.Tags,
                 Limit = itemLimit,
                 IncludeItemTypes = itemTypes.ToArray(),
                 IsMovie = true,
                 EnableGroupByMetadataKey = true,
-                DtoOptions = dtoOptions
+                DtoOptions = dtoOptions,
+                ExcludeItemIds = [item.Id],
+                OrderBy = [(ItemSortBy.Random, SortOrder.Ascending)]
             });
 
             if (similar.Count > 0)

--- a/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/MoviesControllerTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Jellyfin.Api.Controllers;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class MoviesControllerTests
+{
+    private readonly Mock<IUserManager> _mockUserManager = new();
+    private readonly Mock<ILibraryManager> _mockLibraryManager = new();
+    private readonly Mock<IDtoService> _mockDtoService = new();
+    private readonly Mock<IServerConfigurationManager> _mockServerConfigurationManager = new();
+    private readonly MoviesController _subject;
+
+    public MoviesControllerTests()
+    {
+        _subject = new MoviesController(
+            _mockUserManager.Object,
+            _mockLibraryManager.Object,
+            _mockDtoService.Object,
+            _mockServerConfigurationManager.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) }
+            }
+        };
+    }
+
+    [Fact]
+    public void GetMovieRecommendations_BuildsSimilarQueryFromBaselineGenresAndTags()
+    {
+        _mockUserManager.Setup(x => x.GetUserById(It.IsAny<Guid>()))
+            .Returns(new User("test", "Default", "Default"));
+        _mockServerConfigurationManager.Setup(x => x.Configuration)
+            .Returns(new ServerConfiguration { EnableExternalContentInSuggestions = false });
+        _mockLibraryManager.Setup(x => x.GetPeople(It.IsAny<InternalPeopleQuery>()))
+            .Returns(Array.Empty<PersonInfo>());
+        _mockDtoService.Setup(x => x.GetBaseItemDtos(It.IsAny<IReadOnlyList<BaseItem>>(), It.IsAny<DtoOptions>(), It.IsAny<User>(), It.IsAny<BaseItem>()))
+            .Returns(new List<BaseItemDto> { new() });
+
+        var baseline = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Baseline",
+            Genres = new[] { "Action", "Thriller" },
+            Tags = new[] { "spy" }
+        };
+
+        var capturedQueries = new List<InternalItemsQuery>();
+        _mockLibraryManager.Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns<InternalItemsQuery>(q =>
+            {
+                capturedQueries.Add(q);
+                if (q.IsPlayed == true)
+                {
+                    return new List<BaseItem> { baseline };
+                }
+
+                if (q.IsMovie == true && q.IsFavoriteOrLiked is null && q.IsPlayed is null)
+                {
+                    return new List<BaseItem> { new Movie { Id = Guid.NewGuid(), Name = "SimilarResult" } };
+                }
+
+                return new List<BaseItem>();
+            });
+
+        _subject.GetMovieRecommendations(null, null, Array.Empty<ItemFields>());
+
+        var similarQuery = capturedQueries.Single(q => q.IsMovie == true && q.IsFavoriteOrLiked is null && q.IsPlayed is null);
+
+        Assert.Equal(baseline.Genres, similarQuery.Genres);
+        Assert.Equal(baseline.Tags, similarQuery.Tags);
+        Assert.Contains(baseline.Id, similarQuery.ExcludeItemIds);
+        Assert.Contains(similarQuery.OrderBy, o => o.OrderBy == ItemSortBy.Random);
+    }
+}


### PR DESCRIPTION
## Changes
Fixes the movie **Suggestions** view (`/Movies/Recommendations`) returning items in **alphabetical order** instead of items similar to each baseline.

`MoviesController.GetSimilarTo` built its `InternalItemsQuery` without the baseline item's `Genres`/`Tags` and without an `OrderBy`, so the repository applied no similarity filter and fell back to default (SortName) ordering — every "Because you watched …" category returned the same alphabetical slice of the library.

This mirrors the already-working `LibraryController.GetSimilarItems` (powering "More Like This") by passing `Genres`, `Tags`, `ExcludeItemIds`, and a `Random` `OrderBy`.

## Issues
Fixes #17137

## Notes
Targets `release-10.11.z`: on `master` this subsystem was rewritten into `SimilarItemsManager`, so the bug doesn't exist there — this is a backport-style fix for the maintained 10.11 line.

Verified on a live 10.11.11 server: before, all categories returned `#Alive, (500) Days of Summer, 2 Fast 2 Furious …`; after, each baseline returns themed, distinct results (horror baseline → horror, animated baseline → animated, etc.).
