### PR TITLE
Added tabs to the experimental UI branch to include options to view actors or crew pulled from all of the media in the library.  Clicking on an actor shows you the media in which that actor appears.  For crew, you can have multiple entries for the same person depending on their role - director, producer, etc.  The videos shown when you click on the crew person is the list of vidoes that corresponds to that person and their position.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
+- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4516,11 +4516,34 @@ where AncestorIdText not null and ItemValues.Value not null and ItemValues.Type 
                 commandText.Append(" where ").AppendJoin(" AND ", whereClauses);
             }
 
-            commandText.Append(" order by ListOrder");
+            if (string.Equals(query.SortBy, "SortName", StringComparison.OrdinalIgnoreCase))
+            {
+                commandText.Append(string.Equals(query.SortOrder, "Descending", StringComparison.OrdinalIgnoreCase)
+                    ? " order by p.Name DESC"
+                    : " order by p.Name ASC");
+            }
+            else if (string.Equals(query.SortBy, "Random", StringComparison.OrdinalIgnoreCase))
+            {
+                commandText.Append(" order by RANDOM()");
+            }
+            else if (query.ItemId.IsEmpty())
+            {
+                // Default alphabetical order when querying across the library (not within a specific item)
+                commandText.Append(" order by p.Name ASC");
+            }
+            else
+            {
+                commandText.Append(" order by ListOrder");
+            }
 
             if (query.Limit > 0)
             {
                 commandText.Append(" LIMIT ").Append(query.Limit);
+            }
+
+            if (query.StartIndex > 0)
+            {
+                commandText.Append(" OFFSET ").Append(query.StartIndex);
             }
 
             var list = new List<string>();
@@ -4537,6 +4560,28 @@ where AncestorIdText not null and ItemValues.Value not null and ItemValues.Type 
             }
 
             return list;
+        }
+
+        /// <inheritdoc />
+        public int GetPeopleNamesCount(InternalPeopleQuery query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            CheckDisposed();
+
+            var commandText = new StringBuilder("select COUNT(DISTINCT p.Name) from People p");
+
+            var whereClauses = GetPeopleWhereClauses(query, null);
+
+            if (whereClauses.Count != 0)
+            {
+                commandText.Append(" where ").AppendJoin(" AND ", whereClauses);
+            }
+
+            using var connection = GetConnection(true);
+            using var statement = PrepareStatement(connection, commandText.ToString());
+            GetPeopleWhereClauses(query, statement);
+            return statement.ExecuteQuery().Select(row => row.GetInt32(0)).FirstOrDefault();
         }
 
         /// <inheritdoc />
@@ -4605,6 +4650,12 @@ AND Type = @InternalPersonType)");
                 statement?.TryBind("@AppearsInItemId", query.AppearsInItemId);
             }
 
+            if (!query.AncestorId.IsEmpty())
+            {
+                whereClauses.Add("p.Name in (Select Name from People where ItemId in (Select ItemId from AncestorIds where AncestorIdText=@AncestorId))");
+                statement?.TryBind("@AncestorId", query.AncestorId.ToString("N", System.Globalization.CultureInfo.InvariantCulture));
+            }
+
             var queryPersonTypes = query.PersonTypes.Where(IsValidPersonType).ToList();
 
             if (queryPersonTypes.Count == 1)
@@ -4645,7 +4696,89 @@ AND Type = @InternalPersonType)");
                 statement?.TryBind("@NameContains", "%" + query.NameContains + "%");
             }
 
+            if (!string.IsNullOrWhiteSpace(query.NameStartsWith))
+            {
+                whereClauses.Add("p.Name like @NameStartsWith");
+                statement?.TryBind("@NameStartsWith", query.NameStartsWith + "%");
+            }
+
+            if (!string.IsNullOrWhiteSpace(query.NameLessThan))
+            {
+                whereClauses.Add("p.Name < @NameLessThan");
+                statement?.TryBind("@NameLessThan", query.NameLessThan);
+            }
+
             return whereClauses;
