### PR TITLE
Fix NullReferenceException in GetStreamingState for closed live streams

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -144,6 +144,15 @@ public static class StreamingHelpers
             mediaSource = liveStreamInfo.Item1;
             state.DirectStreamProvider = liveStreamInfo.Item2;
 
+            // The requested live stream is no longer open. This commonly happens when a client keeps
+            // polling the HLS playlist (e.g. live.m3u8) after the stream was disposed because its
+            // consumer count dropped to zero. GetLiveStreamWithDirectStreamProvider returns a null
+            // MediaSource in that case, so return 404 instead of dereferencing it below.
+            if (mediaSource is null)
+            {
+                throw new ResourceNotFoundException($"The live stream with id {streamingRequest.LiveStreamId} could not be found or is no longer available.");
+            }
+
             // Cap the max bitrate when it is too high. This is usually due to ffmpeg is unable to probe the source liveTV streams' bitrate.
             if (mediaSource.FallbackMaxStreamingBitrate is not null && streamingRequest.VideoBitRate is not null)
             {


### PR DESCRIPTION
**Changes**

The live-stream branch of `StreamingHelpers.GetStreamingState` dereferenced the `MediaSource` returned by `GetLiveStreamWithDirectStreamProvider` without a null check. That method returns null when the `liveStreamId` is no longer open, so an HLS client polling `live.m3u8` after the stream was disposed (its consumer count dropped to zero) hit a `NullReferenceException` → HTTP 500 on every poll until it re-opened. This adds a null guard that throws `ResourceNotFoundException` (→ 404), matching the non-live branch directly above.

**Code assistance**

Developed with LLM assistance (Claude): root-caused from production logs, with the fix written and reviewed with that assistance.

**Issues**

Fixes #17009