### PR TITLE
Fix XMLTV fallback ShowId collisions

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -221,12 +221,12 @@ namespace Jellyfin.LiveTv.Listings
 
                 if (programInfo.SeasonNumber.HasValue)
                 {
-                    uniqueString = "-" + programInfo.SeasonNumber.Value.ToString(CultureInfo.InvariantCulture);
+                    uniqueString += "-" + programInfo.SeasonNumber.Value.ToString(CultureInfo.InvariantCulture);
                 }
 
                 if (programInfo.EpisodeNumber.HasValue)
                 {
-                    uniqueString = "-" + programInfo.EpisodeNumber.Value.ToString(CultureInfo.InvariantCulture);
+                    uniqueString += "-" + programInfo.EpisodeNumber.Value.ToString(CultureInfo.InvariantCulture);
                 }
 
                 programInfo.ShowId = uniqueString.GetMD5().ToString("N", CultureInfo.InvariantCulture);

--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using Jellyfin.LiveTv.Listings;
+using MediaBrowser.Common.Extensions;
 using MediaBrowser.Model.LiveTv;
 using Moq;
 using Moq.Protected;
@@ -85,5 +87,23 @@ public class XmlTvListingsProviderTests
         var program = programsList[0];
         Assert.DoesNotContain(program.Genres, g => string.IsNullOrEmpty(g));
         Assert.Equal("3297", program.ChannelId);
+    }
+
+    [Fact]
+    public async Task GetProgramsAsync_NoProgramId_UsesSeriesIdentityForShowId()
+    {
+        var info = new ListingsProviderInfo()
+        {
+            Path = "Test Data/LiveTv/Listings/XmlTv/showidcollision.xml"
+        };
+
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
+        var programs = await _xmlTvListingsProvider.GetProgramsAsync(info, "3297", startDate, startDate.AddDays(1), CancellationToken.None);
+        var programsList = programs.ToList();
+
+        Assert.Equal(2, programsList.Count);
+        Assert.NotEqual(programsList[0].ShowId, programsList[1].ShowId);
+        Assert.Equal("First Series-1-1".GetMD5().ToString("N", CultureInfo.InvariantCulture), programsList[0].ShowId);
+        Assert.Equal("Second Series-1-1".GetMD5().ToString("N", CultureInfo.InvariantCulture), programsList[1].ShowId);
     }
 }

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/showidcollision.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/showidcollision.xml
@@ -1,0 +1,10 @@
+<tv date="20221104">
+  <programme channel="3297" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">First Series</title>
+    <episode-num system="xmltv_ns">0.0.</episode-num>
+  </programme>
+  <programme channel="3297" start="20221104140000 +0000" stop="20221104150000 +0000">
+    <title lang="en">Second Series</title>
+    <episode-num system="xmltv_ns">0.0.</episode-num>
+  </programme>
+</tv>


### PR DESCRIPTION
**Changes**

Retain the title-based fallback identity when XMLTV programme data has no `dd_progid`, then append season and episode coordinates before hashing it into `ShowId`.

Add a minimal XMLTV fixture with two unrelated S01E01 programmes and a regression test that verifies their `ShowId` values are distinct and derived from each title.

Verification:

```text
RED before source fix: Failed 1, Passed 0, Total 1
Both ShowId values: afca93acfbef5b2d815376e35b31887a

GREEN after source fix: Failed 0, Passed 5, Skipped 0, Total 5
```

Focused class command:

```shell
dotnet test tests/Jellyfin.LiveTv.Tests/Jellyfin.LiveTv.Tests.csproj --filter "FullyQualifiedName~Jellyfin.LiveTv.Tests.Listings.XmlTvListingsProviderTests"
```

**Code assistance**

OpenCode was used to implement the focused fixture, regression test, and two-line source fix. The resulting diff and test evidence were independently reviewed, and the focused test class was rerun before submission.

**Issues**

Fixes #17335
