### PR TITLE
Audiobooks: Add CUE chapter support

### DIFF
--- a/Emby.Naming/AudioBook/AudioBookResolver.cs
+++ b/Emby.Naming/AudioBook/AudioBookResolver.cs
@@ -42,6 +42,11 @@ namespace Emby.Naming.AudioBook
                 return null;
             }
 
+            if (extension.Equals(".cue", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
             var container = extension.TrimStart('.');
 
             var parsingResult = new AudioBookFilePathParser(_options).Parse(path);

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -36,6 +36,7 @@ namespace MediaBrowser.Model.Configuration
 
             PreferNonstandardArtistsTag = false;
             UseCustomTagDelimiters = false;
+            PreferCueSidecarForAudiobookChapters = false;
             CustomTagDelimiters = _defaultTagDelimiters;
             DelimiterWhitelist = Array.Empty<string>();
         }
@@ -126,6 +127,9 @@ namespace MediaBrowser.Model.Configuration
 
         [DefaultValue(false)]
         public bool UseCustomTagDelimiters { get; set; }
+
+        [DefaultValue(false)]
+        public bool PreferCueSidecarForAudiobookChapters { get; set; }
 
         public string[] CustomTagDelimiters { get; set; }
 

--- a/MediaBrowser.Providers/Books/AudioBookCueChapterParser.cs
+++ b/MediaBrowser.Providers/Books/AudioBookCueChapterParser.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MediaBrowser.Model.Entities;
+
+namespace MediaBrowser.Providers.Books;
+
+internal static class AudioBookCueChapterParser
+{
+    private const long TicksPerSecond = 10_000_000L;
+    private const long TicksPerFrame = TicksPerSecond / 75;
+
+    internal static IReadOnlyList<ChapterInfo> ParseCueSidecar(string audioPath)
+    {
+        var cuePath = FindCueSidecar(audioPath);
+        if (cuePath is null)
+        {
+            return Array.Empty<ChapterInfo>();
+        }
+
+        return ParseCueFile(cuePath);
+    }
+
+    private static string? FindCueSidecar(string audioPath)
+    {
+        var dir = Path.GetDirectoryName(audioPath);
+        if (dir is null)
+        {
+            return null;
+        }
+
+        var sameName = Path.ChangeExtension(audioPath, ".cue");
+        if (File.Exists(sameName))
+        {
+            return sameName;
+        }
+
+        var cueFiles = Directory.GetFiles(dir, "*.cue");
+        return cueFiles.Length == 1 ? cueFiles[0] : null;
+    }
+
+    private static IReadOnlyList<ChapterInfo> ParseCueFile(string cuePath)
+    {
+        var chapters = new List<ChapterInfo>();
+        ChapterInfo? current = null;
+
+        foreach (var line in File.ReadLines(cuePath))
+        {
+            var trimmed = line.TrimStart();
+
+            if (trimmed.StartsWith("TRACK ", StringComparison.OrdinalIgnoreCase))
+            {
+                current = new ChapterInfo();
+                chapters.Add(current);
+            }
+            else if (current is not null && trimmed.StartsWith("TITLE ", StringComparison.OrdinalIgnoreCase))
+            {
+                current.Name = trimmed[6..].Trim('"', ' ');
+            }
+            else if (current is not null && trimmed.StartsWith("INDEX 01 ", StringComparison.OrdinalIgnoreCase))
+            {
+                current.StartPositionTicks = ParseTimestamp(trimmed[9..]);
+            }
+        }
+
+        return chapters;
+    }
+
+    private static long ParseTimestamp(string timestamp)
+    {
+        var parts = timestamp.Trim().Split(':');
+        if (parts.Length != 3
+            || !int.TryParse(parts[0], out var minutes)
+            || !int.TryParse(parts[1], out var seconds)
+            || !int.TryParse(parts[2], out var frames))
+        {
+            return 0;
+        }
+
+        return (((minutes * 60L) + seconds) * TicksPerSecond) + (frames * TicksPerFrame);
+    }
+}

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -20,6 +20,7 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Providers.Books;
 using Microsoft.Extensions.Logging;
 using static Jellyfin.Extensions.StringExtensions;
 
@@ -158,9 +159,42 @@ namespace MediaBrowser.Providers.MediaInfo
 
             _mediaStreamRepository.SaveMediaStreams(audio.Id, mediaStreams, cancellationToken);
 
-            if (audio is AudioBook && mediaInfo.Chapters is { Length: > 0 })
+            if (audio is AudioBook audioBook)
             {
-                _chapterManager.SaveChapters(audio, mediaInfo.Chapters);
+                SaveAudioBookChapters(audioBook, mediaInfo);
+            }
+        }
+
+        internal void SaveAudioBookChapters(AudioBook audioBook, Model.MediaInfo.MediaInfo mediaInfo)
+        {
+            var libraryOptions = _libraryManager.GetLibraryOptions(audioBook);
+
+            if (libraryOptions.PreferCueSidecarForAudiobookChapters)
+            {
+                var cueChapters = AudioBookCueChapterParser.ParseCueSidecar(audioBook.Path);
+                if (cueChapters.Count > 0)
+                {
+                    _chapterManager.SaveChapters(audioBook, cueChapters);
+                }
+                else if (mediaInfo.Chapters is { Length: > 0 })
+                {
+                    _chapterManager.SaveChapters(audioBook, mediaInfo.Chapters);
+                }
+            }
+            else
+            {
+                if (mediaInfo.Chapters is { Length: > 0 })
+                {
+                    _chapterManager.SaveChapters(audioBook, mediaInfo.Chapters);
+                }
+                else
+                {
+                    var cueChapters = AudioBookCueChapterParser.ParseCueSidecar(audioBook.Path);
+                    if (cueChapters.Count > 0)
+                    {
+                        _chapterManager.SaveChapters(audioBook, cueChapters);
+                    }
+                }
             }
         }
 

