### PR TITLE
Fix format negotiation in hybrid SW decode and CUDA tonemap pipeline

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -4054,7 +4054,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doCuTonemap ? "yuv420p10le" : "yuv420p";
+                var outFormat = doCuTonemap ? "p010le" : "yuv420p";
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 // sw scale
                 mainFilters.Add(swScaleFilter);


### PR DESCRIPTION
The CUDA hwcontext in FFmpeg 8.1 has added support for 10bit fully planar formats, but few CUDA filters support them.

**Changes**
- Fix format negotiation in hybrid SW decode and CUDA tonemap pipeline

**Issues**
- Fixes https://github.com/jellyfin/jellyfin-ffmpeg/issues/740