### PR TITLE
Parse ReplayGain album gain field

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -235,6 +235,7 @@
  - [Lampan-git](https://github.com/Lampan-git)
  - [elio42](https://github.com/elio42)
  - [rwebster85](https://github.com/rwebster85)
+ - [Florin-Popescu](https://github.com/Florin-Popescu)
 
 # Emby Contributors
 

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -479,7 +479,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
                 if (float.TryParse(trackAlbumGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) && float.IsFinite(value))
                 {
-                    if (!audio.AlbumEntity.NormalizationGain.HasValue)
+                    if (audio.AlbumEntity is not null && !audio.AlbumEntity.NormalizationGain.HasValue)
                     {
                         audio.AlbumEntity.NormalizationGain = value;
                     }

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -468,6 +468,24 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
+            TryGetSanitizedAdditionalFields(track, "REPLAYGAIN_ALBUM_GAIN", out var trackAlbumGainTag);
+
+            if (trackAlbumGainTag is not null)
+            {
+                if (trackAlbumGainTag.EndsWith("db", StringComparison.OrdinalIgnoreCase))
+                {
+                    trackAlbumGainTag = trackAlbumGainTag[..^2].Trim();
+                }
+
+                if (float.TryParse(trackAlbumGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) && float.IsFinite(value))
+                {
+                    if (!audio.AlbumEntity.NormalizationGain.HasValue)
+                    {
+                        audio.AlbumEntity.NormalizationGain = value;
+                    }
+                }
+            }
+
             if (options.ReplaceAllMetadata || !audio.TryGetProviderId(MetadataProvider.MusicBrainzArtist, out _))
             {
                 if ((TryGetSanitizedAdditionalFields(track, "MUSICBRAINZ_ARTISTID", out var musicBrainzArtistTag)

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -468,18 +468,18 @@ namespace MediaBrowser.Providers.MediaInfo
                 }
             }
 
-            TryGetSanitizedAdditionalFields(track, "REPLAYGAIN_ALBUM_GAIN", out var trackAlbumGainTag);
-
-            if (trackAlbumGainTag is not null)
+            if (audio.AlbumEntity is not null && !audio.AlbumEntity.NormalizationGain.HasValue)
             {
-                if (trackAlbumGainTag.EndsWith("db", StringComparison.OrdinalIgnoreCase))
-                {
-                    trackAlbumGainTag = trackAlbumGainTag[..^2].Trim();
-                }
+                TryGetSanitizedAdditionalFields(track, "REPLAYGAIN_ALBUM_GAIN", out var trackAlbumGainTag);
 
-                if (float.TryParse(trackAlbumGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) && float.IsFinite(value))
+                if (trackAlbumGainTag is not null)
                 {
-                    if (audio.AlbumEntity is not null && !audio.AlbumEntity.NormalizationGain.HasValue)
+                    if (trackAlbumGainTag.EndsWith("db", StringComparison.OrdinalIgnoreCase))
+                    {
+                        trackAlbumGainTag = trackAlbumGainTag[..^2].Trim();
+                    }
+
+                    if (float.TryParse(trackAlbumGainTag, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) && float.IsFinite(value))
                     {
                         audio.AlbumEntity.NormalizationGain = value;
                     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Hello! First time contributor here.

I'm missing proper support for ReplayGain tags for volume normalization in Music Assistant. This PR parses the ReplayGain tags internally if present in the music files and exposes them on the server API to be usable by 3rd party clients such as Music Assistant. The following tags are parsed if available in music files:

- REPLAYGAIN_TRACK_GAIN
  - was already handled in the code base, I didn't change it
- REPLAYGAIN_ALBUM_GAIN
  - covers the measured loudness over an entire album. Here I chose to add it to the parent album of a track when parsed, since it's a tag in the track files themselves
  - I chose to only set it once for the parent album if the album doesn't have its NormalizationGain property already set. Normally all tracks in an album should have this tag set to the same value if the files are coming from the same source, so this implementation seems sensible to me vs. for example averaging the REPLAYGAIN_ALBUM_GAIN for all tracks in an album and setting that as the album's NormalizationGain
  - It is exposed by the server API using the field AlbumNormalizationGain when querying for a certain track as well as by the NormalizationGain field when querying for an album. The support for AlbumNormalizationGain field for a track was added in #14745 but to my understanding the album gain was internally populated (and therefore exposed by the API) only from jellyfin's own LUFS measurement, but not from a file's ReplayGain tags.
- REPLAYGAIN_REFERENCE_LOUDNESS
  - we can't always assume ReplayGain was ran with its default target loudness of -18 LUFS nor can clients make such assumptions. Music Assistant for example uses -17 LUFS by default for playback. Clients need this information to play the files at the correct volume
  - this required adding a new ReferenceLoudness field in the entity database. Hope I did it correctly, including the migration file.
  - I don't know if it's really necessary, but depending on how the clients parse the library, I thought it useful to add this information to a track's parent album in addition to the track itself. The gain information by itself is not very useful without the reference LUFS for either a track or an album. It's added in the same way as REPLAYGAIN_ALBUM_GAIN: only once if not already present in the album's properties, for the first track parsed for that album. Assumption is that all files were processed to add ReplayGain tags in an album using the same settings.
  - I'm exposing the ReferenceLoudness field in the DTO API only if NormalizationGain is also present. I thought it wouldn't be useful if only the reference loudness were present in a file but not the actual gain values. That would anyway not make much sense (corrupted tags in the files?) but it doesn't hurt to protect for.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
I'm normally a developer from the embedded world, so my C# experience is limited. I used an LLM to understand the code base, where to plug my changes, but I did the actual implementation and debugging. Tested and confirmed it works on my machine, not just AI slop.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
This change just exposes the information but doesn't really fix anything by itself. I'm submitting related PRs to Music Assistant to parse this information:
Jc2k/aiojellyfin#10
music-assistant/server#4784
I haven't found any issues related to ReplayGain or volume normalization in this repo.