### PR TITLE
Revert setting default BaseItemKind for CollectionType

### DIFF
--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -316,7 +316,6 @@ public class ItemsController : BaseJellyfinApiController
         if (folder is IHasCollectionType hasCollectionType)
         {
             collectionType = hasCollectionType.CollectionType;
-            includeItemTypes = [.. includeItemTypes.Union(DtoExtensions.GetBaseItemKindsForCollectionType(collectionType))];
         }
 
         if (collectionType == CollectionType.playlists)
@@ -329,7 +328,6 @@ public class ItemsController : BaseJellyfinApiController
             includeItemTypes = collectionType switch
             {
                 CollectionType.boxsets => [BaseItemKind.BoxSet],
-                null => [BaseItemKind.Movie, BaseItemKind.Series],
                 _ => []
             };
         }


### PR DESCRIPTION
In #15954 we added default `BaseItemKind` types for collection types.  This creates an issue in the web UI when the modern and legacy layouts differ in expected `BaseItemKind` types.

For example, in the legacy layout, HomeVideos, Music Videos, Books, and Mixed Libraries should include `BaseItemKind.Folder.` But the modern layout does not include folders and has a separate folder tab view. 

So, as-is, the legacy layout incorrectly presents a flat view instead of a folder structure.  While the modern layout correctly presents as a flat view.

Trying to fix this by adding `BaseItemKind.Folder` to the Book collection will fix the legacy layout , but then the modern layout incorrectly presents with a folder structure:
```
case CollectionType.books:
return [BaseItemKind.Book, BaseItemKind.AudioBook, BaseItemKind.Folder];
```


**Changes**
Remove the defaults for the collections folder, leaving it up to the client. 

**Code assistance**
N/A

**Issues**
N/A