### PR TITLE
Use Convert.ToHexStringLower for Schedules Direct password hash

### DIFF
--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -1002,9 +1002,7 @@ public class LiveTvController : BaseJellyfinApiController
     {
         if (!string.IsNullOrEmpty(pw))
         {
-            // TODO: remove ToLower when Convert.ToHexString supports lowercase
-            // Schedules Direct requires the hex to be lowercase
-            listingsProviderInfo.Password = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(pw))).ToLowerInvariant();
+            listingsProviderInfo.Password = Convert.ToHexStringLower(SHA1.HashData(Encoding.UTF8.GetBytes(pw)));
         }
 
         return await _listingsManager.SaveListingProvider(listingsProviderInfo, validateLogin, validateListings).ConfigureAwait(false);

--- a/src/Jellyfin.LiveTv/Listings/SchedulesDirect.cs
+++ b/src/Jellyfin.LiveTv/Listings/SchedulesDirect.cs
@@ -748,9 +748,7 @@ namespace Jellyfin.LiveTv.Listings
 #pragma warning disable CA5350 // SchedulesDirect is always SHA1.
             var hashedPasswordBytes = SHA1.HashData(Encoding.ASCII.GetBytes(password));
 #pragma warning restore CA5350
-            // TODO: remove ToLower when Convert.ToHexString supports lowercase
-            // Schedules Direct requires the hex to be lowercase
-            string hashedPassword = Convert.ToHexString(hashedPasswordBytes).ToLowerInvariant();
+            string hashedPassword = Convert.ToHexStringLower(hashedPasswordBytes);
             options.Content = new StringContent("{\"username\":\"" + username + "\",\"password\":\"" + hashedPassword + "\"}", Encoding.UTF8, MediaTypeNames.Application.Json);
 
             var root = await Request<TokenDto>(options, false, null, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Changes**

Replace `Convert.ToHexString(...).ToLowerInvariant()` with `Convert.ToHexStringLower(...)` in two Schedules Direct password hashing sites. `Convert.ToHexStringLower` was added in .NET 9 and resolves the TODO comments left at both call sites.

**Issues**

N/A