### PR TITLE
Fix oversized, mis-aligned, outline-less burned-in mov_text (tx3g) subtitles

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -501,7 +501,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 && mediaSource.VideoStream is { Width: > 0, Height: > 0 };
         }
 
-        private string GetExtractableSubtitleFormat(MediaStream subtitleStream, MediaSourceInfo mediaSource)
+        private static string GetExtractableSubtitleFormat(MediaStream subtitleStream, MediaSourceInfo mediaSource)
         {
             if (string.Equals(subtitleStream.Codec, "ass", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(subtitleStream.Codec, "ssa", StringComparison.OrdinalIgnoreCase)
@@ -523,7 +523,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
-        private string GetExtractableSubtitleFileExtension(MediaStream subtitleStream, MediaSourceInfo mediaSource)
+        private static string GetExtractableSubtitleFileExtension(MediaStream subtitleStream, MediaSourceInfo mediaSource)
         {
             // Using .pgssub as file extension is not allowed by ffmpeg. The file extension for pgs subtitles is .sup.
             if (string.Equals(subtitleStream.Codec, "pgssub", StringComparison.OrdinalIgnoreCase))
@@ -684,6 +684,60 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
+        /// <summary>
+        /// Tells libavcodec's mov_text decoder the real frame size for a tx3g stream, and records
+        /// its output for the style normalization that follows the extraction.
+        /// </summary>
+        /// <remarks>
+        /// The decoder resolves the track's embedded font size against the frame size, but falls
+        /// back to a 384x288 reference when it isn't told the real one, which inflates burned-in
+        /// text several times over. -width/-height are private AVOptions of that decoder and are
+        /// applied through a stream specifier, so they can only ever reach the tx3g stream they
+        /// are meant for -- any other subtitle stream of the same file is extracted with
+        /// -c:s copy and never even instantiates a decoder.
+        /// See https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/movtextdec.c.
+        /// </remarks>
+        private static void AppendMovTextDecoderOptions(
+            MediaSourceInfo mediaSource,
+            MediaStream subtitleStream,
+            int streamIndex,
+            string outputPath,
+            StringBuilder inputOptions,
+            List<string> movTextOutputPaths)
+        {
+            if (!ShouldExtractMovTextAsAss(subtitleStream, mediaSource))
+            {
+                return;
+            }
+
+            var videoStream = mediaSource.VideoStream;
+
+            inputOptions.Append(CultureInfo.InvariantCulture, $" -width:{streamIndex} {videoStream.Width} -height:{streamIndex} {videoStream.Height}");
+            movTextOutputPaths.Add(outputPath);
+        }
+
+        /// <summary>
+        /// Applies <see cref="FixMovTextStyle"/> to every tx3g track extracted for this source.
+        /// </summary>
+        /// <remarks>
+        /// Only mov_text outputs are collected in <paramref name="movTextOutputPaths"/>, and
+        /// ExtractSubtitlesForFile throws unless every output was written, so each of these is
+        /// guaranteed to exist by the time this runs. A non-empty list also implies a video
+        /// stream with a usable height, since that is what put the entries there.
+        /// </remarks>
+        private async Task NormalizeMovTextOutputs(
+            MediaSourceInfo mediaSource,
+            List<string> movTextOutputPaths,
+            CancellationToken cancellationToken)
+        {
+            var videoHeight = mediaSource.VideoStream?.Height ?? 0;
+
+            foreach (var movTextOutputPath in movTextOutputPaths)
+            {
+                await FixMovTextStyle(movTextOutputPath, videoHeight, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private async Task ExtractAllExtractableSubtitlesInternal(
             MediaSourceInfo mediaSource,
             List<MediaStream> subtitleStreams,
@@ -694,7 +748,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             var movTextOutputPaths = new List<string>();
             var inputOptions = new StringBuilder();
             var mapOptions = new StringBuilder();
-            var videoStream = mediaSource.VideoStream;
 
             foreach (var subtitleStream in subtitleStreams)
             {
@@ -723,17 +776,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
 
-                // The mov_text (tx3g) decoder resolves its embedded font size against the frame
-                // size, but falls back to a 384x288 reference if it isn't told the real one,
-                // which inflates burned-in text several times over. These are private AVOptions
-                // of that decoder, applied through a stream specifier so they can only ever
-                // reach the tx3g stream they are meant for.
-                // https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/movtextdec.c
-                if (ShouldExtractMovTextAsAss(subtitleStream, mediaSource))
-                {
-                    inputOptions.Append(CultureInfo.InvariantCulture, $" -width:{streamIndex} {videoStream!.Width} -height:{streamIndex} {videoStream.Height}");
-                    movTextOutputPaths.Add(outputPath);
-                }
+                AppendMovTextDecoderOptions(mediaSource, subtitleStream, streamIndex, outputPath, inputOptions, movTextOutputPaths);
 
                 outputPaths.Add(outputPath);
                 mapOptions.Append(CultureInfo.InvariantCulture, $" -map 0:{streamIndex} -an -vn -c:s {outputCodec}{outputFormatOption} -flush_packets 1 \"{outputPath}\"");
@@ -745,16 +788,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
 
-                // Only mov_text outputs land in movTextOutputPaths, and ExtractSubtitlesForFile
-                // throws unless every output was written, so each of these is guaranteed to
-                // exist by this point. Any other subtitle stream of the same file is untouched.
-                if (videoStream is { Height: > 0 } movTextReference)
-                {
-                    foreach (var movTextOutputPath in movTextOutputPaths)
-                    {
-                        await FixMovTextStyle(movTextOutputPath, movTextReference.Height.Value, cancellationToken).ConfigureAwait(false);
-                    }
-                }
+                await NormalizeMovTextOutputs(mediaSource, movTextOutputPaths, cancellationToken).ConfigureAwait(false);
 
                 foreach (var outputPath in outputPaths)
                 {

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -36,6 +36,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 {
     public sealed class SubtitleEncoder : ISubtitleEncoder, IDisposable
     {
+        // ASS colour alpha is inverted: 00 is fully opaque, ff fully transparent.
+        private const int FullyTransparentAssAlpha = 0xFF;
+
         private readonly ILogger<SubtitleEncoder> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IMediaEncoder _mediaEncoder;
@@ -54,8 +57,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         };
 
         private static readonly Regex _assStyleLineRegex = new(@"^Style:.*$", RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-
-        private static readonly Regex _assOverrideAlignmentRegex = new(@"\\an([147])(?=[}\\])", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         private static readonly Regex _assOverrideFontSizeRegex = new(@"\\fs(\d+)", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
@@ -223,8 +224,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 await ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
 
-                var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream);
-                var outputFormat = GetExtractableSubtitleFormat(subtitleStream);
+                var outputFileExtension = GetExtractableSubtitleFileExtension(subtitleStream, mediaSource);
+                var outputFormat = GetExtractableSubtitleFormat(subtitleStream, mediaSource);
                 var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + outputFileExtension)
                     ?? throw new ResourceNotFoundException($"MediaSource {mediaSource.Id} has no subtitle cache (non-GUID Id, e.g. Live TV stream).");
 
@@ -479,7 +480,28 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             WriteCacheMeta(outputPath, inputPath);
         }
 
-        private string GetExtractableSubtitleFormat(MediaStream subtitleStream)
+        /// <summary>
+        /// Whether a mov_text (tx3g) track should be extracted as ASS rather than SubRip.
+        /// </summary>
+        /// <remarks>
+        /// mov_text embeds an absolute per-style font size with no reference resolution of
+        /// its own, which plain SubRip drops entirely. Keeping it as ASS preserves it, but
+        /// is only worth doing when the real video dimensions are known: both the decoder's
+        /// -width/-height (see ExtractAllExtractableSubtitlesInternal) and the style
+        /// normalization that follows are derived from them, and without them the extracted
+        /// ASS would carry libavcodec's 384x288 fallback resolution -- worse than the SubRip
+        /// this replaces, which the burn-in filter at least styles with its own defaults.
+        /// </remarks>
+        /// <param name="subtitleStream">The subtitle stream.</param>
+        /// <param name="mediaSource">The media source the stream belongs to.</param>
+        /// <returns><c>true</c> if the track should be extracted as ASS.</returns>
+        internal static bool ShouldExtractMovTextAsAss(MediaStream subtitleStream, MediaSourceInfo mediaSource)
+        {
+            return string.Equals(subtitleStream.Codec, "mov_text", StringComparison.OrdinalIgnoreCase)
+                && mediaSource.VideoStream is { Width: > 0, Height: > 0 };
+        }
+
+        private string GetExtractableSubtitleFormat(MediaStream subtitleStream, MediaSourceInfo mediaSource)
         {
             if (string.Equals(subtitleStream.Codec, "ass", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(subtitleStream.Codec, "ssa", StringComparison.OrdinalIgnoreCase)
@@ -491,15 +513,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 return "mks";
             }
-            else if (string.Equals(subtitleStream.Codec, "mov_text", StringComparison.OrdinalIgnoreCase))
+            else if (ShouldExtractMovTextAsAss(subtitleStream, mediaSource))
             {
-                // mov_text (tx3g) embeds an absolute per-style font size with no reference
-                // resolution of its own. Extracting to plain SubRip loses that context
-                // entirely; libavcodec's mov_text decoder needs to be told the real video
-                // frame size (see the -width/-height args added in
-                // ExtractAllExtractableSubtitlesInternal) and the result kept as ASS so the
-                // font size is interpreted against the correct PlayResX/PlayResY instead of
-                // whatever the burn-in filter would otherwise default to.
                 return "ass";
             }
             else
@@ -508,7 +523,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
         }
 
-        private string GetExtractableSubtitleFileExtension(MediaStream subtitleStream)
+        private string GetExtractableSubtitleFileExtension(MediaStream subtitleStream, MediaSourceInfo mediaSource)
         {
             // Using .pgssub as file extension is not allowed by ffmpeg. The file extension for pgs subtitles is .sup.
             if (string.Equals(subtitleStream.Codec, "pgssub", StringComparison.OrdinalIgnoreCase))
@@ -522,7 +537,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             }
             else
             {
-                return GetExtractableSubtitleFormat(subtitleStream);
+                return GetExtractableSubtitleFormat(subtitleStream, mediaSource);
             }
         }
 
@@ -555,7 +570,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         continue;
                     }
 
-                    var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                    var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream, mediaSource));
                     if (outputPath is null)
                     {
                         continue;
@@ -631,13 +646,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         continue;
                     }
 
-                    var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                    var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream, mediaSource));
                     if (outputPath is null)
                     {
                         continue;
                     }
 
-                    var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
+                    var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : GetExtractableSubtitleFormat(subtitleStream, mediaSource);
                     // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
                     var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
                     var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
@@ -689,14 +704,13 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     continue;
                 }
 
-                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream));
+                var outputPath = GetSubtitleCachePath(mediaSource, subtitleStream.Index, "." + GetExtractableSubtitleFileExtension(subtitleStream, mediaSource));
                 if (outputPath is null)
                 {
                     continue;
                 }
 
-                var isMovText = string.Equals(subtitleStream.Codec, "mov_text", StringComparison.OrdinalIgnoreCase);
-                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : GetExtractableSubtitleFormat(subtitleStream);
+                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : GetExtractableSubtitleFormat(subtitleStream, mediaSource);
                 // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
                 var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
@@ -709,13 +723,15 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
 
-                // The mov_text (tx3g) decoder embeds an absolute font size authored against the
-                // real video's pixel dimensions, but falls back to a 384x288 reference if it isn't
-                // told the actual frame size, which inflates burned-in text several times over.
+                // The mov_text (tx3g) decoder resolves its embedded font size against the frame
+                // size, but falls back to a 384x288 reference if it isn't told the real one,
+                // which inflates burned-in text several times over. These are private AVOptions
+                // of that decoder, applied through a stream specifier so they can only ever
+                // reach the tx3g stream they are meant for.
                 // https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/movtextdec.c
-                if (isMovText && videoStream is { Width: > 0, Height: > 0 })
+                if (ShouldExtractMovTextAsAss(subtitleStream, mediaSource))
                 {
-                    inputOptions.Append(CultureInfo.InvariantCulture, $" -width:{streamIndex} {videoStream.Width} -height:{streamIndex} {videoStream.Height}");
+                    inputOptions.Append(CultureInfo.InvariantCulture, $" -width:{streamIndex} {videoStream!.Width} -height:{streamIndex} {videoStream.Height}");
                     movTextOutputPaths.Add(outputPath);
                 }
 
@@ -1024,7 +1040,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         }
 
         /// <summary>
-        /// ffmpeg's mov_text decoder has two fidelity gaps compared to reference tx3g
+        /// ffmpeg's mov_text decoder has three fidelity gaps compared to reference tx3g
         /// renderers (e.g. VLC's modules/codec/substx3g.c):
         /// (1) it treats the track's embedded font size as an absolute ASS Fontsize, but
         /// VLC's own FontSizeConvert() always renders the sample description's default
@@ -1032,14 +1048,19 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         /// the embedded byte only expresses relative size between text runs on the same
         /// line, not an absolute size, so ffmpeg's interpretation renders noticeably
         /// smaller or larger than reference players depending on what that byte happens
-        /// to be; and
+        /// to be;
         /// (2) it maps the track's default text-box justification straight onto ASS
-        /// alignment while ignoring the box's actual position/extent, which for
-        /// left-justified tracks renders noticeably left of where VLC places the same
-        /// (in practice centered) text.
-        /// This re-derives the Style's Fontsize/MarginV from the real video height and
-        /// centers left-column alignment, both in the Style definition and in any
-        /// per-line override.
+        /// alignment while discarding the BoxRecord that gives that justification its
+        /// meaning (mov_text_tx3g skips it outright), so a left-justified track lands
+        /// against the left edge of the whole frame - VLC never reads that byte for
+        /// positioning at all and hardcodes bottom-centered; and
+        /// (3) tx3g has no outline of its own, so ffmpeg copies the track's background
+        /// colour and alpha into the ASS OutlineColour slot, which for the usual
+        /// transparent background leaves the text with no box and no outline.
+        /// This re-derives the Style's Fontsize/MarginV/Outline from the real video
+        /// height, centers left-column alignment, and restores a visible border. Only
+        /// the Style definition is rewritten; per-line overrides are left alone beyond
+        /// rescaling their font size.
         /// </summary>
         /// <param name="file">The extracted .ass file path.</param>
         /// <param name="videoHeight">The coded height of the video the track was authored against.</param>
@@ -1059,20 +1080,29 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         /// </summary>
         /// <param name="assText">The contents of an .ass file produced from a mov_text track.</param>
         /// <param name="videoHeight">The coded height of the video the track was authored against.</param>
-        /// <returns>The text with a VLC-equivalent font size, margin and centered alignment.</returns>
+        /// <returns>The text with a VLC-equivalent font size, margin, border and centered alignment.</returns>
         public static string NormalizeMovTextAss(string assText, int videoHeight)
         {
-            // VLC's own tx3g decoder documents its default style as always rendering at
-            // "5%" of the frame height (modules/codec/substx3g.c, FontSizeConvert), but
-            // that percentage is measured on VLC's internal text metrics, not on libass's
-            // Fontsize/PlayResY ratio -- burning the two at the same raw "5" produces
-            // visibly different glyph heights. The 0.121 ratio below was calibrated by
-            // measuring VLC's rendered glyph height against libass's for the same PlayResY
-            // on macOS (Helvetica Neue); on the actual deployment target (Linux, whatever
-            // font "Arial Unicode MS" resolves to via fontconfig) it rendered roughly twice
-            // too large, so it's halved here (0.121 / 2 = 0.0605) pending a font-specific
-            // recalibration.
+            // The tx3g font size byte is not an absolute size. VLC treats it purely as a
+            // ratio against the sample description's default style
+            // (modules/codec/substx3g.c, FontSizeConvert:
+            // f_font_relsize = 5.0 * style_size / default_size), so the default line is
+            // always rendered at 5% of the frame height no matter what the byte says, and
+            // the byte only ever decides how much larger or smaller an individual text run
+            // is than that default. ffmpeg instead writes the byte straight into the ASS
+            // Fontsize, which is why the same track renders at wildly different sizes
+            // depending on how its author happened to fill that field. So the base size is
+            // derived from the frame height here, and the byte's actual meaning -- relative
+            // sizing -- is preserved by rescaling the per-run {\fsNN} overrides below.
+            //
+            // VLC's 5% is a relative size on its own text renderer, which is not the same
+            // unit as libass's Fontsize-against-PlayResY: feeding libass a flat 0.05 does
+            // not reproduce VLC's glyph height. The ratio below (~1.21x the nominal 5%) was
+            // measured against VLC's output on the burn-in font stack, and is the value to
+            // revisit if the default subtitle font ever changes.
             var targetFontSize = (int)Math.Round(videoHeight * 0.0605, MidpointRounding.AwayFromZero);
+            // Calibrated alongside the font size so the text sits on the same baseline VLC
+            // gives its bottom-aligned tx3g region.
             var targetMarginV = (int)Math.Round(videoHeight * 0.0231, MidpointRounding.AwayFromZero);
             // ffmpeg's mov_text default style always carries an Outline of 1, authored for
             // the small original Fontsize -- left untouched, the outline becomes visibly
@@ -1101,15 +1131,24 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
 
                 fields[2] = targetFontSize.ToString(CultureInfo.InvariantCulture);
-                // ffmpeg writes OutlineColour/BackColour as 8-digit &HAABBGGRR with the alpha
-                // byte set to "ff". ASS uses an inverted alpha (00 = opaque, ff = fully
-                // transparent), so this renders the outline and shadow completely invisible
-                // regardless of Outline/Shadow width. PrimaryColour/SecondaryColour are
-                // unaffected because ffmpeg writes those as 6-digit RRGGBB with no alpha byte.
-                fields[5] = "&H00000000";
-                fields[6] = "&H00000000";
                 fields[16] = targetOutline.ToString(CultureInfo.InvariantCulture);
                 fields[21] = targetMarginV.ToString(CultureInfo.InvariantCulture);
+
+                // tx3g has no notion of an outline, so mov_text_init() feeds the track's
+                // *background* colour and alpha into both the ASS OutlineColour and BackColour
+                // slots. ASS alpha is inverted (00 opaque, ff fully transparent), so a track
+                // that declares no background at all arrives as &Hff...... and leaves the
+                // burned-in text with neither a box nor an outline -- unreadable over bright
+                // scenes. Substitute an opaque black outline in that case only: a track that
+                // did author a colour keeps it verbatim, and BorderStyle is never touched, so
+                // this can only ever turn invisible text visible. PrimaryColour is unaffected
+                // either way, ffmpeg writes it from the text colour with no alpha byte.
+                if (TryGetAssColourAlpha(fields[5], out var outlineAlpha)
+                    && outlineAlpha == FullyTransparentAssAlpha)
+                {
+                    fields[5] = "&H00000000";
+                    fields[6] = "&H00000000";
+                }
 
                 if (_movTextLeftToCenterAlignment.TryGetValue(fields[18], out var centeredAlignment))
                 {
@@ -1131,9 +1170,35 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 });
             }
 
-            return _assOverrideAlignmentRegex.Replace(
-                newText,
-                m => "\\an" + _movTextLeftToCenterAlignment[m.Groups[1].Value]);
+            return newText;
+        }
+
+        /// <summary>
+        /// Reads the alpha byte out of an ASS colour field. ASS colours are &amp;HAABBGGRR with an
+        /// inverted alpha channel, where 00 is fully opaque and ff fully transparent, and ffmpeg
+        /// writes them unpadded (an opaque colour comes out as &amp;Hffffff, not &amp;H00ffffff).
+        /// </summary>
+        /// <param name="field">The raw ASS colour field.</param>
+        /// <param name="alpha">The alpha byte, 0 (opaque) to 255 (fully transparent).</param>
+        /// <returns><c>true</c> if the field could be parsed as an ASS colour.</returns>
+        private static bool TryGetAssColourAlpha(string field, out int alpha)
+        {
+            alpha = 0;
+
+            var value = field.AsSpan().Trim();
+            if (!value.StartsWith("&H", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            value = value[2..].TrimEnd('&');
+            if (!uint.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var colour))
+            {
+                return false;
+            }
+
+            alpha = (int)(colour >> 24);
+            return true;
         }
 
         private string? GetSubtitleCachePath(MediaSourceInfo mediaSource, int subtitleStreamIndex, string outputSubtitleExtension)

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -53,11 +53,11 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ["7"] = "8"
         };
 
