### PR TITLE
Track a stable SyncPlay host and reassign it when the host leaves

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -115,6 +115,16 @@ namespace Emby.Server.Implementations.SyncPlay
         public string GroupName { get; private set; }
 
         /// <summary>
+        /// Gets the username of the session that created this group. Set once at group
+        /// creation time and never reassigned afterward, regardless of participants joining
+        /// or leaving. Unlike deriving "who is host" from participant/dictionary ordering
+        /// (which is unspecified and shifts once any entry is removed), this is a stable
+        /// identity for the lifetime of the group.
+        /// </summary>
+        /// <value>The host's username.</value>
+        public string HostUsername { get; private set; }
+
+        /// <summary>
         /// Gets the group identifier.
         /// </summary>
         /// <value>The group identifier.</value>
@@ -251,6 +261,7 @@ namespace Emby.Server.Implementations.SyncPlay
         public void CreateGroup(SessionInfo session, NewGroupRequest request, CancellationToken cancellationToken)
         {
             GroupName = request.GroupName;
+            HostUsername = session.UserName;
             AddSession(session);
 
             var sessionIsPlayingAnItem = session.FullNowPlayingItem is not null;
@@ -356,7 +367,7 @@ namespace Emby.Server.Implementations.SyncPlay
         public GroupInfoDto GetInfo()
         {
             var participants = _participants.Values.Select(session => session.UserName).Distinct().ToList();
-            return new GroupInfoDto(GroupId, GroupName, _state.Type, participants, DateTime.UtcNow);
+            return new GroupInfoDto(GroupId, GroupName, _state.Type, participants, DateTime.UtcNow, HostUsername);
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/SyncPlay/Group.cs
+++ b/Emby.Server.Implementations/SyncPlay/Group.cs
@@ -115,11 +115,9 @@ namespace Emby.Server.Implementations.SyncPlay
         public string GroupName { get; private set; }
 
         /// <summary>
-        /// Gets the username of the session that created this group. Set once at group
-        /// creation time and never reassigned afterward, regardless of participants joining
-        /// or leaving. Unlike deriving "who is host" from participant/dictionary ordering
-        /// (which is unspecified and shifts once any entry is removed), this is a stable
-        /// identity for the lifetime of the group.
+        /// Gets the username of the group's host: the creating session's username, reassigned
+        /// when the host's last session leaves while other participants remain
+        /// (see <see cref="SessionLeave"/>). Always identifies a current member of the group.
         /// </summary>
         /// <value>The host's username.</value>
         public string HostUsername { get; private set; }
@@ -325,6 +323,21 @@ namespace Emby.Server.Implementations.SyncPlay
             _state.SessionLeaving(this, _state.Type, session, cancellationToken);
 
             RemoveSession(session);
+
+            // The host left but the group lives on: promote the longest-standing remaining member.
+            // The check is by username so a host with multiple sessions keeps the role until the
+            // last one leaves.
+            if (_participants.Count > 0
+                && !_participants.Values.Any(member => string.Equals(member.UserName, HostUsername, StringComparison.OrdinalIgnoreCase)))
+            {
+                HostUsername = _participants.Values
+                    .OrderBy(member => member.JoinedAt)
+                    .ThenBy(member => member.SessionId, StringComparer.Ordinal)
+                    .First()
+                    .UserName;
+
+                _logger.LogInformation("Host of group {GroupId} left, new host is {HostUsername}.", GroupId.ToString(), HostUsername);
+            }
 
             var updateSession = new SyncPlayGroupLeftUpdate(GroupId, GroupId.ToString());
             SendGroupUpdate(session, SyncPlayBroadcastType.CurrentSession, updateSession, cancellationToken);

--- a/MediaBrowser.Controller/SyncPlay/GroupMember.cs
+++ b/MediaBrowser.Controller/SyncPlay/GroupMember.cs
@@ -19,6 +19,7 @@ namespace MediaBrowser.Controller.SyncPlay
             SessionId = session.Id;
             UserId = session.UserId;
             UserName = session.UserName;
+            JoinedAt = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -38,6 +39,13 @@ namespace MediaBrowser.Controller.SyncPlay
         /// </summary>
         /// <value>The username.</value>
         public string UserName { get; }
+
+        /// <summary>
+        /// Gets the time this member was added to the group. Used to pick a
+        /// deterministic replacement when the host leaves.
+        /// </summary>
+        /// <value>The date the member joined the group.</value>
+        public DateTime JoinedAt { get; }
 
         /// <summary>
         /// Gets or sets the ping, in milliseconds.

--- a/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
+++ b/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
@@ -16,13 +16,15 @@ namespace MediaBrowser.Model.SyncPlay
         /// <param name="state">The group state.</param>
         /// <param name="participants">The participants.</param>
         /// <param name="lastUpdatedAt">The date when this DTO has been created.</param>
-        public GroupInfoDto(Guid groupId, string groupName, GroupStateType state, IReadOnlyList<string> participants, DateTime lastUpdatedAt)
+        /// <param name="hostUsername">The username of the session that created the group.</param>
+        public GroupInfoDto(Guid groupId, string groupName, GroupStateType state, IReadOnlyList<string> participants, DateTime lastUpdatedAt, string? hostUsername = null)
         {
             GroupId = groupId;
             GroupName = groupName;
             State = state;
             Participants = participants;
             LastUpdatedAt = lastUpdatedAt;
+            HostUsername = hostUsername ?? string.Empty;
         }
 
         /// <summary>
@@ -54,5 +56,14 @@ namespace MediaBrowser.Model.SyncPlay
         /// </summary>
         /// <value>The date when this DTO has been created.</value>
         public DateTime LastUpdatedAt { get; }
+
+        /// <summary>
+        /// Gets the username of the session that created the group. This is set once at
+        /// group creation and never changes for the lifetime of the group, regardless of
+        /// participants joining or leaving, so clients can use it as a stable "who is host"
+        /// identity instead of deriving it from participant list ordering.
+        /// </summary>
+        /// <value>The host's username.</value>
+        public string HostUsername { get; }
     }
 }

