### PR TITLE
Don't throw on logout if session does not exist

### DIFF
--- a/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
+++ b/Jellyfin.Server.Implementations/Devices/DeviceManager.cs
@@ -213,8 +213,10 @@ namespace Jellyfin.Server.Implementations.Devices
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                dbContext.Devices.Remove(device);
-                await dbContext.SaveChangesAsync().ConfigureAwait(false);
+                await dbContext.Devices
+                    .Where(d => d.Id == device.Id)
+                    .ExecuteDeleteAsync()
+                    .ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
If a client sends multiple logout requests of the same session, first request will delete, second will throw because we are running in a tracked environment but nothing changed.

**Changes**
* Delete by device ID instead of using the tracked entity

**Code assistance**
Noe

**Issues**
