### PR TITLE
Use Enumerable.LeftJoin for activity log user query

### DIFF
--- a/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
+++ b/Jellyfin.Server.Implementations/Activity/ActivityManager.cs
@@ -56,11 +56,11 @@ public class ActivityManager : IActivityManager
         var dbContext = await _provider.CreateDbContextAsync().ConfigureAwait(false);
         await using (dbContext.ConfigureAwait(false))
         {
-            // TODO switch to LeftJoin in .NET 10.
-            var entries = from a in dbContext.ActivityLogs
-                          join u in dbContext.Users on a.UserId equals u.Id into ugj
-                          from u in ugj.DefaultIfEmpty()
-                          select new ExpandedActivityLog { ActivityLog = a, Username = u.Username };
+            var entries = dbContext.ActivityLogs.LeftJoin(
+                dbContext.Users,
+                a => a.UserId,
+                u => u.Id,
+                (a, u) => new ExpandedActivityLog { ActivityLog = a, Username = u == null ? null : u.Username });
 
             if (query.HasUserId is not null)
             {


### PR DESCRIPTION
**Changes**

Replace the manual group join pattern with `Enumerable.LeftJoin`, which was added in .NET 10 and is supported by EF Core 10. The previous approach used `into ugj` with `DefaultIfEmpty()` to emulate a left join. The TODO comment at this site specifically requested this change once .NET 10 was available.

**Issues**

N/A