### PR TITLE
Fix CA1819 warnings in LibraryUpdateInfo and QueryFiltersLegacy

### DIFF
--- a/MediaBrowser.Model/Entities/LibraryUpdateInfo.cs
+++ b/MediaBrowser.Model/Entities/LibraryUpdateInfo.cs
@@ -1,6 +1,6 @@
 #pragma warning disable CS1591
 
-using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Entities
 {
@@ -14,46 +14,46 @@ namespace MediaBrowser.Model.Entities
         /// </summary>
         public LibraryUpdateInfo()
         {
-            FoldersAddedTo = Array.Empty<string>();
-            FoldersRemovedFrom = Array.Empty<string>();
-            ItemsAdded = Array.Empty<string>();
-            ItemsRemoved = Array.Empty<string>();
-            ItemsUpdated = Array.Empty<string>();
-            CollectionFolders = Array.Empty<string>();
+            FoldersAddedTo = [];
+            FoldersRemovedFrom = [];
+            ItemsAdded = [];
+            ItemsRemoved = [];
+            ItemsUpdated = [];
+            CollectionFolders = [];
         }
 
         /// <summary>
         /// Gets or sets the folders added to.
         /// </summary>
         /// <value>The folders added to.</value>
-        public string[] FoldersAddedTo { get; set; }
+        public IReadOnlyList<string> FoldersAddedTo { get; set; }
 
         /// <summary>
         /// Gets or sets the folders removed from.
         /// </summary>
         /// <value>The folders removed from.</value>
-        public string[] FoldersRemovedFrom { get; set; }
+        public IReadOnlyList<string> FoldersRemovedFrom { get; set; }
 
         /// <summary>
         /// Gets or sets the items added.
         /// </summary>
         /// <value>The items added.</value>
-        public string[] ItemsAdded { get; set; }
+        public IReadOnlyList<string> ItemsAdded { get; set; }
 
         /// <summary>
         /// Gets or sets the items removed.
         /// </summary>
         /// <value>The items removed.</value>
-        public string[] ItemsRemoved { get; set; }
+        public IReadOnlyList<string> ItemsRemoved { get; set; }
 
         /// <summary>
         /// Gets or sets the items updated.
         /// </summary>
         /// <value>The items updated.</value>
-        public string[] ItemsUpdated { get; set; }
+        public IReadOnlyList<string> ItemsUpdated { get; set; }
 
-        public string[] CollectionFolders { get; set; }
+        public IReadOnlyList<string> CollectionFolders { get; set; }
 
-        public bool IsEmpty => FoldersAddedTo.Length == 0 && FoldersRemovedFrom.Length == 0 && ItemsAdded.Length == 0 && ItemsRemoved.Length == 0 && ItemsUpdated.Length == 0 && CollectionFolders.Length == 0;
+        public bool IsEmpty => FoldersAddedTo.Count == 0 && FoldersRemovedFrom.Count == 0 && ItemsAdded.Count == 0 && ItemsRemoved.Count == 0 && ItemsUpdated.Count == 0 && CollectionFolders.Count == 0;
     }
 }

--- a/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
+++ b/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
@@ -1,7 +1,7 @@
 #nullable disable
 #pragma warning disable CS1591
 
-using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Querying
 {
@@ -9,18 +9,18 @@ namespace MediaBrowser.Model.Querying
     {
         public QueryFiltersLegacy()
         {
-            Genres = Array.Empty<string>();
-            Tags = Array.Empty<string>();
-            OfficialRatings = Array.Empty<string>();
-            Years = Array.Empty<int>();
+            Genres = [];
+            Tags = [];
+            OfficialRatings = [];
+            Years = [];
         }
 
-        public string[] Genres { get; set; }
+        public IReadOnlyList<string> Genres { get; set; }
 
-        public string[] Tags { get; set; }
+        public IReadOnlyList<string> Tags { get; set; }
 
-        public string[] OfficialRatings { get; set; }
+        public IReadOnlyList<string> OfficialRatings { get; set; }
 
-        public int[] Years { get; set; }
+        public IReadOnlyList<int> Years { get; set; }
     }
 }


### PR DESCRIPTION
Replaces the array-typed properties on two `MediaBrowser.Model` response DTOs with `IReadOnlyList<T>`, clearing six CA1819 warnings in `LibraryUpdateInfo` and four in `QueryFiltersLegacy`. This follows the pattern already used for the same warning elsewhere (e.g. #16853 for `ChannelFeatures`).

Changes:
- `LibraryUpdateInfo`: `FoldersAddedTo`, `FoldersRemovedFrom`, `ItemsAdded`, `ItemsRemoved`, `ItemsUpdated`, `CollectionFolders` → `IReadOnlyList<string>`; `IsEmpty` uses `.Count` instead of `.Length`.
- `QueryFiltersLegacy`: `Genres`, `Tags`, `OfficialRatings` → `IReadOnlyList<string>`, `Years` → `IReadOnlyList<int>`.
- `Array.Empty<T>()` initializers replaced with collection expressions (`[]`).

No behavioural or wire-format change. Both classes are only ever serialized to JSON — `QueryFiltersLegacy` is the `/Items/Filters` response and `LibraryUpdateInfo` is the `LibraryChanged` websocket message — and each has a single construction site that assigns the result of `.ToArray()` (an array still satisfies `IReadOnlyList<T>`), so no callers required changes. `IReadOnlyList<T>` serializes identically to a JSON array, leaving the OpenAPI schema unchanged.

Verified locally: the targeted warning count drops from 10 to 0, the full solution builds clean in both Debug and Release (`TreatWarningsAsErrors`), `dotnet format --verify-no-changes` is clean, and `Jellyfin.Server.Implementations.Tests` (561) and `Jellyfin.Model.Tests` (658) all pass.

Part of #2149