### PR TITLE
Add per-member SyncPlay buffering timeout so one client cannot stall the group forever

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -27,6 +27,18 @@ namespace Emby.Server.Implementations.SyncPlay
     public class Group : IGroupStateContext
     {
         /// <summary>
+        /// The maximum time, in milliseconds, a session that is still preparing playback for the first
+        /// time in the current buffering cycle (e.g. waiting on a transcode) can keep the group waiting.
+        /// </summary>
+        private const long PreparingTimeoutMs = 60000;
+
+        /// <summary>
+        /// The maximum time, in milliseconds, a session that has already caught up once in the current
+        /// cycle (and is therefore assumed to be re-buffering from network lag) can keep the group waiting.
+        /// </summary>
+        private const long NetworkLagTimeoutMs = 10000;
+
+        /// <summary>
         /// The logger.
         /// </summary>
         private readonly ILogger<Group> _logger;
@@ -61,22 +73,6 @@ namespace Emby.Server.Implementations.SyncPlay
         /// The internal group state.
         /// </summary>
         private IGroupState _state;
-
-        /// <summary>
-        /// The maximum time, in milliseconds, a session is allowed to keep the group waiting while it is
-        /// still preparing playback for the first time in the current buffering cycle (e.g. a transcode
-        /// that has not started yet). This is intentionally generous since it covers slow-start scenarios
-        /// rather than steady-state network drift.
-        /// </summary>
-        private const long PreparingTimeoutMs = 60000;
-
-        /// <summary>
-        /// The maximum time, in milliseconds, a session is allowed to keep the group waiting once it has
-        /// already reported ready/buffering at least once in the current cycle. A session re-buffering
-        /// after that point is assumed to be suffering from network drift rather than a slow start, so a
-        /// much tighter timeout applies.
-        /// </summary>
-        private const long NetworkLagTimeoutMs = 10000;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Group" /> class.
@@ -481,13 +477,14 @@ namespace Emby.Server.Implementations.SyncPlay
                     if (!value.IsBuffering)
                     {
                         value.BufferingSince = DateTime.UtcNow;
-                        value.HasReportedSinceBuffering = false;
                     }
                 }
                 else
                 {
                     value.BufferingSince = null;
-                    value.HasReportedSinceBuffering = false;
+
+                    // Any further buffering this cycle is treated as network lag rather than a slow start.
+                    value.HasCaughtUpSinceReset = true;
                 }
 
                 value.IsBuffering = isBuffering;
@@ -499,27 +496,11 @@ namespace Emby.Server.Implementations.SyncPlay
         {
             foreach (var session in _participants.Values)
             {
-                if (isBuffering)
-                {
-                    session.BufferingSince = DateTime.UtcNow;
-                    session.HasReportedSinceBuffering = false;
-                }
-                else
-                {
-                    session.BufferingSince = null;
-                    session.HasReportedSinceBuffering = false;
-                }
+                session.BufferingSince = isBuffering ? DateTime.UtcNow : null;
 
+                // A group-wide reset (e.g. seek, playlist change) starts a new cycle for everyone.
+                session.HasCaughtUpSinceReset = false;
                 session.IsBuffering = isBuffering;
-            }
-        }
-
-        /// <inheritdoc />
-        public void MarkBufferingReported(SessionInfo session)
-        {
-            if (_participants.TryGetValue(session.Id, out GroupMember value))
-            {
-                value.HasReportedSinceBuffering = true;
             }
         }
 
@@ -536,7 +517,7 @@ namespace Emby.Server.Implementations.SyncPlay
 
                 if (session.BufferingSince.HasValue)
                 {
-                    var timeoutMs = session.HasReportedSinceBuffering ? NetworkLagTimeoutMs : PreparingTimeoutMs;
+                    var timeoutMs = session.HasCaughtUpSinceReset ? NetworkLagTimeoutMs : PreparingTimeoutMs;
                     var elapsedMs = (now - session.BufferingSince.Value).TotalMilliseconds;
                     if (elapsedMs > timeoutMs)
                     {
@@ -545,11 +526,11 @@ namespace Emby.Server.Implementations.SyncPlay
                             session.SessionId,
                             GroupId.ToString(),
                             timeoutMs,
-                            session.HasReportedSinceBuffering ? "network lag" : "still preparing");
+                            session.HasCaughtUpSinceReset ? "network lag" : "still preparing");
 
                         session.IsBuffering = false;
                         session.BufferingSince = null;
-                        session.HasReportedSinceBuffering = false;
+                        session.HasCaughtUpSinceReset = false;
                         continue;
                     }
                 }

--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -63,6 +63,22 @@ namespace Emby.Server.Implementations.SyncPlay
         private IGroupState _state;
 
         /// <summary>