--- a/tests/Jellyfin.Providers.Tests/Books/AudioBookCueChapterParserTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Books/AudioBookCueChapterParserTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using MediaBrowser.Providers.Books;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.Books;
+
+public class AudioBookCueChapterParserTests
+{
+    private const long TicksPerSecond = 10_000_000L;
+    private const long TicksPerFrame = TicksPerSecond / 75;
+
+    [Fact]
+    public void ParseCueSidecar_NoCueFile_ReturnsEmpty()
+    {
+        using var dir = new TempDir();
+        Assert.Empty(AudioBookCueChapterParser.ParseCueSidecar(dir.File("book.mp3")));
+    }
+
+    [Fact]
+    public void ParseCueSidecar_SameNamedCue_ParsesTracksWithTimestamps()
+    {
+        using var dir = new TempDir();
+        var audioPath = dir.File("book.mp3");
+        dir.Write("book.cue", Cue(
+            "FILE \"book.mp3\" MP3",
+            "  TRACK 01 AUDIO",
+            "    TITLE \"Opening Credits\"",
+            "    INDEX 01 00:00:00",
+            "  TRACK 02 AUDIO",
+            "    TITLE \"Chapter 1\"",
+            "    INDEX 01 01:30:00",
+            "  TRACK 03 AUDIO",
+            "    TITLE \"Chapter 2\"",
+            "    INDEX 01 03:00:37"));
+
+        var chapters = AudioBookCueChapterParser.ParseCueSidecar(audioPath);
+
+        Assert.Equal(3, chapters.Count);
+
+        Assert.Equal("Opening Credits", chapters[0].Name);
+        Assert.Equal(0, chapters[0].StartPositionTicks);
+
+        Assert.Equal("Chapter 1", chapters[1].Name);
+        Assert.Equal(90L * TicksPerSecond, chapters[1].StartPositionTicks);
+
+        Assert.Equal("Chapter 2", chapters[2].Name);
+        Assert.Equal((180L * TicksPerSecond) + (37L * TicksPerFrame), chapters[2].StartPositionTicks);
+    }
+
+    [Fact]
+    public void ParseCueSidecar_SingleCueWithDifferentName_IsUsed()
+    {
+        using var dir = new TempDir();
+        var audioPath = dir.File("audiobook.mp3");
+        dir.Write("tracklist.cue", Cue(
+            "TRACK 01 AUDIO",
+            "  TITLE \"Only\"",
+            "  INDEX 01 00:10:00"));
+
+        var chapters = AudioBookCueChapterParser.ParseCueSidecar(audioPath);
+
+        Assert.Single(chapters);
+        Assert.Equal("Only", chapters[0].Name);
+        Assert.Equal(10L * TicksPerSecond, chapters[0].StartPositionTicks);
+    }
+
+    [Fact]
+    public void ParseCueSidecar_MultipleCuesNoNameMatch_ReturnsEmpty()
+    {
+        using var dir = new TempDir();
+        var audioPath = dir.File("book.mp3");
+        dir.Write("a.cue", Cue("TRACK 01 AUDIO", "  INDEX 01 00:00:00"));
+        dir.Write("b.cue", Cue("TRACK 01 AUDIO", "  INDEX 01 00:00:00"));
+
+        Assert.Empty(AudioBookCueChapterParser.ParseCueSidecar(audioPath));
+    }
+
+    [Fact]
+    public void ParseCueSidecar_MalformedTimestamp_IsZero()
+    {
+        using var dir = new TempDir();
+        var audioPath = dir.File("book.mp3");
+        dir.Write("book.cue", Cue(
+            "TRACK 01 AUDIO",
+            "  TITLE \"Bad\"",
+            "  INDEX 01 not:a:time"));
+
+        var chapters = AudioBookCueChapterParser.ParseCueSidecar(audioPath);
+
+        Assert.Single(chapters);
+        Assert.Equal(0, chapters[0].StartPositionTicks);
+    }
+
+    private static string Cue(params string[] lines) => string.Join('\n', lines);
+
+    private sealed class TempDir : IDisposable
+    {
+        private readonly string _path;
+
+        public TempDir()
+        {
+            _path = Path.Combine(Path.GetTempPath(), "jf-cue-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_path);
+        }
+
+        public string File(string name) => Path.Combine(_path, name);
+
+        public void Write(string name, string content) => System.IO.File.WriteAllText(File(name), content);
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_path, true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
- Support Audiobook CUE files (music unhandled)
- Parse CUE sidecar file
- Add a setting for preferring CUE chapters vs embedded chapters

**Code assistance**
- Had Opus help me with tests, only code it wrote
- Code review

**Feature Requests**
- https://features.jellyfin.org/posts/794/audiobook-metadata-support (Partially)
- https://features.jellyfin.org/posts/1782/support-side-by-side-external-chapter-metadata (doesn't support XML)

**Why?**
A lot of audiobooks (Amazon especially) add CUE sidecar files. Users adding CUE files currently make Jellyfin audiobook item pages break (see change in Emby.Naming/AudioBook/AudioBookResolver.cs). The sidecar also allows users much more easy access to change their chapter data without needing to get some external 3rd party app. Just change it in a text file, reset the metadata and it's updated

Split from my much bigger more [general purpose Audiobook PR](https://github.com/jellyfin/jellyfin/pull/17199)

**Frontend**
I'm at my 3 PR limit over there so I'll update this section when I have access.