### PR TITLE
Add endpoint for targeted media additions

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -32,6 +32,7 @@ using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Authorization;
@@ -58,6 +59,7 @@ public class LibraryController : BaseJellyfinApiController
     private readonly ILibraryMonitor _libraryMonitor;
     private readonly ILogger<LibraryController> _logger;
     private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly IFileSystem _fileSystem;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LibraryController"/> class.
@@ -73,6 +75,7 @@ public class LibraryController : BaseJellyfinApiController
     /// <param name="libraryMonitor">Instance of the <see cref="ILibraryMonitor"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{LibraryController}"/> interface.</param>
     /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     public LibraryController(
         IProviderManager providerManager,
         ISimilarItemsManager similarItemsManager,
@@ -84,7 +87,8 @@ public class LibraryController : BaseJellyfinApiController
         ILocalizationManager localization,
         ILibraryMonitor libraryMonitor,
         ILogger<LibraryController> logger,
-        IServerConfigurationManager serverConfigurationManager)
+        IServerConfigurationManager serverConfigurationManager,
+        IFileSystem fileSystem)
     {
         _providerManager = providerManager;
         _similarItemsManager = similarItemsManager;
@@ -97,6 +101,7 @@ public class LibraryController : BaseJellyfinApiController
         _libraryMonitor = libraryMonitor;
         _logger = logger;
         _serverConfigurationManager = serverConfigurationManager;
+        _fileSystem = fileSystem;
     }
 
     /// <summary>
@@ -657,6 +662,218 @@ public class LibraryController : BaseJellyfinApiController
 
         return NoContent();
     }
+
+    /// <summary>
+    /// Directly adds new media paths to the library without refreshing the nearest known parent folder.
+    /// </summary>
+    /// <param name="dto">The media paths to add.</param>
+    /// <response code="200">Media add results returned.</response>
+    /// <returns>The per-path add results.</returns>
+    [HttpPost("Library/Media/Added")]
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<MediaAddResultDto> PostAddedMedia([FromBody, Required] MediaAddRequestDto dto)
+    {
+        var results = dto.Paths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => AddMediaPath(path, dto.RefreshExisting, dto.RefreshNewItems))
+            .ToArray();
+
+        return new MediaAddResultDto
+        {
+            Results = results
+        };
+    }
+
+    private MediaAddPathResultDto AddMediaPath(string path, bool refreshExisting, bool refreshNewItems)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                Status = "Invalid",
+                Error = "Path must not be empty."
+            };
+        }
+
+        string normalizedPath;
+        try
+        {
+            normalizedPath = Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or System.Security.SecurityException)
+        {
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                Status = "Invalid",
+                Error = ex.Message
+            };
+        }
+
+        if (!Directory.Exists(normalizedPath) && !System.IO.File.Exists(normalizedPath))
+        {
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                Status = "NotFound",
+                Error = "Path does not exist on the Jellyfin server."
+            };
+        }
+
+        var existing = _libraryManager.FindByPath(normalizedPath, null);
+        if (existing is not null)
+        {
+            if (refreshExisting)
+            {
+                QueueRefresh(existing);
+            }
+
+            return CreateResult(path, existing, existing.GetParent() as Folder, "Exists", normalizedPath, null);
+        }
+
+        var addTarget = GetAddTarget(normalizedPath);
+        if (addTarget is null)
+        {
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                Status = "NoParent",
+                Error = "No existing Jellyfin folder parent was found for this path."
+            };
+        }
+
+        var (parent, childPath) = addTarget.Value;
+        var alreadyCreated = _libraryManager.FindByPath(childPath, null);
+        if (alreadyCreated is not null)
+        {
+            if (refreshExisting)
+            {
+                QueueRefresh(alreadyCreated);
+            }
+
+            return CreateResult(path, alreadyCreated, parent, "Exists", childPath, null);
+        }
+
+        BaseItem? resolvedItem;
+        try
+        {
+            resolvedItem = _libraryManager.ResolvePath(
+                _fileSystem.GetFileSystemInfo(childPath),
+                parent,
+                new DirectoryService(_fileSystem),
+                _libraryManager.GetContentType(parent));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error resolving added media path {Path}", childPath);
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                ResolvedPath = childPath,
+                ParentId = parent.Id,
+                ParentPath = parent.Path,
+                Status = "Error",
+                Error = ex.Message
+            };
+        }
+
+        if (resolvedItem is null)
+        {
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                ResolvedPath = childPath,
+                ParentId = parent.Id,
+                ParentPath = parent.Path,
+                Status = "Ignored",
+                Error = "Path could not be resolved to a Jellyfin item."
+            };
+        }
+
+        resolvedItem.SetParent(parent);
+        try
+        {
+            _libraryManager.CreateItems([resolvedItem], parent, CancellationToken.None);
+
+            if (refreshNewItems)
+            {
+                QueueRefresh(resolvedItem);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving added media path {Path}", childPath);
+            return new MediaAddPathResultDto
+            {
+                Path = path,
+                ResolvedPath = childPath,
+                ParentId = parent.Id,
+                ParentPath = parent.Path,
+                Status = "Error",
+                Error = ex.Message
+            };
+        }
+
+        return CreateResult(path, resolvedItem, parent, "Created", childPath, null);
+    }
+
+    private (Folder Parent, string ChildPath)? GetAddTarget(string path)
+    {
+        var childPath = Directory.Exists(path)
+            ? Path.TrimEndingDirectorySeparator(path)
+            : path;
+
+        while (!string.IsNullOrEmpty(childPath))
+        {
+            var parentPath = Path.GetDirectoryName(childPath);
+            if (string.IsNullOrEmpty(parentPath))
+            {
+                return null;
+            }
+
+            if (_libraryManager.FindByPath(parentPath, true) is Folder parent)
+            {
+                return (parent, childPath);
+            }
+
+            childPath = Path.TrimEndingDirectorySeparator(parentPath);
+        }
+
+        return null;
+    }
+
+    private void QueueRefresh(BaseItem item)
+    {
+        var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+        {
+            IsAutomated = true
+        };
+
+        _providerManager.QueueRefresh(item.Id, refreshOptions, RefreshPriority.High);
+    }
+
+    private static MediaAddPathResultDto CreateResult(
+        string requestedPath,
+        BaseItem item,
+        Folder? parent,
+        string status,
+        string? resolvedPath,
+        string? error)
+        => new()
+        {
+            Path = requestedPath,
+            ItemPath = item.Path,
+            ResolvedPath = resolvedPath,
+            ParentPath = parent?.Path,
+            ItemId = item.Id,
+            ParentId = parent?.Id,
+            ItemName = item.Name,
+            ItemType = item.GetType().Name,
+            Status = status,
+            Error = error
+        };
 
     /// <summary>
     /// Downloads item media.

