### PR TITLE
Allow SeriesName to be editable from Item Metadata (books)

### DIFF
--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -279,6 +279,11 @@ public class ItemUpdateController : BaseJellyfinApiController
             item.DateCreated = NormalizeDateTime(request.DateCreated.Value);
         }
 
+        if (request.SeriesName is not null && item is IHasSeries hasSeries)
+        {
+            hasSeries.SeriesName = request.SeriesName;
+        }
+
         item.EndDate = request.EndDate.HasValue ? NormalizeDateTime(request.EndDate.Value) : null;
         item.PremiereDate = request.PremiereDate.HasValue ? NormalizeDateTime(request.PremiereDate.Value) : null;
         item.ProductionYear = request.ProductionYear;


### PR DESCRIPTION
**Changes**
`SeriesName` on Books is viewable from the frontend (web) but not editable. This PR allows the editing of this attr if passed to the `ItemUpdateController`

**Code assistance**
Opus reviewed my change and suggested I add ` && item is IHasSeries hasSeries` instead of just `item.SeriesName = request.SeriesName`

**Issues**
None that I can find

**Web Change**
* https://github.com/jellyfin/jellyfin-web/pull/8164
