### PR TITLE
Remove unreachable conditions and redundant null checks

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -970,8 +970,7 @@ namespace Emby.Server.Implementations.Library
             // Filter content based on ignore rules
             if (args.IsDirectory)
             {
-                var filtered = args.GetActualFileSystemChildren().ToArray();
-                args.FileSystemChildren = filtered ?? [];
+                args.FileSystemChildren = args.GetActualFileSystemChildren().ToArray();
             }
 
             return ResolveItem(args, resolvers);

--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -134,7 +134,7 @@ namespace Emby.Server.Implementations.Library
             {
                 // Always load (full/non-forced) subtitles of the user's preferred subtitle language if possible, otherwise OnlyForced behavior.
                 filteredStreams = sortedStreams.Where(s => !s.IsForced && MatchesPreferredLanguage(s.Language, preferredLanguages))
-                    .ToList() ?? BehaviorOnlyForced(sortedStreams, preferredLanguages);
+                    .ToList();
             }
             else if (mode == SubtitlePlaybackMode.OnlyForced)
             {

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4444,12 +4444,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             // preferred qsv(d3d11) + opencl filters pipeline
-            if (isIntelDx11OclSupported)
-            {
-                return GetIntelQsvDx11VidFiltersPrefered(state, options, vidDecoder, vidEncoder);
-            }
-
-            return (null, null, null);
+            return GetIntelQsvDx11VidFiltersPrefered(state, options, vidDecoder, vidEncoder);
         }
 
         public (List<string> MainFilters, List<string> SubFilters, List<string> OverlayFilters) GetIntelQsvDx11VidFiltersPrefered(
@@ -5967,12 +5962,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             // preferred rkmpp + rkrga + opencl filters pipeline
-            if (isRkmppOclSupported)
-            {
-                return GetRkmppVidFiltersPrefered(state, options, vidDecoder, vidEncoder);
-            }
-
-            return (null, null, null);
+            return GetRkmppVidFiltersPrefered(state, options, vidDecoder, vidEncoder);
         }
 
         public (List<string> MainFilters, List<string> SubFilters, List<string> OverlayFilters) GetRkmppVidFiltersPrefered(

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -1149,29 +1149,31 @@ namespace MediaBrowser.Model.Dlna
         {
             if (!string.IsNullOrEmpty(audioCodec))
             {
+                var channels = audioChannels ?? 0;
+
                 // Default to a higher bitrate for stream copy
                 if (string.Equals(audioCodec, "aac", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(audioCodec, "mp3", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(audioCodec, "ac3", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(audioCodec, "eac3", StringComparison.OrdinalIgnoreCase))
                 {
-                    if ((audioChannels ?? 0) < 2)
+                    if (channels < 2)
                     {
                         return 128000;
                     }
 
-                    return (audioChannels ?? 0) >= 6 ? 640000 : 384000;
+                    return channels >= 6 ? 640000 : 384000;
                 }
 
                 if (string.Equals(audioCodec, "flac", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(audioCodec, "alac", StringComparison.OrdinalIgnoreCase))
                 {
-                    if ((audioChannels ?? 0) < 2)
+                    if (channels < 2)
                     {
                         return 768000;
                     }
 
-                    return (audioChannels ?? 0) >= 6 ? 3584000 : 1536000;
+                    return channels >= 6 ? 3584000 : 1536000;
                 }
             }
 


### PR DESCRIPTION
SonarCloud (S2589) flagged a handful of conditions that can never take their other branch, so the checks were just dead weight:

- LibraryManager / MediaStreamSelector: Enumerable.ToArray()/ToList() never return null, so the '?? []' and '?? BehaviorOnlyForced(...)' fallbacks were unreachable. The MediaStreamSelector fallback never ran, so dropping it doesn't change behavior.
**Changes**

SonarCloud (rule S2589) flagged a few conditions whose "other" branch can
never be reached, so the checks were just dead weight. This cleans them up
without changing runtime behavior:

- `LibraryManager` / `MediaStreamSelector`: `Enumerable.ToArray()` / `.ToList()`
  never return `null`, so the `?? []` and `?? BehaviorOnlyForced(...)` fallbacks
  were unreachable.
- `EncodingHelper`: in both the QSV (d3d11) and RKMPP filter chains the early
  guard already returns whenever the OpenCL path isn't supported, so the final
  `if (…OclSupported)` is always `true` by the time we reach it. I return the
  preferred pipeline directly and drop the now-unreachable trailing return.
- `StreamBuilder.GetDefaultAudioBitrate`: after the `< 2 channels` branch has
  returned, `audioChannels` can no longer be `null`, so `audioChannels ?? 0`
  was redundant. I hoisted it into a local so it's computed once.

No behavior change is intended — each change resolves to exactly what the code
already did at runtime. Existing tests for all three areas pass.

Note: the `MediaStreamSelector` comment mentions an "otherwise OnlyForced"
fallback that, because of the never-null `.ToList()`, never actually ran. This
PR only removes the dead fallback; wiring it up for real would be a behavior
change and is left for a separate PR.

**Code assistance**

Claude Code was used to verify with data-flow
reasoning that each branch is genuinely unreachable, and run the build and
tests. I reviewed every change.

**Issues**

<!-- none -->