### PR TITLE
Don't crash the server when a keepalive target socket is disposed

### DIFF
--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -171,7 +171,7 @@ namespace Emby.Server.Implementations.Session
             {
                 await SendForceKeepAlive(webSocket).ConfigureAwait(false);
             }
-            catch (WebSocketException exception)
+            catch (Exception exception) when (exception is WebSocketException or ObjectDisposedException or OperationCanceledException)
             {
                 _logger.LogWarning(exception, "Cannot send ForceKeepAlive message to WebSocket {0}.", webSocket);
             }
@@ -232,7 +232,8 @@ namespace Emby.Server.Implementations.Session
                 {
                     await SendForceKeepAlive(webSocket).ConfigureAwait(false);
                 }
-                catch (WebSocketException exception)
+                // Socket may be disposed/canceled between selection and send; treat as lost, don't crash the process.
+                catch (Exception exception) when (exception is WebSocketException or ObjectDisposedException or OperationCanceledException)
                 {
                     _logger.LogInformation(exception, "Error sending ForceKeepAlive message to WebSocket.");
                     lost.Add(webSocket);

--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -232,9 +232,9 @@ namespace Emby.Server.Implementations.Session
                 {
                     await SendForceKeepAlive(webSocket).ConfigureAwait(false);
                 }
-                // Socket may be disposed/canceled between selection and send; treat as lost, don't crash the process.
                 catch (Exception exception) when (exception is WebSocketException or ObjectDisposedException or OperationCanceledException)
                 {
+                    // Socket may be disposed/canceled between selection and send; treat as lost, don't crash.
                     _logger.LogInformation(exception, "Error sending ForceKeepAlive message to WebSocket.");
                     lost.Add(webSocket);
                 }


### PR DESCRIPTION
**Changes**

A client can close its WebSocket in the window between `KeepAliveSockets` selecting it and `SendForceKeepAlive` writing to it. The send then throws `ObjectDisposedException` (wrapped in `OperationCanceledException`); because `KeepAliveSockets` is `async void` and the `catch` only handled `WebSocketException`, it escapes unhandled and crashes the whole server process. This widens both keepalive send `catch` blocks to also treat disposed/canceled sockets as lost.

Observed crash on 10.11.11, 3 ms after the client socket closed:

```
[FTL] Main: Unhandled Exception
System.OperationCanceledException ---> System.ObjectDisposedException: Cannot access a disposed object. 'WebSocket'
   at ManagedWebSocket.ThrowIfInvalidState(...)
   at WebSocketConnection.SendAsync[T](...)
   at SessionWebSocketListener.SendForceKeepAlive(...)
   at SessionWebSocketListener.KeepAliveSockets(...)
```

**Code assistance**

Developed with LLM assistance (Claude): the crash was root-caused from production server logs, and the fix was written and reviewed with that assistance.

**Issues**

Fixes #15709