### PR TITLE
Add XML docs to small DLNA model types and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Model/Dlna/CodecType.cs
+++ b/MediaBrowser.Model/Dlna/CodecType.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// The codec type of a codec profile.
+    /// </summary>
     public enum CodecType
     {
+        /// <summary>
+        /// The profile applies to a video codec.
+        /// </summary>
         Video = 0,
+
+        /// <summary>
+        /// The profile applies to the audio codec of a video stream.
+        /// </summary>
         VideoAudio = 1,
+
+        /// <summary>
+        /// The profile applies to an audio codec.
+        /// </summary>
         Audio = 2
     }
 }

--- a/MediaBrowser.Model/Dlna/EncodingContext.cs
+++ b/MediaBrowser.Model/Dlna/EncodingContext.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// The encoding context.
+    /// </summary>
     public enum EncodingContext
     {
+        /// <summary>
+        /// The media is transcoded on the fly and delivered as a stream.
+        /// </summary>
         Streaming = 0,
+
+        /// <summary>
+        /// The media is transcoded to a static file.
+        /// </summary>
         Static = 1
     }
 }

--- a/MediaBrowser.Model/Dlna/PlaybackErrorCode.cs
+++ b/MediaBrowser.Model/Dlna/PlaybackErrorCode.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// The playback error code.
+    /// </summary>
     public enum PlaybackErrorCode
     {
+        /// <summary>
+        /// Playback of the item is not allowed.
+        /// </summary>
         NotAllowed = 0,
+
+        /// <summary>
+        /// No stream compatible with the device profile was found.
+        /// </summary>
         NoCompatibleStream = 1,
+
+        /// <summary>
+        /// The rate limit has been exceeded.
+        /// </summary>
         RateLimitExceeded = 2
     }
 }

--- a/MediaBrowser.Model/Dlna/ResolutionOptions.cs
+++ b/MediaBrowser.Model/Dlna/ResolutionOptions.cs
@@ -1,11 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// The resolution constraints.
+    /// </summary>
     public class ResolutionOptions
     {
+        /// <summary>
+        /// Gets or sets the maximum width.
+        /// </summary>
         public int? MaxWidth { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximum height.
+        /// </summary>
         public int? MaxHeight { get; set; }
     }
 }

--- a/MediaBrowser.Model/Dlna/TranscodeSeekInfo.cs
+++ b/MediaBrowser.Model/Dlna/TranscodeSeekInfo.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dlna
 {
+    /// <summary>
+    /// The transcode seek info.
+    /// </summary>
     public enum TranscodeSeekInfo
     {
+        /// <summary>
+        /// The seek method is chosen automatically.
+        /// </summary>
         Auto = 0,
+
+        /// <summary>
+        /// Seeking is performed by byte position.
+        /// </summary>
         Bytes = 1
     }
 }


### PR DESCRIPTION
**Changes**

Adds XML documentation to five small types in `MediaBrowser.Model.Dlna` (`EncodingContext`, `TranscodeSeekInfo`, `CodecType`, `PlaybackErrorCode`, `ResolutionOptions`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149