### PR TITLE
Fix additional parts for non-admins

### DIFF
--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -492,8 +492,8 @@ namespace MediaBrowser.Controller.Entities
         public IOrderedEnumerable<Video> GetAdditionalParts(User user = null)
         {
             return GetAdditionalPartIds()
-                .Select(i => LibraryManager.GetItemById<Video>(i, user))
-                .Where(i => i is not null)
+                .Select(i => LibraryManager.GetItemById<Video>(i))
+                .Where(i => i is not null && (user is null || i.IsVisible(user)))
                 .OrderBy(i => i.SortName);
         }
 


### PR DESCRIPTION
Since additional parts a "internal" child items, we need to not run the full ACL checks but the lessened, like we do for extras

**Changes**
Use the simpler validation we already use on Extras

**Code assistance**
None

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/5685
