### PR TITLE
Add XML docs to provider lookup info types and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Controller/Providers/BookInfo.cs
+++ b/MediaBrowser.Controller/Providers/BookInfo.cs
@@ -1,11 +1,15 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for books.
+    /// </summary>
     public class BookInfo : ItemLookupInfo
     {
+        /// <summary>
+        /// Gets or sets the name of the series the book belongs to.
+        /// </summary>
         public string SeriesName { get; set; }
     }
 }

--- a/MediaBrowser.Controller/Providers/BoxSetInfo.cs
+++ b/MediaBrowser.Controller/Providers/BoxSetInfo.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for box sets.
+    /// </summary>
     public class BoxSetInfo : ItemLookupInfo
     {
     }

--- a/MediaBrowser.Controller/Providers/IHasLookupInfo.cs
+++ b/MediaBrowser.Controller/Providers/IHasLookupInfo.cs
@@ -1,10 +1,16 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// Interface for items that provide lookup info for metadata providers.
+    /// </summary>
+    /// <typeparam name="TLookupInfoType">The type of the lookup info.</typeparam>
     public interface IHasLookupInfo<out TLookupInfoType>
         where TLookupInfoType : ItemLookupInfo, new()
     {
+        /// <summary>
+        /// Gets the lookup info.
+        /// </summary>
+        /// <returns>The lookup info.</returns>
         TLookupInfoType GetLookupInfo();
     }
 }

--- a/MediaBrowser.Controller/Providers/IPreRefreshProvider.cs
+++ b/MediaBrowser.Controller/Providers/IPreRefreshProvider.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// Marker interface for custom metadata providers that run before the regular metadata refresh.
+    /// </summary>
     public interface IPreRefreshProvider : ICustomMetadataProvider
     {
     }

--- a/MediaBrowser.Controller/Providers/MovieInfo.cs
+++ b/MediaBrowser.Controller/Providers/MovieInfo.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for movies.
+    /// </summary>
     public class MovieInfo : ItemLookupInfo
     {
     }

--- a/MediaBrowser.Controller/Providers/PersonLookupInfo.cs
+++ b/MediaBrowser.Controller/Providers/PersonLookupInfo.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for persons.
+    /// </summary>
     public class PersonLookupInfo : ItemLookupInfo
     {
     }

--- a/MediaBrowser.Controller/Providers/SeriesInfo.cs
+++ b/MediaBrowser.Controller/Providers/SeriesInfo.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for series.
+    /// </summary>
     public class SeriesInfo : ItemLookupInfo
     {
     }

--- a/MediaBrowser.Controller/Providers/TrailerInfo.cs
+++ b/MediaBrowser.Controller/Providers/TrailerInfo.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Providers
 {
+    /// <summary>
+    /// The lookup info for trailers.
+    /// </summary>
     public class TrailerInfo : ItemLookupInfo
     {
     }


### PR DESCRIPTION
**Changes**

Adds XML documentation to the small lookup info marker types in `MediaBrowser.Controller.Providers` (`BoxSetInfo`, `MovieInfo`, `SeriesInfo`, `PersonLookupInfo`, `TrailerInfo`, `BookInfo`, `IPreRefreshProvider`, `IHasLookupInfo<T>`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149