### PR TITLE
Fix too many SQL variables in DeleteItem for large batch deletes

### DIFF
--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -65,8 +65,13 @@ public class ItemPersistenceService : IItemPersistenceService
             descendantIds.Add(id);
         }
 
+        // Use WhereOneOrMany instead of a raw HashSet.Contains so large id sets are bound as a
+        // single parameter (json_each) rather than one SQL variable per id, which would otherwise
+        // overflow SQLite's variable limit when deleting many items at once (e.g. migrations).
+        var ownerIds = descendantIds.ToArray();
         var extraIds = context.BaseItems
-            .Where(e => e.OwnerId.HasValue && descendantIds.Contains(e.OwnerId.Value))
+            .Where(e => e.OwnerId.HasValue)
+            .WhereOneOrMany(ownerIds, e => e.OwnerId!.Value)
             .Select(e => e.Id)
             .ToArray();
 

--- a/Jellyfin.Server/Migrations/Routines/20260115120000_FixIncorrectOwnerIdRelationships.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260115120000_FixIncorrectOwnerIdRelationships.cs
@@ -136,19 +136,38 @@ public class FixIncorrectOwnerIdRelationships : IAsyncMigrationRoutine
 
         if (allIdsToDelete.Count > 0)
         {
-            // Batch-resolve items for metadata path cleanup, then delete all at once
-            var itemsToDelete = allIdsToDelete
-                .Select(id => _libraryManager.GetItemById(id))
-                .Where(item => item is not null)
-                .ToList();
-            _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+            _logger.LogInformation("Deleting {Count} duplicate database entries...", allIdsToDelete.Count);
 
-            // Fall back to direct DB deletion for any items that couldn't be resolved via LibraryManager
-            var deletedIds = itemsToDelete.Select(i => i!.Id).ToHashSet();
-            var unresolvedIds = allIdsToDelete.Where(id => !deletedIds.Contains(id)).ToList();
-            if (unresolvedIds.Count > 0)
+            // Delete in batches so progress is visible (item resolution and deletion can take a
+            // long time on large libraries) and so we never issue one massive delete transaction.
+            const int deleteBatchSize = 500;
+            var deletedSoFar = 0;
+            for (var offset = 0; offset < allIdsToDelete.Count; offset += deleteBatchSize)
             {
-                _persistenceService.DeleteItem(unresolvedIds);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var batchIds = allIdsToDelete.GetRange(offset, Math.Min(deleteBatchSize, allIdsToDelete.Count - offset));
+
+                // Resolve items for metadata path cleanup, then delete this batch
+                var itemsToDelete = batchIds
+                    .Select(id => _libraryManager.GetItemById(id))
+                    .Where(item => item is not null)
+                    .ToList();
+                if (itemsToDelete.Count > 0)
+                {
+                    _libraryManager.DeleteItemsUnsafeFast(itemsToDelete!);
+                }
+
+                // Fall back to direct DB deletion for any items that couldn't be resolved via LibraryManager
+                var deletedIds = itemsToDelete.Select(i => i!.Id).ToHashSet();
+                var unresolvedIds = batchIds.Where(id => !deletedIds.Contains(id)).ToList();
+                if (unresolvedIds.Count > 0)
+                {
+                    _persistenceService.DeleteItem(unresolvedIds);
+                }
+
+                deletedSoFar += batchIds.Count;
+                _logger.LogInformation("Deleting duplicates: {Deleted}/{Total} items", deletedSoFar, allIdsToDelete.Count);
             }
         }
 


### PR DESCRIPTION
**Changes**

Fix a few bugs in the FixIncorrectOwnerIdRelationships migration.

1. Fix the single DeleteItemsUnsafeFast -> DeleteItem(ids) call to use WhereOneOrMany so the id set is bound as a single
json_each parameter, like the rest of the method, making bulk deletes work for unlimited library sizes - my library was breaking hard on this.
2. Add progress indication in steps of 500 like other migrations, to keep the log reflecting what's actually happening.

**Code assistance**
Claude Opus 4.8 for troubleshooting and generation of patch

**Issues**
N/A