+        }
+
+        /// <inheritdoc />
+        public (List<CrewMemberDto> Items, int TotalCount) GetCrewMembers(InternalPeopleQuery query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            CheckDisposed();
+
+            // Reuse existing where clauses but exclude actor-only types
+            var baseWhere = GetPeopleWhereClauses(query, null);
+            baseWhere.Add("p.PersonType NOT IN ('Actor', 'GuestStar')");
+            baseWhere.Add("p.PersonType IS NOT NULL");
+            baseWhere.Add("p.PersonType != ''");
+
+            var whereText = baseWhere.Count > 0
+                ? " where " + string.Join(" AND ", baseWhere)
+                : string.Empty;
+
+            var countSql = $"select COUNT(*) from (select DISTINCT p.Name, p.PersonType from People p{whereText})";
+
+            var orderBy = string.Equals(query.SortBy, "Random", StringComparison.OrdinalIgnoreCase)
+                ? " order by RANDOM()"
+                : string.Equals(query.SortBy, "SortName", StringComparison.OrdinalIgnoreCase) && string.Equals(query.SortOrder, "Descending", StringComparison.OrdinalIgnoreCase)
+                    ? " order by p.Name DESC, p.PersonType ASC"
+                    : " order by p.Name ASC, p.PersonType ASC";
+
+            var itemsSql = new StringBuilder(
+                "select DISTINCT p.Name, p.PersonType, " +
+                "(select guid from TypedBaseItems where Name = p.Name and Type = 'MediaBrowser.Controller.Entities.Person' LIMIT 1) as PersonId " +
+                "from People p");
+            itemsSql.Append(whereText);
+            itemsSql.Append(orderBy);
+
+            if (query.Limit > 0)
+            {
+                itemsSql.Append(" LIMIT ").Append(query.Limit);
+            }
+
+            if (query.StartIndex > 0)
+            {
+                itemsSql.Append(" OFFSET ").Append(query.StartIndex);
+            }
+
+            using var connection = GetConnection(true);
+
+            int totalCount;
+            using (var countStatement = PrepareStatement(connection, countSql))
+            {
+                GetPeopleWhereClauses(query, countStatement);
+                totalCount = countStatement.ExecuteQuery().Select(row => row.GetInt32(0)).FirstOrDefault();
+            }
+
+            var items = new List<CrewMemberDto>();
+            using (var itemsStatement = PrepareStatement(connection, itemsSql.ToString()))
+            {
+                GetPeopleWhereClauses(query, itemsStatement);
+                foreach (var row in itemsStatement.ExecuteQuery())
+                {
+                    var personIdText = row.IsDBNull(2) ? null : row.GetString(2);
+                    items.Add(new CrewMemberDto
+                    {
+                        Name = row.GetString(0),
+                        PersonType = row.GetString(1),
+                        PersonId = personIdText is not null && Guid.TryParse(personIdText, out var pid) ? pid : Guid.Empty
+                    });
+                }
+            }
+
+            return (items, totalCount);
         }
 
         private void UpdateAncestors(Guid itemId, List<Guid> ancestorIds, ManagedConnection db, SqliteCommand deleteAncestorsStatement)

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2784,6 +2784,16 @@ namespace Emby.Server.Implementations.Library
             return _itemRepository.GetPeopleNames(query);
         }
 
