### PR TITLE
Reconnect remote HTTP sources dropped before EOF

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7415,6 +7415,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 inputModifier += " -stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
             }
+            else if (state.InputProtocol == MediaProtocol.Http)
+            {
+                // Reconnect a remote HTTP source (e.g. a .strm-backed VOD item) if it drops before EOF.
+                // No -stream_loop/-reconnect_at_eof/-reconnect_streamed: VOD is finite and seekable.
+                inputModifier += " -reconnect 1 -reconnect_delay_max 2";
+            }
 
             return inputModifier;
         }

--- a/tests/Jellyfin.MediaEncoding.Tests/EncodingHelperTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncodingHelperTests.cs
@@ -1,0 +1,82 @@
+using System;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests;
+
+public class EncodingHelperTests
+{
+    private static EncodingHelper CreateEncodingHelper()
+    {
+        return new EncodingHelper(
+            Mock.Of<IApplicationPaths>(),
+            Mock.Of<IMediaEncoder>(),
+            Mock.Of<ISubtitleEncoder>(),
+            Mock.Of<IConfiguration>(),
+            Mock.Of<MediaBrowser.Common.Configuration.IConfigurationManager>(),
+            Mock.Of<IPathManager>());
+    }
+
+    private static EncodingJobInfo CreateJobInfo(MediaProtocol protocol, bool requiresLooping)
+    {
+        return new EncodingJobInfo(TranscodingJobType.Progressive)
+        {
+            BaseRequest = new BaseEncodingJobOptions(),
+            InputProtocol = protocol,
+            MediaSource = new MediaSourceInfo
+            {
+                Protocol = protocol,
+                RequiresLooping = requiresLooping
+            }
+        };
+    }
+
+    [Fact]
+    public void GetInputModifier_RemoteHttpSource_AddsReconnectWithoutLoopOrEofReconnect()
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateJobInfo(MediaProtocol.Http, requiresLooping: false);
+
+        var modifier = helper.GetInputModifier(state, new EncodingOptions(), null);
+
+        Assert.Contains("-reconnect 1 -reconnect_delay_max 2", modifier, StringComparison.Ordinal);
+
+        // VOD is finite and seekable: it must not loop, must not reconnect at a real EOF,
+        // and must not restart a non-seekable stream from byte zero.
+        Assert.DoesNotContain("-stream_loop", modifier, StringComparison.Ordinal);
+        Assert.DoesNotContain("-reconnect_at_eof", modifier, StringComparison.Ordinal);
+        Assert.DoesNotContain("-reconnect_streamed", modifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetInputModifier_LocalFileSource_DoesNotAddReconnectFlags()
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateJobInfo(MediaProtocol.File, requiresLooping: false);
+
+        var modifier = helper.GetInputModifier(state, new EncodingOptions(), null);
+
+        Assert.DoesNotContain("-reconnect", modifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetInputModifier_RequiresLooping_KeepsLoopingFlagsAndSkipsVodBranch()
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateJobInfo(MediaProtocol.Http, requiresLooping: true);
+
+        var modifier = helper.GetInputModifier(state, new EncodingOptions(), null);
+
+        Assert.Contains("-stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2", modifier, StringComparison.Ordinal);
+
+        // An HTTP Live TV source must not also pick up the VOD reconnect flags via the else-if.
+        Assert.DoesNotContain("-reconnect 1", modifier, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
**Changes**

The ffmpeg reconnect flags were only emitted for `MediaSource.RequiresLooping`, which only the Live TV M3U tuner sets. So a remote HTTP `.strm` VOD item whose connection dropped mid-stream got no reconnect, and its server-side transcode/remux died with a demuxer I/O error. This adds `-reconnect 1 -reconnect_delay_max 2` for HTTP inputs (`state.InputProtocol == MediaProtocol.Http`), as an `else if` after the looping branch so Live TV is unchanged.

`-reconnect` is the flag that handles a disconnect before EOF; `-reconnect_at_eof`/`-reconnect_streamed` are omitted since they target live streams and would mishandle finite VOD. This only helps server-side ffmpeg paths (transcode, remux, HLS), and resume depends on the source honoring HTTP Range requests.

**Code assistance**

Used an LLM to trace the reconnect decision through `libavformat/http.c` (confirming a premature close returns `AVERROR(EIO)` and that `-reconnect` is the flag that path checks, whereas `-reconnect_at_eof`/`-reconnect_streamed` do not apply to finite seekable VOD) and to draft the unit tests. The change and flag choice were reviewed against the ffmpeg source rather than taken as generated.

**Issues**

Fixes #17332
