### PR TITLE
Fix/livetv published url override

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -955,8 +955,16 @@ namespace Emby.Server.Implementations
         /// <inheritdoc/>
         public string GetApiUrlForLocalAccess(IPAddress ipAddress = null, bool allowHttps = true)
         {
-            // With an empty source, the port will be null
-            var smart = NetManager.GetBindAddress(ipAddress, out _, false);
+            // CLI/env-var override takes precedence, same as GetSmartApiUrl.
+            if (!string.IsNullOrEmpty(PublishedServerUrl))
+            {
+                return PublishedServerUrl.Trim('/');
+            }
+
+            // Default to loopback so published-server overrides can still apply when no
+            // specific source IP is given (e.g. Live TV buffer file paths generated
+            // server-side with no request context).
+            var smart = NetManager.GetBindAddress(ipAddress ?? IPAddress.Loopback, out _, false);
             var scheme = !allowHttps ? Uri.UriSchemeHttp : null;
             int? port = !allowHttps ? HttpPort : null;
             return GetLocalApiUrl(smart, scheme, port);


### PR DESCRIPTION
Fix - Live TV stream URLs are leaking the docker-internal IP to clients in some cases (in particular using a reverse proxy on an internal LAN).

**Changes**
GetApiUrlForLocalAccess was passing a null source IP into NetworkManager.GetBindAddress. This applies a "published server URL" overrides when a URL is specified. 
With no override applied, it fell back to the server's own network interface and used the docker bridge IP (e,g. 172.23.0.5) into the live TV paths (SharedHttpStream etc) instead of the configured public/reverse-proxy address. This broke Live TV direct-play for clients outside the container's own network. 

**Code assistance**
Used Claude Code to trace the bug end-to-end and to correlated it to live ADB Fire TV device logcat output. 

**Issues**
This issue seems to be similar and/or related to this closed PR...but not quite the same.
Related to jellyfin/jellyfin#15411 and supersedes the approach in the closed jellyfin/jellyfin#15575.

Still a major work in process as the FFMPEG issues noted in the closed 15575 PR needs addressing. 