### PR TITLE
Fix SchedulesDirect image limit recognition

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/SchedulesDirect.cs
+++ b/src/Jellyfin.LiveTv/Listings/SchedulesDirect.cs
@@ -491,6 +491,12 @@ namespace Jellyfin.LiveTv.Listings
             var results = new List<ShowImagesDto>();
             for (int i = 0; i < programIds.Count; i += BatchSize)
             {
+                // The daily image limit may be surfaced mid-batch.
+                if (IsImageDailyLimitActive())
+                {
+                    break;
+                }
+
                 var batch = programIds.Skip(i).Take(BatchSize);
 
                 using var message = new HttpRequestMessage(HttpMethod.Post, ApiUrl + "/metadata/programs/");
@@ -511,6 +517,18 @@ namespace Jellyfin.LiveTv.Listings
                                     entry.ProgramId,
                                     entry.Code,
                                     entry.Message);
+
+                                // The image download limit can be reported per-entry inside an
+                                // otherwise successful (HTTP 200) response when the limit is hit
+                                // mid-batch. Back off so we stop requesting images until SD resets.
+                                if (entry.Code is (int)SdErrorCode.MaxImageDownloads or (int)SdErrorCode.MaxImageDownloadsTrial)
+                                {
+                                    _logger.LogError(
+                                        "Schedules Direct image download limit hit (code {Code}). Disabling image acquisition until SD reset.",
+                                        entry.Code);
+                                    SetImageLimitHit();
+                                }
+
                                 continue;
                             }
 

--- a/tests/Jellyfin.LiveTv.Tests/SchedulesDirect/SchedulesDirectDeserializeTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/SchedulesDirect/SchedulesDirectDeserializeTests.cs
@@ -176,6 +176,30 @@ namespace Jellyfin.LiveTv.Tests.SchedulesDirect
         }
 
         /// <summary>
+        /// /metadata/programs response where the daily image limit is hit mid-batch,
+        /// so individual entries carry an error code inside an otherwise successful response.
+        /// </summary>
+        [Fact]
+        public void Deserialize_Metadata_Programs_Image_Limit_Response_Success()
+        {
+            var bytes = File.ReadAllBytes("Test Data/SchedulesDirect/metadata_programs_image_limit_response.json");
+            var showImagesDtos = JsonSerializer.Deserialize<IReadOnlyList<ShowImagesDto>>(bytes, _jsonOptions);
+
+            Assert.NotNull(showImagesDtos);
+            Assert.Equal(2, showImagesDtos!.Count);
+
+            // First entry is a normal result with image data and no error code.
+            Assert.Equal("SH00712240", showImagesDtos[0].ProgramId);
+            Assert.Null(showImagesDtos[0].Code);
+            Assert.Single(showImagesDtos[0].Data);
+
+            // Second entry is a per-entry trial image download limit error (SD code 5003).
+            Assert.Equal("SH00712241", showImagesDtos[1].ProgramId);
+            Assert.Equal((int)SdErrorCode.MaxImageDownloadsTrial, showImagesDtos[1].Code);
+            Assert.Empty(showImagesDtos[1].Data);
+        }
+
+        /// <summary>
         /// /headends response.
         /// </summary>
         [Fact]

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/SchedulesDirect/metadata_programs_image_limit_response.json
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/SchedulesDirect/metadata_programs_image_limit_response.json
@@ -1,0 +1,1 @@
+[{"programID":"SH00712240","data":[{"width":"135","height":"180","uri":"assets/p282288_b_v2_aa.jpg","size":"Sm","aspect":"3x4","category":"Banner-L3","text":"yes","primary":"true","tier":"Series"}]},{"programID":"SH00712241","code":5003,"message":"Image download limit exceeded. Try again tomorrow."}]


### PR DESCRIPTION
When reaching rate limits in SD image API this can happen mid-batch, we need to recognize it and handle it properly

**Changes**
Identify mid-batch failures and handle them properly

**Code assistance**
Claude Opus for the test

**Issues**
Fixes #17345