### PR TITLE
Return created API key on POST /Auth/Keys

### DIFF
--- a/Jellyfin.Api/Controllers/ApiKeyController.cs
+++ b/Jellyfin.Api/Controllers/ApiKeyController.cs
@@ -47,16 +47,14 @@ public class ApiKeyController : BaseJellyfinApiController
     /// Create a new api key.
     /// </summary>
     /// <param name="app">Name of the app using the authentication key.</param>
-    /// <response code="204">Api key created.</response>
-    /// <returns>A <see cref="NoContentResult"/>.</returns>
+    /// <response code="200">Api key created and returned.</response>
+    /// <returns>An <see cref="OkObjectResult"/> containing the created <see cref="AuthenticationInfo"/>.</returns>
     [HttpPost("Keys")]
     [Authorize(Policy = Policies.RequiresElevation)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> CreateKey([FromQuery, Required] string app)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AuthenticationInfo>> CreateKey([FromQuery, Required] string app)
     {
-        await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
-
-        return NoContent();
+        return await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
@@ -23,14 +23,25 @@ namespace Jellyfin.Server.Implementations.Security
         }
 
         /// <inheritdoc />
-        public async Task CreateApiKey(string name)
+        public async Task<AuthenticationInfo> CreateApiKey(string name)
         {
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                dbContext.ApiKeys.Add(new ApiKey(name));
+                var apiKey = new ApiKey(name);
+                dbContext.ApiKeys.Add(apiKey);
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                return new AuthenticationInfo
+                {
+                    AppName = apiKey.Name,
+                    AccessToken = apiKey.AccessToken,
+                    DateCreated = apiKey.DateCreated,
+                    DeviceId = string.Empty,
+                    DeviceName = string.Empty,
+                    AppVersion = string.Empty
+                };
             }
         }
 

--- a/MediaBrowser.Controller/Security/IAuthenticationManager.cs
+++ b/MediaBrowser.Controller/Security/IAuthenticationManager.cs
@@ -12,8 +12,8 @@ namespace MediaBrowser.Controller.Security
         /// Creates an API key.
         /// </summary>
         /// <param name="name">The name of the key.</param>
-        /// <returns>A task representing the creation of the key.</returns>
-        Task CreateApiKey(string name);
+        /// <returns>A task representing the creation of the key, containing the created <see cref="AuthenticationInfo"/>.</returns>
+        Task<AuthenticationInfo> CreateApiKey(string name);
 
         /// <summary>
         /// Gets the API keys.

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/ApiKeyControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/ApiKeyControllerTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Extensions.Json;
+using MediaBrowser.Controller.Security;
+using MediaBrowser.Model.Querying;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers
+{
+    public sealed class ApiKeyControllerTests : IClassFixture<JellyfinApplicationFactory>
+    {
+        private readonly JellyfinApplicationFactory _factory;
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
+        private static string? _accessToken;
+
+        public ApiKeyControllerTests(JellyfinApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task Post_CreateKey_ReturnsCreatedKey()
+        {
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+            const string AppName = "ApiKeyControllerTests_App";
+
+            using var response = await client.PostAsync($"/Auth/Keys?app={AppName}", null, TestContext.Current.CancellationToken);
+
+            // The endpoint must return the created key, not an empty 204 No Content.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var createdKey = await response.Content.ReadFromJsonAsync<AuthenticationInfo>(_jsonOptions, TestContext.Current.CancellationToken);
+            Assert.NotNull(createdKey);
+            Assert.Equal(AppName, createdKey!.AppName);
+            Assert.False(string.IsNullOrWhiteSpace(createdKey.AccessToken));
+
+            // The returned token must match one of the persisted keys.
+            using var getResponse = await client.GetAsync("/Auth/Keys", TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+            var keys = await getResponse.Content.ReadFromJsonAsync<QueryResult<AuthenticationInfo>>(_jsonOptions, TestContext.Current.CancellationToken);
+            Assert.NotNull(keys);
+            Assert.Contains(keys!.Items, k => k.AccessToken == createdKey.AccessToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #16258

The `POST /Auth/Keys` endpoint created an API key but returned `204 No Content`, forcing clients to `GET /Auth/Keys` and filter by app name to find the new key.

## Changes

- `CreateKey` now returns `200 OK` with the created `AuthenticationInfo` (same DTO as `GET /Auth/Keys`)
- `IAuthenticationManager.CreateApiKey` returns the created `AuthenticationInfo`
- Implementation builds and returns the entity

## Test plan

- [x] New integration test: POST returns 200 with non-empty `AccessToken`/`AppName`, token matches subsequent GET
- [x] `dotnet build` — 0 errors