### PR TITLE
Fix multi-character custom tag delimiters being dropped

### DIFF
--- a/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
+++ b/MediaBrowser.Model/Extensions/LibraryOptionsExtension.cs
@@ -18,16 +18,11 @@ public static class LibraryOptionsExtension
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        var delimiterList = options.CustomTagDelimiters.Select<string, char?>(x =>
-        {
-            var isChar = char.TryParse(x, out var c);
-            if (isChar)
-            {
-                return c;
-            }
-
-            return null;
-        }).Where(x => x is not null).Select(x => x!.Value).ToList();
+        var delimiterList = options.CustomTagDelimiters
+            .Where(x => !string.IsNullOrEmpty(x))
+            .SelectMany(x => x.ToCharArray())
+            .Distinct()
+            .ToList();
         delimiterList.Add('\0');
         return delimiterList.ToArray();
     }

--- a/tests/Jellyfin.Model.Tests/Extensions/LibraryOptionsExtensionTests.cs
+++ b/tests/Jellyfin.Model.Tests/Extensions/LibraryOptionsExtensionTests.cs
@@ -1,0 +1,33 @@
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Extensions;
+using Xunit;
+
+namespace Jellyfin.Model.Tests.Extensions
+{
+    public class LibraryOptionsExtensionTests
+    {
+        [Fact]
+        public void GetCustomTagDelimiters_MultiCharacterEntry_SplitsIntoIndividualCharacters()
+        {
+            var options = new LibraryOptions { CustomTagDelimiters = [",&"] };
+
+            var delimiters = options.GetCustomTagDelimiters();
+
+            Assert.Contains(',', delimiters);
+            Assert.Contains('&', delimiters);
+        }
+
+        [Fact]
+        public void GetCustomTagDelimiters_SingleCharacterEntries_AreKept()
+        {
+            var options = new LibraryOptions { CustomTagDelimiters = ["/", "|", ";", "\\"] };
+
+            var delimiters = options.GetCustomTagDelimiters();
+
+            Assert.Contains('/', delimiters);
+            Assert.Contains('|', delimiters);
+            Assert.Contains(';', delimiters);
+            Assert.Contains('\\', delimiters);
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
Setting a custom tag delimiter to more than one character (the reporter used `,&`) broke tag splitting completely. `GetCustomTagDelimiters` parsed each entry with `char.TryParse`, which only accepts one character, so a multi-char entry got dropped and the library ended up with no delimiters. `María Dueñas, Vienna Symphony & Manfred Honeck` stayed as a single artist, and long names hit `PathTooLongException` on save, so the album showed no artist.

Now each character of an entry is used as a delimiter instead of dropping multi-char entries. Single characters and the defaults (`/ | ; \`) are unchanged. Added a unit test that fails without the fix.

Kept it server-side since the field is really a set of single characters and the web client already stores it that way (`value.split('')`). Supporting real multi-character delimiters would be the bigger change (client and defaults too), happy to go there if you prefer.

**Code assistance**
N/A

**Issues**
Fixes #16917
