### PR TITLE
Use InvariantCulture when parsing machine-generated dates

### DIFF
--- a/Emby.Naming/TV/EpisodePathParser.cs
+++ b/Emby.Naming/TV/EpisodePathParser.cs
@@ -125,7 +125,7 @@ namespace Emby.Naming.TV
                             result.Success = true;
                         }
                     }
-                    else if (DateTime.TryParse(match.Groups[0].ValueSpan, out date))
+                    else if (DateTime.TryParse(match.Groups[0].ValueSpan, CultureInfo.InvariantCulture, out date))
                     {
                         result.Year = date.Year;
                         result.Month = date.Month;

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -2049,7 +2049,7 @@ public class ImageController : BaseJellyfinApiController
             }
 
             // Check If-Modified-Since header for time-based validation
-            if (DateTime.TryParse(Request.Headers[HeaderNames.IfModifiedSince], out var ifModifiedSinceHeader))
+            if (DateTime.TryParse(Request.Headers[HeaderNames.IfModifiedSince], CultureInfo.InvariantCulture, out var ifModifiedSinceHeader))
             {
                 // Return 304 if the image has not been modified since the client's cached version
                 if (dateImageModified <= ifModifiedSinceHeader)

--- a/Jellyfin.Server/Migrations/Routines/20250420140000_MigrateAuthenticationDb.cs
+++ b/Jellyfin.Server/Migrations/Routines/20250420140000_MigrateAuthenticationDb.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Emby.Server.Implementations.Data;
 using Jellyfin.Database.Implementations;
@@ -79,9 +80,9 @@ namespace Jellyfin.Server.Migrations.Routines
                 foreach (var row in authenticatedDevices)
                 {
                     var dateCreatedStr = row.GetString(9);
-                    _ = DateTime.TryParse(dateCreatedStr, out var dateCreated);
+                    _ = DateTime.TryParse(dateCreatedStr, CultureInfo.InvariantCulture, out var dateCreated);
                     var dateLastActivityStr = row.GetString(10);
-                    _ = DateTime.TryParse(dateLastActivityStr, out var dateLastActivity);
+                    _ = DateTime.TryParse(dateLastActivityStr, CultureInfo.InvariantCulture, out var dateLastActivity);
 
                     if (row.IsDBNull(6))
                     {

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -1641,7 +1641,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
             // Credit to MCEBuddy: https://mcebuddy2x.codeplex.com/
             // DateTime is reported along with timezone info (typically Z i.e. UTC hence assume None)
-            if (tags.TryGetValue("WM/MediaOriginalBroadcastDateTime", out var premiereDateString) && DateTime.TryParse(year, null, DateTimeStyles.AdjustToUniversal, out var parsedDate))
+            if (tags.TryGetValue("WM/MediaOriginalBroadcastDateTime", out var premiereDateString) && DateTime.TryParse(year, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var parsedDate))
             {
                 video.PremiereDate = parsedDate;
             }

--- a/MediaBrowser.Providers/Books/OpenPackagingFormat/OpfReader.cs
+++ b/MediaBrowser.Providers/Books/OpenPackagingFormat/OpfReader.cs
@@ -125,7 +125,7 @@ namespace MediaBrowser.Providers.Books.OpenPackagingFormat
 
             ReadStringInto("//dc:date", date =>
             {
-                if (DateTime.TryParse(date, out var dateValue))
+                if (DateTime.TryParse(date, CultureInfo.InvariantCulture, out var dateValue))
                 {
                     book.PremiereDate = dateValue.Date;
                     book.ProductionYear = dateValue.Date.Year;


### PR DESCRIPTION
**Changes**

`DateTime.TryParse` without an explicit `IFormatProvider` falls back to the current thread culture, so the same date string can parse differently — or fail outright — depending on the server's locale. That's a real risk for a server that runs on machines all over the world.

None of the call sites touched here deal with user-entered text. They parse dates that come from episode filenames, the `If-Modified-Since` HTTP header, ffprobe metadata, and values the app itself previously wrote to the authentication database. All of those are machine- or protocol-generated, so `CultureInfo.InvariantCulture` is the correct provider in every case (as opposed to `CurrentCulture`, which would only make sense for text a human typed into the UI).

Affected files:
- `Emby.Naming/TV/EpisodePathParser.cs` – date parsed out of an episode filename
- `Jellyfin.Api/Controllers/ImageController.cs` – the `If-Modified-Since` request header
- `MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs` – broadcast date from ffprobe tags (was passing `null`)
- `MediaBrowser.Providers/Books/OpenPackagingFormat/OpfReader.cs` – `<dc:date>` from an OPF/EPUB document
- `Jellyfin.Server/Migrations/Routines/20250420140000_MigrateAuthenticationDb.cs` – timestamps read back from the old auth DB

This clears the SonarCloud `S6580` / Roslyn `CA1305` warnings on these lines. No behavior change is intended for correctly-formatted input; it just makes parsing independent of the host locale.

**Code assistance**

Claude Code was used to locate the call sites, reason through which culture is correct for each one, and run the build and naming tests. I reviewed every change.

**Issues**

<!-- none -->
