### PR TITLE
Fix 3D format detection when the tag is the last token of the path

### DIFF
--- a/Emby.Naming/Video/Format3DParser.cs
+++ b/Emby.Naming/Video/Format3DParser.cs
@@ -52,13 +52,18 @@ namespace Emby.Naming.Video
             while (path.Length > 0)
             {
                 var index = path.IndexOfAny(delimiters);
+                ReadOnlySpan<char> currentSlice;
                 if (index == -1)
                 {
-                    index = path.Length - 1;
+                    // No delimiter left, the last token is the remainder of the path
+                    currentSlice = path;
+                    path = default;
                 }
-
-                var currentSlice = path[..index];
-                path = path[(index + 1)..];
+                else
+                {
+                    currentSlice = path[..index];
+                    path = path[(index + 1)..];
+                }
 
                 if (!foundPrefix)
                 {

--- a/tests/Jellyfin.Naming.Tests/Video/Format3DTests.cs
+++ b/tests/Jellyfin.Naming.Tests/Video/Format3DTests.cs
@@ -20,6 +20,27 @@ namespace Jellyfin.Naming.Tests.Video
         }
 
         [Fact]
+        public void TestFormat3DAtEndOfPath()
+        {
+            // Directory based media (eg. DVD or BluRay folder rips) have no file extension,
+            // so the 3D tag can be the last token of the path.
+            Test("Super movie (2009) 3d hsbs", true, "hsbs");
+            Test("Super movie (2009).3d.sbs", true, "sbs");
+            Test("Super movie (2009) 3d htab", true, "htab");
+            Test("Super movie (2009).hsbs", true, "hsbs");
+            Test("Super movie (2009) 3d", false, null);
+        }
+
+        [Fact]
+        public void TestResolveDirectory3D()
+        {
+            var result = VideoResolver.ResolveDirectory("/movies/Oblivion (2013) 3d hsbs", _namingOptions);
+
+            Assert.True(result?.Is3D);
+            Assert.Equal("hsbs", result?.Format3D, true);
+        }
+
+        [Fact]
         public void Test3DName()
         {
             var result = VideoResolver.ResolveFile("C:/Users/media/Desktop/Video Test/Movies/Oblivion/Oblivion.3d.hsbs.mkv", _namingOptions);


### PR DESCRIPTION
### Changes

`Format3DParser` drops the last character of the final path token: when `IndexOfAny` finds no more delimiters it slices with `index = path.Length - 1`, so a trailing tag such as `hsbs` is compared as `hsb` and never matches any 3D rule.

File paths are unaffected because the extension is always the final token, but **directory-based media have no extension** — for DVD/BluRay folder rips, `BaseVideoResolver.Set3DFormat` parses the folder path, so a trailing 3D tag such as `Gravity (2013) 3d hsbs/BDMV` is silently ignored and `Video3DFormat` is never set. The movie then plays as squashed side-by-side 2D.

This is a regression from 42a2cc174 ("Remove some unnecessary allocations"), which replaced the `string.Split`-based `FlagParser` — whose final token stayed intact — with span slicing. Fixed by taking the remainder of the path as the last token when no delimiter is left.

Added regression tests, including one that goes through `VideoResolver.ResolveDirectory`.

### Testing

`tests/Jellyfin.Naming.Tests` passes in full (684/684); the two new tests fail on `master` and pass with this change. Also verified with a differential fuzz (300k random token/delimiter/extension combinations) against a `string.Split` reference built from the documented tag semantics — zero divergence after the fix.

### Code assistance

This bug was found, fixed, and tested with the assistance of Claude (Anthropic AI) during a code audit of the naming subsystem; the change was human-reviewed and verified before submission.