--- a/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
+++ b/MediaBrowser.Model/SyncPlay/GroupInfoDto.cs
@@ -16,7 +16,7 @@ namespace MediaBrowser.Model.SyncPlay
         /// <param name="state">The group state.</param>
         /// <param name="participants">The participants.</param>
         /// <param name="lastUpdatedAt">The date when this DTO has been created.</param>
-        /// <param name="hostUsername">The username of the session that created the group.</param>
+        /// <param name="hostUsername">The username of the group's host.</param>
         public GroupInfoDto(Guid groupId, string groupName, GroupStateType state, IReadOnlyList<string> participants, DateTime lastUpdatedAt, string? hostUsername = null)
         {
             GroupId = groupId;
@@ -58,10 +58,11 @@ namespace MediaBrowser.Model.SyncPlay
         public DateTime LastUpdatedAt { get; }
 
         /// <summary>
-        /// Gets the username of the session that created the group. This is set once at
-        /// group creation and never changes for the lifetime of the group, regardless of
-        /// participants joining or leaving, so clients can use it as a stable "who is host"
-        /// identity instead of deriving it from participant list ordering.
+        /// Gets the username of the group's host. Initially the user that created the group;
+        /// if the host leaves while other participants remain, the server promotes the
+        /// longest-standing remaining participant. This always identifies a current member
+        /// of the group, so clients can use it as a stable "who is host" identity instead of
+        /// deriving it from participant list ordering.
         /// </summary>
         /// <value>The host's username.</value>
         public string HostUsername { get; }


### PR DESCRIPTION
**Changes**

SyncPlay groups have no stable notion of "who created / hosts this group". Anything a client
bases on `Participants[0]` is built on `Dictionary<TKey,TValue>` enumeration order, which is
unspecified and shifts whenever an entry is removed (`_participants.Remove` runs on every
SessionLeave) — so "who is host" can silently reassign to an arbitrary member after ordinary
group churn.

Commit 1 tracks `HostUsername` on `Group`, set in `CreateGroup` from the creating session's
username, and exposes it on `GroupInfoDto` (additive, following the same optional-parameter
pattern as other DTO additions) so clients have a stable identity to key off.

Commit 2 handles the host leaving: on SessionLeave, if no remaining participant carries the
host's username (checked by username, so a host with multiple sessions keeps the role until
the last one leaves) and the group is not empty, the longest-standing remaining member is
promoted (`GroupMember` now records `JoinedAt`; ties broken by session id — deterministic and
independent of dictionary order). Reassignment happens before the leave updates go out, so
every subsequent `GetInfo()` carries the new value.

Tested by building the touched projects and by running the change in production on a private
Jellyfin server with regular multi-client SyncPlay sessions, including host-leave scenarios.

**Code assistance**

Developed with LLM assistance (Claude): root-cause analysis and initial patch generation.
All code was human-reviewed, built, and has been running in production on a private server.

**Issues**

None.
