### PR TITLE
Remove PlaybackPositionTicks from MediaSourceInfo

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -418,10 +418,10 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <summary>
-        /// Populates each source's own playback position for the user and, when the queried item is a
-        /// primary, moves the most recently played version to the front so that resuming without an
-        /// explicit source selection plays the version that was last watched. A directly queried
-        /// alternate version keeps its own source first.
+        /// When the queried item is a primary, moves the most recently played version to the front so
+        /// that resuming without an explicit source selection plays the version that was last watched.
+        /// A directly queried alternate version keeps its own source first. Per-user playback position
+        /// is not surfaced on the source itself; it is carried by each version's own UserData.
         /// </summary>
         /// <param name="item">The queried item.</param>
         /// <param name="sources">The item's media sources.</param>
@@ -448,16 +448,6 @@ namespace Emby.Server.Implementations.Library
                 if (userDataByVersion.TryGetValue(version.Id, out var data))
                 {
                     dataBySourceId[version.Id.ToString("N", CultureInfo.InvariantCulture)] = data;
-                }
-            }
-
-            foreach (var source in sources)
-            {
-                if (source.Id is not null
-                    && dataBySourceId.TryGetValue(source.Id, out var data)
-                    && data.PlaybackPositionTicks > 0)
-                {
-                    source.PlaybackPositionTicks = data.PlaybackPositionTicks;
                 }
             }
 

--- a/MediaBrowser.Model/Dto/MediaSourceInfo.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceInfo.cs
@@ -55,11 +55,6 @@ namespace MediaBrowser.Model.Dto
 
         public long? RunTimeTicks { get; set; }
 
-        /// <summary>
-        /// Gets or sets the playback position for this specific source.
-        /// </summary>
-        public long? PlaybackPositionTicks { get; set; }
-
         public bool ReadAtNativeFramerate { get; set; }
 
         public bool IgnoreDts { get; set; }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
@@ -150,7 +150,7 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         }
 
         [Fact]
-        public void GetStaticMediaSources_PrimaryQueried_PopulatesPerVersionPositionsAndDefaultsToMostRecent()
+        public void GetStaticMediaSources_PrimaryQueried_DefaultsToMostRecentlyPlayedVersion()
         {
             var (primary, alt1, alt2) = SetupVersionGroup();
             SetupUserDataBatch(new Dictionary<Guid, UserItemData>
@@ -161,12 +161,8 @@ namespace Jellyfin.Server.Implementations.Tests.Library
 
             var sources = _mediaSourceManager.GetStaticMediaSources(primary, false, _user);
 
-            // Each version carries its own resume point; the primary has none.
-            Assert.Equal((long?)10, sources.First(s => s.Id == alt1.Id.ToString("N")).PlaybackPositionTicks);
-            Assert.Equal((long?)20, sources.First(s => s.Id == alt2.Id.ToString("N")).PlaybackPositionTicks);
-            Assert.Null(sources.First(s => s.Id == primary.Id.ToString("N")).PlaybackPositionTicks);
-
             // The most recently played version is the default source, so resuming plays the right file.
+            // Per-user positions live in each version's UserData, not on the source.
             Assert.Equal(alt2.Id.ToString("N"), sources[0].Id);
         }
 
@@ -182,9 +178,8 @@ namespace Jellyfin.Server.Implementations.Tests.Library
             var sources = _mediaSourceManager.GetStaticMediaSources(alt1, false, _user);
 
             // An explicitly opened version keeps its own source first, even when a sibling was
-            // played more recently, but the sibling's resume point is still populated.
+            // played more recently.
             Assert.Equal(alt1.Id.ToString("N"), sources[0].Id);
-            Assert.Equal((long?)20, sources.First(s => s.Id == alt2.Id.ToString("N")).PlaybackPositionTicks);
             Assert.Equal(3, sources.Count);
         }
 
@@ -197,7 +192,6 @@ namespace Jellyfin.Server.Implementations.Tests.Library
             var sources = _mediaSourceManager.GetStaticMediaSources(primary, false, _user);
 
             Assert.Equal(primary.Id.ToString("N"), sources[0].Id);
-            Assert.All(sources, s => Assert.Null(s.PlaybackPositionTicks));
         }
 
         [Fact]


### PR DESCRIPTION
**Changes**
Reverts the API changes from #17044

Still needs https://github.com/jellyfin/jellyfin-web/pull/7984 in web for the resume to work correctly client side.

**Code assistance**
None

**Issues**
