### PR TITLE
Close live TV stream on session stop when client omits LiveStreamId

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -317,6 +317,10 @@ namespace Emby.Server.Implementations.Session
                     await CloseLiveStreamIfNeededAsync(session.PlayState.LiveStreamId, session.Id).ConfigureAwait(false);
                 }
 
+                // Close any live streams that are still mapped to this session but were
+                // not reported via PlayState (e.g. the client never sent a clean stop).
+                await CloseLiveStreamsForSessionAsync(session.Id).ConfigureAwait(false);
+
                 await OnSessionEnded(session).ConfigureAwait(false);
             }
         }
@@ -354,6 +358,37 @@ namespace Emby.Server.Implementations.Session
                 {
                     _logger.LogError(ex, "Error closing live stream");
                 }
+            }
+        }
+
+        /// <summary>
+        /// Closes any live streams still associated with the given session.
+        /// </summary>
+        /// <remarks>
+        /// Some clients report playback stopped without a LiveStreamId, and the transcode
+        /// kill path does not close the live stream on its own. Without this fallback the
+        /// underlying shared live stream is never closed, its consumer count never reaches
+        /// zero, and the tuner keeps copying to disk until the server is restarted.
+        /// </remarks>
+        /// <param name="sessionId">The session id.</param>
+        /// <returns>A task.</returns>
+        private async Task CloseLiveStreamsForSessionAsync(string sessionId)
+        {
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                return;
+            }
+
+            // Snapshot the matching live stream ids first to avoid mutating the
+            // dictionary while enumerating it.
+            var liveStreamIds = _activeLiveStreamSessions
+                .Where(kvp => kvp.Value.ContainsKey(sessionId))
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var liveStreamId in liveStreamIds)
+            {
+                await CloseLiveStreamIfNeededAsync(liveStreamId, sessionId).ConfigureAwait(false);
             }
         }
 
@@ -1022,6 +1057,8 @@ namespace Emby.Server.Implementations.Session
                     await CloseLiveStreamIfNeededAsync(info.LiveStreamId, session.Id).ConfigureAwait(false);
                 }
 
+                await CloseLiveStreamsForSessionAsync(session.Id).ConfigureAwait(false);
+
                 throw new ArgumentOutOfRangeException(nameof(info), "The PlaybackStopInfo's PositionTicks was negative.");
             }
 
@@ -1093,6 +1130,10 @@ namespace Emby.Server.Implementations.Session
             {
                 await CloseLiveStreamIfNeededAsync(info.LiveStreamId, session.Id).ConfigureAwait(false);
             }
+
+            // Fallback: some clients (e.g. Swiftfin) report playback stopped without a
+            // LiveStreamId, which would otherwise leak the underlying shared live stream.
+            await CloseLiveStreamsForSessionAsync(session.Id).ConfigureAwait(false);
 
             var eventArgs = new PlaybackStopEventArgs
             {

--- a/tests/Jellyfin.Server.Implementations.Tests/SessionManager/SessionManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SessionManager/SessionManagerTests.cs
@@ -9,6 +9,8 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -107,5 +109,69 @@ public class SessionManagerTests
         };
 
         return data;
