### PR TITLE
Check numeric rating value after splitting country code

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -385,7 +385,7 @@ namespace Emby.Server.Implementations.Localization
 
             // Convert ints directly
             // This may override some of the locale specific age ratings (but those always map to the same age)
-            if (int.TryParse(rating, out var ratingAge))
+            if (TryParseRatingAsScore(rating, out var ratingAge))
             {
                 return new(ratingAge, null);
             }
@@ -487,6 +487,13 @@ namespace Emby.Server.Implementations.Localization
                     return true;
                 }
 
+                // If it's not a recognized rating string, fall back to using the number as the score
+                if (TryParseRatingAsScore(ratingPart, out var numericScore))
+                {
+                    result = new ParentalRatingScore(numericScore, null);
+                    return true;
+                }
+
                 _logger.LogWarning(
                     "Rating '{Rating}' not found in the '{CountryCode}' rating system, treating as unrated",
                     rating,
@@ -499,6 +506,18 @@ namespace Emby.Server.Implementations.Localization
             result = GetRatingScore(ratingPart, resolvedCountryCode);
 
             return true;
+        }
+
+        /// <summary>
+        /// Tries to parse a rating as a number, allowing an optional trailing '+' (e.g. "16" or "18+").
+        /// </summary>
+        /// <param name="ratingValue">Rating value to parse.</param>
+        /// <param name="score">Parsed score.</param>
+        /// <returns>Returns true if parsing was successful.</returns>
+        private static bool TryParseRatingAsScore(string ratingValue, out int score)
+        {
+            var trimmed = ratingValue.TrimEnd('+');
+            return int.TryParse(trimmed, out score);
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -514,7 +514,7 @@ namespace Emby.Server.Implementations.Localization
         /// <param name="ratingValue">Rating value to parse.</param>
         /// <param name="score">Parsed score.</param>
         /// <returns>Returns true if parsing was successful.</returns>
-        private static bool TryParseRatingAsScore(string ratingValue, out int score)
+        private static bool TryParseRatingAsScore(ReadOnlySpan<char> ratingValue, out int score)
         {
             var trimmed = ratingValue.TrimEnd('+');
             return int.TryParse(trimmed, out score);


### PR DESCRIPTION
We were already converting plain numeric ratings straight to a score, e.g., a rating of 16 became a score of 16. But we only did that as a whole, not when a country code was present. So GR-16 would not match and would be treated as unrated.

**Changes**
- After splitting a rating into country code & rating, if there is no match, try parsing it as a plain number before giving up and treating it as unrated.
- Also handle a trailing "+"  so  JP-18+ will be be scored as `18` 

**Code assistance**
N/A

**Issues**
I've been seeing lots of log reports with parental rating being treated as unrated when there is a numerical value and a country code present. 

[2026-07-08 02:51:46.466 +03:00] [WRN] [32] Emby.Server.Implementations.Localization.LocalizationManager: Rating '"GR-16"' not found in the '"GR"' rating system, treating as unrated