### PR TITLE
Add XML docs to small session model types and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Model/Session/MessageCommand.cs
+++ b/MediaBrowser.Model/Session/MessageCommand.cs
@@ -1,17 +1,28 @@
 #nullable disable
-#pragma warning disable CS1591
 
 using System.ComponentModel.DataAnnotations;
 
 namespace MediaBrowser.Model.Session
 {
+    /// <summary>
+    /// A command to display a message on a client.
+    /// </summary>
     public class MessageCommand
     {
+        /// <summary>
+        /// Gets or sets the message header.
+        /// </summary>
         public string Header { get; set; }
 
+        /// <summary>
+        /// Gets or sets the message text.
+        /// </summary>
         [Required(AllowEmptyStrings = false)]
         public string Text { get; set; }
 
+        /// <summary>
+        /// Gets or sets the timeout in milliseconds after which the message should be dismissed.
+        /// </summary>
         public long? TimeoutMs { get; set; }
     }
 }

--- a/MediaBrowser.Model/Session/PlayMethod.cs
+++ b/MediaBrowser.Model/Session/PlayMethod.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Session
 {
+    /// <summary>
+    /// The play method.
+    /// </summary>
     public enum PlayMethod
     {
+        /// <summary>
+        /// The media is transcoded before it is sent to the client.
+        /// </summary>
         Transcode = 0,
+
+        /// <summary>
+        /// The media is remuxed into a compatible container but the streams are not re-encoded.
+        /// </summary>
         DirectStream = 1,
+
+        /// <summary>
+        /// The media is sent to the client as-is.
+        /// </summary>
         DirectPlay = 2
     }
 }

--- a/MediaBrowser.Model/Session/PlaystateRequest.cs
+++ b/MediaBrowser.Model/Session/PlaystateRequest.cs
@@ -1,11 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Session
 {
+    /// <summary>
+    /// A request to change the playstate of a session.
+    /// </summary>
     public class PlaystateRequest
     {
+        /// <summary>
+        /// Gets or sets the playstate command.
+        /// </summary>
         public PlaystateCommand Command { get; set; }
 
+        /// <summary>
+        /// Gets or sets the seek position in ticks.
+        /// </summary>
         public long? SeekPositionTicks { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Session/QueueItem.cs
+++ b/MediaBrowser.Model/Session/QueueItem.cs
@@ -1,13 +1,21 @@
 #nullable disable
-#pragma warning disable CS1591
 
 using System;
 
 namespace MediaBrowser.Model.Session;
 
+/// <summary>
+/// An item in a play queue.
+/// </summary>
 public record QueueItem
 {
+    /// <summary>
+    /// Gets or sets the item id.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the playlist item id.
+    /// </summary>
     public string PlaylistItemId { get; set; }
 }

--- a/MediaBrowser.Model/Session/RepeatMode.cs
+++ b/MediaBrowser.Model/Session/RepeatMode.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Session
 {
+    /// <summary>
+    /// The repeat mode of a play queue.
+    /// </summary>
     public enum RepeatMode
     {
+        /// <summary>
+        /// Nothing is repeated.
+        /// </summary>
         RepeatNone = 0,
+
+        /// <summary>
+        /// The whole queue is repeated.
+        /// </summary>
         RepeatAll = 1,
+
+        /// <summary>
+        /// The current item is repeated.
+        /// </summary>
         RepeatOne = 2
     }
 }


### PR DESCRIPTION
**Changes**

Adds XML documentation to five small types in `MediaBrowser.Model.Session` (`PlayMethod`, `RepeatMode`, `QueueItem`, `MessageCommand`, `PlaystateRequest`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149