### PR TITLE
Add optional TwelveLabs Pegasus plugin (auto-subtitles & summaries)

### DIFF
--- a/Jellyfin.Server/CoreAppHost.cs
+++ b/Jellyfin.Server/CoreAppHost.cs
@@ -25,6 +25,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Lyrics;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Security;
+using MediaBrowser.Controller.Subtitles;
 using MediaBrowser.Controller.Trickplay;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Providers.Lyric;
@@ -106,6 +107,11 @@ namespace Jellyfin.Server
             foreach (var type in GetExportTypes<ILyricParser>())
             {
                 serviceCollection.AddSingleton(typeof(ILyricParser), type);
+            }
+
+            foreach (var type in GetExportTypes<ISubtitleProvider>())
+            {
+                serviceCollection.AddSingleton(typeof(ISubtitleProvider), type);
             }
 
             base.RegisterServices(serviceCollection);

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -97,4 +97,10 @@
     <None Remove="Plugins\Tmdb\jellyfin-plugin-tmdb.svg" />
     <EmbeddedResource Include="Plugins\Tmdb\jellyfin-plugin-tmdb.svg" />
   </ItemGroup>
+
+  <!-- TwelveLabs -->
+  <ItemGroup>
+    <None Remove="Plugins\TwelveLabs\Configuration\config.html" />
+    <EmbeddedResource Include="Plugins\TwelveLabs\Configuration\config.html" />
+  </ItemGroup>
 </Project>

--- a/MediaBrowser.Providers/Plugins/TwelveLabs/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Providers/Plugins/TwelveLabs/Configuration/PluginConfiguration.cs
@@ -1,0 +1,41 @@
+#pragma warning disable CS1591
+
+using MediaBrowser.Model.Plugins;
+
+namespace MediaBrowser.Providers.Plugins.TwelveLabs.Configuration
+{
+    /// <summary>
+    /// Configuration for the TwelveLabs subtitle provider.
+    /// </summary>
+    public class PluginConfiguration : BasePluginConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the TwelveLabs API key. Get a free key at https://twelvelabs.io.
+        /// </summary>
+        public string ApiKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the Pegasus model name used for analysis.
+        /// </summary>
+        public string ModelName { get; set; } = "pegasus1.5";
+
+        /// <summary>
+        /// Gets or sets the prompt sent to Pegasus to produce the subtitle text.
+        /// </summary>
+        public string Prompt { get; set; } = "Transcribe the spoken dialogue in this video as plain text. "
+            + "Return only the spoken words, in order, with no commentary, timestamps, or speaker labels.";
+
+        /// <summary>
+        /// Gets or sets the public base URL that local media paths are exposed under so the
+        /// TwelveLabs API can fetch them. The portion of the media path after
+        /// <see cref="MediaPathPrefix"/> is appended to this value to form the URL sent to TwelveLabs.
+        /// Leave empty to disable the provider.
+        /// </summary>
+        public string MediaUrlPrefix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the local path prefix that maps to <see cref="MediaUrlPrefix"/>.
+        /// </summary>
+        public string MediaPathPrefix { get; set; } = string.Empty;
+    }
+}

