### PR TITLE
Truncate ISO-639-2 language display names at first delimiter

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -262,6 +262,24 @@ namespace Emby.Server.Implementations.Localization
         }
 
         /// <inheritdoc />
+        public string? GetLanguageDisplayName(string language)
+        {
+            if (string.IsNullOrEmpty(language))
+            {
+                return null;
+            }
+
+            var displayName = FindLanguageInfo(language)?.DisplayName;
+            if (displayName is null)
+            {
+                return null;
+            }
+
+            // Truncate at the first delimiter to avoid cluttered display names
+            return displayName.Split([';', ','], StringSplitOptions.None)[0].Trim();
+        }
+
+        /// <inheritdoc />
         public IReadOnlyList<CountryInfo> GetCountries()
         {
             using var stream = _assembly.GetManifestResourceStream(CountriesPath) ?? throw new InvalidOperationException($"Invalid resource path: '{CountriesPath}'");

--- a/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
@@ -175,7 +175,7 @@ public class MediaStreamRepository : IMediaStreamRepository
                 var culture = _localization.FindLanguageInfo(dto.Language);
                 // Truncate at the first delimiter to avoid cluttered display names
                 dto.LocalizedLanguage = culture?.DisplayName is { } name
-                    ? name.Split(';', ',')[0].Trim()
+                    ? name.Split([';', ','])[0].Trim()
                     : null;
             }
 

--- a/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
@@ -173,7 +173,10 @@ public class MediaStreamRepository : IMediaStreamRepository
             if (!string.IsNullOrEmpty(dto.Language))
             {
                 var culture = _localization.FindLanguageInfo(dto.Language);
-                dto.LocalizedLanguage = culture?.DisplayName;
+                // Truncate at the first delimiter to avoid cluttered display names
+                dto.LocalizedLanguage = culture?.DisplayName is { } name
+                    ? name.Split(';', ',')[0].Trim()
+                    : null;
             }
 
             if (dto.Type is MediaStreamType.Audio)

--- a/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/MediaStreamRepository.cs
@@ -172,11 +172,7 @@ public class MediaStreamRepository : IMediaStreamRepository
 
             if (!string.IsNullOrEmpty(dto.Language))
             {
-                var culture = _localization.FindLanguageInfo(dto.Language);
-                // Truncate at the first delimiter to avoid cluttered display names
-                dto.LocalizedLanguage = culture?.DisplayName is { } name
-                    ? name.Split([';', ','])[0].Trim()
-                    : null;
+                dto.LocalizedLanguage = _localization.GetLanguageDisplayName(dto.Language);
             }
 
             if (dto.Type is MediaStreamType.Audio)

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -732,9 +732,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedOriginal = _localization.GetLocalizedString("Original");
                 if (!string.IsNullOrEmpty(stream.Language))
                 {
-                    stream.LocalizedLanguage = _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
-                        ? name.Split([';', ','])[0].Trim()
-                        : null;
+                    stream.LocalizedLanguage = _localization.GetLanguageDisplayName(stream.Language);
                 }
 
                 stream.Channels = streamInfo.Channels;
@@ -776,9 +774,7 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
                 if (!string.IsNullOrEmpty(stream.Language))
                 {
-                    stream.LocalizedLanguage = _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
-                        ? name.Split([';', ','])[0].Trim()
-                        : null;
+                    stream.LocalizedLanguage = _localization.GetLanguageDisplayName(stream.Language);
                 }
 
                 if (string.IsNullOrEmpty(stream.Title))

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -732,7 +732,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedOriginal = _localization.GetLocalizedString("Original");
                 stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
                     ? null
-                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName;
+                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
+                        ? name.Split(';', ',')[0].Trim()
+                        : null;
 
                 stream.Channels = streamInfo.Channels;
 
@@ -773,7 +775,9 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
                 stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
                     ? null
-                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName;
+                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
+                        ? name.Split(';', ',')[0].Trim()
+                        : null;
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -730,11 +730,12 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedDefault = _localization.GetLocalizedString("Default");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
                 stream.LocalizedOriginal = _localization.GetLocalizedString("Original");
