### PR TITLE
Audiobooks: Add multi-file chapter support

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -1252,6 +1252,11 @@ namespace Emby.Server.Implementations.Dto
                     .ToArray();
             }
 
+            if (item is AudioBook audioBookItem && audioBookItem.AdditionalParts.Length != 0)
+            {
+                dto.PartCount = audioBookItem.AdditionalParts.Length + 1;
+            }
+
             // Add video info
             if (item is Video video)
             {

--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -393,7 +393,8 @@ namespace Emby.Server.Implementations.Library
                 sources = sources
                     .Where(source => !Guid.TryParse(source.Id, out var sourceId)
                         || sourceId.Equals(item.Id)
-                        || _libraryManager.GetItemById<BaseItem>(sourceId, user) is not null)
+                        || _libraryManager.GetItemById<BaseItem>(sourceId, user) is not null
+                        || item is AudioBook)
                     .ToArray();
 
                 foreach (var source in sources)

--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Emby.Naming.Audio;
@@ -186,38 +187,164 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
             foreach (var resolvedItem in resolverResult)
             {
-                if (resolvedItem.Files.Count > 1)
-                {
-                    // For now, until we sort out naming for multi-part books
-                    continue;
-                }
-
-                // Until multi-part books are handled letting files stack hides them from browsing in the client
-                if (resolvedItem.Files.Count == 0 || resolvedItem.Extras.Count > 0 || resolvedItem.AlternateVersions.Count > 0)
-                {
-                    continue;
-                }
-
-                var firstMedia = resolvedItem.Files[0];
-
-                var libraryItem = new AudioBook
-                {
-                    Path = firstMedia.Path,
-                    IsInMixedFolder = isInMixedFolder,
-                    ProductionYear = resolvedItem.Year,
-                    Name = parseName ?
-                        resolvedItem.Name :
-                        Path.GetFileNameWithoutExtension(firstMedia.Path),
-                    // AdditionalParts = resolvedItem.Files.Skip(1).Select(i => i.Path).ToArray(),
-                    // LocalAlternateVersions = resolvedItem.AlternateVersions.Select(i => i.Path).ToArray()
-                };
-
-                result.Items.Add(libraryItem);
+                result.Items.AddRange(CreateAudioBookItems(resolvedItem, isInMixedFolder, parseName));
             }
 
             result.ExtraFiles.AddRange(files.Where(i => !ContainsFile(resolverResult, i)));
 
             return result;
