### PR TITLE
Add XML docs to small channel types and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Controller/Channels/ChannelItemResult.cs
+++ b/MediaBrowser.Controller/Channels/ChannelItemResult.cs
@@ -1,19 +1,29 @@
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// The result of a channel item query.
+    /// </summary>
     public class ChannelItemResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelItemResult"/> class.
+        /// </summary>
         public ChannelItemResult()
         {
             Items = Array.Empty<ChannelItemInfo>();
         }
 
+        /// <summary>
+        /// Gets or sets the items.
+        /// </summary>
         public IReadOnlyList<ChannelItemInfo> Items { get; set; }
 
+        /// <summary>
+        /// Gets or sets the total record count.
+        /// </summary>
         public int? TotalRecordCount { get; set; }
     }
 }

--- a/MediaBrowser.Controller/Channels/ChannelItemType.cs
+++ b/MediaBrowser.Controller/Channels/ChannelItemType.cs
@@ -1,11 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// The type of a channel item.
+    /// </summary>
     public enum ChannelItemType
     {
+        /// <summary>
+        /// The item is a media item.
+        /// </summary>
         Media = 0,
 
+        /// <summary>
+        /// The item is a folder.
+        /// </summary>
         Folder = 1
     }
 }

--- a/MediaBrowser.Controller/Channels/ChannelLatestMediaSearch.cs
+++ b/MediaBrowser.Controller/Channels/ChannelLatestMediaSearch.cs
@@ -1,11 +1,15 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// The request for a latest media search in a channel.
+    /// </summary>
     public class ChannelLatestMediaSearch
     {
+        /// <summary>
+        /// Gets or sets the user id.
+        /// </summary>
         public string UserId { get; set; }
     }
 }

--- a/MediaBrowser.Controller/Channels/ChannelParentalRating.cs
+++ b/MediaBrowser.Controller/Channels/ChannelParentalRating.cs
@@ -1,17 +1,33 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// The parental rating of a channel.
+    /// </summary>
     public enum ChannelParentalRating
     {
+        /// <summary>
+        /// Suitable for a general audience.
+        /// </summary>
         GeneralAudience = 0,
 
+        /// <summary>
+        /// Parental guidance suggested (US PG).
+        /// </summary>
         UsPG = 1,
 
+        /// <summary>
+        /// Parents strongly cautioned (US PG-13).
+        /// </summary>
         UsPG13 = 2,
 
+        /// <summary>
+        /// Restricted (US R).
+        /// </summary>
         UsR = 3,
 
+        /// <summary>
+        /// Suitable for adults only.
+        /// </summary>
         Adult = 4
     }
 }

--- a/MediaBrowser.Controller/Channels/ChannelSearchInfo.cs
+++ b/MediaBrowser.Controller/Channels/ChannelSearchInfo.cs
@@ -1,13 +1,20 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// The request for a search in a channel.
+    /// </summary>
     public class ChannelSearchInfo
     {
+        /// <summary>
+        /// Gets or sets the search term.
+        /// </summary>
         public string SearchTerm { get; set; }
 
+        /// <summary>
+        /// Gets or sets the user id.
+        /// </summary>
         public string UserId { get; set; }
     }
 }

--- a/MediaBrowser.Controller/Channels/IHasCacheKey.cs
+++ b/MediaBrowser.Controller/Channels/IHasCacheKey.cs
@@ -1,14 +1,15 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// Interface for channels that provide a cache key.
+    /// </summary>
     public interface IHasCacheKey
     {
         /// <summary>
         /// Gets the cache key.
         /// </summary>
         /// <param name="userId">The user identifier.</param>
-        /// <returns>System.String.</returns>
+        /// <returns>The cache key.</returns>
         string? GetCacheKey(string? userId);
     }
 }

--- a/MediaBrowser.Controller/Channels/ISupportsDelete.cs
+++ b/MediaBrowser.Controller/Channels/ISupportsDelete.cs
@@ -1,15 +1,27 @@
-#pragma warning disable CS1591
-
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
 
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// Interface for channels that support deleting items.
+    /// </summary>
     public interface ISupportsDelete
     {
+        /// <summary>
+        /// Gets a value indicating whether the item can be deleted.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns><c>true</c> if the item can be deleted, <c>false</c> otherwise.</returns>
         bool CanDelete(BaseItem item);
 
+        /// <summary>
+        /// Deletes the item with the provided id.
+        /// </summary>
+        /// <param name="id">The item id.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing the deletion of the item.</returns>
         Task DeleteItem(string id, CancellationToken cancellationToken);
     }
 }

--- a/MediaBrowser.Controller/Channels/ISupportsLatestMedia.cs
+++ b/MediaBrowser.Controller/Channels/ISupportsLatestMedia.cs
@@ -1,11 +1,12 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace MediaBrowser.Controller.Channels
 {
+    /// <summary>
+    /// Interface for channels that support retrieving the latest media.
+    /// </summary>
     public interface ISupportsLatestMedia
     {
         /// <summary>


### PR DESCRIPTION
**Changes**

Adds XML documentation to eight small types in `MediaBrowser.Controller.Channels` (`ChannelItemType`, `ChannelParentalRating`, `ChannelItemResult`, `ChannelSearchInfo`, `ChannelLatestMediaSearch`, `IHasCacheKey`, `ISupportsDelete`, `ISupportsLatestMedia`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149