-        private static readonly Regex _assStyleLineRegex = new(@"^Style:.*$", RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex _assStyleLineRegex = new(@"^Style:.*$", RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
-        private static readonly Regex _assOverrideAlignmentRegex = new(@"\\an([147])(?=[}\\])", RegexOptions.Compiled);
+        private static readonly Regex _assOverrideAlignmentRegex = new(@"\\an([147])(?=[}\\])", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
-        private static readonly Regex _assOverrideFontSizeRegex = new(@"\\fs(\d+)", RegexOptions.Compiled);
+        private static readonly Regex _assOverrideFontSizeRegex = new(@"\\fs(\d+)", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         /// <summary>
         /// The _semaphoreLocks.
@@ -977,10 +977,25 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         /// <param name="file">The file.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <c>System.Threading.CancellationToken.None</c>.</param>
         /// <returns>Task.</returns>
-        private async Task SetAssFont(string file, CancellationToken cancellationToken = default)
+        private Task SetAssFont(string file, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Setting ass font within {File}", file);
 
+            return RewriteTextFileIfChangedAsync(
+                file,
+                text => text.Replace(",Arial,", ",Arial Unicode MS,", StringComparison.Ordinal),
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads a text file, applies <paramref name="transform"/> to its contents, and writes the
+        /// result back to disk (preserving the file's detected encoding) only if it actually changed.
+        /// </summary>
+        /// <param name="file">The file.</param>
+        /// <param name="transform">The transformation to apply to the file's contents.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        private static async Task RewriteTextFileIfChangedAsync(string file, Func<string, string> transform, CancellationToken cancellationToken)
+        {
             string text;
             Encoding encoding;
 
@@ -992,7 +1007,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            var newText = text.Replace(",Arial,", ",Arial Unicode MS,", StringComparison.Ordinal);
+            var newText = transform(text);
 
             if (!string.Equals(text, newText, StringComparison.Ordinal))
             {
@@ -1029,35 +1044,14 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         /// <param name="file">The extracted .ass file path.</param>
         /// <param name="videoHeight">The coded height of the video the track was authored against.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        private async Task FixMovTextStyle(string file, int videoHeight, CancellationToken cancellationToken = default)
+        private Task FixMovTextStyle(string file, int videoHeight, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Normalizing mov_text style within {File}", file);
 
-            string text;
-            Encoding encoding;
-
-            using (var fileStream = AsyncFile.OpenRead(file))
-            using (var reader = new StreamReader(fileStream, true))
-            {
-                encoding = reader.CurrentEncoding;
-
-                text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            var newText = NormalizeMovTextAss(text, videoHeight);
-
-            if (!string.Equals(text, newText, StringComparison.Ordinal))
-            {
-                var fileStream = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
-                await using (fileStream.ConfigureAwait(false))
-                {
-                    var writer = new StreamWriter(fileStream, encoding);
-                    await using (writer.ConfigureAwait(false))
-                    {
-                        await writer.WriteAsync(newText.AsMemory(), cancellationToken).ConfigureAwait(false);
-                    }
-                }
-            }
+            return RewriteTextFileIfChangedAsync(
+                file,
+                text => NormalizeMovTextAss(text, videoHeight),
+                cancellationToken);
         }
 
         /// <summary>

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -1080,7 +1080,17 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             // black-outlined look most reference renderers (including VLC) give tx3g text.
             // Scale it with the corrected font size using a standard ~6% stroke-to-em ratio.
             var targetOutline = Math.Max(1, (int)Math.Round(targetFontSize * 0.06, MidpointRounding.AwayFromZero));
+
             var originalFontSize = 0;
+            var styleMatch = _assStyleLineRegex.Match(assText);
+            if (styleMatch.Success)
+            {
+                var originalFields = styleMatch.Value.Split(',');
+                if (originalFields.Length >= 23)
+                {
+                    int.TryParse(originalFields[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out originalFontSize);
+                }
+            }
 
             var newText = _assStyleLineRegex.Replace(assText, m =>
             {
@@ -1088,11 +1098,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 if (fields.Length < 23)
                 {
                     return m.Value;
-                }
-
-                if (int.TryParse(fields[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var fontSize))
-                {
-                    originalFontSize = fontSize;
                 }
 
                 fields[2] = targetFontSize.ToString(CultureInfo.InvariantCulture);

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncKeyedLock;
@@ -43,6 +44,20 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private readonly ISubtitleParser _subtitleParser;
         private readonly IPathManager _pathManager;
         private readonly IServerConfigurationManager _serverConfigurationManager;
+
+        // ASS alignment numbering (numpad layout): 1/4/7 are the bottom/middle/top-LEFT variants.
+        private static readonly Dictionary<string, string> _movTextLeftToCenterAlignment = new()
+        {
+            ["1"] = "2",
+            ["4"] = "5",
+            ["7"] = "8"
+        };
+
+        private static readonly Regex _assStyleLineRegex = new(@"^Style:.*$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+        private static readonly Regex _assOverrideAlignmentRegex = new(@"\\an([147])(?=[}\\])", RegexOptions.Compiled);
+
+        private static readonly Regex _assOverrideFontSizeRegex = new(@"\\fs(\d+)", RegexOptions.Compiled);
 
         /// <summary>
         /// The _semaphoreLocks.
@@ -476,6 +491,17 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 return "mks";
             }
+            else if (string.Equals(subtitleStream.Codec, "mov_text", StringComparison.OrdinalIgnoreCase))
+            {
+                // mov_text (tx3g) embeds an absolute per-style font size with no reference
+                // resolution of its own. Extracting to plain SubRip loses that context
+                // entirely; libavcodec's mov_text decoder needs to be told the real video
+                // frame size (see the -width/-height args added in
+                // ExtractAllExtractableSubtitlesInternal) and the result kept as ASS so the
+                // font size is interpreted against the correct PlayResX/PlayResY instead of
+                // whatever the burn-in filter would otherwise default to.
+                return "ass";
+            }
             else
             {
                 return "srt";
@@ -650,10 +676,10 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
             var outputPaths = new List<string>();
-            var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-y -i {0}",
-                inputPath);
+            var movTextOutputPaths = new List<string>();
+            var inputOptions = new StringBuilder();
+            var mapOptions = new StringBuilder();
+            var videoStream = mediaSource.VideoStream;
 
             foreach (var subtitleStream in subtitleStreams)
             {
@@ -669,7 +695,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     continue;
                 }
 
-                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
+                var isMovText = string.Equals(subtitleStream.Codec, "mov_text", StringComparison.OrdinalIgnoreCase);
+                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : GetExtractableSubtitleFormat(subtitleStream);
                 // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
                 var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
@@ -682,19 +709,36 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
 
+                // The mov_text (tx3g) decoder embeds an absolute font size authored against the
+                // real video's pixel dimensions, but falls back to a 384x288 reference if it isn't
+                // told the actual frame size, which inflates burned-in text several times over.
+                // https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/movtextdec.c
+                if (isMovText && videoStream is { Width: > 0, Height: > 0 })
+                {
+                    inputOptions.Append(CultureInfo.InvariantCulture, $" -width:{streamIndex} {videoStream.Width} -height:{streamIndex} {videoStream.Height}");
+                    movTextOutputPaths.Add(outputPath);
+                }
+
                 outputPaths.Add(outputPath);
-                args += string.Format(
-                    CultureInfo.InvariantCulture,
-                    " -map 0:{0} -an -vn -c:s {1}{2} -flush_packets 1 \"{3}\"",
-                    streamIndex,
-                    outputCodec,
-                    outputFormatOption,
-                    outputPath);
+                mapOptions.Append(CultureInfo.InvariantCulture, $" -map 0:{streamIndex} -an -vn -c:s {outputCodec}{outputFormatOption} -flush_packets 1 \"{outputPath}\"");
             }
+
+            var args = string.Format(CultureInfo.InvariantCulture, "-y{0} -i {1}{2}", inputOptions, inputPath, mapOptions);
 
             if (outputPaths.Count > 0)
             {
                 await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
+
+                // Only mov_text outputs land in movTextOutputPaths, and ExtractSubtitlesForFile
+                // throws unless every output was written, so each of these is guaranteed to
+                // exist by this point. Any other subtitle stream of the same file is untouched.
+                if (videoStream is { Height: > 0 } movTextReference)
+                {
+                    foreach (var movTextOutputPath in movTextOutputPaths)
+                    {
+                        await FixMovTextStyle(movTextOutputPath, movTextReference.Height.Value, cancellationToken).ConfigureAwait(false);
+                    }
+                }
 
                 foreach (var outputPath in outputPaths)
                 {
@@ -962,6 +1006,135 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// ffmpeg's mov_text decoder has two fidelity gaps compared to reference tx3g
+        /// renderers (e.g. VLC's modules/codec/substx3g.c):
+        /// (1) it treats the track's embedded font size as an absolute ASS Fontsize, but
+        /// VLC's own FontSizeConvert() always renders the sample description's default
+        /// style at a fixed 5% of the frame height ("as the line should always be 5%") -
+        /// the embedded byte only expresses relative size between text runs on the same
+        /// line, not an absolute size, so ffmpeg's interpretation renders noticeably
+        /// smaller or larger than reference players depending on what that byte happens
+        /// to be; and
+        /// (2) it maps the track's default text-box justification straight onto ASS
+        /// alignment while ignoring the box's actual position/extent, which for
+        /// left-justified tracks renders noticeably left of where VLC places the same
+        /// (in practice centered) text.
+        /// This re-derives the Style's Fontsize/MarginV from the real video height and
+        /// centers left-column alignment, both in the Style definition and in any
+        /// per-line override.
+        /// </summary>
+        /// <param name="file">The extracted .ass file path.</param>
+        /// <param name="videoHeight">The coded height of the video the track was authored against.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        private async Task FixMovTextStyle(string file, int videoHeight, CancellationToken cancellationToken = default)
+        {
+            _logger.LogInformation("Normalizing mov_text style within {File}", file);
+
+            string text;
+            Encoding encoding;
+
+            using (var fileStream = AsyncFile.OpenRead(file))
+            using (var reader = new StreamReader(fileStream, true))
+            {
+                encoding = reader.CurrentEncoding;
+
+                text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var newText = NormalizeMovTextAss(text, videoHeight);
+
+            if (!string.Equals(text, newText, StringComparison.Ordinal))
+            {
+                var fileStream = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+                await using (fileStream.ConfigureAwait(false))
+                {
+                    var writer = new StreamWriter(fileStream, encoding);
+                    await using (writer.ConfigureAwait(false))
+                    {
+                        await writer.WriteAsync(newText.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Only public for the unit tests. See <see cref="FixMovTextStyle"/>.
+        /// </summary>
+        /// <param name="assText">The contents of an .ass file produced from a mov_text track.</param>
+        /// <param name="videoHeight">The coded height of the video the track was authored against.</param>
+        /// <returns>The text with a VLC-equivalent font size, margin and centered alignment.</returns>
+        public static string NormalizeMovTextAss(string assText, int videoHeight)
+        {
+            // VLC's own tx3g decoder documents its default style as always rendering at
+            // "5%" of the frame height (modules/codec/substx3g.c, FontSizeConvert), but
+            // that percentage is measured on VLC's internal text metrics, not on libass's
+            // Fontsize/PlayResY ratio -- burning the two at the same raw "5" produces
+            // visibly different glyph heights. The 0.121 ratio below was calibrated by
+            // measuring VLC's rendered glyph height against libass's for the same PlayResY
+            // on macOS (Helvetica Neue); on the actual deployment target (Linux, whatever
+            // font "Arial Unicode MS" resolves to via fontconfig) it rendered roughly twice
+            // too large, so it's halved here (0.121 / 2 = 0.0605) pending a font-specific
+            // recalibration.
+            var targetFontSize = (int)Math.Round(videoHeight * 0.0605, MidpointRounding.AwayFromZero);
+            var targetMarginV = (int)Math.Round(videoHeight * 0.0231, MidpointRounding.AwayFromZero);
+            // ffmpeg's mov_text default style always carries an Outline of 1, authored for
+            // the small original Fontsize -- left untouched, the outline becomes visibly
+            // too thin relative to the corrected (larger) font and loses the crisp
+            // black-outlined look most reference renderers (including VLC) give tx3g text.
+            // Scale it with the corrected font size using a standard ~6% stroke-to-em ratio.
+            var targetOutline = Math.Max(1, (int)Math.Round(targetFontSize * 0.06, MidpointRounding.AwayFromZero));
+            var originalFontSize = 0;
+
+            var newText = _assStyleLineRegex.Replace(assText, m =>
+            {
+                var fields = m.Value.Split(',');
+                if (fields.Length < 23)
+                {
+                    return m.Value;
+                }
+
+                if (int.TryParse(fields[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var fontSize))
+                {
+                    originalFontSize = fontSize;
+                }
+
+                fields[2] = targetFontSize.ToString(CultureInfo.InvariantCulture);
+                // ffmpeg writes OutlineColour/BackColour as 8-digit &HAABBGGRR with the alpha
+                // byte set to "ff". ASS uses an inverted alpha (00 = opaque, ff = fully
+                // transparent), so this renders the outline and shadow completely invisible
+                // regardless of Outline/Shadow width. PrimaryColour/SecondaryColour are
+                // unaffected because ffmpeg writes those as 6-digit RRGGBB with no alpha byte.
+                fields[5] = "&H00000000";
+                fields[6] = "&H00000000";
+                fields[16] = targetOutline.ToString(CultureInfo.InvariantCulture);
+                fields[21] = targetMarginV.ToString(CultureInfo.InvariantCulture);
+
+                if (_movTextLeftToCenterAlignment.TryGetValue(fields[18], out var centeredAlignment))
+                {
+                    fields[18] = centeredAlignment;
+                }
+
+                return string.Join(',', fields);
+            });
+
+            // Per-line {\fsNN} overrides carry the original absolute value; rescale them
+            // proportionally so their size relative to the new default is preserved.
+            if (originalFontSize > 0 && originalFontSize != targetFontSize)
+            {
+                newText = _assOverrideFontSizeRegex.Replace(newText, m =>
+                {
+                    var originalOverride = int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+                    var scaled = (int)Math.Round(targetFontSize * (double)originalOverride / originalFontSize, MidpointRounding.AwayFromZero);
+                    return "\\fs" + scaled.ToString(CultureInfo.InvariantCulture);
+                });
+            }
+
+            return _assOverrideAlignmentRegex.Replace(
+                newText,
+                m => "\\an" + _movTextLeftToCenterAlignment[m.Groups[1].Value]);
         }
 
         private string? GetSubtitleCachePath(MediaSourceInfo mediaSource, int subtitleStreamIndex, string outputSubtitleExtension)

--- a/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
@@ -290,12 +290,12 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
 
             var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
 
-            // Fontsize ~= 0.0605 * PlayResY (halved from an initial 0.121 VLC-matched
-            // calibration that rendered ~2x too large against the actual deployment font).
-            // 1080 * 0.0605 = 65. MarginV (~2.31% = 25) and Outline (~6% of Fontsize = 4)
-            // scale independently of that halving. OutlineColour/BackColour are forced to
-            // fully opaque (&H00000000) since ffmpeg writes them with a transparent alpha
-            // byte (&Hff......), making the outline/shadow invisible regardless of width.
+            // Fontsize is derived from the frame height rather than from the track's own
+            // byte (41), the way VLC's FontSizeConvert does: 1080 * 0.0605 = 65. MarginV
+            // (~2.31% = 25) and Outline (~6% of Fontsize = 4) follow. This track authors no background box
+            // (ffmpeg emits it as &Hff...... = fully transparent), so the invisible
+            // OutlineColour/BackColour are substituted with opaque black; BorderStyle
+            // stays 1 (outline + shadow).
             Assert.Contains(
                 "Style: Default,Arial,65,&Hffffff,&Hffffff,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,4,0,2,10,10,25,1",
                 result,
@@ -323,14 +323,96 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
             Assert.EndsWith(centerAlignment + ",10,10,25,1", result, StringComparison.Ordinal);
         }
 
-        [Fact]
-        public void NormalizeMovTextAss_PerLineAlignmentOverrideTag_RemapsToCenter()
+        public static TheoryData<string, int?, int?, bool> ShouldExtractMovTextAsAss_TestData()
         {
-            const string Input = "Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\\an1}Left-aligned override.";
+            return new TheoryData<string, int?, int?, bool>
+            {
+                { "mov_text", 1920, 1080, true },
+                // Without real dimensions the decoder would fall back to 384x288 and the
+                // style could not be normalized, so ASS would be worse than SubRip here.
+                { "mov_text", null, null, false },
+                { "mov_text", 0, 0, false },
+                { "mov_text", 1920, null, false },
+                { "subrip", 1920, 1080, false },
+                { "dvbsub", 1920, 1080, false }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(ShouldExtractMovTextAsAss_TestData))]
+        public void ShouldExtractMovTextAsAss_OnlyForMovTextWithKnownVideoSize(string codec, int? width, int? height, bool expected)
+        {
+            var mediaSource = new MediaSourceInfo
+            {
+                MediaStreams = width is null && height is null
+                    ? []
+                    : [new MediaStream { Type = MediaStreamType.Video, Width = width, Height = height }]
+            };
+
+            var subtitleStream = new MediaStream { Type = MediaStreamType.Subtitle, Codec = codec };
+
+            Assert.Equal(expected, SubtitleEncoder.ShouldExtractMovTextAsAss(subtitleStream, mediaSource));
+        }
+
+        [Fact]
+        public void NormalizeMovTextAss_CrlfLineEndings_StyleRewrittenAndLineEndingsPreserved()
+        {
+            // ff_ass_subtitle_header_full builds the header with CRLF and the current ASS
+            // muxer normalizes it back to LF on the way out, so today's extracted files are
+            // LF. This pins down the other case anyway: the Style regex is anchored with
+            // RegexOptions.Multiline, whose '$' matches before the LF, so a CR would land
+            // inside the match and has to survive the field split and rejoin intact.
+            const string Input =
+                "[V4+ Styles]\r\n" +
+                "Style: Default,Arial,41,&Hffffff,&Hffffff,&Hff000000,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,1,10,10,10,1\r\n" +
+                "\r\n" +
+                "[Events]\r\n" +
+                "Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Line one.\r\n";
 
             var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
 
-            Assert.Contains("{\\an2}", result, StringComparison.Ordinal);
+            Assert.Contains(
+                "Style: Default,Arial,65,&Hffffff,&Hffffff,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,4,0,2,10,10,25,1\r\n",
+                result,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("1\r,", result, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        // Opaque black, which is how ffmpeg's own mov_text muxer authors the track
+        // (back_alpha 255 -> (255 - 255) << 24 = 0). Verified against a real remux.
+        [InlineData("&H0")]
+        // A coloured background at 25% transparency.
+        [InlineData("&H40403020")]
+        public void NormalizeMovTextAss_TrackAuthorsABorderColour_ColourAndBorderStylePreserved(string colour)
+        {
+            var input = "Style: Default,Arial,41,&Hffffff,&Hffffff," + colour + "," + colour
+                + ",0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(input, 1080);
+
+            // Nothing was invisible here, so the authored colour survives untouched and
+            // BorderStyle stays on ffmpeg's outline (1). Only the size-derived fields move.
+            Assert.Contains(
+                "Style: Default,Arial,65,&Hffffff,&Hffffff," + colour + "," + colour
+                    + ",0,0,0,0,100,100,0,0,1,4,0,2,10,10,25,1",
+                result,
+                StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NormalizeMovTextAss_UnparseableOutlineColour_LeavesColoursAndBorderStyleAlone()
+        {
+            const string Input = "Style: Default,Arial,41,&Hffffff,&Hffffff,not-a-colour,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
+
+            // Font size, outline width and margin are still normalized, but the colour
+            // fields are not guessed at.
+            Assert.Contains(
+                "Style: Default,Arial,65,&Hffffff,&Hffffff,not-a-colour,&Hff000000,0,0,0,0,100,100,0,0,1,4,0,2,10,10,25,1",
+                result,
+                StringComparison.Ordinal);
         }
 
         [Fact]

--- a/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Subtitles/SubtitleEncoderTests.cs
@@ -269,6 +269,98 @@ namespace Jellyfin.MediaEncoding.Subtitles.Tests
             }
         }
 
+        [Fact]
+        public void NormalizeMovTextAss_RealMovTextStyleLine_MatchesVlcFontSizeConvention()
+        {
+            // Actual header ffmpeg produces for a tx3g track authored with left justification
+            // (h_align=0 per 3GPP TS 26.245), reproduced from a real anime mp4 sample
+            // (1440x1080 video, tx3g Fontsize byte = 41).
+            const string Input =
+                "[Script Info]\n" +
+                "ScriptType: v4.00+\n" +
+                "PlayResX: 1440\n" +
+                "PlayResY: 1080\n" +
+                "\n" +
+                "[V4+ Styles]\n" +
+                "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n" +
+                "Style: Default,Arial,41,&Hffffff,&Hffffff,&Hff000000,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,1,10,10,10,1\n" +
+                "\n" +
+                "[Events]\n" +
+                "Dialogue: 0,0:01:46.65,0:01:49.78,Default,,0,0,0,,Cela commence à bien faire,\\Ninspecteur Megure.\n";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
+
+            // Fontsize ~= 0.0605 * PlayResY (halved from an initial 0.121 VLC-matched
+            // calibration that rendered ~2x too large against the actual deployment font).
+            // 1080 * 0.0605 = 65. MarginV (~2.31% = 25) and Outline (~6% of Fontsize = 4)
+            // scale independently of that halving. OutlineColour/BackColour are forced to
+            // fully opaque (&H00000000) since ffmpeg writes them with a transparent alpha
+            // byte (&Hff......), making the outline/shadow invisible regardless of width.
+            Assert.Contains(
+                "Style: Default,Arial,65,&Hffffff,&Hffffff,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,4,0,2,10,10,25,1",
+                result,
+                StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("7")] // top-left
+        [InlineData("4")] // middle-left
+        [InlineData("1")] // bottom-left
+        public void NormalizeMovTextAss_AnyLeftColumnStyleAlignment_MapsToCenterColumn(string leftAlignment)
+        {
+            var centerAlignment = leftAlignment switch
+            {
+                "7" => "8",
+                "4" => "5",
+                _ => "2"
+            };
+
+            var input = "Style: Default,Arial,41,&Hffffff,&Hffffff,&Hff000000,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,"
+                + leftAlignment + ",10,10,10,1";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(input, 1080);
+
+            Assert.EndsWith(centerAlignment + ",10,10,25,1", result, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NormalizeMovTextAss_PerLineAlignmentOverrideTag_RemapsToCenter()
+        {
+            const string Input = "Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\\an1}Left-aligned override.";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
+
+            Assert.Contains("{\\an2}", result, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NormalizeMovTextAss_AlreadyCenteredOrRightAligned_AlignmentIsUnchanged()
+        {
+            const string Input = "Style: Default,Arial,41,&Hffffff,&Hffffff,&Hff000000,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,3,10,10,10,1";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
+
+            // Alignment (right, "3") is untouched -- only the left column is remapped --
+            // but font size, outline and margin are still normalized to the video's real height.
+            Assert.EndsWith(",1,4,0,3,10,10,25,1", result, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NormalizeMovTextAss_PerLineFontSizeOverride_RescaledProportionally()
+        {
+            // A segment emphasized at roughly double the default style's font size
+            // (e.g. a STYL box override) should stay roughly twice the new base size too.
+            const string Input =
+                "Style: Default,Arial,41,&Hffffff,&Hffffff,&Hff000000,&Hff000000,0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1\n"
+                + "Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\\fs82}Emphasized text.";
+
+            var result = SubtitleEncoder.NormalizeMovTextAss(Input, 1080);
+
+            // original override (82) was 2x the original default (41); new default is 65,
+            // so the rescaled override should be 2x that too (130).
+            Assert.Contains("{\\fs130}", result, StringComparison.Ordinal);
+        }
+
         private static SubtitleEncoder CreateEncoder()
         {
             var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });


### PR DESCRIPTION
This is my first contribution to Jellyfin. I found a bug that bothered me, I am satisfying functionnally with how great this patch works so I want to share it with the community. Thank you

**Code assistance / AI usage**
Code generated by Sonnet 5

I hand tested manually with several contents containing tx3g subtitles to ensure subtitles now looks great in all common transcoded resolution (480p, 720p).

When you will test my patch and switch between several versions of Jellyfin, don't forget to enter your config folder then run this between each test ```sudo find . -iname "*.ass" -delete -print``` : it's crucial to clear the cache so Jellyfin recreates the subtitles each time you want to do a new test.

**Issues**
All of my content containing tx3g subtitles appeared wrong in a very wrong way when burn + transcoding is done by Jellyfin. It seems like no one bothered creating an issue for this problem. It happens only if you burn tx3g subtitles into the video stream. I decided to make screenshots so you can visually understand what the problem is.

Directly loading an affected content on VLC3 on MacOS (I used this as a visual reference, as it looks really great and wanted Jellyfin to produce a similar result for me) : 
<img width="1440" height="1080" alt="image" src="https://github.com/user-attachments/assets/76ad85e4-60af-47c3-a3f4-474899b94cf9" />

Transcoding with subtitles burn on that content : 
<img width="1440" height="1080" alt="image" src="https://github.com/user-attachments/assets/3213d623-fffd-40f4-a0f2-a78f99c7a181" />

As you can see it's very bad & too disturbing to watch the content this way, which is why I spent time iterating with Claude on this subject.

Transcoding with subtitles burn on that content, with the content from this patch : 
<img width="1440" height="1080" alt="image" src="https://github.com/user-attachments/assets/667871e0-f999-46da-b8e2-f9755b698873" />

Looks very satisfying to see and compares very well to what VLC provides. It's comfortable to read.

**Code changes**
- Extract mov_text to ASS instead of SubRip, passing the mov_text decoder's own -width/-height options so PlayResX/PlayResY match the real video.
- Recenter left-column alignment (both in the Style definition and any per-line \an override).
- Force OutlineColour/BackColour to fully opaque black.
- Replace the track's own Fontsize with one derived from the video's height (calibrated against real-world testing across burn-in pipelines), scaling MarginV and Outline to match, and rescaling any per-line {\fsNN} emphasis overrides proportionally to the new default.