### PR TITLE
Make RequestHelpers.GetOrderBy generic and reuse it in ActivityLogController

### DIFF
--- a/Jellyfin.Api/Controllers/ActivityLogController.cs
+++ b/Jellyfin.Api/Controllers/ActivityLogController.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using Jellyfin.Api.Helpers;
 using Jellyfin.Data.Enums;
 using Jellyfin.Data.Queries;
 using Jellyfin.Database.Implementations.Enums;
@@ -84,36 +84,9 @@ public class ActivityLogController : BaseJellyfinApiController
             ItemId = itemId,
             Username = username,
             Severity = severity,
-            OrderBy = GetOrderBy(sortBy ?? [], sortOrder ?? []),
+            OrderBy = RequestHelpers.GetOrderBy(sortBy ?? [], sortOrder ?? []),
         };
 
         return await _activityManager.GetPagedResultAsync(query).ConfigureAwait(false);
-    }
-
-    private static (ActivityLogSortBy SortBy, SortOrder SortOrder)[] GetOrderBy(
-        IReadOnlyList<ActivityLogSortBy> sortBy,
-        IReadOnlyList<SortOrder> requestedSortOrder)
-    {
-        if (sortBy.Count == 0)
-        {
-            return [];
-        }
-
-        var result = new (ActivityLogSortBy, SortOrder)[sortBy.Count];
-        var i = 0;
-        for (; i < requestedSortOrder.Count; i++)
-        {
-            result[i] = (sortBy[i], requestedSortOrder[i]);
-        }
-
-        // Add remaining elements with the first specified SortOrder
-        // or the default one if no SortOrders are specified
-        var order = requestedSortOrder.Count > 0 ? requestedSortOrder[0] : SortOrder.Ascending;
-        for (; i < sortBy.Count; i++)
-        {
-            result[i] = (sortBy[i], order);
-        }
-
-        return result;
     }
 }

--- a/Jellyfin.Api/Helpers/RequestHelpers.cs
+++ b/Jellyfin.Api/Helpers/RequestHelpers.cs
@@ -5,7 +5,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
@@ -31,15 +30,16 @@ public static class RequestHelpers
     /// </summary>
     /// <param name="sortBy">Sort By. Comma delimited string.</param>
     /// <param name="requestedSortOrder">Sort Order. Comma delimited string.</param>
+    /// <typeparam name="TSortBy">The type of the sort by field.</typeparam>
     /// <returns>Order By.</returns>
-    public static (ItemSortBy, SortOrder)[] GetOrderBy(IReadOnlyList<ItemSortBy> sortBy, IReadOnlyList<SortOrder> requestedSortOrder)
+    public static (TSortBy, SortOrder)[] GetOrderBy<TSortBy>(IReadOnlyList<TSortBy> sortBy, IReadOnlyList<SortOrder> requestedSortOrder)
     {
         if (sortBy.Count == 0)
         {
-            return Array.Empty<(ItemSortBy, SortOrder)>();
+            return Array.Empty<(TSortBy, SortOrder)>();
         }
 
-        var result = new (ItemSortBy, SortOrder)[sortBy.Count];
+        var result = new (TSortBy, SortOrder)[sortBy.Count];
         var i = 0;
         // Add elements which have a SortOrder specified
         for (; i < requestedSortOrder.Count; i++)


### PR DESCRIPTION
**Changes**
`ActivityLogController` carries a private `GetOrderBy` helper that is a line-for-line copy of `RequestHelpers.GetOrderBy`, differing only in the sort-by enum (`ActivityLogSortBy` vs `ItemSortBy`). This makes `RequestHelpers.GetOrderBy` generic over the sort-by type and deletes the copy in the controller. All existing call sites (8 controllers plus the unit tests) compile unchanged via type inference, and the generic instantiation for `ItemSortBy` is identical to the old method, so there is no behavior change.

**Code assistance**

Developed with AI assistance. I reviewed the diff, checked every existing call site, and ran the full Tests workflow (3-OS matrix) on my fork before submitting.


**Issues**
