### PR TITLE
Undo breaking change to "BreakOnNonKeyFrames"

### DIFF
--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -143,7 +143,7 @@ public class TranscodingProfile
     [DefaultValue(false)]
     [XmlAttribute("breakOnNonKeyFrames")]
     [Obsolete("This is always false")]
-    public bool? BreakOnNonKeyFrames { get; set; }
+    public bool BreakOnNonKeyFrames { get; set; }
 
     /// <summary>
     /// Gets or sets the profile conditions.

--- a/tests/Jellyfin.Model.Tests/Dlna/SerializationTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/SerializationTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Emby.Server.Implementations.Serialization;
+using MediaBrowser.Model.Dlna;
+using Xunit;
+
+namespace Jellyfin.Model.Tests.Dlna;
+
+public class SerializationTests
+{
+    [Fact]
+    public void DeviceProfile_XmlSerialization()
+    {
+        var serializer = new MyXmlSerializer();
+        var original = new DeviceProfile
+        {
+            Name = "Test Device",
+            Id = Guid.NewGuid(),
+            MaxStreamingBitrate = 9500000,
+            MaxStaticBitrate = 8500000,
+            MusicStreamingTranscodingBitrate = 192000,
+            MaxStaticMusicBitrate = 5000000,
+            DirectPlayProfiles =
+            [
+                new DirectPlayProfile
+                {
+                    Container = "mp4,mkv",
+                    AudioCodec = "aac,ac3",
+                    VideoCodec = "h264,hevc",
+                    Type = DlnaProfileType.Video
+                }
+            ],
+            TranscodingProfiles =
+            [
+                new TranscodingProfile
+                {
+                    Container = "ts",
+                    Type = DlnaProfileType.Video,
+                    VideoCodec = "h264",
+                    AudioCodec = "aac",
+                    SegmentLength = 6,
+                    Conditions =
+                    [
+                        new ProfileCondition(ProfileConditionType.Equals, ProfileConditionValue.VideoBitDepth, "8")
+                    ]
+                }
+            ],
+            ContainerProfiles =
+            [
+                new ContainerProfile
+                {
+                    Type = DlnaProfileType.Video,
+                    Container = "mkv",
+                    SubContainer = "matroska",
+                    Conditions =
+                    [
+                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.Width, "1920")
+                    ]
+                }
+            ],
+            CodecProfiles =
+            [
+                new CodecProfile
+                {
+                    Type = CodecType.Video,
+                    Codec = "h264",
+                    Container = "mp4",
+                    Conditions =
+                    [
+                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoLevel, "41")
+                    ],
+                    ApplyConditions =
+                    [
+                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoBitrate, "10000000")
+                    ]
+                }
+            ],
+            SubtitleProfiles =
+            [
+                new SubtitleProfile
+                {
+                    Format = "srt",
+                    Method = SubtitleDeliveryMethod.Embed,
+                    Language = "eng",
+                    Container = "mp4"
+                }
+            ]
+        };
+
+        using var stream = new MemoryStream();
+        serializer.SerializeToStream(original, stream);
+        stream.Position = 0;
+
+        var deserialized = Assert.IsType<DeviceProfile>(serializer.DeserializeFromStream(typeof(DeviceProfile), stream));
+
+        Assert.Equivalent(original, deserialized, strict: false);
+    }
+}

--- a/tests/Jellyfin.Model.Tests/Jellyfin.Model.Tests.csproj
+++ b/tests/Jellyfin.Model.Tests/Jellyfin.Model.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../MediaBrowser.Model/MediaBrowser.Model.csproj" />
+    <ProjectReference Include="../../Emby.Server.Implementations/Emby.Server.Implementations.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes introduced regression in DLNA profile that caused issues due to the XmlSerializer does not support "Nullable<bool>"

This should hopefully fix https://github.com/jellyfin/jellyfin/issues/16621

**Changes**
Revert the change of BreakOnNonKeyFrames  from bool to "Nullable<bool>"

**Issues**
* #16621
* https://github.com/jellyfin/jellyfin-plugin-dlna/issues/224