+        }
+
+        private IEnumerable<BaseItem> CreateAudioBookItems(AudioBookInfo resolvedItem, bool isInMixedFolder, bool parseName)
+        {
+            if (resolvedItem.Files.Count == 0)
+            {
+                return Array.Empty<BaseItem>();
+            }
+
+            // Descriptive names that contain their own numbers (e.g. "04 Chapter 1") collide on the
+            // parsed chapter number and get split into alternate versions. A distinct order number on
+            // every file means they are really separate parts, so keep them together as one book.
+            if (resolvedItem.Extras.Count == 0)
+            {
+                var allParts = resolvedItem.Files.Concat(resolvedItem.AlternateVersions).ToList();
+                if (allParts.Count > 1 && HasDistinctTrackNumbers(allParts))
+                {
+                    return new[] { BuildStackedAudioBook(allParts, isInMixedFolder, parseName, resolvedItem) };
+                }
+            }
+
+            if (resolvedItem.Extras.Count > 0 || resolvedItem.AlternateVersions.Count > 0)
+            {
+                return Array.Empty<BaseItem>();
+            }
+
+            if (resolvedItem.Files.Count > 1 && !IsCoherentMultiPartBook(resolvedItem))
+            {
+                return resolvedItem.Files.Select(file => new AudioBook
+                {
+                    Path = file.Path,
+                    IsInMixedFolder = isInMixedFolder,
+                    ProductionYear = resolvedItem.Year,
+                    Name = Path.GetFileNameWithoutExtension(file.Path)
+                });
+            }
+
+            return new[] { BuildStackedAudioBook(resolvedItem.Files, isInMixedFolder, parseName, resolvedItem) };
+        }
+
+        private static AudioBook BuildStackedAudioBook(IReadOnlyList<AudioBookFileInfo> files, bool isInMixedFolder, bool parseName, AudioBookInfo resolvedItem)
+        {
+            var orderedFiles = files
+                .OrderBy(f => GetTrackNumber(f.Path) ?? int.MaxValue)
+                .ToList();
+            var firstMedia = orderedFiles[0];
+
+            return new AudioBook
+            {
+                Path = firstMedia.Path,
+                IsInMixedFolder = isInMixedFolder,
+                ProductionYear = resolvedItem.Year,
+                Name = parseName ?
+                    resolvedItem.Name :
+                    Path.GetFileNameWithoutExtension(firstMedia.Path),
+                AdditionalParts = orderedFiles.Skip(1).Select(i => i.Path).ToArray()
+            };
+        }
+
+        private static bool IsCoherentMultiPartBook(AudioBookInfo info)
+        {
+            var files = info.Files;
+            if (files.Count <= 1)
+            {
+                return true;
+            }
+
+            return HasSharedBaseName(files) || HasDistinctTrackNumbers(files);
+        }
+
+        private static bool HasSharedBaseName(IReadOnlyList<AudioBookFileInfo> files)
+        {
+            if (!files.All(f => f.ChapterNumber is not null || f.PartNumber is not null))
+            {
+                return false;
+            }
+
+            var baseName = GetComparableBaseName(files[0].Path);
+            if (baseName.Length == 0)
+            {
+                return false;
+            }
+
+            return files.All(f => string.Equals(GetComparableBaseName(f.Path), baseName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool HasDistinctTrackNumbers(IReadOnlyList<AudioBookFileInfo> files)
+        {
+            var seen = new HashSet<int>();
+            foreach (var file in files)
+            {
+                var number = GetTrackNumber(file.Path);
+                if (number is null || !seen.Add(number.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string GetComparableBaseName(string path)
+        {
+            var name = Path.GetFileNameWithoutExtension(path.AsSpan()).Trim();
+            var end = name.Length;
+            while (end > 0)
+            {
+                var c = name[end - 1];
+                if (char.IsDigit(c) || c == ' ' || c == '_' || c == '-' || c == '.' || c == '#')
+                {
+                    end--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return name[..end].ToString();
+        }
+
+        private static int? GetTrackNumber(string path)
+        {
+            var name = Path.GetFileNameWithoutExtension(path.AsSpan()).Trim();
+            if (name.Length == 0)
+            {
+                return null;
+            }
+
+            var leading = 0;
+            while (leading < name.Length && char.IsDigit(name[leading]))
+            {
+                leading++;
+            }
+
+            if (leading > 0 && int.TryParse(name[..leading], NumberStyles.Integer, CultureInfo.InvariantCulture, out var leadingNumber))
+            {
+                return leadingNumber;
+            }
+
+            var trailing = name.Length;
+            while (trailing > 0 && char.IsDigit(name[trailing - 1]))
+            {
+                trailing--;
+            }
+
+            if (trailing < name.Length && int.TryParse(name[trailing..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var trailingNumber))
+            {
+                return trailingNumber;
+            }
+
+            return null;
         }
 
         private static bool ContainsFile(IEnumerable<AudioBookInfo> result, FileSystemMetadata file)

--- a/MediaBrowser.Controller/Entities/AudioBook.cs
+++ b/MediaBrowser.Controller/Entities/AudioBook.cs
@@ -3,15 +3,25 @@
 #pragma warning disable CA1724, CS1591
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
 
 namespace MediaBrowser.Controller.Entities
 {
-    [Common.RequiresSourceSerialisation]
     public class AudioBook : Audio.Audio, IHasSeries, IHasLookupInfo<SongInfo>
     {
+        public string[] AdditionalParts { get; set; } = Array.Empty<string>();
+
+        public long[] PartRunTimeTicks { get; set; } = Array.Empty<long>();
+
         [JsonIgnore]
         public override bool SupportsPositionTicksResume => true;
 
@@ -26,6 +36,58 @@ namespace MediaBrowser.Controller.Entities
 
         [JsonIgnore]
         public Guid SeriesId { get; set; }
+
+        public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
+        {
+            if (AdditionalParts.Length == 0 || PartRunTimeTicks.Length < AdditionalParts.Length + 1)
+            {
+                return base.GetMediaSources(enablePathSubstitution);
+            }
+
+            var sources = new List<MediaSourceInfo>(base.GetMediaSources(enablePathSubstitution));
+            if (sources.Count > 0)
+            {
+                sources[0].RunTimeTicks = PartRunTimeTicks[0];
+            }
+
+            var template = sources.Count > 0 ? sources[0] : null;
+            for (int i = 0; i < AdditionalParts.Length; i++)
+            {
+                sources.Add(new MediaSourceInfo
+                {
+                    Id = LibraryManager.GetNewItemId(AdditionalParts[i], typeof(AudioBook)).ToString("N", CultureInfo.InvariantCulture),
+                    Path = AdditionalParts[i],
+                    Protocol = template?.Protocol ?? MediaProtocol.File,
+                    RunTimeTicks = PartRunTimeTicks[i + 1],
+                    Container = template?.Container,
+                    Type = MediaSourceType.Default,
+                    MediaStreams = template?.MediaStreams ?? new List<MediaStream>(),
+                    IsInfiniteStream = false,
+                    SupportsDirectPlay = template?.SupportsDirectPlay ?? true,
+                    SupportsDirectStream = template?.SupportsDirectStream ?? true,
+                    SupportsTranscoding = template?.SupportsTranscoding ?? true,
+                    Bitrate = template?.Bitrate,
+                    DefaultAudioStreamIndex = template?.DefaultAudioStreamIndex,
+                    Name = System.IO.Path.GetFileNameWithoutExtension(AdditionalParts[i]),
+                });
+            }
+
+            return sources;
+        }
+
+        internal override ItemUpdateType UpdateFromResolvedItem(BaseItem newItem)
+        {
+            var updateType = base.UpdateFromResolvedItem(newItem);
+
+            if (newItem is AudioBook newAudioBook
+                && !AdditionalParts.SequenceEqual(newAudioBook.AdditionalParts, StringComparer.Ordinal))
+            {
+                AdditionalParts = newAudioBook.AdditionalParts;
+                updateType |= ItemUpdateType.MetadataImport;
+            }
+
+            return updateType;
+        }
 
         public string FindSeriesSortName()
         {

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Jellyfin.Extensions;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Lyrics;
 using MediaBrowser.Controller.MediaEncoding;
@@ -22,6 +24,7 @@ using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Logging;
 using static Jellyfin.Extensions.StringExtensions;
+using ChapterInfo = MediaBrowser.Model.Entities.ChapterInfo;
 
 namespace MediaBrowser.Providers.MediaInfo
 {
@@ -40,6 +43,7 @@ namespace MediaBrowser.Providers.MediaInfo
         private readonly ILyricManager _lyricManager;
         private readonly IMediaStreamRepository _mediaStreamRepository;
         private readonly IChapterManager _chapterManager;
+        private readonly IPathManager _pathManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioFileProber"/> class.
@@ -52,6 +56,7 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <param name="lyricManager">Instance of the <see cref="ILyricManager"/> interface.</param>
         /// <param name="mediaStreamRepository">Instance of the <see cref="IMediaStreamRepository"/>.</param>
         /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
+        /// <param name="pathManager">Instance of the <see cref="IPathManager"/> interface.</param>
         public AudioFileProber(
             ILogger<AudioFileProber> logger,
             IMediaSourceManager mediaSourceManager,
@@ -60,7 +65,8 @@ namespace MediaBrowser.Providers.MediaInfo
             LyricResolver lyricResolver,
             ILyricManager lyricManager,
             IMediaStreamRepository mediaStreamRepository,
-            IChapterManager chapterManager)
+            IChapterManager chapterManager,
+            IPathManager pathManager)
         {
             _mediaEncoder = mediaEncoder;
             _libraryManager = libraryManager;
@@ -70,6 +76,7 @@ namespace MediaBrowser.Providers.MediaInfo
             _lyricManager = lyricManager;
             _mediaStreamRepository = mediaStreamRepository;
             _chapterManager = chapterManager;
+            _pathManager = pathManager;
             ATL.Settings.DisplayValueSeparator = InternalValueSeparator;
             ATL.Settings.UseFileNameWhenNoTitle = false;
             ATL.Settings.ID3v2_separatev2v3Values = false;
@@ -158,9 +165,132 @@ namespace MediaBrowser.Providers.MediaInfo
 
             _mediaStreamRepository.SaveMediaStreams(audio.Id, mediaStreams, cancellationToken);
 
-            if (audio is AudioBook && mediaInfo.Chapters is { Length: > 0 })
+            if (audio is AudioBook audioBook)
             {
-                _chapterManager.SaveChapters(audio, mediaInfo.Chapters);
+                await SaveAudioBookChaptersAsync(audioBook, mediaInfo, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        internal async Task SaveAudioBookChaptersAsync(AudioBook audioBook, Model.MediaInfo.MediaInfo mediaInfo, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<ChapterInfo>? multiPartChapters = null;
+            if (audioBook.AdditionalParts.Length > 0)
+            {
+                var (chapters, totalTicks, partTicks) = await BuildMultiPartChaptersAsync(
+                    audioBook, mediaInfo.RunTimeTicks ?? 0, cancellationToken).ConfigureAwait(false);
+                audioBook.RunTimeTicks = totalTicks;
+                audioBook.PartRunTimeTicks = partTicks;
+                multiPartChapters = chapters;
+            }
+
+            if (mediaInfo.Chapters is { Length: > 0 })
+            {
+                _chapterManager.SaveChapters(audioBook, mediaInfo.Chapters);
+            }
+            else if (multiPartChapters is not null)
+            {
+                _chapterManager.SaveChapters(audioBook, multiPartChapters);
+            }
+        }
+
+        internal async Task<(IReadOnlyList<ChapterInfo> Chapters, long TotalRunTimeTicks, long[] PartRunTimeTicks)> BuildMultiPartChaptersAsync(
+            AudioBook audioBook,
+            long firstPartTicks,
+            CancellationToken cancellationToken)
+        {
+            var chapters = new List<ChapterInfo>();
+            var partTicks = new List<long> { firstPartTicks };
+
+            var firstChapter = new ChapterInfo
+            {
+                Name = StripLeadingTrackNumber(Path.GetFileNameWithoutExtension(audioBook.Path)),
+                StartPositionTicks = 0
+            };
+            TrySetChapterImage(audioBook, firstChapter, audioBook.Path);
+            chapters.Add(firstChapter);
+
+            var cumulativeTicks = firstPartTicks;
+
+            foreach (var partPath in audioBook.AdditionalParts)
+            {
+                var partInfo = await _mediaEncoder.GetMediaInfo(
+                    new MediaInfoRequest
+                    {
+                        MediaType = DlnaProfileType.Audio,
+                        MediaSource = new MediaSourceInfo
+                        {
+                            Path = partPath,
+                            Protocol = MediaProtocol.File
+                        }
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                var partDuration = partInfo.RunTimeTicks ?? 0;
+                partTicks.Add(partDuration);
+
+                var chapter = new ChapterInfo
+                {
+                    Name = StripLeadingTrackNumber(Path.GetFileNameWithoutExtension(partPath)),
+                    StartPositionTicks = cumulativeTicks
+                };
+                TrySetChapterImage(audioBook, chapter, partPath);
+                chapters.Add(chapter);
+
+                cumulativeTicks += partDuration;
+            }
+
+            return (chapters, cumulativeTicks, partTicks.ToArray());
+        }
+
+        internal static string StripLeadingTrackNumber(string name)
+        {
+            var digitsEnd = 0;
+            while (digitsEnd < name.Length && char.IsDigit(name[digitsEnd]))
+            {
+                digitsEnd++;
+            }
+
+            if (digitsEnd == 0)
+            {
+                return name;
+            }
+
+            var index = digitsEnd;
+            while (index < name.Length && (name[index] == ' ' || name[index] == '_' || name[index] == '-' || name[index] == '.' || name[index] == '#'))
+            {
+                index++;
+            }
+
+            if (index == digitsEnd)
+            {
+                return name;
+            }
+
+            var stripped = name[index..];
+            return stripped.Length > 0 ? stripped : name;
+        }
+
+        private void TrySetChapterImage(AudioBook audioBook, ChapterInfo chapter, string filePath)
+        {
+            try
+            {
+                var atlTrack = new Track(filePath);
+                var picture = atlTrack.EmbeddedPictures
+                    .FirstOrDefault(p => p.PicType == PictureInfo.PIC_TYPE.Front)
+                    ?? atlTrack.EmbeddedPictures.FirstOrDefault();
+
+                if (picture?.PictureData is { Length: > 0 })
+                {
+                    var imagePath = _pathManager.GetChapterImagePath(audioBook, chapter.StartPositionTicks);
+                    Directory.CreateDirectory(Path.GetDirectoryName(imagePath)!);
+                    File.WriteAllBytes(imagePath, picture.PictureData);
+                    chapter.ImagePath = imagePath;
+                    chapter.ImageDateModified = DateTime.UtcNow;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to extract embedded artwork from {Path}", filePath);
             }
         }
 

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Lyrics;
 using MediaBrowser.Controller.MediaEncoding;
@@ -67,6 +68,7 @@ namespace MediaBrowser.Providers.MediaInfo
         /// <param name="lyricManager">Instance of the <see cref="ILyricManager"/> interface.</param>
         /// <param name="mediaAttachmentRepository">Instance of the <see cref="IMediaAttachmentRepository"/> interface.</param>
         /// <param name="mediaStreamRepository">Instance of the <see cref="IMediaStreamRepository"/> interface.</param>
+        /// <param name="pathManager">Instance of the <see cref="IPathManager"/> interface.</param>
         public ProbeProvider(
             IMediaSourceManager mediaSourceManager,
             IMediaEncoder mediaEncoder,
@@ -81,7 +83,8 @@ namespace MediaBrowser.Providers.MediaInfo
             NamingOptions namingOptions,
             ILyricManager lyricManager,
             IMediaAttachmentRepository mediaAttachmentRepository,
-            IMediaStreamRepository mediaStreamRepository)
+            IMediaStreamRepository mediaStreamRepository,
+            IPathManager pathManager)
         {
             _logger = loggerFactory.CreateLogger<ProbeProvider>();
             _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
@@ -111,7 +114,8 @@ namespace MediaBrowser.Providers.MediaInfo
                 _lyricResolver,
                 lyricManager,
                 mediaStreamRepository,
-                chapterManager);
+                chapterManager,
+                pathManager);
         }
 
         /// <inheritdoc />

--- a/tests/Jellyfin.Controller.Tests/Entities/AudioBookTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/AudioBookTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Extensions.Json;
+using MediaBrowser.Common;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.Entities;
+
+public class AudioBookTests
+{
+    [Fact]
+    public void AudioBook_DoesNotRequireSourceSerialisation()
+    {
+        // Without this attribute the Data blob round-trips AdditionalParts/PartRunTimeTicks.
+        // Re-adding it would silently break multi-part persistence across restarts.
+        Assert.Null(typeof(AudioBook).GetCustomAttribute<RequiresSourceSerialisationAttribute>());
+    }
+
+    [Fact]
+    public void AudioBook_MultiPartFields_SurviveJsonRoundTrip()
+    {
+        var book = new AudioBook
+        {
+            Path = "/books/Defiant/01.mp3",
+            AdditionalParts = ["/books/Defiant/02.mp3", "/books/Defiant/03.mp3"],
+            PartRunTimeTicks = [1000, 2000, 3000]
+        };
+
+        var json = JsonSerializer.Serialize(book, JsonDefaults.Options);
+        var restored = JsonSerializer.Deserialize<AudioBook>(json, JsonDefaults.Options);
+
+        Assert.NotNull(restored);
+        Assert.Equal(book.AdditionalParts, restored!.AdditionalParts);
+        Assert.Equal(book.PartRunTimeTicks, restored.PartRunTimeTicks);
+    }
+
+    [Fact]
+    public void UpdateFromResolvedItem_AppliesChangedAdditionalParts()
+    {
+        var existing = new AudioBook { AdditionalParts = [] };
+        var resolved = new AudioBook { AdditionalParts = ["/p/02.mp3", "/p/03.mp3"] };
+
+        var updateType = existing.UpdateFromResolvedItem(resolved);
+
+        Assert.Equal(["/p/02.mp3", "/p/03.mp3"], existing.AdditionalParts);
+        Assert.True(updateType.HasFlag(ItemUpdateType.MetadataImport));
+    }
+
+    [Fact]
+    public void UpdateFromResolvedItem_UnchangedAdditionalParts_DoesNotFlagImport()
+    {
+        var existing = new AudioBook { AdditionalParts = ["/p/02.mp3"] };
+        var resolved = new AudioBook { AdditionalParts = ["/p/02.mp3"] };
+
+        var updateType = existing.UpdateFromResolvedItem(resolved);
+
+        Assert.False(updateType.HasFlag(ItemUpdateType.MetadataImport));
+    }
+
+    [Fact]
+    public void GetMediaSources_MultiPart_YieldsOneSourcePerPartWithValidGuidIds()
+    {
+        SetupBaseItemStatics();
+
+        var book = new AudioBook
+        {
+            Id = Guid.NewGuid(),
+            Path = "/books/Defiant/01.mp3",
+            AdditionalParts = ["/books/Defiant/02.mp3", "/books/Defiant/03.mp3"],
+            PartRunTimeTicks = [1000, 2000, 3000]
+        };
+
+        var sources = book.GetMediaSources(false);
+
+        Assert.Equal(3, sources.Count);
+        Assert.Equal(1000, sources[0].RunTimeTicks);
+        Assert.Equal("/books/Defiant/02.mp3", sources[1].Path);
+        Assert.Equal(2000, sources[1].RunTimeTicks);
+        Assert.Equal("/books/Defiant/03.mp3", sources[2].Path);
+        Assert.Equal(3000, sources[2].RunTimeTicks);
+
+        // DynamicHlsController calls Guid.Parse on the source id when transcoding, so every id must be a valid Guid.
+        foreach (var source in sources)
+        {
+            Assert.True(Guid.TryParseExact(source.Id, "N", out _));
+        }
+    }
+
+    [Fact]
+    public void GetMediaSources_NoAdditionalParts_FallsBackToBase()
+    {
+        SetupBaseItemStatics();
+
+        var book = new AudioBook
+        {
+            Id = Guid.NewGuid(),
+            Path = "/books/Single/book.mp3"
+        };
+
+        var sources = book.GetMediaSources(false);
+
+        Assert.Single(sources);
+    }
+
+    private static void SetupBaseItemStatics()
+    {
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>())).Returns(MediaProtocol.File);
+        mediaSourceManager.Setup(x => x.GetMediaStreams(It.IsAny<Guid>())).Returns(Array.Empty<MediaStream>());
+        mediaSourceManager.Setup(x => x.GetMediaAttachments(It.IsAny<Guid>())).Returns(Array.Empty<MediaAttachment>());
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(x => x.GetNewItemId(It.IsAny<string>(), It.IsAny<Type>()))
+            .Returns((string key, Type type) => Guid.NewGuid());
+
+        var mediaSegmentManager = new Mock<IMediaSegmentManager>();
+        mediaSegmentManager.Setup(x => x.IsTypeSupported(It.IsAny<BaseItem>())).Returns(false);
+
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        BaseItem.LibraryManager = libraryManager.Object;
+        BaseItem.MediaSegmentManager = mediaSegmentManager.Object;
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/Entities/AudioBookTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/AudioBookTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("BaseItem static state")]
 public class AudioBookTests
 {
     [Fact]

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemStaticStateCollection.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemStaticStateCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.Entities;
+
+[CollectionDefinition("BaseItem static state")]
+public class BaseItemStaticStateCollection
+{
+}

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("BaseItem static state")]
 public class BaseItemTests
 {
     [Theory]

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioFileProberChapterTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioFileProberChapterTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Chapters;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ModelMediaInfo = MediaBrowser.Model.MediaInfo.MediaInfo;
+
+namespace Jellyfin.Providers.Tests.MediaInfo;
+
+public class AudioFileProberChapterTests
+{
+    [Fact]
+    public async Task BuildMultiPartChaptersAsync_BuildsCumulativeChaptersWithStrippedNames()
+    {
+        var durations = new Dictionary<string, long>
+        {
+            ["/b/02 Prologue.mp3"] = 2000,
+            ["/b/03 Chapter 1.mp3"] = 3000
+        };
+
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder.Setup(x => x.GetMediaInfo(It.IsAny<MediaInfoRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaInfoRequest req, CancellationToken ct) =>
+                new ModelMediaInfo { RunTimeTicks = durations[req.MediaSource.Path] });
+
+        var prober = CreateProber(mediaEncoder: mediaEncoder);
+        var book = new AudioBook
+        {
+            Path = "/b/01 Opening.mp3",
+            AdditionalParts = ["/b/02 Prologue.mp3", "/b/03 Chapter 1.mp3"]
+        };
+
+        var (chapters, total, partTicks) = await prober.BuildMultiPartChaptersAsync(book, 1000, CancellationToken.None);
+
+        Assert.Equal(3, chapters.Count);
+        Assert.Equal("Opening", chapters[0].Name);
+        Assert.Equal(0, chapters[0].StartPositionTicks);
+        Assert.Equal("Prologue", chapters[1].Name);
+        Assert.Equal(1000, chapters[1].StartPositionTicks);
+        Assert.Equal("Chapter 1", chapters[2].Name);
+        Assert.Equal(3000, chapters[2].StartPositionTicks);
+        Assert.Equal(6000, total);
+        Assert.Equal([1000L, 2000L, 3000L], partTicks);
+    }
+
+    [Fact]
+    public async Task SaveAudioBookChaptersAsync_PrefersEmbeddedChapters_WhenPresent()
+    {
+        var chapterManager = new Mock<IChapterManager>();
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder.Setup(x => x.GetMediaInfo(It.IsAny<MediaInfoRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ModelMediaInfo { RunTimeTicks = 1000 });
+
+        var prober = CreateProber(chapterManager: chapterManager, mediaEncoder: mediaEncoder);
+        var book = new AudioBook { Path = "/b/01.mp3", AdditionalParts = ["/b/02.mp3"], PartRunTimeTicks = [0, 0] };
+        var embedded = new[] { new ChapterInfo { Name = "Embedded", StartPositionTicks = 0 } };
+
+        await prober.SaveAudioBookChaptersAsync(book, new ModelMediaInfo { Chapters = embedded }, CancellationToken.None);
+
+        chapterManager.Verify(x => x.SaveChapters(book, embedded), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAudioBookChaptersAsync_UsesMultiPart_WhenNoEmbeddedChapters()
+    {
+        var chapterManager = new Mock<IChapterManager>();
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder.Setup(x => x.GetMediaInfo(It.IsAny<MediaInfoRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ModelMediaInfo { RunTimeTicks = 2000 });
+
+        var prober = CreateProber(mediaEncoder: mediaEncoder, chapterManager: chapterManager);
+        var book = new AudioBook { Path = "/b/01 Intro.mp3", AdditionalParts = ["/b/02 Part.mp3"] };
+
+        await prober.SaveAudioBookChaptersAsync(book, new ModelMediaInfo { RunTimeTicks = 1000, Chapters = Array.Empty<ChapterInfo>() }, CancellationToken.None);
+
+        chapterManager.Verify(x => x.SaveChapters(book, It.Is<IReadOnlyList<ChapterInfo>>(c => c.Count == 2)), Times.Once);
+        Assert.Equal(3000L, book.RunTimeTicks!.Value);
+        Assert.Equal([1000L, 2000L], book.PartRunTimeTicks);
+    }
+
+    private static AudioFileProber CreateProber(
+        Mock<IMediaEncoder>? mediaEncoder = null,
+        Mock<ILibraryManager>? libraryManager = null,
+        Mock<IChapterManager>? chapterManager = null)
+    {
+        return new AudioFileProber(
+            NullLogger<AudioFileProber>.Instance,
+            null!,
+            (mediaEncoder ?? new Mock<IMediaEncoder>()).Object,
+            (libraryManager ?? new Mock<ILibraryManager>()).Object,
+            null!,
+            null!,
+            null!,
+            (chapterManager ?? new Mock<IChapterManager>()).Object,
+            null!);
+    }
+}

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/AudioFileProberTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/AudioFileProberTests.cs
@@ -1,0 +1,22 @@
+using MediaBrowser.Providers.MediaInfo;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.MediaInfo;
+
+public class AudioFileProberTests
+{
+    [Theory]
+    [InlineData("01 Opening Credits", "Opening Credits")]
+    [InlineData("04 Chapter 1", "Chapter 1")]
+    [InlineData("076 End Credits", "End Credits")]
+    [InlineData("01_Prologue", "Prologue")]
+    [InlineData("12-Epilogue", "Epilogue")]
+    [InlineData("Rhythm of War Chapter 34", "Rhythm of War Chapter 34")]
+    [InlineData("1984Foreword", "1984Foreword")]
+    [InlineData("01 ", "01 ")]
+    [InlineData("Plain Name", "Plain Name")]
+    public void StripLeadingTrackNumber_RemovesOnlyLeadingOrderPrefix(string input, string expected)
+    {
+        Assert.Equal(expected, AudioFileProber.StripLeadingTrackNumber(input));
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Emby.Naming.Common;
 using Emby.Server.Implementations.Library.Resolvers.Audio;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
@@ -21,6 +22,16 @@ public class AudioResolverTests
     [InlineData("chapter 01.mp3", "non-media.txt")]
     [InlineData("title.mp3", "title.epub")]
     [InlineData("01.mp3", "subdirectory/")] // single media file with sub-directory - note that this will hide any contents in the subdirectory
+    /* Multi-part books stack into one item when every file has a distinct order number. */
+    [InlineData("01.mp3", "02.mp3")]
+    [InlineData("chapter 01.mp3", "chapter 02.mp3")]
+    [InlineData("part 1.mp3", "part 2.mp3")]
+    [InlineData("chapter 01 part 01.mp3", "chapter 01 part 02.mp3")]
+    [InlineData("chapter 01.mp3", "part 2.mp3")]
+    /* Descriptive names stack as long as the leading order number is distinct, even when the
+       descriptive text contains its own numbers that would otherwise collide. */
+    [InlineData("01 Opening Credits.mp3", "02 Prologue.mp3", "03 Part I.mp3", "04 Chapter 1.mp3", "05 Chapter 2.mp3")]
+    [InlineData("Defiant Part 1 01.mp3", "Defiant Chapter 1 02.mp3", "Defiant Chapter 2 03.mp3")]
     public void Resolve_AudiobookDirectory_SingleResult(params string[] children)
     {
         var resolved = TestResolveChildren("/parent/title", children);
@@ -34,20 +45,29 @@ public class AudioResolverTests
     [InlineData("non-media.txt")]
     /* Names don't indicate parts of a single book. */
     [InlineData("Name.mp3", "Another Name.mp3")]
-    /* Results that are an audio book but not currently navigable as such (multiple chapters and/or parts). */
-    [InlineData("01.mp3", "02.mp3")]
-    [InlineData("chapter 01.mp3", "chapter 02.mp3")]
-    [InlineData("part 1.mp3", "part 2.mp3")]
-    [InlineData("chapter 01 part 01.mp3", "chapter 01 part 02.mp3")]
-    /* Mismatched chapters, parts, and named files. */
-    [InlineData("chapter 01.mp3", "part 2.mp3")]
+    /* Same order number, so they are alternate versions rather than separate parts. */
+    [InlineData("01 Content.mp3", "01 Credits.mp3")]
     [InlineData("book title.mp3", "chapter name.mp3")] // "book title" resolves as alternate version of book based on directory name
-    [InlineData("01 Content.mp3", "01 Credits.mp3")] // resolves as alternate versions of chapter 1
+    /* A file without an order number breaks the sequence. */
     [InlineData("Chapter Name.mp3", "Part 1.mp3")]
     public void Resolve_AudiobookDirectory_NoResult(params string[] children)
     {
         var resolved = TestResolveChildren("/parent/book title", children);
         Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Resolve_TrackNumberedParts_StackInOrder()
+    {
+        var resolved = TestResolveChildren(
+            "/parent/Defiant",
+            ["03 Chapter 2.mp3", "01 Opening Credits.mp3", "02 Chapter 1.mp3"]);
+
+        var book = Assert.IsType<AudioBook>(resolved);
+        Assert.Equal("/parent/Defiant/01 Opening Credits.mp3", book.Path);
+        Assert.Equal(
+            ["/parent/Defiant/02 Chapter 1.mp3", "/parent/Defiant/03 Chapter 2.mp3"],
+            book.AdditionalParts);
     }
 
     private Audio? TestResolveChildren(string parent, string[] children)


### PR DESCRIPTION
**Changes**
- Add support for taking audiobooks split into multiple files in the same folder and combining into one Item, by chapter
- Add support for per file artwork (every file can have it's own artwork, [Graphic Audio](https://www.graphicaudio.net/the-stormlight-archive-1-download-series-set.html) is a prime example)
- Support multifile progress for the api (admin dashboard usecase)

**Code assistance**
- Multiple code reviews and suggestions to tighten up my code
- Had Opus help me with tests, only code it wrote

**Issues**
- https://github.com/jellyfin/jellyfin/issues/10668

**Feature Requests**
- https://features.jellyfin.org/posts/794/audiobook-metadata-support

**Frontend**
I'm at my 3 PR limit over there so I'll update this section when I have access.

**Notes**
- A [previous attempt](https://github.com/jellyfin/jellyfin/pull/11517) had this at 40 files changed
- Split from my much bigger more [general purpose Audiobook PR](https://github.com/jellyfin/jellyfin/pull/17199)