### PR TITLE
Add TVDB provider ID support for movies

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -379,6 +379,9 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 // The fallback filename is only used when the item isn't in a mixed folder
                 var fileName = item.IsInMixedFolder ? ReadOnlySpan<char>.Empty : Path.GetFileName(item.Path.AsSpan());
 
+                item.TrySetProviderId(MetadataProvider.Tmdb, GetIdFromNameOrPath(justName, fileName, "tmdbid"));
+                item.TrySetProviderId(MetadataProvider.Tvdb, GetIdFromNameOrPath(justName, fileName, "tvdbid"));
+
                 string GetIdFromNameOrPath(ReadOnlySpan<char> name, ReadOnlySpan<char> fallbackName, string attribute)
                 {
                     var id = name.GetAttributeValue(attribute);
@@ -391,9 +394,6 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
 
                     return id;
                 }
-
-                item.TrySetProviderId(MetadataProvider.Tmdb, GetIdFromNameOrPath(justName, fileName, "tmdbid"));
-                item.TrySetProviderId(MetadataProvider.Tvdb, GetIdFromNameOrPath(justName, fileName, "tvdbid"));
 
                 if (!string.IsNullOrEmpty(item.Path))
                 {

--- a/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Movies/MovieResolver.cs
@@ -376,15 +376,24 @@ namespace Emby.Server.Implementations.Library.Resolvers.Movies
                 // We need to only look at the name of this actual item (not parents)
                 var justName = item.IsInMixedFolder ? Path.GetFileName(item.Path.AsSpan()) : Path.GetFileName(item.ContainingFolderPath.AsSpan());
 
-                var tmdbid = justName.GetAttributeValue("tmdbid");
+                // The fallback filename is only used when the item isn't in a mixed folder
+                var fileName = item.IsInMixedFolder ? ReadOnlySpan<char>.Empty : Path.GetFileName(item.Path.AsSpan());
 
-                // If not in a mixed folder and ID not found in folder path, check filename
-                if (string.IsNullOrEmpty(tmdbid) && !item.IsInMixedFolder)
+                string GetIdFromNameOrPath(ReadOnlySpan<char> name, ReadOnlySpan<char> fallbackName, string attribute)
                 {
-                    tmdbid = Path.GetFileName(item.Path.AsSpan()).GetAttributeValue("tmdbid");
+                    var id = name.GetAttributeValue(attribute);
+
+                    // If not in a mixed folder and ID not found in folder path, check filename
+                    if (string.IsNullOrEmpty(id) && !item.IsInMixedFolder)
+                    {
+                        id = fallbackName.GetAttributeValue(attribute);
+                    }
+
+                    return id;
                 }
 
-                item.TrySetProviderId(MetadataProvider.Tmdb, tmdbid);
+                item.TrySetProviderId(MetadataProvider.Tmdb, GetIdFromNameOrPath(justName, fileName, "tmdbid"));
+                item.TrySetProviderId(MetadataProvider.Tvdb, GetIdFromNameOrPath(justName, fileName, "tvdbid"));
 
                 if (!string.IsNullOrEmpty(item.Path))
                 {


### PR DESCRIPTION
We were only parsing `tmdbid` and `imdbid` for movies, so movies could never be identified via a `tvdbid` provider tag, even though series already support this.

**Changes**
Add `tvdbid` parsing support to the movie resolver

**Code assistance**
N/A

**Issues**
N/A