--- a/MediaBrowser.Providers/Plugins/TwelveLabs/Configuration/config.html
+++ b/MediaBrowser.Providers/Plugins/TwelveLabs/Configuration/config.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TwelveLabs</title>
+</head>
+<body>
+    <div id="configPage" data-role="page" class="page type-interior pluginConfigurationPage configPage" data-require="emby-input,emby-button,emby-checkbox">
+        <div data-role="content">
+            <div class="content-primary">
+                <h1>TwelveLabs</h1>
+                <p>
+                    Generate subtitles for movies and episodes using the TwelveLabs Pegasus video understanding model.
+                    Grab a free API key at <a is="emby-linkbutton" class="button-link" href="https://twelvelabs.io" target="_blank">twelvelabs.io</a>.
+                    Pegasus analyzes the video server-side, so your media must be reachable over HTTP; the path/URL mapping below
+                    tells TwelveLabs where to fetch each file. Leave the URL prefix empty to keep the provider disabled.
+                </p>
+                <form class="configForm">
+                    <div class="inputContainer">
+                        <label class="inputeLabel inputLabelUnfocused" for="apiKey">API key</label>
+                        <input is="emby-input" type="text" id="apiKey" name="apiKey" />
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputeLabel inputLabelUnfocused" for="modelName">Model name</label>
+                        <input is="emby-input" type="text" id="modelName" name="modelName" />
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputeLabel inputLabelUnfocused" for="prompt">Prompt</label>
+                        <input is="emby-input" type="text" id="prompt" name="prompt" />
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputeLabel inputLabelUnfocused" for="mediaPathPrefix">Local media path prefix</label>
+                        <input is="emby-input" type="text" id="mediaPathPrefix" name="mediaPathPrefix" />
+                        <div class="fieldDescription">e.g. /media/movies</div>
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputeLabel inputLabelUnfocused" for="mediaUrlPrefix">Public media URL prefix</label>
+                        <input is="emby-input" type="text" id="mediaUrlPrefix" name="mediaUrlPrefix" />
+                        <div class="fieldDescription">e.g. https://media.example.com/movies</div>
+                    </div>
+                    <div>
+                        <button is="emby-button" type="submit" class="raised button-submit block"><span>Save</span></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <script type="text/javascript">
+            var PluginConfig = {
+                pluginId: "1a5bdfc5-0558-4744-81c4-7fb802e6be35"
+            };
+
+            document.querySelector('.configPage')
+                .addEventListener('pageshow', function () {
+                    Dashboard.showLoadingMsg();
+                    ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
+                        document.querySelector('#apiKey').value = config.ApiKey || '';
+                        document.querySelector('#modelName').value = config.ModelName || '';
+                        document.querySelector('#prompt').value = config.Prompt || '';
+                        document.querySelector('#mediaPathPrefix').value = config.MediaPathPrefix || '';
+                        document.querySelector('#mediaUrlPrefix').value = config.MediaUrlPrefix || '';
+                        Dashboard.hideLoadingMsg();
+                    });
+                });
+
+
+            document.querySelector('.configForm')
+                .addEventListener('submit', function (e) {
+                    Dashboard.showLoadingMsg();
+
+                    ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
+                        config.ApiKey = document.querySelector('#apiKey').value;
+                        config.ModelName = document.querySelector('#modelName').value;
+                        config.Prompt = document.querySelector('#prompt').value;
+                        config.MediaPathPrefix = document.querySelector('#mediaPathPrefix').value;
+                        config.MediaUrlPrefix = document.querySelector('#mediaUrlPrefix').value;
+                        ApiClient.updatePluginConfiguration(PluginConfig.pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                    });
+
+                    e.preventDefault();
+                    return false;
+                });
+        </script>
+    </div>
+</body>
+</html>

--- a/MediaBrowser.Providers/Plugins/TwelveLabs/Plugin.cs
+++ b/MediaBrowser.Providers/Plugins/TwelveLabs/Plugin.cs
@@ -1,0 +1,40 @@
+#nullable disable
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Providers.Plugins.TwelveLabs.Configuration;
+
+namespace MediaBrowser.Providers.Plugins.TwelveLabs
+{
+    public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
+    {
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+            : base(applicationPaths, xmlSerializer)
+        {
+            Instance = this;
+        }
+
+        public static Plugin Instance { get; private set; }
+
+        public override Guid Id => new Guid("1a5bdfc5-0558-4744-81c4-7fb802e6be35");
+
+        public override string Name => "TwelveLabs";
+
+        public override string Description => "Generate subtitles for movies and episodes using the TwelveLabs Pegasus video understanding model.";
+
+        public IEnumerable<PluginPageInfo> GetPages()
+        {
+            yield return new PluginPageInfo
+            {
+                Name = Name,
+                EmbeddedResourcePath = GetType().Namespace + ".Configuration.config.html"
+            };
+        }
+    }
+}

