### PR TITLE
fix(playlists): prevent IndexOutOfRangeException in MoveItemAsync

### DIFF
--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -335,6 +335,11 @@ namespace Emby.Server.Implementations.Playlists
             var children = playlist.GetManageableItems().ToList();
             var accessibleChildren = children.Where(c => c.Item2.IsVisible(user)).ToArray();
 
+            if (accessibleChildren.Length == 0)
+            {
+                return;
+            }
+
             var oldIndexAll = children.FindIndex(i => string.Equals(entryId, i.Item1.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
             var oldIndexAccessible = accessibleChildren.FindIndex(i => string.Equals(entryId, i.Item1.ItemId?.ToString("N", CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
 
@@ -343,7 +348,7 @@ namespace Emby.Server.Implementations.Playlists
                 return;
             }
 
-            var newPriorItemIndex = Math.Max(newIndex - 1, 0);
+            var newPriorItemIndex = Math.Clamp(newIndex - 1, 0, accessibleChildren.Length - 1);
             var newPriorItemId = accessibleChildren[newPriorItemIndex].Item1.ItemId;
             var newPriorItemIndexOnAllChildren = children.FindIndex(c => c.Item1.ItemId.Equals(newPriorItemId));
             var adjustedNewIndex = DetermineAdjustedIndex(newPriorItemIndexOnAllChildren, newIndex);


### PR DESCRIPTION
## Summary

Fixes #17066. When moving a playlist item to an out-of-range index, `MoveItemAsync` threw an unhandled `IndexOutOfRangeException` causing HTTP 500.

## Root Cause

`newPriorItemIndex` was calculated with `Math.Max(newIndex - 1, 0)` which only clamped the lower bound. When `newIndex` exceeded the playlist's item count, `accessibleChildren[newPriorItemIndex]` threw.

## Fix

- Use `Math.Clamp(newIndex - 1, 0, accessibleChildren.Length - 1)` to bound both sides
- Add early return when `accessibleChildren` is empty (prevents edge case with empty playlist)

## Testing

```bash
dotnet test --filter "MoveItemAsync"
```

## Checklist

- [x] Code follows project style
- [x] No new warnings introduced