+        /// The maximum time, in milliseconds, a session is allowed to keep the group waiting while it is
+        /// still preparing playback for the first time in the current buffering cycle (e.g. a transcode
+        /// that has not started yet). This is intentionally generous since it covers slow-start scenarios
+        /// rather than steady-state network drift.
+        /// </summary>
+        private const long PreparingTimeoutMs = 60000;
+
+        /// <summary>
+        /// The maximum time, in milliseconds, a session is allowed to keep the group waiting once it has
+        /// already reported ready/buffering at least once in the current cycle. A session re-buffering
+        /// after that point is assumed to be suffering from network drift rather than a slow start, so a
+        /// much tighter timeout applies.
+        /// </summary>
+        private const long NetworkLagTimeoutMs = 10000;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Group" /> class.
         /// </summary>
         /// <param name="loggerFactory">The logger factory.</param>
@@ -356,7 +372,8 @@ namespace Emby.Server.Implementations.SyncPlay
         public GroupInfoDto GetInfo()
         {
             var participants = _participants.Values.Select(session => session.UserName).Distinct().ToList();
-            return new GroupInfoDto(GroupId, GroupName, _state.Type, participants, DateTime.UtcNow);
+            var bufferingParticipants = GetBufferingParticipants();
+            return new GroupInfoDto(GroupId, GroupName, _state.Type, participants, DateTime.UtcNow, bufferingParticipants);
         }
 
         /// <summary>
@@ -459,6 +476,20 @@ namespace Emby.Server.Implementations.SyncPlay
         {
             if (_participants.TryGetValue(session.Id, out GroupMember value))
             {
+                if (isBuffering)
+                {
+                    if (!value.IsBuffering)
+                    {
+                        value.BufferingSince = DateTime.UtcNow;
+                        value.HasReportedSinceBuffering = false;
+                    }
+                }
+                else
+                {
+                    value.BufferingSince = null;
+                    value.HasReportedSinceBuffering = false;
+                }
+
                 value.IsBuffering = isBuffering;
             }
         }
