### PR TITLE
Fix CA1819 warnings in QueryFiltersLegacy

### DIFF
--- a/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
+++ b/MediaBrowser.Model/Querying/QueryFiltersLegacy.cs
@@ -1,7 +1,7 @@
 #nullable disable
 #pragma warning disable CS1591
 
-using System;
+using System.Collections.Generic;
 
 namespace MediaBrowser.Model.Querying
 {
@@ -9,18 +9,18 @@ namespace MediaBrowser.Model.Querying
     {
         public QueryFiltersLegacy()
         {
-            Genres = Array.Empty<string>();
-            Tags = Array.Empty<string>();
-            OfficialRatings = Array.Empty<string>();
-            Years = Array.Empty<int>();
+            Genres = [];
+            Tags = [];
+            OfficialRatings = [];
+            Years = [];
         }
 
-        public string[] Genres { get; set; }
+        public IReadOnlyList<string> Genres { get; set; }
 
-        public string[] Tags { get; set; }
+        public IReadOnlyList<string> Tags { get; set; }
 
-        public string[] OfficialRatings { get; set; }
+        public IReadOnlyList<string> OfficialRatings { get; set; }
 
-        public int[] Years { get; set; }
+        public IReadOnlyList<int> Years { get; set; }
     }
 }


### PR DESCRIPTION
Replaces the four array-typed properties on `QueryFiltersLegacy` with `IReadOnlyList<T>`, clearing the CA1819 (Properties should not return arrays) warnings for this type. Follows the same approach used in #16853 for `ChannelFeatures`.

**Changes:**
- `Genres`, `Tags`, `OfficialRatings` → `IReadOnlyList<string>`
- `Years` → `IReadOnlyList<int>`
- `Array.Empty<T>()` initializers → collection expressions (`[]`)

No behavioural or wire-format change. `QueryFiltersLegacy` is the `/Items/Filters` response DTO, only ever serialized to JSON. `IReadOnlyList<T>` serializes identically to a JSON array, so the OpenAPI schema is unchanged. The single construction site assigns `.ToArray()` output, which still satisfies `IReadOnlyList<T>`.

**Testing:**
- `dotnet build -c Release` is clean (the CI gate); the Debug analyzer pass no longer reports CA1819 for `QueryFiltersLegacy`.
- Existing unit suites pass: `Jellyfin.Model.Tests` and `Jellyfin.Server.Implementations.Tests`.
- Verified wire compatibility of `GET /Items/Filters` (the only consumer of this DTO): `System.Text.Json` serializes `IReadOnlyList<T>` identically to `T[]` (a JSON array), and the generated OpenAPI schema is unchanged. Confirmed  by CURLing the endpoint's JSON response from a running server both before and after the change. This produced byte-identical output.

Part of #2149
