### PR TITLE
Preserve resume position on near-start playback reports

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -312,7 +312,9 @@ namespace Emby.Server.Implementations.Library
         /// <inheritdoc />
         public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks)
         {
+            var previousPositionTicks = data.PlaybackPositionTicks;
             var playedToCompletion = false;
+            var zeroedNearStart = false;
 
             var runtimeTicks = item.GetRunTimeTicksForPlayState();
 
@@ -328,6 +330,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     // ignore progress during the beginning
                     positionTicks = 0;
+                    zeroedNearStart = true;
                 }
                 else if (pctIn > _config.Configuration.MaxResumePct || positionTicks >= (runtimeTicks - TimeSpan.TicksPerSecond))
                 {
@@ -355,6 +358,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     // ignore progress during the beginning
                     positionTicks = 0;
+                    zeroedNearStart = true;
                 }
                 else if (remainingTimeInMinutes < _config.Configuration.MaxAudiobookResume || positionTicks >= runtimeTicks)
                 {
@@ -368,6 +372,11 @@ namespace Emby.Server.Implementations.Library
                 // If we don't know the runtime we'll just have to assume it was fully played
                 data.Played = playedToCompletion = true;
                 positionTicks = 0;
+            }
+
+            if (zeroedNearStart && previousPositionTicks > 0)
+            {
+                positionTicks = previousPositionTicks;
             }
 
             if (!item.SupportsPlayedStatus)

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -1,0 +1,175 @@
+using System;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class UserDataManagerTests
+{
+    private readonly UserDataManager _userDataManager;
+
+    public UserDataManagerTests()
+    {
+        var config = new Mock<IServerConfigurationManager>();
+        config.SetupGet(c => c.Configuration).Returns(new ServerConfiguration
+        {
+            MinResumePct = 5,
+            MaxResumePct = 90,
+            MinResumeDurationSeconds = 300,
+            MinAudiobookResume = 5,
+            MaxAudiobookResume = 5
+        });
+
+        var repository = Mock.Of<IDbContextFactory<JellyfinDbContext>>();
+
+        _userDataManager = new UserDataManager(config.Object, repository);
+    }
+
+    private static AudioBook CreateAudioBook(TimeSpan runtime)
+    {
+        return new AudioBook
+        {
+            RunTimeTicks = runtime.Ticks
+        };
+    }
+
+    private static Movie CreateMovie(TimeSpan runtime)
+    {
+        return new Movie
+        {
+            RunTimeTicks = runtime.Ticks
+        };
+    }
+
+    private static UserItemData CreateUserData(long positionTicks)
+    {
+        return new UserItemData
+        {
+            Key = "test-key",
+            PlaybackPositionTicks = positionTicks
+        };
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearStartReportAfterLongResume_PreservesResume()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, TimeSpan.FromSeconds(20).Ticks);
+
+        Assert.Equal(existingResume.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+        Assert.False(data.Played);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearStartReportWithNoExistingResume_StaysZero()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var data = CreateUserData(0);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, TimeSpan.FromSeconds(20).Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookLiteralZeroReportAfterLongResume_HonorsExplicitRestart()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNormalForwardProgress_UpdatesPosition()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromHours(6);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(reported.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearEndReport_MarksCompletedAndClearsResume()
+    {
+        var runtime = TimeSpan.FromHours(16);
+        var item = CreateAudioBook(runtime);
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = runtime - TimeSpan.FromMinutes(2);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.True(playedToCompletion);
+        Assert.True(data.Played);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieBelowMinResumePctAfterHalfwayResume_PreservesResume()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.01));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(existingResume.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieGenuineBackwardSeek_PreservesReportedPosition()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.40));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(reported.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieAboveMaxResumePct_MarksCompletedAndClearsResume()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.96));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.True(playedToCompletion);
+        Assert.True(data.Played);
+    }
+}


### PR DESCRIPTION
**Changes**
- Store the previous position before attempting to overwrite play position to help prevent an accidental overwrite of position to 0:00 on HLS transcoding error

**Code assistance**
- Opus for code research
- Opus for reviewing my code change
- Opus for building the table below
- No code written by AI

**Issues**
I searched a bunch of terms in the issues page but found nothing exactly like this. The closest I could find was https://github.com/jellyfin/jellyfin/issues/14689, but my solution I don't think would solve their underlying issue as they wouldn't have gotten past the min % for video or min minutes for audiobooks. However myself and 2 others who use my server reproduced the issue independently. I traced it down to this code path. The gist is that resuming an item that needs transcoding and the server runs into an issue, can result in a state where the resume time gets reset to 0:00.

**Product callout**
There is a slight change in behavior that is worth calling out here, but I think it's worth the change. On Master (this includes 10.11.x) if you're at 50% progress and you decide to set the progress to 4% for some reason and then close out the app, any resumes will start at 0%. For manually seeking this is fine, it's a server setting, makes sense. The issue is if this was either accidental or the existing HLS pattern of starting from 0 then seeking to the resume position errors out on the server side and the user closes the client, it can report that the resume position at that point is 0:00. For movies & audiobooks, this really stinks if you're hours in and an error happens and your progress is lost, especially when you don't know exactly where you were.

I had Claude build a table to help explain the UX patterns:
  | Action | Master | With this PR |
  |---|---|---|
  | Seek back near the start, keep playing | Continues; resume moves forward again once you pass the threshold | Same |
  | Pause near the start, then resume (same session) | Continues from where you paused | Same |
  | **Stop, or close the app, near the start, then reopen** | **Starts over from the beginning** (your progress is lost) | **Resumes where you last were** |
  | **A background/phantom session reports a near-start position** | **Progress lost, starts over** | **Progress kept** |
  | Drag to the very start (0:00) and stop | Starts from the beginning | Starts from the beginning |