### PR TITLE
Fix Live TV tuner not releasing

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -343,6 +343,10 @@ namespace Emby.Server.Implementations.Session
                     _activeLiveStreamSessions.TryRemove(liveStreamId, out _);
                 }
             }
+            else
+            {
+                liveStreamNeedsToBeClosed = true;
+            }
 
             if (liveStreamNeedsToBeClosed)
             {


### PR DESCRIPTION
In #13220 we changed `CloseLiveStream` to only trigger if the live stream was registered in a tracking map. This fixed a double closure bug for browsers but broke clients that never report `LiveStreamId`, since the map never gets populated, `CloseLiveStream` is never called and the tuner was never released. 

**Fix**
If the `liveStreamId` isn't in the map at all, skip the map check and just close it. 

**Code assistance**
N/A

**Issues**
Fixes: #15769
Fiexs: #16880

Closes: #17177