### PR TITLE
Keep authenticated user entity in sync with persisted login timestamps

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -616,6 +616,12 @@ namespace Jellyfin.Server.Implementations.Users
                                 .SetProperty(f => f.LastActivityDate, date)
                                 .SetProperty(f => f.LastLoginDate, date))
                             .ConfigureAwait(false);
+
+                        // ExecuteUpdateAsync bypasses the change tracker, so keep the
+                        // returned entity in sync. Otherwise SessionManager.LogSessionActivity
+                        // saves this (stale) entity in full and reverts LastLoginDate.
+                        user.LastActivityDate = date;
+                        user.LastLoginDate = date;
                     }
 
                     await dbContext.Users


### PR DESCRIPTION
**Changes**
Sets `LastActivityDate`/`LastLoginDate` on the in-memory user entity right after `AuthenticateUser` persists them with `ExecuteUpdateAsync`.

**Issues**
Fixes #17301

**Why**

`ExecuteUpdateAsync` bypasses the EF change tracker, so the entity `AuthenticateUser` returns still carries the old timestamps (and `RowVersion` is not bumped). `SessionManager.AuthenticateNewSessionInternal` passes that stale entity to `LogSessionActivity`, whose 60-second guard then passes (stale `LastActivityDate`) and which saves the entity in full via `UpdateUserAsync` — writing the stale `LastLoginDate` (usually `null`) back over the value persisted milliseconds earlier, without tripping the `DbUpdateConcurrencyException` catch.

Net effect: users who sign in show "never logged in" indefinitely, unless they happened to be active within 60 seconds before signing in (which makes the bug look intermittent). Full analysis with an API-only reproduction is in #17301, verified against 10.11.11.

Keeping the entity in sync fixes the revert and also lets the activity guard correctly skip the redundant full-row write during login.