### PR TITLE
Fix parental rating lookup for multi-rating entries

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -356,6 +356,27 @@ namespace Emby.Server.Implementations.Localization
         {
             ArgumentException.ThrowIfNullOrEmpty(rating);
 
+            // Some providers may list multiple ratings separated by '/' (e.g. "SE:15 / SE:15+ / SE:Från 15 år").
+            // Try each one in order and use the first that resolves.
+            var ratingValues = rating.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var ratingValue in ratingValues)
+            {
+                var score = GetSingleRatingScore(ratingValue, countryCode);
+                if (score is not null)
+                {
+                    return score;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves a single rating value to a score.
+        /// </summary>
+        private ParentalRatingScore? GetSingleRatingScore(string rating, string? countryCode)
+        {
             // Handle unrated content
             if (_unratedValues.Contains(rating.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
We weren't correctly parsing ratings that contained multiple entries. The code basically only used the last part of the string, so if that part wasn't a recognized rating, even when there was an earlier valid entry, the string wouldn't match and would come back as unrated.

**Changes**
Split the field on `/` and try each rating value on its own, returning the first one that resolves.

**Code assistance**
N/A

**Issues**
Fixes these issues: 
`[WRN] [15] Emby.Server.Implementations.Localization.LocalizationManager: Rating '"DE:FSK 12 / DE:FSK-12 / DE:FSK12 / DE:12 / DE:12+ / DE:ab 12"' not found in the '"DE"' rating system, treating as unrated`
