### PR TITLE
Don't gate -readrate on EnableSegmentDeletion for HLS stream-copy

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7349,14 +7349,13 @@ namespace MediaBrowser.Controller.MediaEncoding
                 readrate = 1;
                 inputModifier += " -re";
             }
-            else if (encodingOptions.EnableSegmentDeletion
-                && state.VideoStream is not null
+            else if (state.VideoStream is not null
                 && state.TranscodingType == TranscodingJobType.Hls
                 && IsCopyCodec(state.OutputVideoCodec)
                 && _mediaEncoder.EncoderVersion >= _minFFmpegReadrateOption)
             {
-                // Set an input read rate limit 10x for using SegmentDeletion with stream-copy
-                // to prevent ffmpeg from exiting prematurely (due to fast drive)
+                // Limit read rate for all HLS stream-copy jobs to prevent premature exit
+                // on fast drives, not just when segment deletion is enabled.
                 readrate = 10;
                 inputModifier += $" -readrate {readrate}";
             }


### PR DESCRIPTION
\`-readrate 10\` is applied for HLS stream-copy jobs to prevent premature ffmpeg exit on fast drives — the existing comment says exactly this.

Currently gated on \`EnableSegmentDeletion\`, which is off by default. No comment or doc explains why the protection should only apply when segment deletion is on; looks like an oversight.

Removing the gate so the limit applies to all HLS stream-copy jobs. The existing \`-readrate_catchup\` handles recovery from momentary slowdowns, so this doesn't regress seeking.