### PR TITLE
fix: don't 500 password reset PIN redemption on a corrupt reset file (#16579)

### DIFF
--- a/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
@@ -58,11 +58,7 @@ namespace Jellyfin.Server.Implementations.Users
             var usersReset = new List<string>();
             foreach (var resetFile in Directory.EnumerateFiles(_passwordResetFileBaseDir, $"{BaseResetFileName}*"))
             {
-                // Reset file names embed a hash derived from the target username, so avoid
-                // logging the raw path/file name verbatim. Log a short, non-reversible
-                // identifier instead so an administrator can still correlate log entries
-                // with a specific file (e.g. to cross-reference file system timestamps)
-                // without the sensitive value being written to the log in clear text.
+                // Hash path to avoid logging sensitive file names verbatim.
                 var resetFileId = resetFile.GetMD5().ToString("N", CultureInfo.InvariantCulture)[..8];
 
                 SerializablePasswordReset? spr;
@@ -76,10 +72,7 @@ namespace Jellyfin.Server.Implementations.Users
                 }
                 catch (JsonException ex)
                 {
-                    // A reset file can be left in a corrupt/partial state if the server was
-                    // terminated while it was being written. Such a file can never be parsed
-                    // successfully, so it is safe - and necessary, to avoid it being re-parsed
-                    // and re-logged on every future redemption attempt - to delete it.
+                    // File is unrecoverably corrupt; delete it so it won't be retried.
                     _logger.LogWarning(ex, "Deleting corrupt password reset file (id {ResetFileId}) that failed to deserialize", resetFileId);
                     File.Delete(resetFile);
                     continue;
@@ -87,10 +80,6 @@ namespace Jellyfin.Server.Implementations.Users
 
                 if (spr is null)
                 {
-                    // The file contained valid JSON that deserialized to null. This is not the
-                    // same kind of unambiguous, unrecoverable corruption as a JsonException, so
-                    // it is left in place rather than deleted, in case it is a symptom of a
-                    // different underlying issue an administrator may want to investigate.
                     _logger.LogWarning("Ignoring password reset file (id {ResetFileId}) that deserialized to null", resetFileId);
                     continue;
                 }

--- a/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
@@ -58,7 +58,6 @@ namespace Jellyfin.Server.Implementations.Users
             var usersReset = new List<string>();
             foreach (var resetFile in Directory.EnumerateFiles(_passwordResetFileBaseDir, $"{BaseResetFileName}*"))
             {
-                // Hash path to avoid logging sensitive file names verbatim.
                 var resetFileId = resetFile.GetMD5().ToString("N", CultureInfo.InvariantCulture)[..8];
 
                 SerializablePasswordReset? spr;
@@ -72,7 +71,6 @@ namespace Jellyfin.Server.Implementations.Users
                 }
                 catch (JsonException ex)
                 {
-                    // File is unrecoverably corrupt; delete it so it won't be retried.
                     _logger.LogWarning(ex, "Deleting corrupt password reset file (id {ResetFileId}) that failed to deserialize", resetFileId);
                     File.Delete(resetFile);
                     continue;

--- a/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Server.Implementations.Users
 {
@@ -24,6 +25,7 @@ namespace Jellyfin.Server.Implementations.Users
         private const string BaseResetFileName = "passwordreset";
 
         private readonly IApplicationHost _appHost;
+        private readonly ILogger<DefaultPasswordResetProvider> _logger;
 
         private readonly string _passwordResetFileBase;
         private readonly string _passwordResetFileBaseDir;
@@ -33,11 +35,13 @@ namespace Jellyfin.Server.Implementations.Users
         /// </summary>
         /// <param name="configurationManager">The configuration manager.</param>
         /// <param name="appHost">The application host.</param>
-        public DefaultPasswordResetProvider(IServerConfigurationManager configurationManager, IApplicationHost appHost)
+        /// <param name="logger">The logger.</param>
+        public DefaultPasswordResetProvider(IServerConfigurationManager configurationManager, IApplicationHost appHost, ILogger<DefaultPasswordResetProvider> logger)
         {
             _passwordResetFileBaseDir = configurationManager.ApplicationPaths.ProgramDataPath;
             _passwordResetFileBase = Path.Combine(_passwordResetFileBaseDir, BaseResetFileName);
             _appHost = appHost;
+            _logger = logger;
             // TODO: Remove the circular dependency on UserManager
         }
 
@@ -54,12 +58,30 @@ namespace Jellyfin.Server.Implementations.Users
             var usersReset = new List<string>();
             foreach (var resetFile in Directory.EnumerateFiles(_passwordResetFileBaseDir, $"{BaseResetFileName}*"))
             {
-                SerializablePasswordReset spr;
-                var str = AsyncFile.OpenRead(resetFile);
-                await using (str.ConfigureAwait(false))
+                SerializablePasswordReset? spr;
+                try
                 {
-                    spr = await JsonSerializer.DeserializeAsync<SerializablePasswordReset>(str).ConfigureAwait(false)
-                        ?? throw new ResourceNotFoundException($"Provided path ({resetFile}) is not valid.");
+                    var str = AsyncFile.OpenRead(resetFile);
+                    await using (str.ConfigureAwait(false))
+                    {
+                        spr = await JsonSerializer.DeserializeAsync<SerializablePasswordReset>(str).ConfigureAwait(false);
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    // A reset file can be left in a corrupt/partial state if the server was
+                    // terminated while it was being written. Without this, a single bad file
+                    // would make every future password reset attempt fail with a 500 error.
+                    _logger.LogWarning(ex, "Ignoring invalid password reset file {ResetFile}", resetFile);
+                    File.Delete(resetFile);
+                    continue;
+                }
+
+                if (spr is null)
+                {
+                    _logger.LogWarning("Ignoring invalid password reset file {ResetFile}", resetFile);
+                    File.Delete(resetFile);
+                    continue;
                 }
 
                 if (spr.ExpirationDate < DateTime.UtcNow)

--- a/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
@@ -58,6 +58,13 @@ namespace Jellyfin.Server.Implementations.Users
             var usersReset = new List<string>();
             foreach (var resetFile in Directory.EnumerateFiles(_passwordResetFileBaseDir, $"{BaseResetFileName}*"))
             {
+                // Reset file names embed a hash derived from the target username, so avoid
+                // logging the raw path/file name verbatim. Log a short, non-reversible
+                // identifier instead so an administrator can still correlate log entries
+                // with a specific file (e.g. to cross-reference file system timestamps)
+                // without the sensitive value being written to the log in clear text.
+                var resetFileId = resetFile.GetMD5().ToString("N", CultureInfo.InvariantCulture)[..8];
+
                 SerializablePasswordReset? spr;
                 try
                 {
@@ -70,17 +77,21 @@ namespace Jellyfin.Server.Implementations.Users
                 catch (JsonException ex)
                 {
                     // A reset file can be left in a corrupt/partial state if the server was
-                    // terminated while it was being written. Without this, a single bad file
-                    // would make every future password reset attempt fail with a 500 error.
-                    _logger.LogWarning(ex, "Ignoring invalid password reset file {ResetFile}", resetFile);
+                    // terminated while it was being written. Such a file can never be parsed
+                    // successfully, so it is safe - and necessary, to avoid it being re-parsed
+                    // and re-logged on every future redemption attempt - to delete it.
+                    _logger.LogWarning(ex, "Deleting corrupt password reset file (id {ResetFileId}) that failed to deserialize", resetFileId);
                     File.Delete(resetFile);
                     continue;
                 }
 
                 if (spr is null)
                 {
-                    _logger.LogWarning("Ignoring invalid password reset file {ResetFile}", resetFile);
-                    File.Delete(resetFile);
+                    // The file contained valid JSON that deserialized to null. This is not the
+                    // same kind of unambiguous, unrecoverable corruption as a JsonException, so
+                    // it is left in place rather than deleted, in case it is a symptom of a
+                    // different underlying issue an administrator may want to investigate.
+                    _logger.LogWarning("Ignoring password reset file (id {ResetFileId}) that deserialized to null", resetFileId);
                     continue;
                 }
 

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
@@ -59,8 +59,6 @@ namespace Jellyfin.Server.Implementations.Tests.Users
                 "{ this is not valid json",
                 TestContext.Current.CancellationToken);
 
-            // Previously this threw an unhandled JsonException, resulting in a 500 error
-            // for every password reset attempt until the corrupt file was removed manually.
             var ex = await Record.ExceptionAsync(() => _provider.RedeemPasswordResetPin("1234"));
 
             Assert.IsType<ResourceNotFoundException>(ex);
@@ -99,9 +97,6 @@ namespace Jellyfin.Server.Implementations.Tests.Users
             var nullFile = Path.Combine(_passwordResetFileBaseDir, "passwordreset-null.json");
             await File.WriteAllTextAsync(nullFile, "null", TestContext.Current.CancellationToken);
 
-            // A file that deserializes to null isn't unambiguously corrupt the way a
-            // JsonException is, so unlike the corrupt-JSON case it should be left in place
-            // for an administrator to investigate rather than being deleted automatically.
             var ex = await Record.ExceptionAsync(() => _provider.RedeemPasswordResetPin("1234"));
 
             Assert.IsType<ResourceNotFoundException>(ex);
@@ -121,12 +116,6 @@ namespace Jellyfin.Server.Implementations.Tests.Users
             Assert.All(_logger.Messages, message => Assert.DoesNotContain(_passwordResetFileBaseDir, message, StringComparison.Ordinal));
         }
 
-        /// <summary>
-        /// A minimal <see cref="ILogger{TCategoryName}"/> that records the formatted text of
-        /// every log message, so tests can assert on what would actually be written to the log
-        /// without depending on a specific logging framework.
-        /// </summary>
-        /// <typeparam name="T">The logging category.</typeparam>
         private sealed class RecordingLogger<T> : ILogger<T>
         {
             public List<string> Messages { get; } = new();

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -18,6 +19,7 @@ namespace Jellyfin.Server.Implementations.Tests.Users
     public sealed class DefaultPasswordResetProviderTests : IDisposable
     {
         private readonly string _passwordResetFileBaseDir;
+        private readonly RecordingLogger<DefaultPasswordResetProvider> _logger;
         private readonly DefaultPasswordResetProvider _provider;
         private readonly Mock<IUserManager> _userManager;
 
@@ -36,10 +38,12 @@ namespace Jellyfin.Server.Implementations.Tests.Users
             var appHost = new Mock<IApplicationHost>();
             appHost.Setup(x => x.Resolve<IUserManager>()).Returns(_userManager.Object);
 
+            _logger = new RecordingLogger<DefaultPasswordResetProvider>();
+
             _provider = new DefaultPasswordResetProvider(
                 configManager.Object,
                 appHost.Object,
-                NullLogger<DefaultPasswordResetProvider>.Instance);
+                _logger);
         }
 
         public void Dispose()
@@ -87,6 +91,56 @@ namespace Jellyfin.Server.Implementations.Tests.Users
             Assert.True(result.Success);
             Assert.Contains("testuser", result.UsersReset);
             Assert.False(File.Exists(corruptFile));
+        }
+
+        [Fact]
+        public async Task RedeemPasswordResetPin_NullDeserializedResetFilePresent_DoesNotDeleteFile()
+        {
+            var nullFile = Path.Combine(_passwordResetFileBaseDir, "passwordreset-null.json");
+            await File.WriteAllTextAsync(nullFile, "null", TestContext.Current.CancellationToken);
+
+            // A file that deserializes to null isn't unambiguously corrupt the way a
+            // JsonException is, so unlike the corrupt-JSON case it should be left in place
+            // for an administrator to investigate rather than being deleted automatically.
+            var ex = await Record.ExceptionAsync(() => _provider.RedeemPasswordResetPin("1234"));
+
+            Assert.IsType<ResourceNotFoundException>(ex);
+            Assert.True(File.Exists(nullFile));
+        }
+
+        [Fact]
+        public async Task RedeemPasswordResetPin_CorruptResetFilePresent_DoesNotLogFilePathOrPin()
+        {
+            var corruptFile = Path.Combine(_passwordResetFileBaseDir, "passwordreset-corrupt.json");
+            await File.WriteAllTextAsync(corruptFile, "{ this is not valid json", TestContext.Current.CancellationToken);
+
+            await Record.ExceptionAsync(() => _provider.RedeemPasswordResetPin("1234"));
+
+            Assert.NotEmpty(_logger.Messages);
+            Assert.All(_logger.Messages, message => Assert.DoesNotContain(corruptFile, message, StringComparison.Ordinal));
+            Assert.All(_logger.Messages, message => Assert.DoesNotContain(_passwordResetFileBaseDir, message, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// A minimal <see cref="ILogger{TCategoryName}"/> that records the formatted text of
+        /// every log message, so tests can assert on what would actually be written to the log
+        /// without depending on a specific logging framework.
+        /// </summary>
+        /// <typeparam name="T">The logging category.</typeparam>
+        private sealed class RecordingLogger<T> : ILogger<T>
+        {
+            public List<string> Messages { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
+                => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/DefaultPasswordResetProviderTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Users;
+using MediaBrowser.Common;
+using MediaBrowser.Common.Extensions;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Users
+{
+    public sealed class DefaultPasswordResetProviderTests : IDisposable
+    {
+        private readonly string _passwordResetFileBaseDir;
+        private readonly DefaultPasswordResetProvider _provider;
+        private readonly Mock<IUserManager> _userManager;
+
+        public DefaultPasswordResetProviderTests()
+        {
+            _passwordResetFileBaseDir = Directory.CreateTempSubdirectory(nameof(DefaultPasswordResetProviderTests)).FullName;
+
+            var appPaths = new Mock<IServerApplicationPaths>();
+            appPaths.Setup(x => x.ProgramDataPath).Returns(_passwordResetFileBaseDir);
+
+            var configManager = new Mock<IServerConfigurationManager>();
+            configManager.Setup(x => x.ApplicationPaths).Returns(appPaths.Object);
+
+            _userManager = new Mock<IUserManager>();
+
+            var appHost = new Mock<IApplicationHost>();
+            appHost.Setup(x => x.Resolve<IUserManager>()).Returns(_userManager.Object);
+
+            _provider = new DefaultPasswordResetProvider(
+                configManager.Object,
+                appHost.Object,
+                NullLogger<DefaultPasswordResetProvider>.Instance);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(_passwordResetFileBaseDir, true);
+        }
+
+        [Fact]
+        public async Task RedeemPasswordResetPin_CorruptResetFilePresent_DoesNotThrowJsonException()
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(_passwordResetFileBaseDir, "passwordreset-corrupt.json"),
+                "{ this is not valid json",
+                TestContext.Current.CancellationToken);
+
+            // Previously this threw an unhandled JsonException, resulting in a 500 error
+            // for every password reset attempt until the corrupt file was removed manually.
+            var ex = await Record.ExceptionAsync(() => _provider.RedeemPasswordResetPin("1234"));
+
+            Assert.IsType<ResourceNotFoundException>(ex);
+        }
+
+        [Fact]
+        public async Task RedeemPasswordResetPin_CorruptResetFilePresent_DeletesCorruptFileAndStillRedeemsValidOne()
+        {
+            var corruptFile = Path.Combine(_passwordResetFileBaseDir, "passwordreset-corrupt.json");
+            await File.WriteAllTextAsync(corruptFile, "{ this is not valid json", TestContext.Current.CancellationToken);
+
+            var user = new User("testuser", "DefaultAuthenticationProvider", "DefaultPasswordResetProvider");
+            _userManager.Setup(x => x.GetUserByName("testuser")).Returns(user);
+            _userManager.Setup(x => x.ChangePassword(user.Id, "1234")).Returns(Task.CompletedTask);
+
+            var validFile = Path.Combine(_passwordResetFileBaseDir, "passwordreset-valid.json");
+            var validReset = new
+            {
+                ExpirationDate = DateTime.UtcNow.AddMinutes(30),
+                Pin = "1234",
+                PinFile = validFile,
+                UserName = "testuser"
+            };
+            await File.WriteAllTextAsync(validFile, JsonSerializer.Serialize(validReset), TestContext.Current.CancellationToken);
+
+            var result = await _provider.RedeemPasswordResetPin("1234");
+
+            Assert.True(result.Success);
+            Assert.Contains("testuser", result.UsersReset);
+            Assert.False(File.Exists(corruptFile));
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerNormalizedUsernameTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Users/UserManagerNormalizedUsernameTests.cs
@@ -61,7 +61,8 @@ namespace Jellyfin.Server.Implementations.Tests.Users
             var invalidAuthProvider = new InvalidAuthProvider();
             var defaultPasswordResetProvider = new DefaultPasswordResetProvider(
                 configManager.Object,
-                appHost.Object);
+                appHost.Object,
+                NullLogger<DefaultPasswordResetProvider>.Instance);
 
             _userManager = new UserManager(
                 factory.Object,


### PR DESCRIPTION
**Changes**

`StartForgotPasswordProcess` writes `passwordreset*.json` files directly to their final path with no atomic temp-file/rename pattern, so an interrupted write (crash, forced container stop, disk full, etc.) can leave a partial/corrupt file behind. `RedeemPasswordResetPin` enumerates and deserializes every matching file with no error handling, and `ExceptionMiddleware` has no case for `JsonException`, so it falls through to a generic 500. This means a single leftover corrupt file makes `POST /Users/ForgotPassword/Pin` fail with an unhandled 500 for *every* password reset attempt, for *every* user, until someone finds and manually deletes the bad file.

This wraps the per-file read/deserialize step in a try/catch: on a `JsonException` (or a `null` deserialization result), the offending file is logged and deleted, and the loop continues to the next reset file instead of aborting the whole request.

**Code assistance**

Code generated by LLM (Claude Code) based on my own investigation of the reported issue and the surrounding code; reviewed for correctness, root-caused against `ExceptionMiddleware`'s exception-to-status-code mapping, and verified locally before submission.

**Test evidence**

Added `DefaultPasswordResetProviderTests` with two cases:
- A corrupt reset file no longer throws an unhandled `JsonException` (confirmed to fail with the old code, passes with the fix).
- A corrupt reset file is deleted and doesn't block a concurrent valid reset file from being redeemed successfully.

Ran locally:
- `dotnet build Jellyfin.sln -c Debug` — succeeds, no new warnings/errors.
- `dotnet test tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj` — 571 passed, 0 failed, 5 pre-existing skips.
- `dotnet format --verify-no-changes Jellyfin.sln` — clean.

**Issues**

Fixes #16579