### PR TITLE
Match VobSub MKS subtitle profiles by container

### DIFF
--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -576,11 +576,8 @@ namespace MediaBrowser.Model.Dlna
                     foreach (var profile in subtitleProfiles)
                     {
                         if (profile.Method == SubtitleDeliveryMethod.External
-                            && (string.Equals(profile.Format, stream.Codec, StringComparison.OrdinalIgnoreCase)
-                                // FFmpeg cannot mux VobSub back into an .idx/.sub pair, so extracted VobSub streams are exposed as .mks.
-                                || (string.Equals(profile.Format, "mks", StringComparison.OrdinalIgnoreCase)
-                                    && stream.IsVobSubSubtitleStream
-                                    && (!stream.IsExternal || stream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase)))))
+                            && (IsVobSubMksProfile(profile, stream)
+                                || (!IsVobSubMksDeliveryProfile(profile) && string.Equals(profile.Format, stream.Codec, StringComparison.OrdinalIgnoreCase))))
                         {
                             return stream.Index;
                         }
@@ -1590,13 +1587,11 @@ namespace MediaBrowser.Model.Dlna
                     continue;
                 }
 
-                // FFmpeg cannot mux VobSub back into an .idx/.sub pair, so extracted VobSub streams are matched against external .mks delivery profiles.
-                bool isVobSubMksProfile = string.Equals(profile.Format, "mks", StringComparison.OrdinalIgnoreCase)
-                    && subtitleStream.IsVobSubSubtitleStream
-                    && (!subtitleStream.IsExternal || subtitleStream.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase));
+                bool isVobSubMksProfile = IsVobSubMksProfile(profile, subtitleStream);
 
                 if ((profile.Method == SubtitleDeliveryMethod.External
-                        && (isVobSubMksProfile || subtitleStream.IsTextSubtitleStream == MediaStream.IsTextFormat(profile.Format))) ||
+                        && (isVobSubMksProfile
+                            || (!IsVobSubMksDeliveryProfile(profile) && subtitleStream.IsTextSubtitleStream == MediaStream.IsTextFormat(profile.Format)))) ||
                     (profile.Method == SubtitleDeliveryMethod.Hls && subtitleStream.IsTextSubtitleStream))
                 {
                     bool requiresConversion = !isVobSubMksProfile
@@ -1626,6 +1621,21 @@ namespace MediaBrowser.Model.Dlna
             }
 
             return null;
+        }
+
+        private static bool IsVobSubMksDeliveryProfile(SubtitleProfile profile)
+        {
+            return MediaStream.IsVobSubFormat(profile.Format)
+                && !string.IsNullOrWhiteSpace(profile.Container)
+                && ContainerHelper.ContainsContainer(profile.Container, "mks");
+        }
+
+        private static bool IsVobSubMksProfile(SubtitleProfile profile, MediaStream subtitleStream)
+        {
+            // FFmpeg cannot mux VobSub back into an .idx/.sub pair, so extracted VobSub streams are exposed as .mks.
+            return IsVobSubMksDeliveryProfile(profile)
+                && subtitleStream.IsVobSubSubtitleStream
+                && (!subtitleStream.IsExternal || subtitleStream.Path?.EndsWith(".mks", StringComparison.OrdinalIgnoreCase) == true);
         }
 
         private bool IsBitrateLimitExceeded(MediaSourceInfo item, long maxBitrate)

--- a/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
+++ b/tests/Jellyfin.Model.Tests/Dlna/StreamBuilderTests.cs
@@ -677,6 +677,48 @@ namespace Jellyfin.Model.Tests
         }
 
         [Theory]
+        [InlineData(false, null, true, SubtitleDeliveryMethod.External)]
+        [InlineData(false, null, false, SubtitleDeliveryMethod.Encode)]
+        [InlineData(true, "/media/sub.mks", true, SubtitleDeliveryMethod.External)]
+        [InlineData(true, "/media/sub.idx", true, SubtitleDeliveryMethod.Encode)]
+        [InlineData(true, "/media/sub.sub", true, SubtitleDeliveryMethod.Encode)]
+        public void GetSubtitleProfile_MatchesVobSubMksProfileOnlyWhenDeliveredAsMks(
+            bool isExternal,
+            string? path,
+            bool enableSubtitleExtraction,
+            SubtitleDeliveryMethod expectedMethod)
+        {
+            var mediaSource = new MediaSourceInfo();
+            var subtitleStream = new MediaStream
+            {
+                Type = MediaStreamType.Subtitle,
+                Index = 0,
+                IsExternal = isExternal,
+                Path = path,
+                Codec = "vobsub"
+            };
+
+            var subtitleProfiles = new[]
+            {
+                new SubtitleProfile { Format = "vobsub", Container = "mks", Method = SubtitleDeliveryMethod.External }
+            };
+
+            var transcoderSupport = new Mock<ITranscoderSupport>();
+            transcoderSupport.Setup(t => t.CanExtractSubtitles(It.IsAny<string>())).Returns(enableSubtitleExtraction);
+
+            var result = StreamBuilder.GetSubtitleProfile(
+                mediaSource,
+                subtitleStream,
+                subtitleProfiles,
+                PlayMethod.Transcode,
+                transcoderSupport.Object,
+                null,
+                null);
+
+            Assert.Equal(expectedMethod, result.Method);
+        }
+
+        [Theory]
         // External text subs embedded into MKV when transcoding (#16403)
         [InlineData("srt", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]
         [InlineData("ass", true, PlayMethod.Transcode, "mkv", MediaStreamProtocol.http, SubtitleDeliveryMethod.Embed)]


### PR DESCRIPTION
**Changes**
Match VobSub subtitle profiles using `Format=vobsub` with `Container=mks` instead of treating `mks` as a subtitle format. This lets clients advertise support for rendering VobSub delivered in an MKS container without implying support for arbitrary MKS subtitles. Add focused tests for internal VobSub extraction, external `.mks` delivery, and external `.idx/.sub` fallback behavior.

**Code assistance**
Codex was used to inspect the subtitle profile matching flow, implement the matcher and test updates, and run focused validation.

**Issues**
Continues #16484