+        public int GetPeopleCount(InternalPeopleQuery query)
+        {
+            return _itemRepository.GetPeopleNamesCount(query);
+        }
+
+        public (List<MediaBrowser.Model.Dto.CrewMemberDto> Items, int TotalCount) GetCrewMembers(InternalPeopleQuery query)
+        {
+            return _itemRepository.GetCrewMembers(query);
+        }
+
         public void UpdatePeople(BaseItem item, List<PersonInfo> people)
         {
             UpdatePeopleAsync(item, people, CancellationToken.None).GetAwaiter().GetResult();

--- a/Jellyfin.Api/Controllers/PersonsController.cs
+++ b/Jellyfin.Api/Controllers/PersonsController.cs
@@ -60,6 +60,12 @@ public class PersonsController : BaseJellyfinApiController
     /// <param name="appearsInItemId">Optional. If specified, person results will be filtered on items related to said persons.</param>
     /// <param name="userId">User id.</param>
     /// <param name="enableImages">Optional, include image information in output.</param>
+    /// <param name="parentId">Optional. Specify an item Id to search within a specific library (folder/collection).</param>
+    /// <param name="nameStartsWith">Optional. Filter persons whose name starts with this string.</param>
+    /// <param name="nameLessThan">Optional. Filter persons whose name is alphabetically less than this string.</param>
+    /// <param name="sortBy">Optional. Sort persons by this field (SortName, Random).</param>
+    /// <param name="sortOrder">Optional. Sort order (Ascending, Descending).</param>
+    /// <param name="startIndex">Optional. The record index to start at.</param>
     /// <response code="200">Persons returned.</response>
     /// <returns>An <see cref="OkResult"/> containing the queryresult of persons.</returns>
     [HttpGet]
@@ -77,7 +83,13 @@ public class PersonsController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedArrayModelBinder))] string[] personTypes,
         [FromQuery] Guid? appearsInItemId,
         [FromQuery] Guid? userId,
-        [FromQuery] bool? enableImages = true)
+        [FromQuery] bool? enableImages = true,
+        [FromQuery] Guid? parentId = null,
+        [FromQuery] string? nameStartsWith = null,
+        [FromQuery] string? nameLessThan = null,
+        [FromQuery] string? sortBy = null,
+        [FromQuery] string? sortOrder = null,
+        [FromQuery] int? startIndex = null)
     {
         userId = RequestHelpers.GetUserId(User, userId);
         var dtoOptions = new DtoOptions { Fields = fields }
@@ -89,21 +101,66 @@ public class PersonsController : BaseJellyfinApiController
             : _userManager.GetUserById(userId.Value);
 
         var isFavoriteInFilters = filters.Any(f => f == ItemFilter.IsFavorite);
-        var peopleItems = _libraryManager.GetPeopleItems(new InternalPeopleQuery(
-            personTypes,
-            excludePersonTypes)
+        var query = new InternalPeopleQuery(personTypes, excludePersonTypes)
         {
             NameContains = searchTerm,
             User = user,
             IsFavorite = !isFavorite.HasValue && isFavoriteInFilters ? true : isFavorite,
             AppearsInItemId = appearsInItemId ?? Guid.Empty,
-            Limit = limit ?? 0
-        });
+            AncestorId = parentId ?? Guid.Empty,
+            Limit = limit ?? 0,
+            NameStartsWith = nameStartsWith,
+            NameLessThan = nameLessThan,
+            SortBy = sortBy,
+            SortOrder = sortOrder,
+            StartIndex = startIndex ?? 0
+        };
 