--- a/Jellyfin.Api/Models/LibraryDtos/MediaAddRequestDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/MediaAddRequestDto.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LibraryDtos;
+
+/// <summary>
+/// Request for directly adding media paths to the library.
+/// </summary>
+public class MediaAddRequestDto
+{
+    /// <summary>
+    /// Gets or sets the media paths to add.
+    /// </summary>
+    public IReadOnlyList<string> Paths { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether existing items should be refreshed.
+    /// </summary>
+    public bool RefreshExisting { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether newly created items should be refreshed.
+    /// </summary>
+    public bool RefreshNewItems { get; set; } = true;
+}

--- a/Jellyfin.Api/Models/LibraryDtos/MediaAddResultDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/MediaAddResultDto.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LibraryDtos;
+
+/// <summary>
+/// Result of directly adding media paths to the library.
+/// </summary>
+public class MediaAddResultDto
+{
+    /// <summary>
+    /// Gets or sets the per-path add results.
+    /// </summary>
+    public IReadOnlyList<MediaAddPathResultDto> Results { get; set; } = Array.Empty<MediaAddPathResultDto>();
+}
+
+/// <summary>
+/// Result of directly adding one media path to the library.
+/// </summary>
+public class MediaAddPathResultDto
+{
+    /// <summary>
+    /// Gets or sets the requested path.
+    /// </summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the existing or created item path.
+    /// </summary>
+    public string? ItemPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path that was resolved and inserted.
+    /// </summary>
+    public string? ResolvedPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent item path.
+    /// </summary>
+    public string? ParentPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item id.
+    /// </summary>
+    public Guid? ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent item id.
+    /// </summary>
+    public Guid? ParentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item name.
+    /// </summary>
+    public string? ItemName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item type.
+    /// </summary>
+    public string? ItemType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the result status.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a status detail.
+    /// </summary>
+    public string? Error { get; set; }
+}


### PR DESCRIPTION
## Summary

- add `POST /Library/Media/Added` for directly adding newly available media paths
- resolve each submitted path under the nearest existing Jellyfin folder parent
- return per-path results instead of reporting the parent folder to the library monitor

## Motivation

`POST /Library/Media/Updated` is useful for filesystem change notifications, but it reports paths to the library monitor and can cause parent-folder refreshes. External automation tools (e.g. Autopulse/Autoscan) that already know the exact new file path need a narrower API surface, especially when media is on mounts that do not provide reliable inotify events.

This endpoint lets callers submit exact media paths and lets Jellyfin resolve/insert the missing child item directly.

## Testing

```text
dotnet build Jellyfin.Api/Jellyfin.Api.csproj --configuration Release
```

Result:

```text
Build succeeded.
0 Warning(s)
0 Error(s)
```

# EDIT 16 July 2026
## Use case

In setups with remote filesystems (nfs, smb, etc.) this PR would allow users to add media immediately (10-20sec after download is finished) to jellyfin instead of having to wait for the next scheduled library scan to happen. 

I'm running this PR since ~3 weeks in an Arr-setup together with a patched version of Autopulse that calls this new endpoint and did not experience any issues so far.