@@ -468,22 +499,82 @@ namespace Emby.Server.Implementations.SyncPlay
         {
             foreach (var session in _participants.Values)
             {
+                if (isBuffering)
+                {
+                    session.BufferingSince = DateTime.UtcNow;
+                    session.HasReportedSinceBuffering = false;
+                }
+                else
+                {
+                    session.BufferingSince = null;
+                    session.HasReportedSinceBuffering = false;
+                }
+
                 session.IsBuffering = isBuffering;
+            }
+        }
+
+        /// <inheritdoc />
+        public void MarkBufferingReported(SessionInfo session)
+        {
+            if (_participants.TryGetValue(session.Id, out GroupMember value))
+            {
+                value.HasReportedSinceBuffering = true;
             }
         }
 
         /// <inheritdoc />
         public bool IsBuffering()
         {
+            var now = DateTime.UtcNow;
             foreach (var session in _participants.Values)
             {
-                if (session.IsBuffering && !session.IgnoreGroupWait)
+                if (!session.IsBuffering || session.IgnoreGroupWait)
                 {
-                    return true;
+                    continue;
                 }
+
+                if (session.BufferingSince.HasValue)
+                {
+                    var timeoutMs = session.HasReportedSinceBuffering ? NetworkLagTimeoutMs : PreparingTimeoutMs;
+                    var elapsedMs = (now - session.BufferingSince.Value).TotalMilliseconds;
+                    if (elapsedMs > timeoutMs)
+                    {
+                        _logger.LogWarning(
+                            "Session {SessionId} in group {GroupId} did not report ready within {TimeoutMs}ms ({Reason}), no longer waiting on it.",
+                            session.SessionId,
+                            GroupId.ToString(),
+                            timeoutMs,
+                            session.HasReportedSinceBuffering ? "network lag" : "still preparing");
+
+                        session.IsBuffering = false;
+                        session.BufferingSince = null;
+                        session.HasReportedSinceBuffering = false;
+                        continue;
+                    }
+                }
+
+                return true;
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Gets the usernames of sessions that are currently buffering and blocking the group.
+        /// </summary>
+        /// <returns>The list of usernames of the sessions still buffering.</returns>
+        private IReadOnlyList<string> GetBufferingParticipants()
+        {
+            // Calling IsBuffering() first ensures stale/timed-out sessions are cleared before reporting.
+            IsBuffering();
+
+            return _participants
+                .Values
+                .Where(member => member.IsBuffering && !member.IgnoreGroupWait)
+                .Select(member => member.UserName)
+                .Distinct()
+                .ToList();
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Controller/SyncPlay/GroupMember.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupMember.cs
@@ -58,14 +58,12 @@ namespace MediaBrowser.Controller.SyncPlay
         public DateTime? BufferingSince { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this member has sent at least one
-        /// Ready/Buffer request since it started its current buffering period. Used to
-        /// distinguish a client that is still preparing playback for the first time
-        /// (e.g. waiting on a transcode to start) from one that has already caught up
-        /// once and is now re-buffering because of network drift.
+        /// Gets or sets a value indicating whether this member has caught up with the group at least
+        /// once since the last group-wide buffering reset (see <see cref="IGroupStateContext.SetAllBuffering"/>).
+        /// Distinguishes a client still preparing its first playback from one re-buffering due to network lag.
         /// </summary>
-        /// <value><c>true</c> if the member has reported since it started buffering; <c>false</c> otherwise.</value>
-        public bool HasReportedSinceBuffering { get; set; }
+        /// <value><c>true</c> if the member has caught up since the last group-wide reset; <c>false</c> otherwise.</value>
+        public bool HasCaughtUpSinceReset { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this member is following group playback.

--- a/MediaBrowser.Controller/SyncPlay/GroupMember.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupMember.cs
@@ -52,6 +52,22 @@ namespace MediaBrowser.Controller.SyncPlay
         public bool IsBuffering { get; set; }
 
         /// <summary>
+        /// Gets or sets the time at which this member started its current buffering period.
+        /// </summary>
+        /// <value>The date the member started buffering, or <c>null</c> if not buffering.</value>
+        public DateTime? BufferingSince { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this member has sent at least one
+        /// Ready/Buffer request since it started its current buffering period. Used to
+        /// distinguish a client that is still preparing playback for the first time
+        /// (e.g. waiting on a transcode to start) from one that has already caught up
+        /// once and is now re-buffering because of network drift.
+        /// </summary>
+        /// <value><c>true</c> if the member has reported since it started buffering; <c>false</c> otherwise.</value>
+        public bool HasReportedSinceBuffering { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this member is following group playback.
         /// </summary>
         /// <value><c>true</c> to ignore member on group wait; <c>false</c> if they're following group playback.</value>

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
@@ -331,10 +331,6 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 InitialStateSet = true;
             }
 
-            // The session is actively communicating, so it is not stuck preparing playback
-            // (e.g. waiting on a slow transcode start); any further re-buffering is network drift.
-            context.MarkBufferingReported(session);
-
             // Make sure the client is playing the correct item.
             if (!request.PlaylistItemId.Equals(context.PlayQueue.GetPlayingItemPlaylistId()))
             {
@@ -408,10 +404,6 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 InitialState = prevState;
                 InitialStateSet = true;
             }
-
-            // The session is actively communicating, so it is not stuck preparing playback
-            // (e.g. waiting on a slow transcode start); any further re-buffering is network drift.
-            context.MarkBufferingReported(session);
 
             // Make sure the client is playing the correct item.
             if (!request.PlaylistItemId.Equals(context.PlayQueue.GetPlayingItemPlaylistId()))

--- a/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupStates/WaitingGroupState.cs
@@ -331,6 +331,10 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 InitialStateSet = true;
             }
 
+            // The session is actively communicating, so it is not stuck preparing playback
+            // (e.g. waiting on a slow transcode start); any further re-buffering is network drift.
+            context.MarkBufferingReported(session);
+
             // Make sure the client is playing the correct item.
             if (!request.PlaylistItemId.Equals(context.PlayQueue.GetPlayingItemPlaylistId()))
             {
@@ -404,6 +408,10 @@ namespace MediaBrowser.Controller.SyncPlay.GroupStates
                 InitialState = prevState;
                 InitialStateSet = true;
             }
+
+            // The session is actively communicating, so it is not stuck preparing playback
+            // (e.g. waiting on a slow transcode start); any further re-buffering is network drift.
+            context.MarkBufferingReported(session);
 
             // Make sure the client is playing the correct item.
             if (!request.PlaylistItemId.Equals(context.PlayQueue.GetPlayingItemPlaylistId()))

--- a/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
+++ b/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
@@ -132,14 +132,6 @@ namespace MediaBrowser.Controller.SyncPlay
         bool IsBuffering();
 
         /// <summary>
-        /// Marks that the session has sent a Ready/Buffer request during its current buffering period.
-        /// Used to tell apart a client still preparing playback for the first time from one that is
-        /// re-buffering after already having caught up once.
-        /// </summary>
-        /// <param name="session">The session.</param>
-        void MarkBufferingReported(SessionInfo session);
-
-        /// <summary>
         /// Sets the session's group wait state.
         /// </summary>
         /// <param name="session">The session.</param>

--- a/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
+++ b/MediaBrowser.Controller/SyncPlay/IGroupStateContext.cs
@@ -125,10 +125,19 @@ namespace MediaBrowser.Controller.SyncPlay
         void SetAllBuffering(bool isBuffering);
 
         /// <summary>
-        /// Gets the group buffering state.
+        /// Gets the group buffering state. Sessions that have been buffering for longer than
+        /// the applicable timeout are no longer considered to be blocking the group.
         /// </summary>
         /// <returns><c>true</c> if there is a session buffering in the group; <c>false</c> otherwise.</returns>
         bool IsBuffering();
+
+        /// <summary>
+        /// Marks that the session has sent a Ready/Buffer request during its current buffering period.
+        /// Used to tell apart a client still preparing playback for the first time from one that is
+        /// re-buffering after already having caught up once.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        void MarkBufferingReported(SessionInfo session);
 
         /// <summary>
         /// Sets the session's group wait state.

--- a/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
+++ b/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
@@ -16,13 +16,15 @@ namespace MediaBrowser.Model.SyncPlay
         /// <param name="state">The group state.</param>
         /// <param name="participants">The participants.</param>
         /// <param name="lastUpdatedAt">The date when this DTO has been created.</param>
-        public GroupInfoDto(Guid groupId, string groupName, GroupStateType state, IReadOnlyList<string> participants, DateTime lastUpdatedAt)
+        /// <param name="bufferingParticipants">The usernames of participants currently buffering and blocking the group.</param>
+        public GroupInfoDto(Guid groupId, string groupName, GroupStateType state, IReadOnlyList<string> participants, DateTime lastUpdatedAt, IReadOnlyList<string>? bufferingParticipants = null)
         {
             GroupId = groupId;
             GroupName = groupName;
             State = state;
             Participants = participants;
             LastUpdatedAt = lastUpdatedAt;
+            BufferingParticipants = bufferingParticipants ?? Array.Empty<string>();
         }
 
         /// <summary>
@@ -54,5 +56,12 @@ namespace MediaBrowser.Model.SyncPlay
         /// </summary>
         /// <value>The date when this DTO has been created.</value>
         public DateTime LastUpdatedAt { get; }
+
+        /// <summary>
+        /// Gets the usernames of the participants that are currently buffering and blocking the group
+        /// from progressing, so clients can surface who is holding things up.
+        /// </summary>
+        /// <value>The usernames of the participants currently buffering.</value>
+        public IReadOnlyList<string> BufferingParticipants { get; }
     }
 }

--- a/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
+++ b/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
@@ -58,8 +58,7 @@ namespace MediaBrowser.Model.SyncPlay
         public DateTime LastUpdatedAt { get; }
 
         /// <summary>
-        /// Gets the usernames of the participants that are currently buffering and blocking the group
-        /// from progressing, so clients can surface who is holding things up.
+        /// Gets the usernames of the participants that are currently buffering and blocking the group.
         /// </summary>
         /// <value>The usernames of the participants currently buffering.</value>
         public IReadOnlyList<string> BufferingParticipants { get; }


### PR DESCRIPTION
**Changes**

`Group.IsBuffering()` blocks on any buffering member with no time bound, so a client whose
playback/transcode never starts is indistinguishable from ordinary network drift and can hang
a SyncPlay group indefinitely — everyone else stays frozen until someone manually removes the
stuck client.

Commit 1 tracks when each member started its current buffering period and applies a generous
timeout (60 s) while a member is still preparing playback for the first time vs. a tight
timeout (10 s) once it has already caught up and is merely re-buffering. A member that exceeds
its timeout is dropped from the wait (with a warning naming the session) so the rest of the
group proceeds. Stalled usernames are surfaced on `GroupInfoDto` as `BufferingParticipants`
(additive/optional field) so clients can show who is holding up playback.

Commit 2 fixes a flaw in commit 1's "has reported since buffering started" heuristic: because
`SetAllBuffering(true)` (seek, next item, unpause-from-idle) marks everyone buffering up
front, the very first Buffer/Ready report after a seek flipped a still-preparing session onto
the tight 10 s clock — exactly the slow-start case the timeout was meant to protect. Replaced
with `GroupMember.HasCaughtUpSinceReset`, set only on a genuine catch-up and cleared only by a
group-wide reset. (Kept as two commits to preserve the reasoning; happy to squash on merge.)

Tested by building the touched projects and by running the change in production on a private
Jellyfin server: previously a client with a slow-starting transcode regularly hung group
playback; with this change the group resumes and the stuck client is identified in the UI.

**Code assistance**

Developed with LLM assistance (Claude): root-cause analysis and initial patch generation.
All code was human-reviewed, built, and has been running in production on a private server.

**Issues**

None.