-        return new QueryResult<BaseItemDto>(
-            peopleItems
+        var totalCount = _libraryManager.GetPeopleCount(query);
+        var peopleItems = _libraryManager.GetPeopleItems(query);
+        var dtos = peopleItems
             .Select(person => _dtoService.GetItemByNameDto(person, dtoOptions, null, user))
-            .ToArray());
+            .ToArray();
+
+        return new QueryResult<BaseItemDto>(startIndex, totalCount, dtos);
+    }
+
+    /// <summary>
+    /// Gets crew members (non-actors), one entry per person+role combination.
+    /// </summary>
+    /// <param name="limit">Optional. The maximum number of records to return.</param>
+    /// <param name="parentId">Optional. Specify a library Id to scope results to that library.</param>
+    /// <param name="nameStartsWith">Optional. Filter crew whose name starts with this string.</param>
+    /// <param name="nameLessThan">Optional. Filter crew whose name is alphabetically less than this string.</param>
+    /// <param name="sortBy">Optional. Sort by field (SortName, Random).</param>
+    /// <param name="sortOrder">Optional. Sort order (Ascending, Descending).</param>
+    /// <param name="startIndex">Optional. The record index to start at.</param>
+    /// <response code="200">Crew returned.</response>
+    /// <returns>An <see cref="OkResult"/> containing the queryresult of crew members.</returns>
+    [HttpGet("Crew")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<QueryResult<CrewMemberDto>> GetCrew(
+        [FromQuery] int? limit,
+        [FromQuery] Guid? parentId = null,
+        [FromQuery] string? nameStartsWith = null,
+        [FromQuery] string? nameLessThan = null,
+        [FromQuery] string? sortBy = null,
+        [FromQuery] string? sortOrder = null,
+        [FromQuery] int? startIndex = null)
+    {
+        var query = new InternalPeopleQuery([], [])
+        {
+            AncestorId = parentId ?? Guid.Empty,
+            Limit = limit ?? 0,
+            NameStartsWith = nameStartsWith,
+            NameLessThan = nameLessThan,
+            SortBy = sortBy,
+            SortOrder = sortOrder,
+            StartIndex = startIndex ?? 0
+        };
+
+        var (items, totalCount) = _libraryManager.GetCrewMembers(query);
+        return new QueryResult<CrewMemberDto>(startIndex, totalCount, items);
     }
 
     /// <summary>

--- a/Jellyfin.Api/Middleware/ServerStartupMessageMiddleware.cs
+++ b/Jellyfin.Api/Middleware/ServerStartupMessageMiddleware.cs
@@ -45,6 +45,13 @@ public class ServerStartupMessageMiddleware
         var message = localizationManager.GetLocalizedString("StartupEmbyServerIsLoading");
         httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
         httpContext.Response.ContentType = MediaTypeNames.Text.Html;
-        await httpContext.Response.WriteAsync(message, httpContext.RequestAborted).ConfigureAwait(false);
+        try
+        {
+            await httpContext.Response.WriteAsync(message, httpContext.RequestAborted).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected before the response could be written — normal during startup.
+        }
     }
 }