+    }
+
+    [Fact]
+    public async Task OnPlaybackStopped_WithoutLiveStreamId_ClosesMappedLiveStream()
+    {
+        const string LiveStreamId = "live-stream-1";
+
+        var user = new User("test", "default", "default");
+
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager
+            .Setup(x => x.CloseLiveStream(It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var userManager = new Mock<IUserManager>();
+        userManager.Setup(x => x.GetUserById(user.Id)).Returns(user);
+
+        var configManager = new Mock<IServerConfigurationManager>();
+        configManager.Setup(x => x.Configuration).Returns(new ServerConfiguration());
+
+        await using var sessionManager = new Emby.Server.Implementations.Session.SessionManager(
+            NullLogger<Emby.Server.Implementations.Session.SessionManager>.Instance,
+            Mock.Of<IEventManager>(),
+            Mock.Of<IUserDataManager>(),
+            configManager.Object,
+            Mock.Of<ILibraryManager>(),
+            userManager.Object,
+            Mock.Of<IMusicManager>(),
+            Mock.Of<IDtoService>(),
+            Mock.Of<IImageProcessor>(),
+            Mock.Of<IServerApplicationHost>(),
+            Mock.Of<IDeviceManager>(),
+            mediaSourceManager.Object,
+            Mock.Of<IHostApplicationLifetime>());
+
+        var session = await sessionManager.LogSessionActivity(
+            "TestApp",
+            "1.0.0",
+            "device-1",
+            "Test Device",
+            "127.0.0.1",
+            user);
+
+        // Client reports the live stream id on playback start, populating the
+        // session -> live stream mapping.
+        await sessionManager.OnPlaybackStart(new PlaybackStartInfo
+        {
+            SessionId = session.Id,
+            ItemId = Guid.Empty,
+            LiveStreamId = LiveStreamId,
+            PlaySessionId = "play-session-1"
+        });
+
+        // Client stops playback WITHOUT echoing the live stream id (e.g. Roku,
+        // Android, Swiftfin). The live stream must still be released.
+        await sessionManager.OnPlaybackStopped(new PlaybackStopInfo
+        {
+            SessionId = session.Id,
+            ItemId = Guid.Empty,
+            PositionTicks = 0,
+            LiveStreamId = null
+        });
+
+        mediaSourceManager.Verify(x => x.CloseLiveStream(LiveStreamId), Times.Once);
     }
 }


### PR DESCRIPTION
This is the server side of the live TV / HDHomeRun tuner leak I described in https://github.com/jellyfin/jellyfin/issues/16880\#issuecomment-4792467368.

Short version: when a transcoded live TV session stops, the consumer ffmpeg gets killed but the underlying SharedHttpStream is never closed if the client's stop report doesn't include a LiveStreamId. The consumer count stays at 1, so the tuner keeps copying to disk until the server is restarted.

Since #13220 the only thing that closes a live stream on stop is `CloseLiveStreamIfNeededAsync`, and `OnPlaybackStopped` only calls it when `info.LiveStreamId` is set. The `_activeLiveStreamSessions` dictionary already knows which live stream a session is mapped to (it gets populated from playback start and progress), but nothing uses it in reverse when the stop report has no LiveStreamId. Clients that don't echo it back (Swiftfin in my case, and this lines up with the Roku and Android reports in #15769) never trigger the close.

What this does:

- Adds `CloseLiveStreamsForSessionAsync(sessionId)`, which looks up any live stream still mapped to the session in `_activeLiveStreamSessions` and closes it.
- Calls it from `OnPlaybackStopped` (both the normal stop and the negative-PositionTicks guard) and from `CloseIfNeededAsync` when a session ends.
- Does not change the ConsumerCount model or the #13220 dedup behavior. Closing is idempotent because `CloseLiveStreamIfNeededAsync` only acts if the id is still in the map.

What this does not cover:

This handles the stop and disconnect paths. It does not cover the pure pause case in #16880 where the app stays alive and paused (that's the inactive-session sweeper, which only reaps sessions with NowPlayingItem set), and it doesn't touch the `KillTranscodingJobs(closeLiveStream: false)` path. Those are separate follow-ups if that direction sounds reasonable.

Testing:

- Added a unit test in `SessionManagerTests` that starts playback with a LiveStreamId, reports stop without one, and asserts the live stream gets closed.
- Full solution builds, and the unit test project passes (549 passed, 5 skipped).

Related: #16880, #15769, #16728


Relationship to other open live TV PRs:

This is orthogonal to #17128 and #17127 and stacks cleanly with both.

- #17128 (live tv stream buffer unbounded growth) caps how big the buffered/on-disk data gets while a stream is open. It doesn't change the close path, so the tuner still stays open until something actually closes the live stream. This PR is the part that closes it.
- #17127 (HLS segment cleanup) handles leftover transcode segments on the TranscodeManager side. Different layer, no overlap with the session stop path.

None of them touch SessionManager or the live stream close decision, so there's no conflict regardless of merge order.
