### PR TITLE
Add XML docs to DeviceId and remove CS1591 suppression

### DIFF
--- a/Emby.Server.Implementations/Devices/DeviceId.cs
+++ b/Emby.Server.Implementations/Devices/DeviceId.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Globalization;
 using System.IO;
@@ -10,6 +8,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Devices
 {
+    /// <summary>
+    /// Provides the persistent unique identifier of this server installation.
+    /// </summary>
     public class DeviceId
     {
         private readonly IApplicationPaths _appPaths;
@@ -18,12 +19,20 @@ namespace Emby.Server.Implementations.Devices
 
         private string? _id;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceId"/> class.
+        /// </summary>
+        /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger{DeviceId}"/> interface.</param>
         public DeviceId(IApplicationPaths appPaths, ILogger<DeviceId> logger)
         {
             _appPaths = appPaths;
             _logger = logger;
         }
 
+        /// <summary>
+        /// Gets the device id, loading it from disk or generating and persisting a new one if none exists.
+        /// </summary>
         public string Value => _id ??= GetDeviceId();
 
         private string CachePath => Path.Combine(_appPaths.DataPath, "device.txt");


### PR DESCRIPTION
**Changes**

Adds XML documentation to the public members of `DeviceId` (class, constructor and `Value` property) and removes the `#pragma warning disable CS1591` suppression from the file.

**Issues**

Part of #2149