### PR TITLE
Sort trailers for TV Shows

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -320,13 +320,26 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             if (seriesResult.Videos?.Results is not null)
             {
-                foreach (var video in seriesResult.Videos.Results)
+                var trailers = new List<MediaUrl>();
+
+                var sortedVideos = seriesResult.Videos.Results
+                    .OrderByDescending(video => string.Equals(video.Type, "trailer", StringComparison.OrdinalIgnoreCase));
+
+                foreach (var video in sortedVideos)
                 {
-                    if (TmdbUtils.IsTrailerType(video))
+                    if (!TmdbUtils.IsTrailerType(video))
                     {
-                        series.AddTrailerUrl("https://www.youtube.com/watch?v=" + video.Key);
+                        continue;
                     }
+
+                    trailers.Add(new MediaUrl
+                    {
+                        Url = string.Format(CultureInfo.InvariantCulture, "https://www.youtube.com/watch?v={0}", video.Key),
+                        Name = video.Name
+                    });
                 }
+
+                series.RemoteTrailers = trailers;
             }
 
             if (!string.IsNullOrEmpty(seriesResult.OriginalLanguage))


### PR DESCRIPTION
**Changes**
Apply the same logic we use for movie trailers, so teaser trailers appear after the regular trailer.  

**Code assistance**
N/A

**Issues**
Fixes: #17202