--- a/Jellyfin.Server/Properties/launchSettings.json
+++ b/Jellyfin.Server/Properties/launchSettings.json
@@ -6,7 +6,8 @@
       "applicationUrl": "http://localhost:8096",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "commandLineArgs": "--webdir D:\\GitHub\\jellyfin-web\\dist"
     },
     "Jellyfin.Server (nowebclient)": {
       "commandName": "Project",

--- a/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalPeopleQuery.cs
@@ -36,7 +36,19 @@ namespace MediaBrowser.Controller.Entities
 
         public Guid AppearsInItemId { get; set; }
 
+        public Guid AncestorId { get; set; }
+
         public string NameContains { get; set; }
+
+        public string NameStartsWith { get; set; }
+
+        public string NameLessThan { get; set; }
+
+        public string SortBy { get; set; }
+
+        public string SortOrder { get; set; }
+
+        public int StartIndex { get; set; }
 
         public User User { get; set; }
 

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -500,6 +500,20 @@ namespace MediaBrowser.Controller.Library
         List<Person> GetPeopleItems(InternalPeopleQuery query);
 
         /// <summary>
+        /// Gets the total count of people matching the query, ignoring Limit and StartIndex.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>Total count of matching people.</returns>
+        int GetPeopleCount(InternalPeopleQuery query);
+
+        /// <summary>
+        /// Gets distinct crew member (Name, PersonType) pairs, excluding Actors.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>Crew members and total count.</returns>
+        (List<MediaBrowser.Model.Dto.CrewMemberDto> Items, int TotalCount) GetCrewMembers(InternalPeopleQuery query);
+
+        /// <summary>
         /// Updates the people.
         /// </summary>
         /// <param name="item">The item.</param>

--- a/MediaBrowser.Controller/Persistence/IItemRepository.cs
+++ b/MediaBrowser.Controller/Persistence/IItemRepository.cs
@@ -127,6 +127,20 @@ namespace MediaBrowser.Controller.Persistence
         List<string> GetPeopleNames(InternalPeopleQuery query);
 
         /// <summary>
+        /// Gets the total count of distinct people names matching the query (ignoring Limit and StartIndex).
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>Total count of matching people.</returns>
+        int GetPeopleNamesCount(InternalPeopleQuery query);
+
+        /// <summary>
+        /// Gets distinct (Name, PersonType) crew member pairs, excluding Actors.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>Crew members and total count.</returns>
+        (List<MediaBrowser.Model.Dto.CrewMemberDto> Items, int TotalCount) GetCrewMembers(InternalPeopleQuery query);
+
+        /// <summary>
         /// Gets the item list.
         /// </summary>
         /// <param name="query">The query.</param>

--- a/MediaBrowser.Model/Dto/CrewMemberDto.cs
+++ b/MediaBrowser.Model/Dto/CrewMemberDto.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace MediaBrowser.Model.Dto;
+
+/// <summary>
+/// Represents a crew member entry — one per person+role combination.
+/// </summary>
+public class CrewMemberDto
+{
+    /// <summary>
+    /// Gets or sets the Id of the Person item, used to construct image URLs.
+    /// </summary>
+    public Guid PersonId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the person's display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the role type (Director, Producer, Writer, Composer, etc.).
+    /// </summary>
+    public string PersonType { get; set; } = string.Empty;
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/PersonsControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/PersonsControllerTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class PersonsControllerTests
+{
+    private readonly Mock<ILibraryManager> _mockLibraryManager;
+    private readonly Mock<IDtoService> _mockDtoService;
+    private readonly Mock<IUserManager> _mockUserManager;
+    private readonly PersonsController _subject;
+
+    public PersonsControllerTests()
+    {
+        _mockLibraryManager = new Mock<ILibraryManager>();
+        _mockDtoService = new Mock<IDtoService>();
+        _mockUserManager = new Mock<IUserManager>();
+
+        _mockLibraryManager
+            .Setup(m => m.GetPeopleItems(It.IsAny<InternalPeopleQuery>()))
+            .Returns(new List<Person>());
+
+        _subject = new PersonsController(
+            _mockLibraryManager.Object,
+            _mockDtoService.Object,
+            _mockUserManager.Object);
+
+        // Wire up a ClaimsPrincipal so RequestHelpers.GetUserId doesn't throw.
+        var userId = Guid.NewGuid();
+        var claims = new[] { new Claim(InternalClaimTypes.UserId, userId.ToString("N")) };
+        var identity = new ClaimsIdentity(claims);
+        var claimsPrincipal = new ClaimsPrincipal(identity);
+
+        _subject.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = claimsPrincipal }
+        };
+    }
+
+    [Fact]
+    public void GetPersons_WithoutParentId_QueryHasEmptyAncestorId()
+    {
+        _subject.GetPersons(
+            limit: null,
+            searchTerm: null,
+            fields: Array.Empty<ItemFields>(),
+            filters: Array.Empty<ItemFilter>(),
+            isFavorite: null,
+            enableUserData: null,
+            imageTypeLimit: null,
+            enableImageTypes: Array.Empty<ImageType>(),
+            excludePersonTypes: Array.Empty<string>(),
+            personTypes: Array.Empty<string>(),
+            appearsInItemId: null,
+            userId: null,
+            enableImages: null,
+            parentId: null);
+
+        _mockLibraryManager.Verify(
+            m => m.GetPeopleItems(It.Is<InternalPeopleQuery>(q => q.AncestorId.Equals(Guid.Empty))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetPersons_WithParentId_QueryHasMatchingAncestorId()
+    {
+        var parentId = Guid.NewGuid();
+
+        _subject.GetPersons(
+            limit: null,
+            searchTerm: null,
+            fields: Array.Empty<ItemFields>(),
+            filters: Array.Empty<ItemFilter>(),
+            isFavorite: null,
+            enableUserData: null,
+            imageTypeLimit: null,
+            enableImageTypes: Array.Empty<ImageType>(),
+            excludePersonTypes: Array.Empty<string>(),
+            personTypes: Array.Empty<string>(),
+            appearsInItemId: null,
+            userId: null,
+            enableImages: null,
+            parentId: parentId);
+
+        _mockLibraryManager.Verify(
+            m => m.GetPeopleItems(It.Is<InternalPeopleQuery>(q => q.AncestorId.Equals(parentId))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetPersons_WithActorPersonType_QueryHasMatchingPersonTypes()
+    {
+        var personTypes = new[] { "Actor" };
+
+        _subject.GetPersons(
+            limit: null,
+            searchTerm: null,
+            fields: Array.Empty<ItemFields>(),
+            filters: Array.Empty<ItemFilter>(),
+            isFavorite: null,
+            enableUserData: null,
+            imageTypeLimit: null,
+            enableImageTypes: Array.Empty<ImageType>(),
+            excludePersonTypes: Array.Empty<string>(),
+            personTypes: personTypes,
+            appearsInItemId: null,
+            userId: null,
+            enableImages: null,
+            parentId: null);
+
+        _mockLibraryManager.Verify(
+            m => m.GetPeopleItems(It.Is<InternalPeopleQuery>(q =>
+                q.PersonTypes.Count.Equals(1) && q.PersonTypes[0].Equals("Actor", StringComparison.Ordinal))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetPersons_WithParentIdAndPersonType_BothSetOnQuery()
+    {
+        var parentId = Guid.NewGuid();
+        var personTypes = new[] { "Actor" };
+
+        _subject.GetPersons(
+            limit: null,
+            searchTerm: null,
+            fields: Array.Empty<ItemFields>(),
+            filters: Array.Empty<ItemFilter>(),
+            isFavorite: null,
+            enableUserData: null,
+            imageTypeLimit: null,
+            enableImageTypes: Array.Empty<ImageType>(),
+            excludePersonTypes: Array.Empty<string>(),
+            personTypes: personTypes,
+            appearsInItemId: null,
+            userId: null,
+            enableImages: null,
+            parentId: parentId);
+
+        _mockLibraryManager.Verify(
+            m => m.GetPeopleItems(It.Is<InternalPeopleQuery>(q =>
+                q.AncestorId.Equals(parentId) &&
+                q.PersonTypes.Count.Equals(1) &&
+                q.PersonTypes[0].Equals("Actor", StringComparison.Ordinal))),
+            Times.Once);
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/PersonsControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/PersonsControllerTests.cs
@@ -1,5 +1,11 @@
+using System;
 using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Jellyfin.Extensions.Json;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
 using Xunit;
 
 namespace Jellyfin.Server.Integration.Tests.Controllers;
@@ -7,6 +13,7 @@ namespace Jellyfin.Server.Integration.Tests.Controllers;
 public class PersonsControllerTests : IClassFixture<JellyfinApplicationFactory>
 {
     private readonly JellyfinApplicationFactory _factory;
+    private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
     private static string? _accessToken;
 
     public PersonsControllerTests(JellyfinApplicationFactory factory)
@@ -20,7 +27,63 @@ public class PersonsControllerTests : IClassFixture<JellyfinApplicationFactory>
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
 
-        using var response = await client.GetAsync($"Persons/DoesntExist");
+        using var response = await client.GetAsync("Persons/DoesntExist");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPersons_NoParams_ReturnsOk()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync("Persons");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<QueryResult<BaseItemDto>>(_jsonOptions);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetPersons_WithUnknownParentId_ReturnsEmptyResult()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var nonExistentParentId = Guid.NewGuid();
+        using var response = await client.GetAsync($"Persons?parentId={nonExistentParentId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<QueryResult<BaseItemDto>>(_jsonOptions);
+        Assert.NotNull(result);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetPersons_WithActorPersonType_ReturnsOk()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync("Persons?personTypes=Actor");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<QueryResult<BaseItemDto>>(_jsonOptions);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetPersons_WithParentIdAndPersonType_ReturnsOk()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var nonExistentParentId = Guid.NewGuid();
+        using var response = await client.GetAsync($"Persons?parentId={nonExistentParentId}&personTypes=Actor");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<QueryResult<BaseItemDto>>(_jsonOptions);
+        Assert.NotNull(result);
+        Assert.Empty(result.Items);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Added support for showing videos by actor and other crew members.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
- Claude Code for most of the implementation.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->


Added tabs to the experimental UI branch to include options to view actors or crew pulled from all of the media in the library.  Clicking on an actor shows you the media in which that actor appears.  For crew, you can have multiple entries for the same person depending on their role - director, producer, etc.  The videos shown when you click on the crew person is the list of vidoes that corresponds to that person and their position.