### PR TITLE
support external images for audiobooks

### DIFF
--- a/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
+++ b/MediaBrowser.LocalMetadata/Images/LocalImageProvider.cs
@@ -84,7 +84,7 @@ namespace MediaBrowser.LocalMetadata.Images
             if (item.SupportsLocalMetadata)
             {
                 // Episode has its own provider
-                if (item is Episode || item is Audio || item is Photo)
+                if (item is Episode || (item is Audio && item is not AudioBook) || item is Photo)
                 {
                     return false;
                 }

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -90,7 +90,7 @@ namespace MediaBrowser.Providers.Manager
         {
             ArgumentException.ThrowIfNullOrEmpty(mimeType);
 
-            var saveLocally = item.SupportsLocalMetadata && item.IsSaveLocalMetadataEnabled() && !item.ExtraType.HasValue && item is not Audio;
+            var saveLocally = item.SupportsLocalMetadata && item.IsSaveLocalMetadataEnabled() && !item.ExtraType.HasValue && (item is AudioBook || item is not Audio);
 
             if (type != ImageType.Primary && item is Episode)
             {


### PR DESCRIPTION
**Changes**

At the moment only embedded images are supported for audiobooks. This adds external image support, which is currently referenced in our documentation.

**Code Assistance**

None

**Issues**

None