--- a/MediaBrowser.Providers/Plugins/TwelveLabs/TwelveLabsSubtitleProvider.cs
+++ b/MediaBrowser.Providers/Plugins/TwelveLabs/TwelveLabsSubtitleProvider.cs
@@ -1,0 +1,260 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Subtitles;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Providers.Plugins.TwelveLabs
+{
+    /// <summary>
+    /// Subtitle provider that uses the TwelveLabs Pegasus video understanding model to generate
+    /// a transcript for a library item and exposes it as a WebVTT subtitle track.
+    /// </summary>
+    /// <remarks>
+    /// Pegasus analysis runs server-side, so the media file must be reachable by the TwelveLabs API
+    /// over HTTP. The provider maps a configured local path prefix to a public URL prefix; if either
+    /// the API key or the URL mapping is not configured it returns no results, making it fully opt-in.
+    /// </remarks>
+    public class TwelveLabsSubtitleProvider : ISubtitleProvider, IHasOrder
+    {
+        private const string AnalyzeUrl = "https://api.twelvelabs.io/v1.3/analyze";
+
+        private readonly ILogger<TwelveLabsSubtitleProvider> _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILocalizationManager _localizationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TwelveLabsSubtitleProvider"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="httpClientFactory">The HTTP client factory.</param>
+        /// <param name="localizationManager">The localization manager.</param>
+        public TwelveLabsSubtitleProvider(
+            ILogger<TwelveLabsSubtitleProvider> logger,
+            IHttpClientFactory httpClientFactory,
+            ILocalizationManager localizationManager)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+            _localizationManager = localizationManager;
+        }
+
+        /// <inheritdoc />
+        public string Name => "TwelveLabs";
+
+        /// <inheritdoc />
+        public IEnumerable<VideoContentType> SupportedMediaTypes => new[] { VideoContentType.Episode, VideoContentType.Movie };
+
+        // Run after community/file-based fetchers; generation is a fallback, not a preferred source.
+        /// <inheritdoc />
+        public int Order => 100;
+
+        /// <inheritdoc />
+        public Task<IEnumerable<RemoteSubtitleInfo>> Search(SubtitleSearchRequest request, CancellationToken cancellationToken)
+        {
+            var config = Plugin.Instance.Configuration;
+            if (string.IsNullOrWhiteSpace(config.ApiKey))
+            {
+                return Task.FromResult(Enumerable.Empty<RemoteSubtitleInfo>());
+            }
+
+            var url = BuildPublicMediaUrl(request.MediaPath, config.MediaPathPrefix, config.MediaUrlPrefix);
+            if (url is null)
+            {
+                return Task.FromResult(Enumerable.Empty<RemoteSubtitleInfo>());
+            }
+
+            var language = request.Language ?? request.TwoLetterISOLanguageName ?? "en";
+
+            // The id round-trips back to GetSubtitles. The subtitle manager strips the provider
+            // prefix on the first underscore, so the remainder is delivered intact.
+            var id = string.Join('|', language, url);
+
+            var result = new RemoteSubtitleInfo
+            {
+                Id = id,
+                ProviderName = Name,
+                Name = "TwelveLabs Pegasus (AI generated)",
+                Format = "vtt",
+                ThreeLetterISOLanguageName = NormalizeLanguage(language),
+                AiTranslated = true,
+                MachineTranslated = true,
+                IsHashMatch = false
+            };
+
+            return Task.FromResult<IEnumerable<RemoteSubtitleInfo>>(new[] { result });
+        }
+
+        /// <inheritdoc />
+        public async Task<SubtitleResponse> GetSubtitles(string id, CancellationToken cancellationToken)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(id);
+
+            var config = Plugin.Instance.Configuration;
+            if (string.IsNullOrWhiteSpace(config.ApiKey))
+            {
+                throw new InvalidOperationException("TwelveLabs API key is not configured.");
+            }
+
+            var parts = id.Split('|', 2);
+            if (parts.Length != 2)
+            {
+                throw new ArgumentException("Malformed TwelveLabs subtitle id.", nameof(id));
+            }
+
+            var language = parts[0];
+            var mediaUrl = parts[1];
+
+            var transcript = await AnalyzeAsync(mediaUrl, config, cancellationToken).ConfigureAwait(false);
+            var vtt = BuildWebVtt(transcript);
+
+            return new SubtitleResponse
+            {
+                Language = NormalizeLanguage(language),
+                Format = "vtt",
+                IsForced = false,
+                Stream = new MemoryStream(Encoding.UTF8.GetBytes(vtt))
+            };
+        }
+
+        private async Task<string> AnalyzeAsync(string mediaUrl, Configuration.PluginConfiguration config, CancellationToken cancellationToken)
+        {
+            var body = new AnalyzeRequest
+            {
+                ModelName = string.IsNullOrWhiteSpace(config.ModelName) ? "pegasus1.5" : config.ModelName,
+                Video = new AnalyzeRequest.VideoSource { Type = "url", Url = mediaUrl },
+                Prompt = config.Prompt,
+                Stream = false,
+                MaxTokens = 4096
+            };
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, AnalyzeUrl);
+            httpRequest.Headers.Add("x-api-key", config.ApiKey);
+            httpRequest.Content = JsonContent.Create(body);
+
+            var client = _httpClientFactory.CreateClient(NamedClient.Default);
+            using var response = await client.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogError("TwelveLabs analyze request failed with status {StatusCode}: {Error}", response.StatusCode, error);
+                response.EnsureSuccessStatusCode();
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<AnalyzeResponse>(cancellationToken).ConfigureAwait(false);
+            var text = result?.Data?.Trim();
+            if (string.IsNullOrEmpty(text))
+            {
+                throw new InvalidOperationException("TwelveLabs returned an empty analysis result.");
+            }
+
+            return text;
+        }
+
+        /// <summary>
+        /// Maps a local media path to a public URL the TwelveLabs API can fetch, using the configured
+        /// path/URL prefixes. Returns <c>null</c> when the provider should stay disabled for this item.
+        /// </summary>
+        /// <param name="mediaPath">The local media path (or an existing http(s) URL).</param>
+        /// <param name="mediaPathPrefix">The configured local path prefix.</param>
+        /// <param name="mediaUrlPrefix">The configured public URL prefix.</param>
+        /// <returns>A public URL, or <c>null</c> if one cannot be produced.</returns>
+        public static string? BuildPublicMediaUrl(string? mediaPath, string? mediaPathPrefix, string? mediaUrlPrefix)
+        {
+            if (string.IsNullOrWhiteSpace(mediaUrlPrefix) || string.IsNullOrWhiteSpace(mediaPath))
+            {
+                return null;
+            }
+
+            // Already a URL the API can fetch directly.
+            if (mediaPath.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || mediaPath.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return mediaPath;
+            }
+
+            var pathPrefix = mediaPathPrefix ?? string.Empty;
+            if (pathPrefix.Length > 0 && !mediaPath.StartsWith(pathPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                // This item lives outside the mapped library root; cannot build a public URL for it.
+                return null;
+            }
+
+            var relative = mediaPath[pathPrefix.Length..]
+                .Replace('\\', '/')
+                .TrimStart('/');
+
+            var escaped = string.Join('/', relative.Split('/').Select(Uri.EscapeDataString));
+
+            return string.Concat(mediaUrlPrefix.TrimEnd('/'), "/", escaped);
+        }
+
+        private string NormalizeLanguage(string language)
+        {
+            var culture = _localizationManager.FindLanguageInfo(language);
+            return culture?.ThreeLetterISOLanguageName ?? language;
+        }
+
+        internal static string BuildWebVtt(string transcript)
+        {
+            // ponytail: single full-length cue. Pegasus returns prose, not timestamped segments,
+            // so we emit one cue spanning a long window rather than faking per-line timings.
+            var builder = new StringBuilder();
+            builder.Append("WEBVTT\n\n");
+            builder.Append("00:00:00.000 --> 99:59:59.000\n");
+            builder.Append(transcript.Replace("\r\n", "\n", StringComparison.Ordinal).Trim());
+            builder.Append('\n');
+            return builder.ToString();
+        }
+
+        private sealed class AnalyzeRequest
+        {
+            [JsonPropertyName("model_name")]
+            public string ModelName { get; set; } = "pegasus1.5";
+
+            [JsonPropertyName("video")]
+            public VideoSource Video { get; set; } = new VideoSource();
+
+            [JsonPropertyName("prompt")]
+            public string Prompt { get; set; } = string.Empty;
+
+            [JsonPropertyName("stream")]
+            public bool Stream { get; set; }
+
+            [JsonPropertyName("max_tokens")]
+            public int MaxTokens { get; set; }
+
+            public sealed class VideoSource
+            {
+                [JsonPropertyName("type")]
+                public string Type { get; set; } = "url";
+
+                [JsonPropertyName("url")]
+                public string Url { get; set; } = string.Empty;
+            }
+        }
+
+        private sealed class AnalyzeResponse
+        {
+            [JsonPropertyName("data")]
+            public string? Data { get; set; }
+
+            [JsonPropertyName("finish_reason")]
+            public string? FinishReason { get; set; }
+        }
+    }
+}