-                stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
-                    ? null
-                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
-                        ? name.Split(';', ',')[0].Trim()
+                if (!string.IsNullOrEmpty(stream.Language))
+                {
+                    stream.LocalizedLanguage = _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
+                        ? name.Split([';', ','])[0].Trim()
                         : null;
+                }
 
                 stream.Channels = streamInfo.Channels;
 
@@ -773,11 +774,12 @@ namespace MediaBrowser.MediaEncoding.Probing
                 stream.LocalizedForced = _localization.GetLocalizedString("Forced");
                 stream.LocalizedExternal = _localization.GetLocalizedString("External");
                 stream.LocalizedHearingImpaired = _localization.GetLocalizedString("HearingImpaired");
-                stream.LocalizedLanguage = string.IsNullOrEmpty(stream.Language)
-                    ? null
-                    : _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
-                        ? name.Split(';', ',')[0].Trim()
+                if (!string.IsNullOrEmpty(stream.Language))
+                {
+                    stream.LocalizedLanguage = _localization.FindLanguageInfo(stream.Language)?.DisplayName is { } name
+                        ? name.Split([';', ','])[0].Trim()
                         : null;
+                }
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {

--- a/MediaBrowser.Model/Globalization/ILocalizationManager.cs
+++ b/MediaBrowser.Model/Globalization/ILocalizationManager.cs
@@ -73,6 +73,14 @@ public interface ILocalizationManager
     CultureDto? FindLanguageInfo(string language);
 
     /// <summary>
+    /// Gets a human-readable display name for the given language code.
+    /// Truncates at the first semicolon or comma to avoid cluttered ISO-639-2 names.
+    /// </summary>
+    /// <param name="language">An ISO language code.</param>
+    /// <returns>The display name, or null if not found.</returns>
+    string? GetLanguageDisplayName(string language);
+
+    /// <summary>
     /// Returns the language in ISO 639-2/T when the input is ISO 639-2/B.
     /// </summary>
     /// <param name="isoB">The language in ISO 639-2/B.</param>

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -119,6 +119,40 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             Assert.Equal(code, culture.ThreeLetterISOLanguageName);
         }
 
+        [Theory]
+        [InlineData("ell", "Greek")] // Comma truncation
+        [InlineData("nld", "Dutch")] // Semicolon truncation
+        [InlineData("ron", "Romanian")] // Semicolon truncation, multiple
+        [InlineData("eng", "English")] // No truncation
+        [InlineData("zh-CN", "Chinese (Simplified)")] // No truncation, with parentheses
+        public async Task GetLanguageDisplayName_DelimitedName_ReturnsTruncatedName(string language, string expected)
+        {
+            var localizationManager = Setup(new ServerConfiguration
+            {
+                UICulture = "en-US"
+            });
+            await localizationManager.LoadAll();
+
+            var result = localizationManager.GetLanguageDisplayName(language);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("xyz")]
+        public async Task GetLanguageDisplayName_InvalidInput_ReturnsNull(string? language)
+        {
+            var localizationManager = Setup(new ServerConfiguration
+            {
+                UICulture = "en-US"
+            });
+            await localizationManager.LoadAll();
+
+            var result = localizationManager.GetLanguageDisplayName(language!);
+            Assert.Null(result);
+        }
+
         [Fact]
         public async Task GetParentalRatings_Default_Success()
         {


### PR DESCRIPTION
**Changes**
Prevents raw ISO-639-2 values (e.g. "Greek, Modern (1453-)") from cluttering the audio and subtitle display names by truncating them at the first comma or semicolon ("Greek").

This behaviour was a (probably unintended) side effect of #15947 and was introduced in ProbeResultNormalizer in #16567 . Explanation and examples of why this is undesirable in #16859 .

Some examples:
| Before| After |
|--------|--------|
| Romanian; Moldavian; Moldovan | Romanian |
| Greek, Modern (1453-) | Greek |
| Spanish; Castilian | Spanish |
| Asturian; Bable; Leonese; Asturleonese | Asturian |
| Dutch; Flemish | Dutch |

Built locally and verified working.

**Code assistance**
Gemini for double checking

**Issues**
Fixes #16859 
