### PR TITLE
Fix incorrect protocol used for subtitle charset detection

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -167,7 +167,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             if (fileInfo.Protocol == MediaProtocol.Http)
             {
-                var result = await DetectCharset(fileInfo.Path, fileInfo.Protocol, cancellationToken).ConfigureAwait(false);
+                var result = await DetectCharset(fileInfo.Path, cancellationToken).ConfigureAwait(false);
                 var detected = result.Detected;
 
                 if (detected is not null)
@@ -1104,7 +1104,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 }
             }
 
-            var result = await DetectCharset(path, mediaSource.Protocol, cancellationToken).ConfigureAwait(false);
+            var result = await DetectCharset(path, cancellationToken).ConfigureAwait(false);
             var charset = result.Detected?.EncodingName ?? string.Empty;
 
             // UTF16 is automatically converted to UTF8 by FFmpeg, do not specify a character encoding
@@ -1120,8 +1120,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             return charset;
         }
 
-        private async Task<DetectionResult> DetectCharset(string path, MediaProtocol protocol, CancellationToken cancellationToken)
+        private async Task<DetectionResult> DetectCharset(string path, CancellationToken cancellationToken)
         {
+            var protocol = _mediaSourceManager.GetPathProtocol(path);
             switch (protocol)
             {
                 case MediaProtocol.Http:
@@ -1141,7 +1142,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(protocol), protocol, "Unsupported protocol");
+                    throw new NotSupportedException($"Unsupported protocol: {protocol}");
             }
         }
 


### PR DESCRIPTION
It's possible that the subtitleStream and mediaSource don't share the same protocol (e.g. .STRM file with local subs), and at one of the call sites we were only checking the `mediaSource`, so` DetectCharset` would treat local subtitles as if they were remote and try to fetch them over HTTP, which would fail.

**Changes**
Calculate protocol directly in `DetectCharset` instead of passing it in. 

**Code assistance**
N/A

**Issues**
Fixes:  #17300