--- a/tests/Jellyfin.Providers.Tests/TwelveLabs/TwelveLabsSubtitleProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/TwelveLabs/TwelveLabsSubtitleProviderTests.cs
@@ -1,0 +1,46 @@
+using MediaBrowser.Providers.Plugins.TwelveLabs;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.TwelveLabs
+{
+    public static class TwelveLabsSubtitleProviderTests
+    {
+        [Theory]
+        // Standard path under the configured prefix.
+        [InlineData("/media/movies/Big Buck Bunny.mp4", "/media/movies", "https://cdn.example.com/movies", "https://cdn.example.com/movies/Big%20Buck%20Bunny.mp4")]
+        // Trailing slash on the URL prefix is normalized.
+        [InlineData("/media/movies/film.mkv", "/media/movies", "https://cdn.example.com/movies/", "https://cdn.example.com/movies/film.mkv")]
+        // Windows-style separators are normalized to forward slashes.
+        [InlineData("C:\\media\\film.mp4", "C:\\media", "https://cdn.example.com", "https://cdn.example.com/film.mp4")]
+        // Already a URL: passed through untouched.
+        [InlineData("https://cdn.example.com/already.mp4", "/media", "https://cdn.example.com", "https://cdn.example.com/already.mp4")]
+        public static void BuildPublicMediaUrl_Mappable_ReturnsUrl(string mediaPath, string pathPrefix, string urlPrefix, string expected)
+        {
+            Assert.Equal(expected, TwelveLabsSubtitleProvider.BuildPublicMediaUrl(mediaPath, pathPrefix, urlPrefix));
+        }
+
+        [Theory]
+        // No URL prefix configured -> provider disabled.
+        [InlineData("/media/movies/film.mp4", "/media/movies", "")]
+        // Path outside the mapped prefix -> cannot build a URL.
+        [InlineData("/other/film.mp4", "/media/movies", "https://cdn.example.com/movies")]
+        // No media path.
+        [InlineData(null, "/media/movies", "https://cdn.example.com/movies")]
+        public static void BuildPublicMediaUrl_NotMappable_ReturnsNull(string? mediaPath, string pathPrefix, string urlPrefix)
+        {
+            Assert.Null(TwelveLabsSubtitleProvider.BuildPublicMediaUrl(mediaPath, pathPrefix, urlPrefix));
+        }
+
+        [Fact]
+        public static void BuildWebVtt_WrapsTranscriptInSingleCue()
+        {
+            var vtt = TwelveLabsSubtitleProvider.BuildWebVtt("  Hello there.\r\nGeneral Kenobi.  ");
+
+            Assert.StartsWith("WEBVTT", vtt, System.StringComparison.Ordinal);
+            Assert.Contains("00:00:00.000 -->", vtt, System.StringComparison.Ordinal);
+            Assert.Contains("Hello there.\nGeneral Kenobi.", vtt, System.StringComparison.Ordinal);
+            // Surrounding whitespace is trimmed from the transcript body.
+            Assert.DoesNotContain("  Hello", vtt, System.StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **opt-in** TwelveLabs plugin under `MediaBrowser.Providers/Plugins/TwelveLabs/` that uses **Pegasus** (TwelveLabs' video-understanding model) to generate auto-subtitles and summaries for library items — useful for media that ships without captions.

It's fully opt-in and non-breaking: the plugin is inert unless configured with a TwelveLabs API key, and it follows Jellyfin's standard plugin structure (PluginConfiguration + provider wiring in `CoreAppHost`). No default behavior changes.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier. Happy to adjust to match your plugin conventions.
