### PR TITLE
Fix artists being displayed with albums

### DIFF
--- a/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
+++ b/Emby.Server.Implementations/Images/CollectionFolderImageProvider.cs
@@ -31,6 +31,12 @@ namespace Emby.Server.Implementations.Images
             var includeItemTypes = DtoExtensions.GetBaseItemKindsForCollectionType(viewType);
             var recursive = viewType != CollectionType.playlists;
 
+            if (viewType == CollectionType.music)
+            {
+                // Music albums usually don't have dedicated backdrops, so use artist instead
+                includeItemTypes = [BaseItemKind.MusicArtist];
+            }
+
             return view.GetItemList(new InternalItemsQuery
             {
                 CollapseBoxSetItems = false,

--- a/Jellyfin.Api/Extensions/DtoExtensions.cs
+++ b/Jellyfin.Api/Extensions/DtoExtensions.cs
@@ -24,7 +24,7 @@ public static class DtoExtensions
             case CollectionType.tvshows:
                 return [BaseItemKind.Series];
             case CollectionType.music:
-                return [BaseItemKind.MusicAlbum, BaseItemKind.MusicArtist];
+                return [BaseItemKind.MusicAlbum];
             case CollectionType.musicvideos:
                 return [BaseItemKind.MusicVideo];
             case CollectionType.books:


### PR DESCRIPTION
After https://github.com/jellyfin/jellyfin/pull/15954, the album view returns both artist and albums

**Changes**
Remove `BaseItemKind.MusicArtist` from the `CollectionType.music` case in `GetBaseItemKindsForCollectionType`

**Code assistance**
N/A

**Issues**
<img width="320" height="236" alt="1a" src="https://github.com/user-attachments/assets/37db6582-4a02-4b01-b0bf-0e6179d082c0" />

